### PR TITLE
refactor(blossom): type avatar upload failures at the service boundary

### DIFF
--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
@@ -29,43 +30,24 @@ import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+/// Maps a [BlossomUploadFailureReason] from the upload service to the
+/// localized message shown to the user when an avatar upload fails.
+///
+/// `null` (no reason supplied — defensive for older paths or unmapped
+/// failures) falls through to the generic "upload failed" copy.
 String profileSetupUploadErrorMessage(
   AppLocalizations l10n,
-  Object error,
+  BlossomUploadFailureReason? reason,
 ) {
-  final errorMessage = error.toString().toLowerCase();
-
-  if (errorMessage.contains('network') ||
-      errorMessage.contains('connection') ||
-      errorMessage.contains('cannot connect') ||
-      errorMessage.contains('timeout')) {
-    return l10n.profileSetupUploadNetworkError;
-  }
-
-  if (errorMessage.contains('auth') ||
-      errorMessage.contains('401') ||
-      errorMessage.contains('403')) {
-    return l10n.profileSetupUploadAuthError;
-  }
-
-  if (errorMessage.contains('file too large') ||
-      errorMessage.contains('payload too large') ||
-      errorMessage.contains('413') ||
-      errorMessage.contains('size')) {
-    return l10n.profileSetupUploadFileTooLarge;
-  }
-
-  if (errorMessage.contains('server error') ||
-      errorMessage.contains('server') ||
-      errorMessage.contains('unavailable') ||
-      errorMessage.contains('500') ||
-      errorMessage.contains('502') ||
-      errorMessage.contains('503') ||
-      errorMessage.contains('504')) {
-    return l10n.profileSetupUploadServerError;
-  }
-
-  return l10n.profileSetupUploadFailedGeneric;
+  return switch (reason) {
+    BlossomUploadFailureReason.network => l10n.profileSetupUploadNetworkError,
+    BlossomUploadFailureReason.auth => l10n.profileSetupUploadAuthError,
+    BlossomUploadFailureReason.fileTooLarge =>
+      l10n.profileSetupUploadFileTooLarge,
+    BlossomUploadFailureReason.server => l10n.profileSetupUploadServerError,
+    BlossomUploadFailureReason.unknown ||
+    null => l10n.profileSetupUploadFailedGeneric,
+  };
 }
 
 class ProfileSetupScreen extends ConsumerWidget {
@@ -1356,7 +1338,10 @@ class _ProfileSetupScreenViewState
       final uploadService = ref.read(blossomUploadServiceProvider);
 
       if (authService.currentPublicKeyHex == null) {
-        throw Exception('No public key available');
+        // No signed-in identity: classify as auth so the user sees the
+        // sign-in-again copy rather than a generic "upload failed".
+        _showUploadFailureSnackBar(l10n, BlossomUploadFailureReason.auth);
+        return;
       }
 
       final result = await uploadService.uploadImage(
@@ -1394,11 +1379,20 @@ class _ProfileSetupScreenViewState
           );
         }
       } else {
-        throw Exception(result.errorMessage ?? 'Upload failed');
+        Log.error(
+          'Image upload failed: ${result.errorMessage} '
+          '(reason: ${result.failureReason}, status: ${result.statusCode})',
+          name: 'ProfileSetupScreen',
+          category: LogCategory.ui,
+        );
+        _showUploadFailureSnackBar(l10n, result.failureReason);
       }
     } catch (e) {
+      // Defensive: uploadImage normally returns a result rather than
+      // throwing, so anything reaching here is unexpected (file IO,
+      // provider lookup). Surface the generic copy.
       Log.error(
-        'Error uploading image: $e',
+        'Unexpected error uploading image: $e',
         name: 'ProfileSetupScreen',
         category: LogCategory.ui,
       );
@@ -1407,23 +1401,7 @@ class _ProfileSetupScreenViewState
         name: 'ProfileSetupScreen',
         category: LogCategory.ui,
       );
-
-      final userMessage = profileSetupUploadErrorMessage(l10n, e);
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(userMessage),
-            backgroundColor: VineTheme.error,
-            duration: const Duration(seconds: 5),
-            action: SnackBarAction(
-              label: l10n.profileSetupGotItButton,
-              textColor: VineTheme.whiteText,
-              onPressed: () {},
-            ),
-          ),
-        );
-      }
+      _showUploadFailureSnackBar(l10n, null);
     } finally {
       if (mounted) {
         setState(() {
@@ -1431,6 +1409,25 @@ class _ProfileSetupScreenViewState
         });
       }
     }
+  }
+
+  void _showUploadFailureSnackBar(
+    AppLocalizations l10n,
+    BlossomUploadFailureReason? reason,
+  ) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(profileSetupUploadErrorMessage(l10n, reason)),
+        backgroundColor: VineTheme.error,
+        duration: const Duration(seconds: 5),
+        action: SnackBarAction(
+          label: l10n.profileSetupGotItButton,
+          textColor: VineTheme.whiteText,
+          onPressed: () {},
+        ),
+      ),
+    );
   }
 
   void _showNostrInfoSheet(BuildContext context) {

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -17,6 +17,73 @@ import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Why a Blossom upload failed.
+///
+/// Classification lives at the HTTP/service boundary so that callers
+/// (UI, analytics, telemetry) can branch on a stable enum rather than
+/// inspecting raw [BlossomUploadResult.errorMessage] text or HTTP
+/// status codes themselves.
+enum BlossomUploadFailureReason {
+  /// Connection / send / receive timeout, connection error, transient
+  /// connectivity loss. Caller may show "check your connection".
+  network,
+
+  /// Authentication failure: HTTP 401 / 403, or the service was unable
+  /// to produce a signed Blossom auth header. Caller may prompt the
+  /// user to sign in again.
+  auth,
+
+  /// Server rejected the upload because the file exceeds size limits
+  /// (HTTP 413 "payload too large"). Caller may suggest a smaller file.
+  fileTooLarge,
+
+  /// Server-side error (HTTP 5xx) — usually transient. Caller may show
+  /// "our servers are temporarily unavailable".
+  server,
+
+  /// Anything else: unmapped 4xx, malformed responses, configuration
+  /// errors, or unexpected exceptions. Caller falls back to a generic
+  /// "upload failed" message.
+  unknown
+  ;
+
+  /// Classifies an HTTP [statusCode] into a [BlossomUploadFailureReason].
+  ///
+  /// Returns `null` when [statusCode] is null or represents a success
+  /// (`< 400`), so callers can distinguish "not a failure" from
+  /// `unknown`.
+  static BlossomUploadFailureReason? fromStatusCode(int? statusCode) {
+    if (statusCode == null || statusCode < 400) return null;
+    if (statusCode == 401 || statusCode == 403) {
+      return BlossomUploadFailureReason.auth;
+    }
+    if (statusCode == 413) return BlossomUploadFailureReason.fileTooLarge;
+    if (statusCode >= 500 && statusCode < 600) {
+      return BlossomUploadFailureReason.server;
+    }
+    return BlossomUploadFailureReason.unknown;
+  }
+
+  /// Classifies a [DioException] into a [BlossomUploadFailureReason].
+  ///
+  /// Connection / timeout errors map to [network]. For [bad responses]
+  /// (`DioExceptionType.badResponse`) the status code is used; if no
+  /// status is available the reason falls through to [unknown].
+  ///
+  /// [bad responses]: https://pub.dev/documentation/dio/latest/dio/DioExceptionType.html
+  static BlossomUploadFailureReason fromDioException(DioException error) {
+    return switch (error.type) {
+      DioExceptionType.connectionTimeout ||
+      DioExceptionType.sendTimeout ||
+      DioExceptionType.receiveTimeout ||
+      DioExceptionType.connectionError => BlossomUploadFailureReason.network,
+      _ =>
+        fromStatusCode(error.response?.statusCode) ??
+            BlossomUploadFailureReason.unknown,
+    };
+  }
+}
+
 /// Result type for Blossom upload operations
 class BlossomUploadResult {
   /// Creates a [BlossomUploadResult].
@@ -34,6 +101,7 @@ class BlossomUploadResult {
     this.errorMessage,
     this.statusCode,
     this.isTransientNetworkFailure = false,
+    this.failureReason,
   });
 
   /// Whether the upload succeeded.
@@ -78,6 +146,16 @@ class BlossomUploadResult {
   /// rethrowing. Surfaced as a retry signal symmetric with [statusCode]
   /// for the cases where there is no HTTP status to classify on.
   final bool isTransientNetworkFailure;
+
+  /// Typed reason for the failure, set at the HTTP/service boundary.
+  ///
+  /// Always `null` on success. On failure, callers should switch on this
+  /// rather than parsing [errorMessage] or [statusCode] — the
+  /// classification is owned by the service layer so the contract stays
+  /// stable across UI, analytics, and telemetry. A `null` value on a
+  /// failure result means the boundary couldn't classify the failure;
+  /// callers should treat it as [BlossomUploadFailureReason.unknown].
+  final BlossomUploadFailureReason? failureReason;
 
   /// Convenience getter for backwards compatibility.
   String? get cdnUrl => fallbackUrl ?? url;
@@ -468,6 +546,32 @@ class BlossomUploadService {
     return false;
   }
 
+  /// Classifies a thrown upload exception into a
+  /// [BlossomUploadFailureReason].
+  ///
+  /// Handles the two thrown shapes the upload internals produce:
+  ///
+  ///   * [DioException] — delegated to
+  ///     [BlossomUploadFailureReason.fromDioException].
+  ///   * [BlossomResumableUploadException] — classified by its
+  ///     `statusCode` when present. Throws without a status (auth-header
+  ///     build failure, malformed init response) fall through to
+  ///     [BlossomUploadFailureReason.unknown] — the boundary can't tell
+  ///     them apart from the typed exception alone, and surfacing
+  ///     "authentication error" for a missing init field would mislead.
+  ///
+  /// Anything else falls through to [BlossomUploadFailureReason.unknown].
+  static BlossomUploadFailureReason _classifyUploadException(Object error) {
+    if (error is DioException) {
+      return BlossomUploadFailureReason.fromDioException(error);
+    }
+    if (error is BlossomResumableUploadException) {
+      return BlossomUploadFailureReason.fromStatusCode(error.statusCode) ??
+          BlossomUploadFailureReason.unknown;
+    }
+    return BlossomUploadFailureReason.unknown;
+  }
+
   /// Whether a [BlossomUploadResult] failure is transient and worth retrying.
   ///
   /// Some failure modes are caught inside the upload internals (notably the
@@ -617,6 +721,7 @@ class BlossomUploadService {
       result = BlossomUploadResult(
         success: false,
         errorMessage: error.toString(),
+        failureReason: _classifyUploadException(error),
       );
     }
 
@@ -1204,6 +1309,7 @@ class BlossomUploadService {
       return const BlossomUploadResult(
         success: false,
         errorMessage: 'Upload response missing URL field',
+        failureReason: BlossomUploadFailureReason.unknown,
       );
     }
 
@@ -1227,6 +1333,9 @@ class BlossomUploadService {
       statusCode: response.statusCode,
       errorMessage:
           'Upload failed: ${response.statusCode} - ${xReason ?? response.data}',
+      failureReason:
+          BlossomUploadFailureReason.fromStatusCode(response.statusCode) ??
+          BlossomUploadFailureReason.unknown,
     );
   }
 
@@ -1252,6 +1361,7 @@ class BlossomUploadService {
         return BlossomUploadResult(
           success: false,
           errorMessage: 'Invalid Blossom server URL: $serverUrl',
+          failureReason: BlossomUploadFailureReason.unknown,
         );
         // coverage:ignore-end
       }
@@ -1267,6 +1377,7 @@ class BlossomUploadService {
         return const BlossomUploadResult(
           success: false,
           errorMessage: 'Failed to create Blossom authentication',
+          failureReason: BlossomUploadFailureReason.auth,
         );
       }
 
@@ -1341,6 +1452,7 @@ class BlossomUploadService {
           statusCode: statusCode,
           errorMessage: 'Connection timeout - check server URL',
           isTransientNetworkFailure: true,
+          failureReason: BlossomUploadFailureReason.network,
         );
       } else if (e.type == DioExceptionType.sendTimeout) {
         return BlossomUploadResult(
@@ -1348,6 +1460,7 @@ class BlossomUploadService {
           statusCode: statusCode,
           errorMessage: 'Send timeout - upload too slow or connection dropped',
           isTransientNetworkFailure: true,
+          failureReason: BlossomUploadFailureReason.network,
         );
       } else if (e.type == DioExceptionType.receiveTimeout) {
         return BlossomUploadResult(
@@ -1355,6 +1468,7 @@ class BlossomUploadService {
           statusCode: statusCode,
           errorMessage: 'Receive timeout - server not responding',
           isTransientNetworkFailure: true,
+          failureReason: BlossomUploadFailureReason.network,
         );
       } else if (e.type == DioExceptionType.connectionError) {
         return BlossomUploadResult(
@@ -1362,30 +1476,37 @@ class BlossomUploadService {
           statusCode: statusCode,
           errorMessage: 'Cannot connect to Blossom server: $errorDetail',
           isTransientNetworkFailure: true,
+          failureReason: BlossomUploadFailureReason.network,
         );
       } else if (e.type == DioExceptionType.cancel) {
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,
           errorMessage: 'Upload cancelled',
+          failureReason: BlossomUploadFailureReason.unknown,
         );
       } else if (e.type == DioExceptionType.badResponse) {
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,
           errorMessage: 'Server error ($statusCode): $errorDetail',
+          failureReason:
+              BlossomUploadFailureReason.fromStatusCode(statusCode) ??
+              BlossomUploadFailureReason.unknown,
         );
       } else {
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,
           errorMessage: 'Network error: $errorDetail',
+          failureReason: BlossomUploadFailureReason.fromDioException(e),
         );
       }
     } on Object catch (e) {
       return BlossomUploadResult(
         success: false,
         errorMessage: 'Upload error: $e',
+        failureReason: BlossomUploadFailureReason.unknown,
       );
     }
   }
@@ -1423,6 +1544,7 @@ class BlossomUploadService {
         return const BlossomUploadResult(
           success: false,
           errorMessage: 'User not authenticated - please sign in to upload',
+          failureReason: BlossomUploadFailureReason.auth,
         );
       }
 
@@ -1593,6 +1715,7 @@ class BlossomUploadService {
             success: false,
             statusCode: statusCode,
             errorMessage: 'Upload to $serverUrl failed: $e',
+            failureReason: _classifyUploadException(e),
           );
           Log.warning(
             'Upload to $serverUrl failed: $e, '
@@ -1616,6 +1739,7 @@ class BlossomUploadService {
           const BlossomUploadResult(
             success: false,
             errorMessage: 'All servers failed',
+            failureReason: BlossomUploadFailureReason.unknown,
           );
     } on Object catch (e) {
       Log.error(
@@ -1627,6 +1751,7 @@ class BlossomUploadService {
       return BlossomUploadResult(
         success: false,
         errorMessage: 'Blossom upload failed: $e',
+        failureReason: _classifyUploadException(e),
       );
     } finally {
       // Stop performance trace
@@ -1662,6 +1787,7 @@ class BlossomUploadService {
         return const BlossomUploadResult(
           success: false,
           errorMessage: 'Not authenticated',
+          failureReason: BlossomUploadFailureReason.auth,
         );
       }
 
@@ -1796,6 +1922,7 @@ class BlossomUploadService {
             success: false,
             statusCode: statusCode,
             errorMessage: 'Upload to $serverUrl failed: $e',
+            failureReason: _classifyUploadException(e),
           );
           Log.warning(
             'Upload to $serverUrl failed: $e, '
@@ -1820,6 +1947,7 @@ class BlossomUploadService {
           const BlossomUploadResult(
             success: false,
             errorMessage: 'All servers failed',
+            failureReason: BlossomUploadFailureReason.unknown,
           );
     } on Object catch (e) {
       Log.error(
@@ -1830,6 +1958,7 @@ class BlossomUploadService {
       return BlossomUploadResult(
         success: false,
         errorMessage: 'Image upload failed: $e',
+        failureReason: _classifyUploadException(e),
       );
     }
   }
@@ -2040,6 +2169,7 @@ class BlossomUploadService {
         return const BlossomUploadResult(
           success: false,
           errorMessage: 'Not authenticated',
+          failureReason: BlossomUploadFailureReason.auth,
         );
       }
 
@@ -2126,6 +2256,7 @@ class BlossomUploadService {
             success: false,
             statusCode: statusCode,
             errorMessage: 'Upload to $serverUrl failed: $e',
+            failureReason: _classifyUploadException(e),
           );
           Log.warning(
             'Upload to $serverUrl failed: $e, '
@@ -2150,6 +2281,7 @@ class BlossomUploadService {
           const BlossomUploadResult(
             success: false,
             errorMessage: 'All servers failed',
+            failureReason: BlossomUploadFailureReason.unknown,
           );
     } on Object catch (e) {
       Log.error(
@@ -2160,6 +2292,7 @@ class BlossomUploadService {
       return BlossomUploadResult(
         success: false,
         errorMessage: 'Audio upload failed: $e',
+        failureReason: _classifyUploadException(e),
       );
     }
   }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -2261,6 +2261,212 @@ void main() {
           expect(exception.statusCode, equals(500));
         });
       });
+
+      group(BlossomUploadFailureReason, () {
+        group('fromStatusCode', () {
+          test('returns null for null status', () {
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(null),
+              isNull,
+            );
+          });
+
+          test('returns null for 2xx success codes', () {
+            expect(BlossomUploadFailureReason.fromStatusCode(200), isNull);
+            expect(BlossomUploadFailureReason.fromStatusCode(201), isNull);
+            expect(BlossomUploadFailureReason.fromStatusCode(204), isNull);
+          });
+
+          test('returns null for 3xx redirect codes', () {
+            expect(BlossomUploadFailureReason.fromStatusCode(301), isNull);
+            expect(BlossomUploadFailureReason.fromStatusCode(304), isNull);
+          });
+
+          test('returns auth for 401 and 403', () {
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(401),
+              equals(BlossomUploadFailureReason.auth),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(403),
+              equals(BlossomUploadFailureReason.auth),
+            );
+          });
+
+          test('returns fileTooLarge for 413', () {
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(413),
+              equals(BlossomUploadFailureReason.fileTooLarge),
+            );
+          });
+
+          test('returns server for 5xx codes', () {
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(500),
+              equals(BlossomUploadFailureReason.server),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(502),
+              equals(BlossomUploadFailureReason.server),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(503),
+              equals(BlossomUploadFailureReason.server),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(504),
+              equals(BlossomUploadFailureReason.server),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(599),
+              equals(BlossomUploadFailureReason.server),
+            );
+          });
+
+          test('returns unknown for unmapped 4xx codes', () {
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(400),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(404),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(429),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+          });
+
+          test('returns unknown for codes outside 4xx/5xx', () {
+            expect(
+              BlossomUploadFailureReason.fromStatusCode(600),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+          });
+        });
+
+        group('fromDioException', () {
+          DioException dioException(
+            DioExceptionType type, {
+            int? statusCode,
+          }) {
+            final requestOptions = RequestOptions(path: '/upload');
+            return DioException(
+              requestOptions: requestOptions,
+              type: type,
+              response: statusCode == null
+                  ? null
+                  : Response<dynamic>(
+                      requestOptions: requestOptions,
+                      statusCode: statusCode,
+                    ),
+            );
+          }
+
+          test('returns network for connection timeout', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.connectionTimeout),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns network for send timeout', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.sendTimeout),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns network for receive timeout', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.receiveTimeout),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns network for connection error', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.connectionError),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns server for badResponse with 5xx status', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(
+                  DioExceptionType.badResponse,
+                  statusCode: 503,
+                ),
+              ),
+              equals(BlossomUploadFailureReason.server),
+            );
+          });
+
+          test('returns auth for badResponse with 401', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(
+                  DioExceptionType.badResponse,
+                  statusCode: 401,
+                ),
+              ),
+              equals(BlossomUploadFailureReason.auth),
+            );
+          });
+
+          test('returns fileTooLarge for badResponse with 413', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(
+                  DioExceptionType.badResponse,
+                  statusCode: 413,
+                ),
+              ),
+              equals(BlossomUploadFailureReason.fileTooLarge),
+            );
+          });
+
+          test('returns unknown for badResponse with no status', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.badResponse),
+              ),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+          });
+
+          test('returns unknown for cancel', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.cancel),
+              ),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+          });
+
+          test('uses status code for badCertificate when present', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(
+                  DioExceptionType.badCertificate,
+                  statusCode: 502,
+                ),
+              ),
+              equals(BlossomUploadFailureReason.server),
+            );
+          });
+        });
+      });
     });
 
     group('testServerConnection', () {
@@ -2607,6 +2813,7 @@ void main() {
 
         expect(result.success, isFalse);
         expect(result.errorMessage, equals('Not authenticated'));
+        expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
       });
 
       test('returns failure when all servers fail', () async {
@@ -2641,9 +2848,232 @@ void main() {
         );
 
         expect(result.success, isFalse);
+        // Auth-header build failure (unsigned event) classifies as auth.
+        expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
 
         await tempDir.delete(recursive: true);
       });
+    });
+
+    group('uploadImage - failure classification', () {
+      late _MockDio mockDio;
+
+      setUp(() {
+        mockDio = _MockDio();
+        service = BlossomUploadService(
+          authProvider: mockAuthProvider,
+          dio: mockDio,
+          // Skip retry backoff so each failure test runs in milliseconds.
+          sleep: (_) async {},
+        );
+      });
+
+      Future<File> writeTempImage(String name) async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'image_upload_classification_',
+        );
+        return File('${tempDir.path}/$name')
+          ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+      }
+
+      void arrangeAuthenticated() {
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+        );
+      }
+
+      void arrangeLegacyCapability() {
+        when(
+          () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/upload'),
+            statusCode: 200,
+            headers: Headers(),
+          ),
+        );
+      }
+
+      void arrangePutThrows(DioException exception) {
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenThrow(exception);
+      }
+
+      void arrangePutResponse({
+        required int statusCode,
+        Map<String, dynamic>? data,
+      }) {
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => Response<dynamic>(
+            requestOptions: RequestOptions(path: '/upload'),
+            statusCode: statusCode,
+            data: data,
+          ),
+        );
+      }
+
+      test('classifies connection timeout as network', () async {
+        arrangeAuthenticated();
+        arrangeLegacyCapability();
+        arrangePutThrows(
+          DioException(
+            requestOptions: RequestOptions(path: '/upload'),
+            type: DioExceptionType.connectionTimeout,
+          ),
+        );
+
+        final imageFile = await writeTempImage('timeout.jpg');
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.network),
+        );
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('classifies connection error as network', () async {
+        arrangeAuthenticated();
+        arrangeLegacyCapability();
+        arrangePutThrows(
+          DioException(
+            requestOptions: RequestOptions(path: '/upload'),
+            type: DioExceptionType.connectionError,
+            message: 'DNS lookup failed',
+          ),
+        );
+
+        final imageFile = await writeTempImage('connection_error.jpg');
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.network),
+        );
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('classifies HTTP 503 from server as server', () async {
+        arrangeAuthenticated();
+        arrangeLegacyCapability();
+        arrangePutResponse(
+          statusCode: 503,
+          data: {'error': 'Service Unavailable'},
+        );
+
+        final imageFile = await writeTempImage('server_503.jpg');
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.server),
+        );
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('classifies HTTP 401 from server as auth', () async {
+        arrangeAuthenticated();
+        arrangeLegacyCapability();
+        arrangePutResponse(
+          statusCode: 401,
+          data: {'error': 'Unauthorized'},
+        );
+
+        final imageFile = await writeTempImage('auth_401.jpg');
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('classifies HTTP 413 from server as fileTooLarge', () async {
+        arrangeAuthenticated();
+        arrangeLegacyCapability();
+        arrangePutResponse(
+          statusCode: 413,
+          data: {'error': 'Payload Too Large'},
+        );
+
+        final imageFile = await writeTempImage('too_large.jpg');
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.fileTooLarge),
+        );
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test(
+        'classifies HTTP 400 (unmapped 4xx) from server as unknown',
+        () async {
+          arrangeAuthenticated();
+          arrangeLegacyCapability();
+          arrangePutResponse(
+            statusCode: 400,
+            data: {'error': 'Bad Request'},
+          );
+
+          final imageFile = await writeTempImage('bad_request.jpg');
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isFalse);
+          expect(
+            result.failureReason,
+            equals(BlossomUploadFailureReason.unknown),
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
     });
 
     group('uploadBugReport - error paths', () {

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests status indicators, pre-population, and validation behavior
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -444,13 +445,13 @@ void main() {
       expect(
         profileSetupUploadErrorMessage(
           l10n,
-          Exception('Server error (503): Service Unavailable'),
+          BlossomUploadFailureReason.server,
         ),
         l10n.profileSetupUploadServerError,
       );
     });
 
-    testWidgets('uses a generic fallback without leaking raw exception text', (
+    testWidgets('maps network failures to the network error message', (
       tester,
     ) async {
       final l10n = await loadL10n(tester);
@@ -458,15 +459,62 @@ void main() {
       expect(
         profileSetupUploadErrorMessage(
           l10n,
-          Exception('weird upstream blob storage failure'),
+          BlossomUploadFailureReason.network,
+        ),
+        l10n.profileSetupUploadNetworkError,
+      );
+    });
+
+    testWidgets('maps auth failures to the auth error message', (
+      tester,
+    ) async {
+      final l10n = await loadL10n(tester);
+
+      expect(
+        profileSetupUploadErrorMessage(
+          l10n,
+          BlossomUploadFailureReason.auth,
+        ),
+        l10n.profileSetupUploadAuthError,
+      );
+    });
+
+    testWidgets('maps fileTooLarge failures to the file-too-large message', (
+      tester,
+    ) async {
+      final l10n = await loadL10n(tester);
+
+      expect(
+        profileSetupUploadErrorMessage(
+          l10n,
+          BlossomUploadFailureReason.fileTooLarge,
+        ),
+        l10n.profileSetupUploadFileTooLarge,
+      );
+    });
+
+    testWidgets('falls back to the generic message for unknown failures', (
+      tester,
+    ) async {
+      final l10n = await loadL10n(tester);
+
+      expect(
+        profileSetupUploadErrorMessage(
+          l10n,
+          BlossomUploadFailureReason.unknown,
         ),
         l10n.profileSetupUploadFailedGeneric,
       );
+    });
+
+    testWidgets('falls back to the generic message when reason is null', (
+      tester,
+    ) async {
+      final l10n = await loadL10n(tester);
+
       expect(
-        l10n.profileSetupUploadFailedGeneric.contains(
-          'weird upstream blob storage failure',
-        ),
-        isFalse,
+        profileSetupUploadErrorMessage(l10n, null),
+        l10n.profileSetupUploadFailedGeneric,
       );
     });
   });


### PR DESCRIPTION
## Description

Follow-up to #3877 / [PR #3880](https://github.com/divinevideo/divine-mobile/pull/3880).

PR #3880 stopped leaking raw `Exception: 503 ...` text to the avatar-upload snackbar by adding a UI-side classifier that grepped `error.toString().toLowerCase().contains('503' | 'auth' | 'timeout' | ...)`. That worked but kept the cross-layer contract fragile — any rewording of an internal error message could silently downgrade the user-facing copy back to the generic fallback.

This PR moves the classification down to where it belongs: the HTTP/service boundary inside `packages/blossom_upload_service`.

### What changed

**Package — `packages/blossom_upload_service`**
- New `BlossomUploadFailureReason` enum (`network`, `auth`, `fileTooLarge`, `server`, `unknown`) with two static classifiers: `fromStatusCode(int?)` and `fromDioException(DioException)`.
- New `failureReason` field on `BlossomUploadResult` (defaults to `null`; always set on failure paths).
- Wired into every failure-construction site in `_uploadToServer`, `_parseUploadResponse`, `_uploadWithSingleLegacyFallback`, `uploadImage`, `uploadVideo`, and `uploadAudio` — plus a private `_classifyUploadException` helper that handles both `DioException` and `BlossomResumableUploadException` thrown shapes.

**UI — `mobile/lib/screens/profile_setup_screen.dart`**
- `profileSetupUploadErrorMessage` is now a single `switch` over `BlossomUploadFailureReason?` instead of substring-matching on `error.toString()`. `null` falls through to the generic copy.
- `_uploadImage()` reads `result.failureReason` directly. The previous `throw Exception(result.errorMessage)` round-trip through the catch block is gone; the catch is now a defensive fallback for genuinely unexpected exceptions (file IO, provider lookup) and surfaces the generic copy.
- Snackbar display extracted to `_showUploadFailureSnackBar(l10n, reason)`.

### Why this exists

- `ProfileSetupScreen` previously mapped upload failures by inspecting `error.toString()` — better than leaking `Exception: 503 ...` to users, but still a fragile cross-layer contract.
- The service package already knows whether the failure is network / auth / file-size / server / unknown, so that classification belongs there.

**Related Issue:** Closes #3879

## Type of Change

- [x] 🧹 Code refactor

## Reproducing the original bug (#3877)

Pre-PR-#3880 behavior — confirms the surface this refactor is preserving:

1. Open Profile setup or Edit profile.
2. Tap the avatar → pick an image from library / camera.
3. Force a service failure. Pick the matrix row to verify:

   | Failure | How to trigger | Expected snackbar copy |
   |---|---|---|
   | Network | Toggle airplane mode after picking, before tap-to-upload completes | `profileSetupUploadNetworkError` |
   | Server (5xx) | Point `media.divine.video` at a host returning 503 (or use Charles map-local) | `profileSetupUploadServerError` |
   | Auth (401/403) | Sign out from another tab so the Blossom auth header is rejected | `profileSetupUploadAuthError` |
   | File too large (413) | Upload a > 10 MB image against a server that enforces the limit | `profileSetupUploadFileTooLarge` |
   | Unknown / other | Any unmapped failure (e.g. 400 with custom server response) | `profileSetupUploadFailedGeneric` |

4. Confirm the snackbar shows the localized copy from the right column. Confirm no raw exception text (e.g. `Exception: 503 ...`, `DioException [...]`) appears.

## Test plan

- [x] `flutter analyze lib test integration_test packages/blossom_upload_service/lib packages/blossom_upload_service/test` — no issues
- [x] `dart format` — clean
- [x] `flutter test packages/blossom_upload_service` — 174 passed (17 new enum-classification tests + 6 new boundary tests against `uploadImage` proving each failure mode → correct typed `failureReason`)
- [x] `flutter test test/screens/profile_setup_screen_test.dart` — 32 passed (existing tests rewritten to assert on the typed enum; new tests cover all five reasons + null)
- [x] `flutter test test/services/upload_manager_*` — 32 passed (other `BlossomUploadResult` consumers unaffected; new field is optional)
- [x] `blossom_upload_service` line coverage: 632/632 (CI gate is `min_coverage: 100`)
- [ ] Manual smoke test on iOS / Android using the matrix above — reviewer to verify on-device

## Notes for reviewers

- `BlossomUploadFailureReason.fromStatusCode` returns `null` for `< 400` (success or redirect) so call sites can distinguish "not a failure" from `unknown`. Failure-construction sites coalesce to `unknown` explicitly.
- `BlossomResumableUploadException` without a status code (auth-header build failure, malformed init response) falls through to `unknown` rather than `auth`, since the typed exception alone can't tell those apart and surfacing "authentication error" for a missing init field would mislead the user.
- The `divine_ui` strict-coverage gate is untouched — all new code lives in `blossom_upload_service`, whose 100% coverage gate is verified locally and will be enforced again in CI.