### PR TITLE
fix(android): add /invite to App Links intent-filter pathPrefix

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -128,6 +128,7 @@
                 <data android:pathPrefix="/profile"/>
                 <data android:pathPrefix="/hashtag"/>
                 <data android:pathPrefix="/search"/>
+                <data android:pathPrefix="/invite"/>
                 <data android:pathPrefix="/reset-password"/>
                 <data android:pathPrefix="/verify-email"/>
             </intent-filter>


### PR DESCRIPTION
## Summary
- Adds `<data android:pathPrefix="/invite"/>` to the auto-verifying intent-filter in `AndroidManifest.xml`.
- Without it, `https://divine.video/invite/*` links never reach the app via App Links — Android falls back to the browser.
- `DeepLinkService.parseDeepLink` already handles the `invite` path segment (lib/services/deep_link_service.dart:209), so the manifest entry was the only missing piece.

## Context
- iOS path is unaffected (AASA is the verification surface there).
- Verification on Android still requires `/.well-known/assetlinks.json` on `divine.video` to advertise the app's package + signing fingerprints. If divine-web's assetlinks update is still pending, first-install verification can fail until that lands — coordinate the rollout with the web team.

Closes #3696

## Test plan
- [ ] Install the build on Android and tap an `https://divine.video/invite/<code>` link from another app — verify the app opens directly (not the browser) and the invite flow runs.
- [ ] Tap an `https://divine.video/invite?code=ABCD-EFGH` link — verify the same.
- [ ] `adb shell pm get-app-links co.openvine.app` shows `/invite` among the verified paths once assetlinks.json is in place.
- [ ] Existing deep links (`/video`, `/profile`, `/hashtag`, `/search`, `/reset-password`, `/verify-email`) still resolve.