### PR TITLE
perf(playback): gate 100ms diagnostics on kDebugMode by default (#3351)

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -24,17 +24,27 @@ enum LoadState {
   error,
 }
 
-/// Temporary diagnostic switch for the iOS playback investigation.
+/// Compile-time gate for the verbose playback diagnostics added during the
+/// iOS pause investigation.
 ///
-/// When `true`, [VideoFeedController] emits extra source-selection and
-/// session-summary logs alongside the existing stutter/stall diagnostics.
-/// The goal is to answer: which media source (progressive /720p.mp4, raw
-/// blob, HLS, or original) is chosen on each platform, and which one is
-/// actually streaming when a pause or stall is observed.
+/// When `true`, [VideoFeedController] emits source-selection, session
+/// summary, `player_state_snapshot`, and `slow_playback_detected` logs, and
+/// performs the per-heartbeat rate/state-snapshot work that backs them.
+/// When `false`, those branches are dead code and tree-shaken out — the
+/// 100ms heartbeat keeps running but only does the work that is actually
+/// load-bearing for playback (stale-position recovery, loop enforcement,
+/// position callbacks). Stall recovery is intentionally not gated by this
+/// flag.
 ///
-/// Leave enabled while we still need the data; flip to `false` (or delete
-/// along with the log call sites) once the iOS pause cause is known.
-const bool kPlaybackDiagnosticsEnabled = true;
+/// Defaults to [kDebugMode] so debug builds and `flutter test` keep the
+/// full diagnostic stream while release and profile builds do not pay the
+/// cost. Override with `--dart-define=PLAYBACK_DIAGNOSTICS=true` (or
+/// `=false`) to force a specific mode for a build — useful when capturing
+/// production traces against a specific user report.
+const bool kPlaybackDiagnosticsEnabled = bool.fromEnvironment(
+  'PLAYBACK_DIAGNOSTICS',
+  defaultValue: kDebugMode,
+);
 
 /// Classification of a playback URL used by diagnostic logs.
 ///

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -5904,12 +5904,14 @@ void main() {
   });
 
   group('kPlaybackDiagnosticsEnabled', () {
-    test('flag is currently enabled (set to false to remove diagnostics)', () {
-      // This test exists to make removal of the diagnostics gate
-      // visible: when iOS playback investigation wraps up, set the
-      // const to false (or delete the call sites) and update this
-      // expectation in the same commit.
-      expect(kPlaybackDiagnosticsEnabled, isTrue);
+    test('defaults to kDebugMode so debug + tests capture diagnostics', () {
+      // The diagnostic gate defaults to [kDebugMode] (overridable with
+      // `--dart-define=PLAYBACK_DIAGNOSTICS=...`). This assertion pins
+      // that contract so a future edit cannot silently flip the gate
+      // off under tests — if it did, the diagnostic-emission tests
+      // above would stop producing logs and start passing for the
+      // wrong reason.
+      expect(kPlaybackDiagnosticsEnabled, equals(kDebugMode));
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes #3351.

`mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart` declared `kPlaybackDiagnosticsEnabled = true` as a temporary switch for the iOS pause investigation. With the gate hardcoded `true`, every active video has been paying for `_emitStateSnapshotIfDue` and `_checkPlaybackRate` on every 100 ms heartbeat in production — plus the source-selection and session-summary log emissions — for the lifetime of the playback session.

This PR turns the const into a compile-time gate that defaults to `kDebugMode`, so release and profile builds no longer pay for the diagnostic capture, while debug builds and `flutter test` keep emitting everything they did before. Builds that need to capture a production trace (e.g. for a specific user report) can opt in with `--dart-define=PLAYBACK_DIAGNOSTICS=true`.

The 100 ms heartbeat itself stays — `_checkStalePosition` (B-frame decoder freeze recovery), `maxLoopDuration` enforcement, and the `positionCallback` invocation are load-bearing playback logic, not diagnostics. Only the diagnostic-only branches (`_emitStateSnapshotIfDue`, `_checkPlaybackRate`, the verbose `source_selected` / `stuck_failover` / `session_summary` blocks, and the `_diagXxx` counter increments) are now compile-time-dropped in non-debug builds.

## Why a const, not a runtime flag

`bool.fromEnvironment(..., defaultValue: kDebugMode)` is a compile-time constant in Dart, which means Dart's tree-shaker can drop every `if (kPlaybackDiagnosticsEnabled) { ... }` branch in release builds. A `final` runtime flag would still incur the conditional-jump cost on every heartbeat — small, but unnecessary for a gate that is fixed at build time.

## Test plan

- [x] `dart format` clean on changed files
- [x] `flutter analyze lib test` in `mobile/packages/pooled_video_player` — no issues
- [x] `flutter test` in `mobile/packages/pooled_video_player` — 459/459 pass
- [x] Existing `slow_playback_detected` and `player_state_snapshot` tests still produce expected logs (debug mode → flag stays `true` under `flutter test`)
- [x] Sentinel test updated to assert the new contract (`flag == kDebugMode`) so a future edit cannot silently disable the gate under tests