### PR TITLE
refactor(notifications): drop hardcoded English from notification_item model

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3175,6 +3175,8 @@
       }
     }
   },
+  "notificationSystemUpdate": "አዲስ ማሻሻያ አለህ።",
+  "notificationSomeoneLikedYourVideo": "አንድ ሰው ቪዲዮህን ወድዶታል።",
   "commentReplyToPrefix": "ድጋሚ፡",
   "@commentReplyToPrefix": {
     "description": "Short prefix shown before a replied-to username (e.g. 'Re: alice'). Used in the orphaned-reply chip on a comment item and above the comment input when actively replying."

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2991,6 +2991,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "لديك تحديث جديد",
+    "notificationSomeoneLikedYourVideo": "شخص ما أعجب بفيديوك",
     "peopleListsAddToList": "أضف إلى القائمة",
     "peopleListsAddToListSubtitle": "ضع هذا المنشئ في إحدى قوائمك",
     "peopleListsSheetTitle": "أضف إلى القائمة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2879,6 +2879,8 @@
       }
     }
   },
+  "notificationSystemUpdate": "Имаш ново известие",
+  "notificationSomeoneLikedYourVideo": "Някой хареса видеото ти",
   "commentReplyToPrefix": "Отг.:",
   "@commentReplyToPrefix": {
     "description": "Short prefix shown before a replied-to username (e.g. 'Re: alice'). Used in the orphaned-reply chip on a comment item and above the comment input when actively replying."

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Du hast eine neue Aktualisierung",
+    "notificationSomeoneLikedYourVideo": "Jemand hat dein Video geliked",
     "peopleListsAddToList": "Zur Liste hinzufügen",
     "peopleListsAddToListSubtitle": "Füge diesen Creator einer deiner Listen hinzu",
     "peopleListsSheetTitle": "Zur Liste hinzufügen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3229,6 +3229,14 @@
       "count": { "type": "int" }
     }
   },
+  "notificationSystemUpdate": "You have a new update",
+  "@notificationSystemUpdate": {
+    "description": "Default body text for a system notification row when no actor is associated with it (e.g. an app-level update or announcement)."
+  },
+  "notificationSomeoneLikedYourVideo": "Someone liked your video",
+  "@notificationSomeoneLikedYourVideo": {
+    "description": "Defensive fallback shown on a grouped like notification when the actor list is empty (e.g. the backend returned a count without resolved actors). Should be rare in practice."
+  },
 
   "commentReplyToPrefix": "Re:",
   "@commentReplyToPrefix": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3006,6 +3006,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Tienes una nueva actualización",
+    "notificationSomeoneLikedYourVideo": "Alguien le dio like a tu video",
     "peopleListsAddToList": "Añadir a la lista",
     "peopleListsAddToListSubtitle": "Añade este creador a una de tus listas",
     "peopleListsSheetTitle": "Añadir a la lista",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Tu as une nouvelle mise à jour",
+    "notificationSomeoneLikedYourVideo": "Quelqu'un a aimé ta vidéo",
     "peopleListsAddToList": "Ajouter à la liste",
     "peopleListsAddToListSubtitle": "Mets ce créateur dans une de tes listes",
     "peopleListsSheetTitle": "Ajouter à la liste",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Kamu punya pembaruan baru",
+    "notificationSomeoneLikedYourVideo": "Seseorang menyukai videomu",
     "peopleListsAddToList": "Tambahkan ke daftar",
     "peopleListsAddToListSubtitle": "Masukkan kreator ini ke salah satu daftarmu",
     "peopleListsSheetTitle": "Tambahkan ke daftar",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Hai un nuovo aggiornamento",
+    "notificationSomeoneLikedYourVideo": "Qualcuno ha messo like al tuo video",
     "peopleListsAddToList": "Aggiungi alla lista",
     "peopleListsAddToListSubtitle": "Inserisci questo creator in una delle tue liste",
     "peopleListsSheetTitle": "Aggiungi alla lista",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2991,6 +2991,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "新しいお知らせがあります",
+    "notificationSomeoneLikedYourVideo": "誰かがあなたの動画にいいねしました",
     "peopleListsAddToList": "リストに追加",
     "peopleListsAddToListSubtitle": "このクリエイターをリストに追加する",
     "peopleListsSheetTitle": "リストに追加",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2287,6 +2287,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "새로운 업데이트가 있어요",
+    "notificationSomeoneLikedYourVideo": "누군가 회원님의 동영상을 좋아해요",
     "peopleListsAddToList": "목록에 추가",
     "peopleListsAddToListSubtitle": "이 크리에이터를 목록 중 하나에 추가하세요",
     "peopleListsSheetTitle": "목록에 추가",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Je hebt een nieuwe update",
+    "notificationSomeoneLikedYourVideo": "Iemand vond je video leuk",
     "peopleListsAddToList": "Toevoegen aan lijst",
     "peopleListsAddToListSubtitle": "Voeg deze maker toe aan een van je lijsten",
     "peopleListsSheetTitle": "Toevoegen aan lijst",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Masz nową aktualizację",
+    "notificationSomeoneLikedYourVideo": "Ktoś polubił(a) Twoje wideo",
     "peopleListsAddToList": "Dodaj do listy",
     "peopleListsAddToListSubtitle": "Dodaj tego twórcę do jednej ze swoich list",
     "peopleListsSheetTitle": "Dodaj do listy",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Você tem uma nova atualização",
+    "notificationSomeoneLikedYourVideo": "Alguém curtiu seu vídeo",
     "peopleListsAddToList": "Adicionar à lista",
     "peopleListsAddToListSubtitle": "Coloca este criador numa das tuas listas",
     "peopleListsSheetTitle": "Adicionar à lista",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Ai o actualizare nouă",
+    "notificationSomeoneLikedYourVideo": "Cineva a apreciat videoclipul tău",
     "peopleListsAddToList": "Adaugă la listă",
     "peopleListsAddToListSubtitle": "Pune acest creator în una dintre listele tale",
     "peopleListsSheetTitle": "Adaugă la listă",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Du har en ny uppdatering",
+    "notificationSomeoneLikedYourVideo": "Någon gillade din video",
     "peopleListsAddToList": "Lägg till i lista",
     "peopleListsAddToListSubtitle": "Lägg till den här skaparen i en av dina listor",
     "peopleListsSheetTitle": "Lägg till i lista",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2998,6 +2998,8 @@
             }
         }
     },
+    "notificationSystemUpdate": "Yeni bir güncellemen var",
+    "notificationSomeoneLikedYourVideo": "Birisi videonu beğendi",
     "peopleListsAddToList": "Listeye ekle",
     "peopleListsAddToListSubtitle": "Bu içerik üreticisini listelerinden birine ekle",
     "peopleListsSheetTitle": "Listeye ekle",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10482,6 +10482,18 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 other} other{{count} others}}'**
   String notificationOthersCount(int count);
 
+  /// Default body text for a system notification row when no actor is associated with it (e.g. an app-level update or announcement).
+  ///
+  /// In en, this message translates to:
+  /// **'You have a new update'**
+  String get notificationSystemUpdate;
+
+  /// Defensive fallback shown on a grouped like notification when the actor list is empty (e.g. the backend returned a count without resolved actors). Should be rare in practice.
+  ///
+  /// In en, this message translates to:
+  /// **'Someone liked your video'**
+  String get notificationSomeoneLikedYourVideo;
+
   /// Short prefix shown before a replied-to username (e.g. 'Re: alice'). Used in the orphaned-reply chip on a comment item and above the comment input when actively replying.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5841,6 +5841,12 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'አዲስ ማሻሻያ አለህ።';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'አንድ ሰው ቪዲዮህን ወድዶታል።';
+
+  @override
   String get commentReplyToPrefix => 'ድጋሚ፡';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5912,6 +5912,12 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'لديك تحديث جديد';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'شخص ما أعجب بفيديوك';
+
+  @override
   String get commentReplyToPrefix => 'رد:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6019,6 +6019,12 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Имаш ново известие';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Някой хареса видеото ти';
+
+  @override
   String get commentReplyToPrefix => 'Отг.:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6024,6 +6024,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Du hast eine neue Aktualisierung';
+
+  @override
+  String get notificationSomeoneLikedYourVideo =>
+      'Jemand hat dein Video geliked';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5962,6 +5962,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'You have a new update';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Someone liked your video';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6010,6 +6010,13 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Tienes una nueva actualización';
+
+  @override
+  String get notificationSomeoneLikedYourVideo =>
+      'Alguien le dio like a tu video';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6032,6 +6032,12 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Tu as une nouvelle mise à jour';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Quelqu\'un a aimé ta vidéo';
+
+  @override
   String get commentReplyToPrefix => 'Re :';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5930,6 +5930,12 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Kamu punya pembaruan baru';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Seseorang menyukai videomu';
+
+  @override
   String get commentReplyToPrefix => 'Bls:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6006,6 +6006,13 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Hai un nuovo aggiornamento';
+
+  @override
+  String get notificationSomeoneLikedYourVideo =>
+      'Qualcuno ha messo like al tuo video';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5739,6 +5739,12 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => '新しいお知らせがあります';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => '誰かがあなたの動画にいいねしました';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5762,6 +5762,12 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => '새로운 업데이트가 있어요';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => '누군가 회원님의 동영상을 좋아해요';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5982,6 +5982,12 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Je hebt een nieuwe update';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Iemand vond je video leuk';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6098,6 +6098,12 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Masz nową aktualizację';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Ktoś polubił(a) Twoje wideo';
+
+  @override
   String get commentReplyToPrefix => 'Odp.:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5991,6 +5991,12 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Você tem uma nova atualização';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Alguém curtiu seu vídeo';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6096,6 +6096,13 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Ai o actualizare nouă';
+
+  @override
+  String get notificationSomeoneLikedYourVideo =>
+      'Cineva a apreciat videoclipul tău';
+
+  @override
   String get commentReplyToPrefix => 'Re:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5953,6 +5953,12 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Du har en ny uppdatering';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Någon gillade din video';
+
+  @override
   String get commentReplyToPrefix => 'Sv:';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5938,6 +5938,12 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get notificationSystemUpdate => 'Yeni bir güncellemen var';
+
+  @override
+  String get notificationSomeoneLikedYourVideo => 'Birisi videonu beğendi';
+
+  @override
   String get commentReplyToPrefix => 'Yan:';
 
   @override

--- a/mobile/lib/notifications/widgets/notification_list_item.dart
+++ b/mobile/lib/notifications/widgets/notification_list_item.dart
@@ -273,7 +273,7 @@ class _MessageText extends StatelessWidget {
         if (type == NotificationKind.system) {
           spans.add(
             TextSpan(
-              text: notification.message,
+              text: l10n.notificationSystemUpdate,
               style: VineTheme.bodyMediumFont(),
             ),
           );
@@ -302,7 +302,7 @@ class _MessageText extends StatelessWidget {
         if (actors.isEmpty) {
           spans.add(
             TextSpan(
-              text: notification.message,
+              text: l10n.notificationSomeoneLikedYourVideo,
               style: VineTheme.bodyMediumFont(),
             ),
           );

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -48,13 +48,6 @@ sealed class NotificationItem extends Equatable {
 
   /// Title of the target video, if applicable.
   final String? videoTitle;
-
-  /// Human-readable message for display.
-  ///
-  /// Note: Type icon and formatted timestamp are presentation concerns.
-  /// Use DivineIcon from divine_ui for type icons in the widget layer.
-  /// Use a time formatter for relative timestamps.
-  String get message;
 }
 
 /// A notification from a single actor.
@@ -79,27 +72,6 @@ class SingleNotification extends NotificationItem {
 
   /// Whether the current user is already following this actor back.
   final bool isFollowingBack;
-
-  @override
-  String get message {
-    final name = actor.displayName;
-    final title = videoTitle;
-    return switch (type) {
-      NotificationKind.like when title != null =>
-        '$name liked your video $title',
-      NotificationKind.like => '$name liked your video',
-      NotificationKind.comment when title != null =>
-        '$name commented on your video $title',
-      NotificationKind.comment => '$name commented on your video',
-      NotificationKind.reply => '$name replied to your comment',
-      NotificationKind.follow => '$name started following you',
-      NotificationKind.repost when title != null =>
-        '$name reposted your video $title',
-      NotificationKind.repost => '$name reposted your video',
-      NotificationKind.mention => '$name mentioned you',
-      NotificationKind.system => 'You have a new update',
-    };
-  }
 
   /// Returns a copy with the given fields replaced.
   SingleNotification copyWith({
@@ -180,23 +152,6 @@ class GroupedNotification extends NotificationItem {
       targetEventId: targetEventId ?? this.targetEventId,
       videoTitle: videoTitle ?? this.videoTitle,
     );
-  }
-
-  @override
-  String get message {
-    if (actors.isEmpty) return 'Someone liked your video';
-    final name = actors.first.displayName;
-    final othersCount = totalCount - 1;
-    final title = videoTitle;
-    if (othersCount <= 0) {
-      return title != null
-          ? '$name liked your video $title'
-          : '$name liked your video';
-    }
-    final others = '$othersCount ${othersCount == 1 ? 'other' : 'others'}';
-    return title != null
-        ? '$name and $others liked your video $title'
-        : '$name and $others liked your video';
   }
 
   @override

--- a/mobile/packages/models/test/src/notification_item_test.dart
+++ b/mobile/packages/models/test/src/notification_item_test.dart
@@ -61,138 +61,18 @@ void main() {
       expect(notification.videoTitle, isNull);
     });
 
-    test('message includes video title for like', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.like,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-        videoTitle: 'My Video',
-      );
+    test('every NotificationKind round-trips through the constructor', () {
+      for (final kind in NotificationKind.values) {
+        final notification = SingleNotification(
+          id: 'notif_${kind.name}',
+          type: kind,
+          actor: _testActor,
+          timestamp: DateTime(2026, 4, 6),
+        );
 
-      expect(
-        notification.message,
-        equals('alice_rebel liked your video My Video'),
-      );
-    });
-
-    test('message without video title for like', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.like,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(notification.message, equals('alice_rebel liked your video'));
-    });
-
-    test('message for comment with title', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.comment,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-        videoTitle: 'My Video',
-      );
-
-      expect(
-        notification.message,
-        equals('alice_rebel commented on your video My Video'),
-      );
-    });
-
-    test('message for comment without title', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.comment,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(
-        notification.message,
-        equals('alice_rebel commented on your video'),
-      );
-    });
-
-    test('message for reply', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.reply,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(
-        notification.message,
-        equals('alice_rebel replied to your comment'),
-      );
-    });
-
-    test('message for follow', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.follow,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(
-        notification.message,
-        equals('alice_rebel started following you'),
-      );
-    });
-
-    test('message for repost with title', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.repost,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-        videoTitle: 'My Video',
-      );
-
-      expect(
-        notification.message,
-        equals('alice_rebel reposted your video My Video'),
-      );
-    });
-
-    test('message for repost without title', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.repost,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(
-        notification.message,
-        equals('alice_rebel reposted your video'),
-      );
-    });
-
-    test('message for mention', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.mention,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(notification.message, equals('alice_rebel mentioned you'));
-    });
-
-    test('message for system', () {
-      final notification = SingleNotification(
-        id: 'notif_1',
-        type: NotificationKind.system,
-        actor: _testActor,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(notification.message, equals('You have a new update'));
+        expect(notification.type, equals(kind));
+        expect(notification.actor, equals(_testActor));
+      }
     });
 
     test('isRead defaults to false', () {
@@ -278,80 +158,7 @@ void main() {
       expect(notification.videoTitle, equals('Best Post Ever'));
     });
 
-    test('message returns grouped format', () {
-      const actors = [
-        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
-      ];
-
-      final notification = GroupedNotification(
-        id: 'group_1',
-        type: NotificationKind.like,
-        actors: actors,
-        totalCount: 94,
-        timestamp: DateTime(2026, 4, 6),
-        videoTitle: 'Best Post Ever',
-      );
-
-      expect(notification.message, contains('alice'));
-      expect(notification.message, contains('93 others'));
-      expect(notification.message, contains('Best Post Ever'));
-    });
-
-    test('message for single actor group', () {
-      const actors = [
-        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
-      ];
-
-      final notification = GroupedNotification(
-        id: 'group_1',
-        type: NotificationKind.like,
-        actors: actors,
-        totalCount: 1,
-        timestamp: DateTime(2026, 4, 6),
-        videoTitle: 'My Video',
-      );
-
-      expect(
-        notification.message,
-        equals('alice liked your video My Video'),
-      );
-    });
-
-    test('message for single actor group without title', () {
-      const actors = [
-        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
-      ];
-
-      final notification = GroupedNotification(
-        id: 'group_1',
-        type: NotificationKind.like,
-        actors: actors,
-        totalCount: 1,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(notification.message, equals('alice liked your video'));
-    });
-
-    test('message uses singular other for count of 2', () {
-      const actors = [
-        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
-        ActorInfo(pubkey: _pubkeyBob, displayName: 'bob'),
-      ];
-
-      final notification = GroupedNotification(
-        id: 'group_1',
-        type: NotificationKind.like,
-        actors: actors,
-        totalCount: 2,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(notification.message, contains('1 other'));
-      expect(notification.message, isNot(contains('others')));
-    });
-
-    test('message for empty actors list', () {
+    test('preserves an empty actors list with zero totalCount', () {
       final notification = GroupedNotification(
         id: 'group_1',
         type: NotificationKind.like,
@@ -360,26 +167,8 @@ void main() {
         timestamp: DateTime(2026, 4, 6),
       );
 
-      expect(notification.message, equals('Someone liked your video'));
-    });
-
-    test('message without title', () {
-      const actors = [
-        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
-      ];
-
-      final notification = GroupedNotification(
-        id: 'group_1',
-        type: NotificationKind.like,
-        actors: actors,
-        totalCount: 94,
-        timestamp: DateTime(2026, 4, 6),
-      );
-
-      expect(
-        notification.message,
-        equals('alice and 93 others liked your video'),
-      );
+      expect(notification.actors, isEmpty);
+      expect(notification.totalCount, equals(0));
     });
 
     test('equality works', () {

--- a/mobile/test/notifications/widgets/notification_list_item_test.dart
+++ b/mobile/test/notifications/widgets/notification_list_item_test.dart
@@ -243,5 +243,55 @@ void main() {
         expect(tapped, isTrue);
       });
     });
+
+    group('localized fallback messages', () {
+      testWidgets('system notification renders localized update text', (
+        tester,
+      ) async {
+        final notification = SingleNotification(
+          id: '20',
+          type: NotificationKind.system,
+          actor: actor,
+          timestamp: DateTime.now(),
+        );
+
+        await tester.pumpWidget(buildSubject(notification));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          _findRichTextContaining(l10n.notificationSystemUpdate),
+          findsOneWidget,
+        );
+        // Prove the text actually goes through l10n: the German string must
+        // not appear under an English MaterialApp.
+        final deL10n = lookupAppLocalizations(const Locale('de'));
+        expect(
+          _findRichTextContaining(deL10n.notificationSystemUpdate),
+          findsNothing,
+        );
+      });
+
+      testWidgets('grouped notification with empty actors renders fallback', (
+        tester,
+      ) async {
+        final notification = GroupedNotification(
+          id: '21',
+          type: NotificationKind.like,
+          actors: const [],
+          totalCount: 0,
+          timestamp: DateTime.now(),
+        );
+
+        await tester.pumpWidget(buildSubject(notification));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          _findRichTextContaining(l10n.notificationSomeoneLikedYourVideo),
+          findsOneWidget,
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

The sealed `NotificationItem` model carried `String get message` getters
returning hardcoded English ("liked your video", "You have a new update",
"Someone liked your video"). The user-visible verb path already went
through `context.l10n` via `_verbFor`, but two fallback branches in
`notification_list_item.dart` still read `notification.message`:

- the **system** notification body, and
- the **empty-actors** grouped fallback.

This PR pushes presentation fully into the UI layer so the `models`
package no longer leaks an English string into a Flutter-free package.

**Related Issue:** Closes #3965 — follow-up to #3961.

## Type of Change

- [x] 🧹 Code refactor

## Changes

- Add `notificationSystemUpdate` ("You have a new update") and
  `notificationSomeoneLikedYourVideo` ("Someone liked your video") ARB
  keys, translated into all 17 locales (en + 16 non-English files).
  Regenerate `lib/l10n/generated/`.
- Reroute the two `TextSpan` fallbacks in
  `lib/notifications/widgets/notification_list_item.dart` from
  `notification.message` to `l10n.notificationSystemUpdate` /
  `l10n.notificationSomeoneLikedYourVideo`.
- Delete the abstract `String get message` getter from
  `NotificationItem` and the overrides on `SingleNotification` and
  `GroupedNotification` in
  `mobile/packages/models/lib/src/notification_item.dart`.
- Update `notification_item_test.dart`: drop per-shape `message`
  assertions; keep / consolidate structural assertions, including a
  round-trip test that exercises every `NotificationKind` value.
- Add widget tests in `notification_list_item_test.dart` covering both
  fallback paths, asserting the rendered text matches the localized
  strings (and that the German translation is *not* present under an
  English MaterialApp, proving the path goes through `context.l10n`).

The legacy `NotificationModel` (`notification_model.dart`) keeps its
stored `message: String` field — it's a separate, JSON-serialized
class with different consumers and is out of scope for this issue.

## Test Plan

- [x] `flutter analyze lib test integration_test` — clean.
- [x] `flutter analyze packages/models` — clean.
- [x] `flutter test packages/models` — 539 tests pass (incl. new
  `NotificationKind` round-trip test).
- [x] `flutter test packages/notification_repository` — 44 tests pass.
- [x] `flutter test test/notifications` — 56 tests pass (incl. new
  localized-fallback widget tests).
- [x] `flutter test test/widgets/notification_list_item_test.dart` —
  17 tests pass (legacy `NotificationModel` widget unaffected).