### PR TITLE
refactor(feeds): per-call funnelcake availability in popular_now/profile_feed

### DIFF
--- a/mobile/lib/providers/popular_now_feed_provider.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.dart
@@ -32,8 +32,12 @@ part 'popular_now_feed_provider.g.dart';
 @Riverpod(keepAlive: true) // Keep alive to prevent state loss on tab switches
 class PopularNowFeed extends _$PopularNowFeed {
   VideoFeedBuilder? _builder;
-  bool _usingRestApi = false;
-  int? _nextCursor; // Cursor for REST API pagination
+
+  /// REST API pagination cursor (oldest video timestamp). Non-null implies
+  /// REST is the active source; null means we are in Nostr-fallback mode.
+  /// Reset on every build/refresh so a transient REST failure doesn't
+  /// disable REST for subsequent calls — see issue #3849.
+  int? _nextCursor;
 
   @override
   Future<VideoFeedState> build() async {
@@ -94,7 +98,6 @@ class PopularNowFeed extends _$PopularNowFeed {
         final stats = await client.getWatchingVideos();
         final apiVideos = stats.toVideoEvents();
         if (apiVideos.isNotEmpty) {
-          _usingRestApi = true;
           // Store cursor for pagination (oldest video timestamp)
           _nextCursor = getOldestTimestamp(apiVideos);
           Log.info(
@@ -139,7 +142,6 @@ class PopularNowFeed extends _$PopularNowFeed {
     }
 
     // Fall back to Nostr subscription
-    _usingRestApi = false;
     _nextCursor = null;
     _builder = VideoFeedBuilder(videoEventService);
 
@@ -220,8 +222,12 @@ class PopularNowFeed extends _$PopularNowFeed {
     try {
       final videoEventService = ref.read(videoEventServiceProvider);
 
-      // If using REST API, load more using cursor-based pagination
-      if (_usingRestApi) {
+      // Per-call availability check — never trust a sticky flag (#3849).
+      // We paginate REST only when we have a cursor (i.e. the active source
+      // is REST) AND funnelcake is currently reachable.
+      final funnelcakeAvailable =
+          ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
+      if (funnelcakeAvailable && _nextCursor != null) {
         final client = ref.read(funnelcakeApiClientProvider);
 
         Log.info(
@@ -353,8 +359,9 @@ class PopularNowFeed extends _$PopularNowFeed {
   /// Call this after a video is updated to sync the provider's state
   /// Only applies to Nostr mode - REST API mode re-fetches on refresh()
   void refreshFromService() {
-    // Skip if using REST API - refreshFromService is only for Nostr mode
-    if (_usingRestApi) return;
+    // Skip if a REST cursor is active — refreshFromService syncs the Nostr
+    // state object, which doesn't reflect REST-loaded videos.
+    if (_nextCursor != null) return;
 
     final videoEventService = ref.read(videoEventServiceProvider);
     final updatedVideos = _filterAndSortNostrVideos(
@@ -392,8 +399,11 @@ class PopularNowFeed extends _$PopularNowFeed {
       );
     }
 
-    // If using REST API, try to refresh from there first
-    if (_usingRestApi) {
+    // Per-call availability check — never trust a sticky flag (#3849).
+    // A previous REST failure must not disable REST for this refresh.
+    final funnelcakeAvailable =
+        ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
+    if (funnelcakeAvailable) {
       try {
         final client = ref.read(funnelcakeApiClientProvider);
         final stats = await client.getWatchingVideos();
@@ -445,7 +455,6 @@ class PopularNowFeed extends _$PopularNowFeed {
     }
 
     // Reset cursor state before forced Nostr refresh
-    _usingRestApi = false;
     _nextCursor = null;
 
     try {
@@ -517,7 +526,9 @@ class PopularNowFeed extends _$PopularNowFeed {
       nostrService: ref.read(nostrServiceProvider),
       callerName: 'PopularNowFeedProvider',
       onEnriched: (enrichedVideos) {
-        if (!ref.mounted || !_usingRestApi || !state.hasValue) return;
+        if (!ref.mounted || !state.hasValue) return;
+        // Skip if we've left REST mode while enrichment was running.
+        if (_nextCursor == null) return;
 
         final currentState = state.value;
         if (currentState == null || currentState.videos.isEmpty) return;

--- a/mobile/lib/providers/popular_now_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.g.dart
@@ -63,7 +63,7 @@ final class PopularNowFeedProvider
   PopularNowFeed create() => PopularNowFeed();
 }
 
-String _$popularNowFeedHash() => r'e46368a193272b2c6951089be202afb85792f71f';
+String _$popularNowFeedHash() => r'89c24e72061f65508d707d794257bc623ea04f08';
 
 /// PopularNow feed provider - shows newest videos (sorted by creation time)
 ///

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -39,9 +39,11 @@ class ProfileFeed extends _$ProfileFeed {
   /// Timeout for funnelcake REST API calls to prevent indefinite loading.
   static const _restApiTimeout = Duration(seconds: 10);
 
-  // REST API mode state
-  bool _usingRestApi = false;
-  int? _nextOffset; // Offset for REST API pagination
+  /// REST API pagination offset. Non-null implies REST is the active source
+  /// for pagination; null means we are in Nostr-fallback mode. Reset on every
+  /// build so a transient REST failure doesn't disable REST for subsequent
+  /// calls — see issue #3849.
+  int? _nextOffset;
   int? _totalVideoCount; // Total count from X-Total-Count header
   // Cache of video metadata from REST API (preserves loops, likes, etc.)
   // Key: video ID, Value: metadata fields
@@ -64,7 +66,6 @@ class ProfileFeed extends _$ProfileFeed {
   @override
   Future<VideoFeedState> build(String userId) async {
     // Reset REST pagination state at start of build to ensure clean state.
-    _usingRestApi = false;
     _nextOffset = null;
     _listenersRegistered = false;
 
@@ -94,8 +95,12 @@ class ProfileFeed extends _$ProfileFeed {
     _registerRetainedRealtimeListeners();
 
     if (retainedState != null && retainedState.videos.isNotEmpty) {
-      _usingRestApi = funnelcakeAvailable;
-      _nextOffset = estimateNextRestOffset(retainedState);
+      // Only seed REST pagination state when funnelcake is currently
+      // reachable; otherwise leave _nextOffset null so loadMore falls back
+      // to Nostr until a successful REST call repopulates the offset.
+      if (funnelcakeAvailable) {
+        _nextOffset = estimateNextRestOffset(retainedState);
+      }
       _totalVideoCount = retainedState.totalVideoCount;
       unawaited(Future(() => refresh(retainedState: retainedState)));
       return retainedState.copyWith(
@@ -123,7 +128,7 @@ class ProfileFeed extends _$ProfileFeed {
     }
 
     Log.info(
-      'ProfileFeed: Initial load complete - ${authorVideos.length} videos for user=$userId (REST API: $_usingRestApi)',
+      'ProfileFeed: Initial load complete - ${authorVideos.length} videos for user=$userId (funnelcakeAvailable: $funnelcakeAvailable)',
       name: 'ProfileFeedProvider',
       category: LogCategory.video,
     );
@@ -281,7 +286,6 @@ class ProfileFeed extends _$ProfileFeed {
 
         final filteredVideos = _videoEventService.filterVideoList(authorVideos);
 
-        _usingRestApi = true;
         _mergeSourceVideos(
           filteredVideos,
           hasMoreContent: apiVideos.length >= AppConstants.paginationBatchSize,
@@ -317,7 +321,6 @@ class ProfileFeed extends _$ProfileFeed {
           category: LogCategory.video,
         );
       } else {
-        _usingRestApi = true;
         _mergeSourceVideos(
           const <VideoEvent>[],
           hasMoreContent: false,
@@ -365,7 +368,7 @@ class ProfileFeed extends _$ProfileFeed {
     if (!ref.mounted) return;
 
     Log.info(
-      'ProfileFeed: loadMore() called for user=$userId - isLoadingMore: ${currentState.isLoadingMore}, usingRestApi: $_usingRestApi',
+      'ProfileFeed: loadMore() called for user=$userId - isLoadingMore: ${currentState.isLoadingMore}, restCursor: $_nextOffset',
       name: 'ProfileFeedProvider',
       category: LogCategory.video,
     );
@@ -392,8 +395,12 @@ class ProfileFeed extends _$ProfileFeed {
     state = AsyncData(currentState.copyWith(isLoadingMore: true));
 
     try {
-      // If using REST API, load more using offset-based pagination.
-      if (_usingRestApi) {
+      // Per-call availability check — never trust a sticky flag (#3849).
+      // Paginate REST only when we have an offset (i.e. the active source is
+      // REST) AND funnelcake is currently reachable.
+      final funnelcakeAvailable =
+          ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
+      if (funnelcakeAvailable && _nextOffset != null) {
         final client = ref.read(funnelcakeApiClientProvider);
         final offset = _nextOffset ?? estimateNextRestOffset(currentState);
         Log.info(

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'1a00da4dd770a87aafe5f762e4c8cddb8dd89e45';
+String _$profileFeedHash() => r'0a9f91c87bc8ad5a98358961141020159566cb43';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -421,6 +421,99 @@ void main() {
         expect(finalState.isRefreshing, isFalse);
       },
     );
+
+    // Regression for #3849. Pre-fix, popular_now's refresh() flipped a sticky
+    // _usingRestApi=false in the catch fall-through, so the *next* refresh
+    // skipped REST entirely and stayed on Nostr until app restart. The fix
+    // re-checks funnelcakeAvailable per call, so a transient REST failure
+    // must not disable REST for subsequent refreshes.
+    test(
+      'popular now re-attempts REST after a transient refresh failure',
+      () async {
+        var watchingCallCount = 0;
+
+        when(
+          () => mockFunnelcakeApiClient.getWatchingVideos(
+            limit: any(named: 'limit'),
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer((_) async {
+          watchingCallCount += 1;
+          if (watchingCallCount == 2) {
+            throw const FunnelcakeApiException(
+              message: 'transient',
+              statusCode: 500,
+            );
+          }
+          return [_videoStats('popular-now-call-$watchingCallCount')];
+        });
+
+        // Mocks needed for the Nostr fall-through that runs after refresh #1
+        // fails — we don't assert on the Nostr state, only that REST recovers
+        // afterwards.
+        when(() => mockVideoEventService.popularNowVideos).thenReturn([]);
+        when(
+          () => mockVideoEventService.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.popularNow,
+            limit: AppConstants.paginationBatchSize,
+            sortBy: VideoSortField.createdAt,
+            force: true,
+          ),
+        ).thenAnswer((_) async {});
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+            nostrServiceProvider.overrideWithValue(mockNostrClient),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(
+          popularNowFeedProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+
+        // Build: REST call #1 succeeds.
+        final initialState = await container.read(
+          popularNowFeedProvider.future,
+        );
+        expect(initialState.videos.map((video) => video.id), [
+          'popular-now-call-1',
+        ]);
+
+        // Refresh #1: REST call #2 throws — must not poison subsequent calls.
+        await container.read(popularNowFeedProvider.notifier).refresh();
+
+        // Refresh #2: REST call #3 must be issued. Pre-fix this never ran.
+        await container.read(popularNowFeedProvider.notifier).refresh();
+
+        expect(
+          watchingCallCount,
+          3,
+          reason:
+              'Refresh after a REST failure must re-attempt REST, not skip it.',
+        );
+        final recoveredState = container.read(popularNowFeedProvider).value;
+        expect(recoveredState, isNotNull);
+        expect(recoveredState!.videos.map((video) => video.id), [
+          'popular-now-call-3',
+        ]);
+      },
+    );
   });
 }
 

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -629,6 +629,134 @@ void main() {
         );
       },
     );
+
+    // Pins the per-call funnelcake-availability contract from #3849: a
+    // transient REST failure during build must NOT prevent a subsequent
+    // refresh() from re-attempting REST. Will fail loudly if a future
+    // change ever reintroduces a sticky-disable shape that gates
+    // _refreshFromRestApi on previous-call success.
+    test(
+      'refresh after a build-time REST failure re-attempts REST and recovers',
+      () async {
+        var restCallCount = 0;
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) async {
+          restCallCount++;
+          if (restCallCount == 1) {
+            throw const FunnelcakeApiException(
+              message: 'transient server error',
+              statusCode: 500,
+            );
+          }
+          return _videoStats(count: 3, pubkey: userId);
+        });
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        final notifier = container.read(profileFeedProvider(userId).notifier);
+
+        // Initial build: REST throws on the first call → falls back to relay
+        // (empty in this test setup).
+        final initialState = await container.read(
+          profileFeedProvider(userId).future,
+        );
+        expect(initialState.videos, isEmpty);
+
+        // Wait for the background _refreshFromRestApi triggered by build to
+        // settle so the failure is observed before we trigger refresh().
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // refresh() must re-attempt REST instead of skipping it.
+        await notifier.refresh();
+
+        // Allow the parallel _refreshFromRestApi inside refresh() to complete.
+        final hydrated = Completer<VideoFeedState>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 3 &&
+                !hydrated.isCompleted) {
+              hydrated.complete(value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        final recoveredState = await hydrated.future.timeout(
+          const Duration(milliseconds: 300),
+        );
+        expect(recoveredState.videos, hasLength(3));
+        expect(restCallCount, greaterThanOrEqualTo(2));
+      },
+    );
+
+    // Pins the per-call funnelcake-availability contract from #3849: a REST
+    // failure on loadMore must not poison the pagination state. The next
+    // loadMore should still attempt REST when funnelcake remains available
+    // and the REST cursor (_nextOffset) is set.
+    test(
+      'loadMore retries REST after a transient pagination failure',
+      () async {
+        var nextPageCallCount = 0;
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) async => _videoStats(count: 50, pubkey: userId));
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 50,
+          ),
+        ).thenAnswer((_) async {
+          nextPageCallCount++;
+          if (nextPageCallCount == 1) {
+            throw const FunnelcakeApiException(
+              message: 'service unavailable',
+              statusCode: 503,
+            );
+          }
+          return _videoStats(count: 5, pubkey: userId, startIndex: 50);
+        });
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        final notifier = container.read(profileFeedProvider(userId).notifier);
+
+        await container.read(profileFeedProvider(userId).future);
+
+        final hydrated = Completer<VideoFeedState>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 50 &&
+                value.hasMoreContent &&
+                !hydrated.isCompleted) {
+              hydrated.complete(value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await hydrated.future.timeout(const Duration(milliseconds: 200));
+
+        // First loadMore: REST fails. Pagination state must NOT be wiped.
+        await notifier.loadMore();
+
+        // Second loadMore: REST should be retried (was previously skipped).
+        await notifier.loadMore();
+
+        expect(nextPageCallCount, 2);
+        final updatedState = container
+            .read(profileFeedProvider(userId))
+            .requireValue;
+        expect(updatedState.videos.length, 55);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Description

Replace the sticky `_usingRestApi` boolean in `PopularNowFeed` and `ProfileFeed` with a per-call `funnelcakeAvailableProvider` check plus the existing pagination cursor (`_nextCursor` / `_nextOffset`) as the proxy for "REST is the active source". Mirrors the precedent already in `videos_repository.dart`.

The previous shape collapsed two distinct concerns — service availability and "this last call failed" — into one boolean. Because both providers are `keepAlive: true`, a single transient REST failure in `PopularNowFeed.refresh()` flipped `_usingRestApi = false` in the catch fall-through and never re-evaluated, so subsequent refreshes skipped REST entirely until app restart.

**Related Issue:** Closes #3849

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

## What changed

- Drop the `bool _usingRestApi` field from both `PopularNowFeed` and `ProfileFeed`.
- Reuse the existing pagination cursor (`_nextCursor` for popular_now, `_nextOffset` for profile_feed) as the "REST is the active source" indicator — set on REST success, reset on REST→Nostr fall-through.
- Each `refresh()` / `loadMore()` reads `funnelcakeAvailableProvider` independently, so a REST exception no longer disables REST for the next call.
- In `ProfileFeed.build()` retained-state branch, only seed `_nextOffset` when funnelcake is currently reachable; otherwise let `loadMore` fall back to Nostr until the unawaited refresh repopulates the offset.

## Test plan

- [x] Existing scoped suites green: `flutter test test/providers/` → 514 pass / 31 pre-existing skips.
- [x] Existing screen tests green: profile grid, explore pull-to-refresh, profile router, profile edit nav.
- [x] New regression test (popular_now): `popular now re-attempts REST after a transient refresh failure` in `explore_feed_refresh_retention_test.dart` — fails on the pre-fix code (only 2 REST calls observed; should be 3) and passes after the refactor.
- [x] New contract tests (profile_feed): `refresh after a build-time REST failure re-attempts REST and recovers` and `loadMore retries REST after a transient pagination failure` in `profile_feed_pagination_contract_test.dart` — pin the per-call availability shape so a future change cannot reintroduce a sticky-disable gate without breaking them.
- [x] `flutter analyze` clean across `lib/` and `test/`.
- [x] `dart format` clean on the four edited files.