### PR TITLE
fix(feeds): use v2 funnelcake pagination metadata

### DIFF
--- a/mobile/lib/providers/popular_now_feed_provider.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.dart
@@ -95,11 +95,12 @@ class PopularNowFeed extends _$PopularNowFeed {
       );
 
       try {
-        final stats = await client.getWatchingVideos();
-        final apiVideos = stats.toVideoEvents();
+        final response = await client.getWatchingVideosPage();
+        final apiVideos = response.videos.toVideoEvents();
         if (apiVideos.isNotEmpty) {
-          // Store cursor for pagination (oldest video timestamp)
-          _nextCursor = getOldestTimestamp(apiVideos);
+          // Prefer server pagination metadata; fall back to legacy
+          // oldest-timestamp cursoring when the response is a raw array.
+          _nextCursor = response.nextCursor ?? getOldestTimestamp(apiVideos);
           Log.info(
             '✅ PopularNowFeed: Got ${apiVideos.length} videos from REST API, cursor: $_nextCursor',
             name: 'PopularNowFeedProvider',
@@ -122,7 +123,8 @@ class PopularNowFeed extends _$PopularNowFeed {
           return VideoFeedState(
             videos: filteredVideos,
             hasMoreContent:
-                apiVideos.length >= AppConstants.paginationBatchSize,
+                response.hasMore ??
+                (apiVideos.length >= AppConstants.paginationBatchSize),
             isInitialLoad: filteredVideos.isEmpty,
             lastUpdated: DateTime.now(),
           );
@@ -237,8 +239,10 @@ class PopularNowFeed extends _$PopularNowFeed {
         );
 
         // Use cursor (before parameter) for pagination
-        final stats = await client.getWatchingVideos(before: _nextCursor);
-        final apiVideos = stats.toVideoEvents();
+        final response = await client.getWatchingVideosPage(
+          before: _nextCursor,
+        );
+        final apiVideos = response.videos.toVideoEvents();
 
         if (!ref.mounted) return;
 
@@ -261,7 +265,7 @@ class PopularNowFeed extends _$PopularNowFeed {
           );
 
           // Update cursor for next pagination
-          _nextCursor = getOldestTimestamp(apiVideos);
+          _nextCursor = response.nextCursor ?? getOldestTimestamp(apiVideos);
 
           if (newVideos.isNotEmpty) {
             final allVideos = [...currentState.videos, ...newVideos];
@@ -275,7 +279,8 @@ class PopularNowFeed extends _$PopularNowFeed {
               VideoFeedState(
                 videos: allVideos,
                 hasMoreContent:
-                    apiVideos.length >= AppConstants.paginationBatchSize,
+                    response.hasMore ??
+                    (apiVideos.length >= AppConstants.paginationBatchSize),
                 lastUpdated: DateTime.now(),
               ),
             );
@@ -406,15 +411,15 @@ class PopularNowFeed extends _$PopularNowFeed {
     if (funnelcakeAvailable) {
       try {
         final client = ref.read(funnelcakeApiClientProvider);
-        final stats = await client.getWatchingVideos();
-        final apiVideos = stats.toVideoEvents();
+        final response = await client.getWatchingVideosPage();
+        final apiVideos = response.videos.toVideoEvents();
 
         // Check if provider is still mounted after async gap
         if (!ref.mounted) return;
 
         if (apiVideos.isNotEmpty) {
           // Reset cursor for pagination
-          _nextCursor = getOldestTimestamp(apiVideos);
+          _nextCursor = response.nextCursor ?? getOldestTimestamp(apiVideos);
 
           final blocklistRepository = ref.read(
             contentBlocklistRepositoryProvider,
@@ -432,7 +437,8 @@ class PopularNowFeed extends _$PopularNowFeed {
             VideoFeedState(
               videos: filteredVideos,
               hasMoreContent:
-                  apiVideos.length >= AppConstants.paginationBatchSize,
+                  response.hasMore ??
+                  (apiVideos.length >= AppConstants.paginationBatchSize),
               lastUpdated: DateTime.now(),
             ),
           );

--- a/mobile/lib/providers/popular_now_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.g.dart
@@ -63,7 +63,7 @@ final class PopularNowFeedProvider
   PopularNowFeed create() => PopularNowFeed();
 }
 
-String _$popularNowFeedHash() => r'89c24e72061f65508d707d794257bc623ea04f08';
+String _$popularNowFeedHash() => r'b9f9fe96c39df3f3266034a298707412c7770741';
 
 /// PopularNow feed provider - shows newest videos (sorted by creation time)
 ///

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -274,7 +274,7 @@ class ProfileFeed extends _$ProfileFeed {
       if (!ref.mounted) return;
 
       _totalVideoCount = result.totalCount;
-      _nextOffset = apiVideos.length;
+      _nextOffset = result.nextOffset ?? apiVideos.length;
 
       if (apiVideos.isNotEmpty) {
         final relayVideos = _relayVideosSnapshot();
@@ -288,7 +288,9 @@ class ProfileFeed extends _$ProfileFeed {
 
         _mergeSourceVideos(
           filteredVideos,
-          hasMoreContent: apiVideos.length >= AppConstants.paginationBatchSize,
+          hasMoreContent:
+              result.hasMore ??
+              (apiVideos.length >= AppConstants.paginationBatchSize),
           totalVideoCount: _totalVideoCount,
           isRefreshing: false,
           isInitialLoad: false,
@@ -305,7 +307,8 @@ class ProfileFeed extends _$ProfileFeed {
             _mergeSourceVideos(
               enrichedVideos,
               hasMoreContent:
-                  apiVideos.length >= AppConstants.paginationBatchSize,
+                  result.hasMore ??
+                  (apiVideos.length >= AppConstants.paginationBatchSize),
               totalVideoCount: _totalVideoCount,
               isRefreshing: false,
               isInitialLoad: false,
@@ -419,7 +422,7 @@ class ProfileFeed extends _$ProfileFeed {
 
         if (!ref.mounted) return;
         _totalVideoCount = result.totalCount ?? _totalVideoCount;
-        _nextOffset = offset + apiVideos.length;
+        _nextOffset = result.nextOffset ?? (offset + apiVideos.length);
 
         if (apiVideos.isNotEmpty) {
           var newVideos = apiVideos.where((v) => !v.isRepost).toList();
@@ -449,7 +452,8 @@ class ProfileFeed extends _$ProfileFeed {
               currentState.copyWith(
                 videos: allVideos,
                 hasMoreContent:
-                    apiVideos.length >= AppConstants.paginationBatchSize,
+                    result.hasMore ??
+                    (apiVideos.length >= AppConstants.paginationBatchSize),
                 isLoadingMore: false,
                 lastUpdated: DateTime.now(),
                 totalVideoCount: _totalVideoCount,
@@ -464,7 +468,8 @@ class ProfileFeed extends _$ProfileFeed {
             state = AsyncData(
               currentState.copyWith(
                 hasMoreContent:
-                    apiVideos.length >= AppConstants.paginationBatchSize,
+                    result.hasMore ??
+                    (apiVideos.length >= AppConstants.paginationBatchSize),
                 isLoadingMore: false,
               ),
             );

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'0a9f91c87bc8ad5a98358961141020159566cb43';
+String _$profileFeedHash() => r'f8606985db746c3f71d554faef261c5fdbe23055';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -143,6 +143,11 @@ class FunnelcakeApiClient {
     return (items: const <dynamic>[], hasMore: false, nextCursor: null);
   }
 
+  static int? _parseIntPageToken(String? value) {
+    if (value == null) return null;
+    return int.tryParse(value);
+  }
+
   /// Builds the notifications endpoint URI for a user.
   ///
   /// The returned URI includes the same query parameters used by
@@ -228,7 +233,12 @@ class FunnelcakeApiClient {
             ? int.tryParse(totalCountHeader)
             : null;
 
-        return VideosByAuthorResponse(videos: videos, totalCount: totalCount);
+        return VideosByAuthorResponse(
+          videos: videos,
+          totalCount: totalCount,
+          nextOffset: _parseIntPageToken(nextCursor),
+          hasMore: hasMore,
+        );
       } else if (response.statusCode == 404) {
         throw FunnelcakeNotFoundException(
           resource: 'Author videos',
@@ -388,6 +398,16 @@ class FunnelcakeApiClient {
     int limit = 50,
     int? before,
   }) async {
+    final response = await getWatchingVideosPage(limit: limit, before: before);
+    return response.videos;
+  }
+
+  /// Fetches videos sorted by 24-hour CDN view count with NO age decay,
+  /// returning pagination metadata when the v2 envelope is available.
+  Future<WatchingVideosResponse> getWatchingVideosPage({
+    int limit = 50,
+    int? before,
+  }) async {
     if (!isAvailable) {
       throw const FunnelcakeNotConfiguredException();
     }
@@ -408,14 +428,20 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+        final (:items, :hasMore, :nextCursor) = _unwrapListResponse(
           jsonDecode(response.body),
         );
 
-        return items
+        final videos = items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
+
+        return WatchingVideosResponse(
+          videos: videos,
+          nextCursor: _parseIntPageToken(nextCursor),
+          hasMore: hasMore,
+        );
       } else {
         throw FunnelcakeApiException(
           message: 'Failed to fetch watching videos',

--- a/mobile/packages/funnelcake_api_client/lib/src/models/models.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/models.dart
@@ -4,3 +4,4 @@ export 'video_comment.dart';
 export 'video_comments_response.dart';
 export 'video_search_response.dart';
 export 'videos_by_author_response.dart';
+export 'watching_videos_response.dart';

--- a/mobile/packages/funnelcake_api_client/lib/src/models/videos_by_author_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/videos_by_author_response.dart
@@ -10,6 +10,8 @@ class VideosByAuthorResponse {
   const VideosByAuthorResponse({
     required this.videos,
     this.totalCount,
+    this.nextOffset,
+    this.hasMore,
   });
 
   /// The videos returned for this page.
@@ -19,4 +21,11 @@ class VideosByAuthorResponse {
   ///
   /// May be `null` if the server does not include the header.
   final int? totalCount;
+
+  /// Server-provided offset for the next page when using v2 envelope
+  /// pagination.
+  final int? nextOffset;
+
+  /// Server-provided "has more" flag from the v2 envelope.
+  final bool? hasMore;
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/models/watching_videos_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/watching_videos_response.dart
@@ -1,0 +1,21 @@
+import 'package:models/models.dart';
+
+/// Response model for the watching-sorted videos endpoint.
+class WatchingVideosResponse {
+  /// Creates a parsed response for a watching videos page.
+  const WatchingVideosResponse({
+    required this.videos,
+    this.nextCursor,
+    this.hasMore,
+  });
+
+  /// The videos returned for this page.
+  final List<VideoStats> videos;
+
+  /// Server-provided cursor for the next page when using v2 envelope
+  /// pagination.
+  final int? nextCursor;
+
+  /// Server-provided "has more" flag from the v2 envelope.
+  final bool? hasMore;
+}

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -688,9 +688,7 @@ void main() {
       test('returns feed from legacy {videos} shape', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-        ).thenAnswer(
-          (_) async => http.Response(validFeedResponse, 200),
-        );
+        ).thenAnswer((_) async => http.Response(validFeedResponse, 200));
 
         final result = await client.getHomeFeed(pubkey: testPubkey);
         expect(result.videos, hasLength(1));
@@ -756,6 +754,55 @@ void main() {
 ]
 ''';
 
+      test('parses v2 envelope pagination metadata', () async {
+        const envelope =
+            '''
+{
+  "data": [
+    {
+      "id": "abc123def456",
+      "pubkey": "$testPubkey",
+      "created_at": 1700000000,
+      "kind": 34236,
+      "d_tag": "test-video-1",
+      "title": "Test Video",
+      "content": "A test video description",
+      "thumbnail": "https://example.com/thumb.jpg",
+      "video_url": "https://example.com/video.mp4",
+      "reactions": 100,
+      "comments": 10,
+      "reposts": 5,
+      "engagement_score": 115
+    }
+  ],
+  "pagination": {"has_more": true, "next_offset": 50}
+}
+''';
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(envelope, 200));
+
+        final result = await client.getVideosByAuthor(pubkey: testPubkey);
+
+        expect(result.videos, hasLength(1));
+        expect(result.nextOffset, 50);
+        expect(result.hasMore, isTrue);
+      });
+
+      test(
+        'returns null pagination metadata for legacy array responses',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(validResponseBody, 200));
+
+          final result = await client.getVideosByAuthor(pubkey: testPubkey);
+
+          expect(result.nextOffset, isNull);
+          expect(result.hasMore, isNull);
+        },
+      );
+
       test('returns videos on successful response', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),
@@ -776,6 +823,45 @@ void main() {
         expect(result.videos.first.reactions, equals(100));
         expect(result.totalCount, equals(42));
       });
+
+      test(
+        'getWatchingVideosPage parses v2 envelope pagination metadata',
+        () async {
+          const envelope =
+              '''
+{
+  "data": [
+    {
+      "id": "watching-env-1",
+      "pubkey": "$testPubkey",
+      "created_at": 1700000000,
+      "kind": 34236,
+      "d_tag": "watching-env-1",
+      "title": "Watching Video",
+      "content": "",
+      "thumbnail": "https://example.com/thumb.jpg",
+      "video_url": "https://example.com/video.mp4",
+      "reactions": 5,
+      "comments": 1,
+      "reposts": 0,
+      "engagement_score": 6
+    }
+  ],
+  "pagination": {"has_more": true, "next_cursor": "1699998000"}
+}
+''';
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(envelope, 200));
+
+          final result = await client.getWatchingVideosPage();
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.first.id, 'watching-env-1');
+          expect(result.nextCursor, 1699998000);
+          expect(result.hasMore, isTrue);
+        },
+      );
 
       test(
         'parses total_loops and total_views from author videos response',
@@ -3709,21 +3795,16 @@ void main() {
       });
 
       // Envelope shape tolerance (divine-funnelcake#238 / issue #3521)
-      test(
-        'returns videos from legacy {videos} shape (pre-#238)',
-        () async {
-          when(
-            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-          ).thenAnswer(
-            (_) async => http.Response(validResponse, 200),
-          );
+      test('returns videos from legacy {videos} shape (pre-#238)', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(validResponse, 200));
 
-          final result = await client.getRecommendations(pubkey: testPubkey);
-          expect(result.videos, hasLength(1));
-          expect(result.videos.first.id, equals('rec123'));
-          expect(result.source, equals('personalized'));
-        },
-      );
+        final result = await client.getRecommendations(pubkey: testPubkey);
+        expect(result.videos, hasLength(1));
+        expect(result.videos.first.id, equals('rec123'));
+        expect(result.source, equals('personalized'));
+      });
 
       test(
         'returns videos from post-#238 {data, pagination} envelope shape',
@@ -4417,18 +4498,11 @@ void main() {
         test('raw-array shape returns items correctly', () async {
           when(
             () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-          ).thenAnswer(
-            (_) async => http.Response('[$videoJson]', 200),
-          );
+          ).thenAnswer((_) async => http.Response('[$videoJson]', 200));
 
           final videos = await client.getTrendingVideos();
           expect(videos, hasLength(1));
-          expect(
-            videos.first.id,
-            equals(
-              'envvideo01',
-            ),
-          );
+          expect(videos.first.id, equals('envvideo01'));
         });
 
         test(
@@ -4450,12 +4524,7 @@ void main() {
 
             final videos = await client.getTrendingVideos();
             expect(videos, hasLength(1));
-            expect(
-              videos.first.id,
-              equals(
-                'envvideo01',
-              ),
-            );
+            expect(videos.first.id, equals('envvideo01'));
           },
         );
 
@@ -4497,11 +4566,9 @@ void main() {
       });
 
       group('searchVideos envelope shape', () {
-        test(
-          'envelope returns videos, uses length for totalCount',
-          () async {
-            const envelope =
-                '''
+        test('envelope returns videos, uses length for totalCount', () async {
+          const envelope =
+              '''
 {
   "data": [$videoJson],
   "pagination": {
@@ -4510,23 +4577,20 @@ void main() {
   }
 }
 ''';
-            when(
-              () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-            ).thenAnswer((_) async => http.Response(envelope, 200));
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(envelope, 200));
 
-            final result = await client.searchVideos(query: 'test');
-            expect(result.videos, hasLength(1));
-            // X-Total-Count header is absent; fallback to videos.length.
-            expect(result.totalCount, equals(1));
-          },
-        );
+          final result = await client.searchVideos(query: 'test');
+          expect(result.videos, hasLength(1));
+          // X-Total-Count header is absent; fallback to videos.length.
+          expect(result.totalCount, equals(1));
+        });
 
         test('raw-array shape still returns videos', () async {
           when(
             () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-          ).thenAnswer(
-            (_) async => http.Response('[$videoJson]', 200),
-          );
+          ).thenAnswer((_) async => http.Response('[$videoJson]', 200));
 
           final result = await client.searchVideos(query: 'test');
           expect(result.videos, hasLength(1));
@@ -4556,9 +4620,7 @@ void main() {
         test('raw-array shape returns hashtags', () async {
           when(
             () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-          ).thenAnswer(
-            (_) async => http.Response('[$hashtagJson]', 200),
-          );
+          ).thenAnswer((_) async => http.Response('[$hashtagJson]', 200));
 
           final hashtags = await client.fetchTrendingHashtags();
           expect(hashtags, hasLength(1));
@@ -4633,9 +4695,7 @@ void main() {
         test('raw-array shape returns categories', () async {
           when(
             () => mockHttpClient.get(any(), headers: any(named: 'headers')),
-          ).thenAnswer(
-            (_) async => http.Response('[$categoryJson]', 200),
-          );
+          ).thenAnswer((_) async => http.Response('[$categoryJson]', 200));
 
           final categories = await client.getCategories();
           expect(categories, hasLength(1));

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -79,18 +79,18 @@ void main() {
     test(
       'popular now keeps existing videos visible while refresh is in flight',
       () async {
-        final refreshCompleter = Completer<List<VideoStats>>();
+        final refreshCompleter = Completer<WatchingVideosResponse>();
         var watchingCallCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getWatchingVideos(
+          () => mockFunnelcakeApiClient.getWatchingVideosPage(
             limit: any(named: 'limit'),
             before: any(named: 'before'),
           ),
         ).thenAnswer((_) {
           watchingCallCount += 1;
           if (watchingCallCount == 1) {
-            return Future.value([_videoStats('popular-now-initial')]);
+            return Future.value(_watchingResponse(['popular-now-initial']));
           }
           return refreshCompleter.future;
         });
@@ -140,7 +140,7 @@ void main() {
         ]);
         expect(refreshingState.isRefreshing, isTrue);
 
-        refreshCompleter.complete([_videoStats('popular-now-refreshed')]);
+        refreshCompleter.complete(_watchingResponse(['popular-now-refreshed']));
         await refreshFuture;
 
         final finalState = container.read(popularNowFeedProvider).value;
@@ -155,19 +155,19 @@ void main() {
     test(
       'popular now refresh during resume-time rebuild stays on REST path',
       () async {
-        final resumeBuildCompleter = Completer<List<VideoStats>>();
-        final refreshCompleter = Completer<List<VideoStats>>();
+        final resumeBuildCompleter = Completer<WatchingVideosResponse>();
+        final refreshCompleter = Completer<WatchingVideosResponse>();
         var watchingCallCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getWatchingVideos(
+          () => mockFunnelcakeApiClient.getWatchingVideosPage(
             limit: any(named: 'limit'),
             before: any(named: 'before'),
           ),
         ).thenAnswer((_) {
           watchingCallCount += 1;
           if (watchingCallCount == 1) {
-            return Future.value([_videoStats('popular-now-initial')]);
+            return Future.value(_watchingResponse(['popular-now-initial']));
           }
           if (watchingCallCount == 2) {
             return resumeBuildCompleter.future;
@@ -261,8 +261,10 @@ void main() {
           ),
         );
 
-        resumeBuildCompleter.complete([_videoStats('popular-now-resumed')]);
-        refreshCompleter.complete([_videoStats('popular-now-refreshed')]);
+        resumeBuildCompleter.complete(
+          _watchingResponse(['popular-now-resumed']),
+        );
+        refreshCompleter.complete(_watchingResponse(['popular-now-refreshed']));
         await refreshFuture;
       },
     );
@@ -433,7 +435,7 @@ void main() {
         var watchingCallCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getWatchingVideos(
+          () => mockFunnelcakeApiClient.getWatchingVideosPage(
             limit: any(named: 'limit'),
             before: any(named: 'before'),
           ),
@@ -445,7 +447,7 @@ void main() {
               statusCode: 500,
             );
           }
-          return [_videoStats('popular-now-call-$watchingCallCount')];
+          return _watchingResponse(['popular-now-call-$watchingCallCount']);
         });
 
         // Mocks needed for the Nostr fall-through that runs after refresh #1
@@ -515,6 +517,18 @@ void main() {
       },
     );
   });
+}
+
+WatchingVideosResponse _watchingResponse(
+  List<String> ids, {
+  int? nextCursor,
+  bool? hasMore,
+}) {
+  return WatchingVideosResponse(
+    videos: ids.map(_videoStats).toList(),
+    nextCursor: nextCursor,
+    hasMore: hasMore,
+  );
 }
 
 VideoEvent _video(String id) {

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -560,6 +560,74 @@ void main() {
     );
 
     test(
+      'REST loadMore uses server nextOffset from v2 pagination envelope',
+      () async {
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer(
+          (_) async => _videoStats(
+            count: 12,
+            pubkey: userId,
+            nextOffset: 50,
+            hasMore: true,
+          ),
+        );
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 50,
+          ),
+        ).thenAnswer(
+          (_) async => _videoStats(
+            count: 4,
+            pubkey: userId,
+            startIndex: 50,
+            nextOffset: 54,
+            hasMore: false,
+          ),
+        );
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        final notifier = container.read(profileFeedProvider(userId).notifier);
+
+        await container.read(profileFeedProvider(userId).future);
+
+        final hydrated = Completer<void>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 12 &&
+                value.hasMoreContent &&
+                !hydrated.isCompleted) {
+              hydrated.complete();
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await hydrated.future.timeout(const Duration(milliseconds: 200));
+
+        await notifier.loadMore();
+
+        verifyNever(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 12,
+          ),
+        );
+        verify(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 50,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
       'REST loadMore dedupes replaceable videos by stable identity',
       () async {
         when(
@@ -765,6 +833,8 @@ VideosByAuthorResponse _videoStats({
   required String pubkey,
   int startIndex = 0,
   int? totalCount,
+  int? nextOffset,
+  bool? hasMore,
 }) {
   final now = DateTime(2026, 3, 30, 12);
 
@@ -786,7 +856,12 @@ VideosByAuthorResponse _videoStats({
       engagementScore: videoIndex,
     );
   });
-  return VideosByAuthorResponse(videos: videos, totalCount: totalCount);
+  return VideosByAuthorResponse(
+    videos: videos,
+    totalCount: totalCount,
+    nextOffset: nextOffset,
+    hasMore: hasMore,
+  );
 }
 
 VideoStats _videoStat({


### PR DESCRIPTION
Closes #3974

## Summary
- switch PopularNowFeed to a pagination-aware getWatchingVideosPage client path
- thread Funnelcake v2 has_more and next_offset/next_cursor metadata into the feed providers with legacy-array fallback preserved
- add client and provider tests that pin server-driven pagination for these feed paths

## Testing
- flutter test test/providers/explore_feed_refresh_retention_test.dart
- flutter test test/providers/profile_feed_pagination_contract_test.dart
- flutter test test/src/funnelcake_api_client_test.dart
- flutter analyze lib/providers/popular_now_feed_provider.dart lib/providers/profile_feed_provider.dart test/providers/explore_feed_refresh_retention_test.dart test/providers/profile_feed_pagination_contract_test.dart
- flutter analyze lib/src/funnelcake_api_client.dart lib/src/models/models.dart lib/src/models/videos_by_author_response.dart lib/src/models/watching_videos_response.dart test/src/funnelcake_api_client_test.dart