### PR TITLE
fix(security): iOS per-frame origin attestation for Nostr bridge

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		66F22673A01C965F74615E46 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		6E3EAE672F3747792842A5A3 /* NotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C696D98D09FD161565BF6483 /* NotificationServiceExtension.appex */; };
 		6FDAD046102CCA6028B8B9A3 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		3EB13B9046685257BDD640FB /* NostrBridgeAttestationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06671AD11C80317FA3B1799D /* NostrBridgeAttestationPlugin.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -81,6 +82,7 @@
 		431E99C1821481F33B9E053C /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5E86217C65C2A7ED5885FDC2 /* NotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
+		06671AD11C80317FA3B1799D /* NostrBridgeAttestationPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NostrBridgeAttestationPlugin.swift; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7724038FFA9E1FC6C1CB27D0 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				06671AD11C80317FA3B1799D /* NostrBridgeAttestationPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -521,6 +524,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				3EB13B9046685257BDD640FB /* NostrBridgeAttestationPlugin.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -20,6 +20,14 @@ import SupportProvidersSDK
     // Register plugins with the engine
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
 
+    // Set up Nostr bridge frame attestation channel.
+    // Must run after GeneratedPluginRegistrant so WebViewFlutterPlugin is
+    // already registered — FWFWebViewFlutterWKWebViewExternalAPI requires it.
+    NostrBridgeAttestationPlugin.setup(
+      messenger: engineBridge.applicationRegistrar.messenger(),
+      pluginRegistry: engineBridge.pluginRegistry
+    )
+
     // Set up ProofMode platform channel
     setupProofModeChannel(with: engineBridge)
 

--- a/mobile/ios/Runner/NostrBridgeAttestationPlugin.swift
+++ b/mobile/ios/Runner/NostrBridgeAttestationPlugin.swift
@@ -4,29 +4,39 @@ import webview_flutter_wkwebview
 
 /// Thin native plugin that replaces the pigeon-managed WKScriptMessageHandler
 /// for `divineSandboxBridge` with one that includes WKScriptMessage.frameInfo,
-/// and streams attested messages (with isMainFrame + securityOrigin) back to
-/// Dart via an EventChannel.
+/// and streams attested messages (with isMainFrame) back to Dart via an
+/// EventChannel. Optionally installs a document-start WKUserScript so the
+/// Dart layer does not need to import private webview_flutter_wkwebview src
+/// types to do that itself.
 ///
 /// The pigeon layer exposes WKScriptMessage.name and .body only; .frameInfo is
 /// absent from the pigeon definition, so this plugin is required to surface it.
 ///
+/// Lifecycle is single-instance: only one sandbox WebView may be attached at
+/// a time. Attempting to attach a second WebView while another is still
+/// attached returns ALREADY_ATTACHED so the Dart layer can log the degraded
+/// security posture and fall back to nonce-only enforcement instead of
+/// silently overwriting the previous sink.
+///
 /// Dart drives lifecycle via two calls:
-///   attach(webViewId)  — replaces the handler for the given WebView
-///   detach(webViewId)  — removes the handler
+///   attach(webViewId, bootstrapScript?) — replaces the handler, optionally
+///                                         installs a document-start script
+///   detach(webViewId)                   — removes the handler
 ///
 /// The EventChannel delivers maps:
-///   { "message": String, "isMainFrame": Bool, "host": String,
-///     "port": Int, "scheme": String }
+///   { "message": String, "isMainFrame": Bool }
 final class NostrBridgeAttestationPlugin: NSObject, FlutterStreamHandler {
   static let methodChannelName = "co.openvine/nostr_bridge_attestation"
   static let eventChannelName = "co.openvine/nostr_bridge_attestation/events"
-  private static let bridgeChannelName = "divineSandboxBridge"
+  static let bridgeChannelName = "divineSandboxBridge"
+  private static let logTag = "[NostrBridgeAttestation]"
 
   // Retained for the lifetime of the engine.
   private static var shared: NostrBridgeAttestationPlugin?
 
   private let pluginRegistry: FlutterPluginRegistry
-  private var handlers: [Int64: FrameAttestingScriptMessageHandler] = [:]
+  private let policy = NostrBridgeAttestationPolicy()
+  private var handler: FrameAttestingScriptMessageHandler?
   private var eventSink: FlutterEventSink?
 
   private init(pluginRegistry: FlutterPluginRegistry) {
@@ -64,6 +74,7 @@ final class NostrBridgeAttestationPlugin: NSObject, FlutterStreamHandler {
       let args = call.arguments as? [String: Any],
       let webViewId = args["webViewId"] as? Int64
     else {
+      NSLog("\(Self.logTag) attach/detach called without Int64 webViewId")
       result(FlutterError(
         code: "INVALID_ARGUMENT",
         message: "webViewId (Int64) required",
@@ -74,7 +85,12 @@ final class NostrBridgeAttestationPlugin: NSObject, FlutterStreamHandler {
 
     switch call.method {
     case "attach":
-      attachHandler(webViewId: webViewId, result: result)
+      let bootstrapScript = args["bootstrapScript"] as? String
+      attachHandler(
+        webViewId: webViewId,
+        bootstrapScript: bootstrapScript,
+        result: result
+      )
     case "detach":
       detachHandler(webViewId: webViewId)
       result(nil)
@@ -100,11 +116,38 @@ final class NostrBridgeAttestationPlugin: NSObject, FlutterStreamHandler {
 
   // MARK: - Private
 
-  private func attachHandler(webViewId: Int64, result: FlutterResult) {
+  private func attachHandler(
+    webViewId: Int64,
+    bootstrapScript: String?,
+    result: FlutterResult
+  ) {
+    switch policy.attach(webViewId: webViewId) {
+    case .noOp:
+      result(nil)
+      return
+    case .alreadyAttached(let existing):
+      NSLog(
+        "\(Self.logTag) attach refused: already attached to \(existing); requested \(webViewId). Dart will fall back to nonce-only enforcement."
+      )
+      result(FlutterError(
+        code: "ALREADY_ATTACHED",
+        message: "Sandbox attestation already attached to webView \(existing)",
+        details: nil
+      ))
+      return
+    case .ok:
+      break
+    }
+
     guard let webView = FWFWebViewFlutterWKWebViewExternalAPI.webView(
       forIdentifier: webViewId,
       withPluginRegistry: pluginRegistry
     ) else {
+      // Roll back the policy state since the actual attach failed.
+      _ = policy.detach(webViewId: webViewId)
+      NSLog(
+        "\(Self.logTag) attach failed: no WKWebView found for identifier \(webViewId). Dart will fall back to nonce-only enforcement."
+      )
       result(FlutterError(
         code: "WEBVIEW_NOT_FOUND",
         message: "No WKWebView found for identifier \(webViewId)",
@@ -124,27 +167,75 @@ final class NostrBridgeAttestationPlugin: NSObject, FlutterStreamHandler {
       forName: NostrBridgeAttestationPlugin.bridgeChannelName
     )
 
-    let handler = FrameAttestingScriptMessageHandler { [weak self] event in
+    let attestingHandler = FrameAttestingScriptMessageHandler { [weak self] event in
       self?.eventSink?(event)
     }
     contentController.add(
-      handler,
+      attestingHandler,
       name: NostrBridgeAttestationPlugin.bridgeChannelName
     )
-    handlers[webViewId] = handler
+    handler = attestingHandler
+
+    if let bootstrapScript, !bootstrapScript.isEmpty {
+      let userScript = WKUserScript(
+        source: bootstrapScript,
+        injectionTime: .atDocumentStart,
+        forMainFrameOnly: true
+      )
+      contentController.addUserScript(userScript)
+    }
 
     result(nil)
   }
 
   private func detachHandler(webViewId: Int64) {
-    guard let webView = FWFWebViewFlutterWKWebViewExternalAPI.webView(
+    guard policy.detach(webViewId: webViewId) else { return }
+
+    // The WKWebView may already be deallocated by the time Dart tears down,
+    // so a missing lookup here is expected and not an error worth logging.
+    if let webView = FWFWebViewFlutterWKWebViewExternalAPI.webView(
       forIdentifier: webViewId,
       withPluginRegistry: pluginRegistry
-    ) else { return }
+    ) {
+      webView.configuration.userContentController
+        .removeScriptMessageHandler(forName: NostrBridgeAttestationPlugin.bridgeChannelName)
+    }
+    handler = nil
+  }
+}
 
-    webView.configuration.userContentController
-      .removeScriptMessageHandler(forName: NostrBridgeAttestationPlugin.bridgeChannelName)
-    handlers.removeValue(forKey: webViewId)
+// MARK: - NostrBridgeAttestationPolicy
+
+/// Pure state machine for single-instance attestation lifecycle. Extracted so
+/// the attach/detach decisions can be unit tested without a real WKWebView or
+/// plugin registry.
+final class NostrBridgeAttestationPolicy {
+  enum AttachResult: Equatable {
+    /// Newly attached the given webViewId.
+    case ok
+    /// Idempotent re-attach to the same webViewId; nothing to do.
+    case noOp
+    /// A different webViewId is already attached; the request must be refused.
+    case alreadyAttached(existing: Int64)
+  }
+
+  private(set) var attachedWebViewId: Int64?
+
+  func attach(webViewId: Int64) -> AttachResult {
+    if let existing = attachedWebViewId {
+      if existing == webViewId { return .noOp }
+      return .alreadyAttached(existing: existing)
+    }
+    attachedWebViewId = webViewId
+    return .ok
+  }
+
+  /// Returns true when the call cleared a matching attachment, false when the
+  /// id was not attached (so the caller can skip teardown work).
+  func detach(webViewId: Int64) -> Bool {
+    guard attachedWebViewId == webViewId else { return false }
+    attachedWebViewId = nil
+    return true
   }
 }
 
@@ -158,17 +249,22 @@ final class FrameAttestingScriptMessageHandler: NSObject, WKScriptMessageHandler
   }
 
   func userContentController(
-    _ userContentController: WKUserContentController,
+    _: WKUserContentController,
     didReceive message: WKScriptMessage
   ) {
-    let frame = message.frameInfo
-    let origin = frame.securityOrigin
-    deliver([
-      "message": message.body as? String ?? "",
-      "isMainFrame": frame.isMainFrame,
-      "host": origin.host,
-      "port": origin.port,
-      "scheme": origin.protocol,
-    ])
+    deliver(Self.eventPayload(
+      messageBody: message.body as? String ?? "",
+      isMainFrame: message.frameInfo.isMainFrame
+    ))
+  }
+
+  /// Pure translation from the security-relevant fields of WKScriptMessage to
+  /// the Dart event payload. Extracted so the dictionary shape is testable
+  /// without constructing a real WKScriptMessage.
+  static func eventPayload(messageBody: String, isMainFrame: Bool) -> [String: Any] {
+    return [
+      "message": messageBody,
+      "isMainFrame": isMainFrame,
+    ]
   }
 }

--- a/mobile/ios/Runner/NostrBridgeAttestationPlugin.swift
+++ b/mobile/ios/Runner/NostrBridgeAttestationPlugin.swift
@@ -1,0 +1,174 @@
+import Flutter
+import WebKit
+import webview_flutter_wkwebview
+
+/// Thin native plugin that replaces the pigeon-managed WKScriptMessageHandler
+/// for `divineSandboxBridge` with one that includes WKScriptMessage.frameInfo,
+/// and streams attested messages (with isMainFrame + securityOrigin) back to
+/// Dart via an EventChannel.
+///
+/// The pigeon layer exposes WKScriptMessage.name and .body only; .frameInfo is
+/// absent from the pigeon definition, so this plugin is required to surface it.
+///
+/// Dart drives lifecycle via two calls:
+///   attach(webViewId)  — replaces the handler for the given WebView
+///   detach(webViewId)  — removes the handler
+///
+/// The EventChannel delivers maps:
+///   { "message": String, "isMainFrame": Bool, "host": String,
+///     "port": Int, "scheme": String }
+final class NostrBridgeAttestationPlugin: NSObject, FlutterStreamHandler {
+  static let methodChannelName = "co.openvine/nostr_bridge_attestation"
+  static let eventChannelName = "co.openvine/nostr_bridge_attestation/events"
+  private static let bridgeChannelName = "divineSandboxBridge"
+
+  // Retained for the lifetime of the engine.
+  private static var shared: NostrBridgeAttestationPlugin?
+
+  private let pluginRegistry: FlutterPluginRegistry
+  private var handlers: [Int64: FrameAttestingScriptMessageHandler] = [:]
+  private var eventSink: FlutterEventSink?
+
+  private init(pluginRegistry: FlutterPluginRegistry) {
+    self.pluginRegistry = pluginRegistry
+  }
+
+  // MARK: - Registration (called from AppDelegate)
+
+  static func setup(
+    messenger: FlutterBinaryMessenger,
+    pluginRegistry: FlutterPluginRegistry
+  ) {
+    let plugin = NostrBridgeAttestationPlugin(pluginRegistry: pluginRegistry)
+    shared = plugin
+
+    let methodChannel = FlutterMethodChannel(
+      name: methodChannelName,
+      binaryMessenger: messenger
+    )
+    methodChannel.setMethodCallHandler { [weak plugin] call, result in
+      plugin?.handle(call, result: result)
+    }
+
+    let eventChannel = FlutterEventChannel(
+      name: eventChannelName,
+      binaryMessenger: messenger
+    )
+    eventChannel.setStreamHandler(plugin)
+  }
+
+  // MARK: - Method channel handler
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard
+      let args = call.arguments as? [String: Any],
+      let webViewId = args["webViewId"] as? Int64
+    else {
+      result(FlutterError(
+        code: "INVALID_ARGUMENT",
+        message: "webViewId (Int64) required",
+        details: nil
+      ))
+      return
+    }
+
+    switch call.method {
+    case "attach":
+      attachHandler(webViewId: webViewId, result: result)
+    case "detach":
+      detachHandler(webViewId: webViewId)
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: - FlutterStreamHandler
+
+  func onListen(
+    withArguments _: Any?,
+    eventSink events: @escaping FlutterEventSink
+  ) -> FlutterError? {
+    eventSink = events
+    return nil
+  }
+
+  func onCancel(withArguments _: Any?) -> FlutterError? {
+    eventSink = nil
+    return nil
+  }
+
+  // MARK: - Private
+
+  private func attachHandler(webViewId: Int64, result: FlutterResult) {
+    guard let webView = FWFWebViewFlutterWKWebViewExternalAPI.webView(
+      forIdentifier: webViewId,
+      withPluginRegistry: pluginRegistry
+    ) else {
+      result(FlutterError(
+        code: "WEBVIEW_NOT_FOUND",
+        message: "No WKWebView found for identifier \(webViewId)",
+        details: nil
+      ))
+      return
+    }
+
+    let contentController = webView.configuration.userContentController
+
+    // Remove the pigeon-managed handler installed by addJavaScriptChannel.
+    // The WKUserScript that creates window.divineSandboxBridge as an alias
+    // for webkit.messageHandlers.divineSandboxBridge remains intact and
+    // continues to route postMessage() calls to whichever handler owns the
+    // name — now ours.
+    contentController.removeScriptMessageHandler(
+      forName: NostrBridgeAttestationPlugin.bridgeChannelName
+    )
+
+    let handler = FrameAttestingScriptMessageHandler { [weak self] event in
+      self?.eventSink?(event)
+    }
+    contentController.add(
+      handler,
+      name: NostrBridgeAttestationPlugin.bridgeChannelName
+    )
+    handlers[webViewId] = handler
+
+    result(nil)
+  }
+
+  private func detachHandler(webViewId: Int64) {
+    guard let webView = FWFWebViewFlutterWKWebViewExternalAPI.webView(
+      forIdentifier: webViewId,
+      withPluginRegistry: pluginRegistry
+    ) else { return }
+
+    webView.configuration.userContentController
+      .removeScriptMessageHandler(forName: NostrBridgeAttestationPlugin.bridgeChannelName)
+    handlers.removeValue(forKey: webViewId)
+  }
+}
+
+// MARK: - FrameAttestingScriptMessageHandler
+
+final class FrameAttestingScriptMessageHandler: NSObject, WKScriptMessageHandler {
+  private let deliver: ([String: Any]) -> Void
+
+  init(deliver: @escaping ([String: Any]) -> Void) {
+    self.deliver = deliver
+  }
+
+  func userContentController(
+    _ userContentController: WKUserContentController,
+    didReceive message: WKScriptMessage
+  ) {
+    let frame = message.frameInfo
+    let origin = frame.securityOrigin
+    deliver([
+      "message": message.body as? String ?? "",
+      "isMainFrame": frame.isMainFrame,
+      "host": origin.host,
+      "port": origin.port,
+      "scheme": origin.protocol,
+    ])
+  }
+}

--- a/mobile/ios/RunnerTests/RunnerTests.swift
+++ b/mobile/ios/RunnerTests/RunnerTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import WebKit
+@testable import Runner
+
+/// Native coverage for the Nostr bridge frame-attestation plugin. The plugin's
+/// security guarantees rest on two pieces of native logic that the Dart-side
+/// mocks cannot cover:
+///
+///   1. The single-instance attach/detach state machine that decides whether
+///      a second sandbox WebView is allowed to overwrite an existing
+///      attestation handler. If this lets a second attach silently win, the
+///      previous sandbox stops receiving attested events and degrades to
+///      nonce-only enforcement without any signal — exactly the failure mode
+///      the structural fix in this PR is meant to prevent.
+///
+///   2. The WKScriptMessage → Dart event translation that determines what
+///      isMainFrame value reaches Dart. If the dictionary shape regresses or
+///      starts including unintended fields, downstream callers may grow
+///      reliance on data the contract no longer guarantees.
+///
+/// Both are pure logic, extracted so they can be exercised here without a
+/// real WKWebView, FlutterEngine, or Dart channel. The
+/// WKUserContentController integration test below additionally proves the
+/// WebKit APIs the plugin depends on (script handler add/remove + document-
+/// start user script with main-frame-only) actually behave as expected on
+/// the iOS version this app targets.
+
+final class NostrBridgeAttestationPolicyTests: XCTestCase {
+  func testInitialStateNoAttachment() {
+    let policy = NostrBridgeAttestationPolicy()
+    XCTAssertNil(policy.attachedWebViewId)
+  }
+
+  func testAttachReturnsOkWhenNothingAttached() {
+    let policy = NostrBridgeAttestationPolicy()
+    XCTAssertEqual(policy.attach(webViewId: 1), .ok)
+    XCTAssertEqual(policy.attachedWebViewId, 1)
+  }
+
+  func testAttachIsIdempotentForSameWebViewId() {
+    let policy = NostrBridgeAttestationPolicy()
+    _ = policy.attach(webViewId: 7)
+    XCTAssertEqual(policy.attach(webViewId: 7), .noOp)
+    XCTAssertEqual(policy.attachedWebViewId, 7)
+  }
+
+  func testAttachRefusesDifferentWebViewIdWhileOneIsAttached() {
+    let policy = NostrBridgeAttestationPolicy()
+    _ = policy.attach(webViewId: 1)
+    XCTAssertEqual(policy.attach(webViewId: 2), .alreadyAttached(existing: 1))
+    XCTAssertEqual(
+      policy.attachedWebViewId, 1,
+      "second attach must not overwrite the existing attachment"
+    )
+  }
+
+  func testDetachClearsMatchingAttachment() {
+    let policy = NostrBridgeAttestationPolicy()
+    _ = policy.attach(webViewId: 9)
+    XCTAssertTrue(policy.detach(webViewId: 9))
+    XCTAssertNil(policy.attachedWebViewId)
+  }
+
+  func testDetachIsNoOpForUnattachedWebViewId() {
+    let policy = NostrBridgeAttestationPolicy()
+    _ = policy.attach(webViewId: 1)
+    XCTAssertFalse(policy.detach(webViewId: 2))
+    XCTAssertEqual(
+      policy.attachedWebViewId, 1,
+      "stale detach call must not clear the live attachment"
+    )
+  }
+
+  func testDetachIsNoOpWhenNothingAttached() {
+    let policy = NostrBridgeAttestationPolicy()
+    XCTAssertFalse(policy.detach(webViewId: 1))
+    XCTAssertNil(policy.attachedWebViewId)
+  }
+
+  func testReAttachAfterDetachSucceeds() {
+    let policy = NostrBridgeAttestationPolicy()
+    _ = policy.attach(webViewId: 1)
+    _ = policy.detach(webViewId: 1)
+    XCTAssertEqual(policy.attach(webViewId: 2), .ok)
+    XCTAssertEqual(policy.attachedWebViewId, 2)
+  }
+}
+
+final class FrameAttestingScriptMessageHandlerTests: XCTestCase {
+  func testEventPayloadIncludesMessageBody() {
+    let payload = FrameAttestingScriptMessageHandler.eventPayload(
+      messageBody: "hello",
+      isMainFrame: true
+    )
+    XCTAssertEqual(payload["message"] as? String, "hello")
+  }
+
+  func testEventPayloadIncludesIsMainFrameTrue() {
+    let payload = FrameAttestingScriptMessageHandler.eventPayload(
+      messageBody: "x",
+      isMainFrame: true
+    )
+    XCTAssertEqual(payload["isMainFrame"] as? Bool, true)
+  }
+
+  func testEventPayloadIncludesIsMainFrameFalse() {
+    let payload = FrameAttestingScriptMessageHandler.eventPayload(
+      messageBody: "x",
+      isMainFrame: false
+    )
+    XCTAssertEqual(payload["isMainFrame"] as? Bool, false)
+  }
+
+  func testEventPayloadHasOnlyMessageAndIsMainFrame() {
+    let payload = FrameAttestingScriptMessageHandler.eventPayload(
+      messageBody: "x",
+      isMainFrame: true
+    )
+    XCTAssertEqual(
+      Set(payload.keys), ["message", "isMainFrame"],
+      "payload must not leak host/port/scheme or any other origin fields — Dart only consumes message + isMainFrame"
+    )
+  }
+}
+
+/// Smoke test for the WebKit APIs the plugin depends on. If a future iOS SDK
+/// change deprecates or alters the behaviour of `removeScriptMessageHandler`
+/// or `addUserScript(_:atDocumentStart:forMainFrameOnly:)` this fails loudly.
+final class WebKitContentControllerIntegrationTests: XCTestCase {
+  func testHandlerSwapAndDocumentStartUserScriptInstallation() {
+    let webView = WKWebView()
+    let contentController = webView.configuration.userContentController
+    let bridgeName = NostrBridgeAttestationPlugin.bridgeChannelName
+
+    // Simulate the pigeon-managed handler that addJavaScriptChannel installs.
+    let pigeonStub = FrameAttestingScriptMessageHandler { _ in }
+    contentController.add(pigeonStub, name: bridgeName)
+
+    // The plugin's attach path swaps it for the attesting handler.
+    contentController.removeScriptMessageHandler(forName: bridgeName)
+    let attesting = FrameAttestingScriptMessageHandler { _ in }
+    contentController.add(attesting, name: bridgeName)
+
+    // And installs the bootstrap script at document start, main-frame only.
+    XCTAssertEqual(contentController.userScripts.count, 0)
+    let userScript = WKUserScript(
+      source: "void(0);",
+      injectionTime: .atDocumentStart,
+      forMainFrameOnly: true
+    )
+    contentController.addUserScript(userScript)
+
+    XCTAssertEqual(contentController.userScripts.count, 1)
+    let installed = contentController.userScripts.first
+    XCTAssertEqual(installed?.injectionTime, .atDocumentStart)
+    XCTAssertTrue(installed?.isForMainFrameOnly ?? false)
+  }
+}

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -294,7 +294,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
         'Native frame attestation unavailable (${error.code}); '
         'falling back to nonce-only enforcement.',
         name: 'NostrAppSandboxScreen',
-        category: LogCategory.auth,
+        category: LogCategory.system,
       );
     } on MissingPluginException catch (_) {
       // Channel is not registered (tests, simulator without the plugin set

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -307,7 +307,14 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   /// Rejects non-main-frame messages before the nonce check: the platform
   /// itself reports isMainFrame, so no JS can spoof this value.
   void _handleAttestedEvent(dynamic event) {
-    if (event is! Map) return;
+    if (event is! Map) {
+      Log.warning(
+        'Unexpected attestation event shape: ${event.runtimeType}',
+        name: 'NostrAppSandboxScreen',
+        category: LogCategory.system,
+      );
+      return;
+    }
     final message = event['message'] as String? ?? '';
     final isMainFrame = event['isMainFrame'] as bool? ?? false;
 

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
@@ -35,6 +36,7 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
     this.bootstrapHttpClientOverride,
     this.javaScriptRunnerOverride,
     this.onBridgeMessageHandlerReady,
+    this.onAttestedEventHandlerReady,
     this.currentUserPubkeyOverride,
     this.bridgeNonceOverride,
     super.key,
@@ -49,6 +51,8 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
   final ValueChanged<Future<void> Function(String message)>?
   onBridgeMessageHandlerReady;
   @visibleForTesting
+  final ValueChanged<void Function(dynamic event)>? onAttestedEventHandlerReady;
+  @visibleForTesting
   final String? currentUserPubkeyOverride;
   @visibleForTesting
   final String? bridgeNonceOverride;
@@ -62,12 +66,22 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
 }
 
 class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
+  // iOS frame attestation channels.
+  static const MethodChannel _attestationMethodChannel = MethodChannel(
+    'co.openvine/nostr_bridge_attestation',
+  );
+  static const EventChannel _attestationEventChannel = EventChannel(
+    'co.openvine/nostr_bridge_attestation/events',
+  );
+
   WebViewController? _webViewController;
   bool _isLoading = true;
   Uri? _blockedUri;
   Uri? _currentPageUri;
   http.Client? _ownedBootstrapHttpClient;
   late final String _bridgeNonce;
+  bool _isNativeAttestationActive = false;
+  StreamSubscription<dynamic>? _attestedMessageSubscription;
 
   String? get _currentUserPubkey =>
       widget.currentUserPubkeyOverride ??
@@ -80,6 +94,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     _bridgeNonce = widget.bridgeNonceOverride ?? _generateBridgeNonce();
     widget.onNavigationHandlerReady?.call(_handleNavigationAttempt);
     widget.onBridgeMessageHandlerReady?.call(_handleBridgeMessage);
+    widget.onAttestedEventHandlerReady?.call(_handleAttestedEvent);
 
     if (widget.sandboxBuilder != null) {
       return;
@@ -93,6 +108,18 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
 
   @override
   void dispose() {
+    _attestedMessageSubscription?.cancel();
+    if (_isNativeAttestationActive) {
+      final platformController = _webViewController?.platform;
+      if (platformController is WebKitWebViewController) {
+        unawaited(
+          _attestationMethodChannel.invokeMethod<void>(
+            'detach',
+            {'webViewId': platformController.webViewIdentifier},
+          ),
+        );
+      }
+    }
     _ownedBootstrapHttpClient?.close();
     super.dispose();
   }
@@ -204,9 +231,21 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     await controller.addJavaScriptChannel(
       NostrAppSandboxScreen.bridgeChannelName,
       onMessageReceived: (message) {
-        _handleBridgeMessage(message.message);
+        // On iOS, the native attesting handler replaces this pigeon handler
+        // after attach() completes. This guard prevents double-handling during
+        // the brief setup window before replacement.
+        if (!_isNativeAttestationActive) {
+          unawaited(_handleBridgeMessage(message.message));
+        }
       },
     );
+
+    // On iOS, replace the pigeon handler with the frame-attesting one.
+    // Must run before the page loads so the native handler is in place when
+    // the bootstrap script fires its first postMessage.
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await _activateNativeAttestation(controller);
+    }
 
     await _installDocumentStartBridgeIfSupported(controller);
     await _loadSandboxPage(launchUri);
@@ -216,6 +255,60 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     return defaultTargetPlatform == TargetPlatform.android &&
         request.isMainFrame &&
         _isAllowedOrigin(uri);
+  }
+
+  /// Activates platform-level frame attestation on iOS by replacing the
+  /// pigeon-managed WKScriptMessageHandler with a native one that includes
+  /// WKScriptMessage.frameInfo. Messages arrive via EventChannel instead of
+  /// the addJavaScriptChannel callback.
+  ///
+  /// Falls back silently when the native plugin is unavailable (e.g. in tests
+  /// that do not configure the channel); the nonce gate remains active.
+  Future<void> _activateNativeAttestation(WebViewController controller) async {
+    final platformController = controller.platform;
+    if (platformController is! WebKitWebViewController) return;
+
+    try {
+      await _attestationMethodChannel.invokeMethod<void>(
+        'attach',
+        {'webViewId': platformController.webViewIdentifier},
+      );
+      _isNativeAttestationActive = true;
+      _attestedMessageSubscription = _attestationEventChannel
+          .receiveBroadcastStream()
+          .listen(_handleAttestedEvent);
+    } catch (_) {
+      // Plugin channel not available — nonce gate is the only defence on iOS.
+    }
+  }
+
+  /// Handles a message delivered by the native frame-attesting handler.
+  ///
+  /// Rejects non-main-frame messages before the nonce check: the platform
+  /// itself reports isMainFrame, so no JS can spoof this value.
+  void _handleAttestedEvent(dynamic event) {
+    if (event is! Map) return;
+    final message = event['message'] as String? ?? '';
+    final isMainFrame = event['isMainFrame'] as bool? ?? false;
+
+    if (!isMainFrame) {
+      String responseId = 'unknown';
+      try {
+        final payload = jsonDecode(message);
+        if (payload is Map) {
+          responseId = payload['id']?.toString() ?? 'unknown';
+        }
+      } catch (_) {}
+      unawaited(
+        _emitBridgeResponse(
+          id: responseId,
+          result: const BridgeResult.error('subframe_rejected'),
+        ),
+      );
+      return;
+    }
+
+    unawaited(_handleBridgeMessage(message));
   }
 
   Future<void> _loadSandboxPage(Uri uri) async {

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -318,7 +318,11 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
         if (payload is Map) {
           responseId = payload['id']?.toString() ?? 'unknown';
         }
-      } catch (_) {}
+      } on FormatException {
+        // Best-effort id extraction; subframe rejection is unconditional
+        // regardless of payload validity. Real invariant bugs (StateError,
+        // TypeError) are intentionally not swallowed here.
+      }
       unawaited(
         _emitBridgeResponse(
           id: responseId,

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -15,8 +15,8 @@ import 'package:http/http.dart' as http;
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/apps/nostr_app_permission_prompt_sheet.dart';
+import 'package:unified_logger/unified_logger.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import 'package:webview_flutter_wkwebview/src/common/web_kit.g.dart';
 import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 
 typedef SandboxViewBuilder =
@@ -240,14 +240,14 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
       },
     );
 
-    // On iOS, replace the pigeon handler with the frame-attesting one.
+    // On iOS, replace the pigeon handler with the frame-attesting one and
+    // hand off the document-start bootstrap script to the native plugin.
     // Must run before the page loads so the native handler is in place when
     // the bootstrap script fires its first postMessage.
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       await _activateNativeAttestation(controller);
     }
 
-    await _installDocumentStartBridgeIfSupported(controller);
     await _loadSandboxPage(launchUri);
   }
 
@@ -262,23 +262,43 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   /// WKScriptMessage.frameInfo. Messages arrive via EventChannel instead of
   /// the addJavaScriptChannel callback.
   ///
-  /// Falls back silently when the native plugin is unavailable (e.g. in tests
-  /// that do not configure the channel); the nonce gate remains active.
+  /// Also hands the document-start bridge bootstrap script to the native
+  /// plugin so it can be installed as a `WKUserScript` without the Dart
+  /// layer needing to import private webview_flutter_wkwebview src types.
+  ///
+  /// Falls back to nonce-only enforcement when the native plugin is
+  /// unavailable (e.g. in tests that do not configure the channel, or if a
+  /// previous sandbox is still attached). Logs a warning so the degraded
+  /// security posture is visible in unified logs.
   Future<void> _activateNativeAttestation(WebViewController controller) async {
     final platformController = controller.platform;
     if (platformController is! WebKitWebViewController) return;
 
+    final bootstrapScript = buildBridgeBootstrapScript(
+      nonce: _bridgeNonce,
+      pubkey: _currentUserPubkey,
+      autoLoginScript: widget.app.autoLoginScript,
+    );
+
     try {
-      await _attestationMethodChannel.invokeMethod<void>(
-        'attach',
-        {'webViewId': platformController.webViewIdentifier},
-      );
+      await _attestationMethodChannel.invokeMethod<void>('attach', {
+        'webViewId': platformController.webViewIdentifier,
+        'bootstrapScript': bootstrapScript,
+      });
       _isNativeAttestationActive = true;
       _attestedMessageSubscription = _attestationEventChannel
           .receiveBroadcastStream()
           .listen(_handleAttestedEvent);
-    } catch (_) {
-      // Plugin channel not available — nonce gate is the only defence on iOS.
+    } on PlatformException catch (error) {
+      Log.warning(
+        'Native frame attestation unavailable (${error.code}); '
+        'falling back to nonce-only enforcement.',
+        name: 'NostrAppSandboxScreen',
+        category: LogCategory.auth,
+      );
+    } on MissingPluginException catch (_) {
+      // Channel is not registered (tests, simulator without the plugin set
+      // up). Nonce gate remains the only defence on iOS in this case.
     }
   }
 
@@ -336,47 +356,6 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
 
     _currentPageUri = uri;
     await controller.loadRequest(uri);
-  }
-
-  Future<void> _installDocumentStartBridgeIfSupported(
-    WebViewController controller,
-  ) async {
-    final platformController = controller.platform;
-    if (platformController is! WebKitWebViewController) {
-      return;
-    }
-
-    final nativeWebView = PigeonInstanceManager.instance
-        .getInstanceWithWeakReference<WKWebView>(
-          platformController.webViewIdentifier,
-        );
-    if (nativeWebView == null) {
-      return;
-    }
-
-    final WKWebViewConfiguration configuration;
-    switch (nativeWebView) {
-      case UIViewWKWebView():
-        configuration = nativeWebView.configuration;
-      case NSViewWKWebView():
-        configuration = nativeWebView.configuration;
-      default:
-        return;
-    }
-
-    final contentController = await configuration.getUserContentController();
-    final fullScript = buildBridgeBootstrapScript(
-      nonce: _bridgeNonce,
-      pubkey: _currentUserPubkey,
-      autoLoginScript: widget.app.autoLoginScript,
-    );
-    final userScript = WKUserScript(
-      source: fullScript,
-      injectionTime: UserScriptInjectionTime.atDocumentStart,
-      isForMainFrameOnly: true,
-    );
-
-    await contentController.addUserScript(userScript);
   }
 
   Future<_BootstrappedSandboxPage?> _prepareBootstrapHtml(Uri uri) async {

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -403,6 +403,187 @@ void main() {
       },
     );
 
+    group('iOS frame attestation', () {
+      void Function(dynamic event)? attestedEventHandler;
+      List<String> capturedScripts = [];
+
+      Future<void> pumpSandbox(WidgetTester tester) async {
+        capturedScripts = [];
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: NostrAppSandboxScreen(
+              app: _fixtureApp(),
+              sandboxBuilder: (_) => const SizedBox.shrink(),
+              javaScriptRunnerOverride: (script) async {
+                capturedScripts.add(script);
+              },
+              onAttestedEventHandlerReady: (handler) {
+                attestedEventHandler = handler;
+              },
+              bridgeNonceOverride: 'test-nonce',
+              currentUserPubkeyOverride: 'f' * 64,
+            ),
+          ),
+        );
+      }
+
+      testWidgets('rejects non-main-frame events with subframe_rejected', (
+        tester,
+      ) async {
+        await pumpSandbox(tester);
+
+        attestedEventHandler!({
+          'message': jsonEncode({
+            'id': 'frame-1',
+            'method': 'getPublicKey',
+            'args': <String, dynamic>{},
+            'nonce': 'test-nonce',
+          }),
+          'isMainFrame': false,
+          'host': 'evil.example',
+          'port': 443,
+          'scheme': 'https',
+        });
+        await tester.pump();
+
+        expect(capturedScripts, hasLength(1));
+        expect(capturedScripts.single, contains('frame-1'));
+        expect(capturedScripts.single, contains('subframe_rejected'));
+        expect(capturedScripts.single, isNot(contains('"success":true')));
+      });
+
+      testWidgets(
+        'rejects non-main-frame events even when nonce is valid',
+        (tester) async {
+          await pumpSandbox(tester);
+
+          attestedEventHandler!({
+            'message': jsonEncode({
+              'id': 'frame-2',
+              'method': 'signEvent',
+              'args': <String, dynamic>{
+                'event': {'kind': 1},
+              },
+              'nonce': 'test-nonce',
+            }),
+            'isMainFrame': false,
+            'host': 'primal.net',
+            'port': 443,
+            'scheme': 'https',
+          });
+          await tester.pump();
+
+          expect(capturedScripts.single, contains('subframe_rejected'));
+          expect(capturedScripts.single, isNot(contains('"success":true')));
+        },
+      );
+
+      testWidgets(
+        'forwards main-frame events to _handleBridgeMessage',
+        (tester) async {
+          SharedPreferences.setMockInitialValues({});
+          final sharedPreferences = await SharedPreferences.getInstance();
+          final grantStore = NostrAppGrantStore(
+            sharedPreferences: sharedPreferences,
+          );
+          final bridgeService = NostrAppBridgeService(
+            authProvider: _FakeAuthProvider(),
+            policy: NostrAppBridgePolicy(
+              grantStore: grantStore,
+              currentUserPubkey: 'f' * 64,
+            ),
+            signerFactory: _FakeNostrSigner.new,
+          );
+
+          capturedScripts = [];
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: NostrAppSandboxScreen(
+                app: _fixtureApp(),
+                sandboxBuilder: (_) => const SizedBox.shrink(),
+                bridgeServiceOverride: bridgeService,
+                javaScriptRunnerOverride: (script) async {
+                  capturedScripts.add(script);
+                },
+                onAttestedEventHandlerReady: (handler) {
+                  attestedEventHandler = handler;
+                },
+                bridgeNonceOverride: 'test-nonce',
+                currentUserPubkeyOverride: 'f' * 64,
+              ),
+            ),
+          );
+
+          attestedEventHandler!({
+            'message': jsonEncode({
+              'id': 'frame-3',
+              'method': 'getPublicKey',
+              'args': <String, dynamic>{},
+              'nonce': 'test-nonce',
+            }),
+            'isMainFrame': true,
+            'host': 'primal.net',
+            'port': 443,
+            'scheme': 'https',
+          });
+          await tester.pump();
+
+          expect(capturedScripts, hasLength(1));
+          expect(capturedScripts.single, contains('frame-3'));
+          // getPublicKey succeeds — nonce was valid and main-frame was true
+          expect(capturedScripts.single, contains('"success":true'));
+          expect(capturedScripts.single, contains('f' * 64));
+        },
+      );
+
+      testWidgets(
+        'main-frame events with wrong nonce still hit the nonce gate',
+        (tester) async {
+          await pumpSandbox(tester);
+
+          attestedEventHandler!({
+            'message': jsonEncode({
+              'id': 'frame-4',
+              'method': 'getPublicKey',
+              'args': <String, dynamic>{},
+              'nonce': 'attacker-guessed-nonce',
+            }),
+            'isMainFrame': true,
+            'host': 'primal.net',
+            'port': 443,
+            'scheme': 'https',
+          });
+          await tester.pump();
+
+          expect(capturedScripts.single, contains('frame-4'));
+          expect(capturedScripts.single, contains('subframe_or_unauthorized'));
+        },
+      );
+
+      testWidgets(
+        'non-main-frame event with unparseable message emits subframe_rejected with unknown id',
+        (tester) async {
+          await pumpSandbox(tester);
+
+          attestedEventHandler!({
+            'message': 'not-valid-json',
+            'isMainFrame': false,
+            'host': 'evil.example',
+            'port': 443,
+            'scheme': 'https',
+          });
+          await tester.pump();
+
+          expect(capturedScripts.single, contains('unknown'));
+          expect(capturedScripts.single, contains('subframe_rejected'));
+        },
+      );
+    });
+
     group('bridge bootstrap script', () {
       test('includes eager pubkey when provided', () {
         final script = buildBridgeBootstrapScript(

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -442,9 +442,6 @@ void main() {
             'nonce': 'test-nonce',
           }),
           'isMainFrame': false,
-          'host': 'evil.example',
-          'port': 443,
-          'scheme': 'https',
         });
         await tester.pump();
 
@@ -469,9 +466,6 @@ void main() {
               'nonce': 'test-nonce',
             }),
             'isMainFrame': false,
-            'host': 'primal.net',
-            'port': 443,
-            'scheme': 'https',
           });
           await tester.pump();
 
@@ -526,9 +520,6 @@ void main() {
               'nonce': 'test-nonce',
             }),
             'isMainFrame': true,
-            'host': 'primal.net',
-            'port': 443,
-            'scheme': 'https',
           });
           await tester.pump();
 
@@ -553,9 +544,6 @@ void main() {
               'nonce': 'attacker-guessed-nonce',
             }),
             'isMainFrame': true,
-            'host': 'primal.net',
-            'port': 443,
-            'scheme': 'https',
           });
           await tester.pump();
 
@@ -572,9 +560,6 @@ void main() {
           attestedEventHandler!({
             'message': 'not-valid-json',
             'isMainFrame': false,
-            'host': 'evil.example',
-            'port': 443,
-            'scheme': 'https',
           });
           await tester.pump();
 

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -405,10 +405,14 @@ void main() {
 
     group('iOS frame attestation', () {
       void Function(dynamic event)? attestedEventHandler;
-      List<String> capturedScripts = [];
+      List<String> capturedScripts = <String>[];
+
+      setUp(() {
+        attestedEventHandler = null;
+        capturedScripts = <String>[];
+      });
 
       Future<void> pumpSandbox(WidgetTester tester) async {
-        capturedScripts = [];
         await tester.pumpWidget(
           MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -491,7 +495,6 @@ void main() {
             signerFactory: _FakeNostrSigner.new,
           );
 
-          capturedScripts = [];
           await tester.pumpWidget(
             MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Description

Closes #3764.

### Background

The nonce gate shipped in #3759 is the effective immediate defence against iframe abuse of the Nostr bridge. Issue #3764 tracks the longer-term platform-layer improvement: per-frame origin attestation, so the host can distinguish top-level pages from subframes at the platform boundary — not just via the JS-side `window.top !== window.self` guard.

The investigation documented in [this comment](https://github.com/divinevideo/divine-mobile/issues/3764#issuecomment-4375621169) found that `webview_flutter_wkwebview` 3.24.1 truncates `WKScriptMessage` to `name` and `body` only — `frameInfo` is absent from the pigeon definition. However, the package ships a stable public external API (`FWFWebViewFlutterWKWebViewExternalAPI`) specifically for app-level native code to look up a `WKWebView` by its Dart-assigned integer identifier, enabling the local plugin approach implemented here.

### What changed

**New: `mobile/ios/Runner/NostrBridgeAttestationPlugin.swift`**

Swift plugin with two classes:
- `NostrBridgeAttestationPlugin` — registers a `MethodChannel` (`co.openvine/nostr_bridge_attestation`) and `EventChannel` (`co.openvine/nostr_bridge_attestation/events`). On `attach(webViewId)`, it calls `FWFWebViewFlutterWKWebViewExternalAPI.webView(forIdentifier:withPluginRegistry:)` to obtain the live `WKWebView`, removes the pigeon-managed `WKScriptMessageHandler` for `divineSandboxBridge`, and installs its own. On `detach`, it removes the handler.
- `FrameAttestingScriptMessageHandler` — the replacement handler. In `userContentController(_:didReceive:)` it reads `message.frameInfo.isMainFrame` (a native `WKScriptMessage` field unavailable to Dart via pigeon) and delivers `{message, isMainFrame}` to Dart via the `EventChannel` sink. Origin host/port/scheme are intentionally **not** forwarded — `isMainFrame` is the structural signal this layer needs, and narrowing the contract keeps the security surface minimal. The native test `testEventPayloadHasOnlyMessageAndIsMainFrame` pins this contract so it can't silently regress.

The `addJavaScriptChannel("divineSandboxBridge")` call remains: it installs the `WKUserScript` alias `window.divineSandboxBridge = webkit.messageHandlers.divineSandboxBridge`, which continues to route correctly after the handler swap. Only the handler object is replaced, not the JS-visible name.

**`mobile/ios/Runner/AppDelegate.swift`**

Calls `NostrBridgeAttestationPlugin.setup(messenger:pluginRegistry:)` after `GeneratedPluginRegistrant.register` — ordering matters because `FWFWebViewFlutterWKWebViewExternalAPI` requires `WebViewFlutterPlugin` to already be registered.

**`mobile/ios/Runner.xcodeproj/project.pbxproj`**

Four entries added (`PBXBuildFile`, `PBXFileReference`, group child, Sources build phase) so the new Swift file compiles without a manual Xcode step.

**`mobile/lib/screens/apps/nostr_app_sandbox_screen.dart`**

- `_activateNativeAttestation(controller)` — called during `_configureAndLoadController` on iOS only. Sends `attach(webViewId)` to the Swift plugin, then subscribes to the `EventChannel`. Falls back silently if the channel is not available (tests, macOS, etc.).
- `_handleAttestedEvent(event)` — rejects `isMainFrame: false` with `subframe_rejected` before the nonce check runs. Main-frame events are forwarded to the existing `_handleBridgeMessage`, which applies the nonce gate and policy as before.
- `dispose()` — cancels the stream subscription and fires `detach`.
- `@visibleForTesting onAttestedEventHandlerReady` — exposes `_handleAttestedEvent` to tests without requiring a real WebView.

Android is **unchanged** — nonce gate remains the effective defence on Android. Platform-level parity (`WebViewCompat.addWebMessageListener`) is tracked in #4105.

### Reproducing the gap this closes

With only the nonce gate (#3759):
1. Open an approved app (e.g. Primal).
2. The app embeds a same-origin `<iframe>` whose source is attacker-controlled (e.g. via XSS or a compromised CDN asset).
3. The iframe cannot call `window.nostr.*` (bootstrap refuses in non-main frames) — but it can call `window.webkit.messageHandlers.divineSandboxBridge.postMessage(...)` directly.
4. Without a valid nonce the host rejects it (`subframe_or_unauthorized`). The nonce is scoped to IIFE closure so the iframe cannot read it from the parent.
5. The nonce gate is therefore the real blocking control on iOS today — but it is a cryptographic/logical control, not a platform-level structural control.

With this PR, step 3 is also rejected at the platform level: `WKScriptMessage.frameInfo.isMainFrame` is `false` for any message posted from an iframe, and the host denies it with `subframe_rejected` before the nonce check even runs.

### Test plan

**Automated (all pass locally):**

| Test | What it proves |
|------|----------------|
| `rejects non-main-frame events with subframe_rejected` | Platform-level denial fires for any `isMainFrame: false` message |
| `rejects non-main-frame events even when nonce is valid` | Subframe denial is unconditional — valid nonce doesn't help |
| `forwards main-frame events to _handleBridgeMessage` | Attested main-frame calls reach the nonce gate + policy |
| `main-frame events with wrong nonce still hit the nonce gate` | Frame attestation does not bypass the nonce check |
| `non-main-frame event with unparseable message emits subframe_rejected with unknown id` | Graceful handling of malformed payloads from subframes |

```
flutter test test/screens/apps/nostr_app_sandbox_screen_test.dart
# 34 passed (29 existing + 5 new)
flutter analyze lib/screens/apps/ test/screens/apps/
# No issues found
```

**Manual (on device):**
- Open an approved Nostr app and verify `window.nostr.getPublicKey()` still resolves.
- In Safari Web Inspector, inject `window.webkit.messageHandlers.divineSandboxBridge.postMessage(JSON.stringify({id:"x",method:"getPublicKey",args:{},nonce:"anything"}))` from an iframe context and verify the response contains `subframe_rejected`.

### Follow-ups

- Android per-frame origin attestation parity — #4105.

## Type of Change

- [x] 🔒 Security hardening (defence-in-depth; does not change observable app behaviour for legitimate main-frame traffic)