### PR TITLE
chore(agents): share workflow rules and skill library with the team

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ reviewer to catch the same things.
 Generic Flutter and Dart standards live in `.claude/rules/`:
 
 - `rules/self_review_checklist.md`: consolidated pre-plan / pre-commit / pre-PR checklist
+- `rules/agent_workflow.md`: worktree-from-`origin/main`, rebase-before-push, no-stacked-PRs, no-tech-debt, failing-tests-are-your-fault
 - `rules/architecture.md`: layered flow, package boundaries, barrel files
 - `rules/state_management.md`: BLoC-first UI, BlocProvider laziness, cross-route state persistence, Riverpod legacy rules, event transformers
 - `rules/code_style.md`: naming, widget composition, Effective Dart guidance

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -1,0 +1,197 @@
+# Agent Workflow
+
+The non-negotiables for branch hygiene, PR strategy, technical debt, and
+test discipline. These rules apply to every change, every time. They
+exist because the alternatives have already cost us — each one has a
+specific failure history.
+
+`AGENTS.md` is the entry-point summary; this file is the detailed
+reference. When the two disagree, the stricter version wins.
+
+---
+
+## 1. Always start in a fresh worktree based on `origin/main`
+
+**Every change starts in a NEW worktree branched from `origin/main`.**
+
+```bash
+git fetch origin
+git worktree add .worktrees/<task-name> -b <branch-name> origin/main
+cd .worktrees/<task-name>
+```
+
+Branch from `origin/main`, never from local `main`. Local `main` is often
+stale — branching from it carries forward commits that have already been
+superseded on the remote.
+
+**Forbidden:**
+
+- Editing on `main` (local or otherwise).
+- Reusing an existing worktree for an unrelated task without first
+  rebasing onto fresh `origin/main`.
+- Branching from `main` without `git fetch origin` first.
+
+One task per worktree. If the current worktree is dirty, commit, stash
+intentionally, or discard intentionally before starting new work
+elsewhere. Do not mix unrelated work into one worktree.
+
+---
+
+## 2. Always rebase onto `origin/main` before pushing
+
+Before **every** `git push`, fetch the latest `origin/main` and rebase
+your branch onto it:
+
+```bash
+git fetch origin
+git rebase origin/main
+# resolve any conflicts, re-run tests, then:
+git push --force-with-lease
+```
+
+Rebasing right before push surfaces conflicts and broken assumptions
+while you still have full context — instead of after CI fails on the PR
+or after a reviewer has already started reading.
+
+**Forbidden:**
+
+- `git push` without first `git fetch origin && git rebase origin/main`.
+- `git push --force` without `--lease`. `--force-with-lease` is
+  mandatory on rebased feature branches so a concurrent push from a
+  different machine isn't silently overwritten.
+- Merging `main` into a feature branch instead of rebasing — produces
+  noisy "Merge branch 'main' into..." commits and a non-linear history.
+
+This rule still applies even on a branch you've pushed many times.
+Don't push a stale branch.
+
+---
+
+## 3. Never stack PRs — combine dependent features into one bigger PR
+
+**Every PR targets `main`.** Never `gh pr create --base <other-branch>`.
+
+If features depend on each other, ship them as **one combined PR** on a
+single branch. Use clearly delineated commits and a PR description with
+separate sections for each feature. Reviewers handle one PR; the merge
+story is one click; CI runs against the right base.
+
+```bash
+# One branch, both features, one PR
+git checkout -b feature-a-and-b origin/main
+# ... commit Feature A ...
+# ... commit Feature B ...
+git push --force-with-lease
+gh pr create --base main
+```
+
+**Why stacking is forbidden:** every prior attempt has cost more than it
+saved — cascading rebases when the parent changes, fragmented review
+context, merge order becoming load-bearing, CI running against the
+wrong base, and "fix on parent" forcing a re-review of the child. The
+diff-cleanliness benefit isn't worth the operational cost.
+
+**Forbidden:**
+
+- `gh pr create --base <other-pr-branch>`. Always `--base main` (or
+  omit, since `main` is the default).
+- Branching a feature off another feature branch with the intent to PR
+  it before the parent merges.
+- Splitting truly interdependent work into multiple PRs.
+
+If you catch yourself thinking *"B is based on A,"* that's the signal
+to combine, not to stack.
+
+If A and B are **truly independent**, each gets its own PR targeting
+`main`, in any merge order — that's not stacking, that's parallel.
+
+---
+
+## 4. Do not accumulate technical debt
+
+Fix it now, in the PR that introduces or touches it. No deferral, no
+"we'll clean this up later," no follow-up issue as cover for shipping
+half-finished work.
+
+**Forbidden in any PR:**
+
+- `// TODO`, `// FIXME`, `// XXX` comments deferring real work — the
+  only TODO that is acceptable is the **transitional-code TODO** with a
+  tracking issue link, as `code_style.md` documents (`// TODO(#1234):
+  Remove after migration X ships`).
+- Commented-out code blocks ("might need this later").
+- `skip:` / `@Skip` / `xtest` on tests without a tracked issue and a
+  hard removal date.
+- `// ignore: <lint>` or `// ignore_for_file:` without an inline
+  explanation of *why* the rule cannot be satisfied.
+- Failing tests "we'll fix in a follow-up."
+- Generated files left out of sync with their inputs.
+- Dead code, unused imports, unused variables — fix them, don't
+  suppress them.
+- Half-finished refactors that leave both old and new code paths live.
+
+**If a problem is bigger than the PR, scope-cut the PR — don't ship
+partial work and a TODO.** Open a focused PR for just the fix you can
+finish.
+
+If you discover unrelated rot while working, leave it alone (don't
+scope-creep) — but never make it worse.
+
+Every merged PR should leave the codebase in a state you'd be happy to
+inherit cold.
+
+---
+
+## 5. Failing tests are never acceptable, and always your fault
+
+**`origin/main` always passes.** Therefore any failing test on a feature
+branch is caused by something in that branch's diff. Full stop.
+
+When an agent says *"this test is flaky"* or *"this was already broken
+on main"* or *"we'll fix it in a follow-up,"* it is almost always
+wrong. The real explanations, in order of frequency:
+
+1. The change broke the behavior the test asserts (most common).
+2. The change broke a test setup invariant — mocks, fixtures, or
+   generated files (Riverpod, Freezed, JSON, Mockito, Drift) out of
+   sync with their inputs.
+3. The change reveals a real race or order-dependence the test
+   correctly catches.
+4. A genuinely flaky test — extremely rare. If you find one, fix it;
+   don't tolerate it.
+
+*"It passed locally"* is not evidence the test is flaky. It's evidence
+the local environment differs from CI. Investigate the difference.
+
+### When a test fails on your branch
+
+1. **Assume it's your fault.** Read the failure carefully. Trace from
+   the assertion back through the production code your branch changed.
+2. **Compare against `origin/main`.** Run the same test on
+   `origin/main`. If it passes there, the cause is in your diff:
+   `git diff origin/main -- <file>`.
+3. **If you touched generated-code inputs**, run
+   `dart run build_runner build --delete-conflicting-outputs` from
+   `mobile/` and commit the regenerated files.
+4. **If the test seems unrelated**, look harder. You probably changed a
+   shared dependency, a constant, a default, or a public API consumed
+   by that test.
+5. **Fix the underlying cause.** Do not modify the test to make it
+   pass unless the test was genuinely wrong (rare — be suspicious of
+   yourself when you reach for this).
+
+### Forbidden
+
+- *"Flaky, will retry"* — find the race or order-dependence and fix it.
+- `skip:` / `@Skip` / `xtest` to silence a failing test.
+- *"Already broken on main"* without verifying on `origin/main`.
+- Pushing with red local tests "to see what CI says."
+- Claiming "tests pass" without having actually run them — see
+  `superpowers:verification-before-completion`.
+
+### Before every push
+
+- Run the affected test suites locally.
+- Run `flutter analyze lib test integration_test`.
+- Verify the rebase onto `origin/main` did not break anything.
+- If anything is red, do not push. Fix it.

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -10,6 +10,18 @@ before continuing.
 
 ---
 
+## Before starting any task
+
+Branch hygiene (see [`agent_workflow.md`](agent_workflow.md)):
+
+- [ ] Working in a **new worktree branched from `origin/main`** — not on
+  `main`, not in a stale worktree, not on a branch from local `main`.
+  Did you `git fetch origin` first?
+- [ ] One task per worktree. If the current worktree has unrelated WIP,
+  it's not the right place to start new work.
+
+---
+
 ## Before planning a feature
 
 Architecture and ownership:
@@ -136,7 +148,10 @@ Then:
   emoji TODOs left behind.
 - [ ] No unused imports, unused locals, dead code from a removed
   approach.
-- [ ] Format, analyze, and scoped tests all pass locally.
+- [ ] Format, analyze, and scoped tests all pass locally. **Never push
+  red** — `origin/main` always passes, so any failing test on your
+  branch is caused by your diff. See
+  [`agent_workflow.md`](agent_workflow.md#5-failing-tests-are-never-acceptable-and-always-your-fault).
 - [ ] Generated files (Riverpod, Freezed, JSON, Mockito, Drift) are
   regenerated and staged if you touched inputs.
 - [ ] `pubspec.lock` churn from a different SDK/pub-resolver run is
@@ -149,10 +164,19 @@ Then:
 
 ## Before opening or updating a PR
 
+- [ ] **Rebased onto fresh `origin/main`** before pushing
+  (`git fetch origin && git rebase origin/main`), and pushed with
+  `--force-with-lease`. See
+  [`agent_workflow.md`](agent_workflow.md#2-always-rebase-onto-originmain-before-pushing).
+- [ ] PR targets `main`. **Never `--base <other-branch>`** — if this
+  work depends on another in-flight branch, combine them into one PR.
+  See [`agent_workflow.md`](agent_workflow.md#3-never-stack-prs--combine-dependent-features-into-one-bigger-pr).
 - [ ] PR description follows `pull_request_template.md` (use
   `/pr-summary` to regenerate from commits).
-- [ ] Deferred work is tracked in linked follow-up issues — not left
-  implicit in the PR body.
+- [ ] No deferred work in the diff. No `// TODO` (except
+  transitional-code TODOs with tracking issues), no `@Skip`, no
+  commented-out code, no half-finished refactors. See
+  [`agent_workflow.md`](agent_workflow.md#4-do-not-accumulate-technical-debt).
 - [ ] Screenshots or screen recordings attached for UI changes.
 - [ ] Manual test plan covers both own-profile and other-profile paths
   (or equivalent primary vs secondary code paths) where relevant.

--- a/.claude/skills/argocd-externalsecret-namespace-permission/SKILL.md
+++ b/.claude/skills/argocd-externalsecret-namespace-permission/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: argocd-externalsecret-namespace-permission
+description: |
+  Fix ArgoCD ExternalSecret deployment failing with "namespace X is not permitted in project Y".
+  Use when: (1) ExternalSecret shows OutOfSync in ArgoCD but won't sync, (2) ArgoCD application
+  status shows "namespace X is not permitted in project 'infrastructure'", (3) ExternalSecret
+  targets a namespace managed by a different ArgoCD project, (4) Using apps-of-apps pattern
+  with separate infrastructure and application projects.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# ArgoCD ExternalSecret Namespace Permission Error
+
+## Problem
+ExternalSecrets defined in a shared "external-secrets-resources" ApplicationSet fail to
+deploy to namespaces that aren't in the ArgoCD project's allowed destinations. The sync
+shows OutOfSync but refuses to apply.
+
+## Context / Trigger Conditions
+- ArgoCD application shows `OutOfSync` status but doesn't sync
+- Checking application resources shows:
+  ```
+  message: namespace gorse is not permitted in project 'infrastructure'
+  ```
+- ExternalSecret is in a shared ApplicationSet (e.g., `external-secrets-resources`)
+- Target namespace belongs to a different application (e.g., `gorse` app in `default` project)
+- Using apps-of-apps pattern with project-based isolation
+
+## Root Cause
+ArgoCD projects define allowed destination namespaces. When ExternalSecrets are deployed
+via a centralized "infrastructure" project but target namespaces managed by application-specific
+projects, the infrastructure project doesn't have permission to deploy to those namespaces.
+
+## Solution
+Move the ExternalSecret from the shared external-secrets-resources to the application itself.
+
+### Step 1: Create ExternalSecret in the application
+```yaml
+# k8s/applications/gorse/base/external-secret.yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gorse-secrets
+  namespace: gorse
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: gorse-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: api_key
+      remoteRef:
+        key: gorse-api-key-ENVIRONMENT
+```
+
+### Step 2: Add to application kustomization
+```yaml
+# k8s/applications/gorse/base/kustomization.yaml
+resources:
+  - namespace.yaml
+  - external-secret.yaml  # Add here
+  - deployment.yaml
+```
+
+### Step 3: Add environment-specific patches in overlays
+```yaml
+# k8s/applications/gorse/overlays/staging/kustomization.yaml
+patches:
+  - target:
+      kind: ExternalSecret
+      name: gorse-secrets
+    patch: |-
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: gorse-api-key-staging
+```
+
+### Step 4: Remove from external-secrets-resources
+Remove the ExternalSecret from `k8s/external-secrets/base/` and all overlay patches.
+
+## Verification
+1. Sync the application: `argocd app sync gorse`
+2. Check ExternalSecret status: `kubectl get externalsecrets -n gorse`
+3. Verify secret created: `kubectl get secrets -n gorse`
+
+## Alternative Solutions
+
+### Option 1: Expand project destinations
+Add the namespace to the infrastructure project's allowed destinations in ArgoCD.
+Not recommended as it breaks project isolation.
+
+### Option 2: Use ClusterSecretStore
+If using ClusterSecretStore, the secret can be referenced from any namespace.
+The ExternalSecret itself still needs to be in an allowed namespace.
+
+## Notes
+- This pattern is common when migrating from monolithic to modular ArgoCD setups
+- Each application should own its secret definitions for better isolation
+- ClusterSecretStore remains shared; only ExternalSecret moves
+- The "infrastructure" project typically manages cluster-wide resources, not app-specific secrets

--- a/.claude/skills/art-direct/LICENSE
+++ b/.claude/skills/art-direct/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Noah Raford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/art-direct/README.md
+++ b/.claude/skills/art-direct/README.md
@@ -1,0 +1,88 @@
+# Art Direct
+
+A Claude Code skill for art directing visuals. Point it at any content — an essay, a deck, a document, a webpage — and get back a creative direction you can execute.
+
+## What It Does
+
+1. **Ingests content** — reads any format (HTML, PDF, DOCX, PPTX, markdown, URLs)
+2. **Analyzes** — extracts structure, themes, narrative arc, audience, tone
+3. **Proposes 2-3 visual directions** — each with mood, photography style, reference touchstones, and anti-cliche guidance
+4. **Generates section-by-section visual briefs** using a Five-Lens Framework (Literal, Human, Environmental, Metaphorical, Oblique)
+5. **Outputs AI generation prompts** — formatted for Midjourney, DALL-E, Gemini, Ideogram, and Flux
+6. **Generates images directly** via fal.ai (Flux 2 Pro, ReCraft v3, or any supported model)
+7. **Critiques existing visuals** — reviews images against content intent and recommends replacements
+
+## Installation
+
+Copy the skill files to your Claude Code skills directory:
+
+```bash
+# Clone the repo
+git clone https://github.com/nraford7/art-direct.git
+
+# Copy to Claude Code skills directory
+cp -r art-direct ~/.claude/skills/art-direct
+```
+
+The skill will be available as `/art-direct` in Claude Code.
+
+## Usage
+
+```
+/art-direct                          # Full workflow — ingest, propose, brief
+/art-direct --style editorial-warmth # Apply a house style template
+/art-direct --critique               # Review existing visuals against content
+/art-direct --section "concept"      # Quick single-section visual brief
+```
+
+## Image Generation
+
+When you select "Generate now," the skill generates images via the fal.ai API. Requires `$FAL_API_KEY` environment variable.
+
+Supported models:
+- **Flux 2 Pro** (`fal-ai/flux-pro/v1.1`) — photographic realism
+- **ReCraft v3** (`fal-ai/recraft-v3`) — high-res photorealistic
+- **Ideogram v2** (`fal-ai/ideogram/v2`) — text-in-image, conceptual
+
+Typical cost: ~$0.05-0.10 per image.
+
+## House Style Templates
+
+Reusable visual directions stored as YAML in `styles/`. Two included:
+
+- **Editorial Warmth** — Documentary photography, warm human focus. Think National Geographic meets Kinfolk.
+- **Bold Minimalism** — High-contrast, graphic imagery. Think Apple keynote meets architectural photography.
+
+Create your own by following the template structure in any existing style file.
+
+## The Five-Lens Framework
+
+For any concept, five ways to see it:
+
+| Lens | "Digital transformation" | "Supply chain resilience" |
+|------|--------------------------|--------------------------|
+| **Literal** | Server room corridor, blinking LEDs | Cargo ship cutting through rough seas |
+| **Human** | Developer's face lit by dual monitors at 2am | Dockworker's hands checking manifest in rain |
+| **Environmental** | Empty office at dawn, single laptop glowing | Fog lifting off container yard at sunrise |
+| **Metaphorical** | Old film projector casting light on blank wall | Spider web holding dew drops |
+| **Oblique** | Child's hand drawing a robot | Dominos frozen mid-fall, one glowing |
+
+The oblique lens is the hardest and the most valuable.
+
+## Anti-Cliche Guide
+
+The skill actively rejects visual cliches:
+- Handshakes, lightbulbs, puzzle pieces, mountain summits
+- Hands holding globe, diverse team at whiteboard
+- Plant sprouting = growth, rocket = speed, chess = strategy
+
+Instead, it asks: what does this concept *feel* like? Specificity kills cliche.
+
+## Requirements
+
+- [Claude Code](https://claude.ai/claude-code)
+- `$FAL_API_KEY` for image generation (optional — skill works without it, exporting prompts for manual use)
+
+## License
+
+MIT

--- a/.claude/skills/art-direct/SKILL.md
+++ b/.claude/skills/art-direct/SKILL.md
@@ -1,0 +1,533 @@
+---
+name: art-direct
+description: Art direction for any content — reads text, PDF, Word, HTML, PPT, then proposes 2-3 creative directions with photography style, mood, and visual language. After selection, generates AI image prompts and visual briefs section-by-section. Use when the user shares content and needs visual direction, image sourcing, or creative direction for any material.
+---
+
+# Art Direct
+
+Turn content into visual direction. Point this at anything — a deck, a document, an essay, a brief, a webpage — and get back a creative direction you can actually execute.
+
+## When to Use
+
+- User shares a file (any format) and needs visuals for it
+- Developing visual identity for content before building/designing
+- Translating written material into photography/illustration direction
+- Creating image prompts for AI generation tools
+- Art directing a presentation, document, report, or website
+- Reviewing existing visuals against content intent (critique mode)
+
+## Supported Inputs
+
+Read content from whatever the user provides:
+
+| Format | How to read |
+|--------|-------------|
+| `.txt`, `.md` | Read tool directly |
+| `.html` | Read tool, strip tags to extract text + structure |
+| `.pdf` | Read tool with pages parameter |
+| `.docx` | Extract via `python3 -c "import docx; ..."` or `textutil -convert txt` on macOS |
+| `.pptx` | Extract via `python3 -c "from pptx import Presentation; ..."` |
+| `.rtf` | `textutil -convert txt` on macOS |
+| URL | WebFetch tool |
+
+If a format doesn't extract cleanly, ask the user to paste the text.
+
+## The Workflow
+
+```
+INGEST CONTENT → ANALYSE → PROPOSE 2-3 DIRECTIONS → USER SELECTS → VISUAL BRIEF + PROMPTS
+```
+
+---
+
+## Stage 1: Content Ingestion & Analysis
+
+Read the full content. Extract:
+
+1. **Structure** — What are the units? (slides, sections, chapters, paragraphs, pages)
+2. **Core themes** — The 2-3 big ideas the content is actually about
+3. **Narrative arc** — Does it build? Contrast? Layer? List?
+4. **Audience** — Who receives this? What do they expect to see?
+5. **Tone** — Authoritative? Inspirational? Intimate? Provocative? Technical?
+6. **Key moments** — Which sections carry the most weight, demand the strongest visuals?
+7. **Existing visual language** — If the content already has images, assess what's working and what isn't
+
+**Output a brief content summary** before proceeding. Keep it tight — this is for alignment, not a book report.
+
+---
+
+## Stage 2: Creative Direction Proposals
+
+**If house style template provided** (`--style <name>`):
+- Validate content fits the style
+- Note any tensions and how to bridge them
+- Skip to Stage 3 with adapted style guide
+
+**If no house style:**
+
+Propose **2-3 distinct visual directions**. Each must be genuinely different — not three shades of the same idea. For each:
+
+```
+DIRECTION: [Name — a short handle like "Archival Authority" or "Warm Machinery"]
+
+MOOD
+What it feels like: [emotional quality in 2-3 words]
+Energy: [calm / dynamic / tense / contemplative / electric]
+
+PHOTOGRAPHY STYLE
+Type: [documentary / editorial / conceptual / abstract / archival / illustrative]
+Subjects: [what appears in the images]
+Lighting: [quality of light]
+Color treatment: [warm/cool shift, saturation, film stock reference]
+Composition: [framing approach]
+
+REFERENCE TOUCHSTONES
+"Think [X] meets [Y]" — cite real publications, campaigns, photographers, or brands
+
+WHAT THIS DIRECTION AVOIDS
+[Specific clichés and visual tropes this direction rejects]
+
+WHY THIS FITS THE CONTENT
+[1-2 sentences connecting direction to content themes]
+```
+
+Present all directions. User picks one (or asks for a hybrid). Lock the choice.
+
+---
+
+## Stage 3: Visual Style Guide
+
+Once direction is selected, output the working style guide:
+
+```
+VISUAL STYLE GUIDE: [Content Title]
+Direction: [Chosen direction]
+
+PHOTOGRAPHY STYLE
+─────────────────
+Type: [Documentary / Editorial / Conceptual / Abstract / Archival]
+Subjects: [What to feature — specific, not generic]
+Composition: [Framing rules]
+Lighting: [Light quality]
+Color treatment: [Color approach, film stock if relevant]
+
+MOOD & TONE
+───────────
+Primary emotion: [e.g., quiet confidence]
+Supporting emotions: [e.g., warmth, precision]
+Energy level: [Calm / Dynamic / Tense / Contemplative]
+
+CONSISTENCY RULES
+─────────────────
+• [Shared quality all images must have]
+• [Human subject guidelines]
+• [Color palette anchors — hex codes]
+• [Aspect ratio defaults]
+
+CLICHÉ BLACKLIST
+────────────────
+• [Content-specific images to reject]
+• [Generic tropes to avoid]
+• [Overused metaphors for these themes]
+
+AI GENERATION DEFAULTS
+──────────────────────
+Photography suffix: [standard prompt additions for photo-style generation]
+Illustration suffix: [standard prompt additions for illustration-style generation]
+```
+
+---
+
+## Stage 4: Section-by-Section Execution
+
+Work through the content in its natural units (slides, sections, chapters, key passages). For each:
+
+### Step 1: Interpret the section's job
+What must the visual communicate? What's the emotional beat?
+
+### Step 2: Apply the Five-Lens Framework
+
+Generate options through five lenses:
+
+| Lens | What it shows | When to use |
+|------|---------------|-------------|
+| **Literal** | The thing itself, shot with intention | Content is already specific |
+| **Human** | People experiencing or doing it | Need emotional connection |
+| **Environmental** | Setting, atmosphere, texture | Setting mood, transitions |
+| **Metaphorical** | Concrete visual analogy | Making abstract tangible |
+| **Oblique** | Abstract, unexpected angle | Provoking thought, standing out |
+
+### Step 3: Output the Visual Brief
+
+For the **recommended lens** (guided by the style guide's lens preferences), output:
+
+```
+SECTION: "[Section title or key line]"
+VISUAL JOB: [What this image must do]
+LENS: [Which lens and why]
+
+CONCEPT
+[2-3 sentence description of the exact image — specific enough
+that a photographer could shoot it or a designer could find it]
+
+AI GENERATION PROMPTS
+─────────────────────
+MIDJOURNEY:
+[Full prompt with style suffixes, --ar, --v, --style flags]
+
+DALL-E / GPT IMAGE:
+[Natural language prompt optimized for DALL-E]
+
+GEMINI:
+[Prompt formatted for Gemini image generation]
+
+IDEOGRAM:
+[Prompt formatted for Ideogram, especially for any text-in-image needs]
+
+SOURCING GUIDANCE
+─────────────────
+If searching (not generating):
+  Search: [2-3 specific, refined search queries]
+  Where: [Specific sources — see Source Guide below]
+  Avoid: [What will come up that you should skip]
+
+ALTERNATIVES
+────────────
+[1-2 other lens options briefly described, in case the primary doesn't land]
+```
+
+### Step 4: For content with many sections
+
+Don't generate all sections unprompted. Output:
+1. The first 2-3 sections as examples
+2. A summary table of all remaining sections with recommended lens and one-line concept
+3. Ask which sections to develop fully
+
+---
+
+## The Five-Lens Framework (Detail)
+
+For any concept, five ways to see it:
+
+| Lens | "Digital transformation" | "Supply chain resilience" |
+|------|--------------------------|--------------------------|
+| **Literal** | Server room corridor, blinking LEDs | Cargo ship cutting through rough seas |
+| **Human** | Developer's face lit by dual monitors at 2am | Dockworker's hands checking manifest in rain |
+| **Environmental** | Empty office at dawn, single laptop glowing | Fog lifting off container yard at sunrise |
+| **Metaphorical** | Old film projector casting light on blank wall | Spider web holding dew drops — tension + beauty |
+| **Oblique** | Child's hand drawing a robot | Dominos frozen mid-fall, one glowing |
+
+**The oblique lens is the hardest and the most valuable.** It's the image that makes someone stop and think. Use it for hero images and opening sections.
+
+---
+
+## Source Guide
+
+**Do not default to stock photo sites.** Stock search produces generic results regardless of how specific your terms are. Instead:
+
+### Primary: AI Generation
+The best match for precise creative vision. Generate exactly what the concept describes.
+- **Midjourney** — Best for photographic realism and cinematic quality
+- **DALL-E / GPT Image** — Best for conceptual and illustrative work
+- **Gemini** — Good for diagrams, text-in-image, data visualization
+- **Ideogram** — Best when image includes readable text or typography
+
+### Secondary: Editorial & Archival Sources
+When you need *real* photography (historical, documentary, journalistic):
+- **Getty Editorial** — Photojournalism, historical archives
+- **Magnum Photos** — Documentary photography
+- **Library of Congress** — US historical archives, public domain
+- **NASA Image Gallery** — Space, earth science, technology
+- **Wikimedia Commons** — Public domain, historical
+- **British Museum / Smithsonian** — Historical objects and documents
+- **Internet Archive** — Historical documents, publications, ephemera
+- **Google Arts & Culture** — Museum collections, artworks
+
+### Tertiary: Curated Stock (when you must)
+- **Unsplash** — Best for environmental/atmospheric shots, not people
+- **Pexels** — Acceptable for textures, backgrounds, abstract
+- **Avoid for**: People, business scenarios, technology in use, anything conceptual
+
+### For Specific Needs
+| Need | Best source |
+|------|-------------|
+| Historical technology | Smithsonian, Computer History Museum, Science Museum UK |
+| Architecture | ArchDaily, Dezeen photography |
+| Scientific | Nature journal imagery, NOAA, ESA/Hubble |
+| Cultural | British Library, NYPL Digital Collections |
+| Texture/material | Generate via AI — more control |
+
+---
+
+## Anti-Cliché Guide
+
+### Universal Blacklist
+These images are invisible — viewers have seen them thousands of times:
+- Handshakes (any kind)
+- Lightbulb = idea
+- Puzzle pieces connecting
+- Person on mountain summit
+- Hands holding globe
+- Diverse team pointing at whiteboard
+- Plant sprouting = growth
+- Rocket = launch/speed
+- Chess = strategy
+- Maze = complexity
+- Road diverging in forest = choice
+- Iceberg = hidden depth
+- Bridge = connection
+
+### The Reframing Technique
+When you catch yourself reaching for a cliché:
+
+1. **Name the cliché** — "I'm about to search for a lightbulb"
+2. **Ask: What does this concept *feel* like?** — Not look like. Feel like.
+3. **Ask: What moment captures this for a real person?** — Specificity kills cliché
+4. **Generate that instead**
+
+Example: "Innovation"
+- Cliché: Lightbulb, circuit board, rocket
+- Feels like: The moment before you know if it works
+- Real moment: Engineer's hand hovering over a switch, not yet thrown
+- That's the image
+
+---
+
+## Critique Mode
+
+When pointed at content that already has images (existing deck, webpage, document):
+
+### Step 1: Ingest & View Everything
+
+Read all content. View every image. Do the work before speaking.
+
+### Step 2: Overall Visual Language Summary
+
+Open with a top-level assessment of the visual language across the entire piece. Cover:
+
+- **What register are the images in?** (archival, editorial, stock, mixed — name it)
+- **Is there a unified visual language?** If not, how many competing registers are present?
+- **What's the gap between content intent and visual execution?** The content is trying to say X; the images are saying Y.
+- **What's working and what isn't** — broad strokes, not image-by-image yet
+
+Keep this to a short, direct paragraph or two. This is the headline diagnosis.
+
+### Step 3: Section-by-Section Summary
+
+For each section/slide/chapter, give a **high-level summary** — not an image-by-image table. For each section:
+
+```
+SECTION: [Title or key line]
+CONTENT INTENT: [What this section is trying to communicate]
+VISUAL EXECUTION: [What the images are actually doing — 1-2 sentences]
+VERDICT: [Working / Partially working / Not working — and why in one line]
+STRONGEST IMAGE: [Which one and why, if any]
+WEAKEST IMAGE: [Which one and why — name the specific problem]
+```
+
+Only go image-by-image if the user asks to drill into a specific section.
+
+### Step 4: Recommendations
+
+End with **specific, opinionated recommendations** — not open-ended observations. The format:
+
+```
+RECOMMENDED DIRECTION
+─────────────────────
+Register: [The specific visual register I recommend — e.g., "archival-documentary
+          with warm color treatment" not just "pick a register"]
+Why: [1-2 sentences connecting this to the content's actual themes and audience]
+Reference: [Think X meets Y — cite real touchstones]
+
+WHAT TO KEEP
+────────────
+• [Specific images that already work, and why they're the standard]
+
+WHAT TO REMOVE IMMEDIATELY
+──────────────────────────
+• [Images that actively damage the piece — stock, wrong brand, wrong tone]
+
+WHAT TO REPLACE
+───────────────
+• [Images that are weak/generic — with one-line replacement concepts]
+
+CONSISTENCY RULE
+────────────────
+[The single unifying quality all images should share — stated as a rule
+that can be applied as a yes/no test to any candidate image]
+```
+
+**Be specific. Be opinionated.** Don't say "commit to one register" — say "I recommend archival-documentary with warm tungsten color treatment, because this content is about heritage and the images need to feel like they were pulled from a real company archive. Think Bell Labs photography meets Kinfolk's material warmth."
+
+Then ask: **"Does this direction feel right? If so, I'll generate replacement briefs with AI prompts for every image that needs to change."**
+
+### Step 5: Replacement Briefs (after user confirms)
+
+Once the user agrees to the recommended direction, generate replacement visual briefs for every image flagged for removal or replacement. Use the full Stage 4 section-by-section format:
+
+- Lock the recommended direction as the working style guide
+- For each image to replace, output the full visual brief with:
+  - Concept (specific enough to shoot or generate)
+  - AI generation prompts (Midjourney, DALL-E, Gemini, Ideogram)
+  - Sourcing guidance (where to find real alternatives if not generating)
+  - One alternative lens option
+- For sections that need additional images (currently too few), recommend how many and provide briefs
+
+**Output format:** Generate all replacement briefs at once, numbered to match the original image positions. Export to a text file on the user's Desktop for easy reference and handoff.
+
+### Step 6: Handoff
+
+After replacement briefs are generated, offer next steps:
+
+- **"Generate now"** — Generate images via fal.ai (Flux 2 Pro) directly from the briefs
+- **"Export briefs"** — Save all prompts and guidance to a file for use in Midjourney/DALL-E/external tools
+- **"Rebuild the deck"** — Feed the style guide and replacement images into keynote-slides-skill to produce a revised version
+- **"Save as house style"** — Lock the recommended direction as a reusable YAML template for future work with this brand
+
+---
+
+## Image Generation via fal.ai
+
+When the user selects **"Generate now"**, generate images using Flux 2 Pro via the fal.ai API.
+
+**Requirements:** `$FAL_API_KEY` environment variable must be set.
+
+### How to generate
+
+For each image brief, run this via Bash:
+
+```bash
+curl -s "https://queue.fal.run/fal-ai/flux-pro/v1.1" \
+  -H "Authorization: Key $FAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "<THE DALL-E/FLUX PROMPT FROM THE VISUAL BRIEF>",
+    "image_size": "landscape_16_9",
+    "num_images": 1,
+    "safety_tolerance": "5"
+  }'
+```
+
+This returns a JSON response with a `request_id`. Poll for the result:
+
+```bash
+curl -s "https://queue.fal.run/fal-ai/flux-pro/v1.1/requests/<REQUEST_ID>" \
+  -H "Authorization: Key $FAL_API_KEY"
+```
+
+When status is `"COMPLETED"`, the response contains `images[0].url`. Download it:
+
+```bash
+curl -sL "<IMAGE_URL>" -o "<OUTPUT_PATH>"
+```
+
+### Generation workflow
+
+1. Create an output directory: `.art-direction/generated/` (in the project) or a Desktop folder
+2. For each visual brief, take the DALL-E/GPT Image prompt (these work best with Flux)
+3. Submit to fal.ai, poll for completion, download the result
+4. Name files by section: `section-01-heritage-grid.jpg`, `section-02-legacy-of-discovery.jpg`, etc.
+5. After all images are generated, display them for review using the Read tool
+6. User can approve, request regeneration with adjusted prompts, or switch to a different lens
+
+### Image size options
+
+| `image_size` value | Use for |
+|-------------------|---------|
+| `landscape_16_9` | Presentation slides, hero images |
+| `landscape_4_3` | Standard slides, documents |
+| `portrait_4_3` | Vertical layouts, mobile |
+| `square` | Social media, thumbnails |
+| `square_hd` | High-res square |
+
+### Batch generation
+
+When generating multiple images, submit all requests first (don't wait for each one), then poll for results. This parallelizes the GPU work.
+
+```bash
+# Submit all requests, collect request IDs
+for i in 1 2 3 4 5; do
+  curl -s "https://queue.fal.run/fal-ai/flux-pro/v1.1" \
+    -H "Authorization: Key $FAL_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"prompt\": \"$PROMPT\", \"image_size\": \"landscape_16_9\"}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['request_id'])"
+done
+
+# Then poll each request_id for results
+```
+
+### Cost
+
+Flux 2 Pro via fal.ai is pay-per-image. Typical cost is ~$0.05-0.10 per image. A full deck replacement (10-15 images) runs about $1-2.
+
+### Fallback
+
+If `$FAL_API_KEY` is not set or the API is unavailable:
+- Export briefs to file instead
+- Note that the user can paste prompts into Midjourney, ChatGPT image gen, or higgsfield.ai manually
+
+---
+
+## House Style Templates
+
+Reusable visual directions stored in `~/.claude/skills/art-direct/styles/` as YAML.
+
+```yaml
+name: "Style Name"
+description: "One-line description with reference touchstones"
+
+photography:
+  style: documentary | editorial | conceptual | abstract | archival
+  subjects:
+    preferred: [list of subject types]
+    avoid: [list of subject types to reject]
+  lighting:
+    preferred: [light quality description]
+    avoid: [light quality to reject]
+  composition: [framing rules]
+  color:
+    treatment: [color approach]
+    palette_anchors: [hex codes]
+
+mood:
+  primary: [one emotional quality]
+  supporting: [list of supporting emotions]
+  energy: [calm | dynamic | tense | contemplative]
+
+lens_preferences:
+  default_order: [ordered list of five lenses]
+  weight_toward: [primary lens]
+  notes: "Usage guidance"
+
+cliche_blacklist:
+  universal: [standard clichés]
+  brand_specific: [context-specific clichés]
+
+ai_prompt_suffixes:
+  photography: "prompt suffix for photo-style generation"
+  illustration: "prompt suffix for illustration-style generation"
+
+reference_touchstones:
+  - "Reference 1"
+  - "Reference 2"
+```
+
+---
+
+## Quick Reference
+
+| Invocation | Purpose |
+|------------|---------|
+| `art-direct` | Full workflow — ingest content, propose directions, generate briefs |
+| `art-direct --style <name>` | Apply existing house style template |
+| `art-direct --critique` | Review existing visuals against content intent |
+| `art-direct --section "concept"` | Quick single-section visual brief |
+| `art-direct --from-frontend <project>` | Derive style from frontend-design project |
+
+## Integration
+
+Outputs can feed into:
+- **keynote-slides-skill** — Visual briefs → slide imagery via Gemini generation
+- **branded-pptx-converter** — Visual briefs → PowerPoint image slots
+- **frontend-design** — Style guide → web design visual language

--- a/.claude/skills/art-direct/docs/2026-01-28-art-direct-design.md
+++ b/.claude/skills/art-direct/docs/2026-01-28-art-direct-design.md
@@ -1,0 +1,322 @@
+# Art Direct Skill Design
+
+## Overview
+
+A skill for art directing visuals in PowerPoint and HTML presentations. Transforms concepts into compelling imagery by teaching a structured visual thinking process, then sources actual images across stock libraries and generates AI prompts.
+
+**Core philosophy:** Great visual selection is about *thinking differently*, not searching harder.
+
+## Problem Statement
+
+- Translating abstract concepts into effective image searches is hard
+- Stock photography clichés are invisible to viewers (seen thousands of times)
+- Maintaining visual consistency across a deck requires intentional planning
+- The process is slow and often produces generic results
+
+## The Art Direction Hierarchy
+
+```
+┌─────────────────────────────────────────┐
+│  1. DECK ANALYSIS                       │
+│     Read full content/outline           │
+│     Understand themes, audience, tone   │
+└─────────────────┬───────────────────────┘
+                  ▼
+┌─────────────────────────────────────────┐
+│  2. CONCEPT DIRECTION                   │
+│     Either:                             │
+│     • Match to house style template     │
+│     • Suggest direction based on content│
+└─────────────────┬───────────────────────┘
+                  ▼
+┌─────────────────────────────────────────┐
+│  3. VISUAL STYLE GUIDE                  │
+│     Photography style, color treatment, │
+│     composition rules, what to avoid    │
+└─────────────────┬───────────────────────┘
+                  ▼
+┌─────────────────────────────────────────┐
+│  4. SLIDE-BY-SLIDE EXECUTION            │
+│     Specific images guided by the above │
+└─────────────────────────────────────────┘
+```
+
+## Five-Lens Framework
+
+For each slide, generate options through five distinct lenses:
+
+| Lens | Purpose | Example: "Supply chain resilience" |
+|------|---------|-----------------------------------|
+| **Literal** | The thing itself, cinematically shot | Cargo ship cutting through rough seas |
+| **Human** | People experiencing/doing it | Dockworker's hands checking manifest in rain |
+| **Environmental** | Setting, atmosphere, texture | Fog lifting off container yard at dawn |
+| **Metaphorical** | Concrete visual analogy | Chain with one link glowing, spider web with dew |
+| **Oblique** | Abstract, unexpected angle | Dominos frozen mid-fall |
+
+**When to use each:**
+- **Literal** — Content is already specific ("Our new Rotterdam facility")
+- **Human** — Need emotional connection, trust, relatability
+- **Environmental** — Setting mood, breathing room, transitions
+- **Metaphorical** — Explaining concepts, making abstract tangible
+- **Oblique** — Grabbing attention, provoking thought, standing out
+
+## Stage 1 & 2: Deck Analysis + Concept Direction
+
+**Input:** Deck content (markdown, outline, or existing PPTX) + optional house style template
+
+**Stage 1: Deck Analysis extracts:**
+- Core themes (2-3 big ideas)
+- Narrative arc
+- Audience
+- Tone
+- Key moments (which slides carry most weight)
+
+**Stage 2: Concept Direction**
+
+If house style provided:
+- Validate content fits the style
+- Note tensions and how to bridge them
+- Output adapted style guide
+
+If no house style:
+- Propose 2-3 visual directions based on content analysis
+- Each includes: name, mood, photography style, reference touchstones, what to avoid
+- User picks one, skill locks as working style guide
+
+## Stage 3: Visual Style Guide Format
+
+```
+VISUAL STYLE GUIDE: [Deck Name]
+Direction: [Chosen direction name]
+
+PHOTOGRAPHY STYLE
+─────────────────
+Type: Documentary / Editorial / Conceptual / Abstract
+Subjects: [What to feature - people, environments, objects, textures]
+Composition: [Rule of thirds, off-center, close crop, wide establishing]
+Lighting: [Natural, dramatic, soft, high-contrast]
+Color treatment: [Saturated, muted, warm shift, cool shift, monochromatic]
+
+MOOD & TONE
+───────────
+Primary emotion: [e.g., quiet confidence]
+Supporting emotions: [e.g., warmth, clarity]
+Energy level: [Calm / Dynamic / Tense / Contemplative]
+
+CONSISTENCY RULES
+─────────────────
+• All images share [specific quality - e.g., natural lighting]
+• Human subjects: [candid only / eye contact OK / hands focus]
+• Color palette anchors: [2-3 hex codes that images should harmonize with]
+• Aspect ratio: [16:9 / 4:3 / mixed with rules]
+
+CLICHÉ BLACKLIST
+────────────────
+• [Specific images to avoid for this deck's themes]
+• [Generic stock tropes to reject]
+• [Overused metaphors]
+
+REFERENCE IMAGES
+────────────────
+[Links or descriptions of 3-5 images that nail the style]
+```
+
+## Stage 4: Slide-by-Slide Execution
+
+**Process:**
+1. Interpret the slide's job
+2. Apply style guide filters
+3. Generate options using five-lens framework
+4. Output actionable sourcing (search terms + AI prompts)
+5. Fetch examples from all sources
+6. Display in HTML preview
+
+**Output format:**
+
+```
+SLIDE: "Our market is shifting faster than ever"
+
+STYLE GUIDE CHECK: Documentary Intimacy — candid, warm, natural light
+
+VISUAL OPTIONS
+──────────────
+
+OPTION 1: Literal
+Concept: Trading floor during market hours, screens, movement
+Search terms: "trading floor action", "stock exchange screens traders"
+
+OPTION 2: Human
+Concept: Trader's hands hovering over keyboard, split-second decision
+Search terms: "stock trader hands keyboard tension"
+
+OPTION 3: Environmental
+Concept: Empty trading floor at dawn, screens glowing
+Search terms: "empty trading floor dawn", "financial office early morning"
+
+OPTION 4: Metaphorical
+Concept: Chess pieces mid-game, hand moving knight
+Search terms: "chess strategy hand moving piece", "chess mid-game tension"
+
+OPTION 5: Oblique
+Concept: Blurred city crowds from above — movement, anonymity
+Search terms: "aerial crowd motion blur", "pedestrians overhead long exposure"
+
+RECOMMENDATION: Option 2 — most aligned with style guide's human-focus
+```
+
+## House Style Templates
+
+**Template structure (YAML):**
+
+```yaml
+name: "Editorial Warmth"
+description: "Documentary-style photography with warm, human focus"
+
+photography:
+  style: documentary
+  subjects:
+    preferred: [hands at work, candid faces, real environments]
+    avoid: [posed groups, empty handshakes, obvious stock]
+  lighting: natural, soft, golden hour preferred
+  composition: off-center subjects, negative space, shallow depth of field
+  color:
+    treatment: warm shift, slightly desaturated
+    palette_anchors: ["#D4A574", "#8B7355", "#F5E6D3"]
+
+mood:
+  primary: quiet confidence
+  energy: calm, contemplative
+  emotions: [trust, authenticity, craft]
+
+lens_preferences:
+  default_order: [human, environmental, literal, metaphorical, oblique]
+  weight_toward: human
+
+cliche_blacklist:
+  universal:
+    - handshake silhouette
+    - lightbulb moments
+    - puzzle pieces connecting
+    - person on mountain summit
+  brand_specific:
+    - blue corporate tones
+    - glass building reflections
+
+ai_prompt_suffixes:
+  photography: "documentary style, natural lighting, Kodak Portra 400 --ar 16:9"
+  illustration: "editorial illustration, muted palette, subtle texture"
+```
+
+**Storage locations:**
+- `~/.claude/skills/art-direct/styles/` (user global)
+- `.art-direction/styles/` (project local)
+
+**Cross-skill template sourcing:**
+- Can extract from frontend-design skill when instructed
+- Maps design tokens (colors, typography, principles) to photography direction
+- Command: `art-direct --from-frontend <project-name>`
+
+## Image Fetching
+
+**Sources (query all in parallel):**
+- Unsplash API
+- Pexels API
+- Google Images (web search)
+
+**AI generation — prompt export:**
+Generates formatted prompts for manual use:
+- Midjourney format
+- DALL-E format
+- Ideogram format
+
+Future: `--generate` flag will call configured API directly.
+
+## Display & Review
+
+**Primary: HTML preview file**
+
+Skill generates visual review page at `.art-direction/previews/slide-XX-name.html`
+
+Features:
+- Images organized by lens (Literal, Human, Environmental, Metaphorical, Oblique)
+- Source attribution (Unsplash, Pexels, Google)
+- Style guide match indicators
+- Copy buttons for AI prompts
+- Download selected images
+- Navigate between slides
+
+**Fallback:** Markdown with image URLs or save to `.art-direction/images/`
+
+## Integration with Existing Skills
+
+**Handoff manifest:** `.art-direction/manifest.yaml`
+
+```yaml
+deck: Q4 Strategy Presentation
+style_guide: Editorial Warmth
+created: 2026-01-28
+
+slides:
+  - slide: 1
+    title: "Opening"
+    image:
+      selected: ".art-direction/images/slide-01-selected.jpg"
+      source: "unsplash"
+      url: "https://unsplash.com/photos/abc123"
+      alt: "Morning light through office windows"
+
+color_palette:
+  extracted_from_images: ["#D4A574", "#1A3A5C", "#F5E6D3"]
+
+suggested_brand_overrides:
+  accent_color: "#D4A574"
+```
+
+**Export commands:**
+- `art-direct --export pptx` → Prepares for branded-pptx-converter
+- `art-direct --export keynote` → Prepares for keynote-slides-skill
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `art-direct` | Full workflow from deck content |
+| `art-direct --style <name>` | Apply existing house style |
+| `art-direct --from-frontend <project>` | Derive style from frontend-design |
+| `art-direct --slide "concept"` | Quick single-slide lookup |
+| `art-direct --export pptx` | Prepare assets for branded-pptx-converter |
+| `art-direct --export keynote` | Prepare assets for keynote-slides-skill |
+
+## Anti-Cliché Principle
+
+Stock photography trains us to reach for the obvious:
+- "Innovation" → lightbulb
+- "Teamwork" → hands stacked
+- "Growth" → plant sprouting
+
+These images are invisible — viewers process them as noise.
+
+**Three-level reframing:**
+1. **Literal** → What the concept looks like directly (often cliché)
+2. **Metaphorical** → What the concept is *like* (better but can be tired)
+3. **Emotional/Atmospheric** → What the concept *feels* like (most distinctive)
+
+Example: "Digital transformation"
+- Literal: Circuit boards, binary code (cliché)
+- Metaphorical: Butterfly emerging, bridge old/new (tired)
+- Emotional: Empty office at dawn with single laptop glowing (distinctive)
+
+## Dependencies
+
+- WebSearch tool (Google Images)
+- Unsplash API (MCP tool or script)
+- Pexels API (MCP tool or script)
+- HTML generation for previews
+
+## Next Steps
+
+1. Create SKILL.md with workflow
+2. Create style template examples
+3. Build HTML preview generator
+4. Implement image fetching scripts
+5. Test with real deck content

--- a/.claude/skills/art-direct/styles/bold-minimalism.yaml
+++ b/.claude/skills/art-direct/styles/bold-minimalism.yaml
@@ -1,0 +1,73 @@
+name: "Bold Minimalism"
+description: "High-contrast, graphic imagery with strong visual impact. Think Apple keynote meets architectural photography."
+
+photography:
+  style: conceptual, graphic
+  subjects:
+    preferred:
+      - isolated objects on clean backgrounds
+      - strong architectural lines
+      - dramatic silhouettes
+      - high-contrast textures
+      - single focal point
+    avoid:
+      - busy, cluttered scenes
+      - multiple competing subjects
+      - warm nostalgic tones
+      - candid/documentary style
+  lighting:
+    preferred: dramatic, directional, high contrast, studio
+    avoid: flat lighting, multiple soft sources
+  composition:
+    - centered subjects with symmetry
+    - extreme negative space (60%+ empty)
+    - geometric framing
+    - dramatic angles (very low or overhead)
+  color:
+    treatment: high contrast, limited palette, often monochromatic
+    palette_anchors:
+      - "#000000"  # pure black
+      - "#FFFFFF"  # pure white
+      - "#0066FF"  # electric blue accent
+      - "#1A1A1A"  # near-black
+
+mood:
+  primary: confident authority
+  supporting:
+    - precision
+    - innovation
+    - clarity
+    - power
+  energy: dynamic, assertive
+
+lens_preferences:
+  default_order:
+    - literal
+    - oblique
+    - environmental
+    - metaphorical
+    - human
+  weight_toward: literal
+  notes: "Lead with striking literal imagery. Use oblique for conceptual slides. Human moments should feel iconic, not candid."
+
+cliche_blacklist:
+  universal:
+    - handshake silhouette
+    - lightbulb = idea
+    - puzzle pieces
+    - generic team photos
+  brand_specific:
+    - warm earthy tones
+    - textured/vintage looks
+    - busy lifestyle photography
+    - soft focus
+
+ai_prompt_suffixes:
+  photography: "studio photography, high contrast, dramatic lighting, minimalist composition, pure black or white background --ar 16:9 --style raw"
+  illustration: "geometric illustration, limited color palette, vector-clean, bold shapes, Swiss design influence"
+
+reference_touchstones:
+  - "Apple product photography"
+  - "Tesla presentation imagery"
+  - "Architectural Digest minimalism"
+  - "Swiss International Style graphics"

--- a/.claude/skills/art-direct/styles/editorial-warmth.yaml
+++ b/.claude/skills/art-direct/styles/editorial-warmth.yaml
@@ -1,0 +1,80 @@
+name: "Editorial Warmth"
+description: "Documentary-style photography with warm, human focus. Think National Geographic meets Kinfolk magazine."
+
+photography:
+  style: documentary
+  subjects:
+    preferred:
+      - hands at work
+      - candid faces in concentration
+      - real working environments
+      - natural textures and materials
+      - authentic moments (not staged)
+    avoid:
+      - posed corporate groups
+      - empty handshakes
+      - obvious stock setups
+      - sterile office environments
+      - people pointing at screens
+  lighting:
+    preferred: natural, soft, golden hour, window light
+    avoid: harsh flash, overly lit studio setups
+  composition:
+    - off-center subjects (rule of thirds)
+    - generous negative space
+    - shallow depth of field for intimacy
+    - environmental context visible
+  color:
+    treatment: warm shift, slightly desaturated, film-like
+    palette_anchors:
+      - "#D4A574"  # warm tan
+      - "#8B7355"  # muted brown
+      - "#F5E6D3"  # cream
+      - "#5C4033"  # deep brown
+
+mood:
+  primary: quiet confidence
+  supporting:
+    - authenticity
+    - warmth
+    - craftsmanship
+    - trust
+  energy: calm, contemplative
+
+lens_preferences:
+  default_order:
+    - human
+    - environmental
+    - literal
+    - metaphorical
+    - oblique
+  weight_toward: human
+  notes: "Prioritize candid human moments. Use environmental for transitions and breathing room."
+
+cliche_blacklist:
+  universal:
+    - handshake silhouette
+    - lightbulb = idea
+    - puzzle pieces connecting
+    - person on mountain summit
+    - hands holding globe
+    - diverse team pointing at whiteboard
+    - plant sprouting = growth
+    - rocket launching
+    - chess pieces = strategy
+    - maze = complexity
+  brand_specific:
+    - blue corporate tones
+    - glass building reflections
+    - sterile white backgrounds
+    - overly cheerful stock smiles
+
+ai_prompt_suffixes:
+  photography: "documentary photography, natural lighting, warm tones, Kodak Portra 400 film grain, shallow depth of field --ar 16:9 --style raw"
+  illustration: "editorial illustration style, muted warm palette, subtle paper texture, hand-drawn feel"
+
+reference_touchstones:
+  - "National Geographic documentary photography"
+  - "Kinfolk magazine aesthetic"
+  - "Patagonia brand imagery"
+  - "Apple 'Shot on iPhone' campaign naturalism"

--- a/.claude/skills/async-await-null-race-condition/SKILL.md
+++ b/.claude/skills/async-await-null-race-condition/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: async-await-null-race-condition
+description: |
+  Fix "Null check operator used on a null value" errors when an object is set to null
+  during an async await. Use when: (1) Object reference is nullified while awaiting,
+  (2) Code accesses object with ! after await returns, (3) Cancel/dispose operations
+  run concurrently with async operations on same object. Solution: capture local
+  reference before await.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Async Await Null Race Condition
+
+## Problem
+When an async operation is awaiting, external code can set the object reference to null.
+When the await completes, accessing the object with `!` throws "Null check operator
+used on a null value".
+
+## Context / Trigger Conditions
+- Error: `Null check operator used on a null value`
+- Pattern: `await someObject!.asyncMethod()` followed by `someObject!.property`
+- Object can be nullified by cancel/dispose/cleanup operations
+- Concurrent operations on shared mutable state
+- Typically seen with session objects, connection handlers, or service references
+
+## Solution
+
+### Wrong - Object can become null during await:
+```dart
+Future<Result> waitForResponse() async {
+  // _session might be set to null while we're awaiting
+  final result = await _session!.waitForConnection();
+
+  if (result == null) {
+    // BUG: _session could be null here!
+    final state = _session!.state;  // Throws null check error
+    ...
+  }
+}
+
+void cancel() {
+  _session?.cancel();
+  _session = null;  // This runs while waitForResponse is awaiting
+}
+```
+
+### Correct - Capture local reference before await:
+```dart
+Future<Result> waitForResponse() async {
+  // Capture reference BEFORE await
+  final session = _session!;
+
+  final result = await session.waitForConnection();
+
+  // Check if cancelled during await
+  if (_session == null) {
+    return Result.cancelled();
+  }
+
+  if (result == null) {
+    // Safe - using captured local reference
+    final state = session.state;
+    ...
+  }
+}
+```
+
+## Verification
+1. Trigger the cancel/dispose operation while async operation is in progress
+2. No null check errors should occur
+3. Operation should gracefully handle cancellation
+
+## Example - Full Pattern
+
+```dart
+class ConnectionManager {
+  Session? _session;
+
+  Future<ConnectionResult> connect() async {
+    if (_session == null) {
+      return ConnectionResult.failure('No session');
+    }
+
+    // Capture before await
+    final session = _session!;
+
+    final response = await session.waitForResponse(
+      timeout: Duration(minutes: 2),
+    );
+
+    // Check if cancelled during await
+    if (_session == null) {
+      return ConnectionResult.failure('Cancelled');
+    }
+
+    // Safe to use captured reference
+    if (response == null) {
+      return ConnectionResult.failure(session.errorMessage);
+    }
+
+    return ConnectionResult.success(response);
+  }
+
+  void cancel() {
+    _session?.cancel();
+    _session?.dispose();
+    _session = null;
+  }
+}
+```
+
+## Notes
+- This pattern applies to any mutable reference that can be nullified externally
+- Common in Flutter/Dart with dispose patterns, Riverpod providers, and WebSocket sessions
+- The captured local reference keeps the object alive during the await
+- Always add a null check after await to detect cancellation
+- Consider using `Completer` cancellation patterns for more complex scenarios
+
+## Related Patterns
+- `riverpod-ref-read-in-dispose` - Similar issue with Riverpod ref lifecycle
+- `flutter-dispose-timer-test-failure` - Timer callbacks after disposal

--- a/.claude/skills/aws-v4-signing-custom-headers-gcs/SKILL.md
+++ b/.claude/skills/aws-v4-signing-custom-headers-gcs/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: aws-v4-signing-custom-headers-gcs
+description: |
+  Add custom metadata headers (x-amz-meta-*) to AWS v4 signed requests for GCS S3-compatible
+  API. Use when: (1) Adding custom metadata to GCS uploads via S3 API, (2) Getting signature
+  mismatch errors after adding new headers, (3) x-amz-meta-* headers being ignored or causing
+  403 errors. Custom headers MUST be included in canonical headers and signed headers list.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-20
+---
+
+# AWS v4 Signing with Custom Metadata Headers for GCS
+
+## Problem
+
+When adding custom metadata headers (`x-amz-meta-*`) to GCS S3-compatible API requests,
+the requests fail with signature mismatch errors. The headers must be properly included
+in the AWS v4 signature calculation.
+
+## Context / Trigger Conditions
+
+- Using GCS S3-compatible XML API (not the native JSON API)
+- Adding `x-amz-meta-*` headers for object metadata
+- Error: "SignatureDoesNotMatch" or 403 Forbidden after adding headers
+- Headers work with unsigned requests but fail with AWS v4 signing
+- HMAC credentials configured for GCS interoperability
+
+## Solution
+
+Custom headers must be included in **both** the canonical headers and the signed headers list,
+sorted **alphabetically**:
+
+### 1. Canonical Headers (alphabetically sorted)
+
+```rust
+let canonical_headers = format!(
+    "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\nx-amz-meta-owner:{}\n",
+    host, payload_hash, amz_date, owner  // Note: alphabetical order!
+);
+```
+
+### 2. Signed Headers List
+
+```rust
+let signed_headers = "host;x-amz-content-sha256;x-amz-date;x-amz-meta-owner";
+```
+
+### 3. Complete Example (Rust)
+
+```rust
+fn sign_request_with_owner(
+    req: &mut Request,
+    config: &GCSConfig,
+    payload_hash: Option<String>,
+    owner: &str
+) -> Result<()> {
+    // Set headers first
+    req.set_header("x-amz-date", &amz_date);
+    req.set_header("x-amz-content-sha256", &payload_hash);
+    req.set_header("x-amz-meta-owner", owner);  // Custom metadata
+
+    // Canonical headers - MUST be alphabetically sorted
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date;x-amz-meta-owner";
+    let canonical_headers = format!(
+        "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\nx-amz-meta-owner:{}\n",
+        host, payload_hash, amz_date, owner
+    );
+
+    // Rest of AWS v4 signing...
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method, uri, query, canonical_headers, signed_headers, payload_hash
+    );
+
+    // Sign and add Authorization header...
+}
+```
+
+## Verification
+
+After uploading, verify metadata is present:
+```bash
+gsutil stat gs://bucket/object-name
+# Should show:
+#     Metadata:
+#         owner: <value>
+```
+
+Or via S3 API:
+```bash
+aws s3api head-object --bucket bucket --key object-name --endpoint-url https://storage.googleapis.com
+```
+
+## Example
+
+**Before (broken)** - header not in signature:
+```rust
+let signed_headers = "host;x-amz-content-sha256;x-amz-date";  // Missing x-amz-meta-owner
+req.set_header("x-amz-meta-owner", owner);  // Header added but not signed
+// Result: 403 SignatureDoesNotMatch
+```
+
+**After (working)** - header properly signed:
+```rust
+let signed_headers = "host;x-amz-content-sha256;x-amz-date;x-amz-meta-owner";  // Included!
+req.set_header("x-amz-meta-owner", owner);
+// Include in canonical_headers too
+// Result: 200 OK, metadata visible in GCS
+```
+
+## Notes
+
+- Header names are case-insensitive but conventionally lowercase in canonical form
+- The semicolon-separated signed headers list must match the newline-separated canonical headers
+- For GCS, the metadata appears as `Metadata: key: value` in gsutil stat output
+- When using the native GCS JSON API, use the `metadata` object field instead
+- Multiple custom headers can be added - just ensure all are in canonical/signed lists
+
+## References
+
+- AWS Signature Version 4: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+- GCS S3 Interoperability: https://cloud.google.com/storage/docs/interoperability
+- GCS Object Metadata: https://cloud.google.com/storage/docs/metadata

--- a/.claude/skills/bash-herestring-newline-secrets/SKILL.md
+++ b/.claude/skills/bash-herestring-newline-secrets/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: bash-herestring-newline-secrets
+description: |
+  Fix password/secret authentication failures caused by trailing newlines when creating
+  Google Cloud secrets (or similar) with bash here-strings. Use when: (1) Password
+  authentication fails with correct password, (2) Secret created with `<<< "value"` syntax,
+  (3) Error like "password authentication failed" or "invalid token" despite correct value.
+  Bash here-strings (`<<<`) add a trailing newline that corrupts secrets.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-31
+---
+
+# Bash Here-String Newline in Secrets
+
+## Problem
+When creating secrets using bash here-strings (`<<<`), a trailing newline is silently
+appended to the value. This causes authentication failures with misleading error messages
+that suggest the password/token is wrong when it's actually correct—just with an extra
+newline character.
+
+## Context / Trigger Conditions
+- Secret created with: `gcloud secrets create NAME --data-file=- <<< "value"`
+- Or similar: `echo "value" | gcloud secrets create...` (echo adds newline by default)
+- Error messages like:
+  - "password authentication failed for user X"
+  - "invalid token"
+  - "authentication failed"
+- The secret value appears correct when viewed
+- Works locally but fails when secret is used
+
+## Solution
+
+**Wrong (adds newline):**
+```bash
+gcloud secrets create my-secret --data-file=- <<< "mypassword"
+echo "mypassword" | gcloud secrets create my-secret --data-file=-
+```
+
+**Correct (no newline):**
+```bash
+echo -n "mypassword" | gcloud secrets create my-secret --data-file=-
+printf '%s' "mypassword" | gcloud secrets create my-secret --data-file=-
+```
+
+**To fix an existing secret:**
+```bash
+echo -n "correct-value" | gcloud secrets versions add my-secret --data-file=-
+```
+
+## Verification
+
+Check the secret length to detect trailing newline:
+```bash
+# Get secret and count bytes
+gcloud secrets versions access latest --secret=my-secret | wc -c
+# Compare to expected length (password length, not password length + 1)
+```
+
+Or use `xxd` to see the actual bytes:
+```bash
+gcloud secrets versions access latest --secret=my-secret | xxd | tail -1
+# Look for '0a' (newline) at the end
+```
+
+## Example
+
+**Symptom:**
+```
+Database connection test failed: password authentication failed for user "crawler"
+```
+
+**Investigation:**
+```bash
+$ gcloud secrets versions access latest --secret=my-db-password
+mypassword
+$ gcloud secrets versions access latest --secret=my-db-password | wc -c
+11  # But password is only 10 characters!
+```
+
+**Fix:**
+```bash
+$ echo -n "mypassword" | gcloud secrets versions add my-db-password --data-file=-
+Created version [2] of the secret [my-db-password].
+```
+
+## Notes
+- This affects any system that uses secrets: databases, APIs, tokens, etc.
+- The `<<<` here-string is a bash feature that ALWAYS adds a newline
+- `echo` also adds a newline by default; use `echo -n` or `printf '%s'`
+- Some systems trim whitespace from secrets, but many (like PostgreSQL) don't
+- When debugging auth failures, always check for trailing whitespace first
+
+## References
+- Bash manual on here-strings: https://www.gnu.org/software/bash/manual/bash.html#Here-Strings

--- a/.claude/skills/blossom-content-addressed-url-filtering/SKILL.md
+++ b/.claude/skills/blossom-content-addressed-url-filtering/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: blossom-content-addressed-url-filtering
+description: |
+  Fix silent video/media processing failures caused by URL extraction code that filters
+  on file extensions (.mp4, .webm, .webp). Use when: (1) Media moderation, transcoding,
+  or analysis silently skips files from Blossom or content-addressed storage servers,
+  (2) URL extraction from Nostr event tags (imeta, r tags) drops URLs without recognized
+  extensions, (3) CDN fallback URLs append .mp4 but the actual server uses extensionless
+  content-addressed paths like /{sha256}. Common in Nostr video events (kind 34236)
+  where different clients use different URL formats.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-05
+---
+
+# Blossom Content-Addressed URL Filtering
+
+## Problem
+Code that extracts video URLs from Nostr events (or similar tag-based metadata) silently
+drops URLs from Blossom servers and other content-addressed storage because it filters on
+file extensions like `.mp4`. These servers use hash-based URLs without extensions
+(e.g. `https://blossom.example.com/{sha256}`), causing the URL extraction to fail and
+fall back to a CDN URL that also 404s for non-CDN content.
+
+## Context / Trigger Conditions
+- Videos from certain servers are never processed (moderated, transcoded, etc.)
+- URL extraction code contains patterns like `url.includes('.mp4')` or `url.includes('/video/')`
+- Nostr `imeta` tag URL extraction requires `.mp4` in the URL string
+- Nostr `r` tag filtering checks for `.mp4` or `/video/` in the URL
+- CDN fallback constructs `https://cdn.domain/{sha256}.mp4` but server serves at `/{sha256}`
+- Content-addressed storage (Blossom, IPFS gateways) uses extensionless URLs
+- Failures are silent — no errors, videos just never appear in the processing pipeline
+
+## Solution
+
+### 1. Remove extension filtering from URL extraction
+
+**Bad** (drops blossom URLs):
+```javascript
+// imeta tag extraction
+if (param.startsWith('url ') && param.includes('.mp4')) {
+  url = param.substring(4).trim();
+}
+
+// r tag extraction
+if (url.includes('.mp4') || url.includes('/video/')) {
+  return url;
+}
+```
+
+**Good** (accepts any URL):
+```javascript
+// imeta tag extraction — accept any URL
+if (param.startsWith('url ') && param.length > 4) {
+  url = param.substring(4).trim();
+}
+
+// r tag extraction — accept any http URL
+if (url.startsWith('http')) {
+  return url;
+}
+```
+
+### 2. For kind-specific events, trust the event kind
+
+If you already know an event is a video event (e.g. kind 34236), any URL in its tags
+is a video URL. Don't re-validate the media type by extension.
+
+### 3. Use mime type from imeta instead of extension
+
+If you need to validate media type, use the `m` field in imeta tags:
+```javascript
+for (const param of tag.slice(1)) {
+  if (param.startsWith('m video/')) isVideo = true;
+  if (param.startsWith('url ')) imetaUrl = param.substring(4).trim();
+}
+```
+
+### 4. Fix CDN fallback URLs
+
+```javascript
+// Bad: appends .mp4
+let videoUrl = `https://${CDN_DOMAIN}/${sha256}.mp4`;
+
+// Good: content-addressed path (no extension)
+let videoUrl = `https://${CDN_DOMAIN}/${sha256}`;
+```
+
+## Verification
+- Check that videos from non-CDN blossom servers appear in the moderation/processing queue
+- Verify that `extractVideoUrlFromEvent` returns URLs for events with extensionless imeta/r tags
+- Confirm CDN fallback URLs resolve correctly without `.mp4` extension
+
+## Example
+A Nostr kind 34236 event with tags:
+```json
+["imeta", "url https://blossom.primal.net/abc123def456...", "m video/mp4", "x abc123def456..."]
+```
+
+Old code: `url.includes('.mp4')` → false → URL dropped → CDN fallback → 404 → video never moderated
+
+New code: accepts any URL from imeta → `https://blossom.primal.net/abc123def456...` → HiveAI can fetch it → video moderated
+
+## Notes
+- This applies to ANY media processing pipeline, not just moderation
+- Blossom (BUD-01) uses `/{sha256}` paths; some servers add Content-Type headers
+- HLS streams (.m3u8), WebP thumbnails, and other formats also won't have .mp4 extensions
+- Some rogue clients may not follow any path convention at all
+- The `m` (mime type) field in imeta is the proper way to determine media type, not the URL path
+- Prioritize imeta URLs over r tag URLs (imeta is more specific/reliable)

--- a/.claude/skills/certmanager-dns01-gke-private-cluster/SKILL.md
+++ b/.claude/skills/certmanager-dns01-gke-private-cluster/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: certmanager-dns01-gke-private-cluster
+description: |
+  Fix cert-manager DNS01 ACME challenges stuck in "pending" state with "DNS record not yet
+  propagated" inside GKE private clusters, even when TXT records exist in Cloudflare DNS.
+  Use when: (1) cert-manager challenges show "pending" for hours with propagation check failures,
+  (2) dig from outside cluster shows correct TXT records but cert-manager can't verify them,
+  (3) Using Cloudflare DNS01 solver in a GKE private cluster with Cloud NAT,
+  (4) Google Cloud intercepts 8.8.8.8 DNS queries returning NXDOMAIN for Cloudflare-managed records,
+  (5) Even --dns01-recursive-nameservers with 1.1.1.1 doesn't fix the propagation check despite
+  TXT records being verifiable from busybox pods in the same namespace. Covers the full debugging
+  flow and certbot manual workaround.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-28
+---
+
+# Cert-Manager DNS01 Challenge Failure in GKE Private Clusters
+
+## Problem
+Cert-manager DNS01 ACME challenges get stuck in "pending" state indefinitely inside GKE private
+clusters. The propagation check fails with "DNS record for X not yet propagated" even though
+the TXT records are correctly created in Cloudflare and verifiable from everywhere — including
+from inside the cluster using busybox pods.
+
+## Context / Trigger Conditions
+- cert-manager with Cloudflare DNS01 solver
+- GKE private cluster (private nodes, public endpoint) with Cloud NAT
+- Challenges show `presented: true` but `state: pending` for hours
+- cert-manager logs show: `"propagation check failed" err="DNS record for \"example.com\" not yet propagated"`
+- `dig TXT _acme-challenge.example.com` from outside returns correct value
+- busybox `nslookup` from inside cluster also returns correct value
+- Certificate resource shows `Ready: False` with `reason: RequestChanged`
+
+## Root Causes Discovered
+
+### 1. Google Cloud intercepts DNS to 8.8.8.8
+Inside GKE VPCs, DNS queries to `8.8.8.8` are intercepted by Google Cloud infrastructure.
+For Cloudflare-managed domains, this can return **NXDOMAIN** even when the record exists.
+This is because Google routes 8.8.8.8 through their internal DNS infrastructure which may
+have different resolution behavior than the public Google DNS service.
+
+**Verification:**
+```bash
+# From inside cluster - returns NXDOMAIN
+kubectl run dns-test --image=busybox:1.36 --rm -i --restart=Never -- \
+  nslookup -type=TXT _acme-challenge.example.com 8.8.8.8
+
+# From inside cluster - returns correct result
+kubectl run dns-test --image=busybox:1.36 --rm -i --restart=Never -- \
+  nslookup -type=TXT _acme-challenge.example.com 1.1.1.1
+```
+
+### 2. Cert-manager propagation check still fails with correct resolvers
+Even after configuring `--dns01-recursive-nameservers=1.1.1.1:53,1.0.0.1:53` and
+`--dns01-recursive-nameservers-only=true`, cert-manager's propagation check may still fail.
+The Go DNS library used by cert-manager (miekg/dns) behaves differently from busybox's
+nslookup. The exact cause is unclear but may relate to:
+- DNS response parsing differences between miekg/dns and system resolvers
+- TCP vs UDP DNS query differences
+- Internal cert-manager caching or timing issues
+- Cloud NAT interaction with DNS traffic patterns
+
+## Solution
+
+### Attempt 1: Configure recursive DNS resolvers (may not be sufficient)
+Add to cert-manager Helm values:
+```yaml
+dns01RecursiveNameservers: "1.1.1.1:53,1.0.0.1:53"
+dns01RecursiveNameserversOnly: true
+```
+
+**IMPORTANT:** Do NOT use `8.8.8.8` — Google Cloud intercepts this inside GKE VPCs.
+
+For ArgoCD-managed cert-manager (Helm chart), add to the Application `valuesObject`:
+```yaml
+valuesObject:
+  dns01RecursiveNameservers: "1.1.1.1:53,1.0.0.1:53"
+  dns01RecursiveNameserversOnly: true
+```
+
+### Attempt 2: Manual cert generation with certbot (reliable workaround)
+If the resolver fix doesn't work, generate the cert locally and inject it:
+
+```bash
+# Install certbot with Cloudflare plugin
+pipx install certbot
+pipx inject certbot certbot-dns-cloudflare
+
+# Get Cloudflare API token from cluster
+CF_TOKEN=$(kubectl get secret cloudflare-api-token-secret -n cert-manager \
+  -o jsonpath='{.data.api-token}' | base64 -d)
+
+# Create credentials file
+mkdir -p /tmp/certbot-cf
+echo "dns_cloudflare_api_token = $CF_TOKEN" > /tmp/certbot-cf/cloudflare.ini
+chmod 600 /tmp/certbot-cf/cloudflare.ini
+
+# Generate certificate
+certbot certonly \
+  --dns-cloudflare \
+  --dns-cloudflare-credentials /tmp/certbot-cf/cloudflare.ini \
+  --dns-cloudflare-propagation-seconds 30 \
+  -d '*.example.com' -d 'example.com' \
+  --non-interactive --agree-tos --email admin@example.com \
+  --config-dir /tmp/certbot-cf/config \
+  --work-dir /tmp/certbot-cf/work \
+  --logs-dir /tmp/certbot-cf/logs \
+  --key-type ecdsa --elliptic-curve secp256r1
+
+# Inject into cluster
+kubectl create secret tls wildcard-tls-secret \
+  --cert=/tmp/certbot-cf/config/live/example.com/fullchain.pem \
+  --key=/tmp/certbot-cf/config/live/example.com/privkey.pem \
+  -n nginx-gateway --dry-run=client -o yaml | kubectl apply -f -
+
+# Clean up
+rm -rf /tmp/certbot-cf
+```
+
+## Verification
+```bash
+# Check the certificate served by the gateway
+echo | openssl s_client -connect upload.example.com:443 \
+  -servername upload.example.com 2>/dev/null | \
+  openssl x509 -noout -subject -ext subjectAltName
+
+# Test endpoint
+curl -s https://upload.example.com/
+```
+
+## Debugging Commands
+```bash
+# Check challenge status
+kubectl get challenges -n nginx-gateway
+
+# Check challenge details (key = expected TXT value)
+kubectl get challenge <name> -n nginx-gateway \
+  -o jsonpath='domain: {.spec.dnsName}, key: {.spec.key}, presented: {.status.presented}'
+
+# Check cert-manager args
+kubectl get deployment cert-manager -n cert-manager \
+  -o jsonpath='{.spec.template.spec.containers[0].args}'
+
+# Check certificate status
+kubectl get certificate wildcard-tls -n nginx-gateway -o yaml
+
+# Check what cert is currently in the secret
+kubectl get secret wildcard-tls-secret -n nginx-gateway \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | \
+  openssl x509 -noout -subject -ext subjectAltName
+
+# Test DNS from inside cluster
+kubectl run dns-test --image=busybox:1.36 --rm -i --restart=Never -- \
+  nslookup -type=TXT _acme-challenge.example.com 1.1.1.1
+
+# Delete stale order to force refresh
+kubectl delete order <order-name> -n nginx-gateway
+```
+
+## Notes
+- The manually generated cert expires after 90 days and won't auto-renew
+- cert-manager will eventually overwrite the manually injected secret when/if it
+  successfully issues its own cert — this is fine and desired
+- When requesting both wildcard (`*.example.com`) and base (`example.com`), ACME requires
+  separate authorizations that both use `_acme-challenge.example.com` TXT records with
+  different values
+- ArgoCD root apps with `automated.enabled: false` won't auto-sync — you need to trigger
+  manually via `kubectl patch app root -n argocd --type merge -p '{"operation":{"sync":...}}'`
+- The cert-manager container is distroless (no shell) — you can't exec into it to debug DNS

--- a/.claude/skills/claudeception/LICENSE
+++ b/.claude/skills/claudeception/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Claude Code
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/claudeception/README.md
+++ b/.claude/skills/claudeception/README.md
@@ -1,0 +1,165 @@
+# Claudeception
+
+Claudeception captures what was learned during a work session as dated journal entries.
+
+It is an episodic memory tool, not a skill generator. When Claude discovers something non-obvious through debugging, investigation, or trial and error, Claudeception writes that learning to `~/.claude/journal/` so it can be searched later or promoted through a separate workflow.
+
+## Installation
+
+### Step 1: Clone the skill
+
+**User-level (recommended)**
+
+```bash
+git clone https://github.com/blader/Claudeception.git ~/.claude/skills/claudeception
+```
+
+**Project-level**
+
+```bash
+git clone https://github.com/blader/Claudeception.git .claude/skills/claudeception
+```
+
+### Step 2: Set up the activation hook (recommended)
+
+The skill can activate via semantic matching, but a hook ensures it evaluates every session for journal-worthy learnings.
+
+1. Create the hooks directory and copy the script:
+
+```bash
+mkdir -p ~/.claude/hooks
+cp ~/.claude/skills/claudeception/scripts/claudeception-activator.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/claudeception-activator.sh
+```
+
+2. Add the hook to your Claude settings (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/claudeception-activator.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If you already have a `settings.json`, merge the `hooks` configuration into it.
+
+The hook injects a reminder on every prompt that tells Claude to evaluate whether the task produced a journal-worthy learning.
+
+## Usage
+
+### Automatic Mode
+
+The skill activates automatically when Claude:
+
+- Just completed debugging and found a non-obvious root cause
+- Discovered a workaround through investigation or trial and error
+- Resolved an error where the visible symptom hid the real issue
+- Learned a project-specific or system-specific constraint
+- Completed a task where the solution required meaningful discovery
+
+### Explicit Mode
+
+Trigger a learning retrospective:
+
+```text
+/claudeception
+```
+
+Existing phrases still work:
+
+```text
+Save what we just learned as a skill
+```
+
+```text
+What did we learn?
+```
+
+These now create a journal entry instead of a skill.
+
+## What Gets Captured
+
+Claudeception captures incident notes, discoveries, and debugging outcomes that are worth preserving even when they are narrow or system-specific.
+
+It does not create skills. Promotion to reusable skills is a separate, higher-bar workflow.
+
+## How It Works
+
+Claude skills should stay small and procedural. Journal entries should absorb the episodic sprawl.
+
+Claudeception keeps that boundary clean by writing dated markdown notes under `~/.claude/journal/`:
+
+```text
+~/.claude/journal/2026-04-05-fastly-draft-version-publish-mismatch.md
+~/.claude/journal/2026-04-05-nextjs-server-side-error-debugging.md
+```
+
+Each entry is a factual note about what happened, what was learned, and what evidence supports it. The retrieval mechanism for these notes is search, not startup skill loading.
+
+## Journal Entry Format
+
+Entries use lightweight frontmatter and a small set of sections:
+
+```md
+---
+date: 2026-04-05
+title: Fastly draft version publish mismatch
+tags: [fastly, compute, deployment]
+source_trigger: explicit_request
+---
+
+# What happened
+
+...
+
+# What was learned
+
+...
+
+# Evidence
+
+...
+
+# Reuse signal
+
+...
+```
+
+See `resources/journal-entry-template.md` for the full template.
+
+## Quality Gates
+
+Claudeception is selective, but the threshold is lower than skill creation. A note only needs to preserve something that was genuinely learned and would be annoying to rediscover.
+
+It should not:
+
+- Create reusable procedural skills
+- Rewrite incident notes into generalized runbooks
+- Store secrets or sensitive internal details
+- Turn obvious documentation lookups into memory
+
+## Examples
+
+See `examples/` for sample journal entries:
+
+- `2026-01-15-nextjs-server-side-error-debugging.md`
+- `2026-01-16-prisma-connection-pool-exhaustion.md`
+- `2026-01-17-typescript-circular-dependency.md`
+
+## Contributing
+
+Contributions welcome. Fork, make changes, submit a PR.
+
+## License
+
+MIT

--- a/.claude/skills/claudeception/SKILL.md
+++ b/.claude/skills/claudeception/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: claudeception
+description: Use when reviewing what was learned after debugging, workaround discovery, or trial-and-error investigation, and capture it as a dated journal entry under ~/.claude/journal
+---
+
+# Claudeception
+
+Claudeception captures episodic memory from work sessions.
+
+It does not create or update skills. Its job is to preserve what happened, what was learned, and why it mattered in a dated journal entry that can be searched later or promoted through a separate workflow.
+
+## When To Use
+
+Use this skill when any of these are true:
+
+- A task required non-obvious debugging or investigation
+- A workaround or recovery path was discovered through trial and error
+- An error message was misleading and the real root cause was learned
+- A project-specific or system-specific constraint was uncovered
+- The user asks `/claudeception`
+- The user says "save this as a skill", "extract a skill from this", or "what did we learn?"
+
+Do not use this skill to create durable procedural knowledge. If the learning should become a reusable skill, leave that for a separate promotion step.
+
+## Core Rule
+
+Never create a skill from this skill.
+
+Even when the user says "save this as a skill", honor the intent by writing a journal entry unless they explicitly ask for a separate skill-writing workflow.
+
+## Capture Threshold
+
+Write a journal entry when the session produced knowledge that is worth preserving, even if it is narrow or specific to one system.
+
+Good journal material:
+
+- Incident-specific discoveries
+- System quirks and deployment gotchas
+- Root causes behind confusing failures
+- Investigated tradeoffs and workarounds
+- Repeated patterns that are not generalized yet
+
+Skip capture when:
+
+- The task was a routine documentation lookup
+- The conclusion is already covered cleanly by an existing skill or project docs
+- The note would mostly restate obvious knowledge
+- The note would require storing secrets or sensitive internal details
+
+## Output Location
+
+Write entries to:
+
+`~/.claude/journal/YYYY-MM-DD-topic-slug.md`
+
+Examples:
+
+- `~/.claude/journal/2026-04-05-fastly-draft-version-publish-mismatch.md`
+- `~/.claude/journal/2026-04-05-nextjs-server-side-error-debugging.md`
+
+If multiple notes land on the same date with the same slug, add a short suffix.
+
+## Entry Format
+
+Use the template in `resources/journal-entry-template.md`.
+
+Every entry should include:
+
+- Frontmatter with `date`, `title`, `tags`, and `source_trigger`
+- A short factual description of what happened
+- The actual learning, not just the symptoms
+- Evidence such as errors, commands, files, or observations
+- A brief reuse signal describing whether this looks one-off or recurring
+
+Keep the note concrete. Journal entries are not polished runbooks.
+
+## Workflow
+
+1. Review the task or session
+2. Isolate the single learning worth preserving
+3. Choose a dated filename with a concise slug
+4. Write the journal entry using the template
+5. Include exact evidence and the real takeaway
+6. Stop after writing the entry
+
+Do not create a new skill.
+Do not update an existing skill.
+Do not generalize beyond what the evidence supports.
+
+## Retrospective Mode
+
+When `/claudeception` is invoked at the end of a session:
+
+1. Review the session for journal-worthy learnings
+2. Prefer one focused entry per distinct incident or discovery
+3. If there are multiple unrelated learnings, write separate entries
+4. Summarize what was captured and where it was written
+
+## Quality Gates
+
+Before finalizing a journal entry, verify:
+
+- The filename is dated
+- The note describes something actually observed or verified
+- The writeup includes evidence or concrete trigger conditions
+- The note preserves local context instead of inflating it into a general skill
+- No secrets, credentials, or sensitive URLs are included
+- No new skill files were created
+
+## Anti-Patterns
+
+- Turning every discovery into a reusable skill
+- Rewriting the note as a polished runbook
+- Stripping away the concrete system context that made the discovery useful
+- Capturing vague conclusions without evidence
+- Creating duplicate journal entries for the same learning in the same session
+
+## Self-Check Prompts
+
+Ask:
+
+- What happened that was not obvious at the start?
+- What was the actual root cause or constraint?
+- What would future-me want to grep for?
+- Is this a concrete incident note or a reusable procedure?
+
+If it is an incident note, write it to the journal.
+
+If it is a reusable procedure, do not create it here. Leave it for a separate promotion workflow.

--- a/.claude/skills/claudeception/WARP.md
+++ b/.claude/skills/claudeception/WARP.md
@@ -1,0 +1,47 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+## Project Overview
+
+Claudeception is a Claude Code skill for continuous learning through journal capture. It preserves learned knowledge as dated markdown entries in `~/.claude/journal/`. It is not an application codebase and it does not generate reusable skills.
+
+## Key Files
+
+- `SKILL.md` — The main skill definition Claude Code loads
+- `resources/journal-entry-template.md` — Template for captured journal entries
+- `examples/` — Sample journal entries demonstrating the expected format
+
+## Journal Entry Format
+
+Journal entries are dated markdown files with lightweight YAML frontmatter:
+
+```yaml
+---
+date: 2026-04-05
+title: Fastly draft version publish mismatch
+tags: [fastly, compute, deployment]
+source_trigger: explicit_request
+---
+```
+
+Each note should preserve:
+
+- What happened
+- What was learned
+- Evidence
+- Reuse signal
+
+## Installation Paths
+
+- **User-level**: `~/.claude/skills/claudeception/`
+- **Project-level**: `.claude/skills/claudeception/`
+
+## Quality Criteria
+
+When modifying this skill, ensure:
+
+- It captures episodic learnings, not generalized procedures
+- It writes dated journal entries, not skill files
+- It preserves concrete evidence and local context
+- It does not store secrets or sensitive internal details

--- a/.claude/skills/claudeception/examples/2026-01-15-nextjs-server-side-error-debugging.md
+++ b/.claude/skills/claudeception/examples/2026-01-15-nextjs-server-side-error-debugging.md
@@ -1,0 +1,24 @@
+---
+date: 2026-01-15
+title: Next.js server-side error debugging
+tags: [nextjs, server-side, debugging]
+source_trigger: retrospective
+---
+
+# What happened
+
+A Next.js page showed a generic server error, but the browser console was empty, which made the failure look client-side at first.
+
+# What was learned
+
+The failing code path was server-side, so the useful stack trace lived in the terminal running the app rather than in the browser console.
+
+# Evidence
+
+- The browser showed an error page with no actionable console output
+- The dev server terminal contained the actual exception and file location
+- Adding server-side logging confirmed the failing path
+
+# Reuse signal
+
+Likely recurring. This is a common debugging trap in server-rendered Next.js flows.

--- a/.claude/skills/claudeception/examples/2026-01-16-prisma-connection-pool-exhaustion.md
+++ b/.claude/skills/claudeception/examples/2026-01-16-prisma-connection-pool-exhaustion.md
@@ -1,0 +1,24 @@
+---
+date: 2026-01-16
+title: Prisma connection pool exhaustion in serverless
+tags: [prisma, database, serverless]
+source_trigger: retrospective
+---
+
+# What happened
+
+A serverless deployment started failing under moderate concurrency with connection-count errors that did not reproduce during low-volume local testing.
+
+# What was learned
+
+The root issue was connection churn from per-request client creation in a serverless environment, not an isolated query bug.
+
+# Evidence
+
+- Production logs showed repeated connection limit failures
+- Failures correlated with concurrent traffic rather than a specific endpoint
+- Reusing a shared Prisma client removed the connection spike
+
+# Reuse signal
+
+Likely recurring. This is a recognizable deployment pattern worth retaining as memory and maybe promoting later.

--- a/.claude/skills/claudeception/examples/2026-01-17-typescript-circular-dependency.md
+++ b/.claude/skills/claudeception/examples/2026-01-17-typescript-circular-dependency.md
@@ -1,0 +1,24 @@
+---
+date: 2026-01-17
+title: TypeScript circular dependency diagnosis
+tags: [typescript, imports, architecture]
+source_trigger: retrospective
+---
+
+# What happened
+
+A TypeScript module behaved inconsistently at runtime even though type-checking passed, and the failure moved depending on import order.
+
+# What was learned
+
+The instability came from a circular dependency chain that left one module partially initialized during evaluation.
+
+# Evidence
+
+- Runtime behavior changed with import order
+- Static typing alone did not flag the issue clearly
+- Breaking the import cycle stabilized initialization
+
+# Reuse signal
+
+Likely recurring in larger codebases. Keep as an incident note unless a broader pattern emerges across multiple entries.

--- a/.claude/skills/claudeception/resources/journal-entry-template.md
+++ b/.claude/skills/claudeception/resources/journal-entry-template.md
@@ -1,0 +1,28 @@
+---
+date: YYYY-MM-DD
+title: Short human-readable title
+tags: [system, topic, symptom]
+source_trigger: automatic | explicit_request | retrospective
+---
+
+# What happened
+
+[Brief factual summary of the task, incident, or investigation.]
+
+# What was learned
+
+[State the actual takeaway. Prefer the root cause, hidden constraint, or recovered knowledge over a vague summary.]
+
+# Evidence
+
+- [Exact error message, command, observation, file, or system behavior]
+- [Concrete clue that led to the conclusion]
+- [Verification that the conclusion held]
+
+# Reuse signal
+
+[Say whether this looks one-off, likely recurring, or a possible promotion candidate later.]
+
+# Follow-up
+
+[Optional next step, guardrail, or open question.]

--- a/.claude/skills/claudeception/resources/research-references.md
+++ b/.claude/skills/claudeception/resources/research-references.md
@@ -1,0 +1,183 @@
+# Research References
+
+This document compiles the academic research that informed the design of Claudeception.
+
+## Core Papers
+
+### Voyager: An Open-Ended Embodied Agent with Large Language Models
+
+**Authors**: Wang, Xie, Jiang, Mandlekar, Xiao, Zhu, Fan, Anandkumar  
+**Published**: May 2023  
+**URL**: https://arxiv.org/abs/2305.16291
+
+**Key Contribution**: First LLM-powered embodied lifelong learning agent with a skill library architecture.
+
+**Relevant Concepts Applied**:
+
+1. **Ever-Growing Skill Library**: Voyager maintains "an ever-growing skill library of executable code for storing and retrieving complex behaviors." This inspired our approach of extracting Claude Code skills as executable knowledge packages.
+
+2. **Compositional Skills**: "The skills developed by Voyager are temporally extended, interpretable, and compositional, which compounds the agent's abilities rapidly and alleviates catastrophic forgetting." Our skill structure aims for similar composability.
+
+3. **Self-Verification**: Voyager uses "self-verification for program improvement" before adding skills to the library. We implement similar quality gates before extraction.
+
+4. **Iterative Prompting**: The "iterative prompting mechanism that incorporates environment feedback, execution errors" influenced our retrospective mode design.
+
+---
+
+### CASCADE: Cumulative Agentic Skill Creation through Autonomous Development and Evolution
+
+**Authors**: [Research Team]  
+**Published**: December 2024  
+**URL**: https://arxiv.org/abs/2512.23880
+
+**Key Contribution**: Self-evolving agentic framework demonstrating the transition from "LLM + tool use" to "LLM + skill acquisition."
+
+**Relevant Concepts Applied**:
+
+1. **Meta-Skills for Learning**: CASCADE demonstrates "continuous learning via web search and code extraction, and self-reflection via introspection." Our skill is itself a meta-skill for acquiring skills.
+
+2. **Knowledge Codification**: "CASCADE accumulates executable skills that can be shared across agents" - this principle drives our skill extraction and storage approach.
+
+3. **Memory Consolidation**: The framework uses memory consolidation to prevent forgetting and enable reuse. Our skill library serves a similar purpose.
+
+---
+
+### SEAgent: Self-Evolving Computer Use Agent with Autonomous Learning from Experience
+
+**Authors**: Sun et al.  
+**Published**: August 2025  
+**URL**: https://arxiv.org/abs/2508.04700
+
+**Key Contribution**: Framework enabling agents to autonomously evolve through interactions with unfamiliar software.
+
+**Relevant Concepts Applied**:
+
+1. **Experiential Learning**: "SEAgent empowers computer-use agents to autonomously master novel software environments via experiential learning, where agents explore new software, learn through iterative trial-and-error." Our retrospective mode captures this trial-and-error learning.
+
+2. **Learning from Failures and Successes**: "The agent's policy is optimized through experiential learning from both failures and successes." We extract skills from both successful solutions and debugging processes.
+
+3. **Curriculum Generation**: SEAgent uses a "Curriculum Generator" for increasingly diverse tasks. Our skill descriptions enable semantic matching to surface relevant skills.
+
+---
+
+### Reflexion: Language Agents with Verbal Reinforcement Learning
+
+**Authors**: Shinn et al.  
+**Published**: March 2023  
+**URL**: https://arxiv.org/abs/2303.11366
+
+**Key Contribution**: Framework for verbal reinforcement through linguistic feedback and self-reflection.
+
+**Relevant Concepts Applied**:
+
+1. **Self-Reflection Prompts**: "Reflexion converts feedback from the environment into linguistic feedback, also referred to as self-reflection." Our self-reflection prompts are directly inspired by this.
+
+2. **Memory for Future Trials**: "These experiences (stored in long-term memory) are leveraged by the agent to rapidly improve decision-making." Skills serve as long-term memory.
+
+3. **Verbal Reinforcement**: Instead of scalar rewards, Reflexion uses "nuanced feedback" in natural language. Our skill descriptions capture this nuanced knowledge.
+
+---
+
+### EvoFSM: Controllable Self-Evolution for Deep Research with Finite State Machines
+
+**Authors**: [Research Team]  
+**Published**: 2024
+
+**Key Contribution**: Self-evolving framework with experience pools for continuous learning.
+
+**Relevant Concepts Applied**:
+
+1. **Self-Evolving Memory**: "EvoFSM integrates a Self-Evolving Memory mechanism, which distills successful strategies and failure patterns into an Experience Pool to enable continuous learning and warm-starting for future queries."
+
+2. **Experience Pools**: The concept of storing strategies for later retrieval directly influenced our skill library design.
+
+---
+
+## Supporting Research
+
+### Professional Agents: Evolving LLMs into Autonomous Experts
+
+**URL**: https://arxiv.org/abs/2402.03628
+
+Describes a framework for creating agents with specialized expertise through continuous learning. Influenced our quality criteria for what makes a skill worth extracting.
+
+### Self-Reflection in LLM Agents: Effects on Problem-Solving Performance
+
+**URL**: https://arxiv.org/abs/2405.06682
+
+Empirical study showing self-reflection improves performance. Validated our use of reflection prompts for identifying extractable knowledge.
+
+### Building Scalable and Reliable Agentic AI Systems
+
+Comprehensive survey covering memory architectures, tool use, and continuous learning in agentic AI. Provided the broader architectural context for our design.
+
+---
+
+## Claude Code Skills Documentation
+
+### Anthropic Engineering Blog: Equipping Agents for the Real World with Agent Skills
+
+**URL**: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+
+**Key Insights**:
+
+1. **Progressive Disclosure**: "Skills let Claude load information only as needed" - this enables scaling to many skills without context window bloat.
+
+2. **Future Vision**: "We hope to enable agents to create, edit, and evaluate Skills on their own, letting them codify their own patterns of behavior into reusable capabilities." This skill is an implementation of this vision.
+
+3. **Skill as Onboarding**: "Building a skill for an agent is like putting together an onboarding guide for a new hire." Our template follows this mental model.
+
+### Claude Code Skills Documentation
+
+**URL**: https://code.claude.com/docs/en/skills
+
+**Key Insights**:
+
+1. **SKILL.md Structure**: YAML frontmatter + markdown instructions
+2. **Description Importance**: Semantic matching relies on good descriptions
+3. **Allowed Tools**: Skills can restrict or enable specific tools
+4. **Location Options**: User-level vs. project-level installation
+
+---
+
+## Design Patterns Applied
+
+### From Voyager
+- Skill library as executable code
+- Self-verification before adding to library
+- Compositional skill building
+
+### From CASCADE
+- Meta-skills for learning
+- Knowledge codification into shareable format
+- Memory consolidation
+
+### From SEAgent
+- Learning from both successes and failures
+- Experiential learning through trial-and-error
+- Progressive skill complexity
+
+### From Reflexion
+- Self-reflection prompts
+- Verbal feedback over scalar rewards
+- Long-term memory storage
+
+### From EvoFSM
+- Experience pools
+- Distilling strategies from sessions
+- Warm-starting future work
+
+---
+
+## Citation Format
+
+If referencing this skill in academic work:
+
+```
+@misc{claudeception,
+  title={Claudeception: Autonomous Skill Extraction for LLM Agents},
+  author={Claude Code},
+  year={2024},
+  note={Implements continuous learning patterns from Voyager, CASCADE, SEAgent, and Reflexion research}
+}
+```

--- a/.claude/skills/claudeception/scripts/claudeception-activator.sh
+++ b/.claude/skills/claudeception/scripts/claudeception-activator.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Claudeception Auto-Activation Hook
+# This hook ensures the claudeception skill evaluates every interaction
+# for journal-worthy knowledge worth preserving.
+#
+# Installation:
+#   1. Copy this script to ~/.claude/hooks/
+#   2. Make it executable: chmod +x ~/.claude/hooks/claudeception-activator.sh
+#   3. Add to ~/.claude/settings.json (see README for details)
+
+cat << 'EOF'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🧠 MANDATORY JOURNAL EVALUATION REQUIRED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+CRITICAL: After completing this user request, you MUST evaluate whether
+it produced journal-worthy knowledge using the claudeception skill.
+
+EVALUATION PROTOCOL (NON-NEGOTIABLE):
+
+1. COMPLETE the user's request first
+2. EVALUATE: Ask yourself:
+   - Did this require non-obvious investigation or debugging?
+   - Was the solution something that would help in future similar situations?
+   - Did I discover something not immediately obvious from documentation?
+
+3. IF YES to any question above:
+   ACTIVATE: Use Skill(claudeception) NOW to capture the knowledge
+   as a dated journal entry under ~/.claude/journal
+
+4. IF NO to all questions:
+   SKIP: No journal entry needed
+
+This is NOT optional. Failing to evaluate means valuable knowledge is lost.
+The claudeception skill will decide whether to actually write a new
+journal entry based on its quality criteria.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/.claude/skills/clickhouse-aggregatingmergetree-state-merge/SKILL.md
+++ b/.claude/skills/clickhouse-aggregatingmergetree-state-merge/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: clickhouse-aggregatingmergetree-state-merge
+description: |
+  Fix ClickHouse query errors when querying AggregatingMergeTree tables that use state functions.
+  Use when: (1) Query fails with type mismatch on AggregateFunction columns, (2) Using sum/count
+  on columns created with sumState/countState/uniqState, (3) Creating views that JOIN with
+  materialized views using AggregatingMergeTree, (4) Getting unexpected results from aggregate
+  columns that show as AggregateFunction(sum, ...) type. The *State() functions store intermediate
+  aggregate states, not final values - you must use *Merge() functions to finalize them.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-30
+---
+
+# ClickHouse AggregatingMergeTree State/Merge Pattern
+
+## Problem
+When querying tables or materialized views that use AggregatingMergeTree with state functions
+(`sumState`, `uniqState`, `countState`), queries fail or return wrong results because the
+columns contain aggregate state objects, not regular numeric values.
+
+## Context / Trigger Conditions
+- Query fails with type errors when using `sum()` on AggregateFunction columns
+- Creating views that query AggregatingMergeTree materialized views
+- Column types show as `AggregateFunction(sum, UInt64)` instead of `UInt64`
+- Migration creates a view joining with an existing aggregating materialized view
+- Getting NULL or unexpected values when aggregating pre-aggregated columns
+
+## Root Cause
+AggregatingMergeTree stores **intermediate aggregate states**, not final values. When you define:
+
+```sql
+CREATE MATERIALIZED VIEW stats
+ENGINE = AggregatingMergeTree()
+ORDER BY (user_id)
+AS SELECT
+    user_id,
+    sumState(amount) as total_amount,      -- AggregateFunction(sum, UInt64)
+    uniqState(session_id) as unique_sessions, -- AggregateFunction(uniq, String)
+    countState() as event_count           -- AggregateFunction(count)
+FROM events
+GROUP BY user_id;
+```
+
+The columns `total_amount`, `unique_sessions`, and `event_count` are NOT regular numbers.
+They're binary blobs representing the intermediate state of the aggregation.
+
+**Wrong:**
+```sql
+SELECT user_id, sum(total_amount) FROM stats GROUP BY user_id;
+-- Error: cannot use sum() on AggregateFunction type
+```
+
+**Correct:**
+```sql
+SELECT user_id, sumMerge(total_amount) FROM stats GROUP BY user_id;
+-- Returns the finalized numeric value
+```
+
+## Solution
+
+### Mapping State Functions to Merge Functions
+
+| State Function | Merge Function | Purpose |
+|----------------|----------------|---------|
+| `sumState(x)` | `sumMerge(x)` | Sum aggregation |
+| `countState()` | `countMerge(x)` | Count aggregation |
+| `uniqState(x)` | `uniqMerge(x)` | Unique count (HyperLogLog) |
+| `avgState(x)` | `avgMerge(x)` | Average |
+| `minState(x)` | `minMerge(x)` | Minimum |
+| `maxState(x)` | `maxMerge(x)` | Maximum |
+| `anyState(x)` | `anyMerge(x)` | Any value |
+| `groupArrayState(x)` | `groupArrayMerge(x)` | Array aggregation |
+
+### Example Fix
+
+**Before (broken):**
+```sql
+CREATE VIEW leaderboard AS
+SELECT
+    stats.user_id,
+    sum(stats.daily_views) AS views,        -- WRONG
+    sum(stats.daily_unique) AS uniques,     -- WRONG
+    sum(stats.videos_watched) AS videos     -- WRONG
+FROM daily_stats stats
+GROUP BY stats.user_id;
+```
+
+**After (fixed):**
+```sql
+CREATE VIEW leaderboard AS
+SELECT
+    stats.user_id,
+    sumMerge(stats.daily_views) AS views,        -- Correct
+    uniqMerge(stats.daily_unique) AS uniques,    -- Correct
+    countMerge(stats.videos_watched) AS videos   -- Correct
+FROM daily_stats stats
+GROUP BY stats.user_id;
+```
+
+### Identifying Affected Columns
+
+Check the table schema to see which columns are aggregate states:
+
+```sql
+DESCRIBE TABLE your_table;
+```
+
+Output shows column types like:
+```
+daily_views       AggregateFunction(sum, UInt64)
+daily_unique      AggregateFunction(uniq, String)
+videos_watched    AggregateFunction(count)
+```
+
+Any column with `AggregateFunction(...)` type requires the corresponding `*Merge()` function.
+
+## Verification
+
+1. Check your materialized view definition for `*State()` functions
+2. Ensure all queries use matching `*Merge()` functions
+3. Test the query returns expected numeric values, not NULL or binary blobs
+
+```sql
+-- Should return actual numbers
+SELECT sumMerge(total_views), uniqMerge(unique_visitors)
+FROM aggregated_stats
+WHERE stat_date >= today() - 7;
+```
+
+## Example
+
+**Migration 020 (creates the aggregating table):**
+```sql
+CREATE MATERIALIZED VIEW creator_daily_stats
+ENGINE = AggregatingMergeTree()
+ORDER BY (video_author_pubkey, stat_date)
+AS SELECT
+    video_author_pubkey,
+    toDate(created_at) as stat_date,
+    sumState(view_count) as daily_views,           -- State function
+    uniqState(viewer_hash) as daily_unique_viewers, -- State function
+    sumState(toFloat64(total_loops)) as daily_loops,-- State function
+    countState() as videos_watched                  -- State function
+FROM view_counts
+GROUP BY video_author_pubkey, toDate(created_at);
+```
+
+**Migration 033 (queries the aggregating table - FIXED):**
+```sql
+CREATE VIEW leaderboard_creators_day AS
+SELECT
+    cds.video_author_pubkey AS pubkey,
+    p.name,
+    sumMerge(cds.daily_views) AS views,            -- Merge function
+    uniqMerge(cds.daily_unique_viewers) AS unique_viewers, -- Merge function
+    sumMerge(cds.daily_loops) AS loops,            -- Merge function
+    countMerge(cds.videos_watched) AS videos_with_views -- Merge function
+FROM creator_daily_stats cds
+LEFT JOIN user_profiles p ON cds.video_author_pubkey = p.pubkey
+WHERE cds.stat_date >= today() - 1
+GROUP BY cds.video_author_pubkey, p.name
+ORDER BY views DESC;
+```
+
+## Notes
+
+- **SummingMergeTree is different**: It stores regular values and sums them during merges.
+  With SummingMergeTree, you use regular `sum()` in queries. Only AggregatingMergeTree uses
+  the State/Merge pattern.
+
+- **Why use AggregatingMergeTree?**: For unique counts (`uniq`), you can't simply sum the
+  counts from different parts—that would overcount. AggregatingMergeTree preserves the
+  HyperLogLog state so merging gives correct unique counts across partitions.
+
+- **Performance**: The `*Merge()` functions are efficient—they're designed to combine
+  pre-computed aggregate states, not reprocess raw data.
+
+- **Migration ordering matters**: If migration A creates an AggregatingMergeTree view, and
+  migration B creates a view that queries it, migration B must use `*Merge()` functions.
+
+## References
+
+- [ClickHouse AggregatingMergeTree](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/aggregatingmergetree)
+- [ClickHouse Aggregate Function Combinators](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/combinators)
+- [ClickHouse -State and -Merge combinators](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/combinators#-state)

--- a/.claude/skills/clickhouse-cloud-multi-table-rename/SKILL.md
+++ b/.claude/skills/clickhouse-cloud-multi-table-rename/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: clickhouse-cloud-multi-table-rename
+description: |
+  Fix ClickHouse Cloud migration failures caused by multi-table RENAME statements.
+  Use when: (1) Migration fails with "Database X is Shared, it does not support renaming
+  of multiple tables in single query", (2) golang-migrate or other migration tools show
+  dirty database version after a table-swap migration on ClickHouse Cloud,
+  (3) Schema migration works on self-hosted ClickHouse but fails on ClickHouse Cloud.
+  ClickHouse Cloud uses SharedMergeTree engine which has restrictions not present in
+  regular MergeTree.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-22
+---
+
+# ClickHouse Cloud Multi-Table RENAME Limitation
+
+## Problem
+ClickHouse Cloud (SharedMergeTree engine) does not support renaming multiple tables
+in a single `RENAME TABLE` statement, which is a common pattern for atomic table swaps
+in schema migrations. Self-hosted ClickHouse supports this, so migrations that work
+locally or on self-hosted instances will fail on ClickHouse Cloud.
+
+## Context / Trigger Conditions
+- Error message: `"Database X is Shared, it does not support renaming of multiple tables in single query"`
+- Error code: 48
+- Using golang-migrate (or similar) with ClickHouse Cloud
+- Migration SQL contains a pattern like:
+  ```sql
+  RENAME TABLE db.original TO db.original_old,
+               db.new_version TO db.original;
+  ```
+- Migration works in staging (self-hosted ClickHouse) but fails in production (ClickHouse Cloud)
+
+## Solution
+
+### Prevention: Write ClickHouse Cloud-compatible migrations
+
+Instead of multi-table RENAME:
+```sql
+-- BAD: This fails on ClickHouse Cloud
+RENAME TABLE nostr.my_table TO nostr.my_table_old,
+             nostr.my_table_v2 TO nostr.my_table;
+```
+
+Use separate RENAME statements:
+```sql
+-- GOOD: Split into individual operations
+RENAME TABLE nostr.my_table TO nostr.my_table_old;
+RENAME TABLE nostr.my_table_v2 TO nostr.my_table;
+```
+
+Note: This loses atomicity, but ClickHouse Cloud doesn't support the atomic version anyway.
+
+### Recovery: Fix a dirty migration that already failed
+
+1. **Check the current state** — identify which tables exist and what state they're in:
+   ```sql
+   SHOW TABLES LIKE '%my_table%';
+   DESCRIBE TABLE nostr.my_table;       -- Check if it has old or new schema
+   DESCRIBE TABLE nostr.my_table_v2;    -- Check if the new table was created
+   ```
+
+2. **Complete the migration manually** with separate renames:
+   ```sql
+   -- If both original and v2 exist (RENAME never executed):
+   RENAME TABLE nostr.my_table TO nostr.my_table_old;
+   RENAME TABLE nostr.my_table_v2 TO nostr.my_table;
+   DROP TABLE IF EXISTS nostr.my_table_old;
+   -- Recreate any views that were dropped
+   ```
+
+3. **Force the migration version** to mark it as completed:
+   ```bash
+   # Using golang-migrate
+   migrate -path=/migrations -database "clickhouse://..." force VERSION
+   ```
+
+4. **If using K8s jobs**, recreate the job with `force VERSION` args:
+   ```yaml
+   containers:
+     - name: migrate
+       image: my-migrate-image:tag
+       args: ["force", "65"]  # The migration number that was applied manually
+   ```
+
+## Verification
+
+After manual migration, verify:
+```sql
+-- Check table has new schema
+DESCRIBE TABLE nostr.my_table;
+
+-- Check migration version is clean (not dirty)
+SELECT version, dirty FROM schema_migrations ORDER BY version DESC LIMIT 5;
+
+-- Check old/temp tables are cleaned up
+SHOW TABLES LIKE '%my_table%';
+```
+
+## Example
+
+Migration 65 for funnelcake needed to change `view_traffic_sources.source` from
+`Enum8` to `String`. The migration:
+1. Dropped a dependent view
+2. Created `view_traffic_sources_v2` with new schema
+3. Copied data
+4. Tried `RENAME TABLE original TO old, v2 TO original` — FAILED on ClickHouse Cloud
+
+Recovery:
+```bash
+# Via HTTP API from a curl pod in the cluster:
+curl -s "$CH_URL/?database=nostr&user=$USER&password=$PASS" \
+  --data-binary 'RENAME TABLE nostr.view_traffic_sources TO nostr.view_traffic_sources_old'
+curl -s "$CH_URL/?database=nostr&user=$USER&password=$PASS" \
+  --data-binary 'RENAME TABLE nostr.view_traffic_sources_v2 TO nostr.view_traffic_sources'
+curl -s "$CH_URL/?database=nostr&user=$USER&password=$PASS" \
+  --data-binary 'DROP TABLE IF EXISTS nostr.view_traffic_sources_old'
+# Recreate the summary view...
+# Then force migration version to 65
+```
+
+## Notes
+- SharedMergeTree is the default engine on ClickHouse Cloud — you cannot switch to regular MergeTree
+- Other SharedMergeTree limitations exist (e.g., some ALTER operations behave differently)
+- When writing migrations for dual self-hosted/cloud environments, always use separate RENAME statements
+- The golang-migrate ClickHouse driver uses `x-multi-statement=true` which splits statements on `;`, but the RENAME with commas is still a single statement
+- If a failed migration left a `_v2` table behind, you must `DROP TABLE IF EXISTS` it before re-running the migration, or `CREATE TABLE IF NOT EXISTS` will silently skip creation and the INSERT will duplicate data into the existing v2 table
+- Use `SET alter_sync = 2; SET mutations_sync = 2;` in migrations to ensure synchronous execution on ClickHouse Cloud
+
+## References
+- ClickHouse Cloud SharedMergeTree differences: SharedMergeTree engine has restrictions on operations that require cross-shard coordination
+- golang-migrate ClickHouse driver: github.com/golang-migrate/migrate with clickhouse driver

--- a/.claude/skills/clickhouse-materialized-column-view-filter/SKILL.md
+++ b/.claude/skills/clickhouse-materialized-column-view-filter/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: clickhouse-materialized-column-view-filter
+description: |
+  Fix HTTP 500 / ClickHouse "column not found" errors when filtering by a MATERIALIZED
+  column through a VIEW that doesn't expose it. Use when: (1) a WHERE clause references
+  alias.column on a view but the column is MATERIALIZED on the underlying table, (2) the
+  query works on the raw table but fails through the view, (3) adding a new filter param
+  to an API causes 500 even though the column exists in the base table. Fix by using a
+  subquery against the base table instead of referencing the column directly on the view.
+  Applies to ClickHouse views over tables with MATERIALIZED or ALIAS columns.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-01
+---
+
+# ClickHouse: MATERIALIZED Column Not Accessible Through VIEW
+
+## Problem
+When a ClickHouse `VIEW` selects specific columns from a table (not `SELECT *`), any
+`MATERIALIZED` or `ALIAS` columns not explicitly included in the view's SELECT list are
+invisible to queries through the view. Attempting `WHERE v.materialized_col = ?` on such
+a view produces a "column not found" error, which surfaces as an HTTP 500 in API layers.
+
+## Context / Trigger Conditions
+- You add a new query filter (e.g., `?platform=vine`) that references a column via a view alias
+- The column is defined as `String MATERIALIZED ...` on the underlying table
+- The VIEW was created with an explicit column list (not `SELECT *`)
+- The column works fine when querying the base table directly
+- The API returns HTTP 500 with no useful error message to the client
+- Server logs show a ClickHouse "column not found" or similar schema error
+
+## Solution
+
+### Option A: Subquery (No migration required)
+Replace direct column reference with a subquery against the base table:
+
+```sql
+-- BROKEN: view doesn't expose 'platform'
+WHERE v.platform = ?
+
+-- FIXED: subquery against the base table where MATERIALIZED column exists
+WHERE v.id IN (
+  SELECT id FROM events_deduped
+  WHERE platform = ? AND kind IN (34235, 34236)
+)
+```
+
+### Option B: Migration (Cleaner long-term)
+Create a new migration that drops and recreates the view to include the column:
+
+```sql
+DROP VIEW IF EXISTS nostr.videos;
+CREATE VIEW nostr.videos AS
+SELECT
+    id, pubkey, created_at, kind, content, tags, sig, indexed_at,
+    d_tag, title, thumbnail, video_url, author_name, loops,
+    platform,  -- ADD THE MATERIALIZED COLUMN
+    if(published_at > 0, published_at, toUnixTimestamp(created_at)) AS published_at,
+    expiration_at
+FROM nostr.events_deduped FINAL
+WHERE kind IN (34235, 34236);
+```
+
+**Warning**: Dropping a view cascades — any dependent views (video_stats, trending_videos,
+videos_with_loops, etc.) must also be dropped and recreated in the correct dependency order.
+
+## Verification
+1. Query the view directly: `SELECT platform FROM videos LIMIT 1` — should return data (or empty string for non-vine)
+2. API call with the filter param returns 200 instead of 500
+3. Run full smoke test suite to confirm no regressions
+
+## Example (Funnelcake)
+The `nostr.videos` view (migration 000060) selects a fixed column list from `events_deduped`.
+The `platform` column is `String MATERIALIZED` on `events_deduped` but not in the view.
+
+PR #85 added `v.platform = ?` to `get_recent_videos_with_events()` and
+`get_trending_videos_with_events()`, both of which query `FROM videos v`. This caused
+HTTP 500 for any request with `?platform=vine`.
+
+Fix (PR #86): Changed to subquery approach. Note that `videos_with_loops` (a different view)
+DOES include `platform` — queries through that view (like `get_videos_filtered`) work fine.
+
+## Notes
+- `MATERIALIZED` columns are physically stored but only accessible if explicitly selected
+- `ALIAS` columns are computed on read and have the same visibility constraint in views
+- Always check the view definition before adding WHERE conditions on columns
+- The `videos_with_loops` view includes more columns than `videos` — consider which view
+  your query is actually using
+- In Funnelcake: `videos` view = minimal columns; `videos_with_loops` = full columns including platform

--- a/.claude/skills/clickhouse-nip33-addressable-dedup/SKILL.md
+++ b/.claude/skills/clickhouse-nip33-addressable-dedup/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: clickhouse-nip33-addressable-dedup
+description: |
+  Fix duplicate Nostr events in ClickHouse when using ReplacingMergeTree for NIP-33
+  addressable events (Kind 30000+). Use when: (1) Edited videos/events appear as duplicates,
+  (2) Same d_tag shows multiple events with different IDs, (3) FINAL keyword doesn't
+  deduplicate properly for parameterized replaceable events. The issue is that FINAL
+  deduplicates by ORDER BY key (typically `id`), not by (pubkey, kind, d_tag).
+author: Claude Code
+version: 1.0.0
+date: 2026-01-30
+---
+
+# ClickHouse NIP-33 Addressable Event Deduplication
+
+## Problem
+When storing Nostr events in ClickHouse using ReplacingMergeTree, edited addressable events
+(Kind 30000-39999) appear as duplicates. Users edit their video/event, a new event ID is
+created with the same d_tag, but both versions are shown instead of just the latest.
+
+## Context / Trigger Conditions
+- Nostr relay storing events in ClickHouse with ReplacingMergeTree
+- Users report seeing duplicate videos/events after editing
+- Query returns multiple events with same `(pubkey, kind, d_tag)` but different `id` values
+- Using `FINAL` keyword but duplicates still appear
+- Kind 30000+ events (NIP-33 parameterized replaceable events like Kind 34236 videos)
+
+## Root Cause
+The `FINAL` keyword in ClickHouse deduplicates based on the table's `ORDER BY` key. If
+your table is defined as:
+
+```sql
+ENGINE = ReplacingMergeTree(indexed_at)
+ORDER BY (id)
+```
+
+Then `FINAL` deduplicates by `id`. Two events with different IDs are NOT considered
+duplicates, even if they represent the same addressable "slot" per NIP-33.
+
+For NIP-33 addressable events, the replacement key should be `(pubkey, kind, d_tag)`,
+not `id`.
+
+## Solution
+
+### Option 1: Fix at View Level (Recommended)
+
+Change your videos view to use `LIMIT 1 BY` instead of `FINAL`:
+
+```sql
+CREATE VIEW videos AS
+SELECT
+    id,
+    pubkey,
+    created_at,
+    kind,
+    content,
+    tags,
+    d_tag,
+    title,
+    thumbnail,
+    video_url
+FROM events_local
+WHERE kind IN (34235, 34236)
+ORDER BY pubkey, kind, d_tag, created_at DESC
+LIMIT 1 BY pubkey, kind, d_tag;
+```
+
+The `LIMIT 1 BY` clause keeps only the first row (latest by created_at) for each
+unique combination of `(pubkey, kind, d_tag)`.
+
+### Option 2: Fix at Table Level (Breaking Change)
+
+If you can recreate the table, use a composite ORDER BY:
+
+```sql
+CREATE TABLE events_addressable (
+    ...
+) ENGINE = ReplacingMergeTree(created_at)
+ORDER BY (pubkey, kind, d_tag);
+```
+
+This makes `FINAL` work correctly for NIP-33 events but may not work for all event types.
+
+### Migration Example
+
+```sql
+-- Drop dependent views first
+DROP VIEW IF EXISTS trending_videos;
+DROP VIEW IF EXISTS video_stats;
+DROP VIEW IF EXISTS videos;
+
+-- Recreate with proper deduplication
+CREATE VIEW videos AS
+SELECT *
+FROM events_local
+WHERE kind IN (34235, 34236)
+ORDER BY pubkey, kind, d_tag, created_at DESC
+LIMIT 1 BY pubkey, kind, d_tag;
+
+-- Recreate dependent views...
+```
+
+## Verification
+
+Query for a specific user's videos and confirm no duplicates:
+
+```sql
+SELECT id, d_tag, created_at
+FROM videos
+WHERE pubkey = 'user_pubkey_here'
+ORDER BY created_at DESC;
+```
+
+Each `d_tag` should appear only once, with the highest `created_at` value.
+
+## Example
+
+**Before (broken):**
+```
+| id       | d_tag    | created_at |
+|----------|----------|------------|
+| abc123   | video1   | 1769697188 | ← Newer edit
+| def456   | video1   | 1769697150 | ← Original (should be hidden)
+```
+
+**After (fixed):**
+```
+| id       | d_tag    | created_at |
+|----------|----------|------------|
+| abc123   | video1   | 1769697188 | ← Only latest shown
+```
+
+## Notes
+- This applies to all NIP-33 addressable events (Kind 30000-39999), not just videos
+- The `LIMIT 1 BY` approach is query-time deduplication, not storage deduplication
+- Old event versions remain in storage but won't appear in query results
+- Consider periodic cleanup of old event versions if storage is a concern
+- Don't forget to recreate dependent views in the correct order
+
+## References
+- [NIP-33: Parameterized Replaceable Events](https://github.com/nostr-protocol/nips/blob/master/33.md)
+- [ClickHouse LIMIT BY clause](https://clickhouse.com/docs/en/sql-reference/statements/select/limit-by)
+- [ClickHouse ReplacingMergeTree](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree)

--- a/.claude/skills/clickhouse-rust-type-mismatches/SKILL.md
+++ b/.claude/skills/clickhouse-rust-type-mismatches/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: clickhouse-rust-type-mismatches
+description: |
+  Fix ClickHouse query errors in Rust when using clickhouse-rs crate. Use when:
+  (1) "string is not valid utf8" errors - typically FixedString columns need CAST to String,
+  (2) "tag for enum is not valid" errors - typically Option<T> fields receiving non-NULL values,
+  (3) Sum/count aggregations returning Float64 but Rust expects u64,
+  (4) LEFT JOIN results with empty strings where Rust expects Option::None,
+  (5) "not enough data, probably a row type mismatches a database schema" - query SELECT
+  returns fewer columns than the Rust Row struct expects (common when multiple query functions
+  share the same struct but one function is missing columns added later),
+  (6) Garbled/corrupted data when INSERTing to FixedString(N) columns using String Rust type -
+  silently corrupts data (no error!) because String adds a length prefix but FixedString expects
+  exactly N raw bytes. Fix: use [u8; N] with #[serde(with = "BigArray")] from serde-big-array,
+  (7) "the trait bound `[u8; 64]: serde::Serialize` is not satisfied" when using [u8; N] arrays
+  in Row structs - need #[serde(with = "BigArray")] annotation from serde-big-array crate.
+author: Claude Code
+version: 1.2.0
+date: 2026-03-01
+---
+
+# ClickHouse-Rust Type Mismatches
+
+## Problem
+When using the `clickhouse-rs` Rust crate with ClickHouse, deserialization errors
+occur due to type mismatches between the database schema and Rust struct definitions.
+
+## Context / Trigger Conditions
+- Error: "string is not valid utf8" when querying String columns
+- Error: "tag for enum is not valid" when deserializing rows
+- Error: "not enough data, probably a row type mismatches a database schema" when deserializing rows
+- Using `#[derive(Row)]` from `clickhouse` crate
+- Views that use LEFT JOIN or aggregate functions
+- Multiple query functions sharing the same Row struct but with different SELECT lists
+
+## Root Causes
+
+### 0. Column Count Mismatch ("not enough data")
+When multiple query functions share the same `#[derive(Row)]` struct, adding new fields
+to the struct and some queries but forgetting to update OTHER queries that use the same
+struct causes "not enough data" deserialization errors. The query returns fewer columns
+than the struct expects.
+
+**Symptoms:**
+- Error: "not enough data, probably a row type mismatches a database schema"
+- One query function works, another fails, both using the same Row struct
+- Error is misleading — suggests DB schema issue but is actually a code bug
+
+**Debugging:**
+1. Count the fields in the Rust `Row` struct
+2. Count the SELECT columns in the failing query
+3. Compare with the working query — look for missing columns
+4. Often caused by adding fields (like subtitle/text-track columns) to the struct and
+   one query but forgetting to update a secondary query (e.g., `get_by_id` updated but
+   `get_by_d_tag` forgotten)
+
+**Fix:** Add the missing SELECT columns to the failing query to match the struct:
+```rust
+// Both queries must select the SAME columns in the SAME order as the struct
+// If struct has 17 fields, every query using it must SELECT 17 columns
+```
+
+### 1a. FixedString vs String (SELECT / Deserialization)
+ClickHouse `FixedString(N)` pads with null bytes. These don't deserialize cleanly
+as UTF-8 strings in Rust.
+
+**Fix:** Cast to String in the SQL view:
+```sql
+SELECT CAST(pubkey AS String) AS pubkey FROM ...
+```
+
+### 1b. FixedString vs String (INSERT / Serialization) — SILENT DATA CORRUPTION
+**This is the most dangerous variant because there is NO error message.** When using
+`String` in a Rust `#[derive(Row, Serialize)]` struct for a ClickHouse `FixedString(N)`
+column, the clickhouse-rs binary protocol serializes `String` with a varint length prefix,
+but `FixedString(N)` expects exactly N raw bytes with no prefix. The extra length byte(s)
+shift all subsequent column data, producing garbled rows where data bleeds across columns.
+
+**Symptoms:**
+- No error during INSERT — data appears to write successfully
+- Querying the table shows garbled data with columns shifted/mixed together
+- Materialized views built on the table contain garbled aggregations
+- Often discovered only when downstream queries return nonsensical results
+
+**Fix:** Use `[u8; N]` with `#[serde(with = "BigArray")]` from the `serde-big-array` crate:
+```rust
+use serde_big_array::BigArray;
+
+#[derive(Row, Serialize)]
+pub struct MyInsertRow {
+    #[serde(with = "BigArray")]
+    pub event_id: [u8; 64],   // FixedString(64)
+    #[serde(with = "BigArray")]
+    pub pubkey: [u8; 64],     // FixedString(64)
+    pub name: String,          // String column — fine as-is
+}
+
+/// Helper to convert hex strings to fixed byte arrays
+pub fn hex_string_to_fixed64(hex: &str) -> [u8; 64] {
+    let mut buf = [0u8; 64];
+    let bytes = hex.as_bytes();
+    let len = bytes.len().min(64);
+    buf[..len].copy_from_slice(&bytes[..len]);
+    buf
+}
+```
+
+**IMPORTANT:** Using `[u8; 64]` without `#[serde(with = "BigArray")]` will fail with:
+```
+error[E0277]: the trait bound `[u8; 64]: serde::Serialize` is not satisfied
+```
+This is because the clickhouse crate's serde dependency doesn't support const generic
+array serialization for arrays > 32 elements. The `BigArray` annotation is required.
+
+### 2. Option<T> vs Non-Nullable Columns
+When ClickHouse returns empty strings `""` from LEFT JOINs (because the joined
+table has non-nullable String columns), Rust `Option<String>` expects proper
+NULL values, not empty strings.
+
+**Fix:** Use `String` instead of `Option<String>` in Rust structs:
+```rust
+// Wrong - causes "tag for enum is not valid"
+pub name: Option<String>,
+
+// Correct - handles empty strings from LEFT JOIN
+pub name: String,
+```
+
+### 3. Float64 Aggregation Results
+Sum/count aggregations on certain column types return Float64, not UInt64.
+
+**Fix:** Use `f64` in Rust struct:
+```rust
+// Wrong
+pub loops: u64,
+
+// Correct
+pub loops: f64,
+```
+
+## Solution
+
+### 1. Check ClickHouse column types
+```sql
+DESCRIBE TABLE your_view FORMAT TabSeparated
+```
+
+### 2. Match Rust types to ClickHouse types
+
+**For SELECT (deserialization):**
+| ClickHouse Type | Rust Type |
+|-----------------|-----------|
+| String | String |
+| FixedString(N) | String (with CAST in SQL) or [u8; N] with BigArray |
+| UInt64 | u64 |
+| Float64 | f64 |
+| Nullable(String) | Option<String> |
+| String from LEFT JOIN | String (not Option<String>) |
+
+**For INSERT (serialization):**
+| ClickHouse Type | Rust Type | Notes |
+|-----------------|-----------|-------|
+| String | String | Works as-is |
+| FixedString(N) | [u8; N] + `#[serde(with = "BigArray")]` | NEVER use String — causes silent corruption |
+| UInt64 | u64 | Works as-is |
+| DateTime | DateTime<Utc> + `#[serde(with = "clickhouse::serde::chrono::datetime")]` | |
+
+### 3. Fix views to cast types
+```sql
+CREATE VIEW fixed_view AS
+SELECT
+    CAST(pubkey AS String) AS pubkey,  -- Fix FixedString
+    name,  -- String stays String, handle empty in Rust
+    loops  -- Float64 matches f64 in Rust
+FROM ...
+```
+
+## Verification
+Query directly via HTTP interface to confirm data format:
+```bash
+curl -u 'user:pass' 'https://clickhouse-host:8443' \
+  --data-binary "SELECT * FROM your_view LIMIT 1 FORMAT JSONEachRow"
+```
+
+## Example
+
+**ClickHouse schema:**
+```sql
+pubkey FixedString(64)
+name String  -- from LEFT JOIN, can be empty ""
+loops Float64
+```
+
+**Wrong Rust struct:**
+```rust
+pub struct Entry {
+    pub pubkey: String,       // Fails: FixedString null padding
+    pub name: Option<String>, // Fails: "" not NULL
+    pub loops: u64,           // Fails: Float64 not UInt64
+}
+```
+
+**Correct Rust struct + SQL:**
+```rust
+// Struct
+pub struct Entry {
+    pub pubkey: String,  // Works with CAST
+    pub name: String,    // Handles empty strings
+    pub loops: f64,      // Matches Float64
+}
+```
+```sql
+-- View
+SELECT CAST(pubkey AS String) AS pubkey, name, loops FROM ...
+```
+
+## Notes
+- The clickhouse-rs crate uses binary protocol, not JSON, so errors appear at deserialization
+- AggregatingMergeTree `*State` columns require `*Merge()` functions in queries
+- Run `DESCRIBE TABLE` to see exact column types
+- Test queries via HTTP interface first to isolate schema vs client issues
+
+## References
+- [clickhouse-rs crate](https://crates.io/crates/clickhouse)
+- [ClickHouse FixedString](https://clickhouse.com/docs/en/sql-reference/data-types/fixedstring)
+- [ClickHouse Nullable](https://clickhouse.com/docs/en/sql-reference/data-types/nullable)

--- a/.claude/skills/clickhouse-rust-view-column-order/SKILL.md
+++ b/.claude/skills/clickhouse-rust-view-column-order/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: clickhouse-rust-view-column-order
+description: |
+  Debug ClickHouse deserialization errors in Rust caused by column ORDER mismatch
+  when using SELECT alias.* on a VIEW that adds computed columns. Use when:
+  (1) Some query variants (e.g. sort=trending) return 500 but others (sort=recent) succeed,
+  (2) Queries use SELECT view_alias.*, extra_cols FROM view JOIN ...,
+  (3) The Rust Row struct has the right number and types of fields but deserialization
+  fails anyway (wrong type error, not "not enough data"),
+  (4) The VIEW was recently extended with a computed column (e.g. trending_score).
+author: Claude Code
+version: 1.0.0
+date: 2026-02-25
+---
+
+# ClickHouse Rust: View Computed Column Ordering
+
+## Problem
+
+When using `SELECT alias.* , extra_col FROM my_view alias LEFT JOIN ...`, ClickHouse
+expands `alias.*` to include ALL columns defined in the view — including any computed
+columns added by the view itself (e.g. `SELECT *, expr AS trending_score FROM base`).
+Those computed columns appear INSIDE the `alias.*` expansion, BEFORE any columns
+appended after it in the outer query.
+
+The `clickhouse` Rust crate (`#[derive(Row)]`) deserializes **positionally** — field N
+in the Rust struct receives column N from the query result. If the struct field order
+doesn't match the actual SQL column order, the wrong bytes land in the wrong fields,
+causing type errors at deserialization even though the column count is correct.
+
+## Symptoms
+
+- HTTP 500 on one sort variant (e.g. `sort=trending`, `sort=popular`) but not others
+  (e.g. `sort=recent`) that query a different view or table
+- Error like: `"cannot decode Float64 from String"` or similar type mismatch
+- Column COUNT is correct (no "not enough data" error)
+- Bug appears after adding a computed column to an existing view
+
+## Root Cause Explained
+
+Suppose `trending_videos` is defined as:
+```sql
+CREATE VIEW trending_videos AS
+SELECT
+    *,                                          -- all base columns
+    (views * 0.5 + likes * 2.0) AS trending_score  -- computed column APPENDED HERE
+FROM video_stats;
+```
+
+An outer query then does:
+```sql
+SELECT
+    tv.*,                   -- expands to: base_cols..., trending_score
+    text_track_ref,         -- subtitle columns come AFTER
+    text_track_content
+FROM trending_videos tv
+LEFT JOIN subtitle_subquery USING (id);
+```
+
+The actual SQL result column order is:
+```
+[...base_cols, trending_score, text_track_ref, text_track_content]
+```
+
+But if the Rust struct was written with subtitle fields before trending_score:
+```rust
+pub struct TrendingVideo {
+    // ...base fields...
+    pub text_track_ref: String,      // position N   <- WRONG: gets trending_score bytes
+    pub text_track_content: String,  // position N+1 <- WRONG: gets text_track_ref bytes
+    pub trending_score: f64,         // position N+2 <- WRONG: gets text_track_content bytes
+}
+```
+
+ClickHouse sends a `Float64` where Rust expects a `String` → deserialization error → 500.
+
+## Why Only Some Queries Fail
+
+The `sort=recent` variant queries `video_stats` directly with `vs.*` — that view has
+no extra computed columns, so subtitle columns land at the same relative position the
+struct expects. Only the `trending_videos` view adds `trending_score` inside `vs.*`,
+shifting everything after it.
+
+## Debugging Steps
+
+1. **Identify which query variants fail vs. succeed.** Failing ones likely use a
+   different view or have a different `SELECT *` source.
+
+2. **Expand the failing `SELECT alias.*`** — run the inner view query directly:
+   ```bash
+   curl -u 'user:pass' 'https://clickhouse-host:8443' \
+     --data-binary "SELECT * FROM trending_videos LIMIT 0 FORMAT TabSeparated"
+   ```
+   Or use `DESCRIBE TABLE trending_videos` to see declared column order.
+
+3. **List actual column order** of the full outer query:
+   ```bash
+   curl ... --data-binary \
+     "SELECT tv.*, '' as text_track_ref, '' as text_track_content
+      FROM trending_videos tv LIMIT 0 FORMAT TabSeparatedWithNames"
+   ```
+
+4. **Compare with Rust struct field order** line by line — they must match exactly.
+
+5. **Find the misplaced field** — look for computed columns added to the view that
+   appear inside `alias.*` but after columns that appear in the outer SELECT.
+
+## Fix
+
+Reorder the Rust struct fields to match the actual SQL column order — computed
+VIEW columns belong before any columns appended in the outer SELECT:
+
+```rust
+pub struct TrendingVideo {
+    // ...base fields in same order as base table...
+
+    // trending_score comes from tv.* (view-computed), so it appears
+    // BEFORE the subtitle columns we append in the outer query
+    pub trending_score: f64,
+
+    // Subtitle columns are appended after tv.* in the outer SELECT
+    pub text_track_ref: String,
+    pub text_track_content: String,
+}
+```
+
+Do NOT change the SQL query or the view — just align the struct field order.
+
+## Key Rule
+
+> When a ClickHouse VIEW adds a computed column via `SELECT *, expr AS col FROM base`,
+> that column becomes part of the view's column list. Any `SELECT alias.*` in an outer
+> query will emit it in the view's declared order — BEFORE any extra columns appended
+> after `alias.*` in the outer SELECT. The Rust `#[derive(Row)]` struct must reflect
+> this exact order.
+
+## Prevention
+
+- When adding a computed column to a ClickHouse view, immediately check ALL Rust
+  structs that query that view with `SELECT alias.*` and update field ordering.
+- Add an integration test that queries the affected endpoint; CI will catch future
+  ordering drift before staging.
+- Consider using `SELECT col1, col2, ..., trending_score, text_track_ref, text_track_content`
+  (explicit column list instead of `*`) in the outer query to make ordering explicit
+  and immune to view schema changes.
+
+## Related Skills
+
+- `clickhouse-rust-type-mismatches` — covers "not enough data" (column COUNT mismatch),
+  FixedString encoding, Option vs String nullability issues. This skill covers column
+  ORDER mismatch (column count is correct, types match, but positional order is wrong).
+
+## References
+
+- [clickhouse crate Row derive macro](https://docs.rs/clickhouse/latest/clickhouse/derive.Row.html)
+- ClickHouse `SELECT *` expansion: follows column declaration order of the source table/view

--- a/.claude/skills/clickhouse-system-log-disk-exhaustion/SKILL.md
+++ b/.claude/skills/clickhouse-system-log-disk-exhaustion/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: clickhouse-system-log-disk-exhaustion
+description: |
+  Fix ClickHouse "Code: 243 Cannot reserve 1.00 MiB, not enough space" errors caused by
+  system log tables (text_log, trace_log, processors_profile_log, query_log) filling the disk.
+  Use when: (1) ClickHouse inserts fail with NOT_ENOUGH_SPACE error, (2) Disk is 100% full
+  but application tables are small, (3) system database is 10-100x larger than user databases,
+  (4) Sentry shows batch insert/commit failures across multiple tables simultaneously.
+  Covers both self-hosted ClickHouse (Altinity operator on K8s) and ClickHouse Cloud with
+  different remediation paths for each.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-01
+---
+
+# ClickHouse System Log Disk Exhaustion
+
+## Problem
+ClickHouse internal system log tables (`text_log`, `trace_log`, `processors_profile_log`,
+`query_log`, `metric_log`, `asynchronous_metric_log`) grow unbounded with a default TTL of
+180 days, eventually filling the entire disk. This causes all INSERT operations to fail with
+`Code: 243 - Cannot reserve 1.00 MiB, not enough space`, cascading across all application
+tables simultaneously.
+
+## Context / Trigger Conditions
+- **Error message**: `Code: 243. DB::Exception: Cannot reserve 1.00 MiB, not enough space. (NOT_ENOUGH_SPACE)`
+- **Symptoms**: All writes fail simultaneously across multiple tables; reads may still work
+- **Sentry pattern**: Multiple batch insert/commit failure issues appearing at the same time
+- **Diagnosis query**: `SELECT database, formatReadableSize(sum(total_bytes)) FROM system.tables WHERE total_bytes > 0 GROUP BY database ORDER BY sum(total_bytes) DESC`
+  - If `system` database is 10x+ larger than application databases, this is the cause
+- **ClickHouse Cloud additional symptom**: Numbered suffix tables (`trace_log_16`, `text_log_19`)
+  from decommissioned server nodes accumulate and never get cleaned up within the TTL window
+
+## Solution
+
+### Diagnosis
+```sql
+-- Check database sizes
+SELECT database, formatReadableSize(sum(total_bytes)) as size
+FROM system.tables WHERE total_bytes > 0
+GROUP BY database ORDER BY sum(total_bytes) DESC;
+
+-- Find biggest system tables
+SELECT name, formatReadableSize(total_bytes) as size
+FROM system.tables
+WHERE database = 'system' AND total_bytes > 100000000
+ORDER BY total_bytes DESC LIMIT 20;
+
+-- Check disk usage
+SELECT name, formatReadableSize(free_space) as free, formatReadableSize(total_space) as total
+FROM system.disks WHERE name = 'default';
+```
+
+### Fix: Self-Hosted ClickHouse (kubectl access)
+
+**Step 1: If disk is 100% full (TRUNCATE itself fails with NOT_ENOUGH_SPACE)**
+
+TRUNCATE needs some temporary disk space. When disk is truly 100% full, you must free space
+at the filesystem level first:
+
+```bash
+# Find and remove orphaned _N suffix tables (from old replicas)
+kubectl exec $CH_POD -- du -sh /var/lib/clickhouse/data/system/*_0/
+
+# Detach them first (important!), then remove data
+kubectl exec $CH_POD -- clickhouse-client --query "DETACH TABLE system.text_log_0 PERMANENTLY"
+kubectl exec $CH_POD -- bash -c "rm -rf /var/lib/clickhouse/data/system/text_log_0/"
+# Repeat for other _N tables until you have ~100MB+ free
+```
+
+**Step 2: Drop partitions or truncate tables**
+
+System log tables are partitioned by `toYYYYMM(event_date)`. Drop older partitions first
+(smaller operations), then truncate:
+
+```sql
+-- Check partitions
+SELECT partition, formatReadableSize(sum(bytes_on_disk)) as size
+FROM system.parts
+WHERE database = 'system' AND table = 'text_log' AND active
+GROUP BY partition ORDER BY partition;
+
+-- Drop old partitions one at a time
+ALTER TABLE system.text_log DROP PARTITION 202601 SETTINGS max_partition_size_to_drop = 0;
+ALTER TABLE system.text_log DROP PARTITION 202602 SETTINGS max_partition_size_to_drop = 0;
+
+-- Or truncate entire tables (needs max_table_size_to_drop override if > 50GB)
+TRUNCATE TABLE system.text_log SETTINGS max_table_size_to_drop = 0;
+TRUNCATE TABLE system.trace_log SETTINGS max_table_size_to_drop = 0;
+TRUNCATE TABLE system.processors_profile_log SETTINGS max_table_size_to_drop = 0;
+TRUNCATE TABLE system.query_log SETTINGS max_table_size_to_drop = 0;
+TRUNCATE TABLE system.metric_log SETTINGS max_table_size_to_drop = 0;
+TRUNCATE TABLE system.asynchronous_metric_log SETTINGS max_table_size_to_drop = 0;
+```
+
+**Step 3: Set TTL to prevent recurrence**
+
+```sql
+-- Set 3-day TTL on all major system log tables
+ALTER TABLE system.text_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.trace_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.processors_profile_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.query_log MODIFY TTL event_date + INTERVAL 7 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.metric_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.asynchronous_metric_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.part_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+ALTER TABLE system.query_views_log MODIFY TTL event_date + INTERVAL 3 DAY SETTINGS materialize_ttl_after_modify = 0;
+```
+
+### Fix: ClickHouse Cloud (no shell access)
+
+ClickHouse Cloud revokes all modify permissions on `system.*` from user-created roles:
+```
+REVOKE INSERT, ALTER, CREATE TABLE, DROP TABLE, TRUNCATE, OPTIMIZE ON system.* FROM default_role
+```
+
+**You CANNOT fix this via SQL.** The only options are:
+
+1. **ClickHouse Cloud Console** (https://clickhouse.cloud/): Go to service settings and
+   reduce system log TTLs to 3-7 days
+2. **Get the `default` user password** from the console, then run the ALTER TTL commands
+3. **ClickHouse Cloud Support**: Request system log cleanup
+
+To identify ClickHouse Cloud: check for numbered suffix tables (e.g., `trace_log_16`,
+`text_log_19`) which are from rotated server pods. Also, `system.disks` will show
+`system-tables/mergetree/` paths with 16 EiB (object storage).
+
+## Verification
+```sql
+-- After cleanup, verify disk usage
+-- Self-hosted:
+SELECT formatReadableSize(free_space) FROM system.disks WHERE name = 'default';
+
+-- Both: verify system database is now small
+SELECT database, formatReadableSize(sum(total_bytes)) as size
+FROM system.tables WHERE total_bytes > 0 GROUP BY database;
+
+-- Test that writes work
+INSERT INTO your_table (...) VALUES (...);
+```
+
+## Notes
+- The `max_table_size_to_drop` safety limit defaults to 50 GB. Tables larger than this
+  require `SETTINGS max_table_size_to_drop = 0` to truncate/drop.
+- When disk is truly 100% full, even DDL operations fail. You MUST free space at the
+  filesystem level first (detach+remove orphaned tables, or delete tmp files).
+- `DETACH TABLE ... PERMANENTLY` is important before removing data files - it prevents
+  ClickHouse from trying to access the removed files.
+- `materialize_ttl_after_modify = 0` prevents ClickHouse from immediately trying to
+  rewrite all data to apply TTL (which would need disk space you don't have).
+- On ClickHouse Cloud, each server node rotation leaves behind numbered system log tables
+  (e.g., `_16`, `_19`) that accumulate over time. With 65+ nodes over months, this adds
+  up to tens of GB.
+- The `text_log` is typically the largest offender because it logs at trace/debug level
+  by default and includes every log line from the ClickHouse server.
+
+## References
+- ClickHouse system tables documentation: https://clickhouse.com/docs/en/operations/system-tables
+- ClickHouse TTL documentation: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl
+- ClickHouse max_table_size_to_drop: https://clickhouse.com/docs/en/operations/settings/settings#max-table-size-to-drop

--- a/.claude/skills/cloud-run-gpu-image-update-quota-bypass/SKILL.md
+++ b/.claude/skills/cloud-run-gpu-image-update-quota-bypass/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: cloud-run-gpu-image-update-quota-bypass
+description: |
+  Fix Cloud Run GPU deployment failures caused by quota errors. Use when:
+  (1) `gcloud run deploy` fails with "You do not have quota for using GPUs with zonal redundancy"
+  AND "You do not have quota for using GPUs without zonal redundancy",
+  (2) The service already exists and is running with a GPU,
+  (3) You only need to update the container image, not change GPU config.
+  Uses `gcloud run services update --image` instead of `gcloud run deploy` to bypass
+  quota re-validation on existing GPU services.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-07
+---
+
+# Cloud Run GPU Image Update - Quota Bypass
+
+## Problem
+When deploying updated container images to an existing Cloud Run service with GPU (e.g., NVIDIA L4),
+`gcloud run deploy` fails with quota errors even though the service is already running with a GPU.
+The quota check blocks both zonal and non-zonal redundancy configurations, making it impossible
+to deploy updated code.
+
+## Context / Trigger Conditions
+- `gcloud run deploy` returns:
+  ```
+  metadata.annotations[run.googleapis.com/maxScale]: You do not have quota for
+  using GPUs with zonal redundancy.
+  ```
+  Followed by:
+  ```
+  metadata.annotations[run.googleapis.com/maxScale]: You do not have quota for
+  using GPUs without zonal redundancy.
+  ```
+- The GPU service already exists and has a running revision
+- You're trying to deploy an updated container image, not change GPU configuration
+- The deploy script uses `gcloud run deploy` with `--gpu` flags
+
+## Solution
+
+Instead of `gcloud run deploy` (which re-validates all resource quotas), use
+`gcloud run services update` which only updates the specified fields on the existing service:
+
+```bash
+# Instead of this (fails with quota error):
+gcloud run deploy divine-transcoder \
+  --image gcr.io/PROJECT/divine-transcoder \
+  --region us-central1 \
+  --gpu 1 --gpu-type nvidia-l4 \
+  --cpu 4 --memory 16Gi \
+  ...
+
+# Use this (updates image on existing service):
+gcloud run services update divine-transcoder \
+  --region us-central1 \
+  --image gcr.io/PROJECT/divine-transcoder:latest
+```
+
+Key differences:
+- `gcloud run deploy` creates a new service or replaces the full configuration, triggering quota checks
+- `gcloud run services update --image` only updates the container image on the existing service,
+  preserving all existing GPU/CPU/memory configuration without re-validating quotas
+
+## Verification
+```bash
+# Verify new revision is active
+gcloud run revisions list --service SERVICE_NAME --region REGION --limit=3
+
+# Check the service is serving traffic
+gcloud run services describe SERVICE_NAME --region REGION --format='value(status.url)'
+```
+
+## Example
+
+```bash
+# Build and push updated image
+docker build --platform linux/amd64 -t gcr.io/my-project/divine-transcoder .
+docker push gcr.io/my-project/divine-transcoder
+
+# Update only the image (bypasses GPU quota re-validation)
+gcloud run services update divine-transcoder \
+  --region us-central1 \
+  --image gcr.io/my-project/divine-transcoder:latest
+
+# Output:
+# Deploying...
+# Creating Revision...done
+# Routing traffic...done
+# Service [divine-transcoder] revision [divine-transcoder-00010-vf4] has been deployed
+```
+
+## Notes
+- This only works for existing services that already have GPU configured
+- If you need to change GPU type, CPU, memory, or other settings, you'll need to
+  request additional quota via https://g.co/cloudrun/gpu-quota
+- First-time GPU deployments in a region get automatic quota of 3 GPUs (non-zonal)
+- Quota increases for non-zonal redundancy are granted more quickly than zonal
+- If deploy scripts use `gcloud run deploy`, consider adding a fallback to
+  `gcloud run services update --image` when quota errors are detected
+
+## References
+- [Cloud Run GPU support for services](https://docs.google.com/run/docs/configuring/services/gpu)
+- [Cloud Run Quotas and Limits](https://docs.google.com/run/quotas)
+- [Cloud Run GPUs GA announcement](https://cloud.google.com/blog/products/serverless/cloud-run-gpus-are-now-generally-available)

--- a/.claude/skills/cloud-run-job-cloudsql-setup/SKILL.md
+++ b/.claude/skills/cloud-run-job-cloudsql-setup/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: cloud-run-job-cloudsql-setup
+description: |
+  Set up Cloud Run Jobs with CloudSQL connection. Use when: (1) Deploying long-running
+  batch jobs that need database access, (2) Errors like "Cloud SQL Proxy not found" in
+  container, (3) "password authentication failed" despite correct credentials, (4) Job
+  creation fails with permission errors. Covers socket path configuration, IAM permissions,
+  and common gotchas.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-31
+---
+
+# Cloud Run Job with CloudSQL Setup
+
+## Problem
+Setting up Cloud Run Jobs to connect to CloudSQL involves multiple non-obvious steps
+and gotchas that cause confusing errors. The main issues are:
+1. Wrong gcloud flags for CloudSQL connection
+2. Incorrect socket path configuration
+3. Missing IAM permissions
+4. App code trying to start proxy when Cloud Run already provides it
+
+## Context / Trigger Conditions
+- Error: "unrecognized arguments: --add-cloudsql-instances" (wrong flag name)
+- Error: "Cloud SQL Proxy not found" (app trying to start proxy in container)
+- Error: "password authentication failed" (socket path misconfigured or newline in secret)
+- Error: "Permission denied on secret" (missing secretAccessor role)
+- Error: "does not have permission to access namespaces" (missing cloudsql.client role)
+
+## Solution
+
+### 1. Create the Job with Correct Flags
+
+```bash
+gcloud run jobs create my-job \
+  --region=us-central1 \
+  --image=gcr.io/PROJECT/IMAGE:latest \
+  --set-cloudsql-instances=PROJECT:REGION:INSTANCE \  # NOT --add-cloudsql-instances
+  --set-env-vars="POSTGRES_SOCKET_PATH=/cloudsql/PROJECT:REGION:INSTANCE,POSTGRES_DATABASE=mydb,POSTGRES_USER=myuser" \
+  --set-secrets="POSTGRES_PASSWORD=my-secret:latest"
+```
+
+**Key:** Use `--set-cloudsql-instances` NOT `--add-cloudsql-instances`
+
+### 2. Configure Socket Path in App
+
+For Node.js with `pg` library:
+```typescript
+// Use socketPath for unix socket, not host
+if (config.socketPath) {
+  pool = new Pool({
+    host: config.socketPath,  // e.g., "/cloudsql/project:region:instance"
+    database: config.database,
+    user: config.user,
+    password: config.password,
+  });
+}
+```
+
+Environment variable: `POSTGRES_SOCKET_PATH=/cloudsql/PROJECT:REGION:INSTANCE`
+
+### 3. Grant Required IAM Permissions
+
+```bash
+# Secret access
+gcloud secrets add-iam-policy-binding my-secret \
+  --member="serviceAccount:PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# CloudSQL connection
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
+  --role="roles/cloudsql.client"
+```
+
+### 4. Don't Auto-Start Proxy in Container
+
+Cloud Run automatically provides the CloudSQL proxy socket. If your app has logic to
+start the proxy, skip it when a socket path is configured:
+
+```typescript
+// Skip proxy start if socketPath provided (Cloud Run handles it)
+if (!config.socketPath && config.host === "localhost") {
+  await ensureCloudSqlProxy();  // Only for local development
+}
+```
+
+### 5. Create Secrets Without Newlines
+
+```bash
+# WRONG - adds trailing newline
+gcloud secrets create my-secret --data-file=- <<< "password"
+
+# CORRECT - no trailing newline
+echo -n "password" | gcloud secrets create my-secret --data-file=-
+```
+
+## Verification
+
+```bash
+# Check job config
+gcloud run jobs describe my-job --region=us-central1
+
+# Execute and check logs
+gcloud run jobs execute my-job --region=us-central1
+gcloud run jobs logs read my-job --region=us-central1 --limit=50
+```
+
+## Example: Complete Setup
+
+```bash
+# 1. Create secrets (no newlines!)
+echo -n "dbpassword123" | gcloud secrets create db-password --data-file=-
+
+# 2. Grant permissions
+gcloud secrets add-iam-policy-binding db-password \
+  --member="serviceAccount:123456789-compute@developer.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# 3. Create job
+gcloud run jobs create my-processor \
+  --region=us-central1 \
+  --image=gcr.io/my-project/processor:latest \
+  --memory=4Gi \
+  --cpu=2 \
+  --task-timeout=86400s \
+  --max-retries=3 \
+  --set-cloudsql-instances=my-project:us-central1:my-instance \
+  --set-env-vars="POSTGRES_SOCKET_PATH=/cloudsql/my-project:us-central1:my-instance,POSTGRES_DATABASE=mydb,POSTGRES_USER=myuser" \
+  --set-secrets="POSTGRES_PASSWORD=db-password:latest"
+
+# 4. Execute
+gcloud run jobs execute my-processor --region=us-central1
+```
+
+## Notes
+- Cloud Run Job timeout max is 86400s (24 hours)
+- The socket path format is `/cloudsql/PROJECT:REGION:INSTANCE`
+- Socket appears as a Unix socket at that path when container starts
+- No need for Cloud SQL Proxy binary in your container
+- Cloud Build service account needs different permissions than the compute service account
+- **PostgreSQL password reset gotcha**: When resetting Cloud SQL PostgreSQL passwords, do NOT use `--host='%'`. That flag is MySQL-specific and creates a separate user entry in PostgreSQL, causing intermittent password auth failures (some jobs connect, others don't, despite identical DATABASE_URL). Use: `gcloud sql users set-password USERNAME --instance=INSTANCE --password=PASSWORD` (no `--host` flag)
+- Password changes may take a minute to propagate through Cloud SQL Auth Proxy sidecars. If auth fails immediately after a reset, redeploy the job to force a fresh proxy connection
+
+## References
+- https://cloud.google.com/run/docs/configuring/connect-cloudsql
+- https://cloud.google.com/sql/docs/postgres/connect-run

--- a/.claude/skills/cloud-run-static-outbound-ip/SKILL.md
+++ b/.claude/skills/cloud-run-static-outbound-ip/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: cloud-run-static-outbound-ip
+description: |
+  Configure static outbound IP addresses for Google Cloud Run jobs/services. Use when:
+  (1) External service needs to whitelist your IP (archive.org, APIs, firewalls),
+  (2) Cloud Run requests appear from random/changing IPs, (3) Need consistent source IP
+  for crawlers, scrapers, or API clients running on Cloud Run. Requires VPC connector +
+  Cloud NAT + static IP reservation. Works for both Cloud Run services and jobs.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-26
+---
+
+# Cloud Run Static Outbound IP Address
+
+## Problem
+Cloud Run uses a shared pool of dynamic outbound IP addresses that change frequently
+and are shared across all Google Cloud customers. When external services need to
+whitelist your IP (for rate limit exemptions, firewall rules, or special access),
+you need a static, predictable outbound IP.
+
+## Context / Trigger Conditions
+- External service asks for IP address to whitelist
+- Cloud Run requests are being blocked by IP-based rate limiting
+- Need to identify your traffic to external APIs
+- Running crawlers/scrapers that need consistent source IP
+- Error messages about "IP not whitelisted" or similar
+
+## Solution
+
+### Architecture
+```
+Cloud Run → VPC Connector → VPC Network → Cloud NAT (static IP) → Internet
+```
+
+### Step 1: Reserve Static IP Address
+```bash
+gcloud compute addresses create [NAME]-nat-ip \
+  --region=[REGION] \
+  --description="Static IP for Cloud Run outbound traffic"
+
+# Get the actual IP address
+gcloud compute addresses describe [NAME]-nat-ip \
+  --region=[REGION] \
+  --format="value(address)"
+```
+
+### Step 2: Create Cloud Router
+```bash
+gcloud compute routers create [NAME]-router \
+  --network=default \
+  --region=[REGION]
+```
+
+### Step 3: Create Cloud NAT with Static IP
+```bash
+gcloud compute routers nats create [NAME]-nat \
+  --router=[NAME]-router \
+  --region=[REGION] \
+  --nat-external-ip-pool=[NAME]-nat-ip \
+  --nat-all-subnet-ip-ranges
+```
+
+### Step 4: Enable VPC Access API
+```bash
+gcloud services enable vpcaccess.googleapis.com
+```
+
+### Step 5: Create Serverless VPC Access Connector
+```bash
+gcloud compute networks vpc-access connectors create [NAME]-connector \
+  --region=[REGION] \
+  --network=default \
+  --range=10.8.0.0/28 \
+  --min-instances=2 \
+  --max-instances=3 \
+  --machine-type=e2-micro
+```
+Note: The IP range must not conflict with existing subnets. Use a /28 CIDR block.
+
+### Step 6: Update Cloud Run to Use VPC Connector
+
+For Cloud Run Jobs:
+```bash
+gcloud run jobs deploy [JOB-NAME] \
+  --image=[IMAGE] \
+  --region=[REGION] \
+  --vpc-connector=[NAME]-connector \
+  --vpc-egress=all-traffic \
+  [... other flags ...]
+```
+
+For Cloud Run Services:
+```bash
+gcloud run deploy [SERVICE-NAME] \
+  --image=[IMAGE] \
+  --region=[REGION] \
+  --vpc-connector=[NAME]-connector \
+  --vpc-egress=all-traffic \
+  [... other flags ...]
+```
+
+**Critical**: `--vpc-egress=all-traffic` is required to route ALL outbound traffic
+through the VPC/NAT. Without this, only traffic to internal IPs uses the connector.
+
+## Verification
+
+Test that outbound traffic uses the static IP:
+```bash
+# Run a container that checks its external IP
+gcloud run jobs execute [JOB-NAME] --region=[REGION] \
+  --args="curl,-s,https://api.ipify.org"
+```
+
+Or add a test endpoint to your service that calls an IP echo service.
+
+## Example: Complete Setup Script
+
+```bash
+#!/bin/bash
+set -e
+
+PROJECT_ID="my-project"
+REGION="us-central1"
+NAME="my-crawler"
+
+# Reserve static IP
+gcloud compute addresses create ${NAME}-nat-ip --region=$REGION
+
+# Get and display the IP
+STATIC_IP=$(gcloud compute addresses describe ${NAME}-nat-ip \
+  --region=$REGION --format="value(address)")
+echo "Static IP: $STATIC_IP"
+
+# Create router
+gcloud compute routers create ${NAME}-router \
+  --network=default --region=$REGION
+
+# Create NAT
+gcloud compute routers nats create ${NAME}-nat \
+  --router=${NAME}-router \
+  --region=$REGION \
+  --nat-external-ip-pool=${NAME}-nat-ip \
+  --nat-all-subnet-ip-ranges
+
+# Enable API and create connector
+gcloud services enable vpcaccess.googleapis.com
+gcloud compute networks vpc-access connectors create ${NAME}-connector \
+  --region=$REGION \
+  --network=default \
+  --range=10.8.0.0/28 \
+  --min-instances=2 \
+  --max-instances=3 \
+  --machine-type=e2-micro
+
+echo "Setup complete! Use these flags in Cloud Run deployments:"
+echo "  --vpc-connector=${NAME}-connector"
+echo "  --vpc-egress=all-traffic"
+echo ""
+echo "Static IP for whitelisting: $STATIC_IP"
+```
+
+## Cost Considerations
+- **Static IP**: Free while in use, ~$7/month if reserved but unused
+- **VPC Connector**: ~$7-20/month (2-3 e2-micro instances minimum)
+- **Cloud NAT**: ~$1/month + $0.045/GB processed
+
+Total: ~$10-30/month depending on traffic volume.
+
+## Notes
+
+- All Cloud Run instances/jobs using the same VPC connector share the static IP
+- You can scale Cloud Run horizontally without changing IPs
+- VPC connector has throughput limits (~200-1000 Mbps depending on instance count)
+- For high-throughput needs, increase max-instances on the connector
+- Cloud SQL connections don't need to go through NAT (use Cloud SQL connector instead)
+- The VPC connector adds ~1-5ms latency to requests
+
+## Cleanup
+
+To remove the setup:
+```bash
+gcloud compute networks vpc-access connectors delete ${NAME}-connector --region=$REGION
+gcloud compute routers nats delete ${NAME}-nat --router=${NAME}-router --region=$REGION
+gcloud compute routers delete ${NAME}-router --region=$REGION
+gcloud compute addresses delete ${NAME}-nat-ip --region=$REGION
+```
+
+## References
+- [Cloud Run VPC Connectors](https://cloud.google.com/run/docs/configuring/vpc-connectors)
+- [Cloud NAT Overview](https://cloud.google.com/nat/docs/overview)
+- [Static Outbound IP for Cloud Run](https://cloud.google.com/run/docs/configuring/static-outbound-ip)

--- a/.claude/skills/cloud-scheduler-permission-denied/SKILL.md
+++ b/.claude/skills/cloud-scheduler-permission-denied/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: cloud-scheduler-permission-denied
+description: |
+  Fix Google Cloud Scheduler silently failing to trigger Cloud Run jobs with status code 7
+  (PERMISSION_DENIED). Use when: (1) Cloud Run jobs stop running but schedulers show ENABLED,
+  (2) gcloud scheduler jobs describe shows lastAttemptTime but status.code: 7,
+  (3) Jobs worked before but stopped after IAM changes or project updates.
+  The scheduler service account needs roles/run.invoker on the project.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-08
+---
+
+# Cloud Scheduler Permission Denied (Code 7)
+
+## Problem
+Cloud Scheduler jobs silently fail to trigger Cloud Run jobs. The scheduler shows as
+ENABLED, attempts are made (lastAttemptTime updates), but Cloud Run jobs never start.
+The only indicator is `status.code: 7` which means PERMISSION_DENIED.
+
+## Context / Trigger Conditions
+- Cloud Run jobs previously ran on schedule but stopped
+- Dashboard shows jobs as "FAILED" or "DONE" with old timestamps
+- `gcloud scheduler jobs describe <name>` shows:
+  ```
+  lastAttemptTime: '2026-02-08T14:00:03.316530Z'
+  state: ENABLED
+  status:
+    code: 7
+  ```
+- No obvious errors in Cloud Logging for the scheduler
+
+## Solution
+
+1. **Identify the scheduler's service account**:
+   ```bash
+   gcloud scheduler jobs describe <scheduler-name> \
+     --location=<region> \
+     --project=<project> \
+     --format="yaml(httpTarget.oauthToken.serviceAccountEmail)"
+   ```
+
+2. **Grant run.invoker role to that service account**:
+   ```bash
+   gcloud projects add-iam-policy-binding <project-id> \
+     --member="serviceAccount:<service-account-email>" \
+     --role="roles/run.invoker"
+   ```
+
+3. **Test by manually triggering the scheduler**:
+   ```bash
+   gcloud scheduler jobs run <scheduler-name> \
+     --location=<region> \
+     --project=<project>
+   ```
+
+4. **Verify the Cloud Run job started**:
+   ```bash
+   gcloud run jobs executions list \
+     --region=<region> \
+     --project=<project> \
+     --limit=5
+   ```
+
+## Verification
+After granting permissions and triggering:
+- `status.code` should no longer be 7 on next attempt
+- New Cloud Run job execution should appear in executions list
+- Execution should show RUNNING status
+
+## Example
+
+```bash
+# Check scheduler status - note code: 7
+gcloud scheduler jobs describe profile-crawler-schedule \
+  --location=us-central1 \
+  --project=my-project
+
+# Grant permission
+gcloud projects add-iam-policy-binding my-project \
+  --member="serviceAccount:my-scheduler@my-project.iam.gserviceaccount.com" \
+  --role="roles/run.invoker"
+
+# Test
+gcloud scheduler jobs run profile-crawler-schedule \
+  --location=us-central1 \
+  --project=my-project
+```
+
+## Notes
+- Status code 7 is gRPC's PERMISSION_DENIED - not documented prominently for Cloud Scheduler
+- This commonly happens after:
+  - Creating new service accounts
+  - Migrating projects
+  - IAM policy updates that remove inherited permissions
+  - Using a custom service account instead of the default
+- The scheduler will keep attempting (and failing) silently - no alerts by default
+- Consider adding Cloud Monitoring alerts for scheduler failures
+
+## References
+- [Cloud Scheduler HTTP targets](https://cloud.google.com/scheduler/docs/http-target-auth)
+- [Cloud Run IAM roles](https://cloud.google.com/run/docs/reference/iam/roles)
+- [gRPC status codes](https://grpc.io/docs/guides/status-codes/)

--- a/.claude/skills/cloudsql-idle-connection-timeout/SKILL.md
+++ b/.claude/skills/cloudsql-idle-connection-timeout/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: cloudsql-idle-connection-timeout
+description: |
+  Fix psycopg2 "could not receive data from server: Operation timed out" or
+  "connection already closed" errors when using Cloud SQL with long-running Python scripts.
+  Use when: (1) psycopg2.OperationalError after a period of no DB activity, (2) DB connection
+  works initially but fails after a non-DB phase (API calls, file processing, CDX scans),
+  (3) Cloud SQL managed PostgreSQL kills idle connections. The fix is to defer DB connection
+  opening until needed, or add reconnection logic for long-running batch processes.
+author: Claude Code
+version: 1.0.0
+date: 2025-05-15
+---
+
+# Cloud SQL Idle Connection Timeout Fix
+
+## Problem
+Cloud SQL (and other managed PostgreSQL services) kill idle connections after a timeout
+(typically 10 minutes). Long-running scripts that open a DB connection early, then perform
+non-DB work (HTTP requests, file I/O, CDX scanning), then try to use the DB connection
+again will get a misleading error.
+
+## Context / Trigger Conditions
+- `psycopg2.OperationalError: could not receive data from server: Operation timed out`
+- `psycopg2.InterfaceError: connection already closed`
+- Script has phases: DB setup → long non-DB work → DB writes
+- Using Google Cloud SQL, AWS RDS, or Azure Database for PostgreSQL
+- Connection was working initially, fails after idle period
+- The error appears AFTER a phase that doesn't use the DB (e.g., API crawling, file processing)
+
+## Solution
+
+### Pattern 1: Defer DB Connection (Preferred)
+
+Structure code so the DB connection opens AFTER the non-DB phase:
+
+```python
+# BAD: Connection opens before long CDX scan
+with VineDatabase() as db:
+    ensure_schema(db)
+    results = long_running_api_scan()  # 5-10 minutes, no DB needed
+    process_results(db, results)  # Connection dead here!
+
+# GOOD: CDX scan first, then fresh DB connection
+results = long_running_api_scan()  # No DB connection open
+
+with VineDatabase() as db:  # Fresh connection when actually needed
+    ensure_schema(db)
+    process_results(db, results)
+```
+
+### Pattern 2: Reconnection Logic (For Long Batch Operations)
+
+For operations that DO use the DB but might exceed the idle timeout between writes:
+
+```python
+import psycopg2
+
+def reconnect_db():
+    """Create a fresh database connection."""
+    db = VineDatabase()
+    cursor = db._cursor()
+    return db, cursor
+
+def process_batch(db, cursor, items):
+    for item in items:
+        data = fetch_from_api(item)  # Slow network call
+        try:
+            cursor.execute("INSERT INTO ...", data)
+            db.conn.commit()
+        except (psycopg2.OperationalError, psycopg2.InterfaceError):
+            # Connection died, reconnect and retry
+            try:
+                db.close()
+            except Exception:
+                pass
+            db, cursor = reconnect_db()
+            cursor.execute("INSERT INTO ...", data)
+            db.conn.commit()
+```
+
+### Pattern 3: TCP Keepalive (Alternative)
+
+Configure psycopg2 to send TCP keepalive packets:
+
+```python
+conn = psycopg2.connect(
+    database_url,
+    keepalives=1,
+    keepalives_idle=60,
+    keepalives_interval=10,
+    keepalives_count=5
+)
+```
+
+Note: This may not work with all Cloud SQL proxy configurations.
+
+## Verification
+
+1. Run the script with the long non-DB phase
+2. Confirm no `OperationalError` or `InterfaceError` after the idle period
+3. Verify data is being written to the DB during the fetch phase:
+   ```sql
+   SELECT COUNT(*) FROM your_table WHERE created_at > NOW() - INTERVAL '5 minutes';
+   ```
+
+## Example
+
+A Vine archive crawler that:
+1. Scans Wayback Machine CDX for archived profiles (107 pages, ~6 minutes)
+2. Then fetches and stores each profile in Cloud SQL
+
+The CDX scan doesn't need the DB, so opening the connection before it means the
+connection sits idle for 6 minutes and gets killed by Cloud SQL. Fix: run CDX scan
+first, then open DB connection for the fetch-and-store phase.
+
+## Notes
+- Cloud SQL default idle timeout is ~10 minutes but can vary
+- The error message "could not receive data from server: Operation timed out" is
+  misleading—it sounds like a network issue but is actually an idle timeout
+- `psycopg2.InterfaceError: connection already closed` often follows the OperationalError
+- For very long batch operations (hours), combine Pattern 1 and Pattern 2
+- Also check Cloud SQL authorized networks if connection fails immediately (different error)
+- When using `nohup` or background processes, ensure output is unbuffered (`PYTHONUNBUFFERED=1`)

--- a/.claude/skills/content-addressable-storage-immutability/SKILL.md
+++ b/.claude/skills/content-addressable-storage-immutability/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: content-addressable-storage-immutability
+description: |
+  CRITICAL: Never modify files in content-addressable storage systems where the filename
+  IS the content hash (SHA256, IPFS CID, etc.). Use when: (1) Working with Blossom protocol,
+  IPFS, or any CAS system, (2) Considering "optimizing" stored files (faststart, compression),
+  (3) Implementing transcoding or processing pipelines for hash-identified content,
+  (4) Building on top of ProofMode or any cryptographic verification system. Modifying
+  files in place breaks hash verification and content integrity.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-31
+---
+
+# Content-Addressable Storage Immutability
+
+## Problem
+In content-addressable storage (CAS) systems, files are identified by their content hash.
+If you modify a file in place (even "harmless" optimizations), the content no longer
+matches its identifier, breaking the entire system's integrity guarantees.
+
+## Context / Trigger Conditions
+- Working with Blossom protocol (files at `/{sha256}`)
+- Working with IPFS (files at `/ipfs/{CID}`)
+- Any system where filename = hash of content
+- Considering file optimizations like:
+  - MP4 faststart (moving moov atom)
+  - Image optimization/compression
+  - Metadata stripping
+  - Format conversion
+- Systems using ProofMode or cryptographic verification
+
+## The Fundamental Rule
+
+**NEVER modify a file stored at its content hash.**
+
+The hash IS the identity. Change the content → change the hash → file is now at wrong address.
+
+## What Goes Wrong
+
+```
+Original file: abc123... (hash) → contains bytes X
+After "optimization": abc123... (hash) → contains bytes Y
+
+Result:
+- Hash abc123 no longer verifies
+- ProofMode signatures invalid
+- Content-addressable lookups return wrong data
+- Cryptographic proofs broken
+- Data integrity compromised
+```
+
+## Solution: Store Derivatives Separately
+
+If you need optimized/processed versions, store them at separate paths:
+
+```
+/{hash}                    ← Original file (NEVER MODIFY)
+/{hash}/hls/master.m3u8    ← HLS transcoded version
+/{hash}/faststart.mp4      ← Faststart optimized version
+/{hash}/thumb.jpg          ← Thumbnail
+/{hash}/720p.mp4           ← Resolution variant
+```
+
+The original stays byte-for-byte identical. Derivatives live in subdirectories.
+
+## Implementation Pattern
+
+```rust
+// WRONG - modifies original
+async fn process_video(hash: &str) {
+    let path = format!("/{}", hash);
+    let video = download(&path);
+    let optimized = apply_faststart(video);
+    upload(&path, optimized);  // ❌ BREAKS HASH!
+}
+
+// RIGHT - creates derivative
+async fn process_video(hash: &str) {
+    let original_path = format!("/{}", hash);
+    let derivative_path = format!("/{}/faststart.mp4", hash);
+
+    let video = download(&original_path);
+    let optimized = apply_faststart(video);
+    upload(&derivative_path, optimized);  // ✓ Original untouched
+}
+```
+
+## Verification
+- Original file hash still verifies: `sha256sum file == filename`
+- ProofMode signatures still valid
+- Content lookups return expected data
+
+## Common Mistakes
+
+1. **"It's just moving metadata"** - Still changes bytes, still breaks hash
+2. **"We'll update the hash reference"** - Now you have dangling references everywhere
+3. **"No one will notice"** - Verification systems WILL notice
+4. **"It's an optimization"** - Optimize derivatives, not originals
+
+## Notes
+- This applies to ANY content-addressable system, not just Blossom
+- IPFS, Git objects, Docker layers all follow this principle
+- If you need the optimized version as primary, the client should upload it that way
+- Transcoding to new formats (HLS, DASH) is fine because they're clearly separate files
+
+## References
+- [Content-addressable storage (Wikipedia)](https://en.wikipedia.org/wiki/Content-addressable_storage)
+- [Blossom Protocol (BUD-01)](https://github.com/hzrd149/blossom)
+- [IPFS Content Addressing](https://docs.ipfs.tech/concepts/content-addressing/)

--- a/.claude/skills/curl-head-vs-get-header-debugging/SKILL.md
+++ b/.claude/skills/curl-head-vs-get-header-debugging/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: curl-head-vs-get-header-debugging
+description: |
+  Fix misleading HTTP response header values when debugging with curl -I or curl -sI.
+  Use when: (1) Response headers differ between curl testing and actual browser/client behavior,
+  (2) Cache-Control or other headers show unexpected values despite correct middleware code,
+  (3) Server-side middleware that only applies to GET requests appears to not work when testing
+  with curl -I. The -I flag sends HEAD requests, and middleware that checks for GET method will
+  skip processing, returning handler-level headers instead of middleware-overridden ones.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-31
+---
+
+# curl -I Sends HEAD, Not GET — Header Debugging Trap
+
+## Problem
+When debugging HTTP response headers with `curl -I` or `curl -sI`, the response may show
+different header values than what actual GET requests receive. This is because `-I` sends
+a HEAD request, and server middleware that only processes GET requests will be skipped.
+
+## Context / Trigger Conditions
+- Testing cache headers with `curl -sI` and seeing unexpected values
+- Middleware that checks `method == GET` before setting headers (common in cache middleware)
+- Headers appear correct in automated tests but wrong in manual curl testing
+- `Cache-Control`, `Surrogate-Control`, or `Surrogate-Key` values don't match expectations
+- Axum/Express/any framework middleware with method guards
+
+## Solution
+Use `curl -s -D - -o /dev/null` instead of `curl -I` to get response headers from a **GET** request:
+
+```bash
+# WRONG — sends HEAD request, middleware may skip processing
+curl -sI https://example.com/api/endpoint
+
+# CORRECT — sends GET request, dumps headers, discards body
+curl -s -D - -o /dev/null https://example.com/api/endpoint
+```
+
+If you need just specific headers:
+```bash
+curl -s -D - -o /dev/null https://example.com/api/endpoint | grep -iE 'cache-control|surrogate'
+```
+
+## Verification
+Compare output from both methods:
+```bash
+echo "=== HEAD (curl -I) ===" 
+curl -sI https://example.com/api/endpoint | grep cache-control
+
+echo "=== GET (curl -D) ==="
+curl -s -D - -o /dev/null https://example.com/api/endpoint | grep cache-control
+```
+
+If the values differ, your middleware has a GET-only guard (which is correct behavior).
+
+## Example
+Axum middleware that only sets cache headers for GET requests:
+```rust
+async fn cache_middleware(request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let mut response = next.run(request).await;
+    
+    // HEAD requests skip this — curl -I won't see these headers!
+    if method != Method::GET {
+        return response;
+    }
+    
+    response.headers_mut().insert("cache-control", ...);
+    response.headers_mut().insert("surrogate-control", ...);
+    response
+}
+```
+
+## Notes
+- This is NOT a bug — it's correct behavior. Cache headers should only apply to cacheable GET responses.
+- HTTP spec says HEAD responses SHOULD include the same headers as GET, but middleware implementations
+  often don't replicate this because HEAD is rarely used by CDNs or browsers for caching decisions.
+- Fastly, Cloudflare, and other CDNs send GET requests to origins, so the cache behavior is correct
+  even if `curl -I` shows different headers.
+- This trap is especially insidious because `curl -I` is the most common way to check headers.

--- a/.claude/skills/dart-lifecycle-disposed-flag-overload/SKILL.md
+++ b/.claude/skills/dart-lifecycle-disposed-flag-overload/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: dart-lifecycle-disposed-flag-overload
+description: |
+  Fix Dart/Flutter services where calling start() after stop() is a silent no-op
+  because stop() sets a _disposed (or similar) flag that start()'s guard short-circuits
+  on. Use when: (1) A repository/service/controller has startListening/stopListening,
+  subscribe/unsubscribe, open/close, or similar lifecycle methods, (2) Re-opening
+  the service after closing it appears to do nothing — no subscription, no events,
+  no error, (3) Unit tests that only exercise a single mount/open/start cycle pass
+  while the real app breaks on the second visit to a screen, (4) A boolean flag
+  is used both for "in the middle of tearing down this instance forever" AND for
+  "currently stopped, can be re-started". Common in Riverpod/Bloc-driven screens
+  that wire startListening() in initState and stopListening() in dispose — the
+  second time the user visits the screen, nothing happens.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# Dart Lifecycle `_disposed` Flag Overload
+
+## Problem
+
+A Dart/Flutter class with start/stop lifecycle methods sets a "disposed"/"stopped"
+boolean inside `stop()`, but the guard clause in `start()` short-circuits whenever
+that boolean is true. After a stop→start cycle, `start()` silently returns without
+doing anything. The class has two distinct concerns conflated into one flag:
+
+1. **"This instance is permanently torn down"** (e.g. user switched accounts, object
+   is being discarded) — should prevent any further work.
+2. **"Currently not listening, but could be re-started"** (e.g. user navigated away
+   from the inbox screen and may come back) — must allow future `start()` calls.
+
+When those concerns share a single flag, the second concern silently breaks the
+first.
+
+## Context / Trigger Conditions
+
+- A class (repository, service, controller, bloc, cubit, notifier) has methods like:
+  - `startListening()` / `stopListening()`
+  - `subscribe()` / `unsubscribe()`
+  - `connect()` / `disconnect()`
+  - `open()` / `close()`
+- `stop()` includes a line like `_disposed = true;` or `_stopped = true;`
+- `start()` begins with a guard like:
+  ```dart
+  if (_subscription != null || _disposed || !isInitialized) return;
+  ```
+- Symptom: the feature works on first open, breaks on every subsequent open
+- Unit tests that mock the dependencies pass because they only exercise one cycle
+  OR because the mock doesn't model the real instance's internal state
+- Manual QA finds that leaving and returning to a screen breaks the feature silently
+  (no error thrown, no log emitted, no visible indication)
+
+## Solution
+
+**Separate the two concerns.** Reserve the permanent-teardown flag for the code path
+that actually tears the instance down for good (typically a `_resetState()` called on
+user-switch or full logout), and do NOT set it inside `stop()`.
+
+### Before (broken)
+
+```dart
+class MyRepository {
+  bool _disposed = false;
+  StreamSubscription<Event>? _subscription;
+
+  void startListening() {
+    if (_subscription != null || _disposed || !isInitialized) return;
+    _subscription = _client.subscribe(...).listen(...);
+  }
+
+  Future<void> stopListening() async {
+    _disposed = true;                    // ← THE BUG
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+
+  void _resetState() {
+    _disposed = true;
+    // ... wipe credentials ...
+    _disposed = false;
+  }
+}
+```
+
+After `stopListening()`, `_disposed == true` forever until `_resetState()` is called
+(which only happens on user switch). Any subsequent `startListening()` hits the guard
+and returns silently.
+
+### After (fixed)
+
+```dart
+class MyRepository {
+  bool _disposed = false;
+  StreamSubscription<Event>? _subscription;
+
+  void startListening() {
+    // Guard still checks _disposed for the permanent-teardown case — that
+    // window is only open during _resetState()'s synchronous body.
+    if (_subscription != null || _disposed || !isInitialized) return;
+    _subscription = _client.subscribe(...).listen(...);
+  }
+
+  Future<void> stopListening() async {
+    // Do NOT set _disposed here — _disposed is reserved for _resetState()
+    // (permanent teardown, e.g. user switch). Setting it would make a
+    // subsequent startListening() call a silent no-op and break re-open
+    // flows like "user leaves the screen and comes back later".
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+
+  void _resetState() {
+    _disposed = true;
+    // ... wipe credentials, cancel subscription, etc. ...
+    _disposed = false;
+  }
+}
+```
+
+The `_subscription != null` half of the guard is still sufficient to make
+`startListening()` idempotent against double-calls within a single listening lifetime.
+
+## Verification
+
+1. **Add a regression test** that exercises start → stop → start and asserts the
+   start work happened twice:
+
+   ```dart
+   test('startListening after stopListening re-opens the subscription', () async {
+     final repo = createRepository();
+     repo.initialize(...);
+
+     repo.startListening();
+     await repo.stopListening();
+     repo.startListening();
+
+     // Both opens must hit the client.
+     verify(() => mockClient.subscribe(any(), ...)).called(2);
+
+     await repo.stopListening();
+   });
+   ```
+
+2. **Manual QA:** visit the screen that drives the lifecycle, back out of it,
+   visit it again. The feature should work on the second visit identically to
+   the first.
+
+3. **Run the existing test for the permanent-teardown path** (e.g. user switch /
+   `_resetState()`) and confirm it still passes. The fix should not affect that path.
+
+## Example
+
+From divine-mobile (PR #2769, April 2026): `DmRepository` drove NIP-17 gift-wrap
+subscription lifecycle from the inbox screen's `initState`/`dispose`. On the second
+visit to the inbox, DMs silently stopped arriving. Root cause: `stopListening()` had
+`_disposed = true;` as its first line. Fix: delete that line, leave an explanatory
+comment, add a regression test that asserts `mockNostrClient.subscribe` was called
+twice after an open → close → open cycle. Commit
+`bd1420eb3 fix(dm): allow startListening() to succeed after stopListening()`.
+
+## Notes
+
+- **Why mocks hide this bug:** unit tests that mock the dependency (e.g. a mock
+  `NostrClient`) only verify that the repository calls `subscribe()` once when
+  `startListening()` is called. They don't exercise the real state machine across
+  multiple cycles unless the test explicitly cycles start→stop→start and verifies
+  the second start also called `subscribe`. Add that cycle to your lifecycle test
+  suite preemptively.
+- **Alternative name for the flag:** if you need two flags because both concerns
+  genuinely exist, name them for their actual meaning: `_permanentlyDisposed` (or
+  `_torn_down`) vs `_isListening` (or `_started`). A single `bool` with an overloaded
+  meaning is the root smell.
+- **Riverpod/Bloc lifecycle binding:** this bug is especially common when a screen
+  wires `startListening()` in `initState` and `stopListening()` in `dispose` and
+  the user can leave and return to the screen. If that flow is new, always add a
+  "visit twice" test to your widget test for that screen.
+- **Watch for asymmetric reconnect paths:** `onDone` callbacks on cancelled streams
+  may also read the flag and decide whether to schedule a reconnect. After separating
+  the flags, audit every read of the old flag to confirm the new semantics still
+  match the callsite's intent.
+
+## References
+
+- Dart `StreamSubscription.cancel()` docs: https://api.dart.dev/stable/dart-async/StreamSubscription/cancel.html
+  (cancellation does not deliver a `done` event to the listener, which is relevant
+  when auditing onDone reconnect paths after this fix.)
+- Flutter lifecycle (`State.initState` / `State.dispose`): https://api.flutter.dev/flutter/widgets/State-class.html

--- a/.claude/skills/dead-cdn-dns-bypass/SKILL.md
+++ b/.claude/skills/dead-cdn-dns-bypass/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: dead-cdn-dns-bypass
+description: |
+  Recover content from "dead" CDNs where DNS no longer resolves but servers still respond.
+  Use when: (1) A service shut down but you have URLs to their CDN, (2) DNS lookups fail
+  but you suspect the CDN provider (Fastly, CloudFront, Akamai) still has the content,
+  (3) Archiving content from defunct services like Vine, Tumblr, etc. The key insight:
+  CDN providers often keep serving content long after DNS dies - hit the IP directly
+  with the original Host header.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-27
+---
+
+# Dead CDN DNS Bypass - Recovering Content from Defunct Services
+
+## Problem
+When a service shuts down, their DNS records stop resolving, making URLs appear
+completely dead. However, the actual content often still exists on CDN servers
+(Fastly, CloudFront, Akamai, etc.) that continue serving it - the servers just
+aren't reachable via normal DNS resolution.
+
+## Context / Trigger Conditions
+- Service has shut down (Vine, defunct startups, etc.)
+- Original CDN URLs return DNS resolution errors
+- Content was hosted on a major CDN provider
+- You need to recover/archive historical content
+- Wayback Machine doesn't have the specific content
+
+## Solution
+
+### Step 1: Identify the CDN Provider
+Look at the original URL hostname to identify the CDN:
+- `*.cdn.vine.co` → Fastly
+- `*.cloudfront.net` → AWS CloudFront
+- `*.akamaized.net` → Akamai
+- `*.fastly.net` → Fastly
+
+### Step 2: Find CDN IP Addresses
+For Fastly (common for many defunct services):
+```bash
+# Fastly's anycast IPs
+151.101.1.6
+151.101.65.6
+151.101.129.6
+151.101.193.6
+```
+
+For other CDNs, check their documentation or try known IP ranges.
+
+### Step 3: Test with Host Header
+```bash
+# Test if content is still served
+curl -sI \
+  -H "Host: original-cdn-hostname.com" \
+  "http://FASTLY_IP/path/to/content"
+
+# Example for Vine:
+curl -sI \
+  -H "Host: mtc.cdn.vine.co" \
+  "http://151.101.1.6/r/videos/ABC123.mp4"
+```
+
+### Step 4: Download Content
+```python
+import requests
+
+def download_via_cdn_ip(original_url: str, cdn_ip: str) -> bytes:
+    """Download content bypassing dead DNS."""
+    import re
+
+    # Extract host and path from URL
+    match = re.match(r'https?://([^/]+)(/.+)', original_url)
+    if not match:
+        return None
+
+    host = match.group(1)
+    path = match.group(2)
+
+    # Hit IP directly with Host header
+    response = requests.get(
+        f"http://{cdn_ip}{path}",
+        headers={"Host": host},
+        timeout=30
+    )
+
+    if response.status_code == 200:
+        return response.content
+    return None
+
+# Example usage
+content = download_via_cdn_ip(
+    "http://mtc.cdn.vine.co/r/videos/ABC123.mp4",
+    "151.101.1.6"
+)
+```
+
+## Verification
+1. Check for HTTP 200 response (not 403 or 404)
+2. Verify content-type header matches expected type
+3. Validate file integrity (check magic bytes, file size > 0)
+
+## Example: Vine CDN Recovery
+
+The Vine CDN shut down with DNS in 2017, but as of 2026, Fastly still serves
+the video files:
+
+```python
+# Vine CDN hosts and their Fastly IP
+VINE_CDN_HOSTS = {
+    "mtc.cdn.vine.co": "151.101.1.6",
+    "v.cdn.vine.co": "151.101.1.6",
+}
+
+# Original URL from archived metadata
+video_url = "http://mtc.cdn.vine.co/r/videos/ABC123.mp4?versionId=xyz"
+
+# Download via IP bypass
+import requests
+import re
+
+match = re.match(r'https?://([^/]+)(/.+)', video_url)
+host, path = match.groups()
+
+response = requests.get(
+    f"http://151.101.1.6{path}",
+    headers={"Host": host}
+)
+
+# Save the recovered video
+with open("recovered_video.mp4", "wb") as f:
+    f.write(response.content)
+```
+
+**Result**: Recovered 121,149 Vine videos that Wayback Machine didn't archive.
+
+## Notes
+
+- **CDN caching behavior**: Content may be cached indefinitely on CDN edge servers
+  even after the origin server is gone
+- **Version IDs**: Some CDNs (like S3-backed ones) use versionId parameters -
+  keep these in your requests
+- **Rate limiting**: CDNs may still enforce rate limits even for "dead" domains
+- **HTTPS**: May need to use HTTP instead of HTTPS since SSL certs have expired
+- **Time-sensitive**: This won't work forever - CDNs eventually purge old content
+- **Legal considerations**: Ensure you have rights to archive the content
+
+## Common CDN IP Ranges
+
+| CDN | IP Range | Notes |
+|-----|----------|-------|
+| Fastly | 151.101.0.0/16 | Anycast, try .1.6, .65.6, .129.6, .193.6 |
+| CloudFront | Varies | Check AWS IP ranges JSON |
+| Akamai | Varies | Use GTM lookup tools |
+
+## Related Techniques
+
+- Use Wayback Machine CDX API to find archived metadata with CDN URLs
+- Combine with web.archive.org for content they did capture
+- Check Internet Archive's "Save Page Now" for triggering archival

--- a/.claude/skills/denormalized-priority-column-staleness/SKILL.md
+++ b/.claude/skills/denormalized-priority-column-staleness/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: denormalized-priority-column-staleness
+description: |
+  Fix incorrect priority ordering when using denormalized aggregate columns. Use when:
+  (1) Records are processed in wrong order despite ORDER BY on count/sum columns,
+  (2) Top items by some metric aren't being selected first, (3) Aggregate columns
+  show 0 or NULL for records that should have high values, (4) Priority queue
+  processes low-value items before high-value ones. The root cause is often that
+  denormalized columns (vine_count, loop_count, total_orders, etc.) weren't
+  backfilled or maintained properly. Solution: JOIN with source tables to compute
+  actual aggregates at query time.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-28
+---
+
+# Denormalized Priority Column Staleness
+
+## Problem
+When ordering records by denormalized aggregate columns (like `total_loops`, `vine_count`,
+`order_count`), the query returns items in the wrong priority order because the
+denormalized values are stale, unpopulated, or incorrect.
+
+## Context / Trigger Conditions
+- A batch job processes items in unexpected order
+- Top items (by some aggregate metric) are processed last or skipped
+- `ORDER BY aggregate_column DESC` doesn't return expected results
+- Aggregate columns show 0 or NULL for records that should have high values
+- Only a subset of records have the aggregate column populated
+- Backfill scripts may have run for some records but not others
+
+## Root Cause
+Denormalized columns (copies of aggregated data stored for query performance) can become
+stale when:
+1. Initial data migration didn't populate them
+2. Backfill scripts only ran for some records
+3. New source records were added without updating the denormalized column
+4. The aggregation logic changed but the column wasn't recalculated
+
+## Solution
+
+### Option 1: Compute at Query Time (Immediate Fix)
+Join with the source table to compute actual aggregates:
+
+```sql
+-- BEFORE (broken): Uses potentially stale denormalized column
+SELECT user_id, username
+FROM users
+WHERE status = 'pending'
+ORDER BY total_loops DESC NULLS LAST;
+
+-- AFTER (fixed): Computes actual aggregate from source
+SELECT u.user_id, u.username,
+       COALESCE(SUM(vm.loops), 0) as actual_total_loops
+FROM users u
+LEFT JOIN vine_metadata vm ON u.user_id = vm.user_id
+WHERE u.status = 'pending'
+GROUP BY u.user_id, u.username
+ORDER BY actual_total_loops DESC;
+```
+
+### Option 2: Backfill the Denormalized Column (Permanent Fix)
+Update the denormalized column from the source data:
+
+```sql
+UPDATE users u
+SET total_loops = subq.actual_loops
+FROM (
+    SELECT user_id, COALESCE(SUM(loops), 0) as actual_loops
+    FROM vine_metadata
+    GROUP BY user_id
+) subq
+WHERE u.user_id = subq.user_id;
+```
+
+### Option 3: Use Materialized Views (Best of Both)
+Create a materialized view for the aggregates:
+
+```sql
+CREATE MATERIALIZED VIEW user_stats AS
+SELECT user_id,
+       COUNT(*) as item_count,
+       SUM(loops) as total_loops
+FROM vine_metadata
+GROUP BY user_id;
+
+-- Refresh periodically
+REFRESH MATERIALIZED VIEW user_stats;
+```
+
+## Verification
+After applying the fix, verify the query returns expected results:
+
+```sql
+-- Check that top items are actually top items
+SELECT user_id, username, actual_total_loops
+FROM (your_fixed_query)
+LIMIT 10;
+
+-- Compare against direct aggregate
+SELECT user_id, SUM(loops) as loops
+FROM source_table
+GROUP BY user_id
+ORDER BY loops DESC
+LIMIT 10;
+```
+
+## Example
+
+**Scenario**: Avatar fetcher should process top Viners first (by total loops), but
+instead processes users with ID prefix "10" (effectively random order).
+
+**Investigation**:
+```sql
+-- Check if denormalized column is populated
+SELECT
+    COUNT(*) as total,
+    SUM(CASE WHEN loop_count > 0 THEN 1 ELSE 0 END) as has_loop_count
+FROM users;
+-- Result: Only 29,878 of 119,785 users have loop_count populated
+
+-- Check top users by denormalized vs actual
+SELECT u.user_id, u.username, u.loop_count as denormalized,
+       SUM(vm.loops) as actual
+FROM users u
+JOIN vine_metadata vm ON u.user_id = vm.user_id
+GROUP BY u.user_id, u.username, u.loop_count
+ORDER BY SUM(vm.loops) DESC
+LIMIT 5;
+-- Result: Top creators show loop_count=0 but actual=1,281,730,353
+```
+
+**Fix**: Changed the query to JOIN with vine_metadata and ORDER BY the computed sum.
+
+## Notes
+- This is a classic denormalization trade-off: faster reads vs. stale data
+- When denormalizing, always implement triggers or application-level updates to keep in sync
+- Consider whether the aggregate query is fast enough to compute at runtime
+- LEFT JOIN ensures records without source data still appear (with 0 values)
+- Use `COALESCE(SUM(...), 0)` to handle NULL aggregates properly
+- `NULLS LAST` in ORDER BY prevents NULL values from sorting first in DESC order
+
+## Related Patterns
+- Event sourcing: Keep source events, compute aggregates as needed
+- CQRS: Separate read models that are explicitly updated
+- Triggers: Automatically update denormalized columns on source changes

--- a/.claude/skills/divine-context/SKILL.md
+++ b/.claude/skills/divine-context/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: divine-context
+description: Use when starting work in any divine-* repo (divine-web, divine-mobile, divine-funnelcake, keycast, divine-blossom, divine-router, etc.) or when you've learned a cross-repo fact worth sharing back. The shared divine-context handbook at ~/code/divine/divine-context/ is the source of truth for cross-cutting architecture, Nostr usage, terminology, and the project catalog across the ~50 divine-* repos.
+---
+
+# Divine Context
+
+The [divine-context](https://github.com/divinevideo/divine-context) repo is the cross-repo handbook for the diVine platform. Every divine-* repo's `CLAUDE.md` should pull in `@../divine-context/AGENT_CONTEXT.md`, but if it doesn't, load it manually before doing real cross-repo work.
+
+## On disk
+
+Cloned as a sibling of the current repo:
+
+```
+~/code/divine/
+├── divine-context/          ← read this
+├── divine-web/
+├── divine-mobile/
+├── divine-funnelcake/
+└── ... (~50 divine-* repos)
+```
+
+If divine-context isn't cloned:
+
+```bash
+(cd ~/code/divine && [ -d divine-context ] || gh repo clone divinevideo/divine-context)
+```
+
+## Reading divine-context
+
+For everyday work, `AGENT_CONTEXT.md` is enough. It links out to deeper files:
+
+| File | Read when |
+|------|-----------|
+| `AGENT_CONTEXT.md` | Always — single-page primer |
+| `PROJECT.md` | Need product context (what diVine is, who it's for) |
+| `ARCHITECTURE.md` | Touching cross-service flows |
+| `PROJECTS.md` | Asking "is there already a service for X?" |
+| `NOSTR.md` | Publishing/querying/signing Nostr events |
+| `GLOSSARY.md` | Hit an unfamiliar term |
+| `ANDOTHERSTUFF.md` | Need parent-org context |
+
+These files describe state at the time they were written. If a file in a divine-* repo contradicts divine-context, trust the code — and if the contradiction is durable, propose a divine-context update (see below).
+
+## Updating divine-context
+
+When you learn a **cross-repo** fact while working in a divine-* repo, propose it back. Cross-repo means: would an agent in a *different* divine-* repo benefit from knowing this? If no, it stays in this repo's `CLAUDE.md` or `.claude/rules/`.
+
+### Workflow
+
+1. Read this repo's key files (5 min, no deep dive): `README.md`, `CLAUDE.md`, `AGENTS.md`, `.claude/rules/*`, `docs/**`, `package.json` / `Cargo.toml` / `pubspec.yaml` / `go.mod`, top-level `src/`.
+2. Read every divine-context file (they're short).
+3. Build a proposal list — for each item: one line of *what*, one line of *evidence* (`path:line` in this repo).
+4. **Show the proposal list to the user before editing anything. Wait for approval.**
+5. For approved items only, branch from `origin/main` (not local main, which may be stale) and make the edits:
+   ```bash
+   cd ~/code/divine/divine-context
+   git fetch origin main
+   git worktree add /tmp/dc-<topic> -b update-from-<thisrepo>-<topic>-$(date +%Y-%m-%d) origin/main
+   # edit files
+   cd /tmp/dc-<topic>
+   git add <only the files you changed>          # never -A
+   git commit -m "<short desc>: <what changed>"
+   git push -u origin HEAD
+   gh pr create --title "..." --body "..."
+   ```
+   **Use a `/tmp` worktree.** Other agents may be editing divine-context concurrently; isolating in a worktree avoids branch-state collisions.
+6. **One logical change per PR.** Five unrelated improvements = five PRs.
+
+### What goes in divine-context (and what doesn't)
+
+| Goes in divine-context | Stays in this repo |
+|------------------------|--------------------|
+| Cross-repo architecture / data flow | Repo-local file paths, hooks, components |
+| New event kinds, NIPs, relay gotchas | Implementation details of one repo's code |
+| Domain terms an outside agent would hit cold | Repo-specific code conventions |
+| `<!-- TODO -->` markers you can now answer | Debugging recipes (those go in skills/) |
+| Catalog corrections in `PROJECTS.md` | One-off solutions to one repo's bug |
+
+### Hard rules
+
+- **Don't invent.** Cite a file path (and line if practical) in this repo for every claim. If you can't verify in 2 minutes, mark the proposed change `<!-- TODO: verify -->` instead of guessing.
+- **No secrets, internal URLs, or anything sensitive.** divine-context is intended to eventually be sharable with outside contributors.
+- **No copying of repo-local rules.** Flutter/BLoC specifics belong in divine-mobile, not divine-context. The "Flutter / divine-mobile specifics" subsection of `AGENT_CONTEXT.md` is the only exception.
+- **Length is a budget, not a void to fill.** Prefer tightening existing prose to adding new prose. `AGENT_CONTEXT.md` is loaded into every divine-* agent's session — additions there must earn their place.
+- **Don't `git add -A`.** Stage only the divine-context files you changed.
+- **Don't amend existing commits.** Create new ones.
+- **Don't open empty PRs.** If you have nothing to propose after reading, say so and stop.
+
+## End-of-task report
+
+After running the update workflow, report:
+
+```
+Proposed changes to divine-context:
+- <file>: <one-line description>  — evidence: <path:line in this repo>
+- ...
+
+PR opened: <url>
+(or: No PR — divine-context is accurate for this repo.)
+```
+
+## Common rationalizations to ignore
+
+| Excuse | Reality |
+|--------|---------|
+| "I'll just edit divine-context directly without showing the user first" | Some proposals may be intentional omissions. Show the list first. |
+| "This is repo-local but feels useful, so I'll add it anyway" | Cross-repo only. Repo-local belongs in `CLAUDE.md`. |
+| "Local main looks fine, no need to fetch" | Local main may be days stale. Always branch from `origin/main`. |
+| "I'll skip the worktree, just `git checkout` in place" | Concurrent agents may be editing. Use `/tmp/dc-<topic>` worktree. |
+| "I'll bundle five small fixes into one PR — easier to review" | One logical change per PR. Reviewers can disagree with one without blocking the others. |
+| "I'll `git add -A` — faster" | Catches unrelated files. Stage by name. |
+| "I can't verify this fact, but it sounds right" | Mark `<!-- TODO: verify -->` instead of inventing. |

--- a/.claude/skills/divine-relay-video-requirements/SKILL.md
+++ b/.claude/skills/divine-relay-video-requirements/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: divine-relay-video-requirements
+description: |
+  Fix "blocked: event rejected by relay policy" errors when publishing Kind 34236
+  (video) events to divine relays. Use when: (1) Kind 0 profile events succeed but
+  Kind 34236 fails, (2) Generic policy rejection with no specific reason, (3) Video
+  events work on other relays but fail on divine relays. The divine relay requires
+  thumbnails for all video events - stricter than NIP-71 spec.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-25
+---
+
+# Divine Relay Video Requirements
+
+## Problem
+Publishing Kind 34236 (short-form video) events to divine relays fails with
+"blocked: event rejected by relay policy" even though the events comply with
+NIP-71 spec.
+
+## Context / Trigger Conditions
+- Error message: `blocked: event rejected by relay policy`
+- Kind 0 (profile) events publish successfully to the same relay
+- Kind 34236 events fail on divine relays (wss://relay.poc.dvines.org, wss://relay.dvines.org)
+- Events that work on other relays fail on divine relays
+
+## Root Cause
+The divine relay (funnelcake) has additional validation beyond NIP-71:
+
+From `divine-funnelcake/crates/relay/src/relay.rs:554-564`:
+```rust
+// divine.video requires thumbnail for all videos (stricter than NIP-71)
+// Accept: thumb tag, thumbnail tag, image tag, or imeta with image field
+let has_thumb = event.get_tag("thumb").is_some()
+    || event.get_tag("thumbnail").is_some()
+    || event.get_tag("image").is_some()
+    || has_imeta_with_image(&event);
+
+if !has_thumb {
+    // Event rejected
+}
+```
+
+## Solution
+Ensure video events include a thumbnail in one of these formats:
+
+1. **Inside imeta tag** (preferred - NIP-92 compliant):
+   ```
+   ["imeta", "url https://...", "m video/mp4", "image https://thumbnail.jpg", ...]
+   ```
+
+2. **Standalone tag**:
+   ```
+   ["thumb", "https://thumbnail.jpg"]
+   ["thumbnail", "https://thumbnail.jpg"]
+   ["image", "https://thumbnail.jpg"]
+   ```
+
+### Getting Thumbnails from Blossom
+Blossom (media.divine.video) auto-generates thumbnails for uploaded videos:
+- Thumbnail URL: `https://media.divine.video/{video_sha256}.jpg`
+- Generation is async - may take a few seconds after upload
+- Check with HEAD request before assuming availability
+
+## Verification
+1. Ensure imeta tag contains `image https://...` field
+2. Test publication: `nak event -k 34236 ... wss://relay.poc.dvines.org`
+3. Verify with: `nak req -k 34236 -a {pubkey} --limit 1 wss://relay.poc.dvines.org`
+
+## Example
+```typescript
+// Build imeta with thumbnail
+const imetaParts = [
+  `url ${videoUpload.url}`,
+  "m video/mp4",
+  `image ${videoUpload.url}.jpg`,  // Blossom thumbnail URL
+  "dim 480x480",
+  `x ${videoUpload.sha256}`,
+  "duration 6"
+];
+tags.push(["imeta", ...imetaParts]);
+```
+
+## Notes
+- This is divine-specific - other relays may accept videos without thumbnails
+- The generic error message doesn't indicate which validation failed
+- To debug relay rejections: read the relay source code for policy details
+- Other divine relay validations in the same file:
+  - Required `d` tag for addressable events
+  - Required `title` tag
+  - Required video source (`imeta` or `url` tag)
+
+## Debugging Strategy
+When getting generic "relay policy" rejections:
+1. Test different event kinds (Kind 0 vs target kind) to isolate the issue
+2. Check if the relay codebase is available (divine repos are at ~/code/divine/)
+3. Search for "reject" or "blocked" in the relay handler code
+4. Look for validation beyond standard NIP requirements
+
+## Related Files
+- Relay validation: `divine-funnelcake/crates/relay/src/relay.rs`
+- Allowed kinds seed: `divine-funnelcake/database/migrations/000015_seed_allowed_kinds.up.sql`
+- Relay config: `divine-funnelcake/crates/relay/src/config.rs`

--- a/.claude/skills/docker-buildx-stale-rust-binary/SKILL.md
+++ b/.claude/skills/docker-buildx-stale-rust-binary/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: docker-buildx-stale-rust-binary
+description: |
+  Fix deployed Rust binaries not reflecting code changes when using docker buildx.
+  Use when: (1) Code changes are verified locally (tests pass) but production behavior
+  doesn't change after deploy, (2) Docker image has a new tag but contains old compiled
+  binary, (3) Dockerfile uses multi-stage build with dependency pre-compilation layer
+  and source copy layer. Docker buildx layer caching can serve stale compilation output
+  even when source files change, especially with cross-compilation (--platform linux/amd64).
+author: Claude Code
+version: 1.0.0
+date: 2026-03-31
+---
+
+# Docker Buildx Stale Rust Binary Cache
+
+## Problem
+Docker buildx may serve stale compiled Rust binaries from layer cache even when source
+files have changed. The image gets a new tag and pushes successfully, but contains the
+old compiled binary. This is especially common with cross-platform builds
+(`--platform linux/amd64` on ARM Macs).
+
+## Context / Trigger Conditions
+- Dockerfile uses multi-stage pattern: copy Cargo.toml → build deps → copy source → build
+- Using `docker buildx build --push` with `--platform linux/amd64`
+- Code changes verified locally (tests pass) but production shows old behavior
+- Image digest from cached build differs from `--no-cache` build
+- Adding a simple response header in code and it doesn't appear in production
+
+## Solution
+Always use `--no-cache` when deploying code changes:
+
+```bash
+# WRONG — may use cached compilation layer with old code
+docker buildx build --platform linux/amd64 --target api \
+  -t registry/image:tag --push .
+
+# CORRECT — forces full recompilation
+docker buildx build --platform linux/amd64 --target api \
+  --no-cache -t registry/image:tag --push .
+```
+
+## Verification
+Compare image digests between cached and no-cache builds:
+
+```bash
+# Build with cache
+docker buildx build --platform linux/amd64 --target api \
+  -t registry/image:cached --push . 2>&1 | grep "pushing manifest"
+# Note the sha256 digest
+
+# Build without cache  
+docker buildx build --platform linux/amd64 --target api \
+  --no-cache -t registry/image:nocache --push . 2>&1 | grep "pushing manifest"
+# Note the sha256 digest
+
+# If digests differ, the cached build had stale code
+```
+
+## Example
+Typical Dockerfile pattern vulnerable to this:
+
+```dockerfile
+# Layer 1: Copy manifests (cached if Cargo.toml unchanged)
+COPY Cargo.toml Cargo.lock ./
+COPY crates/*/Cargo.toml crates/
+
+# Layer 2: Build dependencies (cached — this is the good cache)
+RUN cargo build --release && rm -rf src crates
+
+# Layer 3: Copy actual source (SHOULD invalidate on source change)
+COPY crates crates
+COPY bin bin
+
+# Layer 4: Rebuild with actual source
+RUN touch crates/*/src/lib.rs && cargo build --release
+```
+
+The issue: buildx's content-addressable cache may match Layer 4's output from a previous
+build if the intermediate representations happen to collide, especially during cross-compilation
+where the build environment state is more complex.
+
+## Notes
+- This primarily affects `--platform` cross-compilation builds (ARM → x86)
+- Native-platform builds are less likely to hit this issue
+- The `--no-cache` flag adds ~5-10 minutes to Rust builds but guarantees fresh compilation
+- Alternative: use `--cache-from` with explicit cache scoping to avoid stale layers
+- Consider adding a build-time env var (like commit hash) that forces layer invalidation:
+  ```dockerfile
+  ARG BUILD_HASH
+  RUN echo $BUILD_HASH && cargo build --release
+  ```

--- a/.claude/skills/equatable-linkedhashmap-lru-reorder/SKILL.md
+++ b/.claude/skills/equatable-linkedhashmap-lru-reorder/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: equatable-linkedhashmap-lru-reorder
+description: |
+  Fix LRU-bounded Flutter/bloc state classes that silently lose insertion-order
+  updates. Use when: (1) a state class uses `Equatable` with a
+  `LinkedHashMap<K, V>` field to preserve insertion order (LRU, MRU, recent-items
+  caches), (2) `Cubit.emit` appears to drop emissions when an existing key is
+  re-inserted or moved to most-recent, (3) LRU eviction evicts the "wrong"
+  entry after a refresh, (4) a test that reports the same key twice and then
+  overflows the cap sees the refreshed entry evicted instead of the oldest.
+  Root cause: Equatable's default map comparison is structural (unordered), so
+  reordering without changing keys/values produces an "equal" state that
+  `Cubit.emit` suppresses.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# Equatable + LinkedHashMap LRU reorder suppression
+
+## Problem
+
+A Flutter bloc/cubit state class uses an insertion-ordered `LinkedHashMap<K, V>`
+to implement LRU semantics (touch-on-access, evict oldest past a cap). The
+field is included in `props` for value equality. When an existing key is
+re-inserted to move it to most-recent, `Cubit.emit` drops the new state as
+equal to the previous one, leaving LRU order stale. On the next insert past
+the cap, the "touched" entry is evicted instead of the truly oldest one.
+
+This is silent: no errors, no logs. Tests that only check the final status
+of each key pass. The bug surfaces only when a test specifically asserts
+that a refreshed key survives a later cap-overflow eviction.
+
+## Context / Trigger Conditions
+
+- State class `extends Equatable` with a `LinkedHashMap<K, V>` field
+- LRU behavior implemented via `remove(key)` + insert to move-to-most-recent
+- `props` includes the map directly: `List<Object?> get props => [_map, ...]`
+- Symptoms:
+  - `blocTest(..., expect: () => hasLength(N))` reports fewer emissions than expected
+  - LRU eviction test like "refresh key A, then overflow — expect B evicted" fails with A evicted instead
+  - Consumers using `BlocListener` or `context.select` don't react to touch-only updates
+
+## Solution
+
+Add the keys list to `props` alongside the map so insertion-order changes
+produce a distinct state:
+
+```dart
+@override
+List<Object?> get props {
+  // Both entries are required.
+  //
+  // Equatable's default map comparison is structural (unordered), so
+  // `_statuses` alone catches value changes but NOT pure LRU reorders
+  // where the key/value set is unchanged.
+  // `_statuses.keys.toList()` catches those insertion-order changes.
+  // Removing either would silently suppress a whole class of state
+  // updates — do not "simplify" this.
+  return [_statuses, _statuses.keys.toList(), maxEntries];
+}
+```
+
+Keep the map in `props` as well — it catches value-only changes (same key,
+different value, no reorder). The keys list catches order-only changes.
+Together they cover both dimensions. Removing either re-opens the bug.
+
+### Additional hardening (recommended)
+
+While you're here, also:
+
+1. **Defensive-copy in the constructor** if it accepts an externally-built
+   `LinkedHashMap`. A caller can otherwise retain a reference and mutate
+   the "immutable" state:
+
+   ```dart
+   VideoPlaybackStatusState({
+     this.maxEntries = _defaultMaxEntries,
+     LinkedHashMap<K, V>? statuses,
+   }) : _statuses = statuses == null
+             ? LinkedHashMap<K, V>()
+             : LinkedHashMap<K, V>.from(statuses);
+   ```
+
+2. **Short-circuit redundant writes** in the cubit to avoid allocating a
+   new map on every no-op report (e.g. errorBuilder fires every frame
+   during a retry):
+
+   ```dart
+   void report(K key, V value) {
+     if (state.valueFor(key) == value) return;
+     emit(state.withValue(key, value));
+   }
+   ```
+
+## Verification
+
+Write an explicit props-inequality test that pins the invariant directly,
+rather than relying on higher-level LRU tests to transitively catch it:
+
+```dart
+test('states with same entries but different LRU order are not equal', () {
+  final a = MyState()
+      .withStatus(idA, Status.foo)
+      .withStatus(idB, Status.bar);
+  final b = MyState()
+      .withStatus(idB, Status.bar)
+      .withStatus(idA, Status.foo);
+
+  expect(a, isNot(equals(b)));
+});
+```
+
+Mutation test: temporarily revert to `props: [_map, maxEntries]` (no keys
+list) and run the test. It MUST fail. Restore and confirm pass. This
+proves the assertion is load-bearing and guards the invariant.
+
+## Example
+
+Full state class shape (Dart):
+
+```dart
+import 'dart:collection';
+import 'package:equatable/equatable.dart';
+
+class VideoPlaybackStatusState extends Equatable {
+  VideoPlaybackStatusState({
+    this.maxEntries = _defaultMaxEntries,
+    LinkedHashMap<String, PlaybackStatus>? statuses,
+  }) : _statuses = statuses == null
+            ? LinkedHashMap<String, PlaybackStatus>()
+            : LinkedHashMap<String, PlaybackStatus>.from(statuses);
+
+  static const int _defaultMaxEntries = 100;
+  final int maxEntries;
+  final LinkedHashMap<String, PlaybackStatus> _statuses;
+
+  PlaybackStatus statusFor(String id) =>
+      _statuses[id] ?? PlaybackStatus.ready;
+
+  VideoPlaybackStatusState withStatus(String id, PlaybackStatus status) {
+    final next = LinkedHashMap<String, PlaybackStatus>.from(_statuses)
+      ..remove(id)
+      ..[id] = status;
+    while (next.length > maxEntries) {
+      next.remove(next.keys.first);
+    }
+    return VideoPlaybackStatusState(maxEntries: maxEntries, statuses: next);
+  }
+
+  @override
+  List<Object?> get props => [_statuses, _statuses.keys.toList(), maxEntries];
+  //                         ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^
+  //                         catches      catches reorders
+  //                         value changes (LRU touches)
+}
+```
+
+The LRU test that catches the bug:
+
+```dart
+test('reporting same id twice moves it to most-recent', () {
+  final cubit = VideoPlaybackStatusCubit(maxEntries: 2);
+  cubit.report(id1, PlaybackStatus.forbidden);
+  cubit.report(id2, PlaybackStatus.ageRestricted);
+  cubit.report(id1, PlaybackStatus.forbidden); // refresh id1
+  cubit.report(id3, PlaybackStatus.notFound);  // overflow
+
+  // Without the fix: id1 is evicted (wrong — it was just touched)
+  // With the fix: id2 is evicted (correct — it's the oldest)
+  expect(cubit.state.statusFor(id2), PlaybackStatus.ready);
+  expect(cubit.state.statusFor(id1), PlaybackStatus.forbidden);
+});
+```
+
+## Notes
+
+- **Flutter lint interaction**: Using an explicit `LinkedHashMap<K, V>()`
+  literal trips `prefer_collection_literals` (the lint wants `{}`). But
+  `{}` types as `Map<K, V>`, not `LinkedHashMap`, which loses the
+  compile-time guarantee that insertion order is preserved across
+  refactors. Keep the explicit type and suppress the lint locally
+  (`// ignore: prefer_collection_literals`) if the constructor path
+  triggers it.
+- **Applies to any ordered collection in Equatable**: `Queue`, `SplayTreeMap`,
+  or any structure where order is semantic. Anywhere Equatable compares
+  the structure contents unordered but your code depends on order, you
+  need a secondary props entry that captures the order.
+- **Not specific to bloc**: the same bug appears with Riverpod's state
+  notifier `==` checks and any equality-based diffing. Same fix applies.
+- **TDD discipline**: this bug was only caught because a test specifically
+  asserted "refreshed key survives overflow." A test suite that only
+  checks "status X maps to key Y" after individual writes would pass
+  with the bug intact. When writing tests for ordered-collection state,
+  always include at least one test that exercises the ordering itself
+  (not just membership).
+
+## References
+
+- [Equatable package — props semantics](https://pub.dev/packages/equatable)
+- [Dart `LinkedHashMap` — insertion-order guarantee](https://api.dart.dev/stable/dart-collection/LinkedHashMap-class.html)
+- [flutter_bloc — Cubit.emit equality behavior](https://pub.dev/packages/flutter_bloc)
+- Divine mobile fix: `fix(video_playback_status): add cubit for per-video playback status tracking` (commit `fb828df33` on branch `fix/moderated-content-filter`), where the bug was caught and fixed.

--- a/.claude/skills/fastly-compute-async-request-reliability/SKILL.md
+++ b/.claude/skills/fastly-compute-async-request-reliability/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: fastly-compute-async-request-reliability
+description: |
+  Fix silent failures in Fastly Compute@Edge when using send_async for fire-and-forget
+  requests. Use when: (1) Background tasks (migrations, webhooks, notifications) triggered
+  from Compute never complete, (2) send_async PendingRequest is immediately dropped,
+  (3) Fire-and-forget pattern works locally but fails in production, (4) An async trigger
+  "logs as triggered" but the target service never receives the request (especially after
+  renaming backend constants — the URL hostname is cosmetic, the backend name determines
+  routing, so a global rename can silently reroute calls to the wrong service). Also covers
+  silent backend-not-found errors when FALLBACK_BACKENDS or other backend constants
+  reference names not configured in the Fastly dashboard.
+author: Claude Code
+version: 1.1.0
+date: 2026-04-05
+---
+
+# Fastly Compute Async Request Reliability
+
+## Problem
+Fire-and-forget HTTP requests from Fastly Compute@Edge using `send_async` silently fail
+because the worker process can terminate before the async request reaches the backend.
+Additionally, backend names referenced in code but not configured in the Fastly dashboard
+cause silent failures that are easy to miss.
+
+## Context / Trigger Conditions
+- Background migration, webhook, or notification triggered via `req.send_async(backend)`
+- The `PendingRequest` returned by `send_async` is immediately dropped (not awaited)
+- The main response is sent to the client, causing the Compute worker to terminate
+- Error is swallowed with `let _ = ...` or `match ... { Err(_) => ... }`
+- Works in local testing (`fastly compute serve`) but fails in production
+- Backend name in code doesn't match any backend in `fastly backend list --service-id`
+
+## Solution
+
+### 1. Use synchronous `send()` instead of `send_async()` for critical operations
+
+```rust
+// BAD: Fire-and-forget — worker terminates before request completes
+match req.send_async(BACKEND) {
+    Ok(_pending) => {
+        // PendingRequest dropped here — request likely never completes!
+        Ok(())
+    }
+    Err(e) => { /* ... */ }
+}
+
+// GOOD: Synchronous send — waits for response
+match req.send(BACKEND) {
+    Ok(resp) => {
+        let status = resp.get_status();
+        if status.is_success() {
+            eprintln!("[MIGRATE] Success for {}", hash);
+        } else {
+            eprintln!("[MIGRATE] Backend returned {}", status);
+        }
+        Ok(())
+    }
+    Err(e) => {
+        eprintln!("[MIGRATE] Failed: {}", e);
+        Ok(()) // Don't fail the main request
+    }
+}
+```
+
+### 2. When synchronous is too slow, use a caching layer
+
+If a VCL caching layer fronts Compute (service chaining), the extra latency from
+synchronous send only affects cache misses. Subsequent requests hit the cache.
+This makes synchronous send acceptable for operations like migration triggers.
+
+### 3. Always verify backend existence
+
+```bash
+# List backends configured on the service
+fastly backend list --service-id YOUR_SERVICE_ID --version latest
+
+# Add missing backend
+fastly backend create --service-id YOUR_SERVICE_ID --version latest --autoclone \
+  --name cdn_divine --address cdn.divine.video --port 443 \
+  --use-ssl --ssl-sni-hostname cdn.divine.video --override-host cdn.divine.video
+```
+
+Check that every backend name in your Rust code (`req.send("backend_name")`) has a
+corresponding entry in the Fastly dashboard. The `fastly.toml` `[local_server.backends]`
+section is for local dev only — it does NOT create production backends.
+
+### 4. Beware: the URL hostname is cosmetic — the backend name decides routing
+
+In Fastly Compute, `req.send(backend_name)` / `req.send_async(backend_name)` ignores the
+URL's hostname for routing purposes. The backend's dashboard configuration (address,
+override_host, TLS SNI) determines where the request actually lands. This means two
+different Cloud Run services that happen to share a backend constant will both deliver
+to whichever address that one backend is wired to — and the call site that looked
+correct because its URL said `service-A.run.app` will actually hit `service-B`.
+
+This bites hardest after a global rename. Example: a refactor replaces
+`CLOUD_RUN_BACKEND` with `UPLOAD_SERVICE_BACKEND` across the whole file via sed-style
+search-and-replace. Most call sites were legitimately targeting the upload service, so
+they still work. But one call site was doing `POST https://divine-transcoder-XXXX.run.app/transcode`
+and the rename points it at the upload service backend — the request gets a nginx 404
+from the upload service, `send_async` returns Ok (backend accepted the connection), and
+the `eprintln!("[HLS] Triggered on-demand transcoding for {}", hash)` log line is a
+false positive. The transcoder never sees the request. Videos pile up in an "in
+progress" state for days.
+
+**How to catch this class of bug:**
+
+1. When you see a rename of a backend constant, grep for every call site and verify
+   the URL hostname matches what the new backend is configured to route to:
+   ```bash
+   grep -n "send(\|send_async(" src/*.rs
+   grep -n "BACKEND: &str" src/*.rs  # find constant definitions
+   ```
+   Any call site where `format!("https://{}/...", SOMETHING_ELSE)` doesn't match
+   the backend's dashboard `address`/`override_host` is a silent misroute.
+
+2. Probe the "wrong" destination directly from the outside with curl using a
+   synthetic payload. If you get a 404 or 405 from nginx/the wrong service, you've
+   found a misroute. Example:
+   ```bash
+   curl -X POST https://upload.divine.video/transcode -H 'Content-Type: application/json' -d '{"hash":"0"*64}'
+   # HTTP 404 <- wrong service, backend misrouted
+   ```
+
+3. If you own more than one Cloud Run service, define **one backend per service**
+   (`transcoder_backend`, `upload_service`, `transcriber_backend`) and never
+   collapse them just because both are `*.run.app`. The `override_host` on each
+   backend pins its destination regardless of URL.
+
+4. Switch fire-and-forget triggers that you care about to synchronous `send()` at
+   least during investigation — a real non-2xx response from the wrong service
+   makes the bug visible immediately instead of hiding behind `send_async`.
+
+### 5. Never silently swallow backend errors for important operations
+
+```rust
+// BAD: Silent failure
+let _ = trigger_migration(&hash, &source);
+
+// GOOD: Log the error even if you don't fail the request
+if let Err(e) = trigger_migration(&hash, &source) {
+    eprintln!("[MIGRATE] Failed for {}: {}", hash, e);
+}
+```
+
+## Verification
+1. Check Compute logs for the migration/webhook success messages
+2. Verify the side effect actually happened (e.g., blob exists in GCS after migration)
+3. `fastly backend list --service-id ID --version latest` shows all expected backends
+
+## Example
+In Divine Blossom, the on-demand migration from Bunny CDN to GCS never worked because:
+1. `cdn_divine` backend was never configured in the Fastly dashboard (only in `fastly.toml`)
+2. `send_async` for the Cloud Run migration request was dropped before completion
+3. Both errors were silently swallowed with `let _ = ...`
+
+Fix: Added `cdn_divine` backend via CLI, changed `send_async` to `send`, added logging.
+
+## Notes
+- `fastly.toml` `[local_server.backends]` only configures backends for `fastly compute serve`
+- Production backends must be configured via dashboard or CLI (`fastly backend create`)
+- In Fastly Compute, once the main response body starts streaming to the client, the worker
+  can be terminated at any time — async requests in flight may be cancelled
+- If you need true fire-and-forget, consider calling an external queue (Cloud Tasks, PubSub)
+  instead of direct HTTP

--- a/.claude/skills/fastly-compute-backend-production-setup/SKILL.md
+++ b/.claude/skills/fastly-compute-backend-production-setup/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: fastly-compute-backend-production-setup
+description: |
+  Fix "Requested backend named 'X' does not exist" or TLS alert errors in Fastly Compute@Edge.
+  Use when: (1) Backend works locally but fails in production with "backend does not exist",
+  (2) TLS alert received (alert_id=0) errors when calling external APIs from Fastly,
+  (3) Backends defined in fastly.toml aren't available after deployment. The fastly.toml
+  [[backends]] section only applies during initial service creation - existing services
+  require backends to be added via CLI or API with proper SSL/SNI configuration.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-28
+---
+
+# Fastly Compute Backend Production Setup
+
+## Problem
+Backends defined in `fastly.toml` work during local development with `fastly compute serve`
+but return "Requested backend named 'X' does not exist" errors in production after deployment
+with `fastly compute publish`.
+
+## Context / Trigger Conditions
+- Error: `Requested backend named 'funnelcake' does not exist`
+- Error: `TLS alert received (alert_id=0)` when connecting to HTTPS backends
+- Backend works with `fastly compute serve` locally
+- `fastly.toml` has `[[backends]]` section properly configured
+- Service was created before the backend was added to fastly.toml
+
+## Root Cause
+The `[[backends]]` section in `fastly.toml` is only processed during **initial service creation**
+via the `[setup]` configuration. Once a service exists, changes to backends in fastly.toml
+are ignored - you must add/modify backends through the Fastly CLI or API.
+
+From the Fastly CLI output:
+> INFO: Processing of the fastly.toml [setup] configuration happens only for a new service.
+> Once a service is created, any further changes to the service or its resources must be
+> made manually.
+
+## Solution
+
+### Step 1: Create the backend via CLI
+
+```bash
+fastly backend create \
+  --service-id YOUR_SERVICE_ID \
+  --version active \
+  --autoclone \
+  --name backend-name \
+  --address api.example.com \
+  --port 443 \
+  --override-host api.example.com \
+  --use-ssl \
+  --ssl-cert-hostname api.example.com \
+  --ssl-sni-hostname api.example.com
+```
+
+Key flags:
+- `--autoclone`: Creates a new version automatically
+- `--ssl-cert-hostname`: Required for SSL certificate validation
+- `--ssl-sni-hostname`: Required for TLS SNI (fixes alert_id=0 errors)
+
+### Step 2: Activate the new version
+
+```bash
+fastly service-version activate --service-id YOUR_SERVICE_ID --version VERSION_NUMBER
+```
+
+### Step 3: Verify backend exists
+
+```bash
+fastly backend list --service-id YOUR_SERVICE_ID --version active
+```
+
+### Step 4: Redeploy your code
+
+After adding the backend, redeploy to ensure the code and backend are in the same version:
+
+```bash
+fastly compute publish
+```
+
+Then verify backends still exist in the new version:
+
+```bash
+fastly backend list --service-id YOUR_SERVICE_ID --version active
+```
+
+## Verification
+1. Check logs with `fastly log-tail --service-id YOUR_SERVICE_ID`
+2. Make a request that uses the backend
+3. Confirm no "backend does not exist" or TLS errors in logs
+
+## Example
+
+Given this fastly.toml (which works locally but not in production):
+
+```toml
+[[backends]]
+  name = "funnelcake"
+  address = "relay.dvines.org"
+  port = 443
+  override_host = "relay.dvines.org"
+  use_ssl = true
+```
+
+Add the backend to an existing service:
+
+```bash
+# Create backend with SSL properly configured
+fastly backend create \
+  --service-id WfOrPTFYmwwxRvqrfralLA \
+  --version active \
+  --autoclone \
+  --name funnelcake \
+  --address relay.dvines.org \
+  --port 443 \
+  --override-host relay.dvines.org \
+  --use-ssl \
+  --ssl-cert-hostname relay.dvines.org \
+  --ssl-sni-hostname relay.dvines.org
+
+# Activate the new version
+fastly service-version activate --service-id WfOrPTFYmwwxRvqrfralLA --version 49
+
+# Redeploy code
+fastly compute publish
+```
+
+## Notes
+- Each `fastly compute publish` creates a new version that inherits backends from the previous active version
+- If you need different backends for different environments, consider using environment variables or separate services
+- The `--autoclone` flag is essential - you cannot modify an active version directly
+- Backend names in your code must exactly match the `--name` parameter
+
+## Related Errors
+- `Requested backend named 'X' does not exist` - Backend not created in service
+- `TLS alert received (alert_id=0)` - Missing SNI hostname configuration
+- `Mandatory SSL cert checks require specifying cert hostname` - Missing ssl-cert-hostname
+
+## References
+- [Fastly Compute backends documentation](https://www.fastly.com/documentation/reference/compute/fastly-toml/#backends)
+- [Fastly CLI backend commands](https://www.fastly.com/documentation/reference/cli/backend/)

--- a/.claude/skills/fastly-compute-deployment-debugging/SKILL.md
+++ b/.claude/skills/fastly-compute-deployment-debugging/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: fastly-compute-deployment-debugging
+description: |
+  Debug Fastly Compute deployments that appear successful but return stale/wrong responses.
+  Use when: (1) fastly compute publish succeeds but version check shows old version,
+  (2) new endpoints return 404 after deployment, (3) cache-busted requests work but regular
+  requests fail, (4) fastly domain list doesn't show your custom domain. Covers edge
+  propagation timing, cached error responses, and domain management API differences.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-21
+---
+
+# Fastly Compute Deployment Debugging
+
+## Problem
+
+After deploying to Fastly Compute, requests return stale content or 404s even though:
+- `fastly compute publish` reported success
+- The new version shows as "active" in `fastly service-version list`
+- The code is correct and works locally
+
+## Context / Trigger Conditions
+
+- Version endpoint returns old version string after deployment
+- New routes/features return 404
+- `fastly purge --all` doesn't fix the issue
+- Requests with cache buster (`?v=random`) work but regular requests don't
+- `fastly domain list` doesn't show your custom domain
+- Different POPs return different results
+
+## Solution
+
+### 1. Verify Code is Actually Deployed
+
+```bash
+# Check the direct edgecompute.app URL (bypasses custom domain config)
+curl https://your-service.edgecompute.app/version
+
+# Compare to custom domain
+curl https://your-custom-domain.com/version
+```
+
+If edgecompute.app works but custom domain doesn't, it's a domain configuration issue.
+
+### 2. Diagnose Cached Error Responses
+
+The most common issue: 404s get cached at edge POPs before new code propagates.
+
+```bash
+# Test with cache buster
+curl "https://your-domain.com/endpoint?bust=$RANDOM"
+
+# Test without
+curl "https://your-domain.com/endpoint"
+```
+
+If cache-busted works but regular doesn't = **cached error response**.
+
+**Fix**: Wait 2-5 minutes for full propagation, then purge:
+```bash
+fastly purge --all --service-id YOUR_SERVICE_ID
+```
+
+### 3. Check Domain Configuration (Two APIs!)
+
+Fastly has TWO domain management systems:
+
+| System | CLI Command | API Endpoint |
+|--------|-------------|--------------|
+| Classic Domains | `fastly domain list` | `/service/{id}/version/{ver}/domain` |
+| Versionless Domains | *(not shown in CLI)* | `/domain-management/v1/domains` |
+
+**If `fastly domain list` doesn't show your domain**, check the versionless API:
+
+```bash
+# Get your API token
+TOKEN=$(fastly profile token)
+
+# Query domain-management API
+curl -s -H "Fastly-Key: $TOKEN" \
+  "https://api.fastly.com/domain-management/v1/domains?filter%5Bfqdn%5D=your-domain.com"
+```
+
+Look for `"activated": true` and `"verified": true`.
+
+### 4. Force Clean Rebuild
+
+If build caching is suspected:
+
+```bash
+rm -rf pkg target
+fastly compute publish --comment "clean build"
+```
+
+### 5. Wait for Propagation
+
+Fastly Compute deployments can take **2-5 minutes** to propagate to all POPs worldwide.
+Even after `fastly service-version list` shows the version as active, some POPs may
+still serve old code.
+
+**Timeline**:
+- Version marked "active": ~30 seconds
+- Most POPs updated: ~1-2 minutes
+- All POPs updated: ~3-5 minutes (sometimes longer)
+
+### 6. Check Real-time Logs
+
+```bash
+fastly log-tail --service-id YOUR_SERVICE_ID
+```
+
+Then make a request and see if it appears. If no logs appear, the request isn't
+reaching your Compute code (likely a domain/routing issue).
+
+## Verification
+
+After waiting and purging:
+
+```bash
+# Multiple requests to hit different POPs
+for i in 1 2 3 4 5; do
+  curl -s "https://your-domain.com/version"
+  sleep 1
+done
+```
+
+All should return the new version.
+
+## Example
+
+**Scenario**: Deployed thumbnail serving code, but `/hash.jpg` returns 404.
+
+**Debug steps**:
+1. `curl https://service.edgecompute.app/hash.jpg?v=123` → 200 (code works!)
+2. `curl https://custom-domain.com/hash.jpg` → 404 (cached)
+3. Wait 3 minutes
+4. `fastly purge --all --service-id XXX`
+5. `curl https://custom-domain.com/hash.jpg` → 200 (working!)
+
+**Root cause**: 404 was cached at edge before new code propagated.
+
+## Notes
+
+- **Accounts created before Sept 2025**: May have classic domains, newer accounts use versionless
+- **Don't panic**: If version check works on edgecompute.app, the code is deployed - just wait
+- **Purge timing**: Purge AFTER propagation completes, not immediately after deploy
+- **POP variance**: Different geographic POPs may propagate at different speeds
+- **Error caching**: Fastly may cache 404/500 responses - this amplifies propagation issues
+
+## References
+
+- [Fastly Compute Documentation](https://www.fastly.com/documentation/guides/compute/)
+- [Working with versionless domains](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/working-with-domains/)
+- [Working with classic domains](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/working-with-classic-domains/)
+- [Domain Management API](https://www.fastly.com/documentation/reference/api/domain-management/domains/)
+- [Classic Domain API](https://www.fastly.com/documentation/reference/api/services/domain/)

--- a/.claude/skills/fastly-compute-native-test-linker-failure/SKILL.md
+++ b/.claude/skills/fastly-compute-native-test-linker-failure/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: fastly-compute-native-test-linker-failure
+description: |
+  Fix Fastly Compute Rust crate `cargo test` failures with "ld: symbol(s) not found" errors
+  for Fastly SDK symbols like `_version_set`, `_body_new`, `_req_send` on native host builds.
+  Use when: (1) `cargo test` on a Fastly Compute crate fails at link time with errors mentioning
+  libfastly and symbols with names like `fastly::http::response::handle::...`, (2) You added a
+  `#[cfg(test)]` module to a file in a Fastly Compute binary crate and the tests never seem to
+  run or fail to link, (3) Existing `#[cfg(test)]` modules in src/main.rs or its sibling modules
+  appear dead despite being present in the source tree, (4) `cargo test --lib` works but
+  `cargo test` fails.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# Fastly Compute native test linker failure
+
+## Problem
+
+Fastly Compute Rust binaries link against `libfastly`, which provides FFI symbols that only
+exist when targeting `wasm32-wasip1`. On a native host (macOS, Linux x86_64, Linux arm64),
+the FFI symbols are absent, so linking a test binary for the Fastly Compute crate fails with
+errors like:
+
+```
+"_version_set", referenced from:
+    fastly::http::response::handle::ResponseHandle::set_version::h234bdb33f8878476 in libfastly-XXXX.rlib
+"_body_new", referenced from:
+    fastly::http::body::Body::new::hYYYY in libfastly-XXXX.rlib
+ld: symbol(s) not found for architecture arm64
+clang: error: linker command failed with exit code 1
+error: could not compile `fastly-blossom` (bin "fastly-blossom" test)
+```
+
+The error appears during `cargo test` even if none of your tests actually call Fastly SDK
+code — cargo still tries to compile and link the entire binary as a test target.
+
+This has a nasty consequence: **any `#[cfg(test)] mod tests { ... }` block inside a file
+compiled into the binary crate is effectively dead code**. It never runs via `cargo test`
+because cargo can't link the test binary. Developers add tests, the compiler accepts them,
+they're visible in the source tree — but they never execute. Tests that were meant to
+regression-guard behavior silently become documentation that rots.
+
+## Context / Trigger Conditions
+
+- Fastly Compute Rust project with `fastly = "0.11.x"` (or similar) as a dependency
+- The crate has both `src/main.rs` and `src/lib.rs` OR only `src/main.rs`
+- `cargo test` fails at link time with `_version_set` / `_body_new` / `_req_send` undefined
+- `cargo check --target wasm32-wasip1` succeeds
+- `cargo check` (native) succeeds (library code compiles, just can't link the binary)
+- You added tests in `src/admin.rs`, `src/blossom.rs`, `src/metadata.rs`, or any file that's
+  `mod`-included from `src/main.rs` but NOT from `src/lib.rs`
+
+## Root cause
+
+Fastly's Rust SDK (`fastly` crate) is designed exclusively for wasm32-wasip1. Its public
+API calls unsafe FFI functions (`_version_set`, `_req_send`, `_body_new`, etc.) that the
+Fastly Compute runtime provides at execution time inside the POP. On a native host, the
+rustc compiler still compiles the library crate, but the linker can't resolve those FFI
+symbols because libfastly-native doesn't exist.
+
+`cargo test` for a mixed lib+bin crate links **two** artifacts: the library test binary AND
+the binary test binary (the `main` executable with tests enabled). The library test binary
+can avoid the SDK symbols if lib.rs doesn't import them transitively. The binary test binary
+can't, because main.rs wires the whole Fastly Compute runtime.
+
+## Solution
+
+### Structure your crate as lib + bin, and put all testable logic in lib
+
+1. Create `src/lib.rs` if it doesn't exist:
+
+```rust
+// src/lib.rs — library target, testable natively
+pub mod admin_sweep;   // pure logic, no Fastly SDK
+pub mod classifiers;   // pure logic, no Fastly SDK
+pub mod parsers;       // pure logic, no Fastly SDK
+```
+
+2. Put any module you want to unit-test **in a separate file that does NOT import Fastly
+   SDK types**, and expose it via `pub mod` in `lib.rs`:
+
+```rust
+// src/admin_sweep.rs — pure logic, testable natively
+pub enum StuckAction { SkipNotStuck, SkipTooRecent, MarkComplete, ResetPending }
+
+pub fn classify_stuck_record(
+    is_processing: bool,
+    uploaded_iso: &str,
+    threshold_iso: &str,
+    hls_present: bool,
+) -> StuckAction { /* ... */ }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn skip_not_stuck_when_status_is_not_processing() { /* ... */ }
+}
+```
+
+3. In `src/main.rs`, also declare the module so the binary can use it:
+
+```rust
+mod admin_sweep;  // same file, compiled twice — once for lib, once for bin
+```
+
+4. The handler in an admin.rs (or wherever) that DOES use Fastly SDK types extracts
+   primitives from SDK types and calls the pure classifier:
+
+```rust
+// src/admin.rs (part of the bin, uses Fastly SDK types like Request/Response)
+pub fn handle_sweep(req: Request) -> Result<Response> {
+    let is_processing = meta.transcode_status == Some(TranscodeStatus::Processing);
+    let action = crate::admin_sweep::classify_stuck_record(
+        is_processing, &meta.uploaded, &threshold_iso, hls_present,
+    );
+    // ... match on action, make SDK-level calls ...
+}
+```
+
+5. Run tests with:
+
+```bash
+cargo test --lib
+```
+
+**Not** `cargo test` (which tries to link the bin). `--lib` only builds and runs the
+library test binary, which can link because none of its code touches Fastly SDK symbols.
+
+### Do NOT depend on crate internals from the lib module
+
+Your lib-exposed module must NOT transitively import anything that touches the Fastly SDK.
+Common traps:
+
+- `use crate::blossom::BlobMetadata;` — if `blossom.rs` is in the binary crate and uses
+  `fastly::Request`, importing `BlobMetadata` drags SDK symbols into the lib build.
+  Solution: pass raw primitives (Option<TranscodeStatus>, &str, etc.) across the boundary,
+  not full SDK-aware structs.
+- `use crate::storage::current_timestamp;` — if storage.rs calls `fastly::kv_store::*`,
+  same problem. Duplicate the helper in admin_sweep.rs or extract it to a third
+  SDK-free module in lib.rs.
+
+Treat lib.rs as a clean-room: only pure Rust, no SDK types, no platform-specific I/O.
+
+### Verify
+
+```bash
+cargo check --target wasm32-wasip1  # must still succeed (bin compiles for deploy)
+cargo test --lib                     # must run and pass (tests exercise pure logic)
+```
+
+You can also add to CI:
+
+```yaml
+- run: cargo test --lib
+- run: cargo check --target wasm32-wasip1
+```
+
+`cargo test` (no flags) will still fail on this project; that's expected and unavoidable.
+Document it in README or CONTRIBUTING so contributors don't waste time on it.
+
+## Verification
+
+After applying this pattern:
+
+- `cargo test --lib` runs your new tests and they execute (pass or fail, but they RUN)
+- `cargo check --target wasm32-wasip1` still produces a deployable WASM
+- Existing `#[cfg(test)] mod tests` blocks in binary-only files (admin.rs, etc.) are still
+  dead; consider migrating them into lib-exposed modules or deleting them if the behavior
+  they test can be moved
+
+## Example
+
+In the Divine Blossom repo, the Fastly Compute crate (`src/main.rs`) had `#[cfg(test)]`
+modules in `src/delete_policy.rs`, `src/error.rs`, `src/auth.rs`, `src/blossom.rs`, and
+`src/metadata.rs`. None of these ran via `cargo test` — `lib.rs` only exposed
+`resumable_complete`. Attempting to add tests to `src/admin.rs` failed at link time.
+
+The fix was to create `src/admin_sweep.rs` with zero dependencies on the rest of the crate
+(no `use crate::blossom`, no `use crate::storage`), add `pub mod admin_sweep;` to `lib.rs`,
+and have the tests live there. The handler in `src/admin.rs` (binary-only) extracts four
+primitives from `BlobMetadata` before calling the pure classifier.
+
+Result: `cargo test --lib` now runs 11 tests (7 new + 4 pre-existing from
+`resumable_complete`). The wasm32-wasip1 build still produces a valid Fastly Compute
+binary. The binary-only `#[cfg(test)]` modules are still dead, but the logic that matters
+is now covered.
+
+## Notes
+
+- This is a structural constraint imposed by the Fastly SDK's FFI design, not something
+  Fastly will "fix" — the SDK crate has to provide those symbols somehow, and the runtime
+  is wasm.
+- Fastly's own examples tend to avoid tests entirely, which is why this trap is widespread.
+- The same pattern applies to any Rust crate that targets a specific platform via FFI
+  symbols provided by a host runtime: Cloudflare Workers (`worker-rs`), Vercel Edge
+  (`@vercel/edge`), some embedded HAL crates, etc. The "put pure logic in lib, keep SDK
+  calls in bin" pattern generalizes.
+- If you're starting fresh, consider making your Fastly Compute crate a library-only crate
+  with a tiny `src/main.rs` that just calls `lib::run()`. Then everything is in the lib by
+  default and there's no bin/lib split to worry about. This is the cleanest structure.
+- `rust-analyzer` and IDE tooling will still happily analyze and type-check the
+  `#[cfg(test)]` modules in binary-only files, so they *look* live. Only `cargo test`
+  reveals the truth.
+
+## References
+
+- [Fastly Compute Rust SDK crate](https://docs.rs/fastly/) — note the target restriction in
+  the documentation
+- Related skill: `fastly-compute-rust-edition2024-fix` — different failure mode (build-time
+  dependency incompatibility) but shares the "Fastly Compute crate has unusual constraints
+  around native tooling" theme

--- a/.claude/skills/fastly-compute-publish-ignores-draft-versions/SKILL.md
+++ b/.claude/skills/fastly-compute-publish-ignores-draft-versions/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: fastly-compute-publish-ignores-draft-versions
+description: |
+  Fix "backend exists on a draft version but isn't reachable from the new Compute deploy"
+  bugs after `fastly compute publish`. Use when: (1) You ran `fastly service backend create
+  --autoclone` (or any dashboard/CLI change that creates a draft version) but did not
+  activate that draft, (2) You then ran `fastly compute publish` which appeared successful
+  but your backend / ACL / header / dictionary change is missing from the active version,
+  (3) Compute code returns backend-not-found errors or misroutes requests, (4) You're
+  surprised to see your draft version number "skipped over" in the version chain.
+  Root cause: `fastly compute publish` clones from the currently-active version, not from
+  the latest draft, so dashboard changes made in an un-activated draft get stranded.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# `fastly compute publish` ignores non-active draft versions
+
+## Problem
+
+Fastly service versions are immutable. To change a service you clone the active version,
+edit the clone (a draft), then activate the clone. Multiple tools create drafts:
+
+- `fastly service backend create --autoclone` — creates a draft off the active version and
+  adds the backend
+- `fastly service domain create --autoclone` — same, for domains
+- Dashboard UI "Clone" button
+- `fastly compute publish` — also creates a draft, uploads WASM, activates
+
+If you mix these tools on the same service you get a surprising footgun: **each tool clones
+from the currently-active version, independently, and each activates its own clone.** Draft
+versions that were never activated are abandoned. Their edits are invisible to whatever the
+next tool clones from.
+
+Example sequence that bites:
+
+```
+t0  Active = v250
+t1  $ fastly service backend create --version latest --autoclone \
+       --name cloud_run_transcoder --address ...
+    → creates v251 (clone of v250) + adds backend
+    → v251 is DRAFT, not active
+    → "latest" in this context means "highest version number" (v251), not "active version"
+
+t2  $ fastly compute publish --comment "ship fix"
+    → creates v252 (clone of v250, NOT v251) + new WASM
+    → stages and activates v253 (clone of v252) + activates
+    → v251's backend change was never carried forward
+    → active = v253, which does NOT contain cloud_run_transcoder
+
+t3  Compute code at v253 calls send_async("cloud_run_transcoder")
+    → backend name does not exist on v253
+    → silent failure, fire-and-forget hides it
+```
+
+The naming is misleading: `--version latest` does not mean "the latest active version," it
+means "the highest-numbered version," which can be a draft nobody activated. And `fastly
+compute publish` never looks at your draft — it clones from whatever is currently active.
+So your backend change is orphaned in an unreachable draft version, and the active version
+has the new code but the old backend list.
+
+## Context / Trigger Conditions
+
+- Compute logs show `Backend X does not exist` or similar after a deploy that "worked"
+- `send_async(BACKEND)` calls return errors that the code silently swallows (see skill
+  `fastly-compute-async-request-reliability`)
+- `fastly service version list --service-id ID` shows a gap or out-of-order creation
+  timestamps — e.g. v251 created at 23:17, v252/v253 created at 23:27, v253 active, but
+  v252 was cloned from v250 not v251
+- `fastly service backend list --version N` where N is active shows a DIFFERENT backend
+  set from `fastly service backend list --version (N-2)` where N-2 is the draft you
+  thought you were building on
+- You added a dashboard resource "just before" running `fastly compute publish` and the
+  publish succeeded but the resource seems to be ignored
+
+## Solution
+
+### Detection
+
+```bash
+# Find all versions and which is active
+fastly service version list --service-id YOUR_SERVICE_ID
+
+# For each recent version, list backends (or whatever resource you added)
+for v in 250 251 252 253 254; do
+  echo "=== v$v ==="
+  fastly service backend list --service-id YOUR_SERVICE_ID --version $v | grep MY_BACKEND_NAME
+done
+```
+
+If the backend appears on a non-active draft (e.g. v251) but is absent from active (e.g.
+v253), you have this bug.
+
+### Fix: add the resource to the currently-active version via `--autoclone`
+
+```bash
+# Creates a new draft cloned from the active version, with the backend added.
+# Activate the draft atomically afterward.
+fastly service backend create --service-id YOUR_SERVICE_ID --version latest --autoclone \
+  --name cloud_run_transcoder \
+  --address divine-transcoder-149672065768.us-central1.run.app \
+  --port 443 --use-ssl \
+  --ssl-sni-hostname divine-transcoder-149672065768.us-central1.run.app \
+  --override-host divine-transcoder-149672065768.us-central1.run.app
+
+# Confirm the draft has the backend
+fastly service backend list --service-id YOUR_SERVICE_ID --version LATEST_DRAFT \
+  | grep cloud_run_transcoder
+
+# Activate
+fastly service version activate --service-id YOUR_SERVICE_ID --version LATEST_DRAFT
+
+# Purge cache so any poisoned 404/502 responses drop
+fastly purge --all --service-id YOUR_SERVICE_ID
+```
+
+Note: `--version latest` in the `backend create` command here is safe because after the
+previous drifted `fastly compute publish`, the latest draft's parent IS the currently-active
+version. You're cloning off the right base now.
+
+### Prevention (choose one)
+
+1. **Do all non-code changes through `fastly compute publish` first, then WASM changes.**
+   If you ran `fastly compute publish` without any dashboard/CLI changes queued, the active
+   version gets incremented by 2 (clone → activate) and there are no stranded drafts. Add
+   your backend after the publish via `--autoclone`, which then creates a fresh draft off
+   the new active version, and activate it.
+
+2. **Always activate your draft before running `fastly compute publish`.** If you ran
+   `fastly service backend create --autoclone` and got v251, activate v251 before the
+   compute publish. Then compute publish will clone from v251 and carry the backend.
+
+3. **Treat every draft version as an unshipped change.** Before any `fastly compute publish`,
+   run `fastly service version list --service-id ID` and verify no drafts exist that you
+   intended to ship. If there are drafts you don't want, explicitly abandon them; if there
+   are drafts you do want, activate them first.
+
+4. **Use `--verbose` on `fastly compute publish`.** The verbose output shows which version
+   number it cloned from. If that number is older than your last draft, you know you've
+   drifted.
+
+## Verification
+
+After the fix, confirm:
+
+```bash
+# Active version has the backend
+fastly service backend list --service-id YOUR_SERVICE_ID --version $(fastly service version list --service-id YOUR_SERVICE_ID | awk '$3=="true"{print $1}') | grep MY_BACKEND_NAME
+
+# End-to-end: hit a Compute endpoint that exercises the backend and check logs
+# for successful routing (no "backend does not exist" errors)
+fastly log tail --service-id YOUR_SERVICE_ID | grep -iE "backend|MY_BACKEND"
+```
+
+For the Divine Blossom example (2026-04-05), the symptom was that PR #59's fix to route
+transcoder triggers via a new `TRANSCODER_BACKEND = "cloud_run_transcoder"` constant was
+deployed in version 253 but the backend itself was stranded in v251. The compute code was
+silently 404-ing on every `send_async` to the transcoder. Fix was `fastly service backend
+create --version latest --autoclone` → new v254 with both the WASM and the backend →
+activate v254 → purge.
+
+## Notes
+
+- The same issue applies to *any* resource you can add with `--autoclone`: backends,
+  domains, ACLs, dictionaries, edge dictionaries, header rules, VCL snippets (on VCL
+  services), logging endpoints. Anything that creates a draft version is at risk.
+- The `fastly compute publish` command has no `--base-version` flag to explicitly say "clone
+  from this version." It always clones from active.
+- VCL services that mix `fastly vcl snippet create --autoclone` + `fastly vcl custom update`
+  can hit the same trap.
+- If you have multiple people making changes concurrently, the risk multiplies: one person's
+  draft can be invalidated by another person's publish without either of them noticing.
+- The Fastly CLI does not warn about stranded drafts. They don't expire automatically
+  (AFAIK); they just become zombie versions.
+- Check `fastly service version list --service-id ID` output carefully — the "active"
+  column tells you which version is live; everything else is a draft or a previous active.
+  Timestamps can be misleading because draft versions carry the timestamp of the `fastly
+  service version clone` call, not of the content change.
+
+## References
+
+- `fastly compute publish` source behavior documented in the Fastly CLI repo — see the
+  `publish` subcommand implementation for the clone-active-and-activate flow
+- Related skill: `fastly-compute-async-request-reliability` — covers how silently-failing
+  `send_async` hides this exact bug when the backend goes missing
+- Related skill: `fastly-compute-backend-production-setup` — covers the "backend exists
+  locally but not in production" sibling bug

--- a/.claude/skills/fastly-compute-rust-edition2024-fix/SKILL.md
+++ b/.claude/skills/fastly-compute-rust-edition2024-fix/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: fastly-compute-rust-edition2024-fix
+description: |
+  Fix Fastly Compute Rust build failures caused by edition2024 dependencies. Use when:
+  (1) cargo build fails with "feature `edition2024` is required", (2) wit-bindgen or
+  wasip2 crates fail to download/parse, (3) Fastly SDK pulls in incompatible transitive
+  dependencies, (4) Build worked before but fails after dependency update. Solves by
+  pinning wit-bindgen, wasip2, and related crates to pre-edition2024 versions.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-20
+---
+
+# Fastly Compute Rust Edition2024 Dependency Fix
+
+## Problem
+
+Fastly Compute Rust projects fail to build with errors about `edition2024` being required,
+even when using stable Rust. The error appears when transitive dependencies (especially
+`wit-bindgen` 0.51+ and `wasip2` 1.0.2+) require Rust 1.87+ which isn't stable yet.
+
+## Context / Trigger Conditions
+
+- Error: `feature 'edition2024' is required`
+- Error: `failed to parse manifest at .../wit-bindgen-0.51.0/Cargo.toml`
+- Error mentions "requires Rust 1.87.0" for wit-bindgen or wasip2
+- Build previously worked but fails after running `cargo update`
+- Using Fastly SDK (`fastly` crate) version 0.11.x
+
+## Solution
+
+Pin the problematic transitive dependencies in your `Cargo.toml`:
+
+```toml
+[dependencies]
+# Fastly Compute SDK - pin to specific version
+fastly = "=0.11.12"
+
+# Pin these to avoid edition2024 requirement
+wit-bindgen = "=0.46.0"
+wasip2 = "=1.0.1"
+
+# Also pin these if you use k256 or crypto
+k256 = { version = "=0.13.3", features = ["schnorr"] }
+base64ct = "=1.6.0"
+```
+
+Also update `rust-toolchain.toml` to include both WASM targets:
+
+```toml
+[toolchain]
+channel = "1.83.0"
+targets = ["wasm32-wasi", "wasm32-wasip1"]
+```
+
+Then:
+```bash
+rm Cargo.lock
+rustup target add wasm32-wasip1
+cargo build --target wasm32-wasi
+```
+
+## Verification
+
+Build should complete without edition2024 errors:
+```bash
+cargo build --target wasm32-wasi 2>&1 | grep -i "edition2024"
+# Should return nothing (no matches)
+```
+
+## Example
+
+Before fix (Cargo.toml):
+```toml
+[dependencies]
+fastly = "0.11"  # Allows 0.11.x which pulls wit-bindgen 0.51+
+```
+
+After fix (Cargo.toml):
+```toml
+[dependencies]
+fastly = "=0.11.12"
+wit-bindgen = "=0.46.0"
+wasip2 = "=1.0.1"
+```
+
+## Notes
+
+- The `=` prefix in version strings means "exactly this version"
+- Fastly CLI 13.x switched from `wasm32-wasi` to `wasm32-wasip1` target
+- This is a temporary fix until Rust 1.87 becomes stable
+- The warning about `wasm32-wasi` being renamed to `wasm32-wasip1` is expected
+- When Rust 1.87 is stable, these pins can be removed
+
+## References
+
+- Fastly Compute Rust SDK: https://docs.fastly.com/products/compute
+- Rust Edition 2024: https://doc.rust-lang.org/edition-guide/rust-2024/

--- a/.claude/skills/fastly-compute-well-known-spa-fallback/SKILL.md
+++ b/.claude/skills/fastly-compute-well-known-spa-fallback/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: fastly-compute-well-known-spa-fallback
+description: |
+  Fix .well-known files (apple-app-site-association, assetlinks.json) being served as HTML
+  by the @fastly/compute-js-static-publish SPA fallback instead of JSON. Use when: (1) iOS
+  Universal Links or Android App Links are broken because the verification files return
+  text/html instead of application/json, (2) PublisherServer with spaFile config intercepts
+  /.well-known/ paths and returns index.html (200, text/html) instead of 404 for missing
+  files, (3) apple-app-site-association (no file extension) gets wrong content type even
+  when correctly stored in KV. Covers both apex domain and subdomain handler patterns.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-23
+---
+
+# Fastly Compute: .well-known Files Intercepted by SPA Fallback
+
+## Problem
+
+When using `@fastly/compute-js-static-publish` with SPA fallback configured (`spaFile: "/index.html"`), the `PublisherServer.serveRequest()` returns `index.html` with status 200 and Content-Type `text/html` for ANY path not found in the KV store. This includes `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json`, which iOS and Android require to be served as `application/json`.
+
+Symptoms:
+- iOS Universal Links don't work (Apple's verification fetches `.well-known/apple-app-site-association` and gets HTML)
+- Android App Links don't work (Google's verifier fetches `.well-known/assetlinks.json` and gets HTML)
+- `curl -I https://yourdomain.com/.well-known/apple-app-site-association` shows `Content-Type: text/html`
+- The files ARE published to KV (confirmed by `npm run fastly:publish`) but still return HTML
+
+## Non-Obvious Root Causes
+
+1. **SPA fallback returns 200, not 404**: The publisher's SPA mode returns `index.html` with HTTP 200 for missing paths. You cannot distinguish "file served" from "fallback served" by status code alone - you must inspect the Content-Type.
+
+2. **`apple-app-site-association` has no file extension**: The static publisher infers MIME type from file extension. With no extension, it cannot detect `application/json`, so even when the file IS published to KV, it may get `application/octet-stream` or be served incorrectly.
+
+3. **`includeWellKnown: true` in `publish-content.config.js` is necessary but not sufficient**: It ensures the files are uploaded to KV, but doesn't prevent the SPA fallback from intercepting the requests, and doesn't fix the content-type for extension-less files.
+
+4. **Both apex domain and subdomain handlers need the fix**: If your Compute handler has separate code paths for subdomains vs apex, both paths must intercept `.well-known/` requests before reaching the SPA fallback.
+
+## Solution
+
+### Step 1: Ensure Files Are Published
+
+In `publish-content.config.js`, confirm `includeWellKnown: true` is set:
+
+```javascript
+// publish-content.config.js
+module.exports = {
+  // ...
+  includeWellKnown: true,   // Must be true to include /.well-known/ files
+  // ...
+};
+```
+
+Then publish static content:
+```bash
+npm run fastly:publish
+```
+
+### Step 2: Intercept .well-known Paths Before SPA Fallback
+
+In your Compute entry point (`compute-js/src/index.js`), add a `.well-known` handler
+BEFORE any call to `publisherServer.serveRequest(request)` that has SPA fallback enabled.
+
+**Critical guard**: Check that the publisher response is NOT `text/html` - if it is,
+the SPA fallback fired (file not in KV), so return 404 instead of the HTML.
+
+```javascript
+// In your main handleRequest function, BEFORE the final publisherServer.serveRequest() call:
+
+// Handle .well-known requests (must come before SPA fallback)
+if (url.pathname.startsWith('/.well-known/')) {
+  // Handle NIP-05 or other dynamic .well-known endpoints first
+  if (url.pathname === '/.well-known/nostr.json') {
+    return handleNip05(url);  // Your custom handler
+  }
+
+  // For all other .well-known files: fetch from static publisher
+  const wkResponse = await publisherServer.serveRequest(request);
+
+  // CRITICAL: Guard against SPA fallback. The publisher returns index.html (text/html)
+  // for files not in KV. We must detect this and return 404 instead.
+  if (
+    wkResponse != null &&
+    wkResponse.status === 200 &&
+    !wkResponse.headers.get('Content-Type')?.includes('text/html')
+  ) {
+    const headers = new Headers(wkResponse.headers);
+
+    // Explicitly set correct content type.
+    // apple-app-site-association has no extension, so the publisher may not detect JSON.
+    const isJsonFile =
+      url.pathname.endsWith('.json') ||
+      url.pathname.endsWith('/apple-app-site-association') ||
+      url.pathname === '/.well-known/apple-app-site-association';
+
+    headers.set(
+      'Content-Type',
+      isJsonFile ? 'application/json' : (headers.get('Content-Type') || 'application/octet-stream')
+    );
+    headers.set('Cache-Control', 'public, max-age=3600');
+    headers.append('Vary', 'X-Original-Host');  // If using multi-service routing
+
+    return new Response(wkResponse.body, { status: 200, headers });
+  }
+
+  // File not in KV (or publisher returned SPA fallback) - return proper 404
+  return new Response('Not Found', { status: 404 });
+}
+```
+
+### Step 3: Apply the Same Fix in Subdomain Handlers
+
+If you have separate handling for subdomain requests, add the same guard there too.
+Subdomain paths hit a different code branch before reaching the apex domain handler:
+
+```javascript
+if (subdomain) {
+  if (url.pathname.startsWith('/.well-known/')) {
+    if (url.pathname === '/.well-known/nostr.json') {
+      return handleSubdomainNip05(subdomain);
+    }
+
+    // Same pattern: intercept, guard against SPA fallback, force JSON content type
+    const wkResponse = await publisherServer.serveRequest(request);
+    if (
+      wkResponse != null &&
+      wkResponse.status === 200 &&
+      !wkResponse.headers.get('Content-Type')?.includes('text/html')
+    ) {
+      const headers = new Headers(wkResponse.headers);
+      const contentType =
+        url.pathname.endsWith('.json') || url.pathname.endsWith('/apple-app-site-association')
+          ? 'application/json'
+          : headers.get('Content-Type') || 'application/octet-stream';
+      headers.set('Content-Type', contentType);
+      headers.set('Cache-Control', 'public, max-age=3600');
+      return new Response(wkResponse.body, { status: 200, headers });
+    }
+    return new Response('Not Found', { status: 404 });
+  }
+
+  // ... rest of subdomain handling
+}
+```
+
+## Verification
+
+```bash
+# Should return application/json, NOT text/html
+curl -sI https://yourdomain.com/.well-known/apple-app-site-association | grep -i content-type
+
+# Should return JSON body
+curl -s https://yourdomain.com/.well-known/apple-app-site-association | head -c 100
+
+# Android assetlinks.json
+curl -sI https://yourdomain.com/.well-known/assetlinks.json | grep -i content-type
+
+# Verify the SPA fallback guard works (path that does NOT exist in KV)
+curl -sI https://yourdomain.com/.well-known/nonexistent-file
+# Should return 404, not 200
+```
+
+## Complete Working Example
+
+From `compute-js/src/index.js` in divine-web:
+
+```javascript
+// 4. Handle .well-known requests
+if (url.pathname.startsWith('/.well-known/')) {
+  // 4a. NIP-05 from KV store
+  if (url.pathname === '/.well-known/nostr.json') {
+    return await handleNip05(url);
+  }
+
+  // 4b. Serve other .well-known files (apple-app-site-association, assetlinks.json)
+  // These must be served as JSON, not the SPA fallback.
+  // apple-app-site-association has no file extension, so the static publisher
+  // cannot detect its content type - we handle it explicitly here.
+  const wkResponse = await publisherServer.serveRequest(request);
+  // Guard: if publisher returns text/html, it's the SPA fallback, not the real file
+  if (wkResponse != null && wkResponse.status === 200 && !wkResponse.headers.get('Content-Type')?.includes('text/html')) {
+    const headers = new Headers(wkResponse.headers);
+    // Ensure correct content type for app association files
+    const contentType = url.pathname.endsWith('.json') || url.pathname.endsWith('/apple-app-site-association')
+      ? 'application/json'
+      : headers.get('Content-Type') || 'application/octet-stream';
+    headers.set('Content-Type', contentType);
+    headers.set('Cache-Control', 'public, max-age=3600');
+    headers.append('Vary', 'X-Original-Host');
+    return new Response(wkResponse.body, {
+      status: 200,
+      headers,
+    });
+  }
+  // File not found in KV - return 404 instead of SPA fallback
+  return new Response('Not Found', { status: 404 });
+}
+```
+
+## Deployment Checklist
+
+After making code changes:
+
+```bash
+# 1. Publish static content first (uploads .well-known files to KV)
+npm run fastly:publish
+
+# 2. Deploy the edge worker code (with the .well-known interception logic)
+npm run fastly:deploy
+
+# NOTE: Order matters if files weren't in KV before. If you deploy code first,
+# it will correctly return 404 for missing files. Then publish uploads the files.
+# Either order works - the guard handles both cases.
+```
+
+## Notes
+
+- This pattern applies to any Fastly Compute service using `@fastly/compute-js-static-publish` with `spaFile` configured.
+- The SPA fallback is intentional for client-side routing, but it breaks any path that needs a real 404 (like `.well-known` verification files).
+- The content-type detection by file extension is a fundamental limitation of static publishing - extension-less files always need explicit handling.
+- If you serve multiple domains (apex + subdomains), each code path that can call `publisherServer.serveRequest()` needs the `.well-known` interception guard.
+- After `fastly:publish`, allow up to 2-3 minutes for KV propagation before testing.
+
+## References
+
+- [Apple Universal Links documentation](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app)
+- [Android App Links documentation](https://developer.android.com/training/app-links/verify-android-applinks)
+- [@fastly/compute-js-static-publish on npm](https://www.npmjs.com/package/@fastly/compute-js-static-publish)
+- [Fastly Compute KV Store](https://www.fastly.com/documentation/guides/compute/javascript/working-with-kv-store/)

--- a/.claude/skills/fastly-domain-v1-activation/SKILL.md
+++ b/.claude/skills/fastly-domain-v1-activation/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: fastly-domain-v1-activation
+description: |
+  Fix "Fastly error: unknown domain" 500 errors when custom domains return "Domain Not Found"
+  despite being created with domain-v1 CLI. Use when: (1) fastly domain-v1 create succeeds
+  but domain returns 500, (2) Domain shows activated:false in API response, (3) Classic
+  domain API returns "deprecated" error, (4) Custom domain works on edgecompute.app but
+  not on your domain. Covers Fastly Compute domain setup post-September 2025.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Fastly Domain-v1 Activation for Compute Services
+
+## Problem
+After creating a custom domain with `fastly domain-v1 create --fqdn example.com --service-id XXX`,
+the domain returns a 500 error: "Fastly error: unknown domain: example.com. Please check that
+this domain has been added to a service." The edgecompute.app URL works fine.
+
+## Context / Trigger Conditions
+- Classic domain API returns: "The classic domains APIs are deprecated. Please use the domain management API"
+- `fastly domain-v1 create` succeeds with domain-id and service-id
+- HTTP request to custom domain returns 500 "Domain Not Found"
+- Checking domain via API shows `"activated": false, "verified": false`
+- The auto-generated edgecompute.app domain works correctly
+
+## Solution
+
+### Step 1: Create the domain (if not already done)
+```bash
+fastly domain-v1 create --fqdn example.com --service-id YOUR_SERVICE_ID
+```
+
+### Step 2: Create TLS subscription for HTTPS
+```bash
+fastly tls-subscription create --domain example.com
+```
+
+### Step 3: Get DNS configuration requirements
+```bash
+curl -s -H "Fastly-Key: $(fastly profile token)" \
+  "https://api.fastly.com/tls/subscriptions/SUBSCRIPTION_ID?include=tls_authorizations" | jq
+```
+
+Look for the `challenges` array in the response. You'll see options like:
+- `managed-http-a`: A records pointing to Fastly IPs (use for apex domains)
+- `managed-http-cname`: CNAME to `x.sni.global.fastly.net` (use for subdomains)
+- `managed-dns`: ACME challenge CNAME for `_acme-challenge.example.com`
+
+### Step 4: Configure DNS
+For apex domains, add A records:
+```
+example.com → 151.101.1.242
+example.com → 151.101.65.242
+example.com → 151.101.129.242
+example.com → 151.101.193.242
+```
+
+For subdomains, use CNAME:
+```
+www.example.com → x.sni.global.fastly.net
+```
+
+### Step 5: Wait for automatic activation
+Once DNS propagates, Fastly automatically:
+1. Verifies domain ownership via HTTP challenge
+2. Sets `verified: true`
+3. Sets `activated: true`
+4. Issues TLS certificate (state changes from "pending" to "issued")
+
+This typically happens within 1-5 minutes after DNS propagation.
+
+### Step 6: Verify activation status
+```bash
+# Check domain status
+curl -s -H "Fastly-Key: $(fastly profile token)" \
+  "https://api.fastly.com/domain-management/v1/domains/DOMAIN_ID" | jq
+
+# Should show:
+# "activated": true,
+# "verified": true
+
+# Check TLS status
+fastly tls-subscription describe --id SUBSCRIPTION_ID
+# State should be "issued"
+```
+
+## Verification
+```bash
+# Test HTTP (should redirect to HTTPS)
+curl -I http://example.com
+# Expected: 308 Permanent Redirect to https://
+
+# Test HTTPS
+curl -s https://example.com | head -20
+# Expected: Your site content
+```
+
+## Example
+
+```bash
+# 1. Create KV store and link to service
+fastly kv-store create --name my-content
+fastly resource-link create --resource-id KV_STORE_ID --service-id SERVICE_ID --version latest --autoclone
+
+# 2. Build and deploy
+fastly compute publish
+
+# 3. Add custom domain
+fastly domain-v1 create --fqdn mysite.com --service-id SERVICE_ID
+# Output: Created domain 'mysite.com' (domain-id: ABC123, service-id: XYZ789)
+
+# 4. Set up TLS
+fastly tls-subscription create --domain mysite.com
+# Output: Created TLS Subscription 'SUB123' (Authority: certainly, Common Name: mysite.com)
+
+# 5. Configure DNS with A records (apex) or CNAME (subdomain)
+# 6. Wait ~2-5 minutes for verification
+# 7. Site is live at https://mysite.com
+```
+
+## Notes
+
+- **Post-September 2025**: The `fastly domain create` command (classic API) is deprecated. Use `fastly domain-v1` instead.
+- **No manual activation**: Unlike classic domains, domain-v1 domains activate automatically after DNS verification. There's no explicit "activate" API call.
+- **Service version independence**: Domain-v1 creates "versionless domains" that aren't tied to a specific service version. You don't need to clone/activate versions to add domains.
+- **TLS is separate**: Domain creation and TLS certificate management are separate operations. You can have a domain without TLS (HTTP only) but most setups want both.
+- **Fastly IPs are global**: The A record IPs (151.101.x.242) are Fastly's anycast addresses and route to the nearest edge node.
+
+## References
+- [Fastly Domain Management API](https://www.fastly.com/documentation/reference/api/domain-management/domains/)
+- [Working with versionless domains](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/working-with-domains/)
+- [domain-v1 CLI reference](https://www.fastly.com/documentation/reference/cli/domain-v1/)

--- a/.claude/skills/fastly-kv-concurrent-write-retry/SKILL.md
+++ b/.claude/skills/fastly-kv-concurrent-write-retry/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: fastly-kv-concurrent-write-retry
+description: |
+  Fix intermittent 500 errors with "Failed to store" in Fastly KV Store during concurrent
+  writes. Use when: (1) Batch operations fail with ~10-20% error rate, (2) Error contains
+  "Failed to store list" or similar KV write failures, (3) Multiple requests updating the
+  same KV key simultaneously, (4) Read-modify-write pattern without locking. The fix is
+  adding a retry loop that re-reads before each write attempt.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-28
+---
+
+# Fastly KV Store Concurrent Write Race Condition
+
+## Problem
+When multiple concurrent requests perform read-modify-write operations on the same
+Fastly KV Store key, writes can fail with intermittent 500 errors. This commonly
+occurs during batch uploads where each request updates a shared list or counter.
+
+## Context / Trigger Conditions
+- Error message contains "Failed to store list:" or similar KV write failure
+- ~10-20% failure rate during concurrent operations
+- Multiple requests from the same user/session updating shared state
+- Pattern: `read key → modify data → write key` without any locking
+
+Example error:
+```json
+{"error":"Failed to store list:"}
+```
+
+## Solution
+
+Add a retry loop that re-reads the data before each write attempt:
+
+```rust
+/// Add item to list with retry for concurrent writes
+pub fn add_to_list(key: &str, item: &str) -> Result<()> {
+    // Retry up to 5 times for concurrent write conflicts
+    for attempt in 0..5 {
+        // Re-read current state on each attempt
+        let mut items = get_list(key)?;
+
+        if items.contains(&item.to_string()) {
+            return Ok(()); // Already exists, done
+        }
+
+        items.push(item.to_string());
+
+        match put_list(key, &items) {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < 4 => {
+                eprintln!("[KV] Retry {} for list update: {}", attempt + 1, e);
+                // Re-read picks up concurrent writes
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(Error::new("Max retries exceeded for list update"))
+}
+```
+
+Key points:
+1. **Re-read on each retry** - The fresh read picks up changes from concurrent writes
+2. **Check for duplicates** - Avoid adding the same item twice
+3. **Log retries** - Helps debug if issues persist
+4. **Limit retries** - 5 attempts is usually sufficient
+
+## Verification
+- Batch operations that previously failed ~16% should now succeed ~100%
+- Retry log messages (`[KV] Retry N for...`) indicate the mechanism is working
+- If still failing after 5 retries, there may be a deeper issue
+
+## Example
+
+Before (race condition):
+```rust
+pub fn add_to_user_list(pubkey: &str, hash: &str) -> Result<()> {
+    let mut hashes = get_user_blobs(pubkey)?;  // Read
+    if !hashes.contains(&hash) {
+        hashes.push(hash.to_string());         // Modify
+        put_user_list(pubkey, &hashes)?;       // Write - CONFLICT!
+    }
+    Ok(())
+}
+```
+
+After (with retry):
+```rust
+pub fn add_to_user_list(pubkey: &str, hash: &str) -> Result<()> {
+    for attempt in 0..5 {
+        let mut hashes = get_user_blobs(pubkey)?;
+        if hashes.contains(&hash) {
+            return Ok(());
+        }
+        hashes.push(hash.to_string());
+        match put_user_list(pubkey, &hashes) {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < 4 => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(Error::new("Max retries exceeded"))
+}
+```
+
+## Notes
+- Fastly Compute doesn't have `sleep()`, so retries happen immediately
+- The re-read is what provides the "delay" by picking up concurrent changes
+- Consider using atomic operations if available (Fastly KV doesn't support CAS)
+- For high-contention scenarios, consider sharding the key space
+- This pattern also applies to remove operations (read-filter-write)
+
+## References
+- [Fastly KV Store Documentation](https://developer.fastly.com/reference/compute/kv-store/)

--- a/.claude/skills/fastly-multi-service-routing-debug/SKILL.md
+++ b/.claude/skills/fastly-multi-service-routing-debug/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: fastly-multi-service-routing-debug
+description: |
+  Debug Fastly Compute services where code changes don't affect behavior due to
+  multi-service routing architecture. Use when: (1) deployed changes have no effect,
+  (2) unexpected redirects persist after code updates, (3) DNS resolves to Fastly
+  but responses don't match deployed code, (4) `fastly service list` shows multiple
+  related services. The root cause is often a routing/gateway service intercepting
+  requests before they reach your content service.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-02
+---
+
+# Fastly Multi-Service Routing Debug
+
+## Problem
+You deploy changes to a Fastly Compute service but the behavior doesn't change.
+Requests still return old responses, redirects, or errors even after:
+- Deploying new code with `fastly compute publish`
+- Purging the cache with `fastly purge --all`
+- Verifying the correct service version is active
+
+## Context / Trigger Conditions
+- DNS resolves to Fastly IPs (151.101.x.x)
+- Response headers show `x-served-by: cache-xxx` (Fastly cache)
+- Deployed code should return different status/headers but doesn't
+- Multiple Fastly services exist for the same project (e.g., `divine-web`, `divine-router`)
+- Wildcard subdomain routing is involved (*.example.com)
+
+## Solution
+
+### Step 1: Identify Which Service Handles the Domain
+
+```bash
+# List all services
+fastly service list
+
+# Check which service handles your domain using domain-v1
+fastly domain-v1 list | grep your-domain.com
+```
+
+The output shows the service ID for each domain:
+```
+*.divine.video      glh3AfBEmZKzmAmByvGyAg  76fTayX6mBKa8faLeZ1fet  2025-12-28...
+divine.video        1JttvGPc6AlOVg4koUGhPg  76fTayX6mBKa8faLeZ1fet  2025-11-23...
+```
+
+The third column is the **service ID** that handles that domain.
+
+### Step 2: Verify Service Architecture
+
+Common patterns:
+- **Router + Content**: A routing service (often Rust) sits in front, handling
+  subdomain logic, then passes through to a content service
+- **Gateway Pattern**: Edge gateway handles auth/rate-limiting, then proxies to origin
+- **Wildcard Routing**: `*.domain.com` may be handled by a different service than `domain.com`
+
+### Step 3: Debug the Correct Service
+
+Once you identify the routing service:
+
+```bash
+# Check its active version
+fastly service-version list --service-id <router-service-id>
+
+# Check its domains
+fastly domain list --service-id <router-service-id> --version active
+
+# Find and read its source code (usually in a different repo)
+```
+
+### Step 4: Trace Request Flow
+
+Add debug logging to understand the flow:
+1. In the routing service: log the Host header and routing decision
+2. In the content service: log if requests are even reaching it
+3. Check Fastly logs: `fastly log-tail --service-id <id>`
+
+### Step 5: Fix the Correct Service
+
+If the routing service is doing unwanted redirects:
+- Update its routing logic to pass through instead of redirect
+- Or update it to return the desired response directly
+- Deploy to the routing service, not just the content service
+
+## Verification
+
+```bash
+# Test with cache bypass
+curl -sI -H "Cache-Control: no-cache" "https://subdomain.your-domain.com/?t=$(date +%s)"
+
+# Verify new behavior appears
+# Check response headers match what your code should return
+```
+
+## Example
+
+**Symptom**: `rabble.divine.video` returns 301 redirect despite divine-web having
+code to serve HTML directly.
+
+**Discovery**:
+```bash
+$ fastly domain-v1 list | grep divine.video
+*.divine.video      ...  76fTayX6mBKa8faLeZ1fet  ...  # This is divine-router!
+divine.video        ...  76fTayX6mBKa8faLeZ1fet  ...  # Same - router handles both
+```
+
+**Root Cause**: `divine-router` (Rust service) was returning 301 redirects in its
+`serve_profile()` function, never letting requests reach `divine-web`.
+
+**Fix**: Updated `divine-router` to return the desired response directly instead
+of redirecting.
+
+## Notes
+
+- The `fastly domain list` command shows domains on a specific service/version
+- The `fastly domain-v1 list` command shows ALL domains across ALL services
+- Wildcard domains (`*.domain.com`) often route to a different service than apex
+- When using Fastly Compute backends, the request may go: Router → Content → Origin
+- Cache purging only affects the service that's caching; if a router caches, purge there
+- Response headers like `x-publisher-server-collection` indicate which service responded
+
+## Architecture Patterns
+
+### Pattern 1: Router → Content
+```
+User → DNS → Fastly Router Service → Fastly Content Service → Origin/KV Store
+```
+The router handles subdomain logic, auth, or routing rules.
+
+### Pattern 2: Direct
+```
+User → DNS → Fastly Content Service → Origin/KV Store
+```
+Single service handles everything.
+
+### Debugging Tip
+If you're unsure which pattern applies, check the `[setup.backends]` section in each
+service's `fastly.toml` to see if one service proxies to another's edgecompute.app URL.

--- a/.claude/skills/fastly-wildcard-subdomain-compute-edge/SKILL.md
+++ b/.claude/skills/fastly-wildcard-subdomain-compute-edge/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: fastly-wildcard-subdomain-compute-edge
+description: |
+  Fix wildcard subdomain routing for Fastly Compute@Edge services when subdomains resolve
+  but return 500 "Domain Not Found" or empty responses. Use when: (1) TLS subscription
+  "issued" but edge serves default certificate (CN=j.sni-644-default), (2) Fastly domain-v1
+  create succeeds but subdomain returns 500, (3) Static publisher/PublisherServer returns
+  empty content for subdomain requests, (4) DNS wildcard CNAME resolves to wrong target.
+  Covers TLS configuration SNI endpoint selection (x.sni vs j.sni vs w.sni), DNS trailing
+  dot issues, Fastly domain-v1 activation, and reading from KV store directly when
+  PublisherServer fails for subdomains.
+author: Claude Code
+version: 1.1.0
+date: 2026-02-02
+---
+
+# Fastly Wildcard Subdomain Routing for Compute@Edge
+
+## Problem
+Wildcard subdomains (*.example.com) don't work on Fastly Compute@Edge services even after:
+- Creating the domain with `fastly domain-v1 create`
+- Setting up DNS records
+- The static publisher working fine for the apex domain
+
+Symptoms include:
+- 500 errors with "Fastly error: unknown domain: subdomain.example.com"
+- PublisherServer returning empty responses (content-length: 0) for subdomain requests
+- TLS subscriptions stuck in "pending" state
+- DNS resolving to wrong targets
+
+## Context / Trigger Conditions
+
+1. **Wrong SNI endpoint**: TLS certificate is "issued" but edge serves default certificate
+   (`CN=j.sni-644-default.ssl.fastly.net` instead of your domain).
+
+   **CRITICAL**: The TLS configuration name tells you which SNI endpoint to use:
+   - "HTTP/3 & TLS v1.3 + 0RTT **(x.sni)**" → DNS to `x.sni.global.fastly.net.`
+   - "HTTP/3 & TLS v1.3 **(w.sni)**" → DNS to `w.sni.global.fastly.net.`
+   - Default/legacy → DNS to `j.sni.global.fastly.net.`
+
+   Check your TLS configuration:
+   ```bash
+   FASTLY_KEY=$(fastly profile token) && curl -s -H "Fastly-Key: $FASTLY_KEY" \
+     "https://api.fastly.com/tls/configurations" | jq '.data[] | {id: .id, name: .attributes.name}'
+   ```
+
+   Verify by connecting directly to the correct endpoint:
+   ```bash
+   echo | openssl s_client -servername subdomain.yourdomain.com \
+     -connect x.sni.global.fastly.net:443 2>/dev/null | openssl x509 -noout -subject
+   ```
+
+2. **DNS trailing dot issue**: CNAME records resolve to `target.com.yourdomain.com` instead
+   of `target.com` because the DNS provider appends the zone name without a trailing dot.
+
+   Check with: `dig @ns-server *.yourdomain.com CNAME +short`
+
+   Bad: `x.sni.global.fastly.net.yourdomain.com.`
+   Good: `x.sni.global.fastly.net.`
+
+3. **Domain not activated**: Fastly domain-v1 shows `"activated": false, "verified": false`
+   even after DNS is set up.
+
+   Check with:
+   ```bash
+   curl -s -H "Fastly-Key: $(fastly profile token)" \
+     "https://api.fastly.com/domain-management/v1/domains/DOMAIN_ID" | jq
+   ```
+
+3. **PublisherServer returns empty for subdomains**: The `@fastly/compute-js-static-publish`
+   PublisherServer returns null/empty responses when the request hostname is a subdomain,
+   even though it works for the apex domain and edgecompute.app URL.
+
+## Solution
+
+### Part 1: Fix DNS Configuration
+
+1. **Wildcard CNAME with trailing dot** (check your TLS config for correct SNI endpoint):
+   ```
+   Name: *
+   Type: CNAME
+   Value: x.sni.global.fastly.net.   <- Use endpoint from your TLS config name (x.sni, w.sni, or j.sni)
+   ```
+
+2. **ACME challenge CNAME with trailing dot** (for TLS validation):
+   ```
+   Name: _acme-challenge
+   Type: CNAME
+   Value: CHALLENGE_VALUE.fastly-validations.com.   <- MUST include trailing dot
+   ```
+
+3. Alternative: Use A records instead of CNAME (avoids trailing dot issues):
+   ```
+   Name: *
+   Type: A
+   Values: 151.101.1.242, 151.101.65.242, 151.101.129.242, 151.101.193.242
+   ```
+
+### Part 2: Recreate Fastly Domain (if stuck)
+
+If domain shows `activated: false` even after DNS is correct:
+
+```bash
+# 1. Delete TLS subscription first (if exists)
+fastly tls-subscription delete --id SUBSCRIPTION_ID --force
+
+# 2. Delete the domain
+fastly domain-v1 delete --domain-id DOMAIN_ID
+
+# 3. Recreate domain
+fastly domain-v1 create --fqdn "*.yourdomain.com" --service-id SERVICE_ID
+
+# 4. Create new TLS subscription
+fastly tls-subscription create --domain "*.yourdomain.com"
+
+# 5. Wait 1-5 minutes for verification and TLS issuance
+```
+
+### Part 3: Fix PublisherServer for Subdomains
+
+The PublisherServer from `@fastly/compute-js-static-publish` doesn't serve content for
+subdomain hostnames. You must read from the KV store directly:
+
+```javascript
+if (subdomain) {
+  // Open the content KV store
+  const contentStore = new KVStore('your-content-store-name');
+
+  // Read the index file - NOTE: collection name might be 'undefined' not 'default'
+  const indexEntry = await contentStore.get('default_index_undefined');
+  const indexData = await indexEntry.json();
+
+  // Get the index.html entry - structure is { '/path': { key: 'sha256:HASH', ... } }
+  const indexHtmlInfo = indexData['/index.html'];
+
+  // Read the actual content
+  const contentHash = indexHtmlInfo.key.replace('sha256:', '');
+  const contentKey = `default_files_sha256_${contentHash}`;
+  const htmlEntry = await contentStore.get(contentKey);
+  const html = await htmlEntry.text();
+
+  // Inject subdomain-specific data and return
+  const modifiedHtml = html.replace('<head>', `<head><script>window.SUBDOMAIN_DATA = {...}</script>`);
+  return new Response(modifiedHtml, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8' }
+  });
+}
+```
+
+### Part 4: Key Format Discovery
+
+The static publisher uses these KV key formats:
+- Index: `${publishId}_index_${collectionName}` (e.g., `default_index_undefined`)
+- Settings: `${publishId}_settings_${collectionName}`
+- Files: `${publishId}_files_sha256_${hash}`
+
+To discover your actual key names:
+```bash
+curl -s -H "Fastly-Key: $(fastly profile token)" \
+  "https://api.fastly.com/resources/stores/kv/STORE_ID/keys?limit=50" | jq '.data[]' | grep index
+```
+
+## Verification
+
+```bash
+# 1. Verify DNS is correct
+dig @8.8.8.8 subdomain.yourdomain.com A +short
+# Should return Fastly IPs
+
+# 2. Verify domain is activated
+curl -s -H "Fastly-Key: $(fastly profile token)" \
+  "https://api.fastly.com/domain-management/v1/domains/DOMAIN_ID" | jq '{activated, verified}'
+# Both should be true
+
+# 3. Verify TLS is issued
+fastly tls-subscription list | grep yourdomain
+# State should be "issued"
+
+# 4. Test the subdomain
+curl -sI "https://subdomain.yourdomain.com"
+# Should return 200 with content
+```
+
+## Example
+
+Complete fix for `*.divine.space` subdomain routing:
+
+```javascript
+// In Compute@Edge handler
+if (subdomain && namesStore) {
+  const entry = await namesStore.get(`name:${subdomain}`);
+
+  const contentStore = new KVStore('divine-space-content');
+  const indexEntry = await contentStore.get('default_index_undefined');
+  const indexData = await indexEntry.json();
+  const indexHtmlInfo = indexData['/index.html'];
+  const contentHash = indexHtmlInfo.key.replace('sha256:', '');
+  const htmlEntry = await contentStore.get(`default_files_sha256_${contentHash}`);
+  const html = await htmlEntry.text();
+
+  if (entry) {
+    const data = await entry.json();
+    const injectedHtml = html.replace('<head>', `<head>
+      <script>window.__DIVINE_SPACE_USER__ = {
+        subdomain: "${subdomain}",
+        pubkey: "${data.pubkey}"
+      };</script>`);
+    return new Response(injectedHtml, {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' }
+    });
+  }
+}
+```
+
+## Notes
+
+- The `collectionName` in KV keys is often `undefined` (literal string) rather than
+  `default` due to how the static publisher is configured. Always check actual keys.
+- DNS changes can take up to 3 hours to propagate due to TTL settings.
+- Fastly edge cache may serve stale responses—use `fastly purge --all` after changes.
+- Static assets (/assets/*, .js, .css files) should be served BEFORE subdomain handling
+  using the normal PublisherServer.
+- The wildcard TLS cert (*.domain.com) requires the ACME challenge DNS record to be
+  correct before it will issue.
+
+## References
+
+- [Fastly Domain Management API](https://www.fastly.com/documentation/reference/api/domain-management/domains/)
+- [Working with versionless domains](https://www.fastly.com/documentation/guides/getting-started/domains/working-with-domains/)
+- [domain-v1 CLI reference](https://www.fastly.com/documentation/reference/cli/domain-v1/)
+- [TLS Subscriptions API](https://www.fastly.com/documentation/reference/api/tls/subscriptions/)

--- a/.claude/skills/ffmpeg-kit-macos-codesign-crash/SKILL.md
+++ b/.claude/skills/ffmpeg-kit-macos-codesign-crash/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ffmpeg-kit-macos-codesign-crash
+description: |
+  Fix Flutter macOS app crash at launch due to FFmpeg Kit library loading failure. Use when:
+  (1) macOS app builds successfully but crashes immediately on launch, (2) Crash log shows
+  "Library not loaded: libfontconfig.1.dylib" or similar homebrew library, (3) Error mentions
+  "code signature not valid for use in process" with "different Team IDs", (4) Using
+  ffmpeg_kit_flutter_new (Full GPL variant). The Full GPL variant has external dependencies
+  on homebrew libraries that fail macOS code signing. Switch to ffmpeg_kit_flutter_new_min.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-25
+---
+
+# FFmpeg Kit macOS Code Signing Crash
+
+## Problem
+
+Flutter macOS app builds successfully but crashes immediately at launch with a library
+loading failure. The crash is caused by FFmpeg Kit's Full GPL variant having runtime
+dependencies on homebrew-installed libraries (like fontconfig) that fail macOS code
+signature validation.
+
+## Context / Trigger Conditions
+
+- **Platform**: macOS only (iOS and Android are not affected)
+- **Package**: Using `ffmpeg_kit_flutter_new` (Full GPL variant)
+- **Symptom**: App builds successfully but crashes on launch
+- **Crash log shows**:
+  ```
+  Library not loaded: /opt/homebrew/*/libfontconfig.1.dylib
+  Referenced from: .../libswresample.framework/...
+  Reason: code signature in (.../libfontconfig.1.dylib) not valid for use in process:
+  mapping process and mapped file (non-platform) have different Team IDs
+  ```
+
+## Root Cause
+
+The `ffmpeg_kit_flutter_new` package is the "Full GPL" variant which includes many
+FFmpeg libraries for advanced features like text rendering (drawtext filter). These
+libraries have external dependencies on system fonts via `libfontconfig`.
+
+On macOS, when the app tries to load `libswresample.framework`, it attempts to also
+load `libfontconfig.1.dylib` from homebrew. macOS code signing validation rejects
+this because the homebrew library has a different Team ID than your app.
+
+## Solution
+
+Switch from `ffmpeg_kit_flutter_new` (Full GPL) to `ffmpeg_kit_flutter_new_min` (Minimal).
+
+**Step 1: Update pubspec.yaml**
+```yaml
+# Before
+ffmpeg_kit_flutter_new: ^3.2.0
+
+# After
+ffmpeg_kit_flutter_new_min: ^3.1.0
+```
+
+**Step 2: Update imports in all Dart files**
+```dart
+// Before
+import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_new/ffprobe_kit.dart';
+import 'package:ffmpeg_kit_flutter_new/return_code.dart';
+
+// After
+import 'package:ffmpeg_kit_flutter_new_min/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_new_min/ffprobe_kit.dart';
+import 'package:ffmpeg_kit_flutter_new_min/return_code.dart';
+```
+
+**Step 3: Clean and rebuild**
+```bash
+flutter clean
+rm -f macos/Podfile.lock
+flutter pub get
+flutter run -d macos
+```
+
+## What Features Are Preserved
+
+The minimal variant includes everything needed for typical video apps:
+- h264/libx264 video encoding
+- AAC audio encoding
+- VideoToolbox hardware acceleration (Apple platforms)
+- Standard filters: overlay, crop, scale, concat, amix
+- FFprobe for media information
+
+## What Features Are Removed
+
+The minimal variant does NOT include:
+- `drawtext` filter (font rendering) - use PNG overlays instead
+- Advanced codec libraries with external dependencies
+- Features requiring fontconfig, freetype, etc.
+
+## Verification
+
+After the fix:
+1. `flutter run -d macos` should launch the app without crashing
+2. Video encoding/decoding operations should work normally
+3. iOS builds continue to work (they weren't affected)
+
+## Example
+
+**Find files needing import updates:**
+```bash
+grep -r "ffmpeg_kit_flutter_new" lib/ --include="*.dart" -l
+```
+
+**Update all imports (sed example):**
+```bash
+find lib -name "*.dart" -exec sed -i '' \
+  's/ffmpeg_kit_flutter_new/ffmpeg_kit_flutter_new_min/g' {} \;
+```
+
+## Notes
+
+- This issue only affects macOS; iOS and Android don't have the same code signing restrictions
+- The error message is misleading - it mentions fontconfig but the fix is changing FFmpeg Kit variants
+- If you actually need `drawtext` filter on macOS, you'd need to bundle fontconfig with proper signing (complex)
+- Alternative: Use the official `ffmpeg_kit_flutter` from arthenica if you need more control over variants
+
+## References
+
+- [ffmpeg_kit_flutter_new on pub.dev](https://pub.dev/packages/ffmpeg_kit_flutter_new)
+- [ffmpeg_kit_flutter_new_min on pub.dev](https://pub.dev/packages/ffmpeg_kit_flutter_new_min)
+- [Apple Code Signing Documentation](https://developer.apple.com/documentation/security/code_signing_services)

--- a/.claude/skills/flutter-async-test-unhandled-future-rejection/SKILL.md
+++ b/.claude/skills/flutter-async-test-unhandled-future-rejection/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: flutter-async-test-unhandled-future-rejection
+description: |
+  Fix flaky Flutter/Dart tests that fail in CI but pass locally due to unhandled Future
+  rejections. Use when: (1) Test passes locally but fails in CI with cryptic errors,
+  (2) Test creates Futures that will throw errors (e.g., network calls to fake URLs),
+  (3) Even with .catchError() at the end, test still fails, (4) Error message shows
+  test name but truncated error like "ROR]" or "[ERROR]". Solution: Avoid creating
+  Futures that will reject; test state machine behavior with synchronous operations instead.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Flutter Async Test Unhandled Future Rejection
+
+## Problem
+
+Tests that create Futures which will reject (throw errors) can fail in CI even when:
+- You catch the error with `.catchError()` at the end
+- You use `try/catch` around the await
+- The test passes locally
+
+The Flutter/Dart test framework detects "unhandled" Future rejections during test
+execution, even if you plan to handle them later. This causes flaky tests that
+pass locally but fail in CI due to timing differences.
+
+## Context / Trigger Conditions
+
+**Symptoms:**
+- Test passes locally with `flutter test` but fails in CI
+- Error message is truncated or cryptic (e.g., "ROR]" instead of "[ERROR]")
+- Test name appears in error output but no clear assertion failure
+- Test involves creating Futures to URLs/resources that don't exist
+- Using patterns like:
+  ```dart
+  final future = someAsyncOperation(); // This will throw
+  // ... do assertions ...
+  await future.catchError((_) {}); // Too late - already flagged as unhandled
+  ```
+
+**Common scenarios:**
+- Testing that a method can only be called once (state guards)
+- Testing timeout/cancellation behavior
+- Testing error handling paths
+- Any test that intentionally triggers errors in async code
+
+## Solution
+
+### Don't create Futures that will reject - test the state machine directly
+
+**Instead of:**
+```dart
+test('start throws if already started', () async {
+  final session = SomeSession(url: 'wss://fake.url');
+
+  // BAD: This Future will reject when connection fails
+  final startFuture = session.start();
+
+  // Even this won't help - rejection already detected
+  await Future.delayed(Duration.zero);
+
+  expect(() => session.start(), throwsA(isA<StateError>()));
+
+  // Too late to catch - test already failed
+  await startFuture.catchError((_) {});
+});
+```
+
+**Do this:**
+```dart
+test('start throws if already started', () {
+  // GOOD: Completely synchronous, no network calls
+  final session = SomeSession(url: 'wss://example.com');
+
+  // Use a synchronous state transition to exit the "startable" state
+  session.cancel(); // Transitions state without network call
+
+  // Now test that start() throws when not in initial state
+  expect(
+    () => session.start(),
+    throwsA(isA<StateError>()),
+  );
+
+  session.dispose();
+});
+```
+
+### Alternative approaches if you must use async
+
+**Option 1: Wrap the Future creation in a zone that ignores errors**
+```dart
+test('handles async error', () async {
+  late Future<void> errorFuture;
+
+  await runZonedGuarded(() async {
+    errorFuture = operationThatWillFail();
+    // Do synchronous assertions here
+  }, (error, stack) {
+    // Ignore expected errors
+  });
+});
+```
+
+**Option 2: Use expectLater for Futures that should fail**
+```dart
+test('operation fails with specific error', () async {
+  // Let the test framework know this Future SHOULD fail
+  await expectLater(
+    operationThatWillFail(),
+    throwsA(isA<SomeError>()),
+  );
+});
+```
+
+**Option 3: Mock the async dependency**
+```dart
+test('start throws if already started', () async {
+  final mockRelay = MockRelay();
+  when(mockRelay.connect()).thenAnswer((_) async => {}); // Never fails
+
+  final session = SomeSession(relay: mockRelay);
+  await session.start();
+
+  expect(() => session.start(), throwsA(isA<StateError>()));
+});
+```
+
+## Verification
+
+1. Test passes locally: `flutter test path/to/test.dart`
+2. Test passes in CI (check GitHub Actions / other CI)
+3. Test is deterministic - run 10x with `--repeat=10` flag
+
+## Example
+
+### Before (flaky):
+```dart
+test('NostrConnectSession start throws if already started', () async {
+  final session = NostrConnectSession(relays: ['wss://relay.example.com']);
+
+  // This creates a Future that will reject when relay connection fails
+  final startFuture = session.start();
+
+  // State changed synchronously, but Future rejection is pending
+  expect(session.state, isNot(equals(NostrConnectState.idle)));
+  expect(() => session.start(), throwsA(isA<StateError>()));
+
+  session.cancel();
+  session.dispose();
+
+  // This doesn't help - rejection already flagged by test framework
+  await startFuture.catchError((_) {});
+});
+```
+
+### After (reliable):
+```dart
+test('NostrConnectSession start throws if already started', () {
+  // Completely synchronous - no Futures that can reject
+  final session = NostrConnectSession(relays: ['wss://relay.example.com']);
+
+  expect(session.state, equals(NostrConnectState.idle));
+
+  // Use cancel() to transition out of idle state synchronously
+  session.cancel();
+  expect(session.state, equals(NostrConnectState.cancelled));
+
+  // Now start() throws because we're not in idle state
+  expect(
+    () => session.start(),
+    throwsA(
+      isA<StateError>().having(
+        (e) => e.message,
+        'message',
+        contains('already started'),
+      ),
+    ),
+  );
+
+  session.dispose();
+});
+```
+
+## Notes
+
+- This issue is more common in CI because of different timing characteristics
+- The truncated error messages (like "ROR]") happen because CI output gets cut off
+- Local tests may pass because the garbage collector hasn't run yet
+- This is different from the "A Timer is still pending" error (see `flutter-dispose-timer-test-failure` skill)
+- When testing state machines, prefer testing state transitions over testing async behavior
+- If you need to test actual async/network behavior, use proper mocking
+
+## Related Skills
+
+- `flutter-dispose-timer-test-failure`: For timer-related test failures
+- `riverpod-ref-in-provider-lifecycle`: For async callback issues in Riverpod providers
+
+## References
+
+- [Dart Zone Error Handling](https://dart.dev/guides/libraries/futures-error-handling#handling-errors-with-zones)
+- [Flutter Test Package](https://api.flutter.dev/flutter/flutter_test/flutter_test-library.html)

--- a/.claude/skills/flutter-deactivate-setstate-during-build/SKILL.md
+++ b/.claude/skills/flutter-deactivate-setstate-during-build/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: flutter-deactivate-setstate-during-build
+description: |
+  Fix "setState() or markNeedsBuild() called during build" error triggered from deactivate().
+  Use when: (1) Error occurs during widget disposal or navigation away, (2) Stack trace shows
+  deactivate -> some notifier -> ValueListenableBuilder._valueChanged, (3) Video/audio player
+  pause() or stop() calls in deactivate() cause the error. The fix is deferring state-modifying
+  operations to addPostFrameCallback.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-27
+---
+
+# Flutter: setState During Build from deactivate()
+
+## Problem
+When navigating away from a screen, calling methods like `VideoPlayerController.pause()` in
+`deactivate()` triggers `setState() or markNeedsBuild() called during build` because the
+controller notifies its listeners synchronously during widget tree teardown.
+
+## Context / Trigger Conditions
+- Error: `setState() or markNeedsBuild() called during build`
+- Stack trace includes:
+  - `YourWidget.deactivate`
+  - `VideoPlayerController.pause` (or similar)
+  - `ChangeNotifier.notifyListeners`
+  - `ValueListenableBuilder._valueChanged`
+- Widget using `ValueListenableBuilder<VideoPlayerValue>` or similar
+- Trying to pause/stop media playback when navigating away
+
+## Solution
+Defer the state-modifying operation to after the current frame:
+
+```dart
+@override
+void deactivate() {
+  // Capture controller reference while ref/context is still valid
+  final controller = _getController();
+
+  // Defer pause to after current frame
+  if (controller != null && controller.value.isPlaying) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (controller.value.isPlaying) {
+        controller.pause();
+      }
+    });
+  }
+
+  super.deactivate();
+}
+```
+
+## Key Insights
+
+1. **Why deactivate() is problematic**: It's called during the widget tree teardown phase,
+   which is part of the build process. Any synchronous notification to listeners will
+   trigger rebuilds during build.
+
+2. **Why dispose() doesn't have this issue**: By `dispose()`, the widget is fully unmounted
+   and listeners are typically already removed.
+
+3. **Capture references early**: Get controller/state references before the async gap
+   since `ref`, `context`, or other widget state may become invalid.
+
+4. **Guard against double-execution**: Check `isPlaying` again in the callback since
+   state may have changed.
+
+## Verification
+- Navigate away from the screen multiple times
+- No error in console
+- Video/audio properly pauses when leaving
+
+## Example: Full Implementation
+
+```dart
+class _FullscreenVideoScreenState extends ConsumerState<FullscreenVideoScreen> {
+  @override
+  void deactivate() {
+    _schedulePauseCurrentVideo();
+    super.deactivate();
+  }
+
+  void _schedulePauseCurrentVideo() {
+    final controller = _getCurrentController();
+    if (controller == null || !controller.value.isInitialized) {
+      return;
+    }
+
+    // Defer to avoid setState during build
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (controller.value.isPlaying) {
+        controller.pause();
+      }
+    });
+  }
+}
+```
+
+## Notes
+- This pattern applies to any `ChangeNotifier` that updates synchronously
+- Also relevant for: `AnimationController.stop()`, `TextEditingController` updates
+- If you need the pause to happen immediately (rare), consider using
+  `controller.pause()` without notifying, though this breaks the observer pattern
+- The same issue can occur in `didUpdateWidget` when old controllers are disposed
+
+## Related Patterns
+- Use `deactivate()` for cleanup that needs `ref`/`context` (like unsubscribing)
+- Use `dispose()` for cleanup that doesn't (like disposing controllers you own)
+- Never call `setState()` in `deactivate()` or `dispose()`

--- a/.claude/skills/flutter-dispose-timer-test-failure/SKILL.md
+++ b/.claude/skills/flutter-dispose-timer-test-failure/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: flutter-dispose-timer-test-failure
+description: |
+  Fix Flutter test failure "A Timer is still pending even after the widget tree was disposed".
+  Use when: (1) Widget tests fail with timer pending error, (2) dispose() contains Future(),
+  Future.delayed(), or Timer calls, (3) Riverpod provider modifications in dispose().
+  The fix is to use deactivate() instead of dispose() for cleanup that might trigger async work.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-26
+---
+
+# Flutter Dispose Timer Test Failure
+
+## Problem
+Flutter widget tests fail with the error "A Timer is still pending even after the widget
+tree was disposed" when dispose() contains Future-based cleanup code.
+
+## Context / Trigger Conditions
+- Test error: `A Timer is still pending even after the widget tree was disposed`
+- Widget's `dispose()` method contains:
+  - `Future(() => ...)`
+  - `Future.delayed(...)`
+  - `Timer(...)` or `Timer.periodic(...)`
+  - Riverpod `ref.read(provider.notifier).someMethod()` wrapped in Future
+- Tests pass individually but fail when run together
+- Error appears at end of test, not during widget interaction
+
+## Solution
+
+### Step 1: Identify the problematic code
+Look for patterns like this in your widget:
+
+```dart
+// BAD: Creates pending timer that test framework detects
+@override
+void dispose() {
+  final notifier = _overlayNotifier;
+  if (notifier != null) {
+    Future(() => notifier.setSettingsOpen(false));  // <- Problem!
+  }
+  super.dispose();
+}
+```
+
+### Step 2: Move cleanup to deactivate()
+Use `deactivate()` instead of `dispose()` and remove the Future wrapper:
+
+```dart
+// GOOD: Runs synchronously before widget is removed
+@override
+void deactivate() {
+  _overlayNotifier?.setSettingsOpen(false);  // Direct call, no Future
+  super.deactivate();
+}
+```
+
+### Step 3: Understand the lifecycle difference
+- `deactivate()`: Called when widget is removed from tree, but State might be reinserted
+- `dispose()`: Called when State will never build again, permanent cleanup
+
+For most notification/provider cleanup, `deactivate()` is appropriate.
+
+## Verification
+1. Run the specific test that was failing
+2. Run the full test suite
+3. Verify no "Timer is still pending" errors
+
+## Example
+
+### Before (causes test failure):
+```dart
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  OverlayNotifier? _overlayNotifier;
+
+  @override
+  void dispose() {
+    final notifier = _overlayNotifier;
+    if (notifier != null) {
+      // This Future creates a pending timer!
+      Future(() => notifier.setSettingsOpen(false));
+    }
+    super.dispose();
+  }
+}
+```
+
+### After (tests pass):
+```dart
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  OverlayNotifier? _overlayNotifier;
+
+  @override
+  void deactivate() {
+    // Synchronous call, no timer created
+    _overlayNotifier?.setSettingsOpen(false);
+    super.deactivate();
+  }
+}
+```
+
+## Notes
+- The original `Future(() => ...)` pattern is often used to defer provider modifications
+  until after the current build phase, avoiding "Cannot modify provider during build" errors
+- If you need deferred execution, consider `WidgetsBinding.instance.addPostFrameCallback`
+  instead, though this also creates timers that can fail tests
+- For Riverpod, modifying providers in `deactivate()` is usually safe since the widget
+  tree is being torn down, not built
+- This issue often surfaces when multiple tests run sequentially, as the test framework
+  checks for pending timers between tests
+
+## References
+- [Flutter Widget Lifecycle](https://api.flutter.dev/flutter/widgets/State-class.html)
+- [Flutter Testing: Pending Timers](https://docs.flutter.dev/testing/overview)

--- a/.claude/skills/flutter-dynamic-tabcontroller-ticker-mixin/SKILL.md
+++ b/.claude/skills/flutter-dynamic-tabcontroller-ticker-mixin/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: flutter-dynamic-tabcontroller-ticker-mixin
+description: |
+  Fix Flutter TabController crash when dynamically showing/hiding tabs. Use when:
+  (1) TabController rebuild causes "SingleTickerProviderStateMixin but multiple tickers were created",
+  (2) Tabs need to appear/disappear based on feature flags or async state,
+  (3) TabController.length changes at runtime based on provider state.
+  The fix is to use TickerProviderStateMixin instead of SingleTickerProviderStateMixin.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-26
+---
+
+# Flutter Dynamic TabController with TickerProviderStateMixin
+
+## Problem
+When building a TabBar with dynamic tabs (tabs that show/hide based on feature availability,
+user preferences, or async state), recreating the TabController during the widget lifecycle
+causes a crash because `SingleTickerProviderStateMixin` only allows one ticker to be created.
+
+## Context / Trigger Conditions
+
+**Error message:**
+```
+_YourStateClass is a SingleTickerProviderStateMixin but multiple tickers were created.
+A SingleTickerProviderStateMixin can only be used as a TickerProvider once.
+If a State is used for multiple AnimationController objects, or if it is passed to other
+objects and those objects might use it more than one time in total, then instead of mixing
+in a SingleTickerProviderStateMixin, use a regular TickerProviderStateMixin.
+```
+
+**When this happens:**
+- You dispose and recreate a TabController when tab count changes
+- You have tabs that conditionally appear based on async state (e.g., Riverpod providers)
+- Feature flags control which tabs are visible
+- Tab visibility depends on API availability or user permissions
+
+## Solution
+
+### Step 1: Change the Mixin
+
+Replace `SingleTickerProviderStateMixin` with `TickerProviderStateMixin`:
+
+```dart
+// WRONG - crashes when TabController is recreated
+class _MyScreenState extends State<MyScreen>
+    with SingleTickerProviderStateMixin {
+
+// CORRECT - allows multiple TabControllers over widget lifetime
+class _MyScreenState extends State<MyScreen>
+    with TickerProviderStateMixin {
+```
+
+### Step 2: Track Tab Count State
+
+Keep a state variable to track the current tab configuration:
+
+```dart
+bool? _lastFeatureAvailable;
+TabController? _tabController;
+
+int get _tabCount => (_lastFeatureAvailable ?? false) ? 4 : 3;
+
+void _initTabController() {
+  _tabController?.removeListener(_onTabChanged);
+  _tabController?.dispose();
+  _tabController = TabController(
+    length: _tabCount,
+    vsync: this,
+  );
+  _tabController!.addListener(_onTabChanged);
+}
+```
+
+### Step 3: Synchronously Rebuild on State Change
+
+When the condition changes, rebuild the TabController **synchronously** (not in postFrameCallback):
+
+```dart
+@override
+Widget build(BuildContext context) {
+  // Watch the async state
+  final featureAvailableAsync = ref.watch(featureAvailableProvider);
+  final featureAvailable = featureAvailableAsync.asData?.value ?? false;
+
+  // Rebuild TabController SYNCHRONOUSLY when state changes
+  if (_lastFeatureAvailable != featureAvailable) {
+    _lastFeatureAvailable = featureAvailable;
+    _initTabController();  // Synchronous rebuild
+  }
+
+  // Build tabs using the SAME variable for consistency
+  return TabBar(
+    controller: _tabController,
+    tabs: [
+      const Tab(text: 'Tab 1'),
+      const Tab(text: 'Tab 2'),
+      if (_lastFeatureAvailable ?? false) const Tab(text: 'Optional Tab'),
+      const Tab(text: 'Tab 3'),
+    ],
+  );
+}
+```
+
+### Step 4: Keep Tabs and TabBarView in Sync
+
+Use the **same state variable** for both the tabs list and TabBarView children:
+
+```dart
+// TabBar tabs
+tabs: [
+  const Tab(text: 'Always'),
+  if (_lastFeatureAvailable ?? false) const Tab(text: 'Conditional'),
+],
+
+// TabBarView children - MUST match tabs exactly
+TabBarView(
+  controller: _tabController,
+  children: [
+    const AlwaysTab(),
+    if (_lastFeatureAvailable ?? false) const ConditionalTab(),
+  ],
+),
+```
+
+## Verification
+
+After applying the fix:
+1. No crash when the async state changes
+2. Tabs appear/disappear correctly (not just grayed out)
+3. Tab selection state is preserved (clamped to valid range)
+4. No visual glitches during transition
+
+## Example
+
+Real-world example - hiding a "Classics" tab when REST API is unavailable:
+
+```dart
+class _ExploreScreenState extends ConsumerState<ExploreScreen>
+    with TickerProviderStateMixin {  // NOT SingleTickerProviderStateMixin
+
+  TabController? _tabController;
+  bool? _lastClassicsAvailable;
+
+  int get _tabCount => (_lastClassicsAvailable ?? false) ? 4 : 3;
+
+  void _initTabController() {
+    final savedTabIndex = ref.read(exploreTabIndexProvider);
+    final validIndex = savedTabIndex.clamp(0, _tabCount - 1);
+    _tabController?.removeListener(_onTabChanged);
+    _tabController?.dispose();
+    _tabController = TabController(
+      length: _tabCount,
+      vsync: this,
+      initialIndex: validIndex,
+    );
+    _tabController!.addListener(_onTabChanged);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final classicsAvailable =
+        ref.watch(classicVinesAvailableProvider).asData?.value ?? false;
+
+    if (_lastClassicsAvailable != classicsAvailable) {
+      _lastClassicsAvailable = classicsAvailable;
+      _initTabController();  // Synchronous, not postFrameCallback
+    }
+
+    return Column(
+      children: [
+        TabBar(
+          controller: _tabController,
+          tabs: [
+            const Tab(text: 'New'),
+            const Tab(text: 'Popular'),
+            if (_lastClassicsAvailable ?? false) const Tab(text: 'Classics'),
+            const Tab(text: 'Lists'),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              const NewVideosTab(),
+              const PopularVideosTab(),
+              if (_lastClassicsAvailable ?? false) const ClassicsTab(),
+              const ListsTab(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+## Notes
+
+- **Why not postFrameCallback?** Using `addPostFrameCallback` to rebuild the TabController
+  causes a frame where the TabController length doesn't match the tabs list, resulting in
+  tabs appearing "grayed out" or other visual glitches.
+
+- **Performance**: `TickerProviderStateMixin` has slightly more overhead than
+  `SingleTickerProviderStateMixin`, but it's negligible for typical use cases.
+
+- **Tab index preservation**: When reducing tab count, clamp the current index to avoid
+  out-of-bounds errors: `savedIndex.clamp(0, newTabCount - 1)`.
+
+- **Riverpod patterns**: When using Riverpod async providers, remember that
+  `asyncValue.asData?.value ?? false` gives you a synchronous default while loading.
+
+## References
+
+- [Flutter TabController class](https://api.flutter.dev/flutter/material/TabController-class.html)
+- [TickerProviderStateMixin](https://api.flutter.dev/flutter/widgets/TickerProviderStateMixin-mixin.html)
+- [SingleTickerProviderStateMixin](https://api.flutter.dev/flutter/widgets/SingleTickerProviderStateMixin-mixin.html)

--- a/.claude/skills/flutter-macos-duplicate-camera-plugin/SKILL.md
+++ b/.claude/skills/flutter-macos-duplicate-camera-plugin/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: flutter-macos-duplicate-camera-plugin
+description: |
+  Fix Flutter macOS build failure caused by duplicate camera plugins. Use when: (1) macOS build
+  fails with "Ambiguous use of 'CameraMacosPlugin.register(with:)'" error, (2) Both camera_macos
+  and camera_macos_plus are in pubspec.yaml, (3) Build worked before adding a new camera package.
+  The plugins define the same class name causing Swift registration conflicts.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-28
+---
+
+# Flutter macOS Duplicate Camera Plugin Fix
+
+## Problem
+Flutter macOS builds fail when both `camera_macos` and `camera_macos_plus` packages are present
+in pubspec.yaml. Both packages define the same `CameraMacosPlugin` class, causing Swift
+registration ambiguity.
+
+## Context / Trigger Conditions
+
+**Error message:**
+```
+Ambiguous use of 'CameraMacosPlugin.register(with:)'
+```
+
+**Symptoms:**
+- macOS build fails during Swift compilation
+- iOS build may still succeed (different plugin implementations)
+- Error occurs in the generated plugin registration code
+- May be accompanied by Xcode build system crashes or "stat cache file not found" errors
+
+**Common scenarios:**
+- Project has `camera_macos` for basic camera support
+- Added `camera_macos_plus` for additional features
+- Transitive dependency pulled in duplicate plugin
+- Copied pubspec.yaml from another project with different camera requirements
+
+## Solution
+
+1. **Identify the duplicates** - Check pubspec.yaml for both packages:
+   ```yaml
+   # Look for these:
+   camera_macos: ^0.0.9
+   camera_macos_plus: ^0.0.3
+   ```
+
+2. **Choose one to keep** - `camera_macos_plus` is generally preferred as it's a
+   more feature-complete fork of `camera_macos`
+
+3. **Remove the duplicate** from pubspec.yaml:
+   ```yaml
+   # Keep only one:
+   camera_macos_plus: ^0.0.3  # macOS camera support
+   ```
+
+4. **Clean thoroughly** - The Xcode build system may be in a corrupted state:
+   ```bash
+   flutter clean
+   rm -rf build/
+   rm -rf macos/Pods/
+   rm -f macos/Podfile.lock
+   rm -rf ~/Library/Developer/Xcode/DerivedData/Runner-*
+   flutter pub get
+   ```
+
+5. **Rebuild:**
+   ```bash
+   flutter build macos
+   ```
+
+## Verification
+
+After the fix:
+- `flutter build macos` completes successfully
+- No "Ambiguous use" errors in build output
+- The macOS app launches and camera functionality works
+
+## Example
+
+**Before (broken):**
+```yaml
+dependencies:
+  camera_macos_plus: ^0.0.3
+  divine_camera:
+    path: packages/divine_camera
+  camera_macos: ^0.0.9  # DUPLICATE - causes conflict
+```
+
+**After (fixed):**
+```yaml
+dependencies:
+  camera_macos_plus: ^0.0.3  # macOS camera support (replaces camera_macos)
+  divine_camera:
+    path: packages/divine_camera
+  # camera_macos removed
+```
+
+## Notes
+
+- `camera_macos_plus` is a community fork with additional features
+- If you specifically need `camera_macos` instead, remove `camera_macos_plus`
+- Check transitive dependencies with `flutter pub deps` if duplicates reappear
+- The Xcode build system can get into corrupted states after this error;
+  thorough cleaning (including DerivedData) may be required
+- This is specific to macOS - iOS uses different camera plugin implementations
+
+## References
+
+- [camera_macos_plus on pub.dev](https://pub.dev/packages/camera_macos_plus)
+- [camera_macos on pub.dev](https://pub.dev/packages/camera_macos)
+- [Flutter macOS plugin registration](https://docs.flutter.dev/packages-and-plugins/developing-packages#macos)

--- a/.claude/skills/flutter-macos-permission-handler-camera-failure/SKILL.md
+++ b/.claude/skills/flutter-macos-permission-handler-camera-failure/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: flutter-macos-permission-handler-camera-failure
+description: |
+  Fix silent camera/microphone failure on Flutter macOS when using permission_handler plugin.
+  Use when: (1) Camera screen shows placeholder but no error on macOS, (2) CameraPermissionError
+  state is emitted but cause is unclear, (3) permission_handler checkCameraStatus() or
+  checkMicrophoneStatus() throws exceptions on macOS desktop, (4) Camera works on iOS/Android
+  but fails silently on macOS. The permission_handler plugin doesn't work reliably on macOS -
+  bypass it and let macOS handle permissions at the system level.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-28
+---
+
+# Flutter macOS permission_handler Camera Failure
+
+## Problem
+Camera/microphone permission checks using the `permission_handler` Flutter plugin throw
+exceptions on macOS desktop, causing permission gates to emit error states. The camera
+screen never renders, but the user sees a placeholder UI with no clear error message.
+
+## Context / Trigger Conditions
+
+Use this skill when:
+- Flutter app works on iOS/Android but camera fails on macOS
+- Permission gate shows loading or error state on macOS
+- Logs show `CameraPermissionError` state being emitted
+- `Permission.camera.status` or `Permission.microphone.status` throws exceptions
+- Camera placeholder UI appears but `VideoRecorderScreen` (or equivalent) never initializes
+- No camera-related logs appear after navigation to camera screen
+
+**Key diagnostic pattern:**
+```
+🔐 CameraPermissionGate initState
+🔐 Building with state: CameraPermissionInitial
+🔐 Triggering permission refresh
+🔐 Permission state changed: CameraPermissionError  <-- This is the tell
+```
+
+## Root Cause
+
+The `permission_handler` plugin uses platform channels that don't work reliably on macOS
+desktop. When `checkCameraStatus()` or `checkMicrophoneStatus()` is called:
+- On iOS/Android: Returns proper permission status
+- On macOS: Throws exception → BLoC catches → Emits error state → Screen blocked
+
+macOS handles camera/microphone permissions at the system level - the first time an app
+tries to access the camera, macOS shows its own permission dialog.
+
+## Solution
+
+Bypass `permission_handler` on macOS and assume permissions are authorized:
+
+```dart
+Future<void> _onRefresh(
+  CameraPermissionRefresh event,
+  Emitter<CameraPermissionState> emit,
+) async {
+  // On macOS desktop, permission_handler doesn't work reliably.
+  // macOS handles camera permissions at the system level when the app
+  // actually tries to access the camera, showing its own permission dialog.
+  if (!kIsWeb && Platform.isMacOS) {
+    emit(const CameraPermissionLoaded(CameraPermissionStatus.authorized));
+    return;
+  }
+
+  // Normal permission check for iOS/Android
+  try {
+    final status = await checkPermissions();
+    emit(CameraPermissionLoaded(status));
+  } catch (e) {
+    emit(const CameraPermissionError());
+  }
+}
+```
+
+**Required imports:**
+```dart
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+```
+
+## Verification
+
+After implementing the fix:
+1. Logs should show: `🔐 macOS detected - bypassing permission_handler, assuming authorized`
+2. Permission state changes to `CameraPermissionLoaded` with status `authorized`
+3. Camera screen actually renders and camera initialization logs appear
+4. macOS shows its native permission dialog on first camera access (if not already granted)
+
+## Debugging Layers
+
+When debugging silent camera failures, check these layers in order:
+
+1. **Permission layer**: Is the camera screen even being rendered? Check permission gate state.
+2. **Initialization layer**: Is `initialize()` being called? Check for initialization logs.
+3. **Device detection layer**: Are camera devices found? Check `listDevices()` results.
+4. **Controller layer**: Does camera controller initialize? Check for controller errors.
+
+Add logging at each layer to trace where the flow stops.
+
+## Related Fixes
+
+When implementing this fix, also add:
+
+1. **Error tracking in camera service**: Add `initializationError` getter to report why
+   camera failed (no devices, permission denied by macOS, etc.)
+
+2. **UI error display**: Pass error messages to placeholder widgets so users see what's wrong
+
+3. **Try-catch around native calls**: `CameraMacOS.instance.listDevices()` can also throw -
+   wrap in try-catch and set error state
+
+## Example: Complete Fix
+
+```dart
+// In CameraPermissionBloc
+Future<void> _onRefresh(...) async {
+  if (!kIsWeb && Platform.isMacOS) {
+    log('macOS detected - bypassing permission_handler');
+    emit(const CameraPermissionLoaded(CameraPermissionStatus.authorized));
+    return;
+  }
+  // ... normal flow for mobile
+}
+
+// In CameraMacOSService
+@override
+Future<void> initialize() async {
+  try {
+    _videoDevices = await CameraMacOS.instance.listDevices(...);
+  } catch (e) {
+    _initializationError = 'Failed to detect cameras: $e';
+    return;
+  }
+
+  if (_videoDevices?.isEmpty ?? true) {
+    _initializationError = 'No camera found. Please connect a camera.';
+    return;
+  }
+  // ... continue initialization
+}
+```
+
+## Notes
+
+- This is a platform-specific workaround, not a bug in your code
+- macOS Ventura+ has stricter permission handling; the native dialog will still appear
+- Test on actual macOS hardware, not just simulators
+- The `camera_macos` or `camera_macos_plus` packages handle the native permission dialog
+- Consider adding a "Camera permission required" UI that appears if macOS denies access
+
+## References
+
+- [permission_handler plugin](https://pub.dev/packages/permission_handler) - Check platform support matrix
+- [macOS Camera Privacy](https://developer.apple.com/documentation/avfoundation/capture_setup/requesting_authorization_to_capture_and_save_media) - How macOS handles camera permissions
+- [camera_macos package](https://pub.dev/packages/camera_macos) - macOS-specific camera implementation

--- a/.claude/skills/flutter-macos-tcc-responsible-process-camera-denial/SKILL.md
+++ b/.claude/skills/flutter-macos-tcc-responsible-process-camera-denial/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: flutter-macos-tcc-responsible-process-camera-denial
+description: |
+  Fix black camera/microphone preview in Flutter macOS apps launched via `flutter run`
+  from a terminal emulator (cmux, iTerm, Terminal.app, VS Code integrated terminal,
+  Cursor, etc.). Use when: (1) camera plugin reports initialized but preview is black
+  with no frames, (2) logs show "initialization completed via timeout" or similar
+  first-frame timeout fallback, (3) AVCaptureSession.startRunning() returns without
+  error but zero frames arrive, (4) the app's Info.plist has NSCameraUsageDescription
+  and entitlements (com.apple.security.device.camera, audio-input) are correctly set,
+  (5) no permission dialog ever appears, (6) same failure mode for microphone. Root
+  cause is macOS TCC attributing camera/mic requests to the *responsible process*
+  (the parent terminal) rather than the Flutter app itself. TCC refuses to prompt
+  because the terminal is hardened-runtime without a camera entitlement, and silently
+  denies. Not a bug in the camera plugin — would reproduce with ANY camera code.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# Flutter macOS TCC Responsible-Process Camera Denial
+
+## Problem
+
+A Flutter macOS app that should have camera/microphone access shows a black preview
+(or returns zero frames) even though:
+
+- `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` are present in
+  `macos/Runner/Info.plist`.
+- `com.apple.security.device.camera` and `com.apple.security.device.audio-input`
+  are `true` in both `DebugProfile.entitlements` and `Release.entitlements`.
+- The native camera plugin reports `isInitialized: true` and returns a texture ID.
+- No permission dialog ever appears.
+- No errors are logged by the camera plugin or AVFoundation.
+
+The symptom is usually a "timeout fallback" firing in the plugin (e.g.
+`DivineCamera macOS: Initialization completed via timeout`, or similar 2-second
+init guards) because the plugin is waiting for a first sample buffer that never
+arrives. Camera metadata from the plugin shows `iso: 0.0, exposureDuration: 0.0,
+aperture: 0.0` — the device was enumerated but never actually started delivering
+samples.
+
+## Context / Trigger Conditions
+
+All of the following are true:
+
+1. App was launched via `flutter run -d macos` (or via `flutter run` from an IDE
+   that wraps flutter in a terminal — VS Code, Cursor, Android Studio, cmux).
+2. The terminal emulator is a hardened-runtime app **without** camera/mic
+   entitlements in its own code signature.
+3. macOS version is 10.15+ (TCC enforcement tightened; affects Big Sur onwards,
+   intensifies on Sequoia/Tahoe).
+4. No explicit `AVCaptureDevice.requestAccess(for: .video)` call in the plugin,
+   OR the call is being attributed to the wrong process.
+
+Specifically, this is NOT:
+
+- `flutter-macos-permission-handler-camera-failure` (that's about permission_handler
+  plugin silently failing to bridge to TCC).
+- `flutter-macos-duplicate-camera-plugin` (that's a build error).
+- A missing Info.plist entry (the usage description IS present).
+- A missing entitlement (the entitlement IS present).
+
+## Root Cause
+
+macOS TCC attributes permission requests to the **responsible process**, not the
+accessing process. When `flutter run` launches the .app as a child of the terminal,
+TCC walks the process tree and picks the terminal as the "responsible" party for
+any protected resource access. This is the same mechanism that causes "Terminal
+wants access to ..." prompts instead of prompts for individual scripts.
+
+For camera/microphone specifically, TCC enforces that the responsible process has
+the matching entitlement. If cmux / iTerm / VS Code / etc. is the responsible
+process and it's hardened-runtime without `com.apple.security.device.camera`,
+TCC logs:
+
+```
+tccd: Prompting policy for hardened runtime;
+  service: kTCCServiceCamera requires entitlement com.apple.security.device.camera
+  but it is missing for responsible={identifier=<terminal>, ...}
+  accessing={identifier=<YourApp>, binary_path=.../YourApp.app/Contents/MacOS/YourApp}
+tccd: Policy disallows prompt for Sub:{<terminal>}; access to kTCCServiceCamera denied
+```
+
+Critically: **TCC will not even show the user a prompt.** It silently denies. From
+the app's perspective, `AVCaptureSession.startRunning()` returns without error but
+zero sample buffers are ever produced, so any first-frame timeout in the plugin
+fires eventually.
+
+## Diagnosis
+
+Run this while (or just after) reproducing the failure:
+
+```bash
+/usr/bin/log show --last 10m --predicate 'subsystem == "com.apple.TCC"' --info 2>&1 \
+  | grep -iE "camera|microphone|<YourAppName>|Runner" \
+  | tail -40
+```
+
+You are looking for the phrase:
+
+```
+Policy disallows prompt for Sub:{<terminal.bundle.id>}...;
+access to kTCCServiceCamera denied
+```
+
+and the `AttributionChain` showing `responsible={identifier=<terminal>}` and
+`accessing={identifier=<YourApp>}`. Presence of these lines confirms the diagnosis.
+
+Reading the TCC database directly (`~/Library/Application Support/com.apple.TCC/TCC.db`)
+will fail with "authorization denied" unless Terminal has Full Disk Access — the
+`log show` approach is the reliable way.
+
+## Solution
+
+### Immediate fix (smoke test)
+
+Launch the .app bundle via Launch Services instead of `flutter run`. Launch Services
+makes the app its own responsible process, so TCC will prompt the user and attribute
+the request to the app itself (which does have the entitlement).
+
+```bash
+# Build once via flutter
+cd <project>/mobile
+flutter build macos --debug
+
+# Then launch via `open` — NOT via `flutter run`
+open build/macos/Build/Products/Debug/<YourApp>.app
+```
+
+`open` routes through `launchd`/LaunchServices, so the responsible process becomes
+`<YourApp>` rather than the terminal. On first launch from a state where TCC has no
+entry for the app, macOS will show the standard permission prompt.
+
+### If TCC already cached the denied state
+
+If you had previously launched via `flutter run`, TCC may have cached a denied entry
+attributed to the terminal. Reset it:
+
+```bash
+# Narrow scope: reset only this app's permissions
+tccutil reset Camera <your.app.bundle.id>
+tccutil reset Microphone <your.app.bundle.id>
+
+# Or broad reset (re-prompts for EVERY app that uses camera/mic):
+tccutil reset Camera
+tccutil reset Microphone
+```
+
+Then relaunch via `open`.
+
+### Long-term fix (shipping apps)
+
+This issue only affects `flutter run` from a terminal. Production .app bundles
+distributed to end users (via DMG, Mac App Store, notarized download) launch via
+LaunchServices and don't hit this. No code fix is needed for release builds.
+
+For a better developer experience, plugins should call
+`AVCaptureDevice.requestAccess(for: .video)` (and `.audio`) explicitly before
+starting the capture session. This doesn't change the `flutter run` TCC outcome
+(TCC still attributes to the terminal), but it provides a clear `granted=false`
+error path instead of a silent frame-timeout.
+
+```swift
+AVCaptureDevice.requestAccess(for: .video) { videoGranted in
+    guard videoGranted else {
+        completion(nil, "Camera permission denied")
+        return
+    }
+    AVCaptureDevice.requestAccess(for: .audio) { _ in
+        // audio denial can be non-fatal; continue without audio input
+        self.sessionQueue.async { self.setupCamera(completion: completion) }
+    }
+}
+```
+
+## Verification
+
+After launching via `open`:
+
+1. macOS should show a standard system prompt: "YourApp would like to access the
+   camera." Grant it.
+2. Camera preview should appear in the app within ~1 second (no timeout fallback).
+3. `log show --last 2m --predicate 'subsystem == "com.apple.TCC"'` should show
+   `authorized` instead of `denied`, and the responsible process should be the app
+   itself.
+4. Plugin metadata should report non-zero `iso` and `exposureDuration` values —
+   confirming the AVCaptureDevice is actually running.
+
+If the preview is still black after all this, investigate separately (it's a
+real bug in the plugin code, not a TCC issue).
+
+## Example Session
+
+**Symptom observed:** Flutter macOS app under review (PR adding native macOS camera
+support) launched via `flutter run` from cmux. Camera UI rendered, plugin reported
+`isInitialized: true`, but preview was black and log showed
+`DivineCamera macOS: Initialization completed via timeout`. Initial (wrong)
+hypothesis: the plugin's Swift code was missing an `AVCaptureDevice.requestAccess`
+call.
+
+**Diagnostic run:**
+```bash
+/usr/bin/log show --last 15m --predicate 'subsystem == "com.apple.TCC"' --info \
+  | grep -iE "camera|Divine"
+```
+
+**Evidence found:**
+```
+tccd: Prompting policy for hardened runtime; service: kTCCServiceCamera
+  requires entitlement com.apple.security.device.camera but it is missing for
+  responsible={identifier=com.cmuxterm.app, ...}
+  accessing={identifier=Divine, binary_path=.../Divine.app/.../Divine}
+tccd: Policy disallows prompt for Sub:{com.cmuxterm.app}...;
+  access to kTCCServiceCamera denied
+```
+
+**Conclusion:** cmux was the responsible process, not Divine. The plugin was
+innocent — same failure would have occurred with any camera plugin.
+
+**Fix applied:**
+```bash
+cd mobile && flutter build macos --debug
+open build/macos/Build/Products/Debug/Divine.app
+```
+
+App prompted for camera permission on first launch, user granted, preview worked.
+
+## Notes
+
+- **Which terminal emulators are affected:** Any hardened-runtime terminal that
+  doesn't request the camera entitlement. cmux, iTerm2, Terminal.app, Warp, VS Code
+  integrated terminal, Cursor integrated terminal, Android Studio integrated
+  terminal. Essentially all of them.
+- **Does giving the terminal camera access help?** In principle yes (System
+  Settings > Privacy & Security > Camera > enable the terminal), but most terminals
+  are hardened-runtime-signed without the camera entitlement so the checkbox isn't
+  offered. The `open` workaround is more reliable.
+- **Why the error message is misleading:** The plugin logs "initialization completed
+  via timeout" — that log is technically true (the 2-second init guard fired) but
+  says nothing about WHY no frames arrived. The real answer is only in the TCC
+  subsystem log, which most developers never check.
+- **Also affects:** Microphone (`kTCCServiceMicrophone`), screen recording
+  (`kTCCServiceScreenCapture`), contacts, calendar — any TCC-protected resource
+  when launched via a terminal without the matching entitlement. The same
+  `log show` + `open` workflow applies.
+- **Does `flutter run` have a fix?** No. The Flutter tool invokes the app as a
+  subprocess; there's no way to make Flutter-the-tool drop out of the
+  responsibility chain. Apple provides no API for an app to claim its own TCC
+  responsibility. You either use `open`, or accept the first-launch friction in
+  development.
+- **Related but different:** `flutter-macos-permission-handler-camera-failure`
+  covers the permission_handler Dart plugin failing to bridge to TCC. That's a
+  different failure mode where the plugin itself is silent; this skill covers
+  TCC being silent before the plugin ever gets a chance to ask.
+
+## References
+
+- Apple Developer Forums: "App launched from Terminal inherits Terminal's TCC
+  responsibility" (search DTS / Quinn "The Eskimo!" posts on TCC).
+- Apple Technical Note TN3127: "Inside Code Signing: Requirements" — covers
+  responsible-process attribution.
+- `man tccutil` — `reset [service] [bundleID]` syntax.
+- `log show --predicate 'subsystem == "com.apple.TCC"'` — the authoritative
+  source of truth for what TCC actually did.

--- a/.claude/skills/flutter-pageview-implicit-scrolling-snapback/SKILL.md
+++ b/.claude/skills/flutter-pageview-implicit-scrolling-snapback/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: flutter-pageview-scroll-position-preservation
+description: |
+  Fix Flutter PageView "snap back" or scroll position reset issues on provider/state rebuilds.
+  Use when: (1) PageView scrolls then snaps back to previous page after state update,
+  (2) Scroll position resets when Riverpod/Provider rebuilds, (3) Feed scrolls back to top
+  on data refresh, (4) PageView loses position after orientation change or widget rebuild.
+author: Claude Code
+version: 1.1.0
+date: 2026-01-31
+---
+
+# Flutter PageView Scroll Position Preservation
+
+## Problem
+
+Users scrolling through a PageView-based feed report that the scroll position resets or
+"snaps back" to a previous page, especially after state updates from providers (Riverpod,
+Provider, BLoC) or widget rebuilds.
+
+## Context / Trigger Conditions
+
+- PageView with dynamic content from state management
+- Provider/Riverpod state updates causing widget rebuilds
+- Pagination that changes itemCount
+- Orientation changes
+- Tab switching and returning to the PageView
+
+## Root Cause
+
+When Flutter rebuilds the widget tree (due to state changes), the PageView may lose its
+scroll position if:
+
+1. No `PageStorageKey` is provided to persist state
+2. The PageController is recreated during rebuilds
+3. `PageController.keepPage` is set to `false`
+
+**Note:** `allowImplicitScrolling` is for **accessibility focus navigation**, NOT scroll
+position preservation. A specific bug (#76569) involving TextField focus was fixed in Flutter.
+
+## Solution
+
+### 1. Add PageStorageKey (PRIMARY FIX)
+
+```dart
+PageView.builder(
+  // This key tells Flutter to persist scroll state across rebuilds
+  key: const PageStorageKey<String>('my_page_view'),
+  itemCount: videos.length,
+  controller: _pageController,
+  ...
+)
+```
+
+### 2. Keep PageController in State (not build)
+
+```dart
+class _MyScreenState extends State<MyScreen> {
+  // Create in initState, NOT in build()
+  late PageController _pageController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();  // Created once
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Use the same controller instance
+    return PageView.builder(
+      controller: _pageController,
+      ...
+    );
+  }
+}
+```
+
+### 3. Ensure keepPage is true (default)
+
+```dart
+_pageController = PageController(
+  keepPage: true,  // This is the default, but be explicit if needed
+  initialPage: 0,
+);
+```
+
+### 4. For complex state: Use PageStorage widget
+
+```dart
+PageStorage(
+  bucket: PageStorageBucket(),
+  child: PageView.builder(
+    key: const PageStorageKey<String>('feed'),
+    ...
+  ),
+)
+```
+
+## What allowImplicitScrolling Actually Does
+
+This is for **accessibility**, not scroll position:
+
+- `false` (default): Accessibility focus exits PageView at page boundaries
+- `true`: Accessibility focus moves to next page instead of exiting widget
+
+It does NOT cause scroll position issues. Keep it `true` for better accessibility.
+
+## Verification
+
+1. Scroll to page 10+ in the feed
+2. Trigger a state update (like new data arriving)
+3. Verify scroll position is preserved
+4. Rotate device - verify position preserved
+5. Switch tabs and return - verify position preserved
+
+## Example
+
+Full pattern for a Riverpod-based feed:
+
+```dart
+class _VideoFeedScreenState extends ConsumerState<VideoFeedScreen> {
+  late PageController _pageController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final videos = ref.watch(videoFeedProvider);
+
+    return PageView.builder(
+      key: const PageStorageKey<String>('video_feed'),
+      controller: _pageController,
+      itemCount: videos.length,
+      allowImplicitScrolling: true,  // For accessibility
+      itemBuilder: (context, index) => VideoItem(videos[index]),
+    );
+  }
+}
+```
+
+## Notes
+
+- The Riverpod 3.2.0 issue #4661 about ProviderScope rebuilds is separate
+- If using tabs, wrap in `AutomaticKeepAliveClientMixin` to preserve state
+- For very long lists, consider using `restorationId` for app restart persistence
+
+## References
+
+- [PageView class - Flutter docs](https://api.flutter.dev/flutter/widgets/PageView-class.html)
+- [PageStorageKey usage - Medium](https://medium.com/codex/maintaining-pageviews-current-page-after-orientation-changes-using-keys-ac0769234e09)
+- [allowImplicitScrolling property](https://api.flutter.dev/flutter/widgets/PageView/allowImplicitScrolling.html)
+- [GitHub #76569 - TextField snap-back bug (FIXED)](https://github.com/flutter/flutter/issues/76569)

--- a/.claude/skills/flutter-pageview-url-routing-reorder-loop/SKILL.md
+++ b/.claude/skills/flutter-pageview-url-routing-reorder-loop/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: flutter-pageview-url-routing-reorder-loop
+description: |
+  Fix infinite rebuild loop in Flutter when using PageView with URL-based routing (GoRouter)
+  and reactive state management (Riverpod/BLoC). Use when: (1) RAPID REBUILD warnings appear
+  in console (#20+), (2) "setState() or markNeedsBuild() called during build" errors from
+  ValueListenableBuilder, (3) Video feed or list-based PageView is frozen and won't swipe,
+  (4) Overlay or UI elements flicker between visible/invisible rapidly, (5) Logs show item
+  "moved from index X to Y" repeatedly. Caused by tracking items by ID and updating URL
+  when reactive list reorders.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-06
+---
+
+# Flutter PageView + URL Routing Reorder Detection Loop
+
+## Problem
+When a PageView is synced bidirectionally with URL-based routing (e.g., GoRouter `/home/:index`)
+and the data source is a reactive provider (Riverpod, BLoC stream), attempting to track the
+currently-viewed item by its ID and update the URL when the item moves to a different index
+in the list creates an infinite feedback loop.
+
+## Context / Trigger Conditions
+
+**Symptoms:**
+- Console shows `RAPID REBUILD #42!` warnings (build count growing rapidly)
+- `setState() or markNeedsBuild() called during build` errors from `ValueListenableBuilder`
+- PageView is frozen - user swipes but page bounces back to same position
+- UI overlay (social buttons, controls) flickers between visible and invisible
+- Logs show repeated pattern: `Video X moved from index 4 -> 3, updating URL`
+
+**Architecture that triggers this:**
+- `PageView.builder` with `onPageChanged` updating URL via `context.go('/feed/$index')`
+- URL-derived index synced back to PageController via `jumpToPage()` during build
+- Reactive data source (Riverpod provider, stream) that can re-emit with reordered items
+- Item tracking: `_currentItemId` compared against list to detect "moves"
+
+**Example of the anti-pattern:**
+```dart
+// IN BUILD METHOD - creates feedback loop!
+if (_currentVideoStableId != null && videos.isNotEmpty) {
+  final currentVideoIndex = videos.indexWhere(
+    (v) => v.stableId == _currentVideoStableId,
+  );
+  if (currentVideoIndex != -1 && currentVideoIndex != urlIndex) {
+    // This triggers URL update -> rebuild -> PageController sync ->
+    // onPageChanged -> URL update -> INFINITE LOOP
+    context.go('/home/$currentVideoIndex');
+  }
+}
+```
+
+## Solution
+
+**Remove item-tracking reorder detection entirely.** The PageController should be the sole
+source of truth for which page the user is viewing.
+
+### Step 1: Remove tracking state
+```dart
+// REMOVE these fields:
+// String? _currentVideoStableId;
+// bool _urlUpdateScheduled = false;
+```
+
+### Step 2: Remove reorder detection block
+Remove any code in `build()` that:
+- Searches for a tracked item ID in the current list
+- Compares found index against URL index
+- Schedules URL updates when indices differ
+
+### Step 3: Keep only one-way sync patterns
+
+**User swipe -> URL (one-way):**
+```dart
+onPageChanged: (newIndex) {
+  if (newIndex != urlIndex) {
+    context.go('/home/$newIndex');
+  }
+}
+```
+
+**External navigation -> PageController (one-way):**
+```dart
+if (urlIndex != _lastUrlIndex) {
+  _lastUrlIndex = urlIndex;
+  controller.jumpToPage(urlIndex);
+}
+```
+
+These two paths don't create loops because:
+- User swipe: URL updates, next build sees matching urlIndex -> no sync needed
+- External nav: URL changes, sync fires, onPageChanged fires but `newIndex == urlIndex` -> no URL update
+
+## The Feedback Loop Explained
+
+```
+┌─ Reactive provider re-emits (new data from server) ─┐
+│                                                       │
+▼                                                       │
+Build runs with new video list                          │
+│                                                       │
+▼                                                       │
+Reorder detection: "Video X moved from idx 4 to 3"     │
+│                                                       │
+▼                                                       │
+Schedule URL update: context.go('/home/3')              │
+│                                                       │
+▼                                                       │
+Build runs: urlIndex=3, PageController at page 4        │
+│                                                       │
+▼                                                       │
+Sync: jumpToPage(3)                                     │
+│                                                       │
+▼                                                       │
+onPageChanged(3) fires → context.go('/home/3')          │
+│                                                       │
+▼                                                       │
+But PageController was at 4, which showed different     │
+video → _currentVideoStableId mismatches → detects      │
+"move" again → URL update to /home/4                    │
+│                                                       │
+└───────── INFINITE LOOP ──────────────────────────────┘
+```
+
+## Verification
+
+After removing reorder detection:
+1. No more `RAPID REBUILD` warnings in console
+2. No `setState() called during build` errors
+3. Swiping between pages works smoothly
+4. UI overlays stay visible on the active page
+5. No "moved from index X to Y" log spam
+
+## Notes
+
+- **Why reorder detection seems needed:** When a reactive list reorders (e.g., new items
+  prepended), the user's current page index points to a different item. However, trying to
+  "follow" the item creates worse UX (infinite loop) than staying on the same page index.
+
+- **Alternative if position preservation is critical:** Instead of URL-based reorder detection,
+  stabilize the list order. Either:
+  - Don't reorder while the user is actively viewing (batch updates)
+  - Use a stable sort that preserves relative positions of existing items
+  - Only prepend/append new items, never reorder existing ones
+
+- **Related pattern:** `flutter-pageview-implicit-scrolling-snapback` addresses a different
+  PageView issue (snap-back on state rebuild) but can co-occur with this loop.
+
+- **Framework-agnostic:** While this was discovered with GoRouter + Riverpod, the same
+  pattern applies to any PageView + URL routing + reactive state combination (Navigator 2.0,
+  auto_route, BLoC streams, etc.)

--- a/.claude/skills/flutter-startup-network-blocking/SKILL.md
+++ b/.claude/skills/flutter-startup-network-blocking/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: flutter-startup-network-blocking
+description: |
+  Fix slow Flutter app startup caused by blocking network operations during initialization.
+  Use when: (1) App takes several seconds to show first frame, (2) Startup logs show sequential
+  network operations (WebSocket connections, API calls), (3) Services initialize during startup
+  that aren't needed until user authenticates. Covers: converting sequential network ops to
+  parallel with Future.wait(), deferring service initialization until actually needed (lazy init),
+  and identifying blocking operations in Riverpod/provider initialization chains.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Flutter Startup Network Blocking
+
+## Problem
+Flutter app startup is slow because network operations (WebSocket connections, API calls,
+service initialization) run sequentially during the initialization phase, blocking the
+first frame from rendering. With multiple relay/server connections, worst-case startup
+time becomes O(n × timeout) instead of O(max timeout).
+
+## Context / Trigger Conditions
+- App takes 3+ seconds to show first frame on fresh launch
+- Startup logs show sequential "connecting to relay X... connecting to relay Y..."
+- Services that require authentication initialize even for unauthenticated users
+- `_initializeCoreServices()` or similar contains multiple awaited network operations
+- Riverpod providers eagerly initialize network-dependent services in their `build()` method
+
+## Solution
+
+### 1. Identify Blocking Operations
+Look for sequential awaits in startup code:
+```dart
+// BAD: Sequential - each connection blocks the next
+for (final url in relays) {
+  await connectToRelay(url);  // Blocks startup!
+}
+```
+
+### 2. Convert Sequential to Parallel
+Use `Future.wait()` to run all connections simultaneously:
+```dart
+// GOOD: Parallel - all connections run at once
+final results = await Future.wait(
+  relays.map((url) async {
+    final success = await connectToRelay(url);
+    return MapEntry(url, success);
+  }),
+);
+```
+
+### 3. Defer Non-Critical Service Initialization
+Move network-dependent services out of the critical startup path:
+
+**Before (blocking startup):**
+```dart
+Future<void> _initializeCoreServices(ProviderContainer container) async {
+  await container.read(authServiceProvider).initialize();
+  await container.read(nostrServiceProvider).initialize();  // BLOCKS for relay connections!
+  await container.read(otherServiceProvider).initialize();
+}
+```
+
+**After (lazy initialization):**
+```dart
+Future<void> _initializeCoreServices(ProviderContainer container) async {
+  // NOTE: NostrService initializes lazily when user authenticates
+  await container.read(authServiceProvider).initialize();
+  await container.read(seenVideosServiceProvider).initialize();
+  // NostrService NOT initialized here - happens when auth state changes
+}
+```
+
+### 4. Use Provider Dependencies for Lazy Init
+Let Riverpod handle lazy initialization through provider dependencies:
+```dart
+@riverpod
+NostrClient nostrClient(NostrClientRef ref) {
+  final authService = ref.watch(authServiceProvider);
+
+  // Only creates client when auth state is ready
+  if (!authService.isAuthenticated) {
+    return NostrClient.disconnected();
+  }
+
+  // Initialize lazily when actually needed
+  final client = NostrClient(relays: authService.userRelays);
+  Future.microtask(() => client.initialize());
+  return client;
+}
+```
+
+## Verification
+1. Check startup logs for "First frame rendered in Xms" - should be < 2000ms
+2. Verify network operations happen AFTER first frame timestamp in logs
+3. For unauthenticated users, relay connections should NOT appear in startup logs
+
+## Example
+
+**Startup improvement achieved:**
+- Before: First frame at 3500ms+ (waiting for 5 relays × ~700ms each)
+- After: First frame at 1426ms (parallel connections happen post-frame)
+
+**Log pattern showing fix working:**
+```
+[18:15:17.538] First frame rendered in 1426ms
+[18:15:17.556] Creating NostrClient...  // AFTER first frame!
+```
+
+## Notes
+- This pattern applies to any async initialization, not just WebSockets
+- Consider timeout handling when parallelizing - use `Future.wait` with error handling
+- For critical services, use a loading screen rather than blocking the main thread
+- Profile with Flutter DevTools Timeline to identify other startup bottlenecks
+- Remember that `Future.wait()` fails fast by default - use try/catch inside the map if you want partial success
+
+## Related Patterns
+- Splash screen with async initialization
+- Riverpod `AsyncNotifier` for lazy-loaded state
+- Background service initialization after first frame
+
+## References
+- [Flutter Performance Best Practices](https://docs.flutter.dev/perf/best-practices)
+- [Dart Future.wait documentation](https://api.dart.dev/stable/dart-async/Future/wait.html)
+- [Riverpod lazy initialization](https://riverpod.dev/docs/concepts/providers#lazy-initialization)

--- a/.claude/skills/flutter-svg-icon-colorfilter-visibility/SKILL.md
+++ b/.claude/skills/flutter-svg-icon-colorfilter-visibility/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: flutter-svg-icon-colorfilter-visibility
+description: |
+  Fix invisible or poorly visible SVG icons in Flutter when using flutter_svg package.
+  Use when: (1) SVG icons appear invisible despite correct colors in the SVG file,
+  (2) Using Opacity widget to change icon visibility/state but icons don't render properly,
+  (3) Tab bar or navigation icons disappear or have wrong colors,
+  (4) Icons with fill="white" don't show on dark backgrounds.
+  The fix is to use ColorFilter.mode() instead of Opacity widget for SVG icon state styling.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-30
+---
+
+# Flutter SVG Icon ColorFilter vs Opacity
+
+## Problem
+
+SVG icons rendered with `flutter_svg` appear invisible or have incorrect visibility
+when using the `Opacity` widget to indicate selected/unselected states. This commonly
+occurs in bottom navigation bars, tab bars, or any UI with icon state changes.
+
+## Context / Trigger Conditions
+
+- Using `flutter_svg` package with `SvgPicture.asset()`
+- SVG files have explicit fill colors (e.g., `fill="white"`)
+- Icons wrapped in `Opacity` widget for selected/unselected states
+- Icons appear invisible or barely visible despite correct SVG content
+- Background color should provide sufficient contrast (e.g., white on dark green)
+
+## Solution
+
+Replace `Opacity` widget with `ColorFilter` on the SvgPicture:
+
+**Before (problematic):**
+```dart
+Widget _buildTabButton(String iconPath, bool isSelected) {
+  return Opacity(
+    opacity: isSelected ? 1.0 : 0.5,
+    child: SvgPicture.asset(iconPath, width: 32, height: 32),
+  );
+}
+```
+
+**After (correct):**
+```dart
+Widget _buildTabButton(String iconPath, bool isSelected) {
+  final iconColor = isSelected ? Colors.white : Colors.grey;
+
+  return SvgPicture.asset(
+    iconPath,
+    width: 32,
+    height: 32,
+    colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+  );
+}
+```
+
+### Key Points
+
+1. **ColorFilter.mode with BlendMode.srcIn** replaces the SVG's fill color with the
+   specified color wherever the SVG has opaque pixels
+
+2. **Don't rely on Opacity for color changes** - Opacity affects transparency but
+   doesn't change the actual rendered color, which can cause visibility issues
+
+3. **SVG fill attribute is overridden** - Even if your SVG has `fill="white"`, the
+   ColorFilter will replace it with your specified color
+
+## Verification
+
+After applying the fix:
+1. Selected icons should render in the selected color (e.g., white)
+2. Unselected icons should render in the unselected color (e.g., grey)
+3. Both states should be clearly visible against the background
+
+## Example
+
+Bottom navigation with proper icon coloring:
+
+```dart
+Widget _buildNavIcon(String assetPath, int tabIndex, int currentIndex) {
+  final isSelected = tabIndex == currentIndex;
+  final iconColor = isSelected ? Colors.white : const Color(0xFF8A9A94);
+
+  return GestureDetector(
+    onTap: () => _onTabTap(tabIndex),
+    child: Container(
+      width: 48,
+      height: 48,
+      padding: const EdgeInsets.all(8),
+      child: SvgPicture.asset(
+        assetPath,
+        width: 32,
+        height: 32,
+        colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+      ),
+    ),
+  );
+}
+```
+
+## Notes
+
+- This applies to `flutter_svg` package specifically; other SVG rendering solutions
+  may behave differently
+- If you need both color change AND opacity, apply ColorFilter first, then wrap in
+  Opacity if truly needed
+- For icons that should maintain their original multi-color appearance, don't use
+  ColorFilter - but then Opacity alone may work fine
+- BlendMode.srcIn specifically means "show source color where destination (SVG) is opaque"
+
+## References
+
+- [flutter_svg package documentation](https://pub.dev/packages/flutter_svg)
+- [Flutter ColorFilter class](https://api.flutter.dev/flutter/dart-ui/ColorFilter-class.html)
+- [BlendMode.srcIn documentation](https://api.flutter.dev/flutter/dart-ui/BlendMode.html)

--- a/.claude/skills/funnelcake-deployment-workflow/SKILL.md
+++ b/.claude/skills/funnelcake-deployment-workflow/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: funnelcake-deployment-workflow
+description: |
+  Deploy funnelcake (api + relay) to ANY environment (production, staging, poc) on GKE via ArgoCD.
+  Use when: (1) Deploying new funnelcake commits, (2) Building Docker images for GKE (amd64),
+  (3) Running ClickHouse migrations, (4) Troubleshooting ImagePullBackOff errors,
+  (5) Syncing staging/poc after production deployment. Covers complete workflow with
+  PRE-FLIGHT CHECKLIST to prevent common deployment failures.
+author: Claude Code
+version: 2.0.0
+date: 2026-01-31
+---
+
+# Funnelcake Deployment Workflow
+
+## Problem
+Deploying funnelcake requires multiple coordinated steps across DIFFERENT environments,
+each with its own container registry and ArgoCD instance. Common failures:
+- Updating kustomization with image tags that don't exist in target registry
+- Assuming push to main auto-deploys to staging/poc (it doesn't)
+- Not verifying pods actually started (vs stuck in ImagePullBackOff)
+
+## Context / Trigger Conditions
+- User asks to deploy funnelcake to any environment
+- New commits need to be deployed
+- Migrations need to be run
+- Pods stuck in ImagePullBackOff or ErrImagePull
+- Staging/poc is behind production
+
+## CRITICAL: Multi-Environment Architecture
+
+**Each environment is ISOLATED - nothing is shared!**
+
+| Environment | Container Registry | ArgoCD | kubectl Context |
+|-------------|-------------------|--------|-----------------|
+| Production | `us-central1-docker.pkg.dev/dv-platform-prod/containers-production/` | In production cluster | `connectgateway_dv-platform-prod_us-central1_gke-production-membership` |
+| Staging | `us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/` | In staging cluster | `connectgateway_dv-platform-staging_us-central1_gke-staging-membership` |
+| POC | `us-central1-docker.pkg.dev/rich-compiler-479518-d2/containers-poc/` | In POC cluster | `connectgateway_rich-compiler-479518-d2_us-central1_gke-poc-membership` |
+
+**Key Facts:**
+- Images in production registry are NOT available to staging/poc
+- Pushing to `main` branch does NOT auto-sync staging/poc ArgoCD
+- Each environment's ArgoCD must be synced separately
+
+## PRE-FLIGHT CHECKLIST (DO THIS FIRST!)
+
+Before deploying to ANY environment, verify:
+
+### 1. Does the image exist in the TARGET registry?
+```bash
+# Check what images exist
+gcloud artifacts docker images list \
+  us-central1-docker.pkg.dev/<PROJECT>/<REPO>/funnelcake-relay \
+  --include-tags --limit=5
+
+# Projects/repos by environment:
+# - Production: dv-platform-prod/containers-production
+# - Staging: dv-platform-staging/containers-staging
+# - POC: rich-compiler-479518-d2/containers-poc
+```
+
+**If image doesn't exist → BUILD AND PUSH IT FIRST!**
+
+### 2. Am I updating the correct overlay?
+```bash
+# Staging overlay:
+k8s/applications/funnelcake-relay/overlays/staging/kustomization.yaml
+
+# POC overlay:
+k8s/applications/funnelcake-relay/overlays/poc/kustomization.yaml
+
+# Production overlay:
+k8s/applications/funnelcake-relay/overlays/production/kustomization.yaml
+```
+
+### 3. What's currently deployed vs what's in git?
+```bash
+# Check deployed image
+kubectl --context <CONTEXT> get deployment funnelcake-relay -n funnelcake \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+
+# Check git kustomization
+cat k8s/applications/funnelcake-relay/overlays/<ENV>/kustomization.yaml | grep newTag
+```
+
+## Complete Deployment Workflow
+
+### Step 1: Get Latest Code
+```bash
+cd /Users/rabble/code/divine/divine-funnelcake
+git pull
+git log --oneline -3  # Note the commit hash (e.g., e02d3b1)
+```
+
+### Step 2: Build Images for AMD64 (CRITICAL)
+
+**IMPORTANT**: Mac builds arm64 by default. GKE runs amd64. You MUST specify `--platform linux/amd64`.
+
+```bash
+# Build API image
+docker buildx build --platform linux/amd64 --target api \
+  -t us-central1-docker.pkg.dev/dv-platform-prod/containers-production/funnelcake-api:COMMIT_HASH \
+  --push .
+
+# Build Relay image
+docker buildx build --platform linux/amd64 --target relay \
+  -t us-central1-docker.pkg.dev/dv-platform-prod/containers-production/funnelcake-relay:COMMIT_HASH \
+  --push .
+```
+
+If you get auth errors, run:
+```bash
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+```
+
+### Step 3: Update Kustomize and Push
+```bash
+cd /Users/rabble/code/divine/divine-iac-coreconfig
+
+# Update image tags
+sed -i '' 's/newTag: "OLD_HASH"/newTag: "NEW_HASH"/' \
+  k8s/applications/funnelcake-api/overlays/production/kustomization.yaml
+sed -i '' 's/newTag: "OLD_HASH"/newTag: "NEW_HASH"/' \
+  k8s/applications/funnelcake-relay/overlays/production/kustomization.yaml
+
+# Commit and push (handle potential conflicts)
+git add k8s/applications/funnelcake-*/overlays/production/kustomization.yaml
+git commit -m "deploy(production): funnelcake NEW_HASH - description"
+git pull --rebase origin main && git push origin main
+```
+
+### Step 4: Trigger ArgoCD Sync
+```bash
+# Refresh to pick up git changes
+kubectl patch application funnelcake-api -n argocd --type=merge \
+  -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
+kubectl patch application funnelcake-relay -n argocd --type=merge \
+  -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
+
+# Wait, then trigger sync
+sleep 3
+kubectl patch application funnelcake-api -n argocd --type=merge \
+  -p '{"operation":{"sync":{"revision":"HEAD"}}}'
+kubectl patch application funnelcake-relay -n argocd --type=merge \
+  -p '{"operation":{"sync":{"revision":"HEAD"}}}'
+```
+
+### Step 5: Wait for Rollout
+```bash
+kubectl rollout status deploy/funnelcake-api deploy/funnelcake-relay \
+  -n funnelcake --timeout=120s
+```
+
+### Step 6: Verify
+```bash
+kubectl get deploy funnelcake-api -n funnelcake \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+## Running Migrations
+
+### CRITICAL: Migration Entrypoint Has Two Modes
+
+The `database/entrypoint.sh` detects ClickHouse connection mode from env vars:
+
+- **Mode 1 (CLICKHOUSE_URL)**: Assumes ClickHouse Cloud — forces port 9440 with TLS.
+  Use for **production** (ClickHouse Cloud at `*.clickhouse.cloud`).
+- **Mode 2 (CLICKHOUSE_HOST + CLICKHOUSE_PORT)**: Direct host/port, no TLS assumption.
+  Use for **staging/poc** (self-hosted ClickHouse on port 9000).
+
+**If you pass CLICKHOUSE_URL for self-hosted ClickHouse, migrations will fail with
+`i/o timeout` on port 9440 because the self-hosted instance listens on port 9000.**
+
+### Build and Push Migration Image
+```bash
+cd /Users/rabble/code/divine/divine-funnelcake/database
+docker buildx build --platform linux/amd64 \
+  -t us-central1-docker.pkg.dev/dv-platform-prod/containers-production/funnelcake-migrate:COMMIT_HASH \
+  --push .
+```
+
+### Run Migration Job — PRODUCTION (ClickHouse Cloud)
+```bash
+kubectl delete job funnelcake-db-migrate -n funnelcake --ignore-not-found
+cat <<'EOF' | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: funnelcake-db-migrate
+  namespace: funnelcake
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: us-central1-docker.pkg.dev/dv-platform-prod/containers-production/funnelcake-migrate:COMMIT_HASH
+          args: ["up"]
+          env:
+            - name: CLICKHOUSE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_URL
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_USER
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_PASSWORD
+            - name: CLICKHOUSE_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_DATABASE
+EOF
+```
+
+### Run Migration Job — STAGING/POC (Self-hosted ClickHouse)
+```bash
+# Use CLICKHOUSE_HOST + CLICKHOUSE_PORT instead of CLICKHOUSE_URL!
+kubectl --context <STAGING_CONTEXT> delete job funnelcake-db-migrate -n funnelcake --ignore-not-found
+cat <<'EOF' | kubectl --context <STAGING_CONTEXT> apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: funnelcake-db-migrate
+  namespace: funnelcake
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/funnelcake-migrate:COMMIT_HASH
+          args: ["up"]
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "funnelcake-funnelcake-clickhouse.funnelcake.svc.cluster.local"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_USER
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_PASSWORD
+            - name: CLICKHOUSE_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: funnelcake-clickhouse-credentials
+                  key: CLICKHOUSE_DATABASE
+EOF
+```
+
+### Check Migration Logs
+```bash
+sleep 10 && kubectl logs job/funnelcake-db-migrate -n funnelcake
+```
+
+### Handle "Dirty Database" Error
+If you see `error: Dirty database version X`, a previous migration failed partway:
+
+```bash
+# Force the version to clear dirty state
+kubectl delete job funnelcake-db-migrate -n funnelcake --ignore-not-found
+# Create job with args: ["force", "X"] instead of ["up"]
+# Then run "up" again
+```
+
+## Common Errors and Fixes
+
+### Error: "no match for platform in manifest: not found"
+**Cause**: Image built for wrong architecture (arm64 on Mac, but GKE needs amd64)
+**Fix**: Rebuild with `--platform linux/amd64`
+
+### Error: "Unauthenticated request" when pushing
+**Cause**: Docker not authenticated to Artifact Registry
+**Fix**: `gcloud auth configure-docker us-central1-docker.pkg.dev --quiet`
+
+### Error: "failed to push... fetch first"
+**Cause**: Remote has new commits
+**Fix**: `git pull --rebase origin main && git push origin main`
+
+### Error: "Dirty database version X"
+**Cause**: Previous migration failed midway
+**Fix**: Run `force X` to clear dirty state, then `up` again
+
+### Pods stuck in ImagePullBackOff
+**Causes**:
+1. Wrong architecture (check with `kubectl describe pod`)
+2. Image doesn't exist (typo in tag)
+3. Auth issues (check imagePullSecrets)
+
+## Key Paths
+- Funnelcake repo: `/Users/rabble/code/divine/divine-funnelcake`
+- IaC repo: `/Users/rabble/code/divine/divine-iac-coreconfig`
+- API kustomization: `k8s/applications/funnelcake-api/overlays/production/kustomization.yaml`
+- Relay kustomization: `k8s/applications/funnelcake-relay/overlays/production/kustomization.yaml`
+- Migrations: `/Users/rabble/code/divine/divine-funnelcake/database/migrations/`
+
+## Deploying to Staging or POC
+
+### Full Workflow for Non-Production Environments
+
+```bash
+# 1. Check what's in production that we want to deploy
+cat k8s/applications/funnelcake-relay/overlays/production/kustomization.yaml | grep newTag
+# e.g., newTag: "e7e79eb"
+
+# 2. CHECK if that image exists in staging registry
+gcloud artifacts docker images list \
+  us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/funnelcake-relay \
+  --include-tags --limit=10 | grep e7e79eb
+
+# 3. If NOT found → BUILD AND PUSH
+cd /Users/rabble/code/divine/divine-funnelcake
+git checkout e7e79eb
+
+docker build --platform linux/amd64 --target relay \
+  -t us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/funnelcake-relay:e7e79eb .
+docker push us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/funnelcake-relay:e7e79eb
+
+docker build --platform linux/amd64 --target api \
+  -t us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/funnelcake-api:e7e79eb .
+docker push us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/funnelcake-api:e7e79eb
+
+# For POC, tag and push to POC registry too
+docker tag ...staging...:e7e79eb ...poc...:e7e79eb
+docker push ...poc...:e7e79eb
+
+git checkout main  # Return to main
+
+# 4. Update kustomization (only AFTER images exist!)
+cd /Users/rabble/code/divine/divine-iac-coreconfig
+# Edit staging/poc overlays with new tags
+
+# 5. Commit and push
+git add -A && git commit -m "deploy(staging, poc): funnelcake @ e7e79eb" && git push
+
+# 6. Sync ArgoCD (each environment has its own!)
+kubectl --context connectgateway_dv-platform-staging_us-central1_gke-staging-membership \
+  patch application funnelcake-relay -n argocd --type merge \
+  -p '{"operation":{"initiatedBy":{"username":"claude"},"sync":{"syncStrategy":{"apply":{"force":false}}}}}'
+
+# 7. VERIFY pods are actually running (not ImagePullBackOff!)
+kubectl --context connectgateway_dv-platform-staging_us-central1_gke-staging-membership \
+  get pods -n funnelcake
+```
+
+### POST-DEPLOYMENT VERIFICATION CHECKLIST
+
+Always run these after any deployment:
+
+```bash
+# 1. Check pod status (should be Running, not ImagePullBackOff)
+kubectl --context <CONTEXT> get pods -n funnelcake
+
+# 2. Check actual deployed image matches expected
+kubectl --context <CONTEXT> get deployment funnelcake-relay -n funnelcake \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+
+# 3. Check the website actually works
+curl -s https://relay.staging.dvines.org/ | grep -o "version.*" | head -1
+```
+
+## Image Registry
+- Production: `us-central1-docker.pkg.dev/dv-platform-prod/containers-production/`
+- Staging: `us-central1-docker.pkg.dev/dv-platform-staging/containers-staging/`
+- POC: `us-central1-docker.pkg.dev/rich-compiler-479518-d2/containers-poc/`
+
+## Notes
+- Always use short commit hash (7 chars) for image tags
+- Dockerfile has multi-stage build: `--target api` or `--target relay`
+- Migration image is in `database/Dockerfile`
+- ClickHouse credentials are in `funnelcake-clickhouse-credentials` secret
+- ArgoCD needs BOTH refresh AND sync operations

--- a/.claude/skills/gcloud-builds-tag-deploy-false-success/SKILL.md
+++ b/.claude/skills/gcloud-builds-tag-deploy-false-success/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: gcloud-builds-tag-deploy-false-success
+description: |
+  Fix false-positive Cloud Run deploys where `gcloud builds submit --tag` silently fails
+  but the follow-up `gcloud run services update --image :latest` succeeds against a stale
+  image, producing a confident "Deploying... Done" message with pre-fix code still live.
+  Use when: (1) gcloud builds submit prints
+  "ERROR: (gcloud.builds.submit) Invalid value for [source]: Dockerfile required when specifying --tag"
+  but the shell scrolls past it, (2) code changes verified locally aren't visible in production
+  after a deploy that printed "revision ... has been deployed and is serving 100 percent of traffic",
+  (3) Chaining `gcloud builds submit` and `gcloud run services update` in a single copy-paste
+  block, (4) Using the mutable `:latest` tag for Cloud Run deploys.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# gcloud builds submit --tag false-success trap
+
+## Problem
+
+A common Cloud Run deploy recipe looks like this:
+
+```bash
+gcloud builds submit --tag us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:latest
+gcloud run services update SERVICE \
+  --image us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:latest \
+  --region us-central1 --project PROJECT
+```
+
+When the first command fails (most commonly because the current working directory doesn't
+contain a `Dockerfile`), its single-line error scrolls off-screen above the second command's
+verbose progress spinner. The second command then pulls the **existing** `:latest` image
+from Artifact Registry — which is the previous build — and deploys it. You get:
+
+```
+✓ Deploying... Done.
+  ✓ Creating Revision...
+  ✓ Routing traffic...
+Service [...] revision [...] has been deployed and is serving 100 percent of traffic.
+```
+
+A green "SUCCESS" deploy that did not change the running code. The user then spends
+hours debugging why the fix isn't live, or worse, concludes the fix doesn't work and
+reverts good code.
+
+## Context / Trigger Conditions
+
+- User reports "I deployed the fix but production behavior is unchanged"
+- Recent shell output contains both:
+  - `ERROR: (gcloud.builds.submit) Invalid value for [source]: Dockerfile required when specifying --tag`
+  - `revision [...] has been deployed and is serving 100 percent of traffic`
+- The `gcloud builds submit --tag …` was run without a source positional argument AND
+  the working directory does not contain the Dockerfile (common in monorepos where the
+  Dockerfile lives under a subdirectory like `cloud-run-upload/`, `services/api/`, etc.)
+- The deploy targets use the mutable `:latest` tag (or another tag that already exists
+  in the registry)
+
+## Root cause
+
+`gcloud builds submit --tag IMAGE_TAG` needs a source directory. When you omit it, it
+defaults to the current working directory, and if there's no `Dockerfile` there (or a
+`cloudbuild.yaml`), it exits immediately with exit code 1 — without uploading anything,
+without creating a build job, without touching Artifact Registry.
+
+Because `gcloud run services update --image :latest` resolves `:latest` at deploy time
+from Artifact Registry, it happily redeploys whatever was there from the *previous*
+successful build. Cloud Run's response does not compare the resolved digest to what's
+already running; it cheerfully creates a new revision pinning the same digest. Output
+reads "Done" because, from Cloud Run's perspective, everything worked.
+
+Two mistakes compound here:
+1. The build failure is a single red line among otherwise-green output and it's easy to miss.
+2. The `:latest` tag hides the fact that "the image didn't actually change" — an immutable
+   tag (git SHA, timestamp) would have made the staleness obvious.
+
+## Solution
+
+### Immediate fix
+
+Rerun the build from the directory containing the Dockerfile, or pass the source as a
+positional argument:
+
+```bash
+# Option A: cd into the directory
+cd cloud-run-upload
+gcloud builds submit --tag us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:latest
+
+# Option B: pass source as positional
+gcloud builds submit cloud-run-upload \
+  --tag us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:latest
+```
+
+**Wait for `STATUS: SUCCESS`** in the output (not just for the prompt to return).
+Then rerun the `gcloud run services update` command to pull the new digest.
+
+### Permanent prevention (recommended)
+
+1. **Use immutable tags.** Never deploy `:latest` to Cloud Run for anything that matters.
+   Tag with git SHA or timestamp so staleness is visible:
+   ```bash
+   TAG=$(git rev-parse --short HEAD)
+   gcloud builds submit cloud-run-upload \
+     --tag us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:${TAG}
+   gcloud run services update SERVICE \
+     --image us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:${TAG} ...
+   ```
+   If step 1 silently fails, step 2 fails loudly with "image not found" because that
+   tag doesn't exist yet. False-positive converted into a real error.
+
+2. **Chain with `&&` or put the commands in a script with `set -e`.** Copy-pasting two
+   separate commands lets the second run even if the first errored:
+   ```bash
+   #!/bin/bash
+   set -euo pipefail
+   cd "$(dirname "$0")/cloud-run-upload"
+   TAG=$(git rev-parse --short HEAD)
+   IMAGE=us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:${TAG}
+   gcloud builds submit --tag "${IMAGE}"
+   gcloud run services update SERVICE --image "${IMAGE}" --region us-central1
+   ```
+
+3. **Verify the build output contains `STATUS: SUCCESS`** before running the deploy. The
+   last line of a successful `gcloud builds submit` is `STATUS: SUCCESS`. If the last
+   line is anything else (especially `ERROR:`), the build did not happen.
+
+## Verification
+
+After re-running, confirm the deploy actually landed by checking the deployed revision's
+image digest matches the newly-built one:
+
+```bash
+# Digest of the tag you just built
+gcloud artifacts docker images describe \
+  us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:latest \
+  --format='value(image_summary.digest)'
+
+# Digest of the image Cloud Run is currently serving
+gcloud run services describe SERVICE --region us-central1 \
+  --format='value(spec.template.spec.containers[0].image)'
+```
+
+The second command shows the resolved digest (if `:latest` was pinned) or the tag. For
+an end-to-end behavioral check, hit a version endpoint if the service exposes one, or
+tail logs and confirm new log lines that only the fixed code would emit:
+
+```bash
+gcloud logging read 'resource.type=cloud_run_revision AND resource.labels.service_name=SERVICE AND textPayload=~"NEW_LOG_LINE_FROM_FIX"' \
+  --limit=5 --freshness=5m --format='value(timestamp,textPayload)'
+```
+
+## Example
+
+A user runs the following as two separate pasted commands:
+
+```
+$ gcloud builds submit --tag us-central1-docker.pkg.dev/PROJECT/REPO/blossom-upload:latest
+ERROR: (gcloud.builds.submit) Invalid value for [source]: Dockerfile required when specifying --tag
+
+$ gcloud run services update divine-blossom-upload \
+    --image us-central1-docker.pkg.dev/PROJECT/REPO/blossom-upload:latest \
+    --region us-central1 --project PROJECT
+✓ Deploying... Done.
+  ✓ Creating Revision...
+  ✓ Routing traffic...
+Done.
+Service [divine-blossom-upload] revision [divine-blossom-upload-00008-kvg] has been deployed and is serving 100 percent of traffic.
+```
+
+Revision `00008-kvg` is live but runs the pre-fix image. The user tests the fix against
+production, it still misbehaves, and they escalate: "I deployed and it still doesn't work."
+
+The fix is to rerun `gcloud builds submit` from the directory containing the Dockerfile
+(or pass it as a positional), wait for `STATUS: SUCCESS`, then rerun the `gcloud run
+services update`. The next revision will carry the new digest.
+
+## Notes
+
+- This is not specific to Cloud Run. The same shape of bug applies to any deploy pipeline
+  that separates "build image" from "point service at :latest": Kubernetes with
+  `imagePullPolicy: Always`, ECS with a `latest` task definition, Fly.io `fly deploy`
+  after a failed `flyctl image push`, etc. Whenever the deploy step resolves a mutable
+  tag it inherits the previous image on a build-step failure.
+- `gcloud builds submit` also accepts `--gcs-source-staging-dir` and `cloudbuild.yaml`
+  workflows — the error message changes with those but the principle is identical:
+  verify build success, don't chain commands unconditionally.
+- If you see `PERMISSION_DENIED` from `gcloud builds submit`, that's a different
+  failure and also leaves the registry untouched — same false-positive pattern applies.
+- In shells with `rtk`/tee middleware, a multi-command block can be rerun by index;
+  rerunning just the `update` command without the `build` is the exact recipe for
+  recreating this bug.
+
+## References
+
+- [gcloud builds submit reference](https://cloud.google.com/sdk/gcloud/reference/builds/submit) — note that `--tag` requires a source positional that contains a Dockerfile
+- [Cloud Run deploy from source](https://cloud.google.com/run/docs/deploying-source-code) — the `gcloud run deploy --source .` one-shot avoids this split-command footgun entirely and is worth considering as an alternative workflow
+- Related skill: `docker-buildx-stale-rust-binary` — different failure mode (layer cache staleness within a *successful* build) but shares the "deploy looks fine, code is old" symptom

--- a/.claude/skills/gcs-rust-download-object-api/SKILL.md
+++ b/.claude/skills/gcs-rust-download-object-api/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: gcs-rust-download-object-api
+description: |
+  Fix "DownloadObjectRequest not found" error in google-cloud-storage Rust crate. Use when:
+  (1) Trying to download objects from GCS using the Rust SDK, (2) Looking for a download
+  request type in http::objects::download module, (3) Compile error about missing type.
+  The download_object method uses GetObjectRequest from the get module, not a separate
+  DownloadObjectRequest type.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-27
+---
+
+# GCS Rust SDK Download Object API
+
+## Problem
+When using the `google-cloud-storage` Rust crate to download objects, developers often
+look for a `DownloadObjectRequest` type in the `download` module, expecting it to mirror
+the upload pattern. This type doesn't exist, causing confusing compile errors.
+
+## Context / Trigger Conditions
+- Using `google-cloud-storage` crate in Rust
+- Trying to call `client.download_object()`
+- Error: `unresolved import google_cloud_storage::http::objects::download::DownloadObjectRequest`
+- Looking in `http::objects::download` module for request types
+
+## Solution
+
+The `download_object` method uses `GetObjectRequest` from the `get` module, combined with
+`Range` from the `download` module:
+
+```rust
+use google_cloud_storage::http::objects::{
+    download::Range as DownloadRange,
+    get::GetObjectRequest,
+};
+
+// Download full object
+let data = client.download_object(
+    &GetObjectRequest {
+        bucket: "my-bucket".to_string(),
+        object: "path/to/object".to_string(),
+        ..Default::default()
+    },
+    &DownloadRange::default(),
+).await?;
+
+// Download partial object (bytes 0-1023)
+let partial = client.download_object(
+    &GetObjectRequest {
+        bucket: "my-bucket".to_string(),
+        object: "path/to/object".to_string(),
+        ..Default::default()
+    },
+    &DownloadRange::Bounded(0, 1023),
+).await?;
+```
+
+## Verification
+Code compiles and `download_object` returns `Vec<u8>` with the object contents.
+
+## Example
+
+```rust
+use google_cloud_storage::{
+    client::{Client as GcsClient, ClientConfig},
+    http::objects::{
+        download::Range as DownloadRange,
+        get::GetObjectRequest,
+        upload::{Media, UploadObjectRequest, UploadType},
+    },
+};
+
+async fn download_from_gcs(client: &GcsClient, bucket: &str, key: &str) -> Result<Vec<u8>> {
+    let data = client.download_object(
+        &GetObjectRequest {
+            bucket: bucket.to_string(),
+            object: key.to_string(),
+            ..Default::default()
+        },
+        &DownloadRange::default(),
+    ).await?;
+
+    Ok(data)
+}
+```
+
+## Notes
+- The `Range` type is aliased as `DownloadRange` to avoid conflicts with std::ops::Range
+- `DownloadRange::default()` downloads the entire object
+- For checking if an object exists without downloading, use `get_object` with `GetObjectRequest`
+- The `Media.content_type` field is `Cow<'static, str>`, use `.into()` for string conversion
+
+## References
+- [google-cloud-storage crate docs](https://docs.rs/google-cloud-storage)

--- a/.claude/skills/gcs-s3-compat-acl-rejection/SKILL.md
+++ b/.claude/skills/gcs-s3-compat-acl-rejection/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: gcs-s3-compat-acl-rejection
+description: |
+  Fix S3 "InvalidArgument" errors when using Google Cloud Storage S3-compatible API
+  with ObjectCannedAcl::PublicRead or x-amz-acl headers. Use when: (1) put_object or
+  upload_blob fails with InvalidArgument on GCS, (2) Using aws-sdk-s3 Rust crate with
+  GCS endpoint (storage.googleapis.com), (3) Bucket has uniform bucket-level access enabled
+  (GCS default since 2023), (4) S3 operations work on MinIO/AWS but fail on GCS.
+  GCS rejects per-object ACLs when uniform bucket-level access is enabled.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-21
+---
+
+# GCS S3-Compatible API ACL Rejection
+
+## Problem
+S3 `put_object` calls fail with `InvalidArgument` when targeting Google Cloud Storage
+via its S3-compatible API, despite working correctly with MinIO or AWS S3.
+
+## Context / Trigger Conditions
+- Using `aws-sdk-s3` (Rust) or any S3 SDK with GCS endpoint
+- `AWS_ENDPOINT=https://storage.googleapis.com`
+- Error: `Error { code: "InvalidArgument", message: "Invalid argument." }`
+- Stack trace shows `S3BlobStore::put_temp` or similar S3 put operation
+- The GCS bucket has **uniform bucket-level access** enabled (GCS default)
+
+## Solution
+Remove `ObjectCannedAcl::PublicRead` from put_object calls when using GCS:
+
+```rust
+// BEFORE (fails on GCS with uniform bucket-level access)
+self.client
+    .put_object()
+    .body(body)
+    .bucket(&self.s3_bucket)
+    .key(key)
+    .acl(ObjectCannedAcl::PublicRead)  // This causes InvalidArgument
+    .send()
+    .await?;
+
+// AFTER (works with GCS)
+self.client
+    .put_object()
+    .body(body)
+    .bucket(&self.s3_bucket)
+    .key(key)
+    // Remove .acl() — use bucket-level IAM instead
+    .send()
+    .await?;
+```
+
+For public read access, configure the bucket IAM policy instead:
+```bash
+gsutil iam ch allUsers:objectViewer gs://YOUR_BUCKET
+```
+
+Or disable uniform bucket-level access (not recommended):
+```bash
+gsutil ubla set off gs://YOUR_BUCKET
+```
+
+## Verification
+After removing the `.acl()` call, upload should succeed:
+```bash
+curl -X POST "$PDS_URL/xrpc/com.atproto.repo.uploadBlob" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: video/mp4" \
+  --data-binary @test.mp4
+```
+
+## Notes
+- GCS uniform bucket-level access has been the default since 2023
+- The `copy_object` call in `move_object()` also uses `.acl(PublicRead)` and will fail
+- This affects rsky-pds blob storage: `rsky-pds/src/actor_store/aws/s3.rs` lines 69, 97, 212
+- MinIO doesn't enforce this restriction, so local dev works but production GCS fails
+- The same issue applies to `put_permanent()` and `move_object()` methods

--- a/.claude/skills/git-separate-tangled-changes-into-prs/SKILL.md
+++ b/.claude/skills/git-separate-tangled-changes-into-prs/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: git-separate-tangled-changes-into-prs
+description: |
+  Separate a messy working tree with multiple tangled features into clean,
+  focused PRs. Use when: (1) Working tree has uncommitted changes from
+  multiple features mixed together, (2) Need to create a PR for just one
+  feature from a mixed working tree, (3) "git stash pop" fails with
+  "already exists, no checkout" for untracked files, (4) Pre-commit hooks
+  block commits due to unrelated untracked files with errors, (5) Interface
+  changes in one feature break consumer files from another feature in the
+  same working tree. Covers git stash workflows, branch separation,
+  conflict resolution, and pre-commit hook workarounds. Never stack PRs —
+  always target main.
+author: Claude Code
+version: 1.2.0
+date: 2026-05-05
+---
+
+# Separating Tangled Changes into Clean PRs
+
+## Problem
+A working tree accumulates uncommitted changes from multiple features over
+time. When you need to create focused PRs, the changes are tangled together
+— some files have changes from multiple features, generated files (like
+`.mocks.dart`) reflect all features combined, and pre-commit hooks fail on
+unrelated WIP code.
+
+## Context / Trigger Conditions
+- Working tree has 50+ modified/untracked files spanning multiple features
+- `git diff --name-only` shows files from clearly different features
+- You need to create a PR for Feature A but Feature B's files cause
+  analysis errors
+- Pre-commit hooks run `dart analyze` / `eslint` / etc. on ALL files (not
+  just staged), so untracked WIP files block commits
+- Some files have changes from BOTH features (mixed-change files)
+
+## Solution
+
+### Step 1: Stash Everything Safely
+```bash
+git stash -u -m "descriptive-name-for-safety"
+```
+The `-u` flag includes untracked files. This is your safety net.
+
+### Step 2: Create Clean Feature Branch
+```bash
+git checkout main  # or the appropriate base
+git pull
+git checkout -b feature/clean-branch
+```
+
+### Step 3: Pop Stash and Handle Conflicts
+```bash
+git stash pop
+```
+
+**Common issue**: "already exists, no checkout" — happens when untracked
+files from the stash already exist in the working tree. The tracked file
+changes still apply, but the stash is preserved (not dropped). This is
+safe; the files you need are already there.
+
+**Merge conflicts**: Resolve each one. For files belonging to OTHER
+features, take the base version:
+```bash
+git checkout --theirs path/to/other-feature-file.dart
+```
+
+For files belonging to THIS feature, take the stash version or resolve
+manually.
+
+### Step 4: Handle Mixed-Change Files
+Some files have changes from BOTH features. For these:
+1. Restore to the base version: `git checkout main -- path/to/file.dart`
+2. Re-apply ONLY your feature's changes manually (usually just import
+   changes or a few lines)
+
+### Step 5: Deal with Pre-Commit Hooks That Check All Files
+If your pre-commit hook analyzes ALL files (not just staged), untracked
+WIP files from other features will block your commit.
+
+**Workaround**: Temporarily move problematic untracked files:
+```bash
+mkdir -p /tmp/other-features-backup
+mv lib/unrelated_feature/ /tmp/other-features-backup/
+mv test/unrelated_feature/ /tmp/other-features-backup/
+```
+
+Commit, then restore:
+```bash
+cp -r /tmp/other-features-backup/* .
+```
+
+### Step 6: Regenerate Generated Files
+If the project uses code generation (Mockito, Riverpod, Freezed, etc.),
+restore generated files to base and regenerate:
+```bash
+git checkout main -- **/*.mocks.dart **/*.g.dart
+dart run build_runner build --delete-conflicting-outputs
+```
+
+This ensures generated files only reflect YOUR feature's changes.
+
+### Step 7: Fix Interface Break Cascades
+When Feature A changes an interface (renames a method, changes parameter
+types), consumer files that weren't modified by Feature A will break. The
+analyzer catches these. Fix them before committing.
+
+Common pattern:
+- Provider state changed `CompleteParameters?` to `Map<String, dynamic>`
+- Canvas widget still calls `.colorFilters` on what's now a Map
+- Fix: Update the consumer to use the new interface
+
+### Step 8: Do NOT Stack PRs — Combine Dependent Features Into One PR
+**Never create a PR that targets another PR's branch instead of `main`.**
+Stacked PRs cause real problems in this project: rebases cascade, reviewer
+context fragments, merge order becomes load-bearing, CI runs against the
+wrong base, and "fix on parent" forces a re-review of the child.
+
+**If Feature B depends on Feature A, ship them as ONE combined PR.**
+
+```bash
+# Both features live on a single branch, targeting main
+git checkout main && git pull
+git checkout -b feature-a-and-b
+# ... commit Feature A changes ...
+# ... commit Feature B changes (separate commits are fine) ...
+gh pr create --base main  # one PR, both features
+```
+
+Write the PR description so the two features are clearly delineated —
+separate sections, separate test plans. Reviewers can read it as a single
+unit, and the merge story is one click. This is the default when changes
+are interdependent.
+
+The only time to split is when the features are **truly independent** —
+in which case they each get their own PR targeting `main`, in any order.
+If you find yourself wanting "B based on A," that's the signal to combine
+them, not to stack.
+
+## Verification
+1. `git diff main...HEAD --stat` shows only files for YOUR feature
+2. `dart analyze` (or equivalent) passes
+3. Tests pass
+4. Original stash still exists as safety net (if pop failed partially):
+   `git stash list`
+
+## Example
+Session where model-dedup changes and collaborator/watermark feature
+changes were tangled in 140+ modified files. The model-dedup work was
+**independent** of the collab/watermark feature, so they split cleanly:
+
+1. Stashed everything from `fix/profile-copy-shares-url`
+2. Created `chore/model-deduplication` from main, popped stash
+3. Separated model-dedup files, moved 16 untracked feature files to `/tmp/`
+4. Committed, pushed, created PR #1411 (target: main)
+5. Created `feat/collabs-watermark-inspired-by` from main, popped stash
+6. Fixed 3 interface breaks in video_editor_canvas.dart and
+   video_metadata_preview_thumbnail.dart
+7. Committed, pushed, created PR #1412 (target: main — independent of #1411)
+
+If the two features had been interdependent, they would have shipped as
+**one combined PR** — never stacked.
+
+### Alternative: Cherry-Pick Commits + Selective Stash Apply
+When changes are split between commits AND stash (not just stash), use this
+approach instead:
+
+```bash
+# 1. Create branches from origin/main
+git branch feature-a origin/main
+git branch feature-b origin/main
+
+# 2. Cherry-pick commits to appropriate branches
+git checkout feature-a
+git cherry-pick <commit-hash-for-feature-a>
+
+# 3. Apply stashed files selectively (see gotchas below)
+```
+
+### GOTCHA: Deleted Files in Stash
+`git checkout stash@{0} -- <path>` FAILS for files that were DELETED in the
+stash — they don't exist in the stash tree. Handle deletions separately:
+
+```bash
+# For MODIFIED files — checkout from stash works
+git checkout stash@{0} -- path/to/modified_file.dart
+
+# For DELETED files — must use git rm instead
+git rm path/to/deleted_file.dart
+
+# Check which are deletions vs modifications first:
+git stash show stash@{0} --name-status
+# D = deleted (use git rm), M = modified (use checkout)
+```
+
+### GOTCHA: Mono-Repo Stash Path Prefixes
+When git root is a parent directory but you work in a subdirectory, stash
+paths include the subdirectory prefix:
+
+```bash
+# Working in: /project/mobile/
+# Git root:   /project/
+# Stash shows: mobile/lib/file.dart (NOT lib/file.dart)
+
+# Must run checkout from repo root:
+cd $(git rev-parse --show-toplevel)
+git checkout stash@{0} -- mobile/lib/file.dart
+```
+
+### GOTCHA: Cherry-Pick Produces Empty Commit
+If a commit was already merged to main via a different PR (different hash),
+cherry-pick will produce an empty commit:
+
+```bash
+# "The previous cherry-pick is now empty"
+git cherry-pick --skip  # Skip it, it's already on main
+```
+
+### GOTCHA: Pre-Commit Hooks on Cherry-Picked Branches
+When cherry-picking onto branches from `origin/main`, the analyzer may find
+pre-existing errors on main unrelated to your changes. Use `--no-verify`
+only when you've confirmed the errors aren't yours:
+
+```bash
+git commit --no-verify -m "feat: your changes"
+```
+
+### Verify Completeness
+Compare stash contents against all branch diffs:
+```bash
+git stash show stash@{0} --name-only | sort > /tmp/stash_files.txt
+git diff --name-only origin/main..feature-a
+git diff --name-only origin/main..feature-b
+# Every stash file should appear in exactly one branch
+```
+
+## Notes
+- **Always stash with `-u`** to capture untracked files
+- **Never force-drop a stash** until you've verified everything is safe
+- **Mixed-change files are the hardest part** — identify them early by
+  checking which files have changes from multiple features
+- **Pre-commit hooks that check all files** (not just staged) are the
+  biggest blocker. Know your project's hook behavior before starting.
+- **Never stack PRs.** Always target `main`. If features depend on each
+  other, combine them into one bigger PR — see Step 8.
+- The stash is preserved when `pop` fails on untracked files — don't
+  panic, your data is safe

--- a/.claude/skills/gorse-05-config-migration/SKILL.md
+++ b/.claude/skills/gorse-05-config-migration/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: gorse-05-config-migration
+description: |
+  Fix Gorse 0.5.x recommendation engine silently disabled or degraded due to config incompatibility
+  with 0.4. Use when: (1) Gorse 0.5 recommendations are poor/empty despite having data, (2) collaborative
+  filtering appears disabled even though [recommend.collaborative] section exists, (3) migrating Gorse
+  config from 0.4 to 0.5, (4) old config keys like [recommend.popular], [recommend.neighbors],
+  [recommend.online], [recommend.offline] are being used with Gorse 0.5. Critical: type="mf" must be
+  explicitly set in [recommend.collaborative] or CF is silently disabled (default "none").
+author: Claude Code
+version: 1.0.0
+date: 2026-02-28
+---
+
+# Gorse 0.5.x Config Migration from 0.4
+
+## Problem
+
+Gorse 0.5 introduced breaking config changes from 0.4. Old config sections are silently ignored
+(no error, no warning), making it appear that features like collaborative filtering, trending,
+and item neighbors are configured when they're actually disabled.
+
+The most critical issue: `[recommend.collaborative]` defaults to `type = "none"` in 0.5, meaning
+collaborative filtering is **silently disabled** unless you explicitly set `type = "mf"`.
+
+## Context / Trigger Conditions
+
+- Gorse 0.5.x is deployed but recommendations seem random or low quality
+- Collaborative filtering doesn't seem to work despite config having `[recommend.collaborative]`
+- Config has old 0.4 sections: `[recommend.popular]`, `[recommend.neighbors]`, `[recommend.online]`, `[recommend.offline]`
+- Upgrading from Gorse 0.4 to 0.5
+- Gorse master starts successfully but old config features don't take effect
+
+## Solution
+
+### Removed 0.4 Sections (silently ignored in 0.5)
+
+| 0.4 Section | 0.5 Replacement |
+|---|---|
+| `[recommend.popular]` | `[[recommend.non-personalized]]` (TOML array of tables) |
+| `[recommend.neighbors]` | `[[recommend.item-to-item]]` + `[[recommend.user-to-user]]` |
+| `[recommend.online]` (explore/exploit) | `[recommend.ranker]` (FM or LLM-based) |
+| `[recommend.offline]` | `[recommend.ranker]` cache_expire + `[recommend.fallback]` |
+
+### Removed 0.4 Keys (do not exist in 0.5)
+
+- `enable_item_neighbor_index`
+- `enable_user_neighbor_index`
+- `item_neighbor_type`
+- `neighbor_type`
+- `explore_recommend`
+- `popular_window`
+
+### Critical Fix: Enable Collaborative Filtering
+
+```toml
+# 0.4 style (BROKEN in 0.5 — CF silently disabled):
+[recommend.collaborative]
+fit_period = "60m"
+fit_epoch = 100
+
+# 0.5 style (WORKING — must add type = "mf"):
+[recommend.collaborative]
+type = "mf"
+fit_period = "60m"
+fit_epoch = 100
+```
+
+### Complete 0.5 Config Template
+
+```toml
+[recommend]
+cache_size = 100
+cache_expire = "72h"
+context_size = 100
+
+[recommend.data_source]
+positive_feedback_types = ["reaction", "comment", "repost"]
+read_feedback_types = ["view"]
+positive_feedback_ttl = 0
+item_ttl = 0
+
+# Collaborative filtering — MUST set type = "mf" to enable
+[recommend.collaborative]
+type = "mf"
+fit_period = "60m"
+fit_epoch = 100
+optimize_period = "360m"
+optimize_trials = 10
+
+[recommend.collaborative.early_stopping]
+patience = 10
+
+# Trending/popular — TOML array syntax [[...]] for multiple leaderboards
+[[recommend.non-personalized]]
+name = "trending_weekly"
+score = "count(feedback, .FeedbackType == 'reaction') + count(feedback, .FeedbackType == 'comment') * 2"
+filter = "(now() - item.Timestamp).Hours() < 168"
+
+# Content-based item similarity (requires items to have Labels)
+[[recommend.item-to-item]]
+name = "similar_content"
+type = "tags"         # matches on item Labels
+
+# Collaborative item similarity
+[[recommend.item-to-item]]
+name = "also_liked"
+type = "users"        # users who liked X also liked Y
+
+# User similarity
+[[recommend.user-to-user]]
+name = "similar_users"
+type = "items"        # users who share liked items
+
+# FM ranker blends all candidate sources
+[recommend.ranker]
+type = "fm"           # or "llm" for LLM-based reranking
+recommenders = ["latest", "collaborative", "non-personalized/trending_weekly", "item-to-item/similar_content", "item-to-item/also_liked", "user-to-user/similar_users"]
+fit_period = "60m"
+fit_epoch = 100
+
+[recommend.ranker.early_stopping]
+patience = 10
+
+[recommend.fallback]
+recommenders = ["latest"]
+
+[recommend.replacement]
+enable_replacement = true
+positive_replacement_decay = 0.8
+read_replacement_decay = 0.6
+```
+
+### Key 0.5 Config Differences
+
+1. **`[[recommend.non-personalized]]`** uses Expr language for score/filter functions
+   - Available: `count(feedback, .FeedbackType == 'X')`, `item.Timestamp`, `now()`
+   - Filter: `(now() - item.Timestamp).Hours() < N`
+
+2. **`[[recommend.item-to-item]]`** types: `"tags"` (label similarity), `"users"` (collaborative), `"embedding"`
+
+3. **`[[recommend.user-to-user]]`** types: `"items"` (shared items), `"tags"`, `"embedding"`
+
+4. **`[recommend.ranker]`** types: `"none"`, `"fm"` (factorization machines), `"llm"`
+   - `recommenders` list uses `"category/name"` format to reference specific recommenders
+
+5. **Custom feedback types**: Any string is valid in `positive_feedback_types` (e.g., `"extended_view"`, `"bookmark"`)
+
+## Verification
+
+After updating the config:
+1. Restart Gorse master and check logs for config parse errors
+2. Visit Gorse dashboard (port 8088) — new recommenders should appear
+3. Check `/api/dashboard/config` endpoint to verify config was accepted
+4. After fit_period (default 60m), verify model training runs in worker logs
+
+## Notes
+
+- Gorse 0.5 does NOT warn about unrecognized config keys — they're silently ignored
+- The `[[double.bracket]]` syntax is TOML array of tables — allows multiple entries
+- The `[single.bracket]` syntax is a regular table — only one allowed
+- `[recommend.ranker].recommenders` must reference recommenders by their `"category/name"` path
+- Custom feedback types are supported — Gorse doesn't validate feedback type names
+
+## References
+
+- Gorse 0.5 config template: https://github.com/gorse-io/gorse (master branch config)
+- Gorse documentation: https://gorse.io/docs/config

--- a/.claude/skills/gorse-clickhouse-cloud-incompatible/SKILL.md
+++ b/.claude/skills/gorse-clickhouse-cloud-incompatible/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: gorse-clickhouse-cloud-incompatible
+description: |
+  Fix Gorse recommendation engine failing to connect to ClickHouse Cloud with EOF errors.
+  Use when: (1) Gorse pods crash with "failed to connect data database" and "EOF" error,
+  (2) Using ClickHouse Cloud (*.clickhouse.cloud) as Gorse data store,
+  (3) TLS connection works (verified with openssl) but Gorse still fails,
+  (4) Tried secure=true, different ports (8443, 9440), timeout params without success.
+  The Gorse ClickHouse driver is incompatible with ClickHouse Cloud's native protocol.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-30
+---
+
+# Gorse + ClickHouse Cloud Incompatibility
+
+## Problem
+Gorse recommendation engine fails to connect to ClickHouse Cloud with EOF errors
+during protocol negotiation, even though TLS handshake succeeds.
+
+## Context / Trigger Conditions
+- Gorse master/server pods show CrashLoopBackOff
+- Logs show: `failed to connect data database: EOF` or `transport failed to send a request to ClickHouse: EOF`
+- Using ClickHouse Cloud (*.clickhouse.cloud) as the GORSE_DATA_STORE
+- TLS connection works when tested with openssl s_client
+- Tried various connection parameters without success
+
+## Root Cause
+Despite the `clickhouse://` URL scheme suggesting native protocol, Gorse actually uses the
+**HTTP interface** on port 8123 (not the native protocol on port 9000/9440). ClickHouse Cloud's
+HTTP interface on port 8443 has compatibility issues with Gorse's driver.
+
+Key facts:
+- **Gorse uses ClickHouse HTTP interface (port 8123), NOT native protocol (port 9000)**
+- ClickHouse Cloud port 8443: HTTP/HTTPS protocol
+- ClickHouse Cloud port 9440: Native protocol with TLS
+- Gorse only accepts: `clickhouse://`, `mysql://`, `postgres://`, `mongodb://`
+- Gorse does NOT support `https://` scheme (returns "unsupported data storage backend")
+- Redis is only for cache store, NOT data store
+- If you use port 9000 with in-cluster ClickHouse, you'll get: "Port 9000 is for clickhouse-client program. You must use port 8123 for HTTP."
+
+## Solution Options
+
+### Option 1: Use In-Cluster ClickHouse (Recommended)
+Deploy ClickHouse Operator with an in-cluster instance for Gorse:
+```yaml
+# Standard in-cluster connection works
+GORSE_DATA_STORE: "clickhouse://user:password@clickhouse-host:8123/gorse"
+```
+
+### Option 2: Use Different Database
+Gorse supports MySQL and PostgreSQL as data stores:
+```yaml
+GORSE_DATA_STORE: "mysql://user:password@host:3306/gorse"
+# or
+GORSE_DATA_STORE: "postgres://user:password@host:5432/gorse"
+```
+
+### Option 3: Deploy ClickHouse Proxy
+Set up a proxy (like chproxy) that translates between protocols.
+
+### Option 4: Fallback to Popular Videos
+Keep Gorse disabled and let the API fallback to popularity-based recommendations:
+```json
+{"videos": [...], "source": "popular"}
+```
+
+## Verification
+After choosing a solution, check Gorse master logs:
+```bash
+kubectl logs -l app=gorse-master -n gorse --tail=20
+```
+
+Should show successful connection instead of EOF errors.
+
+## Notes
+- The TLS layer works fine - the issue is at the ClickHouse protocol level
+- This may be fixed in future versions of the clickhouse-go driver
+- In-cluster ClickHouse doesn't have this issue because it uses plain connection on port 8123

--- a/.claude/skills/gorse-runasnonroot-failure/SKILL.md
+++ b/.claude/skills/gorse-runasnonroot-failure/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: gorse-runasnonroot-failure
+description: |
+  Fix Gorse recommendation engine pods crashing with "user: unknown userid 65532" error.
+  Use when: (1) Gorse master/server/worker pods show CrashLoopBackOff or Error status,
+  (2) Logs show "failed to get user directory" with unknown userid, (3) Running gorse
+  containers with runAsNonRoot security context and custom UID. The gorse images call
+  os.UserHomeDir() at startup which requires the UID to exist in /etc/passwd.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# Gorse runAsNonRoot Container Failure
+
+## Problem
+Gorse recommendation engine containers (master, server, worker) crash immediately on
+startup when running with Kubernetes `runAsNonRoot: true` and a custom UID like 65532.
+
+## Context / Trigger Conditions
+- Gorse pods show `CrashLoopBackOff` or `Error` status
+- Pod logs show:
+  ```
+  {"level":"fatal","ts":...,"caller":"model/built_in.go:95","msg":"failed to get user directory","error":"user: unknown userid 65532"}
+  ```
+- Deployment has `securityContext.runAsNonRoot: true` and `runAsUser: 65532`
+- Using official gorse images (`zhenghaoz/gorse-master`, `zhenghaoz/gorse-server`, `zhenghaoz/gorse-worker`)
+
+## Root Cause
+The gorse codebase calls Go's `os.UserHomeDir()` during initialization in `model/built_in.go`.
+This function requires the running UID to have an entry in `/etc/passwd`. When running as
+a non-root user that doesn't exist in the container's passwd file, the lookup fails.
+
+## Solution
+Remove the `runAsNonRoot` and `runAsUser` constraints from the pod security context:
+
+```yaml
+# Before (broken)
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+
+# After (working)
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+```
+
+Apply to all gorse deployments:
+- `deployment-master.yaml`
+- `deployment-server.yaml`
+- `deployment-worker.yaml`
+- `init-db-job.yaml` (if using init job)
+
+## Verification
+After updating the security context:
+1. Delete existing crashing pods: `kubectl delete pods -l app.kubernetes.io/name=gorse -n gorse`
+2. Wait for new pods to start
+3. Check logs: `kubectl logs -l app=gorse-master -n gorse`
+4. Verify master shows connection to data store and cache store
+
+## Notes
+- This is a limitation of the official gorse images, not a Kubernetes issue
+- The gorse project may fix this in future versions by not requiring home directory
+- If security policy requires non-root, you would need to build custom gorse images
+  with proper `/etc/passwd` entries for the desired UID
+- Redis Stack images used for gorse cache have the same issue with UID 65532
+
+## Related Issues
+- Gorse GitHub: The images don't document this requirement
+- Similar issues affect other Go applications that use `os.UserHomeDir()`

--- a/.claude/skills/gorse-worker-health-probe-fix/SKILL.md
+++ b/.claude/skills/gorse-worker-health-probe-fix/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: gorse-worker-health-probe-fix
+description: |
+  Fix Gorse worker pods stuck in not-ready state due to failing health probes. Use when:
+  (1) gorse-worker pods show 0/1 Ready but Running status, (2) Readiness probe using
+  pgrep fails silently, (3) Worker logs show normal operation but pod never becomes ready,
+  (4) Using zhenghaoz/gorse-worker image. The gorse-worker container is a minimal image
+  without pgrep or ps commands, so exec-based probes using these fail.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-30
+---
+
+# Gorse Worker Health Probe Fix
+
+## Problem
+Gorse worker pods remain in not-ready state (0/1 Ready) even though the worker process
+is running correctly and processing jobs. This breaks HPA scaling and service health.
+
+## Context / Trigger Conditions
+- gorse-worker pods show `0/1 Ready` but `Running` status
+- Worker logs show normal operation: `"msg":"complete ranking recommendation"`
+- Pod never transitions to Ready state
+- Deployment uses exec-based readiness probe with `pgrep -f gorse-worker`
+- Using the official `zhenghaoz/gorse-worker` Docker image
+
+## Root Cause
+The `zhenghaoz/gorse-worker` image is a minimal/distroless image that doesn't include
+common utilities like `pgrep`, `ps`, or `procps`. The exec probe silently fails because
+the command doesn't exist.
+
+```yaml
+# This probe FAILS silently - pgrep doesn't exist in the container
+readinessProbe:
+  exec:
+    command: ["pgrep", "-f", "gorse-worker"]
+```
+
+## Solution
+Replace the pgrep-based probe with a process check using shell built-ins that exist
+in the minimal image:
+
+```yaml
+# Use kill -0 to check if PID 1 (main process) is alive
+livenessProbe:
+  exec:
+    command: ["sh", "-c", "kill -0 1"]
+  initialDelaySeconds: 30
+  periodSeconds: 10
+readinessProbe:
+  exec:
+    command: ["sh", "-c", "kill -0 1"]
+  initialDelaySeconds: 10
+  periodSeconds: 5
+```
+
+The `kill -0 <pid>` command checks if a process exists without sending any signal.
+PID 1 is the main container process (gorse-worker).
+
+## Verification
+After applying the fix:
+
+```bash
+kubectl get pods -n gorse | grep worker
+# Should show 1/1 Ready
+
+kubectl describe pod <worker-pod> -n gorse | grep -A5 "Readiness:"
+# Should show passing readiness checks
+```
+
+## Example
+Kustomize patch to fix worker probes:
+
+```yaml
+patches:
+  - target:
+      kind: Deployment
+      name: gorse-worker
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe
+        value:
+          exec:
+            command: ["sh", "-c", "kill -0 1"]
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe
+        value:
+          exec:
+            command: ["sh", "-c", "kill -0 1"]
+          initialDelaySeconds: 10
+          periodSeconds: 5
+```
+
+## Notes
+- This issue affects only gorse-worker; gorse-master and gorse-server have HTTP endpoints for probes
+- The worker doesn't expose any HTTP endpoints, so exec probes are required
+- Alternative: use TCP probe on the gRPC port if the worker exposes one
+- This pattern applies to any minimal/distroless container without procps utilities

--- a/.claude/skills/hono-subapp-undefined-response-1101/SKILL.md
+++ b/.claude/skills/hono-subapp-undefined-response-1101/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: hono-subapp-undefined-response-1101
+description: |
+  Fix Cloudflare Workers Error 1101 "Worker threw exception" caused by Hono sub-app route
+  handlers returning undefined instead of a Response. Use when: (1) Error 1101 on a specific
+  hostname but not others sharing the same worker, (2) "the Promise did not resolve to
+  'Response'" in wrangler dev logs, (3) Hono sub-app route handler uses bare `return` to
+  skip handling for non-matching hostnames or conditions. The fix is to add `next` parameter
+  and call `return next()` instead of bare `return` in route handlers that conditionally skip.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-27
+---
+
+# Hono Sub-App Route Handler Returns Undefined → CF Error 1101
+
+## Problem
+A Cloudflare Worker using Hono with sub-apps crashes with Error 1101 ("Worker threw
+exception") when a route handler in a sub-app returns `undefined` instead of a `Response`.
+This commonly happens when route handlers have hostname guards that use bare `return` to
+skip processing, intending to let other routes handle the request.
+
+## Context / Trigger Conditions
+- Cloudflare Workers dashboard or browser shows **Error 1101: Worker threw exception**
+- `wrangler dev` logs show: **"Incorrect type for Promise: the Promise did not resolve to 'Response'"**
+- Multiple hostnames route to the same worker (e.g., `names.divine.video` and `names.admin.divine.video`)
+- Hono sub-app has route handlers with conditional hostname checks that use bare `return`
+- The sub-app has middleware that calls `next()` for non-matching hostnames, but the route handlers duplicate the check and return `undefined`
+
+## Root Cause
+In Hono, **route handlers** (`.get()`, `.post()`, etc.) MUST return a `Response`. Only
+**middleware** (registered via `.use()`) can call `next()` to pass control downstream.
+
+However, if a route handler includes `next` in its parameter list (`async (c, next) => {}`),
+Hono treats it as middleware-like, allowing `return next()` to pass control to the next
+matching handler.
+
+A bare `return` (which returns `undefined`) from a route handler causes the Cloudflare
+Workers runtime to throw because it expects a `Response` object.
+
+## Solution
+
+**Bad** — returns `undefined`, crashes the worker:
+```typescript
+app.get('/', async (c) => {
+  if (!ALLOWED_HOSTNAMES.includes(hostname)) {
+    return // undefined! → Error 1101
+  }
+  return c.html(page())
+})
+```
+
+**Good** — accepts `next` parameter and calls it to pass control:
+```typescript
+app.get('/', async (c, next) => {
+  if (!ALLOWED_HOSTNAMES.includes(hostname)) {
+    return next() // passes to next handler in chain
+  }
+  return c.html(page())
+})
+```
+
+Key insight: Adding `next` to the handler signature changes Hono's treatment of the
+handler, allowing it to delegate to downstream routes.
+
+## Verification
+1. Run `wrangler dev` and curl with the non-matching hostname:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:8787/ -H "Host: other.example.com"
+   ```
+2. Should return a valid HTTP status (200, 404, etc.) instead of 500
+3. No "did not resolve to Response" errors in the terminal
+
+## Example
+A worker serves both `names.divine.video` (public UI) and `names.admin.divine.video`
+(admin SPA). The public routes sub-app has a landing page handler that only responds for
+`names.divine.video`. When `names.admin.divine.video` hits this handler, it should pass
+through to the catch-all admin SPA handler. Using bare `return` crashes the worker;
+using `return next()` (with `next` in params) properly delegates.
+
+## Notes
+- This only applies to Hono route handlers, not middleware (`.use()` handlers always have `next`)
+- The error is invisible in Cloudflare's dashboard — you only see generic "Error 1101"
+- `wrangler dev` gives the real error: "the Promise did not resolve to 'Response'"
+- If your sub-app middleware already guards routes, you may not need hostname checks in individual handlers at all — but if you do, use the `next` pattern
+- This pattern is common in multi-tenant workers where one worker handles multiple hostnames

--- a/.claude/skills/http-video-streaming-headers/SKILL.md
+++ b/.claude/skills/http-video-streaming-headers/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: http-video-streaming-headers
+description: |
+  Fix "Failed to load video" errors when network requests succeed (200/206 status).
+  Use when: (1) Video element shows error but DevTools shows successful requests,
+  (2) Videos download correctly via curl but fail in browser, (3) Range requests
+  work but video won't play, (4) Building CDN/media server for video streaming.
+  The root cause is often missing Accept-Ranges header which browsers need for
+  video seeking and streaming.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# HTTP Video Streaming Header Requirements
+
+## Problem
+HTML5 video elements fail to play with "Failed to load video" error even though
+network requests show successful 200/206 responses. The video file downloads
+correctly when tested with curl, but browsers refuse to play it.
+
+## Context / Trigger Conditions
+- Video element fires `onerror` event despite network success
+- DevTools Network tab shows 200 or 206 status for video requests
+- `curl -O <video-url>` downloads a valid MP4 file
+- Video plays locally when downloaded
+- Error message is generic: "Failed to load video" or media error code 4
+
+## Solution
+
+### Required Headers for Video Streaming
+
+1. **`Accept-Ranges: bytes`** (CRITICAL)
+   - Tells browser that range requests are supported
+   - Without this, browsers may not attempt range requests for seeking
+   - Add to ALL video responses, even full (200) responses
+
+2. **`Content-Type: video/mp4`** (or appropriate MIME type)
+   - Must match actual video format
+   - Browser uses this to select decoder
+
+3. **`Content-Length`** (for full responses)
+   - Required for browser to know file size
+   - Enables progress indicators and seeking calculations
+   - Note: For 206 responses, this should be partial content size
+
+4. **For Range Requests (206 Partial Content)**:
+   - `Content-Range: bytes START-END/TOTAL`
+   - Status code MUST be 206, not 200
+
+### Server Implementation
+
+```rust
+// Fastly Compute@Edge example
+resp.set_header("Accept-Ranges", "bytes");
+resp.set_header("Content-Type", "video/mp4");
+
+// For full responses only (not 206):
+if resp.get_status() != StatusCode::PARTIAL_CONTENT {
+    resp.set_header("Content-Length", file_size.to_string());
+}
+```
+
+### CDN Considerations
+
+- Edge caches may strip or modify headers
+- Verify headers reach the client, not just origin
+- Fastly/CloudFront can serve range requests from cached full content
+- Test with `curl -I -H "Range: bytes=0-1023"` to verify 206 response
+
+## Verification
+
+```bash
+# Check Accept-Ranges header
+curl -I https://cdn.example.com/video.mp4 | grep -i accept-ranges
+# Expected: accept-ranges: bytes
+
+# Test range request support
+curl -I -H "Range: bytes=0-1023" https://cdn.example.com/video.mp4
+# Expected: HTTP/2 206 with Content-Range header
+
+# Verify partial download works
+curl -H "Range: bytes=0-100" https://cdn.example.com/video.mp4 | wc -c
+# Expected: 101 (bytes 0-100 inclusive)
+```
+
+## Example
+
+**Before (broken)**:
+```
+HTTP/2 200
+content-type: video/mp4
+x-custom-header: value
+```
+Video fails to load in browser.
+
+**After (working)**:
+```
+HTTP/2 200
+content-type: video/mp4
+content-length: 1443199
+accept-ranges: bytes
+```
+Video plays correctly with seeking support.
+
+## Notes
+
+- Even if your CDN handles range requests automatically, you should still
+  include `Accept-Ranges: bytes` in the response headers
+- Some browsers are more forgiving than others; Safari often requires
+  proper range support while Chrome may work without
+- HTTP/2 responses may have headers lowercased (this is normal)
+- For HLS/DASH streaming, the manifest and segments all need proper headers
+- Mobile browsers are particularly strict about video headers
+
+## References
+- [MDN: Range Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests)
+- [MDN: Accept-Ranges](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges)
+- [HTTP 206 Partial Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206)

--- a/.claude/skills/js-regex-cjk-word-boundary/SKILL.md
+++ b/.claude/skills/js-regex-cjk-word-boundary/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: js-regex-cjk-word-boundary
+description: |
+  Fix JavaScript regex failures when matching CJK (Chinese/Japanese/Korean) text using \b word
+  boundaries. Use when: (1) Regex pattern with \b silently fails to match Japanese, Chinese, or
+  Korean text, (2) Pattern works for Latin/ASCII text but not CJK, (3) hasDriverLicenceCue or
+  similar text-detection function returns false for CJK input despite correct characters,
+  (4) inferIssuerFromTitleText or pattern-matching functions fail on non-Latin scripts.
+  Root cause: JavaScript \b only recognizes [a-zA-Z0-9_] as "word characters" — CJK characters
+  are classified as \W (non-word), so \b before/after CJK always sees a non-word/non-word
+  boundary and fails to match.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-09
+---
+
+# JavaScript Regex: \b Word Boundary Fails with CJK Characters
+
+## Problem
+
+JavaScript's `\b` (word boundary) assertion silently fails when used with CJK
+(Chinese/Japanese/Korean) characters. The regex compiles without error and runs without
+throwing, but it simply never matches CJK text that should match. This is particularly
+insidious because:
+
+1. No error is thrown — the regex just returns `false`
+2. The same pattern works perfectly for Latin/ASCII text
+3. The CJK characters in the pattern are correct (verified by direct string comparison)
+
+## Context / Trigger Conditions
+
+- Regex pattern like `/\b\u904B\u8EE2\u514D\u8A31\u8A3C\b/` (Japanese: 運転免許証) returns `false`
+  on text containing the exact characters
+- Pattern like `/\b\uC6B4\uC804\uBA74\uD5C8\uC99D\b/` (Korean: 운전면허증) fails similarly
+- Text-detection functions (e.g., `hasDriverLicenceCue()`, `inferIssuerFromTitleText()`) return
+  incorrect results for CJK input while working correctly for all Latin-script patterns
+- Any regex using `\b` boundaries around non-ASCII Unicode characters (also affects Cyrillic,
+  Arabic, Thai, etc.)
+
+## Root Cause
+
+JavaScript's `\b` matches the boundary between a "word character" (`\w` = `[a-zA-Z0-9_]`) and
+a "non-word character" (`\W`). CJK characters are classified as `\W` (non-word characters).
+
+When `\b` appears before a CJK character, it looks for a `\w`-to-`\W` or `\W`-to-`\w`
+transition. But if the preceding character is also `\W` (whitespace, punctuation, start of
+string, or another CJK character), the boundary condition is `\W`-to-`\W`, which `\b` does
+NOT match.
+
+```javascript
+// This FAILS — \b doesn't work with CJK
+/\b\u904B\u8EE2\u514D\u8A31\u8A3C\b/.test("運転免許証")  // false!
+
+// This WORKS — no word boundaries
+/\u904B\u8EE2\u514D\u8A31\u8A3C/.test("運転免許証")  // true
+```
+
+## Solution
+
+### Quick Fix: Remove `\b` from CJK patterns
+
+Simply remove `\b` assertions from any regex pattern that matches CJK characters:
+
+```javascript
+// Before (broken):
+[/\b\u904B\u8EE2\u514D\u8A31\u8A3C\b/, "JAPAN"],      // 運転免許証
+[/\b\uC6B4\uC804\uBA74\uD5C8\uC99D\b/, "KOREA"],      // 운전면허증
+
+// After (working):
+[/\u904B\u8EE2\u514D\u8A31\u8A3C/, "JAPAN"],            // 運転免許証
+[/\uC6B4\uC804\uBA74\uD5C8\uC99D/, "KOREA"],           // 운전면허증
+```
+
+### Better Fix: Use Unicode-aware boundaries (if available)
+
+For environments supporting the `v` flag (ES2024+), you can use Unicode property escapes:
+
+```javascript
+// Unicode-aware approach (requires /v flag support):
+/(?<=^|[\s\p{P}])\u904B\u8EE2\u514D\u8A31\u8A3C(?=$|[\s\p{P}])/v
+```
+
+### Alternative: Manual boundary with lookbehind/lookahead
+
+```javascript
+// Manual boundary that works with CJK:
+/(?<!\p{L})\u904B\u8EE2\u514D\u8A31\u8A3C(?!\p{L})/u
+```
+
+### For mixed Latin/CJK pattern arrays
+
+When you have an array of patterns where some are Latin and some are CJK, use `\b` only for
+Latin patterns:
+
+```javascript
+const patterns = [
+  [/\bDRIVER'?S?\s+LICEN[CS]E\b/, "match"],   // Latin — \b works
+  [/\bFÜHRERSCHEIN\b/, "match"],               // Latin+diacritics — \b works (Ü is \W but context helps)
+  [/\u904B\u8EE2\u514D\u8A31\u8A3C/, "match"], // CJK — no \b needed
+  [/\uC6B4\uC804\uBA74\uD5C8\uC99D/, "match"], // CJK — no \b needed
+];
+```
+
+## Verification
+
+```javascript
+// Test that CJK matching works:
+console.log(/\u904B\u8EE2\u514D\u8A31\u8A3C/.test("運転免許証"));  // true
+console.log(/\uC6B4\uC804\uBA74\uD5C8\uC99D/.test("운전면허증"));  // true
+
+// Verify it doesn't false-match substrings you don't want:
+console.log(/\u904B\u8EE2\u514D\u8A31\u8A3C/.test("別の運転免許証テスト"));  // true (substring match is usually fine for CJK)
+```
+
+## Example
+
+Real-world case from a document-type detection function:
+
+```javascript
+function hasDriverLicenceCue(text) {
+  const combined = text.toUpperCase();
+  return (
+    /\bDRIVER'?S?\s+LICEN[CS]E\b/.test(combined) ||   // English
+    /\bFÜHRERSCHEIN\b/.test(combined) ||               // German
+    /\bPERMIS DE CONDUIRE\b/.test(combined) ||          // French
+    /\u904B\u8EE2\u514D\u8A31\u8A3C/.test(combined) || // Japanese (no \b!)
+    /\uC6B4\uC804\uBA74\uD5C8\uC99D/.test(combined)    // Korean (no \b!)
+  );
+}
+```
+
+## Notes
+
+- This affects ALL non-ASCII Unicode scripts, not just CJK: Cyrillic, Arabic, Thai, Devanagari, etc.
+- The `u` (unicode) flag does NOT fix this — `\b` behavior with `\w`/`\W` is unchanged.
+- Removing `\b` from CJK patterns is generally safe because CJK characters are unlikely to
+  appear as substrings within other words in unrelated contexts.
+- The `regexp-cjk` npm package provides CJK-aware regex utilities if you need more sophisticated matching.
+- When debugging: if a regex works for "DRIVER'S LICENCE" but not "運転免許証", suspect `\b` first.
+
+## References
+
+- [MDN: Word boundary assertion \b](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion)
+- [TC39 Issue #1020: Regexp with word boundaries do not match cyrillic string](https://github.com/tc39/ecma262/issues/1020)
+- [Word boundaries in JavaScript's regular expressions with UTF-8 strings](https://breakthebit.org/post/3446894238/word-boundaries-in-javascripts-regular)
+- [regexp-cjk npm package](https://www.npmjs.com/package/regexp-cjk)

--- a/.claude/skills/local-cache-idempotency-fallback/SKILL.md
+++ b/.claude/skills/local-cache-idempotency-fallback/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: local-cache-idempotency-fallback
+description: |
+  Use database cache when external APIs aren't reliably idempotent. Use when:
+  (1) External API claims idempotency but returns different values for same input,
+  (2) Re-running a script creates duplicate resources, (3) Need stable identifiers
+  across runs but external service generates new ones. Pattern: check database cache
+  first, only call external API for genuinely new items, cache the result.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-25
+---
+
+# Local Cache as Idempotency Fallback
+
+## Problem
+
+External APIs that should be idempotent (same input = same output) sometimes aren't.
+This causes problems when re-running scripts:
+- Duplicate resources created
+- Identifiers change between runs
+- State becomes inconsistent across systems
+
+## Context / Trigger Conditions
+
+- Re-running a script creates new resources instead of finding existing ones
+- External API "fixed" idempotency but still returns different values
+- Need stable identifiers (pubkeys, user IDs, resource IDs) across runs
+- Script works once but fails on subsequent runs due to changed IDs
+
+## Solution
+
+Use database cache as the source of truth for idempotency:
+
+```typescript
+// BEFORE: Always calls external API (brittle)
+const { pubkey, token } = await externalApi.createUser(userId, username);
+await db.saveUser({ userId, pubkey, token });
+
+// AFTER: Check cache first (robust)
+const cached = await db.getUser(userId);
+let pubkey: string;
+let token: string;
+
+if (cached) {
+  // Use cached values - stable across runs
+  pubkey = cached.pubkey;
+  token = cached.token;
+  console.log(`Using cached pubkey: ${pubkey}`);
+} else {
+  // Only call external API for genuinely new items
+  const result = await externalApi.createUser(userId, username);
+  pubkey = result.pubkey;
+  token = result.token;
+
+  // Cache immediately for next run
+  await db.saveUser({ userId, pubkey, token });
+  console.log(`Created new pubkey: ${pubkey}`);
+}
+```
+
+### Key Pattern
+
+1. **Check local first**: Always query your database before calling external API
+2. **Use cached values**: If found, use local values even if stale
+3. **Only create when missing**: External API called only for genuinely new items
+4. **Cache immediately**: Save result right after successful API call
+5. **Log the source**: Indicate whether value is "(cached)" or "(new)" for debugging
+
+## Verification
+
+- Re-run script multiple times
+- Same identifier used each time (from cache)
+- No duplicate resources created in external system
+- Script is idempotent regardless of external API behavior
+
+## Example
+
+Real-world application - Keycast account creation:
+
+```typescript
+// Check if we have a cached account first (local DB is source of truth)
+const cached = await db.getImportedUser(creator.user_id);
+let pubkey: string;
+let token: string;
+
+if (cached) {
+  // Use cached account - pubkey is stable
+  pubkey = cached.pubkey;
+  token = cached.token;
+  console.log(`Pubkey: ${pubkey} (cached)`);
+} else {
+  // Create new account via external API
+  const result = await keycast.createPreloadedUser(
+    creator.user_id,
+    username,
+    displayName
+  );
+  pubkey = result.pubkey;
+  token = result.token;
+  console.log(`Pubkey: ${pubkey} (new)`);
+
+  // Cache account in database immediately
+  await db.saveImportedUser({
+    vine_user_id: creator.user_id,
+    username: creator.username,
+    pubkey,
+    token,
+  });
+}
+```
+
+## Notes
+
+- This pattern works even when the external API claims to be idempotent
+- Database schema should use the input identifier as primary key (prevents duplicates)
+- Consider adding timestamps to track when cached values were created
+- For critical systems, add reconciliation logic to detect/fix drift
+- The cache becomes your source of truth - treat it accordingly
+
+## Related Patterns
+
+- **Upsert on conflict**: Use `ON CONFLICT DO UPDATE` to handle race conditions
+- **Soft delete**: Keep old records to track history of changes
+- **Cache invalidation**: Add TTL or manual refresh if external values can legitimately change
+
+## Related Skills
+
+- `stale-cache-external-service-recovery`: What to do when external service loses data and
+  cached identifiers no longer exist (detect 404, delete cache, recreate)

--- a/.claude/skills/macos-tcc-sigkill-missing-usage-description/SKILL.md
+++ b/.claude/skills/macos-tcc-sigkill-missing-usage-description/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: macos-tcc-sigkill-missing-usage-description
+description: |
+  Fix macOS app hard crashes (EXC_CRASH / SIGKILL) caused by accessing TCC-protected
+  APIs without the matching Info.plist usage description key. Use when: (1) App
+  crashes immediately when touching Photos, Contacts, Calendar, Reminders, Location,
+  Microphone, Camera, Screen Recording, etc., (2) Crash report shows
+  `Exception: EXC_CRASH (SIGKILL)` with `Termination namespace: TCC`, (3) Crash
+  stack includes `TCC.__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__`, (4) Termination
+  details contain "This app has crashed because it attempted to access
+  privacy-sensitive data without a usage description", (5) Flutter macOS publish /
+  gallery-save flow crashes on Gal.putVideo, PHPhotoLibrary, CNContactStore, etc.
+  Critical distinction: macOS does NOT return a deny error — it SIGKILLs the
+  process. This skill also covers the NSPhotoLibraryUsageDescription vs
+  NSPhotoLibraryAddUsageDescription distinction that trips many apps.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# macOS TCC SIGKILL: Missing Info.plist Usage Description
+
+## Problem
+
+A macOS app crashes with `EXC_CRASH (SIGKILL)` the instant it calls a
+privacy-protected API. There is no chance to handle the error, no permission
+prompt, no deny response — just immediate process termination by the OS.
+
+The crash is caused by macOS TCC enforcement: if your app links against or
+calls an API that accesses a privacy-protected resource and your Info.plist
+does NOT contain the matching usage-description key, the OS kills the process
+for privacy violation.
+
+## Context / Trigger Conditions
+
+Crash report (`~/Library/Logs/DiagnosticReports/<App>-*.ips`) has all of these:
+
+- `"exception": { "type": "EXC_CRASH", "signal": "SIGKILL" }`
+- `"termination": { "namespace": "TCC", ... }`
+- Termination details string contains: **"This app has crashed because it
+  attempted to access privacy-sensitive data without a usage description"**
+- The crashed thread stack includes `TCC.__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__`
+- Frames below that are usually `TCC.__TCCAccessRequest_block_invoke`,
+  `libxpc.dylib._xpc_connection_reply_callout`, dispatch queue machinery
+
+The termination details string tells you exactly which key is missing — read it.
+
+## The Info.plist Key Map
+
+| Resource | Info.plist key | Entitlement (sandboxed apps) |
+|---|---|---|
+| Camera | `NSCameraUsageDescription` | `com.apple.security.device.camera` |
+| Microphone | `NSMicrophoneUsageDescription` | `com.apple.security.device.audio-input` |
+| Photos (read/write) | `NSPhotoLibraryUsageDescription` | `com.apple.security.personal-information.photos-library` |
+| Photos (add-only) | `NSPhotoLibraryAddUsageDescription` | `com.apple.security.photos.library.add-only` |
+| Contacts | `NSContactsUsageDescription` | `com.apple.security.personal-information.addressbook` |
+| Calendar | `NSCalendarsUsageDescription` | `com.apple.security.personal-information.calendars` |
+| Reminders | `NSRemindersUsageDescription` | `com.apple.security.personal-information.reminders` |
+| Location | `NSLocationUsageDescription` (+ `WhenInUse` / `Always` variants) | `com.apple.security.personal-information.location` |
+| Speech recognition | `NSSpeechRecognitionUsageDescription` | — |
+| Desktop folder | `NSDesktopFolderUsageDescription` | `com.apple.security.files.user-selected.read-only` etc. |
+| Documents folder | `NSDocumentsFolderUsageDescription` | — |
+| Downloads folder | `NSDownloadsFolderUsageDescription` | `com.apple.security.files.downloads.read-write` |
+
+### The Photos trap (critical)
+
+`NSPhotoLibraryAddUsageDescription` is **not** a substitute for
+`NSPhotoLibraryUsageDescription`. They cover different permission scopes:
+
+- **Add-only** (`NSPhotoLibraryAddUsageDescription` + `com.apple.security.photos.library.add-only`):
+  sufficient for APIs that only *save* an asset, like `PHAssetCreationRequest`
+  from a file, or `Gal.putVideo(path)` with no album.
+- **Full access** (`NSPhotoLibraryUsageDescription`):
+  required for any read, any query, any album lookup/creation, and notably for
+  `Gal.putVideo(path, album: 'SomeAlbum')` — because "put into album X" has to
+  read or create the album, which is a library-level operation.
+
+Symptom of getting this wrong: save-without-album works, save-with-album crashes.
+
+## Solution
+
+1. Read the crash report's termination details — it names the exact key.
+2. Add the key to your app's Info.plist:
+   - Flutter macOS: `mobile/macos/Runner/Info.plist`
+   - Native macOS: `<target>/Info.plist` or the target's `INFOPLIST_FILE` build setting
+3. If the app is sandboxed (`com.apple.security.app-sandbox` = true in release),
+   also add the matching entitlement to both
+   `Runner/DebugProfile.entitlements` and `Runner/Release.entitlements`.
+4. Rebuild. Info.plist changes do not hot-reload in Flutter — a full
+   `flutter build macos --debug` is required.
+5. Relaunch the app.
+
+## Example patch
+
+Flutter macOS app crashing on `gal.putVideo(path, album: 'MyAlbum')`:
+
+```xml
+<!-- mobile/macos/Runner/Info.plist -->
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>MyApp needs access to save videos to your Photos library.</string>
+<!-- ADD THIS: -->
+<key>NSPhotoLibraryUsageDescription</key>
+<string>MyApp needs access to your Photos library to organize videos into albums.</string>
+```
+
+Then:
+```bash
+cd mobile
+flutter build macos --debug
+open build/macos/Build/Products/Debug/MyApp.app
+```
+
+## Verification
+
+1. No crash on the action that previously crashed.
+2. macOS shows a permission prompt the first time (if status is `.notDetermined`).
+3. Check the new crash reports directory — no new `.ips` files should appear
+   after the action:
+   ```bash
+   ls -t ~/Library/Logs/DiagnosticReports/<AppName>-*.ips 2>/dev/null | head -3
+   ```
+4. Verify the built .app bundle contains the key (Info.plist is copied in during
+   build, but sanity-check):
+   ```bash
+   grep -A1 NSPhotoLibrary build/macos/Build/Products/Debug/MyApp.app/Contents/Info.plist
+   ```
+5. `log show --last 2m --predicate 'subsystem == "com.apple.TCC"'` should show
+   an authorization grant for the app's bundle ID instead of a crash.
+
+## Diagnosing from the crash report
+
+A fast one-liner to extract the key info from a .ips crash report:
+
+```bash
+python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    f.readline()  # skip header JSON line
+    d = json.loads(f.read())
+print('Signal:', d.get('exception', {}).get('signal'))
+print('Namespace:', d.get('termination', {}).get('namespace'))
+print('Details:', d.get('termination', {}).get('details'))
+" ~/Library/Logs/DiagnosticReports/MyApp-*.ips
+```
+
+If `namespace == 'TCC'` and details mention "usage description", this skill
+applies.
+
+## Notes
+
+- **Why SIGKILL and not a graceful deny?** Apple decided privacy violations
+  are a policy failure of the developer, not a runtime condition to handle.
+  The OS terminates the process so there is no way for an app to "try anyway"
+  or log workarounds. There is no API to catch this.
+- **It applies even to code paths you do not call.** If a linked framework or
+  plugin touches a protected resource on your behalf (e.g. a media plugin that
+  probes Photos on init), you need the usage description even if your own code
+  never touches Photos. This is why the key should be added whenever you
+  include a plugin that *might* access the resource.
+- **Hot reload will not rescue you.** Flutter hot reload and hot restart do
+  not update Info.plist in the running bundle. You must fully rebuild.
+- **iOS vs macOS:** The same keys exist on iOS, but on iOS a missing key
+  usually results in a silent deny rather than SIGKILL on older iOS versions.
+  Recent iOS versions align with macOS and will crash. Either way, always set
+  the key.
+- **The "Add" vs full Photos distinction was tightened in macOS 14/15/26.**
+  Earlier macOS versions let you do some album operations with add-only; recent
+  releases do not. If an app that worked on older macOS starts crashing after
+  a macOS upgrade, check for this first.
+- **Related but different:** `flutter-macos-tcc-responsible-process-camera-denial`
+  covers TCC denying camera access when the responsible process attribution
+  is wrong (no crash, just silent denial). That is a different TCC failure
+  mode than the SIGKILL covered here.
+
+## References
+
+- Apple: [Requesting access to protected resources](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources)
+- Apple: [`NSPhotoLibraryUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsphotolibraryusagedescription)
+- Apple: [`NSPhotoLibraryAddUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsphotolibraryaddusagedescription)
+- Apple Developer Forums search: "TCC privacy violation SIGKILL Info.plist"
+- `log show --predicate 'subsystem == "com.apple.TCC"'` for live TCC decisions.

--- a/.claude/skills/media-kit-macos-codesign-crash/SKILL.md
+++ b/.claude/skills/media-kit-macos-codesign-crash/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: media-kit-macos-codesign-crash
+description: |
+  Fix Flutter macOS app crash at launch due to media_kit library loading failure. Use when:
+  (1) macOS app builds successfully but crashes immediately on launch, (2) Crash log shows
+  "Library not loaded: @rpath/Ass.framework" or similar media_kit framework, (3) Error says
+  "code signature not valid for use in process: Trying to load an unsigned library",
+  (4) Problem appears after flutter clean or fresh clone, (5) Codesign script exists in
+  Podfile but frameworks are still unsigned after build - check build phase ORDER.
+  Fixes unsigned media_kit native frameworks (Ass.framework, Avcodec.framework, etc.)
+  by adding post-build codesigning AND ensuring correct build phase ordering.
+author: Claude Code
+version: 2.0.0
+date: 2026-02-22
+---
+
+# Media Kit macOS Codesign Crash Fix
+
+## Problem
+
+Flutter macOS apps using `media_kit` (video player library) crash immediately at launch after
+a clean build. The app builds successfully but fails to start due to unsigned native frameworks.
+
+## Context / Trigger Conditions
+
+- macOS Flutter app using `media_kit` or `media_kit_video` package
+- App builds without errors: "Built build/macos/Build/Products/Debug/divine.app"
+- App crashes immediately on launch with no UI appearing
+- Crash report or console shows:
+  ```
+  Library not loaded: @rpath/Ass.framework/Versions/A/Ass
+  Reason: code signature in '...' not valid for use in process: Trying to load an unsigned library
+  ```
+- Often occurs after `flutter clean`, `pod deintegrate` + `pod install`, or fresh git clone
+- **CRITICAL**: Can also occur when the codesign script EXISTS but runs in the wrong order
+
+## Root Cause: Build Phase Ordering
+
+The most common cause (especially after `pod deintegrate` + `pod install`) is that the Xcode
+build phases end up in the wrong order:
+
+**WRONG order** (codesign runs before frameworks are copied):
+```
+1. [CP] Check Pods Manifest.lock
+2. Sources
+3. Frameworks
+4. Resources
+5. Bundle Framework
+6. ShellScript (Flutter assemble)
+7. Codesign media_kit frameworks    ← SIGNS NOTHING (frameworks not embedded yet)
+8. [CP] Embed Pods Frameworks       ← copies frameworks into app bundle
+```
+
+**CORRECT order** (embed first, then codesign):
+```
+1. [CP] Check Pods Manifest.lock
+2. Sources
+3. Frameworks
+4. Resources
+5. Bundle Framework
+6. ShellScript (Flutter assemble)
+7. [CP] Embed Pods Frameworks       ← copies frameworks into app bundle
+8. Codesign media_kit frameworks    ← signs the embedded frameworks
+9. FlutterFire upload symbols        ← (if applicable, should be last)
+```
+
+## Solution
+
+### Step 1: Add Codesign Phase via Podfile (if missing)
+
+Add this block inside the `post_install do |installer|` section:
+
+```ruby
+post_install do |installer|
+  # Add script phase to codesign media_kit frameworks (fixes unsigned library crash)
+  installer.pods_project.targets.each do |target|
+    if target.name == 'media_kit_libs_macos_video'
+      target.build_configurations.each do |config|
+        config.build_settings['CODE_SIGN_IDENTITY'] = '-'
+      end
+    end
+  end
+
+  # Also add codesigning to the main project's frameworks
+  main_project = installer.aggregate_targets.first.user_project
+  main_project.targets.each do |target|
+    if target.name == 'Runner'
+      # Check if script phase already exists
+      phase_name = 'Codesign media_kit frameworks'
+      existing_phase = target.shell_script_build_phases.find { |p| p.name == phase_name }
+
+      unless existing_phase
+        phase = target.new_shell_script_build_phase(phase_name)
+        phase.shell_script = <<-SCRIPT
+# Codesign media_kit frameworks with ad-hoc signature
+for framework in "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks"/*.framework; do
+  if [ -d "$framework" ]; then
+    codesign --force --deep --sign - "$framework" 2>/dev/null || true
+  fi
+done
+        SCRIPT
+        phase.shell_path = '/bin/bash'
+      end
+    end
+  end
+  main_project.save
+
+  # ... rest of your existing post_install code ...
+```
+
+### Step 2: Verify Build Phase Ordering (CRITICAL)
+
+The Podfile adds the codesign phase but **cannot guarantee ordering**. After `pod install`,
+check `macos/Runner.xcodeproj/project.pbxproj` for the Runner target's `buildPhases` array.
+
+Search for the `buildPhases` block in the Runner native target section. Ensure this order:
+
+```
+[CP] Embed Pods Frameworks          ← MUST be BEFORE codesign
+Codesign media_kit frameworks       ← MUST be AFTER embed
+FlutterFire: upload symbols         ← SHOULD be last (if present)
+```
+
+If the order is wrong, swap the lines in the `buildPhases` array. Example fix:
+
+```diff
+ buildPhases = (
+     ...
+     3399D490228B24CF009A79C7 /* ShellScript */,
+-    9AD7FD721DF2C6A84F6A1FC3 /* Codesign media_kit frameworks */,
+-    51BD49356784271F7E3B2B6C /* [CP] Embed Pods Frameworks */,
+-    BBC532B406767D40236ED3DB /* FlutterFire: "flutterfire upload-crashlytics-symbols" */,
++    51BD49356784271F7E3B2B6C /* [CP] Embed Pods Frameworks */,
++    9AD7FD721DF2C6A84F6A1FC3 /* Codesign media_kit frameworks */,
++    BBC532B406767D40236ED3DB /* FlutterFire: "flutterfire upload-crashlytics-symbols" */,
+ );
+```
+
+### Step 3: Rebuild
+
+```bash
+flutter clean
+flutter pub get
+cd macos && pod install && cd ..
+flutter run -d macos
+```
+
+### Emergency Quick Fix (Manual Codesign)
+
+If you need the app running NOW before fixing build phases:
+
+```bash
+for fw in build/macos/Build/Products/Debug/<app>.app/Contents/Frameworks/*.framework; do
+  codesign --force --deep --sign - "$fw"
+done
+codesign --force --deep --sign - "build/macos/Build/Products/Debug/<app>.app"
+open "build/macos/Build/Products/Debug/<app>.app"
+```
+
+## Verification
+
+1. Build output should show: "warning: Run script build phase 'Codesign media_kit frameworks' will be run during every build"
+2. App should launch without crash
+3. Verify frameworks are signed: `codesign -v build/macos/.../app.app/Contents/Frameworks/Ass.framework`
+
+## Diagnosing Build Phase Order Issues
+
+If the codesign script exists but frameworks are still unsigned, check ordering:
+
+```bash
+# Check which frameworks are unsigned in the built app
+for fw in build/macos/Build/Products/Debug/<app>.app/Contents/Frameworks/*.framework; do
+  result=$(codesign -v "$fw" 2>&1)
+  if echo "$result" | grep -q "not signed"; then
+    echo "UNSIGNED: $(basename $fw)"
+  fi
+done
+```
+
+If ALL media_kit frameworks (Ass, Avcodec, Avformat, etc.) are unsigned but the codesign
+script exists in the project, it's almost certainly a build phase ordering problem.
+
+## Notes
+
+- This affects debug builds primarily; release builds with proper code signing may not need this
+- The `-` sign identity means ad-hoc signing (no certificate required)
+- Affected frameworks from media_kit include: `Ass.framework`, `Avcodec.framework`,
+  `Avformat.framework`, `Avutil.framework`, `Dav1d.framework`, `Freetype.framework`,
+  `Fribidi.framework`, `Harfbuzz.framework`, `Mbedcrypto.framework`, `Mbedtls.framework`,
+  `Mbedx509.framework`, `Mpv.framework`, `Png16.framework`, `Swresample.framework`,
+  `Swscale.framework`, `Uchardet.framework`, `Xml2.framework`
+- The `|| true` in the script prevents build failures if codesigning fails for any framework
+- Build phase ordering can silently break after `pod deintegrate` + `pod install` cycles
+- The `new_shell_script_build_phase` CocoaPods API appends to the end of build phases, which
+  may be AFTER CocoaPods' own embed phase—but after pod reinstalls, the embed phase can get
+  re-added at the very end, pushing it AFTER your codesign phase
+
+## Related: Duplicate Mpv.framework Warning
+
+If you see ObjC runtime warnings like:
+```
+Class Application is implemented in both .../Mpv.framework/Versions/A/Mpv (0xADDR1) and
+.../Mpv.framework/Versions/A/Mpv (0xADDR2). This may cause spurious casting failures.
+```
+
+This indicates Mpv.framework is loaded twice, often caused by using a git fork of
+`media_kit_video` alongside pub.dev `media_kit_libs_macos_video`. The fork's podspec
+links `-framework Mpv` directly while the libs package also vendors it. This can cause
+mpv config cache corruption and crashes like:
+```
+Assertion failed: (group_index >= 0), function m_config_cache_from_shadow, file m_config_core.c
+```
+
+A clean build usually resolves this. If persistent, consider switching to the released
+version of media_kit_video.
+
+## References
+
+- media_kit GitHub: https://github.com/media-kit/media-kit
+- Apple Code Signing Guide: https://developer.apple.com/documentation/security/code_signing_services

--- a/.claude/skills/metadata-storage-source-of-truth-desync/SKILL.md
+++ b/.claude/skills/metadata-storage-source-of-truth-desync/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: metadata-storage-source-of-truth-desync
+description: |
+  Fix content serving failures caused by metadata (KV store, database) being out of sync
+  with actual storage (GCS, S3, filesystem). Use when: (1) Content exists in storage but
+  API returns "processing" or "not ready", (2) Webhook callbacks that update metadata
+  failed silently, (3) Backfill scripts generated content but didn't update status records,
+  (4) HLS/transcoded content exists but transcode_status is not "Complete", (5) Handler
+  checks metadata status BEFORE checking if content actually exists in storage.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-27
+---
+
+# Metadata-Storage Source of Truth Desync
+
+## Problem
+When a system has both metadata (KV store, database status field) and actual content
+in object storage, the metadata can become stale. If the serving handler gates on
+metadata status before checking storage, content that exists becomes inaccessible.
+
+Common causes:
+- Webhook callbacks (transcode complete, migration done) failed silently
+- Backfill scripts created content but didn't update metadata
+- Race conditions between metadata write and storage write
+- Manual operations that bypassed the normal status update flow
+
+## Context / Trigger Conditions
+- API returns "processing" or "202 Accepted" for content that actually exists in storage
+- `transcode_status` is Processing/Pending/None but HLS files exist in GCS
+- Content works when accessed directly via storage URL but not through the API
+- Backfill script ran successfully (content in bucket) but metadata wasn't updated
+- Webhook endpoint had downtime or returned errors during batch processing
+
+## Solution
+
+### Pattern: Storage-First with Metadata Auto-Repair
+
+Check storage (source of truth) BEFORE checking metadata status. If content exists,
+serve it and fix metadata as a side effect.
+
+```rust
+// BAD: Metadata-first (blocks access when metadata is stale)
+match metadata.transcode_status {
+    Some(Complete) => { /* serve from storage */ }
+    Some(Processing) => { return 202; }  // Blocks even if content exists!
+    _ => { trigger_transcoding(); return 202; }
+}
+
+// GOOD: Storage-first with auto-repair
+match download_from_storage(&path) {
+    Ok(content) => {
+        // Content exists — serve it and fix metadata if needed
+        if metadata.transcode_status != Some(Complete) {
+            eprintln!("[FIX] {} has content but status was {:?}", id, metadata.transcode_status);
+            update_status(id, Complete);  // Auto-repair
+        }
+        serve(content)
+    }
+    Err(NotFound) => {
+        // Content truly doesn't exist — now check metadata for status
+        match metadata.transcode_status {
+            Some(Processing) => return 202,
+            _ => { trigger_processing(); return 202; }
+        }
+    }
+}
+```
+
+### Key Principles
+
+1. **Storage is the source of truth** — if the file exists, serve it regardless of metadata
+2. **Auto-repair metadata** — when you find a desync, fix it inline (best-effort, don't fail if update fails)
+3. **Log desyncs** — track how often metadata is wrong to find the root cause
+4. **Don't block on metadata** — metadata status should be advisory, not a gate
+
+### Apply to HEAD requests too
+
+HEAD handlers often have the same bug. Apply the same storage-first pattern:
+
+```rust
+// HEAD: Check storage, not just metadata
+match check_storage_exists(&path) {
+    Ok(true) => {
+        if metadata.status != Complete {
+            update_status(id, Complete);
+        }
+        return 200;
+    }
+    Ok(false) | Err(_) => {
+        // Fall back to metadata-based response
+    }
+}
+```
+
+## Verification
+1. Request content that previously returned 202 — should now return 200 with content
+2. Check logs for "[FIX]" messages showing auto-repair in action
+3. After warming traffic, verify metadata has been corrected
+
+## Example
+In Divine Blossom, the HLS handler checked `transcode_status` in KV before GCS:
+- ~57,000 objects in GCS bucket, most with HLS transcodes
+- Many had `transcode_status: None` or `Processing` in KV (webhooks failed during backfill)
+- Handler returned "202 transcoding in progress" for content that was already in GCS
+- Fix: Check GCS first, serve if exists, auto-repair KV metadata as side effect
+
+## Notes
+- The auto-repair is best-effort — if the metadata update fails, don't fail the request
+- This pattern works well with caching layers (CDN, VCL) because the repair only runs
+  on cache misses, and subsequent requests hit the cache
+- Consider running a batch metadata-repair script to fix all desynced records at once,
+  rather than relying solely on on-demand repair
+- Root cause should still be investigated (why did webhooks fail?) to prevent future desyncs

--- a/.claude/skills/microservice-api-endpoint-routing-404/SKILL.md
+++ b/.claude/skills/microservice-api-endpoint-routing-404/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: microservice-api-endpoint-routing-404
+description: |
+  Debug 404 errors for API endpoints in microservice architectures where code exists but
+  routing sends requests to wrong service. Use when: (1) API endpoint returns 404 despite
+  code being deployed, (2) Multiple services share same hostname via HTTPRoute/Ingress,
+  (3) Service logs show "Health server" but you expected API endpoints, (4) Monorepo
+  deploys multiple images and endpoint might be in different service than expected.
+  Covers: verifying which service handles which paths, HTTPRoute path precedence,
+  testing endpoints directly from inside cluster, matching image tags across services.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# Microservice API Endpoint Routing 404 Debugging
+
+## Problem
+API endpoint returns 404 even though the code implementing it has been deployed. This
+commonly happens in microservice architectures where multiple services share the same
+hostname and HTTPRoutes/Ingress rules determine which service handles which paths.
+
+## Context / Trigger Conditions
+- New endpoint returns 404 but code is definitely deployed
+- Multiple services (e.g., relay + api) share the same external hostname
+- Service logs show "Health server listening" or similar health-only messages
+- HTTPRoute or Ingress rules split traffic by path prefix
+- Monorepo builds multiple Docker images from same commit
+
+## Solution
+
+### Step 1: Identify which service actually handles the path
+Check HTTPRoute/Ingress rules to see routing:
+```bash
+kubectl get httproute <name> -n <namespace> -o yaml | grep -A 50 "rules:"
+```
+
+Look for path matching rules and which backend service they point to:
+- `/api/*` might go to `api-service:8080`
+- `/` might go to `websocket-service:7777`
+
+### Step 2: Test the endpoint directly on each service from inside cluster
+```bash
+kubectl run curl-test -n <namespace> --image=curlimages/curl --restart=Never \
+  -- curl -v "http://<service-name>:<port>/<endpoint>" \
+  && sleep 5 \
+  && kubectl logs -n <namespace> curl-test \
+  && kubectl delete pod -n <namespace> curl-test
+```
+
+This bypasses external routing and tests directly against each service.
+
+### Step 3: Check service logs for endpoint registration
+```bash
+kubectl logs -l app=<service-name> -n <namespace> --tail=50 | grep -i -E "(endpoint|route|api|listening)"
+```
+
+Look for messages like:
+- "Health server listening on 0.0.0.0:8080" = health only, no API
+- "API server listening" or "Registered /api/..." = serves API endpoints
+
+### Step 4: For monorepos, check if matching image exists for correct service
+If feature was added to service A but endpoint is served by service B, check if
+service B has the same commit tag:
+```bash
+gcloud artifacts docker images list <registry>/<service-b> --include-tags --limit=10
+```
+
+### Step 5: Deploy the correct service with feature + required env vars
+Update the service that actually handles the endpoint path:
+- New image tag with the feature
+- Any environment variables (API keys, URLs) the feature needs
+- Any secrets referenced by the feature
+
+## Verification
+1. Service logs show endpoint registered: "Recommendations API enabled at /api/users/:pubkey/recommendations"
+2. Direct curl from inside cluster returns 200
+3. External request through HTTPRoute returns expected data
+
+## Example
+
+Architecture:
+```
+Hostname: relay.example.com
+  /api/* → funnelcake-api:8080 (REST API)
+  /      → funnelcake-relay:7777 (WebSocket)
+```
+
+Problem: `/api/users/x/recommendations` returns 404
+
+Investigation:
+1. HTTPRoute shows `/api/*` → funnelcake-api (not relay)
+2. Direct test to relay:8080 returns 404 (health server only)
+3. Direct test to api:8080 also returns 404 (old image)
+4. Registry shows both api and relay have image tag `3c0696a`
+5. API was running old tag `487178e`
+
+Fix: Deploy funnelcake-api with tag `3c0696a` + GORSE_URL + GORSE_API_KEY env vars
+
+## Notes
+- Services in same namespace can share Kubernetes Secrets
+- Health endpoints (/livez, /readyz) are often on separate port from API
+- HTTPRoute path matching: more specific paths take precedence
+- Always check which service handles which paths before assuming endpoint location

--- a/.claude/skills/mock-call-count-retry-fallback/SKILL.md
+++ b/.claude/skills/mock-call-count-retry-fallback/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: mock-call-count-retry-fallback
+description: |
+  Fix test failures when adding retry/fallback logic causes mock call count mismatches.
+  Use when: (1) Test fails with "Expected: <1>, Actual: <2>" or similar call count errors
+  after adding retry or fallback mechanisms, (2) MissingStubError appears for methods
+  in new fallback code paths, (3) Mockito verify().called(N) assertions fail after
+  behavior changes. Applies to Dart/Flutter with Mockito, but pattern is universal.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Mock Call Count Failures After Adding Retry/Fallback Logic
+
+## Problem
+
+When you add retry logic, fallback mechanisms, or alternative code paths to a service,
+existing tests that verify exact mock method call counts will fail. The tests were
+written for the original behavior and don't account for the new retry/fallback calls.
+
+## Context / Trigger Conditions
+
+- Test fails with: `Expected: <N>, Actual: <M>` where M > N
+- Error message: "Unexpected number of calls"
+- `MissingStubError: 'methodName' No stub was found which matches the arguments`
+- You recently added:
+  - Retry logic (e.g., retry after timeout)
+  - Fallback mechanisms (e.g., try primary server, fall back to secondary)
+  - Alternative code paths (e.g., try REST API, fall back to WebSocket)
+- The failing test uses `verify(...).called(N)` assertions
+
+## Solution
+
+### Step 1: Identify the New Code Paths
+
+Trace through your new retry/fallback logic to understand:
+- How many times the mocked method will now be called
+- What new methods are being called that weren't before
+
+### Step 2: Mock New Dependencies
+
+If your fallback code calls methods that weren't previously mocked:
+
+```dart
+// BEFORE: Only mocked the primary method
+when(mockService.primaryMethod(any)).thenAnswer((_) async => 'result');
+
+// AFTER: Also mock fallback-related methods
+when(mockService.primaryMethod(any)).thenAnswer((_) async => 'result');
+when(mockService.addFallbackServer(any)).thenAnswer((_) async => false);  // Graceful failure
+when(mockService.queryFallback(any)).thenAnswer((_) async => []);
+```
+
+### Step 3: Update Expected Call Counts
+
+```dart
+// BEFORE: Expected single call
+verify(mockService.createSubscription(...)).called(1);
+
+// AFTER: Expected calls = initial + retries
+// Document WHY the count changed
+verify(mockService.createSubscription(...)).called(2);  // initial + retry after fallback
+```
+
+### Step 4: Add Comments Explaining the Count
+
+```dart
+// Verify subscription was created
+// Note: With the indexer fallback logic, createSubscription is called twice:
+// 1. First attempt via main relay batch fetch
+// 2. Retry attempt after indexer fallback fails
+verify(
+  mockService.createSubscription(...),
+).called(2);
+```
+
+## Verification
+
+1. Run the specific test: `flutter test --name "test name"`
+2. Verify the test passes
+3. Verify the service's actual behavior matches the expected retry count
+
+## Example
+
+**Scenario**: Added indexer relay fallback to profile fetching
+
+**Original behavior**:
+- Fetch profile from main relay → 1 subscription created
+
+**New behavior**:
+1. Fetch profile from main relay (subscription #1)
+2. If not found, try indexer relays
+3. If indexers fail, retry main relay (subscription #2)
+4. After 2 failures, mark profile as missing
+
+**Test fix**:
+
+```dart
+test('should force refresh profile with forceRefresh parameter', () async {
+  // Setup mock subscription manager
+  when(
+    mockSubscriptionManager.createSubscription(...),
+  ).thenAnswer((_) async => 'sub_123');
+
+  // Mock addRelay to return false (indexer relays not available)
+  // This prevents MissingStubError and simulates unavailable indexers
+  when(mockNostrService.addRelay(any)).thenAnswer((_) async => false);
+
+  // ... test setup ...
+
+  await service.fetchProfile(pubkey, forceRefresh: true);
+
+  // Expect 2 calls: initial attempt + retry after indexer fallback
+  verify(
+    mockSubscriptionManager.createSubscription(...),
+  ).called(2);
+});
+```
+
+## Notes
+
+- **Don't just change the number**: Always understand WHY the count changed
+- **Mock fallback paths to fail gracefully**: Return false/empty instead of throwing
+- **Consider test isolation**: Some tests may need different mock setups for different scenarios
+- **Document behavior changes**: Future maintainers need to understand the expected flow
+- **This pattern applies universally**: Java Mockito, Python unittest.mock, Jest, etc.
+
+## Related Patterns
+
+- When adding caching: methods may be called 0 times on cache hit
+- When adding circuit breakers: methods may be called fewer times on open circuit
+- When adding rate limiting: methods may be delayed or batched
+
+## References
+
+- [Mockito Dart - Verifying Interactions](https://pub.dev/packages/mockito#verifying-interactions)
+- [Flutter Testing - Mocking](https://docs.flutter.dev/testing/overview#mock-dependencies-using-mockito)

--- a/.claude/skills/mockito-stale-mock-silent-trycatch-failure/SKILL.md
+++ b/.claude/skills/mockito-stale-mock-silent-trycatch-failure/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mockito-stale-mock-silent-trycatch-failure
+description: |
+  Fix misleading Flutter/Dart test failures where expected data is empty ([]) or
+  default values instead of the mocked response, caused by stale Mockito generated
+  mocks or missing stubs being silently swallowed by try/catch in provider/repository
+  code. Use when: (1) Test expects non-empty data but gets [], (2) Mock stubs for a
+  method are set up but the code under test returns fallback/empty results, (3) A PR
+  added new methods to a service class and tests that previously passed now fail with
+  misleading "expected X, actual: empty" assertions, (4) "Generated files are out of
+  date" CI error alongside test failures. The root cause is MissingStubError thrown by
+  unstubbed mock methods, caught by production try/catch blocks, causing silent fallback
+  to empty state.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-17
+---
+
+# Mockito Stale Mock + Silent Try/Catch Test Failures
+
+## Problem
+When a PR adds new methods to a service class (e.g., `AnalyticsApiService`), and those
+methods are called from existing code paths that are wrapped in try/catch blocks, tests
+fail with misleading symptoms. The test assertion shows `Expected: non-empty, Actual: []`
+or `Expected: true, Actual: false` — but the actual root cause is a `MissingStubError`
+being silently caught.
+
+## Context / Trigger Conditions
+
+- **Symptom**: Test expects data (non-empty list, specific values) but gets empty/default
+- **No obvious error**: No `MissingStubError` in test output because production code catches it
+- **PR context**: The PR added new methods to a `@GenerateMocks`-annotated service class
+- **CI also shows**: "Generated files are out of date" (stale `.g.dart` / `.mocks.dart`)
+- **Existing tests were passing** before the PR's changes
+
+### The Failure Chain
+
+```
+1. PR adds method `getBulkVideoViews()` to AnalyticsApiService
+2. PR adds `_enrichVideosWithBulkStats()` to HomeFeedProvider.build()
+3. _enrichVideosWithBulkStats calls getBulkVideoViews (new method)
+4. Generated mock is stale — doesn't have getBulkVideoViews at all
+5. Even if regenerated, test setUp doesn't stub getBulkVideoViews
+6. Mock throws MissingStubError when unstubbed method is called
+7. Provider's try/catch catches ALL exceptions (including MissingStubError)
+8. Provider falls back to empty state → test sees [] instead of expected data
+```
+
+## Solution
+
+### Step 1: Regenerate mocks
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+This updates all `.g.dart` and `.mocks.dart` files to include new methods.
+
+### Step 2: Identify new method calls in modified code paths
+
+Trace the code path from the test's entry point. Look for any method calls on mocked
+services that were added or modified by the PR. Pay special attention to methods called
+**after** the already-stubbed method (e.g., enrichment/post-processing steps).
+
+### Step 3: Add stubs for ALL methods in the call chain
+
+```dart
+// In test setUp():
+
+// Existing stub (was already there)
+when(mockService.getHomeFeed(
+  pubkey: anyNamed('pubkey'),
+  limit: anyNamed('limit'),
+)).thenAnswer((_) async => HomeFeedResult(videos: mockVideos));
+
+// NEW stubs needed for enrichment methods added by PR
+when(mockService.getBulkVideoStats(
+  argThat(isA<List<String>>()),  // non-nullable positional param
+)).thenAnswer((_) async => <String, BulkVideoStatsEntry>{});
+
+when(mockService.getBulkVideoViews(
+  argThat(isA<List<String>>()),  // non-nullable positional param
+  maxVideos: anyNamed('maxVideos'),
+  maxConcurrent: anyNamed('maxConcurrent'),
+)).thenAnswer((_) async => <String, int>{});
+```
+
+### Step 4: Handle non-nullable parameters
+
+Mockito's `any` returns `null` which fails for non-nullable params. Use:
+
+- `argThat(isA<List<String>>())` for non-nullable positional params
+- `anyNamed('paramName')` works for named params with default values
+  (but NOT for non-nullable named params without defaults)
+
+## Verification
+
+After fixing:
+1. Run the specific test file: `flutter test test/path/to/test.dart`
+2. Confirm previously failing assertions now pass
+3. Run full test suite to check for no regressions
+
+## Example
+
+**Before (failing)**:
+```
+Expected: non-empty
+  Actual: []
+
+  test/providers/home_feed_loading_fix_test.dart 253:9
+```
+
+**Root cause**: `_enrichVideosWithBulkStats` called `getBulkVideoStats` (unstubbed) →
+`MissingStubError` → caught by provider try/catch → empty fallback state.
+
+**Fix**: Added stubs in `setUp()` for `getBulkVideoStats` and `getBulkVideoViews`.
+
+**After (passing)**: All 11 tests pass, including the 2 that were failing.
+
+## Notes
+
+- **Always regenerate mocks when a PR modifies `@GenerateMocks`-annotated classes**.
+  The `.mocks.dart` files must match the current interface.
+- **Check the full call chain**, not just the primary method. A `getHomeFeed` stub is
+  useless if the provider then calls `enrichVideos` which calls 2 more unstubbed methods.
+- **This pattern is invisible in test output**. The `MissingStubError` is caught by
+  production error handling. You'll never see it unless you add temporary `print`
+  statements inside the catch block or use `@GenerateNiceMocks` (which returns defaults
+  instead of throwing, potentially masking different bugs).
+- **Non-nullable params in Dart null-safety**: Mockito `any` returns `null` at the type
+  level. For non-nullable positional params, use `argThat(isA<Type>())` which returns a
+  properly typed matcher.
+
+## References
+
+- [Mockito Dart - Null Safety](https://pub.dev/packages/mockito#null-safety)
+- [build_runner documentation](https://pub.dev/packages/build_runner)

--- a/.claude/skills/montecarlo-subgroup-prediction/SKILL.md
+++ b/.claude/skills/montecarlo-subgroup-prediction/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: montecarlo-subgroup-prediction
+description: |
+  Fix Monte Carlo project completion simulations that give identical dates for all
+  sub-groups (milestones, priorities, epics). Use when: (1) All sub-group predictions
+  converge to the same date despite different remaining counts, (2) Proportional
+  throughput scaling produces flat/identical results, (3) Applying overall scope rate
+  to individual sub-groups causes simulations to hit max_weeks cap and never converge,
+  (4) Building project forecasting tools that predict completion for sub-groups of
+  a larger backlog. Covers hypergeometric draw model for milestones and cumulative
+  priority model for sequential priorities.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-16
+---
+
+# Monte Carlo Sub-Group Prediction Scaling
+
+## Problem
+
+When running Monte Carlo simulations for project completion, predicting dates for
+sub-groups (milestones, priorities, epics) within a larger project produces identical
+results for all groups, or simulations diverge and hit the max_weeks cap.
+
+## Context / Trigger Conditions
+
+- Building a project forecasting tool that predicts dates for individual milestones
+  or priority groups within a larger project backlog
+- All sub-group predictions show the same date despite very different remaining counts
+  (e.g., 5-item milestone shows same date as 46-item milestone)
+- Simulations hit max_weeks (104) and produce dates 2+ years in the future
+- Scope rate applied per-group causes negative net velocity (items grow each week)
+
+## Root Causes
+
+### 1. Proportional Scaling is Mathematically Constant
+
+If you scale throughput proportionally:
+```
+share = remaining_i / total_remaining
+scaled_throughput = overall_throughput * share
+weeks = remaining_i / scaled_throughput
+      = remaining_i / (overall_throughput * remaining_i / total_remaining)
+      = total_remaining / overall_throughput  # CONSTANT for all groups!
+```
+
+Every sub-group predicts the same number of weeks regardless of size.
+
+### 2. Overall Scope Rate Overwhelms Sub-Group Throughput
+
+If the project's overall scope rate is 50 items/week and you apply it to a sub-group
+with only 5 remaining items (share = 1.6%), the scaled throughput might be ~0.6/week
+while scaled scope is ~0.8/week. Net velocity is negative — the simulation never
+converges and hits max_weeks.
+
+### 3. GitHub `created_at` ≠ "Added to Board"
+
+Scope rate calculated from `created_at` dates reflects when GitHub issues were created,
+not when they were added to the project board. Bulk triaging or importing old issues
+inflates the apparent scope rate dramatically.
+
+## Solution
+
+Use **different simulation models** for different sub-group types:
+
+### For Sequential Priorities (P0, P1, P2...): Cumulative Model
+
+Higher priorities are completed first. Each priority's prediction includes all
+higher-priority work that must finish before it:
+
+```python
+sorted_priorities = sorted(priorities, key=lambda p: p["name"])
+cumulative_before = 0
+
+for p in sorted_priorities:
+    effective_remaining = cumulative_before + p["remaining"]
+    result = simulate(
+        remaining=effective_remaining,
+        throughput_history=full_project_throughput,  # NOT scaled
+        scope_rate=0.0,  # Don't apply scope per-group
+    )
+    result.remaining = p["remaining"]  # Show actual remaining
+    cumulative_before += p["remaining"]
+```
+
+### For Milestones/Epics: Hypergeometric Draw Model
+
+Items from each milestone are randomly drawn from the overall work pool. Smaller
+milestones finish earlier due to higher variance:
+
+```python
+for i in range(n_simulations):
+    subset_left = remaining
+    pool_left = total_remaining
+    weeks = 0
+    while subset_left > 0 and weeks < max_weeks:
+        throughput = rng.choice(throughput_samples)
+        draw_size = min(throughput, pool_left)
+        if draw_size > 0 and pool_left > 0:
+            other = pool_left - subset_left
+            # How many completed items come from this milestone?
+            drawn = rng.hypergeometric(subset_left, max(other, 0), draw_size)
+            subset_left -= drawn
+            pool_left -= draw_size
+            pool_left = max(pool_left, subset_left)
+        weeks += 1
+```
+
+### Key Principles
+
+1. **Don't scale throughput proportionally** — it produces identical results
+2. **Don't apply overall scope rate to sub-groups** — it causes divergence
+3. **Use the full project throughput** for priority predictions (cumulative model)
+4. **Use hypergeometric sampling** for milestone predictions (discrete draws)
+5. **Show scope rate as informational** rather than baking it into per-group MC
+
+## Verification
+
+- Sub-groups with fewer remaining items should predict earlier dates
+- Smaller sub-groups should have wider confidence intervals (more variance)
+- No predictions should hit the max_weeks cap under normal conditions
+- Priority predictions should be ordered (P0 < P1 < P2 < P3)
+
+## Example
+
+With throughput of [2, 29, 44, 34, 11, 24, 33, 54, 34, 101, 57, 81, 0] and
+303 total remaining items:
+
+**Before fix (proportional scaling):**
+```
+MVP Rel 1 (5 left):   Apr 13    # All identical!
+MVP Rel 2 (46 left):  Apr 13
+Release 3 (33 left):  Apr 13
+```
+
+**After fix (hypergeometric draws):**
+```
+MVP Rel 1 (5 left):   Apr 6     # Differentiated by size
+MVP Rel 2 (46 left):  Apr 13
+Release 3 (33 left):  Apr 13
+Zap Store (10 left):  Apr 13
+```
+
+## Notes
+
+- The continuous proportional model (`subset_throughput = throughput * share`)
+  is mathematically equivalent to "everything finishes when the project finishes"
+  because the differential equation d(subset)/dt = -T*(subset/pool) preserves ratios
+- The hypergeometric distribution is the correct statistical model for "drawing
+  without replacement from a mixed pool"
+- For very small sub-groups (< 5 items), the hypergeometric model produces high
+  variance — this is correct and reflects genuine uncertainty
+- Consider capping scope_rate at `min(scope_rate, throughput * 0.5)` if using it,
+  to prevent divergent simulations

--- a/.claude/skills/multi-cluster-api-data-mismatch/SKILL.md
+++ b/.claude/skills/multi-cluster-api-data-mismatch/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: multi-cluster-api-data-mismatch
+description: |
+  Debug "API returns data that doesn't exist in database" when multiple Kubernetes
+  clusters exist (production, staging, POC). Use when: (1) REST API returns records
+  that direct database queries can't find, (2) Data counts match approximately but
+  specific records don't overlap, (3) kubectl context points to a different cluster
+  than the one serving the public domain, (4) ClickHouse/Postgres queries return
+  stale or different data than the API, (5) "completely different datasets" despite
+  same table names and schemas. Root cause: querying the wrong cluster's database.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-02
+---
+
+# Multi-Cluster API Data Mismatch
+
+## Problem
+When investigating why an API returns data that doesn't match direct database queries,
+the root cause may be that your kubectl context points to a different cluster (e.g., POC)
+than the one actually serving the public API (e.g., production). Both clusters have the
+same schemas and similar data volumes, making the mismatch non-obvious.
+
+## Context / Trigger Conditions
+- API returns records that direct database queries (`kubectl exec ... clickhouse-client`)
+  can't find
+- Data counts are similar (e.g., both have ~20k records) but specific records differ
+- You're debugging a data pipeline that "should work" but labels/counts never update
+- Multiple kubectl contexts exist (production, staging, POC, test)
+- The API response header shows `server: nginx` but no ingress exists in the current
+  cluster's namespace
+
+## Solution
+
+### Step 1: Verify which cluster serves the domain
+```bash
+# Check DNS for the public API domain
+dig relay.divine.video +short
+# → 34.58.27.79
+
+# Check your current cluster's gateway/ingress IP
+kubectl get gateway -A  # or kubectl get ingress -A
+# → 35.184.10.63  (different IP = different cluster!)
+```
+
+### Step 2: Check all available contexts
+```bash
+kubectl config get-contexts
+# Look for production vs staging vs POC contexts
+```
+
+### Step 3: Switch to the correct cluster
+```bash
+kubectl config use-context <production-context-name>
+```
+
+### Step 4: Verify the database connection
+```bash
+# Check what database the API actually connects to
+kubectl get secret -n <namespace> <db-credentials> -o jsonpath='{.data.DATABASE_URL}' | base64 -d
+# Production might use managed services (ClickHouse Cloud, Cloud SQL)
+# POC might use in-cluster pods
+```
+
+### Step 5: Also check for ExternalSecrets when updating secrets
+If secrets are managed by ExternalSecrets operator:
+```bash
+# Check if ExternalSecrets manages the secret
+kubectl get externalsecret -n <namespace>
+
+# If yes, update the SOURCE (e.g., GCP Secret Manager), not the k8s secret
+gcloud secrets versions add <secret-name> --project=<project> --data-file=-
+
+# Force sync after updating
+kubectl annotate externalsecret <name> -n <namespace> force-sync=$(date +%s) --overwrite
+
+# Verify the k8s secret updated
+kubectl get secret <name> -n <namespace> -o jsonpath='{.data.<key>}' | base64 -d
+```
+
+## Verification
+After switching to the correct cluster:
+1. Re-run the same database query — the "missing" records should now appear
+2. The latest timestamp in the database should match recent API activity
+3. `kubectl get pods -n <namespace>` should show the same pods the API logs reference
+
+## Key Indicators You're On the Wrong Cluster
+
+| Symptom | Explanation |
+|---------|-------------|
+| API video count ~21k, DB count ~20k | Similar but not identical = different datasets |
+| Latest DB record is days old | API is receiving writes on a different cluster |
+| No ingress/gateway routes match the public domain | Traffic routes elsewhere |
+| Managed DB URL (e.g., ClickHouse Cloud) vs in-cluster pod | Production vs POC architecture |
+| API pod logs show only health checks, no real traffic | Real traffic goes to another cluster |
+
+## Example
+```bash
+# You query POC ClickHouse and find 20,371 videos, latest from Feb 26
+# But the API at relay.divine.video returns videos from today
+# The API returns a video with d_tag that doesn't exist in your ClickHouse
+
+# Fix: switch to production
+kubectl config use-context connectgateway_dv-platform-prod_...
+
+# Now query production ClickHouse Cloud
+CH_URL=$(kubectl get secret -n funnelcake funnelcake-clickhouse-credentials \
+  -o jsonpath='{.data.CLICKHOUSE_URL}' | base64 -d)
+# → https://z1hzyismdt.us-central1.gcp.clickhouse.cloud:8443
+# (managed service, not in-cluster pod)
+
+# Query returns 21,221 videos with latest from minutes ago — matches the API
+```
+
+## Notes
+- Production often uses managed database services (ClickHouse Cloud, Cloud SQL)
+  while POC/staging use in-cluster pods — same schemas, different data
+- The similar-but-not-identical record counts are the most misleading symptom
+- Always check `max(created_at)` or `max(indexed_at)` — if it's days old on a
+  live service, you're querying the wrong instance
+- When updating k8s secrets in production, check for ExternalSecrets first —
+  manual `kubectl create secret` will be immediately overwritten by the operator
+  syncing from GCP Secret Manager / AWS Secrets Manager / Vault

--- a/.claude/skills/ndk-batch-event-queries/SKILL.md
+++ b/.claude/skills/ndk-batch-event-queries/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: ndk-batch-event-queries
+description: |
+  Optimize Nostr relay queries using NDK batch fetching. Use when: (1) Checking existence
+  of many events one-by-one is slow, (2) Loop with individual fetchEvents calls causing
+  N+1 query problem, (3) Need to verify multiple addressable events (Kind 30000+) exist.
+  NDK's fetchEvents accepts arrays for tag filters (#d, #p, #e, authors), enabling
+  batch queries that reduce hundreds of round-trips to a single request.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-25
+---
+
+# NDK Batch Event Queries
+
+## Problem
+
+When checking if many Nostr events exist (e.g., 300 videos for a user), querying
+one-by-one causes hundreds of sequential relay round-trips, making the operation
+extremely slow (minutes instead of seconds).
+
+## Context / Trigger Conditions
+
+- Loop with `await fetchEvents()` inside, checking events individually
+- Processing takes minutes when it should take seconds
+- Checking existence of addressable events (Kind 30000-39999) by d-tag
+- Need to find which items from a list already exist on a relay
+
+## Solution
+
+NDK's `fetchEvents` filter accepts **arrays** for most fields. Instead of:
+
+```typescript
+// SLOW: 300 sequential queries
+for (const id of vineIds) {
+  const exists = await ndk.fetchEvents({
+    kinds: [34236],
+    authors: [pubkey],
+    "#d": [id],  // Single value
+  });
+}
+```
+
+Use a batch query:
+
+```typescript
+// FAST: 1-3 queries (chunked if needed)
+const CHUNK_SIZE = 100;  // Relays may limit query size
+const existingIds = new Set<string>();
+
+for (let i = 0; i < vineIds.length; i += CHUNK_SIZE) {
+  const chunk = vineIds.slice(i, i + CHUNK_SIZE);
+  const events = await ndk.fetchEvents({
+    kinds: [34236],
+    authors: pubkeys,  // Can also be an array
+    "#d": chunk,       // Array of d-tag values
+  });
+
+  for (const event of events) {
+    const dTag = event.tags.find(t => t[0] === "d");
+    if (dTag?.[1]) existingIds.add(dTag[1]);
+  }
+}
+
+// O(1) lookup in processing loop
+for (const id of vineIds) {
+  if (existingIds.has(id)) continue;  // Skip existing
+  // Process new items...
+}
+```
+
+### Key Points
+
+1. **Array filters**: `#d`, `#p`, `#e`, `authors` all accept arrays
+2. **Chunk size**: Use 50-100 items per query to avoid relay limits
+3. **Multiple authors**: Pass array of pubkeys if checking across users
+4. **Extract results**: Parse the d-tag from returned events to build a Set
+
+## Verification
+
+- Processing time drops from minutes to seconds
+- Total relay connections decrease dramatically
+- Same results as individual queries (verified by comparison)
+
+## Example
+
+Real-world application - checking 294 videos across 2 pubkeys:
+
+```typescript
+async videosExistBatch(pubkeys: string[], vineIds: string[]): Promise<Set<string>> {
+  await this.connect();
+  const existingIds = new Set<string>();
+  const CHUNK_SIZE = 100;
+
+  for (let i = 0; i < vineIds.length; i += CHUNK_SIZE) {
+    const chunk = vineIds.slice(i, i + CHUNK_SIZE);
+    const events = await this.ndk.fetchEvents({
+      kinds: [34236],
+      authors: pubkeys,
+      "#d": chunk,
+    });
+
+    for (const event of events) {
+      const dTag = event.tags.find((t) => t[0] === "d");
+      if (dTag && dTag[1]) {
+        existingIds.add(dTag[1]);
+      }
+    }
+  }
+
+  return existingIds;
+}
+```
+
+Usage:
+```typescript
+const vineIds = vines.map(v => v.vine_id);
+const existingVineIds = await relay.videosExistBatch([pubkey, oldPubkey], vineIds);
+console.log(`Found ${existingVineIds.size}/${vineIds.length} already on relay`);
+```
+
+## Notes
+
+- Some relays may have stricter limits on query size; adjust CHUNK_SIZE accordingly
+- The buffered queries feature in NDK can also help with component-level batching
+- For very large sets, consider parallel chunk requests with Promise.all
+- This pattern works for any tag-based lookup, not just #d tags
+
+## References
+
+- [NDK GitHub Repository](https://github.com/nostr-dev-kit/ndk)
+- [NDK Documentation](https://nostr-dev-kit.github.io/ndk/)
+- [Nostr Filter Protocol](https://nostrbook.dev/protocol/filter)

--- a/.claude/skills/ndk-operation-timeout-wrapper/SKILL.md
+++ b/.claude/skills/ndk-operation-timeout-wrapper/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: ndk-operation-timeout-wrapper
+description: |
+  Fix NDK (Nostr Dev Kit) operations hanging indefinitely when relay connections stall.
+  Use when: (1) App freezes during fetchEvents or publish calls, (2) No timeout errors
+  despite network issues, (3) Relay connection appears stuck, (4) Using NDK with unstable
+  or slow relays. NDK operations have no built-in timeout - wrap with Promise.race.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-31
+---
+
+# NDK Operation Timeout Wrapper
+
+## Problem
+NDK (nostr-dev-kit) operations like `fetchEvents()` and `ndkEvent.publish()` have no
+built-in timeout. When relay connections stall or become unresponsive, these operations
+hang indefinitely, causing the application to freeze without any error message.
+
+## Context / Trigger Conditions
+- Application freezes during Nostr operations
+- No timeout error thrown despite minutes of waiting
+- Works sometimes, hangs randomly (relay-dependent)
+- Log shows operation started but never completes
+- Using NDK with multiple relays where some may be unreliable
+
+## Solution
+
+Create a timeout wrapper function:
+
+```typescript
+const NDK_TIMEOUT_MS = 30000; // 30 seconds
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  operation: string
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`${operation} timed out after ${ms}ms`)),
+      ms
+    );
+  });
+
+  try {
+    const result = await Promise.race([promise, timeoutPromise]);
+    clearTimeout(timeoutId!);
+    return result;
+  } catch (error) {
+    clearTimeout(timeoutId!);
+    throw error;
+  }
+}
+```
+
+Wrap all NDK operations:
+
+```typescript
+// Connect with timeout
+await withTimeout(ndk.connect(), NDK_TIMEOUT_MS, "NDK connect");
+
+// Fetch events with timeout
+const events = await withTimeout(
+  ndk.fetchEvents({ kinds: [0], authors: [pubkey] }),
+  NDK_TIMEOUT_MS,
+  "fetch profile"
+);
+
+// Publish with timeout
+const relaySet = NDKRelaySet.fromRelayUrls(relayUrls, ndk);
+await withTimeout(
+  ndkEvent.publish(relaySet),
+  NDK_TIMEOUT_MS,
+  "relay publish"
+);
+```
+
+Also ensure timeout errors are retryable:
+
+```typescript
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    const errorName = error.name.toLowerCase();
+    if (
+      message.includes("timeout") ||
+      message.includes("aborted") ||
+      errorName.includes("timeout") ||
+      errorName.includes("abort")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+```
+
+## Verification
+After implementing, operations that previously hung should now:
+1. Throw a timeout error after the specified duration
+2. Allow retry logic to attempt the operation again
+3. Log the specific operation that timed out
+
+## Example
+
+**Before (hangs forever):**
+```typescript
+const events = await ndk.fetchEvents({ kinds: [34236], "#d": [vineId] });
+```
+
+**After (times out and can retry):**
+```typescript
+const events = await withTimeout(
+  ndk.fetchEvents({ kinds: [34236], "#d": [vineId] }),
+  30000,
+  "check video exists"
+);
+```
+
+## Notes
+- 30 seconds is a reasonable default; adjust based on expected operation duration
+- Consider shorter timeouts for existence checks, longer for batch operations
+- Wrap ALL NDK operations, not just problematic ones (any can hang)
+- This pattern applies to any async library without built-in timeouts
+- For AbortController support (if library supports it), prefer that over Promise.race
+
+## References
+- NDK GitHub: https://github.com/nostr-dev-kit/ndk
+- Promise.race pattern: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race

--- a/.claude/skills/nip46-nostrconnect-url-params/SKILL.md
+++ b/.claude/skills/nip46-nostrconnect-url-params/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: nip46-nostrconnect-url-params
+description: |
+  Fix NIP-46 nostrconnect:// URLs not being recognized by signer apps (Amber, nsec.app, nsecBunker).
+  Use when: (1) QR code or URL paste fails in signer app despite valid-looking URL, (2) Using
+  metadata JSON object instead of separate query params, (3) Implementing client-initiated NIP-46
+  connections. The NIP-46 spec requires name/url/image as separate query parameters, not a metadata
+  JSON object.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# NIP-46 nostrconnect:// URL Parameter Format
+
+## Problem
+When implementing NIP-46 client-initiated connections (nostrconnect://), signer apps may fail
+to recognize the URL if app metadata is passed as a JSON object instead of separate query
+parameters.
+
+## Context / Trigger Conditions
+- Signer app (Amber, nsec.app, nsecBunker) shows error or fails silently when scanning/pasting URL
+- URL contains `metadata={"name":"...","url":"..."}` format
+- QR code generates successfully but signer doesn't connect
+- Other parameters (relay, secret, perms) appear correct
+
+## Solution
+
+### Wrong (metadata JSON object):
+```
+nostrconnect://<pubkey>?relay=wss://relay.example.com&secret=abc123&metadata={"name":"MyApp","url":"https://myapp.com","icon":"https://myapp.com/icon.png"}&perms=sign_event
+```
+
+### Correct (separate parameters per NIP-46):
+```
+nostrconnect://<pubkey>?relay=wss://relay.example.com&secret=abc123&name=MyApp&url=https://myapp.com&image=https://myapp.com/icon.png&perms=sign_event
+```
+
+### Code fix example (Dart):
+```dart
+// WRONG - Don't bundle in metadata JSON
+if (metadata.isNotEmpty) {
+  final metadataJson = jsonEncode(metadata);
+  params.add('metadata=${Uri.encodeComponent(metadataJson)}');
+}
+
+// CORRECT - Use separate params as specified in NIP-46
+if (appName != null && appName.isNotEmpty) {
+  params.add('name=${Uri.encodeComponent(appName)}');
+}
+if (appUrl != null && appUrl.isNotEmpty) {
+  params.add('url=${Uri.encodeComponent(appUrl)}');
+}
+if (appIcon != null && appIcon.isNotEmpty) {
+  params.add('image=${Uri.encodeComponent(appIcon)}');
+}
+```
+
+## Verification
+1. Generate a nostrconnect:// URL
+2. Verify URL contains `name=`, `url=`, `image=` as separate params (not `metadata=`)
+3. Test with signer app (Amber Android, nsec.app web, or nsecBunker)
+4. Signer should show app name and prompt for approval
+
+## NIP-46 Spec Reference
+
+From NIP-46:
+> Additional information should be passed as query parameters:
+> - `name` (optional) - the name of the _client_ application
+> - `url` (optional) - the canonical url of the _client_ application
+> - `image` (optional) - a small image representing the _client_ application
+
+The spec does NOT mention a `metadata` parameter - each field is a separate query param.
+
+## Notes
+- All query parameter values should be URL-encoded
+- The `relay` parameter can appear multiple times for multiple relays
+- The `secret` parameter is REQUIRED for nostrconnect:// (not optional like bunker://)
+- Some signer apps may be more lenient than others - always follow spec exactly
+- Note the param is `image`, not `icon` (easy to confuse with the metadata field name)
+
+## References
+- [NIP-46 Nostr Remote Signing](https://github.com/nostr-protocol/nips/blob/master/46.md)

--- a/.claude/skills/nip98-url-query-param-mismatch/SKILL.md
+++ b/.claude/skills/nip98-url-query-param-mismatch/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: nip98-url-query-param-mismatch
+description: |
+  Fix NIP-98 HTTP authentication 401 errors caused by URL mismatch between the `u` tag
+  and what the server expects. Use when: (1) NIP-98 auth returns 401 with "URL mismatch" error,
+  (2) Token creation succeeds but server rejects authentication, (3) Server logs show
+  expected vs actual URL difference. CRITICAL: Server implementations vary - some strip
+  query params, some don't. Check the actual error message to determine which behavior applies.
+author: Claude Code
+version: 1.1.0
+date: 2026-02-01
+---
+
+# NIP-98 URL Query Parameter Mismatch
+
+## Problem
+NIP-98 HTTP authentication fails with 401 Unauthorized even though the token is created
+successfully and the signature is valid. The actual cause is a URL mismatch between
+the `u` tag in the signed event and what the server expects.
+
+## Context / Trigger Conditions
+- Server returns 401 Unauthorized for NIP-98 protected endpoints
+- Logs show token creation succeeded (event signed and validated)
+- Error response contains "URL mismatch" with expected vs actual URLs
+- The URLs differ only by query parameters
+
+Example error response:
+```json
+{"error":"Auth failed: URL mismatch: expected .../notifications, got .../notifications?limit=50"}
+```
+
+## Root Cause
+
+**The NIP-98 spec says:**
+> The `u` tag MUST be exactly the same as the absolute request URL (including query parameters).
+
+**But server implementations vary:**
+- Some servers follow the spec strictly (require query params in `u` tag)
+- Some servers normalize URLs by stripping query params before validation
+- You MUST match what your specific server does
+
+## Solution
+
+**Step 1: Add logging to see the actual error**
+```dart
+} else if (response.statusCode == 401) {
+  Log.error(
+    'NIP-98 auth failed (401)\n'
+    'URL: $url\n'
+    'Response: ${response.body}',  // <-- This reveals the actual issue
+    ...
+  );
+}
+```
+
+**Step 2: Check the error message**
+- If error says "expected .../path?params, got .../path" → Include query params
+- If error says "expected .../path, got .../path?params" → Strip query params
+
+**Step 3: Adjust URL normalization accordingly**
+
+For servers that STRIP query params (like Divine Relay):
+```dart
+final uri = Uri.parse(url);
+// Server strips query params before NIP-98 validation
+final normalizedUrl = '${uri.scheme}://${uri.host}${uri.path}';
+```
+
+For servers that REQUIRE query params (per NIP-98 spec):
+```dart
+final uri = Uri.parse(url);
+final normalizedUrl = uri.hasQuery
+    ? '${uri.scheme}://${uri.host}${uri.path}?${uri.query}'
+    : '${uri.scheme}://${uri.host}${uri.path}';
+```
+
+## Verification
+1. After the fix, the URLs in the `u` tag should match what server expects
+2. The 401 error should be replaced by successful authentication (200)
+3. Check logs to confirm URL matching
+
+## Example
+
+**Divine Relay behavior (strips query params):**
+- Request URL: `https://relay.dvines.org/api/users/abc/notifications?limit=50`
+- Server validates against: `https://relay.dvines.org/api/users/abc/notifications`
+- `u` tag must be: `https://relay.dvines.org/api/users/abc/notifications`
+
+## Notes
+- The NIP-98 spec is clear about including query params, but not all servers follow it
+- Always check the actual error response to determine server behavior
+- When in doubt, try both approaches and see which works
+- Consider filing a bug with servers that don't follow the spec
+
+## References
+- [NIP-98 HTTP Auth Specification](https://github.com/nostr-protocol/nips/blob/master/98.md)
+- Spec quote: "The `u` tag MUST be exactly the same as the absolute request URL (including query parameters)"
+- Reality: Server implementations vary, always check actual behavior

--- a/.claude/skills/nostr-addressable-event-d-tag-requirement/SKILL.md
+++ b/.claude/skills/nostr-addressable-event-d-tag-requirement/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: nostr-addressable-event-d-tag-requirement
+description: |
+  Fix duplicate Nostr events (Kind 30000+ parameterized replaceable events) caused by missing d-tag.
+  Use when: (1) Same content appears multiple times on relay for same pubkey, (2) Events aren't
+  being replaced/updated as expected, (3) Publishing NIP-71 video events (Kind 34236) or other
+  addressable events and seeing duplicates. The d-tag is REQUIRED for addressability - without it,
+  each publish creates a new non-replaceable event.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# Nostr Addressable Event d-tag Requirement
+
+## Problem
+When publishing parameterized replaceable events (Kind 30000-39999, including NIP-71 video
+events Kind 34236), events appear as duplicates on the relay instead of replacing each other.
+The same content shows up multiple times for the same user.
+
+## Context / Trigger Conditions
+- Publishing Kind 30000+ events (parameterized replaceable events)
+- Same video/content appears multiple times in user's feed
+- Events have identical pubkey, kind, and content but different event IDs
+- Relay returns multiple events when you expect one
+- Using NIP-71 (Kind 34236) for video events
+- Using NIP-23 (Kind 30023) for long-form content
+- Any addressable event type showing duplicates
+
+## Solution
+
+### Root Cause
+Parameterized replaceable events (Kind 30000-39999) require a `d` tag to be addressable.
+The combination of `pubkey + kind + d-tag value` forms the unique address. Without a `d` tag,
+the relay treats each event as a separate non-replaceable event.
+
+### Fix
+Always include a `d` tag with a unique identifier for the content:
+
+```typescript
+// CORRECT - has d tag, will be replaceable
+const event = {
+  kind: 34236, // NIP-71 video
+  pubkey: userPubkey,
+  content: "Video description",
+  tags: [
+    ["d", videoId],  // REQUIRED for addressability
+    ["title", "My Video"],
+    ["url", "https://..."],
+    // ... other tags
+  ]
+};
+
+// WRONG - missing d tag, creates new event each time
+const badEvent = {
+  kind: 34236,
+  pubkey: userPubkey,
+  content: "Video description",
+  tags: [
+    ["title", "My Video"],  // No d tag!
+    ["url", "https://..."],
+  ]
+};
+```
+
+### For NIP-71 Video Events
+Use the video's unique identifier (vine_id, video_id, etc.) as the d-tag value:
+```typescript
+tags.push(["d", video.id]);
+```
+
+### Cleaning Up Existing Duplicates
+1. Fetch all events for the pubkey: `{ kinds: [34236], authors: [pubkey] }`
+2. Identify events without d-tags (these are the duplicates)
+3. Publish NIP-09 deletion events (Kind 5) referencing the bad event IDs
+4. Republish with proper d-tags
+
+## Verification
+After adding the d-tag:
+1. Publish the same content twice
+2. Query the relay for events with that pubkey+kind
+3. Should return only ONE event (the latest)
+4. Event ID will change but d-tag address remains constant
+
+```javascript
+// Verify no duplicates
+const events = await ndk.fetchEvents({ kinds: [34236], authors: [pubkey] });
+const byDTag = new Map();
+for (const e of events) {
+  const d = e.tags.find(t => t[0] === 'd')?.[1];
+  if (!byDTag.has(d)) byDTag.set(d, []);
+  byDTag.get(d).push(e);
+}
+// Each d-tag value should have exactly 1 event
+for (const [d, evts] of byDTag) {
+  if (evts.length > 1) console.log(`Duplicate: d=${d} has ${evts.length} events`);
+}
+```
+
+## Example
+
+Before fix - events without d-tag create duplicates:
+```
+Event 1: id=abc123, kind=34236, tags=[["title", "My Video"]]
+Event 2: id=def456, kind=34236, tags=[["title", "My Video"]]  // Duplicate!
+```
+
+After fix - events with d-tag replace each other:
+```
+Event 1: id=abc123, kind=34236, tags=[["d", "video-001"], ["title", "My Video"]]
+// Republishing same content...
+Event 2: id=xyz789, kind=34236, tags=[["d", "video-001"], ["title", "My Video Updated"]]
+// Event 1 is replaced, only Event 2 exists
+```
+
+## Notes
+- The d-tag value should be stable across republishes (use content ID, not random)
+- Empty string `["d", ""]` is valid but means only one event of that kind per pubkey
+- Regular replaceable events (Kind 0, 3, 10000-19999) don't need d-tag
+- This applies to ALL parameterized replaceable events, not just videos
+- Frontend caching may show old duplicates even after relay is cleaned - hard refresh
+
+## References
+- [NIP-01: d-tag for parameterized replaceable events](https://github.com/nostr-protocol/nips/blob/master/01.md)
+- [NIP-71: Video Events](https://github.com/nostr-protocol/nips/blob/master/71.md)
+- [NIP-33: Parameterized Replaceable Events](https://github.com/nostr-protocol/nips/blob/master/33.md)

--- a/.claude/skills/nostr-addressable-event-dual-tag-query/SKILL.md
+++ b/.claude/skills/nostr-addressable-event-dual-tag-query/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: nostr-addressable-event-dual-tag-query
+description: |
+  Fix "count shows X but list shows empty" bugs when querying related events (comments, reactions,
+  zaps, reposts) for Nostr addressable events (Kind 30000-39999). Use when: (1) REST API shows
+  engagement count > 0 but WebSocket query returns empty, (2) Comments/reactions exist but app
+  shows "No comments yet" or similar, (3) Working with NIP-22 comments, NIP-25 reactions, or
+  NIP-18 reposts on Kind 34235/34236 video events or other addressable events. Root cause:
+  clients may reference addressable events using either E tag (event ID) or A tag
+  (kind:pubkey:d-tag format), and querying only one tag misses events tagged with the other.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Nostr Addressable Event Dual-Tag Query
+
+## Problem
+
+When querying related events (comments, reactions, reposts, zaps) for Nostr addressable events
+(Kind 30000-39999), the query returns fewer or zero results even though an indexing service
+shows the correct count. This happens because addressable events can be referenced two ways,
+and different clients use different methods.
+
+## Context / Trigger Conditions
+
+Use this skill when:
+- Video/post shows comment count of 5, but comments modal says "No comments yet"
+- REST API (like Funnelcake) returns correct engagement counts, but WebSocket queries return empty
+- Working with NIP-22 comments (Kind 1111) on addressable events
+- Working with NIP-25 reactions (Kind 7) on addressable events
+- Working with NIP-18 reposts (Kind 6/16) on addressable events
+- Any feature querying events that reference Kind 30000-39999 events
+
+## Root Cause
+
+For addressable events (Kind 30000-39999, like Kind 34236 videos), related events can reference
+the target using either:
+
+1. **E tag**: References by event ID (64-character hex)
+   ```json
+   ["E", "abc123...def456", "", "author-pubkey"]
+   ```
+
+2. **A tag**: References by addressable identifier (`kind:pubkey:d-tag`)
+   ```json
+   ["A", "34236:abc123...def456:my-video-id", "", "author-pubkey"]
+   ```
+
+Different Nostr clients and indexers use different conventions:
+- Some always use E tags (event ID-based)
+- Some prefer A tags for addressable events (following NIP-22 strictly)
+- Some use both tags
+
+If your app only queries by one tag type, you'll miss events tagged with the other.
+
+## Solution
+
+### 1. Update Filter Class (if needed)
+
+Ensure your Filter class supports uppercase A tag queries:
+
+```dart
+// In Filter class
+List<String>? uppercaseA;  // Add this field
+
+// In toJson()
+if (uppercaseA != null) {
+  data['#A'] = uppercaseA;
+}
+```
+
+### 2. Query by BOTH Tags
+
+When loading related events, run two parallel queries and merge results:
+
+```dart
+Future<List<Event>> loadRelatedEvents({
+  required String eventId,
+  required String? addressableId,  // Format: "kind:pubkey:d-tag"
+}) async {
+  // Query by E tag (event ID)
+  final filterByE = Filter(
+    kinds: [targetKind],
+    uppercaseE: [eventId],
+  );
+
+  // If addressable ID available, also query by A tag
+  if (addressableId != null && addressableId.isNotEmpty) {
+    final filterByA = Filter(
+      kinds: [targetKind],
+      uppercaseA: [addressableId],
+    );
+
+    // Run both queries in parallel
+    final results = await Future.wait([
+      nostrClient.queryEvents([filterByE]),
+      nostrClient.queryEvents([filterByA]),
+    ]);
+
+    // Merge and deduplicate by event ID
+    final eventMap = <String, Event>{};
+    for (final event in results[0]) {
+      eventMap[event.id] = event;
+    }
+    for (final event in results[1]) {
+      eventMap[event.id] = event;
+    }
+
+    return eventMap.values.toList();
+  }
+
+  return nostrClient.queryEvents([filterByE]);
+}
+```
+
+### 3. Post with BOTH Tags
+
+When creating related events, include both E and A tags for maximum compatibility:
+
+```dart
+final tags = <List<String>>[
+  // Always include E tag
+  ['E', rootEventId, '', authorPubkey],
+
+  // Include A tag for addressable events
+  if (rootAddressableId != null && rootAddressableId.isNotEmpty)
+    ['A', rootAddressableId, '', authorPubkey],
+
+  // ... other tags
+];
+```
+
+### 4. Build Addressable ID
+
+Construct the addressable identifier from event metadata:
+
+```dart
+String? get addressableId {
+  if (dTag == null) return null;
+  return '$kind:$pubkey:$dTag';  // e.g., "34236:abc123...:my-video-id"
+}
+```
+
+## Verification
+
+After implementing:
+1. Find an event where REST API shows count > 0 but your app showed empty
+2. Verify the list now shows the expected items
+3. Post a new related event (comment/reaction)
+4. Verify it appears when querying by either E or A tag
+
+## Example
+
+Before fix - only queries by E tag:
+```dart
+final filter = Filter(
+  kinds: [1111],  // Comments
+  uppercaseE: [videoEventId],  // Only E tag!
+);
+// Returns 0 comments even though 5 exist (tagged with A)
+```
+
+After fix - queries both tags:
+```dart
+final filterByE = Filter(kinds: [1111], uppercaseE: [videoEventId]);
+final filterByA = Filter(kinds: [1111], uppercaseA: [addressableId]);
+
+final results = await Future.wait([
+  client.queryEvents([filterByE]),
+  client.queryEvents([filterByA]),
+]);
+// Returns all 5 comments regardless of how they were tagged
+```
+
+## Notes
+
+- This pattern applies to ANY feature that queries events referencing addressable events
+- The d-tag may contain colons, so parse addressable IDs carefully: `parts.sublist(2).join(':')`
+- For count queries (NIP-45), take the maximum of both counts (may over-count if events have both tags)
+- Some relays may not support `#A` filter queries yet - test with your target relays
+- This is especially important for interoperability between different Nostr clients
+
+## Affected NIPs
+
+- NIP-22: Comments (Kind 1111) - uses E/A tags for root scope
+- NIP-25: Reactions (Kind 7) - references target event
+- NIP-18: Reposts (Kind 6/16) - references reposted event
+- NIP-33: Parameterized Replaceable Events (Kind 30000-39999) - defines addressable format
+- NIP-71: Video Events (Kind 34235/34236) - common use case for this pattern
+
+## References
+
+- [NIP-22: Comment](https://github.com/nostr-protocol/nips/blob/master/22.md) - Threading spec with E/A tags
+- [NIP-33: Parameterized Replaceable Events](https://github.com/nostr-protocol/nips/blob/master/33.md) - Addressable event format
+- [Nostr Protocol Spec](https://nostrbook.dev) - General Nostr documentation

--- a/.claude/skills/nostr-replaceable-event-mutation-overwrite/SKILL.md
+++ b/.claude/skills/nostr-replaceable-event-mutation-overwrite/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: nostr-replaceable-event-mutation-overwrite
+description: |
+  Fix silent data loss when mutating Nostr replaceable events (Kind 0 profile, Kind 3 contact/follow
+  list, Kind 10002 relay list, etc.) in client apps. Use when: (1) Following someone wipes the user's
+  entire follow list, (2) Updating profile metadata loses existing fields, (3) Fresh browser session
+  or mobile login causes data loss on first action, (4) Replaceable event mutation uses stale or null
+  cached state. Root cause: Nostr replaceable events are full-replace (no partial update), so
+  publishing based on stale/unloaded cache overwrites the canonical version. Applies to any Nostr
+  client using React, Flutter, or similar reactive frameworks where query state may not be loaded
+  when a mutation fires.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-23
+---
+
+# Nostr Replaceable Event Mutation Overwrite
+
+## Problem
+
+Nostr replaceable events (Kind 0, 3, 10002, etc.) use a full-replace model: publishing a new
+event completely replaces the previous one. If a client publishes a mutation based on stale,
+incomplete, or null cached state, it silently overwrites the canonical version on relays, causing
+data loss. The most common case is follow list (Kind 3) wipes when a user follows someone before
+the client has loaded their existing contact list.
+
+## Context / Trigger Conditions
+
+- User reports "I followed someone and lost all my other follows"
+- Follow/unfollow action on a fresh browser session or mobile login
+- Profile update loses existing metadata fields
+- Relay list update drops existing relays
+- Any mutation on a replaceable event where the UI passes cached state to the mutation function
+- React Query / TanStack Query `data` is `undefined` when mutation fires (query still loading)
+- The mutation function accepts the current event as a parameter from the UI layer
+
+## Solution
+
+### 1. Always Fetch Fresh State Inside the Mutation
+
+Never rely solely on the UI's cached/query state. Fetch the latest version of the replaceable
+event directly from the relay inside the mutation function, before publishing:
+
+```typescript
+// BAD: Relies on UI cache which may be null/stale
+mutationFn: async ({ targetPubkey, currentContactList }) => {
+  const currentTags = currentContactList?.tags || []; // null -> [] -> data loss!
+  // ... publish with only the new follow
+}
+
+// GOOD: Fetches fresh from relay before mutating
+mutationFn: async ({ targetPubkey, currentContactList }) => {
+  let bestContactList = currentContactList;
+
+  try {
+    const relayEvents = await nostr.query([
+      { kinds: [3], authors: [userPubkey], limit: 1 },
+    ], { signal: AbortSignal.timeout(5000) });
+
+    const relayContactList = relayEvents
+      .sort((a, b) => b.created_at - a.created_at)[0] || null;
+
+    if (relayContactList) {
+      // Use whichever has more data to prevent loss
+      const relayCount = relayContactList.tags.filter(t => t[0] === 'p').length;
+      const passedCount = currentContactList?.tags.filter(t => t[0] === 'p').length ?? 0;
+      if (relayCount >= passedCount) {
+        bestContactList = relayContactList;
+      }
+    }
+  } catch {
+    // Fall back to passed contact list
+  }
+
+  if (!bestContactList) {
+    throw new Error('Could not load existing data. Please try again.');
+  }
+
+  // Now mutate bestContactList...
+}
+```
+
+### 2. "Best of Both" Strategy
+
+Compare the relay's version against the UI's cached version and use whichever has MORE data
+(more tags, more fields, etc.). This protects against:
+- Stale relay (UI cache is newer from a recent local action)
+- Stale UI cache (relay has updates from another client)
+- Null UI cache (query hasn't loaded on fresh session)
+
+### 3. Refuse to Publish on Total Failure
+
+If neither the relay fetch nor the UI cache provides data, throw an error instead of
+publishing an empty/minimal replaceable event. A user-friendly error message is always
+better than silent data loss.
+
+### 4. Apply to Both Directions
+
+Apply this pattern to ALL mutation directions (follow AND unfollow, add AND remove relay,
+update AND clear profile fields). The unfollow path is just as dangerous as follow.
+
+## Verification
+
+1. Open the app in a private/incognito browser window
+2. Log in with an account that has multiple follows
+3. Navigate to a profile and tap Follow IMMEDIATELY (before the page fully loads)
+4. Check that the follow count increased by 1 (not reset to 1)
+
+## Example
+
+```typescript
+// Real-world fix from divine-web useFollowUser hook
+export function useFollowUser() {
+  const { nostr } = useNostr();
+
+  return useMutation({
+    mutationFn: async ({ targetPubkey, currentContactList }) => {
+      // Step 1: Fetch fresh from relay
+      let bestContactList = currentContactList;
+      try {
+        const events = await nostr.query([
+          { kinds: [3], authors: [user.pubkey], limit: 1 }
+        ], { signal: AbortSignal.timeout(5000) });
+        const relayList = events.sort((a, b) => b.created_at - a.created_at)[0];
+        if (relayList) {
+          const relayFollows = relayList.tags.filter(t => t[0] === 'p').length;
+          const cachedFollows = currentContactList?.tags.filter(t => t[0] === 'p').length ?? 0;
+          if (relayFollows >= cachedFollows) bestContactList = relayList;
+        }
+      } catch { /* fall back to cached */ }
+
+      // Step 2: Refuse if no data
+      if (!bestContactList) throw new Error('Could not load follow list');
+
+      // Step 3: Mutate safely
+      const tags = [...bestContactList.tags, ['p', targetPubkey]];
+      return publishEvent({ kind: 3, tags, content: bestContactList.content });
+    }
+  });
+}
+```
+
+## Notes
+
+- This pattern applies to ALL Nostr replaceable event kinds: Kind 0 (profile), Kind 3
+  (contacts), Kind 10002 (relay list), Kind 10000 (mute list), Kind 30000+ (addressable)
+- The race condition is most common on mobile browsers where network is slower and users
+  tap quickly
+- Safety check dialogs (like "are you sure?") don't help because they check the same
+  stale cache - the fix must be inside the mutation itself
+- The 5-second timeout on the relay fetch is a reasonable balance between safety and UX
+- Consider also disabling the mutation button while the initial query is loading, as a
+  belt-and-suspenders approach

--- a/.claude/skills/nostr-rest-api-field-mapping-gap/SKILL.md
+++ b/.claude/skills/nostr-rest-api-field-mapping-gap/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: nostr-rest-api-field-mapping-gap
+description: |
+  Fix features broken by REST API responses that flatten Nostr events, losing tag data.
+  Use when: (1) A feature works for WebSocket-loaded events but not REST API-loaded ones,
+  (2) A model field (like sha256, textTrackRef) is null for REST API data but set for
+  WebSocket data, (3) REST API returns denormalized fields (d_tag, video_url) but omits
+  raw tags array, (4) hasSubtitles/hasFeature returns false for REST-loaded videos.
+  Common in Nostr clients that use both REST APIs (for analytics/bulk queries) and
+  WebSocket (for real-time events).
+author: Claude Code
+version: 1.0.0
+date: 2026-02-23
+---
+
+# Nostr REST API Field Mapping Gap
+
+## Problem
+
+Nostr clients that use both REST APIs and WebSocket connections to load events can
+have features that work inconsistently. Features that depend on Nostr tag values
+(like the `x` tag for sha256, or custom tags for text tracks) work when events are
+loaded via WebSocket (which provides the full raw event with all tags), but break
+when the same events are loaded via REST API (which returns flattened/denormalized
+JSON without the raw tags array).
+
+## Context / Trigger Conditions
+
+- A feature works for some videos/events but not others (data source dependent)
+- A UI element (like a CC button) shows for WebSocket-loaded events but not REST ones
+- A model has null fields that should be populated (sha256, textTrackRef, etc.)
+- The REST API response has fields like `d_tag`, `video_url`, `title` but NO `tags` array
+- The `fromJson()` factory parses tags for values like `x` (sha256), but the REST API
+  doesn't include raw tags
+- `hasSubtitles`, `hasFeature`, or similar getters return false for REST API data
+
+## Root Cause
+
+REST APIs that index Nostr events typically:
+1. Extract commonly-used tag values into dedicated columns (d_tag, title, thumbnail, etc.)
+2. Do NOT return the full raw tags array in their response
+3. May have semantically equivalent fields under different names
+
+For example, in a Blossom-based video system:
+- The Nostr `x` tag contains the SHA256 content hash
+- The REST API returns `d_tag` (which for Blossom uploads IS the SHA256) but not `sha256`
+- The model's `fromJson()` tries to find `sha256` from direct field or `x` tag, finds neither
+- Features that depend on `sha256` (like subtitle fetching) break silently
+
+## Solution
+
+### Step 1: Identify the mapping gap
+
+Compare what the REST API returns vs what the model needs:
+
+```bash
+# Fetch a sample REST API response
+curl -s "https://your-api.example.com/api/videos?limit=1" | jq '.[0] | keys'
+```
+
+Check which model fields are null after parsing:
+- Look at the `fromJson()` factory method
+- Identify fields populated from tag parsing (tags array) that won't exist in REST response
+- Check if any REST API fields are semantically equivalent but differently named
+
+### Step 2: Add fallback mappings
+
+In the model's `fromJson()`, add fallback logic AFTER the primary parsing:
+
+```dart
+// Primary: try direct field and tags
+var sha256 = eventData['sha256']?.toString() ?? json['sha256']?.toString();
+
+// Parse from tags if available
+if (eventData['tags'] is List) {
+  // ... tag parsing for 'x' tag ...
+}
+
+// Normalize
+if (sha256 != null && sha256.isEmpty) sha256 = null;
+
+// FALLBACK: Use semantically equivalent field from REST API
+// For Blossom uploads, d_tag IS the content hash (64 hex chars)
+if (sha256 == null && dTag.length == 64 && _isHex(dTag)) {
+  sha256 = dTag;
+}
+```
+
+### Step 3: Validate the fallback is safe
+
+Ensure the fallback only triggers when appropriate:
+- Check format/length (SHA256 = 64 hex chars)
+- Don't override explicitly-set values
+- Handle edge cases (classic imports where d_tag is NOT a hash)
+
+### Step 4: Add tests
+
+```dart
+test('falls back to d_tag as sha256 when d_tag is 64-char hex', () {
+  final json = {
+    'd_tag': 'a04b70820ef370e90aae19d23e46b1482d3af0e7c9d994d1594a1384a62d3972',
+    // No sha256 field, no tags array (REST API response)
+    ...otherFields,
+  };
+  final model = Model.fromJson(json);
+  expect(model.sha256, equals(json['d_tag']));
+});
+
+test('does not use d_tag as sha256 when d_tag is not a hex hash', () {
+  final json = {'d_tag': 'my-video-slug', ...otherFields};
+  final model = Model.fromJson(json);
+  expect(model.sha256, isNull);
+});
+
+test('does not override explicit sha256 with d_tag', () {
+  final json = {
+    'd_tag': 'a04b708...', // 64 hex
+    'sha256': 'explicit-value',
+    ...otherFields,
+  };
+  final model = Model.fromJson(json);
+  expect(model.sha256, equals('explicit-value'));
+});
+```
+
+## Verification
+
+1. Load the app and navigate to a feed that uses the REST API (e.g., trending/discovery)
+2. Verify the feature works (e.g., CC button shows AND subtitles display when toggled)
+3. Also verify WebSocket-loaded events still work (e.g., home feed from followed users)
+4. Check that non-hash d_tags (classic imports, custom slugs) don't get false positives
+
+## Debugging Approach
+
+When a feature works inconsistently across events:
+
+1. **Identify data source**: Is the broken event from REST API or WebSocket?
+2. **Compare raw data**: Fetch the same event from both sources, diff the fields
+3. **Trace the pipeline**: `API response -> fromJson() -> model -> getter -> UI condition`
+4. **Check conditional guards**: Look for `if (model.hasX)` or `if (field != null)` in UI
+5. **Log at the model level**: Add temporary logging in `fromJson()` to see what's null
+
+## Notes
+
+- This pattern applies to ANY Nostr client that uses both REST and WebSocket data sources
+- The REST API may evolve to include more fields over time, so the fallback approach
+  is forward-compatible (explicit fields take priority over fallbacks)
+- Consider requesting the REST API team add the missing fields directly
+- The `_isHex()` validation prevents false positives from non-hash d_tag values
+- Similar gaps may exist for other tag-derived fields (textTrackRef, duration, etc.)
+
+## Related Skills
+
+- `rest-api-optimistic-update-race-condition` - Another REST API data consistency issue
+- `nostr-addressable-event-d-tag-requirement` - Related d_tag handling

--- a/.claude/skills/oauth-pkce-sessionstorage-lost-on-redirect/SKILL.md
+++ b/.claude/skills/oauth-pkce-sessionstorage-lost-on-redirect/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: oauth-pkce-sessionstorage-lost-on-redirect
+description: |
+  Fix OAuth PKCE "Session not found" or "No code verifier" errors in SPAs after redirect
+  from external auth server. Use when: (1) OAuth callback fails with session/verifier not found
+  despite flow starting correctly, (2) PKCE code_verifier stored in sessionStorage is missing
+  after redirect back from auth server, (3) Error only happens in production or cross-origin
+  redirects, not in local dev. Root cause: sessionStorage is lost when the browser opens a new
+  tab, changes browsing context, or certain browsers clear it during cross-origin navigation.
+  Fix: use localStorage instead (clean up after exchange).
+author: Claude Code
+version: 1.0.0
+date: 2026-03-23
+---
+
+# OAuth PKCE sessionStorage Lost on Redirect
+
+## Problem
+OAuth PKCE flow fails at the code exchange step because the PKCE code verifier stored in
+`sessionStorage` is missing after the redirect from the external authorization server.
+The error message typically says "Session not found" or "No code verifier found" with no
+indication that the storage backend is the issue.
+
+## Context / Trigger Conditions
+- SPA initiates OAuth PKCE flow, storing code_verifier in `sessionStorage`
+- User is redirected to external auth server (e.g., `login.example.com`)
+- Auth server redirects back to SPA callback URL with `?code=...&state=...`
+- SPA tries to exchange code but can't find the PKCE verifier
+- Error message is about "session not found" or "missing verifier", NOT about storage
+- Works fine in local development (same-origin), fails in production (cross-origin)
+
+## Root Cause
+`sessionStorage` is scoped per-tab AND per-origin, and has additional fragility:
+1. If the auth server opens a new tab or popup, the new tab has empty sessionStorage
+2. Some browsers (especially Safari with ITP) may clear sessionStorage during cross-origin
+   navigation chains
+3. If the auth server does multiple redirects (302 chains), some browsers treat the
+   return as a new browsing context
+4. Mobile browsers are particularly aggressive about clearing sessionStorage
+
+## Solution
+Switch from `sessionStorage` to `localStorage` for the PKCE code verifier storage:
+
+```typescript
+// BEFORE (fragile)
+const client = createOAuthClient({
+  storage: sessionStorage,
+});
+
+// AFTER (reliable)
+const client = createOAuthClient({
+  storage: localStorage,
+});
+```
+
+The security concern with localStorage (verifier persists longer) is mitigated because:
+- The PKCE verifier is single-use; the auth server rejects it after first exchange
+- Most OAuth SDKs clean up the verifier after successful `exchangeCode()`
+- `getAuthorizationUrl()` overwrites any stale verifier on new flow start
+
+## Verification
+1. Start OAuth flow on the SPA
+2. Complete auth on the external server
+3. Callback should successfully exchange the code without "session not found" errors
+4. Check `localStorage` — the `divine_pkce` (or equivalent) key should be cleaned up
+   after successful exchange
+
+## Example
+From `@divinevideo/login` SDK integration:
+
+```typescript
+function createClient() {
+  return createDivineClient({
+    serverUrl: 'https://login.divine.video',
+    clientId: 'divine-web',
+    redirectUri: buildCallbackUrl(),
+    // localStorage survives cross-origin redirects more reliably than sessionStorage
+    storage: localStorage,
+  });
+}
+```
+
+## Notes
+- If the OAuth SDK doesn't accept a `storage` parameter, you may need to manually
+  store/retrieve the verifier in localStorage and pass it to `exchangeCode(verifier)`
+- Also move any return-path or state data from sessionStorage to localStorage if it
+  needs to survive the redirect
+- In test environments (jsdom/vitest), `localStorage` may not be fully implemented;
+  provide an in-memory Storage stub in test setup
+- The SDK's README often recommends localStorage — check docs before defaulting to
+  sessionStorage for "security"

--- a/.claude/skills/ollama-model-safety-guardrails/SKILL.md
+++ b/.claude/skills/ollama-model-safety-guardrails/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: ollama-model-safety-guardrails
+description: |
+  Select appropriate Ollama models for processing sensitive but legal content. Use when:
+  (1) llama3.2 or deepseek-r1 refuses to process content with "I cannot assist" responses,
+  (2) Local LLM returns generic safety disclaimers instead of following instructions,
+  (3) Need to process adult content, sex work data, or other legal-but-sensitive material
+  through a local LLM. Also covers using /api/chat vs /api/generate for system prompt
+  support, and structuring prompts for consistent format compliance.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-23
+---
+
+# Ollama Model Selection for Sensitive Content Processing
+
+## Problem
+When using Ollama to process legal but sensitive content (e.g., sex work information
+in jurisdictions where it's legal, adult content analysis, harm reduction data), many
+popular models refuse to engage with the content due to built-in safety guardrails,
+even with explicit system prompts establishing legal context.
+
+## Context / Trigger Conditions
+- LLM returns responses like "I cannot assist with this request" or generic safety disclaimers
+- The content is legal in context (e.g., sex work in Uruguay under Ley 17.515)
+- System prompts establishing legal/professional context are ignored
+- You need structured data extraction, summarization, or analysis of sensitive text
+- Using Ollama locally (privacy-first, no API key needed)
+
+## Solution
+
+### Model Selection
+
+| Model | Behavior with Sensitive Content |
+|-------|-------------------------------|
+| `mistral` | Follows instructions, processes content objectively |
+| `llama3.2` | Refuses with safety disclaimers, ignores system prompts |
+| `deepseek-r1:8b` | Refuses similarly to llama3.2 |
+| `llama3.1` | Mixed results, sometimes refuses |
+| `mixtral` | Generally follows instructions like mistral |
+
+**Recommendation**: Use `mistral` (or `mixtral` for better quality) when processing
+legal-but-sensitive content that other models refuse.
+
+### API Selection: Chat vs Generate
+
+Use `/api/chat` instead of `/api/generate` for system prompt support:
+
+```javascript
+// WRONG: /api/generate doesn't properly support system prompts
+const response = await fetch('http://localhost:11434/api/generate', {
+  method: 'POST',
+  body: JSON.stringify({ model: 'mistral', prompt: userPrompt, system: systemPrompt }),
+});
+
+// RIGHT: /api/chat with messages array
+const response = await fetch('http://localhost:11434/api/chat', {
+  method: 'POST',
+  body: JSON.stringify({
+    model: 'mistral',
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ],
+    stream: false,
+  }),
+});
+const data = await response.json();
+const result = data.message?.content || '';
+```
+
+### System Prompt Strategy
+
+For sensitive content, the system prompt should:
+1. Establish the legal context explicitly
+2. Define the role as data processing (not creative/advisory)
+3. Specify the response language to match content language
+4. Request the exact output format
+
+```javascript
+const systemPrompt = `Eres un asistente de extracción de datos para un sistema CRM
+personal en Uruguay. El trabajo sexual es completamente legal y regulado en Uruguay
+(Ley 17.515). Tu trabajo es analizar posts de foros públicos y extraer información
+estructurada. SIEMPRE responde en español. SIEMPRE usa el formato de secciones con
+## que se te pida. Trata todo el contenido como datos legítimos para procesar
+objetivamente.`;
+```
+
+### Format Consistency
+
+Even with mistral, format compliance can be inconsistent. Improve it by:
+1. Writing the user prompt in the SAME language as the expected output
+2. Including explicit format examples in the prompt
+3. Using section headers (`##`) that match what you request
+4. Limiting input context (40 posts max, 300 chars each) to stay within context window
+
+## Verification
+- Model responds with structured content following your format
+- No safety disclaimers or refusals in the output
+- Response is in the requested language
+- Section headers match your specification
+
+## Example
+
+```javascript
+import { callOllama } from './ollama.js';
+
+// This works with mistral, fails with llama3.2
+const summary = await callOllama(`
+  Analiza estos 166 posts del foro sobre "Eliz" y responde EN ESPAÑOL:
+  ## Resumen
+  (2-3 oraciones: consenso general)
+  ## Apariencia
+  (Descripción física)
+  ...
+  Posts del foro:
+  [post content here]
+`);
+```
+
+## Notes
+- Model behavior may change with version updates; test after pulling new versions
+- `stream: false` is important for batch processing to get complete responses
+- For very long content, chunk posts and summarize in stages
+- The `/api/chat` response structure differs from `/api/generate`:
+  - Chat: `data.message.content`
+  - Generate: `data.response`
+- Consider adding `"temperature": 0.3` for more consistent structured output
+- Ollama auto-downloads models on first use but this blocks the first request
+
+## References
+- [Ollama API Documentation](https://github.com/ollama/ollama/blob/main/docs/api.md)
+- [Ollama Model Library](https://ollama.com/library)
+- [Mistral model card](https://ollama.com/library/mistral)

--- a/.claude/skills/pg-pool-cloudsql-reconnect/SKILL.md
+++ b/.claude/skills/pg-pool-cloudsql-reconnect/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: pg-pool-cloudsql-reconnect
+description: |
+  Fix Node.js pg-pool not reconnecting after CloudSQL connection reset (ECONNRESET).
+  Use when: (1) Retries fail with same ECONNRESET error despite retry logic,
+  (2) "Connection terminated" or "connection already closed" errors persist across retries,
+  (3) "remaining connection slots are reserved" errors in CloudSQL,
+  (4) High-concurrency Node.js app with pg-pool and CloudSQL/managed PostgreSQL.
+  The pool caches dead connections - you must recreate the pool, not just retry.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-30
+---
+
+# pg-pool CloudSQL Reconnection
+
+## Problem
+
+Node.js applications using `pg-pool` with CloudSQL (or other managed PostgreSQL) fail to
+recover from connection resets. Retry logic appears to work but keeps failing with the
+same ECONNRESET error because the pool caches dead connections.
+
+## Context / Trigger Conditions
+
+- ECONNRESET errors that persist despite retry logic
+- Error messages like:
+  - `read ECONNRESET`
+  - `Connection terminated`
+  - `connection already closed`
+  - `remaining connection slots are reserved for non-replication superuser connections`
+- High-concurrency applications (parallel batch processing)
+- CloudSQL with small instance tiers (db-f1-micro, db-g1-small)
+- Long-running scripts with periods of inactivity followed by bursts
+
+## Root Cause
+
+pg-pool maintains a pool of database connections. When CloudSQL resets connections
+(due to timeout, maintenance, or connection limits), the pool still holds references
+to those dead connections. Simply retrying the operation uses the same dead connection
+from the pool.
+
+## Solution
+
+Instead of just retrying, **recreate the entire pool** on connection reset errors:
+
+```typescript
+export class PostgresDatabase {
+  private pool: Pool;
+  private config: PostgresConfig;
+
+  constructor(config: PostgresConfig) {
+    this.config = config;
+    this.pool = this.createPool();
+  }
+
+  private createPool(): Pool {
+    const pool = new Pool({
+      ...this.config,
+      max: 25,                          // Adequate for concurrency
+      idleTimeoutMillis: 30000,         // Close idle connections
+      connectionTimeoutMillis: 10000,   // Timeout for new connections
+      keepAlive: true,                  // TCP keepalive
+    });
+
+    pool.on('error', (err) => {
+      console.error('Pool error:', err.message);
+    });
+
+    return pool;
+  }
+
+  private async reconnect(): Promise<void> {
+    console.log("Reconnecting to database...");
+    try {
+      await this.pool.end();
+    } catch {
+      // Ignore cleanup errors
+    }
+    this.pool = this.createPool();
+    await this.pool.query("SELECT 1"); // Verify connection
+    console.log("Database reconnected");
+  }
+
+  private async withRetry<T>(
+    operation: () => Promise<T>,
+    maxRetries = 3
+  ): Promise<T> {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        return await operation();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        const needsReconnect =
+          msg.includes("ECONNRESET") ||
+          msg.includes("Connection terminated") ||
+          msg.includes("connection already closed") ||
+          msg.includes("remaining connection slots");
+
+        if (!needsReconnect || attempt === maxRetries - 1) {
+          throw error;
+        }
+
+        const delay = 1000 * Math.pow(2, attempt);
+        console.log(`Connection error, reconnecting in ${delay}ms...`);
+        await new Promise(r => setTimeout(r, delay));
+
+        // KEY: Recreate the pool, don't just retry
+        await this.reconnect();
+      }
+    }
+    throw new Error("Max retries exceeded");
+  }
+}
+```
+
+## Key Insight
+
+**Retrying with the same pool uses cached dead connections.** The fix is to:
+1. Detect connection reset errors
+2. Call `pool.end()` to close all connections
+3. Create a new pool instance
+4. Verify the new connection works
+5. Then retry the operation
+
+## CloudSQL-Specific Considerations
+
+1. **Instance tier matters**: db-f1-micro only supports ~25 connections. Use db-g1-small or larger for concurrent workloads.
+
+2. **Check max_connections**:
+   ```bash
+   gcloud sql instances describe INSTANCE --format='value(settings.tier)'
+   ```
+
+3. **Cloud SQL Proxy**: Doesn't help with connection pooling - it just tunnels TCP. Consider PgBouncer for true connection pooling.
+
+## Verification
+
+After implementing:
+1. Run high-concurrency workload
+2. Intentionally cause connection reset (restart proxy, wait for idle timeout)
+3. Verify operations resume with "Reconnecting to database..." log
+4. No more cascading failures
+
+## Notes
+
+- This pattern applies to any managed PostgreSQL, not just CloudSQL
+- Consider PgBouncer for production workloads with very high concurrency
+- The `pool.on('error')` handler prevents uncaught exceptions from crashing the app
+- Set `max` pool size to match your concurrency level plus headroom

--- a/.claude/skills/postgres-concurrent-schema-init-deadlock/SKILL.md
+++ b/.claude/skills/postgres-concurrent-schema-init-deadlock/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: postgres-concurrent-schema-init-deadlock
+description: |
+  Fix PostgreSQL deadlock errors caused by concurrent schema initialization in worker processes.
+  Use when: (1) psycopg2.errors.DeadlockDetected during CREATE INDEX/TABLE IF NOT EXISTS,
+  (2) Multiple Cloud Run jobs, Kubernetes pods, or worker processes start simultaneously,
+  (3) Error shows "Process X waits for RowExclusiveLock... blocked by process Y",
+  (4) init_schema() or migration code runs at worker startup. The key insight: "IF NOT EXISTS"
+  is NOT truly concurrent-safe - PostgreSQL still acquires locks that can deadlock.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# PostgreSQL Concurrent Schema Init Deadlock
+
+## Problem
+Multiple worker processes (Cloud Run jobs, K8s pods, serverless functions) starting
+simultaneously all try to run schema initialization code, causing PostgreSQL deadlocks
+even when using "IF NOT EXISTS" clauses.
+
+## Context / Trigger Conditions
+- Error: `psycopg2.errors.DeadlockDetected: deadlock detected`
+- Log shows: `Process X waits for RowExclusiveLock on relation... blocked by process Y`
+- Multiple workers/jobs starting at roughly the same time
+- Each worker calls `init_schema()` or runs migrations at startup
+- Using `CREATE TABLE IF NOT EXISTS` or `CREATE INDEX IF NOT EXISTS`
+
+## Why This Happens
+PostgreSQL's `IF NOT EXISTS` is **not concurrent-safe**:
+1. `CREATE INDEX IF NOT EXISTS` still acquires locks before checking existence
+2. Multiple processes acquiring locks on different objects can deadlock
+3. Even "safe" DDL can conflict when executed concurrently
+
+## Solution
+
+### Option 1: Skip Init in Production (Recommended)
+Schema already exists - don't run init_schema() in workers:
+
+```python
+with Database() as db:
+    # Schema already exists in production - skip to avoid deadlocks
+    # db.init_schema()
+
+    # ... worker code
+```
+
+### Option 2: Use Advisory Locks
+Serialize schema init with PostgreSQL advisory locks:
+
+```python
+def init_schema_safe(self):
+    cursor = self._cursor()
+    # Acquire advisory lock (blocks other processes)
+    cursor.execute("SELECT pg_advisory_lock(12345)")
+    try:
+        self.init_schema()
+    finally:
+        cursor.execute("SELECT pg_advisory_unlock(12345)")
+        self.conn.commit()
+```
+
+### Option 3: Separate Migration Step
+Run migrations as a separate job before starting workers:
+
+```bash
+# In deployment pipeline
+python -m src.migrate  # Single process, runs first
+# Then start workers
+gcloud run jobs execute worker-job
+```
+
+### Option 4: Lock Timeout + Retry
+Set lock timeout and retry on deadlock:
+
+```python
+def init_schema_with_retry(self, max_retries=3):
+    for attempt in range(max_retries):
+        try:
+            cursor = self._cursor()
+            cursor.execute("SET lock_timeout = '5s'")
+            self.init_schema()
+            return
+        except psycopg2.errors.DeadlockDetected:
+            self.conn.rollback()
+            if attempt == max_retries - 1:
+                raise
+            time.sleep(random.uniform(1, 3))
+```
+
+## Verification
+After applying fix:
+1. Start multiple workers simultaneously
+2. Check logs for absence of deadlock errors
+3. Verify all workers start successfully
+
+## Example
+Before (deadlocks with 6 concurrent Cloud Run jobs):
+```python
+# src/download.py
+with VineDatabase() as db:
+    db.init_schema()  # DEADLOCK when multiple jobs start!
+    # ... download logic
+```
+
+After (no deadlocks):
+```python
+# src/download.py
+with VineDatabase() as db:
+    # Schema already exists in production - skip to avoid deadlocks
+    # db.init_schema()
+    # ... download logic
+```
+
+## Notes
+- This applies to any concurrent worker pattern: Cloud Run, Celery, Kubernetes, Lambda
+- The deadlock can be intermittent - depends on exact timing of worker starts
+- `CREATE TABLE IF NOT EXISTS` is generally safer than `CREATE INDEX IF NOT EXISTS`
+- Cloud Run jobs often start simultaneously when triggered, making this common
+- Consider using database migration tools (Alembic, Flyway) with proper locking
+
+## References
+- [PostgreSQL Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)
+- [PostgreSQL Deadlock Detection](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/.claude/skills/proxy-range-header-forwarding/SKILL.md
+++ b/.claude/skills/proxy-range-header-forwarding/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: proxy-range-header-forwarding
+description: |
+  Fix iOS AVPlayer "CoreMediaErrorDomain error -12939 - byte range length mismatch"
+  or similar video streaming failures when a proxy/edge/CDN service sits between the
+  client and object storage (GCS, S3, R2). Use when: (1) iOS video fails with -12939
+  "byte range length mismatch - should be length 2 is length N", (2) curl with
+  Range: bytes=0-1 returns full file instead of 2 bytes, (3) one URL path works with
+  Range but another path to the same storage doesn't, (4) proxy advertises
+  Accept-Ranges: bytes but returns 200 with full file for range requests. The root
+  cause is typically a proxy handler that constructs a new request to the backend
+  without forwarding the client's Range header.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-22
+---
+
+# Proxy Range Header Forwarding for Video Streaming
+
+## Problem
+A proxy/edge service (Fastly Compute, Cloudflare Workers, custom reverse proxy) sits
+between clients and object storage. Some routes correctly forward HTTP Range headers
+to the storage backend, but other routes (added later or by different developers)
+construct backend requests from scratch without forwarding Range headers. This causes
+iOS AVPlayer to fail because it probes with `Range: bytes=0-1` and rejects responses
+where the body size doesn't match the requested range.
+
+## Context / Trigger Conditions
+- iOS error: `CoreMediaErrorDomain error -12939 - byte range length mismatch - should be length 2 is length N`
+- `PlatformException(VideoError, Failed to load video: Operation Stopped)`
+- `curl -H "Range: bytes=0-1"` on the failing URL returns `200` with `Content-Length` equal to full file size
+- The same curl test on a different URL path to the same storage returns `206` with `Content-Length: 2`
+- The proxy/edge code has multiple route handlers that independently construct backend requests
+- Response headers include `Accept-Ranges: bytes` (misleadingly advertising support)
+
+## Root Cause Pattern
+
+In proxy architectures, each route handler independently constructs requests to the
+storage backend. It's common for the "original" handler to properly forward Range
+headers while variant handlers (quality variants, thumbnails, transcoded versions)
+build requests from scratch without considering Range.
+
+```rust
+// BROKEN: Handler ignores client Range header
+fn handle_variant(req: Request, path: &str) -> Response {
+    let gcs_path = resolve_variant(path);
+    let backend_req = Request::new(Method::GET, &gcs_url);  // No Range header!
+    backend_req.send("storage")
+}
+
+// WORKING: Handler forwards Range header
+fn handle_original(req: Request, path: &str) -> Response {
+    let range = req.get_header("Range");  // Extracts Range
+    let backend_req = Request::new(Method::GET, &gcs_url);
+    if let Some(r) = range {
+        backend_req.set_header("Range", r);  // Forwards it
+    }
+    backend_req.send("storage")
+}
+```
+
+## Solution
+
+Three things must all be fixed in the proxy handler:
+
+### 1. Extract Range header from client request
+```rust
+let range = req
+    .get_header(header::RANGE)
+    .and_then(|h| h.to_str().ok())
+    .map(|s| s.to_string());
+```
+
+### 2. Forward Range header to storage backend
+```rust
+if let Some(range_value) = range {
+    backend_req.set_header("Range", range_value);
+}
+```
+
+### 3. Accept 206 responses from the backend
+```rust
+// BEFORE (broken): only accepts 200
+match resp.get_status() {
+    StatusCode::OK => Ok(resp),
+    ...
+}
+
+// AFTER (fixed): accepts both 200 and 206
+match resp.get_status() {
+    StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(resp),
+    ...
+}
+```
+
+GCS/S3/R2 natively handle Range headers and return proper `206 Partial Content` with
+correct `Content-Range` and `Content-Length` headers, so once forwarded, the response
+can be passed through directly to the client.
+
+## Verification
+
+```bash
+# Test the failing endpoint with a range probe (what iOS does)
+curl -sv -H "Range: bytes=0-1" "https://cdn.example.com/hash/variant" \
+  -o /dev/null 2>&1 | grep -iE "< HTTP|content-length|content-range"
+
+# Expected AFTER fix:
+# < HTTP/2 206
+# < content-range: bytes 0-1/TOTAL_SIZE
+# < content-length: 2
+
+# Test mid-file range
+curl -sv -H "Range: bytes=1000-1999" "https://cdn.example.com/hash/variant" \
+  -o /dev/null 2>&1 | grep -iE "< HTTP|content-length|content-range"
+
+# Expected: 206, content-length: 1000, content-range: bytes 1000-1999/TOTAL
+
+# Test full download still works (no Range header)
+curl -sv "https://cdn.example.com/hash/variant" \
+  -o /dev/null 2>&1 | grep -iE "< HTTP|content-length"
+
+# Expected: 200, content-length: TOTAL_SIZE
+```
+
+## Example
+
+**Real case**: Fastly Compute edge service proxying to GCS. The `/{hash}` route (original
+blob) forwarded Range headers via `download_blob(hash, range)`. The `/{hash}/720p` route
+(transcoded quality variant) called `download_hls_from_gcs(gcs_key)` with no range parameter.
+
+Fix required changes in three layers:
+1. Storage function: added `range: Option<&str>` parameter
+2. Wrapper function: passed range through
+3. Route handler: extracted Range from client request
+
+## Notes
+
+- **Audit all route handlers**: If one handler is missing Range forwarding, others likely are too.
+  Search for all places that construct backend requests and verify Range is forwarded.
+- **Don't just set Accept-Ranges**: Adding `Accept-Ranges: bytes` to responses without actually
+  handling ranges is worse than not advertising it - clients will expect it to work.
+- **iOS is strict**: Safari/AVPlayer always probes with `Range: bytes=0-1` before streaming.
+  Chrome/Android are more forgiving and may work without proper Range support.
+- **HEAD requests**: HEAD handlers don't need Range forwarding (they return metadata only),
+  but GET handlers absolutely do.
+- **Cache layers**: If a caching proxy sits in front, it may cache the full 200 response and
+  serve it for Range requests. Purge cache after deploying the fix.
+
+## References
+- [MDN: HTTP Range Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests)
+- [GCS: Resumable Downloads](https://cloud.google.com/storage/docs/resumable-downloads)
+- [Apple: AVPlayer HTTP Live Streaming](https://developer.apple.com/documentation/avfoundation/avplayer)

--- a/.claude/skills/psycopg2-batch-insert-optimization/SKILL.md
+++ b/.claude/skills/psycopg2-batch-insert-optimization/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: psycopg2-batch-insert-optimization
+description: |
+  Optimize slow PostgreSQL inserts in Python using psycopg2. Use when: (1) Row-by-row
+  inserts are taking too long over network, (2) executemany() isn't providing speedup,
+  (3) Migrating large datasets to PostgreSQL, (4) Network latency making individual
+  INSERT statements impractical. The key is using execute_values() from psycopg2.extras
+  instead of executemany() or individual execute() calls.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-20
+---
+
+# psycopg2 Batch Insert Optimization
+
+## Problem
+When inserting thousands of rows into PostgreSQL over a network connection, row-by-row
+inserts are extremely slow. Each INSERT requires a round-trip, and with network latency
+of ~50-100ms, inserting 10,000 rows takes 10+ minutes.
+
+The naive approach of using `cursor.executemany()` doesn't help much—it still sends
+individual statements.
+
+## Context / Trigger Conditions
+- Inserting >100 rows into PostgreSQL via psycopg2
+- Each insert taking ~1 second or more
+- Network latency to database (especially Cloud SQL, RDS, remote databases)
+- Migration scripts running for hours
+- `executemany()` not providing expected speedup
+
+## Solution
+
+Use `execute_values()` from `psycopg2.extras`:
+
+```python
+from psycopg2.extras import execute_values
+
+# Instead of this (SLOW):
+for row in data:
+    cursor.execute("INSERT INTO table (a, b, c) VALUES (%s, %s, %s)", row)
+
+# Or this (STILL SLOW):
+cursor.executemany("INSERT INTO table (a, b, c) VALUES (%s, %s, %s)", data)
+
+# Use this (FAST):
+execute_values(cursor, """
+    INSERT INTO table (a, b, c)
+    VALUES %s
+    ON CONFLICT (id) DO NOTHING
+""", data, page_size=500)
+conn.commit()
+```
+
+### Key Parameters:
+- `page_size`: Number of rows per batch (default 100, try 500-1000)
+- The `VALUES %s` placeholder is replaced with multiple value tuples
+
+### For UPSERT operations:
+```python
+execute_values(cursor, """
+    INSERT INTO users (user_id, username, email)
+    VALUES %s
+    ON CONFLICT (user_id) DO UPDATE SET
+        username = EXCLUDED.username,
+        email = COALESCE(EXCLUDED.email, users.email)
+""", user_data, page_size=500)
+```
+
+### Progress Monitoring for Long Migrations:
+```python
+import sys
+sys.stdout.reconfigure(line_buffering=True)  # Force unbuffered output
+
+BATCH_SIZE = 500
+for i in range(0, len(data), BATCH_SIZE):
+    batch = data[i:i+BATCH_SIZE]
+    execute_values(cursor, query, batch)
+    conn.commit()
+    print(f"Processed {min(i+BATCH_SIZE, len(data))}/{len(data)} rows...")
+```
+
+## Verification
+- Migration that previously took hours completes in minutes
+- You can see batches being processed in real-time with progress output
+- Check row counts after: `SELECT COUNT(*) FROM table`
+
+## Example
+
+Real-world migration of 9,563 users from SQLite to PostgreSQL:
+
+```python
+from psycopg2.extras import execute_values
+import sys
+
+sys.stdout.reconfigure(line_buffering=True)
+BATCH_SIZE = 500
+
+# Fetch from SQLite
+sqlite_cur.execute('SELECT user_id, username, avatar_url, verified FROM users')
+rows = sqlite_cur.fetchall()
+data = [(r['user_id'], r['username'], r['avatar_url'], bool(r['verified']))
+        for r in rows]
+
+# Batch insert to PostgreSQL
+for i in range(0, len(data), BATCH_SIZE):
+    batch = data[i:i+BATCH_SIZE]
+    execute_values(pg_cur, '''
+        INSERT INTO users (user_id, username, avatar_url, verified)
+        VALUES %s
+        ON CONFLICT (user_id) DO UPDATE SET
+            username = COALESCE(EXCLUDED.username, users.username),
+            avatar_url = COALESCE(EXCLUDED.avatar_url, users.avatar_url)
+    ''', batch)
+    pg_conn.commit()
+    print(f"Processed {min(i+BATCH_SIZE, len(data))}/{len(data)} users...")
+```
+
+**Result**: 9,563 users migrated in ~20 seconds instead of ~2.5 hours.
+
+## Notes
+
+- `execute_values()` constructs a single INSERT with multiple VALUES, drastically
+  reducing round-trips
+- `executemany()` is deceptively slow—it still sends individual statements
+- For very large datasets (>100k rows), consider `COPY` command or `copy_expert()`
+- The `page_size` parameter controls memory usage vs. batch efficiency
+- Always commit after each batch for long migrations (allows progress tracking and
+  partial recovery)
+
+### SQLite to PostgreSQL Syntax Differences:
+When migrating, also watch for these SQL differences:
+- `INSERT OR IGNORE` → `ON CONFLICT DO NOTHING`
+- `INSERT OR REPLACE` → `ON CONFLICT DO UPDATE SET ...`
+- `MAX(a, b)` (SQLite) → `GREATEST(a, b)` (PostgreSQL)
+- `MIN(a, b)` (SQLite) → `LEAST(a, b)` (PostgreSQL)
+- `?` placeholders → `%s` placeholders
+- `AUTOINCREMENT` → `SERIAL` or `GENERATED ALWAYS AS IDENTITY`
+
+## References
+- [psycopg2 execute_values documentation](https://www.psycopg.org/docs/extras.html#psycopg2.extras.execute_values)
+- [PostgreSQL COPY for bulk loading](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/.claude/skills/psycopg2-like-percent-escape/SKILL.md
+++ b/.claude/skills/psycopg2-like-percent-escape/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: psycopg2-like-percent-escape
+description: |
+  Fix psycopg2 "IndexError: tuple index out of range" when using LIKE with parameterized queries.
+  Use when: (1) cursor.execute() fails with IndexError on a query containing LIKE '%pattern%',
+  (2) SQL LIKE wildcards conflict with psycopg2 %s parameter placeholders, (3) Query works
+  in psql but fails in Python. The % character has dual meaning: SQL LIKE wildcard AND
+  psycopg2's parameter substitution marker.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-29
+---
+
+# psycopg2 LIKE Clause Percent Sign Escaping
+
+## Problem
+
+When using psycopg2 with parameterized queries containing SQL LIKE patterns, the `%` character
+causes conflicts. The `%` is used both as:
+1. SQL LIKE wildcard (e.g., `'%pattern%'`)
+2. psycopg2's parameter placeholder marker (e.g., `%s`)
+
+This results in confusing errors like `IndexError: tuple index out of range` because psycopg2
+interprets `%c` in `%cdn` as a format specifier.
+
+## Context / Trigger Conditions
+
+- `IndexError: tuple index out of range` from `cursor.execute()`
+- Query contains hardcoded LIKE pattern: `WHERE column LIKE '%something%'`
+- Query also uses `%s` parameters for other values
+- Query works in psql or pgAdmin but fails in Python
+
+Example failing code:
+```python
+cursor.execute("""
+    SELECT * FROM vines
+    WHERE url LIKE '%cdn.vine.co%'
+    LIMIT %s OFFSET %s
+""", (1000, 0))
+# IndexError: tuple index out of range
+```
+
+## Solution
+
+### Option 1: Escape `%` with `%%` (for static patterns)
+
+Double the percent signs in hardcoded LIKE patterns:
+
+```python
+cursor.execute("""
+    SELECT * FROM vines
+    WHERE url LIKE '%%cdn.vine.co%%'
+    LIMIT %s OFFSET %s
+""", (1000, 0))
+```
+
+### Option 2: Pass LIKE pattern as parameter (recommended)
+
+The cleaner approach - pass the entire LIKE pattern as a parameter:
+
+```python
+pattern = '%cdn.vine.co%'
+cursor.execute("""
+    SELECT * FROM vines
+    WHERE url LIKE %s
+    LIMIT %s OFFSET %s
+""", (pattern, 1000, 0))
+```
+
+This is the recommended approach because:
+- No escaping confusion
+- Pattern can be dynamically constructed
+- Follows parameterized query best practices
+
+### Option 3: Use psycopg2.sql module for complex cases
+
+For dynamic SQL construction:
+
+```python
+from psycopg2 import sql
+
+query = sql.SQL("""
+    SELECT * FROM {table}
+    WHERE url LIKE %s
+""").format(table=sql.Identifier('vines'))
+
+cursor.execute(query, ('%cdn.vine.co%',))
+```
+
+## Verification
+
+After applying the fix:
+1. Query executes without IndexError
+2. Results correctly match the LIKE pattern
+3. Other `%s` parameters are still substituted correctly
+
+## Example
+
+Before (broken):
+```python
+def get_vines_by_cdn(db, limit, offset):
+    cursor = db.cursor()
+    cursor.execute("""
+        SELECT vine_id, url FROM discovered_vines
+        WHERE url LIKE '%cdn.vine.co%'
+        ORDER BY created_at
+        LIMIT %s OFFSET %s
+    """, (limit, offset))
+    return cursor.fetchall()
+```
+
+After (fixed with Option 1):
+```python
+def get_vines_by_cdn(db, limit, offset):
+    cursor = db.cursor()
+    cursor.execute("""
+        SELECT vine_id, url FROM discovered_vines
+        WHERE url LIKE '%%cdn.vine.co%%'
+        ORDER BY created_at
+        LIMIT %s OFFSET %s
+    """, (limit, offset))
+    return cursor.fetchall()
+```
+
+After (fixed with Option 2 - recommended):
+```python
+def get_vines_by_cdn(db, limit, offset):
+    cursor = db.cursor()
+    cdn_pattern = '%cdn.vine.co%'
+    cursor.execute("""
+        SELECT vine_id, url FROM discovered_vines
+        WHERE url LIKE %s
+        ORDER BY created_at
+        LIMIT %s OFFSET %s
+    """, (cdn_pattern, limit, offset))
+    return cursor.fetchall()
+```
+
+## Notes
+
+- This issue only affects parameterized queries with `%s` placeholders
+- Raw SQL strings without parameters don't have this problem
+- The `%%` escape only works when the query uses psycopg2's parameter substitution
+- Django's ORM handles this automatically; this is a raw SQL issue
+- psycopg3 uses `$1, $2` style placeholders, avoiding this conflict entirely
+
+## Related Issues
+
+- Searching for literal `%` in data requires additional escaping with `ESCAPE` clause
+- Similar issues can occur with `_` (single character wildcard) if using `%_` pattern
+
+## References
+
+- [psycopg2 Basic Module Usage](https://www.psycopg.org/docs/usage.html)
+- [psycopg2 sql Module Documentation](https://www.psycopg.org/docs/sql.html)
+- [PostgreSQL Pattern Matching](https://www.postgresql.org/docs/current/functions-matching.html)
+- [psycopg2 Issue #825 - Percent sign escaping](https://github.com/psycopg/psycopg2/issues/825)

--- a/.claude/skills/rest-api-optimistic-update-race-condition/SKILL.md
+++ b/.claude/skills/rest-api-optimistic-update-race-condition/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: rest-api-optimistic-update-race-condition
+description: |
+  Fix "content disappears after publishing" bugs caused by REST API indexing lag.
+  Use when: (1) User publishes content but it doesn't appear in their feed/profile,
+  (2) REST API returns stale data immediately after write operations, (3) Async
+  indexing backends (ClickHouse, Elasticsearch, etc.) haven't processed new events,
+  (4) Content shows briefly then vanishes on refresh. Applies to any system with
+  separate write path (WebSocket/direct DB) and read path (REST API with async indexing).
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# REST API Optimistic Update Race Condition
+
+## Problem
+
+When an application uses a dual architecture with:
+- **Write path**: Direct database writes or WebSocket/event publishing
+- **Read path**: REST API backed by async indexing (ClickHouse, Elasticsearch, etc.)
+
+Content can "disappear" after publishing because the read path hasn't indexed
+the new content yet, but the UI re-fetches from the REST API expecting fresh data.
+
+## Context / Trigger Conditions
+
+- User publishes content (video, post, comment, etc.)
+- Content briefly appears, then disappears on refresh or navigation
+- REST API returns N items when N+1 expected
+- Logs show successful write but stale read
+- Backend uses async indexing (ClickHouse, Elasticsearch, Algolia, etc.)
+- Symptoms worsen under load or with slow indexing pipelines
+
+**Log pattern example:**
+```
+✅ Event successfully published to relays
+📊 Fetching from REST API: found 59 videos  // Expected 60!
+```
+
+## Solution
+
+### Option 1: Optimistic State Update (Recommended)
+
+Instead of re-fetching from REST API after publishing, optimistically add the
+new content directly to the local state:
+
+```dart
+// BEFORE (broken): Re-fetch from potentially stale API
+void onNewContentPublished(Content newContent) {
+  refreshFromRestApi(); // API hasn't indexed yet = stale data
+}
+
+// AFTER (fixed): Optimistic local update
+void onNewContentPublished(Content newContent) {
+  final currentItems = state.items;
+
+  // Skip if duplicate
+  if (currentItems.any((item) => item.id == newContent.id)) return;
+
+  // Add to front of list (most recent first)
+  final updatedItems = [newContent, ...currentItems];
+
+  state = state.copyWith(
+    items: updatedItems,
+    lastUpdated: DateTime.now(),
+  );
+}
+```
+
+### Option 2: Hybrid Approach
+
+For long-lived sessions, periodically reconcile local state with REST API:
+
+```dart
+void onNewContentPublished(Content newContent) {
+  // Immediate: optimistic update
+  _addToLocalState(newContent);
+
+  // Delayed: reconcile with API after indexing lag
+  Future.delayed(Duration(seconds: 30), () {
+    _reconcileWithRestApi();
+  });
+}
+```
+
+### Option 3: Write-Through Cache
+
+If your REST API supports it, use write-through caching:
+
+```dart
+// POST to API returns the created item, cache it immediately
+final response = await api.createContent(content);
+_cache.put(response.id, response);
+```
+
+## Verification
+
+After implementing the fix:
+
+1. Publish new content
+2. Immediately navigate to the listing (profile, feed, etc.)
+3. Verify new content appears at the top
+4. Refresh page after 30+ seconds - content should still be there
+5. Check that duplicate prevention works (publish same content twice)
+
+## Example
+
+**Real-world case**: OpenVine video upload
+
+```dart
+// ProfileFeedProvider - fixed version
+final unregisterNew = videoEventService.addNewVideoListener((
+  newVideo,
+  authorPubkey,
+) {
+  if (authorPubkey == userId && ref.mounted) {
+    // CRITICAL FIX: Optimistically add the new video to state immediately
+    // instead of re-fetching from REST API which may have stale data.
+    _addNewVideoToState(newVideo);
+  }
+});
+
+void _addNewVideoToState(VideoEvent newVideo) {
+  final currentState = state.asData?.value;
+  if (currentState == null) return;
+
+  // Check for duplicates
+  if (currentState.videos.any((v) => v.id == newVideo.id)) return;
+
+  // Add new video to the front of the list
+  final updatedVideos = <VideoEvent>[newVideo, ...currentState.videos];
+
+  state = AsyncData(VideoFeedState(
+    videos: updatedVideos,
+    hasMoreContent: currentState.hasMoreContent,
+    isLoadingMore: false,
+    lastUpdated: DateTime.now(),
+  ));
+}
+```
+
+## Notes
+
+- This pattern applies to any system with async indexing, not just Nostr/ClickHouse
+- Consider adding a "pending" or "uploading" visual state for published content
+- The optimistic update should include all metadata the UI needs to render
+- For content that requires server-side processing (thumbnails, transcoding),
+  consider showing a placeholder until processing completes
+- If the write actually failed, the next REST API fetch will correct the state
+
+## Related Patterns
+
+- **Optimistic UI**: Show changes before server confirmation
+- **CQRS**: Command Query Responsibility Segregation (separate read/write models)
+- **Event Sourcing**: Events as source of truth with materialized views for reads
+- **Cache Invalidation**: The "two hard problems" - this is one of them
+
+## References
+
+- [Optimistic UI Patterns](https://www.apollographql.com/docs/react/performance/optimistic-ui/)
+- [CQRS Pattern](https://martinfowler.com/bliki/CQRS.html)

--- a/.claude/skills/riverpod-infinite-rebuild-loop/SKILL.md
+++ b/.claude/skills/riverpod-infinite-rebuild-loop/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: riverpod-infinite-rebuild-loop
+description: |
+  Debug and fix infinite widget rebuild loops in Flutter apps using Riverpod state management.
+  Use when: (1) Logs show "RAPID REBUILD" warnings or 50+ rebuilds in seconds, (2) UI becomes
+  unresponsive or shows same content repeatedly, (3) Bug only affects slower devices or poor
+  network conditions, (4) Provider watching creates circular dependencies with router/URL state.
+  Covers ref.watch() overuse, watch+listener redundancy, and transitive dependency chains.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-02
+---
+
+# Riverpod Infinite Rebuild Loop
+
+## Problem
+
+Flutter widgets using Riverpod enter an infinite rebuild loop, causing:
+- 50+ widget rebuilds in seconds
+- UI becomes unresponsive
+- Same content rendered repeatedly
+- Bug manifests primarily on slower devices or poor network connections
+
+## Context / Trigger Conditions
+
+**Symptoms in logs:**
+```
+⚠️ RAPID REBUILD #54! Only 15ms since last build
+⚠️ RAPID REBUILD DETECTED! Only 6ms since last build
+```
+
+**User-reported symptoms:**
+- "Endless scroll loop" - same video/content keeps appearing
+- "App freezes" or becomes unresponsive
+- "Works on my phone but not on older devices"
+
+**Trigger scenarios:**
+1. Multiple async providers completing at staggered times
+2. Provider that watches route/URL state AND updates URL in build
+3. Using `ref.watch()` AND adding manual listeners to same provider
+4. Transitive watches: Widget watches A, A watches B, Widget also watches B
+
+## Root Cause Analysis
+
+### Pattern 1: URL Update Feedback Loop
+
+```dart
+// BAD: Creates infinite loop
+Widget build(BuildContext context) {
+  final pageContext = ref.watch(pageContextProvider);  // Watches URL
+  final videos = ref.watch(videosProvider);
+
+  // Detect video moved position and "silently" update URL
+  if (currentVideoIndex != urlIndex) {
+    context.go('/home/$currentVideoIndex');  // URL change triggers rebuild!
+  }
+}
+```
+
+**Loop:** Videos reorder → URL updated → pageContextProvider emits → rebuild → videos may reorder again → repeat
+
+### Pattern 2: Watch + Listener Redundancy
+
+```dart
+// BAD: Double-subscribing causes double rebuilds
+final cache = ref.watch(cacheProvider);  // Watch triggers rebuild
+cache.addListener(onCacheChanged);        // Listener ALSO triggers action
+```
+
+### Pattern 3: Transitive Watch Dependencies
+
+```dart
+// BAD: Double-watching same source
+Widget build() {
+  ref.watch(pageContextProvider);           // Watch #1
+  ref.watch(derivedProvider);               // derivedProvider ALSO watches pageContextProvider!
+}
+```
+
+### Pattern 4: Staggered Async Provider Loading
+
+```dart
+// PROBLEMATIC on slow devices: Each watch triggers rebuild when provider completes
+final a = ref.watch(asyncProviderA);  // Completes at T=100ms → rebuild
+final b = ref.watch(asyncProviderB);  // Completes at T=200ms → rebuild
+final c = ref.watch(asyncProviderC);  // Completes at T=350ms → rebuild
+final d = ref.watch(asyncProviderD);  // Completes at T=500ms → rebuild
+// On fast devices: all complete ~simultaneously, 1-2 rebuilds
+// On slow devices: staggered completion, 4+ rebuilds
+```
+
+## Solution
+
+### Step 1: Audit `ref.watch()` Usage
+
+For each `ref.watch()` in build methods, ask:
+- Does this provider change frequently?
+- Do I need to REBUILD when it changes, or just REACT?
+- Am I also manually listening to this provider?
+
+**Riverpod Methods:**
+| Method | Behavior |
+|--------|----------|
+| `ref.watch()` | Subscribe + **REBUILD** on change |
+| `ref.read()` | Read once, **NO rebuild** |
+| `ref.listen()` | Subscribe + callback, **NO rebuild** |
+
+### Step 2: Convert Unnecessary Watches
+
+```dart
+// BEFORE: Rebuilds on every change
+final videoService = ref.watch(videoServiceProvider);
+
+// AFTER: Read once, use listener for reactions
+final videoService = ref.read(videoServiceProvider);
+ref.listen(videoServiceProvider, (prev, next) {
+  // React to changes without rebuilding
+  if (next.hasNewVideos) refreshUI();
+});
+```
+
+### Step 3: Remove Watch + Listener Redundancy
+
+```dart
+// BEFORE: Double-subscription
+final cache = ref.watch(cacheProvider);
+cache.addListener(onCacheChanged);
+
+// AFTER: Choose one approach
+// Option A: Just watch (if rebuild is needed)
+final cache = ref.watch(cacheProvider);
+
+// Option B: Read + listen (if rebuild not needed)
+final cache = ref.read(cacheProvider);
+ref.listen(cacheProvider, (_, __) => onCacheChanged());
+```
+
+### Step 4: Break URL Update Loops
+
+```dart
+// BEFORE: URL update in build causes loop
+if (currentVideoIndex != urlIndex) {
+  context.go('/home/$currentVideoIndex');
+}
+
+// AFTER: Don't update URL on content reorder
+// Just track position with PageController, not URL
+// OR use content ID in URL instead of index: /home/video/abc123
+```
+
+### Step 5: Batch Initial Load
+
+```dart
+// BEFORE: Watch each async provider (N rebuilds on slow devices)
+final a = ref.watch(asyncA);
+final b = ref.watch(asyncB);
+
+// AFTER: Create combined provider that waits for all
+@riverpod
+Future<CombinedState> combinedState(Ref ref) async {
+  final a = await ref.watch(asyncA.future);
+  final b = await ref.watch(asyncB.future);
+  return CombinedState(a, b);
+}
+// Widget watches only the combined provider (1 rebuild)
+```
+
+## Verification
+
+After fixes:
+1. Run app on slow device or use network throttling
+2. Check logs for rebuild warnings - should see ≤5 rebuilds on startup
+3. Scroll/navigate and verify UI remains responsive
+4. No "RAPID REBUILD" warnings in logs
+
+## Example: Full Fix
+
+**Before (problematic):**
+```dart
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final pageContext = ref.watch(pageContextProvider);
+    final videos = ref.watch(videosProvider);  // Also watches pageContextProvider internally!
+
+    // URL update loop
+    if (videos.currentIndex != pageContext.index) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        context.go('/home/${videos.currentIndex}');
+      });
+    }
+
+    return PageView(...);
+  }
+}
+```
+
+**After (fixed):**
+```dart
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  @override
+  Widget build(BuildContext context) {
+    // Only watch videos, read page context
+    final pageContext = ref.read(pageContextProvider).requireValue;
+    final videos = ref.watch(videosProvider);
+
+    // Don't update URL on reorder - track with PageController only
+    // URL only changes on explicit user navigation
+
+    return PageView(...);
+  }
+}
+```
+
+## Notes
+
+- This bug is **timing-dependent** - may not reproduce on fast devices
+- Test on physical devices with network throttling to catch issues
+- Add rebuild detection logging during development:
+  ```dart
+  static int _buildCount = 0;
+  static DateTime? _lastBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    if (_lastBuild != null && now.difference(_lastBuild!).inMilliseconds < 100) {
+      Log.warning('RAPID REBUILD #${++_buildCount}!');
+    }
+    _lastBuild = now;
+    // ...
+  }
+  ```
+
+## References
+
+- [Riverpod: Reading Providers](https://riverpod.dev/docs/concepts/reading)
+- [Riverpod: ref.watch vs ref.read vs ref.listen](https://riverpod.dev/docs/essentials/combining_providers)
+- [Flutter DevTools: Identify Rebuilds](https://docs.flutter.dev/tools/devtools/performance)

--- a/.claude/skills/riverpod-ref-in-provider-lifecycle/SKILL.md
+++ b/.claude/skills/riverpod-ref-in-provider-lifecycle/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: riverpod-ref-in-provider-lifecycle
+description: |
+  Fix Riverpod "Cannot use Ref or modify other providers inside life-cycles/selectors" crash
+  in @riverpod provider bodies. Use when: (1) Crash during provider disposal with this exact
+  error message, (2) Using keepAlive() with timer-based disposal, (3) Async callbacks (.then,
+  .catchError) try to use ref.read() or ref.invalidateSelf(), (4) Error occurs after
+  ref.onCancel/onResume/onDispose callbacks fire. Solution: wrap ref operations in try-catch
+  or avoid using ref in async callbacks entirely.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Riverpod ref Usage in Provider Lifecycle Callbacks
+
+## Problem
+When using `ref.keepAlive()` with timer-based auto-disposal in `@riverpod` providers,
+async callbacks (`.then()`, `.catchError()`) that execute during or after disposal
+will crash when they try to use `ref.read()`, `ref.invalidateSelf()`, or any other
+ref operation.
+
+## Context / Trigger Conditions
+
+**Error message:**
+```
+'package:riverpod/src/core/ref.dart': Failed assertion: line 216 pos 7:
+'_debugCallbackStack == 0': Cannot use Ref or modify other providers inside life-cycles/selectors.
+```
+
+**Typical scenario:**
+1. Provider uses `ref.keepAlive()` with a timer in `ref.onCancel()`:
+```dart
+final link = ref.keepAlive();
+ref.onCancel(() {
+  Timer(Duration(seconds: 15), () {
+    link.close();  // Triggers disposal
+  });
+});
+```
+
+2. Provider has async callbacks that use `ref`:
+```dart
+someAsyncOperation().then((_) {
+  if (ref.mounted) {  // THIS CHECK IS NOT ENOUGH!
+    ref.invalidateSelf();
+  }
+});
+```
+
+3. Timer fires while async callback is pending
+4. CRASH - `ref.mounted` returns `true` but using `ref` is still forbidden
+
+**Key insight:** `ref.mounted` returns `true` during lifecycle callbacks, but
+using `ref` operations is still forbidden. This is counter-intuitive but by design.
+
+## Solution
+
+### Option 1: Wrap ref operations in try-catch (Recommended)
+
+```dart
+someAsyncOperation().then((_) {
+  try {
+    ref.read(someProvider.notifier).update(/*...*/);
+  } catch (e) {
+    Log.debug('Provider likely disposed: $e');
+  }
+});
+```
+
+### Option 2: Avoid ref operations in async callbacks entirely
+
+Instead of:
+```dart
+// BAD - uses ref in async callback
+openVineVideoCache.removeCorruptedVideo(videoId).then((_) {
+  if (ref.mounted) {
+    ref.invalidateSelf();  // CRASH!
+  }
+});
+```
+
+Do:
+```dart
+// GOOD - fire-and-forget without ref
+unawaited(
+  openVineVideoCache.removeCorruptedVideo(videoId).then((_) {
+    Log.info('Cache removed');  // No ref usage
+  }),
+);
+// Let user retry manually or provider recreates on next access
+```
+
+### Option 3: Capture provider state synchronously first
+
+```dart
+// Read state BEFORE async operation
+final notifier = ref.read(someProvider.notifier);
+
+// Use captured reference in callback (not ref)
+someAsyncOperation().then((_) {
+  notifier.doSomething();  // Uses captured reference, not ref
+});
+```
+
+## Anti-Pattern: ref.mounted Check
+
+```dart
+// THIS DOES NOT WORK!
+someAsyncOperation().then((_) {
+  if (ref.mounted) {  // Returns true during lifecycle!
+    ref.invalidateSelf();  // Still crashes!
+  }
+});
+```
+
+The `ref.mounted` check is insufficient because:
+1. Timer fires, `link.close()` called
+2. Riverpod enters disposal lifecycle (callback stack > 0)
+3. `ref.mounted` check passes (still returns `true`!)
+4. `ref.invalidateSelf()` called
+5. CRASH - ref operations forbidden during lifecycle callbacks
+
+## Verification
+
+1. Rapidly scroll through content that uses the provider
+2. Navigate away and back while providers are active
+3. Let the keepAlive timers fire naturally (wait 15+ seconds after scrolling)
+4. Check Crashlytics/console for the lifecycle assertion error
+5. Error should no longer occur
+
+## Example
+
+### Before (causes crash):
+
+```dart
+@riverpod
+VideoPlayerController videoController(Ref ref, String videoId) {
+  final link = ref.keepAlive();
+
+  ref.onCancel(() {
+    Timer(Duration(seconds: 15), () => link.close());
+  });
+
+  final controller = VideoPlayerController.networkUrl(url);
+
+  controller.initialize().catchError((error) {
+    // CRASH! This callback may run during disposal
+    if (ref.mounted) {
+      ref.invalidateSelf();  // Assertion failure!
+    }
+  });
+
+  return controller;
+}
+```
+
+### After (safe):
+
+```dart
+@riverpod
+VideoPlayerController videoController(Ref ref, String videoId) {
+  final link = ref.keepAlive();
+
+  ref.onCancel(() {
+    Timer(Duration(seconds: 15), () => link.close());
+  });
+
+  final controller = VideoPlayerController.networkUrl(url);
+
+  controller.initialize().catchError((error) {
+    // Safe - wrapped in try-catch
+    try {
+      ref.read(fallbackProvider.notifier).state = newValue;
+    } catch (e) {
+      Log.debug('Provider disposed during error handling: $e');
+    }
+    // Don't invalidateSelf - let provider recreate on next access
+  });
+
+  return controller;
+}
+```
+
+## Notes
+
+- This issue is specific to `@riverpod` provider bodies, not widget dispose()
+- The related skill `riverpod-ref-read-in-dispose` covers widget lifecycle issues
+- Consider whether `ref.invalidateSelf()` is even necessary - often the provider
+  will be recreated naturally on next access
+- For truly critical cleanup, use `ref.onDispose()` which runs synchronously
+  before the lifecycle callback stack check
+- This bug is particularly common with video players, image loaders, and other
+  resources that use keepAlive() with timer-based disposal
+
+## Related Skills
+
+- `riverpod-ref-read-in-dispose`: For widget dispose() ref.read() issues
+- `flutter-dispose-timer-test-failure`: For timer-related test failures
+
+## References
+
+- [Riverpod ref.keepAlive](https://riverpod.dev/docs/concepts/modifiers/auto_dispose#refkeepalive)
+- [Riverpod lifecycle callbacks](https://riverpod.dev/docs/concepts/provider_lifecycles)

--- a/.claude/skills/riverpod-ref-listen-build-only/SKILL.md
+++ b/.claude/skills/riverpod-ref-listen-build-only/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: riverpod-ref-listen-build-only
+description: |
+  Fix "ref.listen can only be used within the build method of a ConsumerWidget" assertion
+  error in Flutter Riverpod 3.x. Use when: (1) ConsumerStatefulWidget crashes with
+  "Failed assertion: line 492 pos 7: 'debugDoingBuild'" in flutter_riverpod consumer.dart,
+  (2) ref.listen is called inside initState, addPostFrameCallback, or any lifecycle method
+  other than build(), (3) All widget tests fail with this assertion from scheduler callback.
+  Applies to flutter_riverpod 3.0+ with ConsumerStatefulWidget.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-06
+---
+
+# Riverpod ref.listen Must Be in build() for ConsumerStatefulWidget
+
+## Problem
+In Riverpod 3.x, calling `ref.listen` inside `initState()`, `addPostFrameCallback`, or
+any method other than `build()` causes an assertion failure:
+
+```
+ref.listen can only be used within the build method of a ConsumerWidget
+'package:flutter_riverpod/src/core/consumer.dart':
+Failed assertion: line 492 pos 7: 'debugDoingBuild'
+```
+
+This typically manifests when trying to reactively watch a provider value that may change
+after the widget is first built (e.g., waiting for an async operation to complete).
+
+## Context / Trigger Conditions
+- Using `ConsumerStatefulWidget` with `flutter_riverpod: ^3.0.0`
+- Calling `ref.listen(provider, callback)` inside `initState()` or a post-frame callback
+- All widget tests fail with the assertion error from `ConsumerStatefulElement.listen`
+- The error occurs during `pumpWidget` or `pumpAndSettle` in tests
+- Stack trace shows `SchedulerBinding._invokeFrameCallback` -> `ConsumerStatefulElement.listen`
+
+## Solution
+
+Move `ref.listen` into the `build()` method. Use a guard flag to ensure side effects
+only trigger once.
+
+**Before (broken):**
+```dart
+class _MyScreenState extends ConsumerState<MyScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // THIS WILL CRASH in Riverpod 3.x
+      ref.listen(
+        myProvider.select((s) => s.someValue),
+        (previous, next) {
+          if (previous == null && next != null) {
+            _doSomething(next);
+          }
+        },
+      );
+    });
+  }
+}
+```
+
+**After (fixed):**
+```dart
+class _MyScreenState extends ConsumerState<MyScreen> {
+  bool _actionAttempted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // Immediate check for already-available data
+      final value = ref.read(myProvider).someValue;
+      if (value != null) _tryDoSomething(value);
+    });
+  }
+
+  void _tryDoSomething(SomeType? value) {
+    if (value == null || _actionAttempted) return;
+    _actionAttempted = true;
+    _doSomething(value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // ref.listen is safe here - Riverpod auto-manages the subscription
+    ref.listen(
+      myProvider.select((s) => s.someValue),
+      (previous, next) {
+        if (previous == null && next != null) {
+          _tryDoSomething(next);
+        }
+      },
+    );
+
+    return // ... widget tree
+  }
+}
+```
+
+### Key points:
+1. `ref.listen` in `build()` is auto-managed by Riverpod (no manual disposal needed)
+2. It re-registers each build but Riverpod handles deduplication
+3. Use a guard flag (`_actionAttempted`) to prevent side effects from firing multiple times
+4. Keep the immediate check in `initState`'s post-frame callback for when data is already available
+5. `ref.read` is fine in `initState`/callbacks; only `ref.listen` and `ref.watch` are restricted
+
+## Verification
+- All widget tests pass without assertion errors
+- The listener fires correctly when the watched value changes
+- Side effects only trigger once (verify with a counter or log)
+
+## Notes
+- `ref.watch` is also restricted to `build()` only
+- `ref.read` can be used anywhere (initState, callbacks, dispose, etc.)
+- In older Riverpod versions (< 3.0), `ref.listen` was less restricted
+- If you need a listener outside `build()`, use `ref.listenManual()` which returns
+  a `ProviderSubscription` that must be manually disposed in `dispose()`
+- This constraint exists because Riverpod needs the widget's element context to properly
+  manage subscription lifecycle
+
+## References
+- https://riverpod.dev/docs/essentials/combining_requests
+- https://pub.dev/packages/flutter_riverpod/changelog (3.0.0 breaking changes)

--- a/.claude/skills/riverpod-ref-read-in-dispose/SKILL.md
+++ b/.claude/skills/riverpod-ref-read-in-dispose/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: riverpod-ref-read-in-dispose
+description: |
+  Fix Riverpod "Using ref when widget is unmounted is unsafe" error in ConsumerStatefulWidget.
+  Use when: (1) Error thrown in dispose() when calling ref.read(), (2) Need to call a service
+  method during widget cleanup, (3) ConsumerStatefulWidget needs to perform actions on provider
+  when user navigates away. Solution: cache the service/notifier in initState with late final.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-01
+---
+
+# Riverpod ref.read() in dispose() Error
+
+## Problem
+When a `ConsumerStatefulWidget` needs to call a service method in `dispose()` (e.g., to cancel
+an operation when the user leaves a screen), using `ref.read()` throws an error because the
+widget is already unmounted.
+
+## Context / Trigger Conditions
+- Error message: `Using ref when widget is unmounted is unsafe`
+- Using `ConsumerStatefulWidget` with `ConsumerState`
+- Calling `ref.read(someProvider)` inside `dispose()`
+- Widget navigates away (pop, push replacement, etc.)
+- Stack trace shows the error originating from dispose()
+
+Example problematic code:
+```dart
+@override
+void dispose() {
+  ref.read(authServiceProvider).cancelOperation();  // ERROR!
+  super.dispose();
+}
+```
+
+## Solution
+
+### Step 1: Add a late final field for the service
+```dart
+class _MyScreenState extends ConsumerState<MyScreen> {
+  late final MyService _myService;  // Cache here
+```
+
+### Step 2: Initialize in initState
+```dart
+@override
+void initState() {
+  super.initState();
+  _myService = ref.read(myServiceProvider);  // Safe here
+}
+```
+
+### Step 3: Use cached reference in dispose
+```dart
+@override
+void dispose() {
+  _myService.cancelOperation();  // Use cached reference
+  super.dispose();
+}
+```
+
+## Verification
+1. Navigate to the screen
+2. Navigate away (back button, push replacement, etc.)
+3. No "Using ref when widget is unmounted" error in console
+4. The cleanup action (cancel, close, etc.) still executes
+
+## Example
+
+### Before (causes error):
+```dart
+class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
+  @override
+  void dispose() {
+    // ERROR: ref is not safe to use here
+    ref.read(authServiceProvider).cancelNostrConnect();
+    super.dispose();
+  }
+}
+```
+
+### After (works correctly):
+```dart
+class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
+  // Cache AuthService for use in dispose (can't use ref.read in dispose)
+  late final AuthService _authService;
+
+  @override
+  void initState() {
+    super.initState();
+    _authService = ref.read(authServiceProvider);
+  }
+
+  @override
+  void dispose() {
+    // Cancel the session if user leaves the screen
+    _authService.cancelNostrConnect();
+    super.dispose();
+  }
+}
+```
+
+## Notes
+- This pattern is necessary because Riverpod's `ref` is tied to the widget lifecycle
+- `ref.read()` is safe in `initState()` because the widget is being mounted
+- `ref.read()` is NOT safe in `dispose()` because the widget is being unmounted
+- The `late final` pattern ensures the service is initialized exactly once
+- This applies to any cleanup that requires calling methods on providers
+- For simple provider state changes (not method calls), consider using `deactivate()` instead
+- If the service itself might be disposed, add null checks or try-catch as appropriate
+
+## Related Skills
+- `flutter-dispose-timer-test-failure`: For timer-related dispose issues
+- `flutter-deactivate-setstate-during-build`: For setState/build cycle issues in deactivate
+
+## References
+- [Riverpod ConsumerStatefulWidget](https://riverpod.dev/docs/concepts/reading#using-refread-to-obtain-the-state-of-a-provider)
+- [Flutter State.dispose](https://api.flutter.dev/flutter/widgets/State/dispose.html)

--- a/.claude/skills/riverpod-stream-provider-auth-transition-oscillation/SKILL.md
+++ b/.claude/skills/riverpod-stream-provider-auth-transition-oscillation/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: riverpod-stream-provider-auth-transition-oscillation
+description: |
+  Fix Flutter home feed / main screen stuck on loading spinner after login when using
+  Riverpod StreamProvider that watches GoRouter location changes. Use when: (1) Screen
+  shows BrandedLoadingIndicator or CircularProgressIndicator permanently after successful
+  auth redirect, (2) Widget watches a route-type-gating provider that returns
+  AsyncValue.loading() intermittently, (3) Logs show route location oscillating between
+  stale and current paths during post-login transition (e.g., /welcome/* after /home/0),
+  (4) Provider chain has double-gate: widget gates on pageContext AND data provider also
+  gates on pageContext. Distinct from riverpod-infinite-rebuild-loop (rapid rebuilds) —
+  this causes permanent loading state, not infinite rebuilds.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-16
+---
+
+# Riverpod StreamProvider Auth Transition Oscillation
+
+## Problem
+
+After successful login and redirect, the main screen (home feed, dashboard, etc.) is
+permanently stuck on a loading indicator. The auth redirect works correctly (URL shows
+`/home/0`), but the screen never renders data. This is NOT a rapid rebuild issue — the
+widget builds a few times then settles on a loading state.
+
+## Context / Trigger Conditions
+
+**Symptoms:**
+- Screen stuck on loading spinner after successful login redirect
+- URL bar / GoRouter shows correct path (e.g., `/home/0`)
+- Data provider (e.g., `homeFeedProvider`) has data if checked directly
+- No error messages — just permanent loading
+- May show brief flash of content before reverting to loading
+
+**Architecture that triggers this:**
+1. A `StreamProvider` that watches `router.routerDelegate` for location changes
+2. This stream parses routes into a `RouteContext` with a `type` field (home, explore, etc.)
+3. Downstream providers gate on `routeContext.type == RouteType.home` and return
+   `AsyncValue.loading()` when the type doesn't match
+4. The widget watches the downstream provider and shows loading indicator
+
+**The oscillation pattern:**
+```
+Auth state changes → Router redirects to /home/0
+  → routerDelegate emits /home/0 ✓
+  → routerDelegate emits /welcome/login (stale!) ✗
+  → routerDelegate emits /home/0 ✓
+  → routerDelegate emits /welcome/* (stale!) ✗
+  ...oscillates for several frames
+```
+
+**Why it happens:**
+GoRouter's `routerDelegate` listener fires for EVERY location change during transitions,
+including intermediate/stale states. During post-login, the router processes multiple
+pending navigations (pop welcome screen, push home screen) and the delegate emits each
+intermediate state. A sync `StreamController` propagates these instantly.
+
+**Log signature:**
+```
+CTX derive: type=RouteType.home npub=null index=0
+CTX derive: type=RouteType.welcome npub=null index=null   ← stale!
+CTX derive: type=RouteType.home npub=null index=0
+```
+
+## Root Cause Analysis
+
+The issue is a **double gate** on an oscillating stream:
+
+```
+routerDelegate listener
+  ↓ (emits every location change)
+StreamProvider<RouteContext>  ← oscillates between /home and /welcome
+  ↓
+videosForHomeRouteProvider   ← returns loading() when type != home  [GATE 1]
+  ↓
+HomeScreenRouter.build()     ← watches pageContext for type check   [GATE 2]
+```
+
+When the stream oscillates, both gates open and close rapidly. The widget ends up
+rendering the loading state from whichever emission came last in the settling period.
+
+## Solution
+
+### Pattern: "I Know Who I Am" — Bypass Route-Type Gating
+
+When a widget **knows its own context** (it's only mounted at a specific route), it
+doesn't need to gate on a route-type stream. It can read route info synchronously.
+
+### Step 1: Read URL index synchronously from GoRouter
+
+```dart
+// BEFORE: Watching oscillating stream
+final pageContext = ref.watch(pageContextProvider);
+return pageContext.when(
+  data: (ctx) {
+    if (ctx.type != RouteType.home) return loading();
+    // ...
+  },
+  loading: () => loading(),
+  error: (e, s) => error(),
+);
+
+// AFTER: Read synchronously — this widget IS the home screen
+final router = ref.read(goRouterProvider);
+final location = router.routeInformationProvider.value.uri.toString();
+final segments = location.split('/').where((s) => s.isNotEmpty).toList();
+int urlIndex = 0;
+if (segments.length > 1 && segments[0] == 'home') {
+  urlIndex = int.tryParse(segments[1]) ?? 0;
+}
+```
+
+### Step 2: Watch the data provider directly
+
+```dart
+// BEFORE: Watching intermediate provider that gates on route type
+final videosAsync = ref.watch(videosForHomeRouteProvider);
+
+// AFTER: Watch the data provider directly — no route-type gate needed
+final videosAsync = ref.watch(homeFeedProvider);
+```
+
+### Step 3: Remove unused intermediate provider imports
+
+Clean up imports for any intermediate route-gating providers that are no longer used.
+
+## When NOT to Apply This Fix
+
+- When the widget genuinely needs to render different content based on route type
+  (e.g., a shared shell that shows different feeds)
+- When the widget is mounted at multiple routes and needs to switch behavior
+- If the issue is actually rapid rebuilds (use `riverpod-infinite-rebuild-loop` instead)
+
+## Verification
+
+After the fix:
+1. Login → redirect to home → home feed loads immediately (no permanent spinner)
+2. No `RAPID REBUILD` warnings (this fix doesn't cause those)
+3. Swipe through feed works normally
+4. Pull-to-refresh works
+5. Navigate away and back — feed still loads
+6. Test with `ref.watch(homeFeedProvider)` in initState to confirm data arrives
+
+## Example: Complete Fix (HomeScreenRouter)
+
+**Before (stuck on loading):**
+```dart
+@override
+Widget build(BuildContext context) {
+  final pageContext = ref.watch(pageContextProvider);
+  return buildAsyncUI(
+    pageContext,
+    onData: (ctx) {
+      if (ctx.type != RouteType.home) {
+        return const Center(child: BrandedLoadingIndicator(size: 80));
+      }
+      final videosAsync = ref.watch(videosForHomeRouteProvider);
+      return buildAsyncUI(videosAsync, ...);
+    },
+  );
+}
+```
+
+**After (loads correctly):**
+```dart
+@override
+Widget build(BuildContext context) {
+  // Read URL synchronously — HomeScreenRouter is only at /home/:index
+  final router = ref.read(goRouterProvider);
+  final location = router.routeInformationProvider.value.uri.toString();
+  final segments = location.split('/').where((s) => s.isNotEmpty).toList();
+  int urlIndex = 0;
+  if (segments.length > 1 && segments[0] == 'home') {
+    urlIndex = int.tryParse(segments[1]) ?? 0;
+  }
+
+  // Watch data directly — no route-type gate needed
+  final videosAsync = ref.watch(homeFeedProvider);
+  return buildAsyncUI(videosAsync, onData: (state) { ... });
+}
+```
+
+## Notes
+
+- **Distinct from rebuild loops:** `riverpod-infinite-rebuild-loop` covers rapid rebuilds
+  (50+ per second). This issue causes 3-8 rebuilds that settle on a LOADING state.
+- **Related to auth timing:** Often co-occurs with synchronous router redirect needing
+  data that isn't yet available. See companion fix: pre-fetch data before setting auth
+  state so redirects have what they need.
+- **StreamProvider vs read:** The oscillation only affects `StreamProvider` watching
+  reactive router state. `ref.read()` of GoRouter's current location is stable.
+- **GoRouter's routerDelegate:** This listener fires for every intermediate navigation
+  state. It's reliable for final states but oscillates during multi-step transitions
+  (login → pop welcome → push home).
+- **Debug technique:** Add `print('CTX derive: type=${ctx.type}')` to the StreamProvider
+  to see the oscillation pattern.
+
+## Related Skills
+
+- `riverpod-infinite-rebuild-loop` — rapid rebuilds from watch/listener issues
+- `flutter-pageview-url-routing-reorder-loop` — infinite loop from item reorder tracking
+- `flutter-startup-network-blocking` — blocking network ops during startup

--- a/.claude/skills/rsky-pds-crawler-notify-hang/SKILL.md
+++ b/.claude/skills/rsky-pds-crawler-notify-hang/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: rsky-pds-crawler-notify-hang
+description: |
+  Fix rsky-pds createRecord/putRecord hanging indefinitely with no error logs.
+  Use when: (1) createSession succeeds but createRecord never returns,
+  (2) No error appears in PDS logs despite request hanging for 60+ seconds,
+  (3) PDS health endpoint works but write operations hang,
+  (4) readiness probes intermittently fail on rsky-pds pod.
+  Root cause: PDS_CRAWLERS env var configures crawler notification URLs
+  that are called via reqwest HTTP client WITHOUT any timeout in crawlers.rs.
+  If the crawler URL is unreachable from the cluster, every write hangs forever.
+  Also: setting PDS_CRAWLERS="" produces [""] (one empty string element)
+  which causes a "builder error" instead — must fully unset the env var.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-21
+---
+
+# rsky-pds Crawler Notification Hang
+
+## Problem
+All write operations on rsky-pds (createRecord, putRecord, deleteRecord) hang
+indefinitely with no error output. The PDS appears healthy (health endpoint
+returns 200, createSession works) but any operation that modifies the repo
+never completes.
+
+## Context / Trigger Conditions
+- `createSession` returns a valid JWT instantly
+- `createRecord` or `putRecord` with that JWT hangs forever (60s+ timeout)
+- PDS logs show only `Rocket has launched from http://0.0.0.0:8000` with no error
+- `_health` endpoint returns `{"version":"0.3.0-beta.3"}` (or similar)
+- Kubernetes readiness probes may intermittently fail due to the pod being
+  overwhelmed by hung requests
+- The `PDS_CRAWLERS` env var is set (e.g., `https://bsky.network`)
+
+## Solution
+
+### Quick Fix (Runtime)
+Unset the `PDS_CRAWLERS` environment variable entirely:
+
+```bash
+# IMPORTANT: Use the trailing dash to UNSET, don't set to empty string
+kubectl set env deployment/rsky-pds -n <namespace> PDS_CRAWLERS-
+
+# Wait for rollout
+kubectl rollout status deployment/rsky-pds -n <namespace> --timeout=120s
+```
+
+**Do NOT** set `PDS_CRAWLERS=""` — the `env_list()` parser splits on commas,
+so an empty string produces `vec![""]` (one empty-string element), which
+causes a `"builder error"` when reqwest tries to build a URL from `""`.
+
+### Code Fix (Permanent)
+In `rsky-pds/src/crawlers.rs`, add a timeout to the reqwest client:
+
+```rust
+let client = reqwest::Client::builder()
+    .user_agent(APP_USER_AGENT)
+    .timeout(std::time::Duration::from_secs(5))  // Add this
+    .connect_timeout(std::time::Duration::from_secs(3))  // Add this
+    .build()?;
+```
+
+Also consider making the error non-fatal (use `let _ =` to ignore failures
+instead of propagating with `?`), since crawler notification is not critical
+to the write operation succeeding.
+
+## Root Cause Analysis
+
+The write path in rsky-pds is:
+1. `createRecord` -> `process_writes` -> `format_commit` (DB, works fine)
+2. `sequence_commit` -> `sequence_evt` -> `crawlers.notify_of_update()` (HANGS)
+
+`notify_of_update()` in `crawlers.rs` creates a `reqwest::Client` with no
+timeout configured and POSTs to each crawler URL. From within a GKE cluster,
+the request to `https://bsky.network/xrpc/com.atproto.sync.requestCrawl` may
+hang at the TCP level with no response, causing the entire write to block.
+
+Key files:
+- `rsky-pds/src/crawlers.rs:30-61` — `notify_of_update()` method
+- `rsky-pds/src/sequencer/mod.rs:215` — calls `crawlers.notify_of_update()`
+- `rsky-pds/src/apis/com/atproto/repo/create_record.rs:100` — acquires sequencer lock
+- `rsky-common/src/env.rs:28-33` — `env_list()` parser that splits empty strings
+
+## Verification
+After unsetting `PDS_CRAWLERS`:
+```bash
+# Should return in <10 seconds instead of hanging
+curl -X POST "$PDS_URL/xrpc/com.atproto.repo.createRecord" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"repo":"$DID","collection":"app.bsky.feed.post","record":{"$type":"app.bsky.feed.post","text":"test","createdAt":"2026-01-01T00:00:00Z"}}'
+```
+
+## Notes
+- This affects ALL rsky-pds deployments that set PDS_CRAWLERS to an unreachable URL
+- The upstream TypeScript atproto PDS has proper timeouts; this is an rsky-specific bug
+- The `notify_of_update()` has a 20-minute throttle, so the first write after startup
+  always triggers the notification (and hangs if unreachable)
+- The sequencer write lock at line 99 means a single hung notification blocks ALL
+  subsequent write requests, not just the one that triggered it

--- a/.claude/skills/sqlite-fts5-corruption-rebuild/SKILL.md
+++ b/.claude/skills/sqlite-fts5-corruption-rebuild/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: sqlite-fts5-corruption-rebuild
+description: |
+  Fix SQLite "database disk image is malformed" errors caused by corrupted FTS5 indexes.
+  Use when: (1) UPDATE/INSERT fails with "stepping, database disk image is malformed" but
+  PRAGMA integrity_check returns "ok", (2) Only specific records fail to update while others
+  succeed, (3) Records contain dirty text with tabs, newlines, or unusual characters that
+  were inserted into FTS5-indexed columns. The misleading error message suggests disk
+  corruption, but the actual issue is FTS5 index corruption from malformed text content.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-23
+---
+
+# SQLite FTS5 Index Corruption from Dirty Data
+
+## Problem
+SQLite returns "database disk image is malformed" (error code 11) when trying to
+UPDATE or INSERT records, even though `PRAGMA integrity_check` reports the database
+as "ok". The error only affects specific records, not all writes.
+
+## Context / Trigger Conditions
+- Error message: `Error: stepping, database disk image is malformed (11)`
+- `PRAGMA integrity_check` returns `ok` (misleading!)
+- SELECT queries on the same records work fine
+- Only certain records fail to update; other records in the same table update successfully
+- The affected records contain text with embedded tabs (`\t`), newlines (`\n`), or other
+  control characters in columns that are indexed by FTS5
+- A concurrent process (like a Node.js server) may have the database open
+
+## Solution
+
+1. **Identify FTS5 tables** linked to the affected table:
+   ```sql
+   SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%fts%';
+   ```
+
+2. **Stop any processes** holding the database open (the rebuild requires exclusive access):
+   ```bash
+   kill $(lsof -ti :PORT)  # Kill the server process
+   ```
+
+3. **Rebuild the FTS5 index**:
+   ```sql
+   INSERT INTO table_fts(table_fts) VALUES('rebuild');
+   ```
+   Replace `table_fts` with your actual FTS5 table name (e.g., `people_fts`).
+
+4. **Retry the failed operation** - it should now succeed.
+
+5. **Restart your application server**.
+
+## Verification
+- The previously failing UPDATE/INSERT statement now succeeds
+- Full-text search queries still return correct results
+- No more "malformed" errors on subsequent writes
+
+## Example
+
+```bash
+# Error occurs:
+sqlite3 data/tracker.db "UPDATE people SET name = 'More' WHERE id = 11;"
+# Error: stepping, database disk image is malformed (11)
+
+# But integrity check passes:
+sqlite3 data/tracker.db "PRAGMA integrity_check;"
+# ok
+
+# And SELECT works fine:
+sqlite3 data/tracker.db "SELECT id, name FROM people WHERE id = 11;"
+# 11|More Masajes\t\n\t\tEscort 23 años...
+
+# Fix: Stop server, rebuild FTS5 index
+kill $(lsof -ti :3001)
+sqlite3 data/tracker.db "INSERT INTO people_fts(people_fts) VALUES('rebuild');"
+
+# Now the update works:
+sqlite3 data/tracker.db "UPDATE people SET name = 'More' WHERE id = 11;"
+# Success!
+```
+
+## Prevention
+- Sanitize text before inserting into FTS5-indexed columns:
+  ```javascript
+  const cleanName = rawName.replace(/[\t\n\r]+/g, ' ').trim();
+  ```
+- Strip control characters from scraped data before database insertion
+- Consider using `content=` (external content) FTS5 tables that can be rebuilt
+  independently without affecting the main table
+
+## Notes
+- The error code 11 (`SQLITE_CORRUPT`) is the same as actual disk corruption,
+  making this hard to diagnose
+- The corruption is in the FTS5 shadow tables (`_data`, `_idx`, `_docsize`),
+  not the main table, which is why `integrity_check` passes
+- If `rebuild` fails with "database is locked", ensure no other process has
+  the database open (check with `lsof` or `fuser`)
+- This can also happen when records are deleted or updated externally
+  (e.g., via sqlite3 CLI) while a WAL-mode connection is active
+
+## References
+- [SQLite FTS5 Documentation - rebuild command](https://www.sqlite.org/fts5.html#the_rebuild_command)
+- [SQLite Error Codes](https://www.sqlite.org/rescode.html#corrupt)

--- a/.claude/skills/stale-cache-external-service-recovery/SKILL.md
+++ b/.claude/skills/stale-cache-external-service-recovery/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: stale-cache-external-service-recovery
+description: |
+  Handle stale local cache when external service loses/resets data. Use when:
+  (1) Token refresh fails with "not found" or 404 errors, (2) Cached identifiers
+  (pubkeys, user IDs) don't exist on external service anymore, (3) External service
+  was reset/migrated but local cache has old values. Pattern: detect 404 specifically,
+  delete stale cache entry, recreate on external service, update cache with new values.
+  Complements local-cache-idempotency-fallback skill.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-25
+---
+
+# Stale Cache Recovery When External Service Loses Data
+
+## Problem
+
+When using your database as a cache/idempotency layer (see `local-cache-idempotency-fallback`),
+a new failure mode emerges: the external service loses or resets its data, but your
+cache still has the old values. Operations fail with misleading errors because the cached
+identifiers don't exist on the external service anymore.
+
+## Context / Trigger Conditions
+
+- Token refresh fails with 404 "User with pubkey/id not found"
+- Operations fail with "Invalid or expired token" but the real issue is missing user
+- External service was reset, migrated, or lost data
+- Cached identifiers (pubkeys, API keys, user IDs) are valid in cache but not on service
+- Error message is misleading - suggests token issue when it's actually a missing resource
+
+## Solution
+
+Detect the specific "not found" case and handle it separately from other errors:
+
+```typescript
+if (cached) {
+  pubkey = cached.pubkey;
+  token = cached.token;
+
+  try {
+    // Try to refresh/validate the cached credentials
+    const freshToken = await externalApi.getTokenByPubkey(pubkey);
+    token = freshToken;
+    console.log(`Pubkey: ${pubkey} (token refreshed)`);
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+
+    // CRITICAL: Detect "not found" specifically - cache is stale
+    if (errMsg.includes("not found") || response.status === 404) {
+      console.log(`Cached identifier not on external service, recreating...`);
+
+      // 1. Delete stale cache entry
+      await db.deleteUser(userId);
+
+      // 2. Create fresh resource on external service
+      const result = await externalApi.createUser(userId, username);
+      pubkey = result.pubkey;
+      token = result.token;
+      console.log(`Pubkey: ${pubkey} (recreated)`);
+
+      // 3. Cache new values
+      await db.saveUser({ userId, pubkey, token });
+    } else {
+      // Other error (e.g., user claimed account, rate limit) - can't proceed
+      console.log(`Refresh failed: ${errMsg}`);
+      continue; // or throw
+    }
+  }
+}
+```
+
+### Key Pattern
+
+1. **Attempt normal refresh first**: Try to validate/refresh cached credentials
+2. **Detect 404 specifically**: Check for "not found" in error message or 404 status
+3. **Delete stale entry**: Remove the invalid cache entry before recreating
+4. **Recreate on external**: Create fresh resource with same input identifiers
+5. **Update cache**: Store new values for future runs
+6. **Distinguish from other errors**: Only handle 404; other errors may need different handling
+
+## Verification
+
+1. Simulate external service data loss (or clear its database)
+2. Run script with stale local cache
+3. Should see "recreating" message, not crash with 401/404
+4. New values cached and used for subsequent operations
+5. Script completes successfully
+
+## Example
+
+Real-world application - Keycast pubkey cache recovery:
+
+```typescript
+const cached = await pgDb.getImportedUser(creator.user_id);
+let pubkey: string;
+let token: string;
+
+if (cached) {
+  pubkey = cached.pubkey;
+  token = cached.token;
+
+  try {
+    const freshToken = await keycast.getTokenByPubkey(pubkey);
+    token = freshToken;
+    await pgDb.saveImportedUser({ ...cached, token: freshToken });
+    console.log(`Pubkey: ${pubkey} (token refreshed)`);
+  } catch (refreshError) {
+    const errMsg = refreshError instanceof Error ? refreshError.message : String(refreshError);
+
+    if (errMsg.includes("not found")) {
+      // Keycast doesn't have this pubkey - cache is stale
+      console.log(`Cached pubkey not on Keycast, recreating user...`);
+
+      // Delete stale entry
+      await pgDb.deleteImportedUser(creator.user_id);
+
+      // Create fresh user
+      const result = await keycast.createPreloadedUser(
+        creator.user_id,
+        username,
+        displayName
+      );
+      pubkey = result.pubkey;
+      token = result.token;
+      console.log(`Pubkey: ${pubkey} (recreated)`);
+
+      // Cache new account
+      await pgDb.saveImportedUser({
+        vine_user_id: creator.user_id,
+        username: creator.username,
+        pubkey,
+        token,
+        events_published: 0,
+      });
+    } else {
+      // Other error - user may have claimed account, can't proceed
+      console.log(`Token refresh failed: ${errMsg}`);
+      console.log(`Skipping ${creator.username} - cannot sign events`);
+      continue;
+    }
+  }
+}
+```
+
+## Notes
+
+- This complements `local-cache-idempotency-fallback` - use both together
+- The misleading error chain: 404 "not found" → continue with stale token → 401 "invalid token"
+- Always delete before recreate to avoid accumulating orphan cache entries
+- Consider logging which entries were stale for debugging/monitoring
+- If external service is frequently losing data, investigate root cause
+- The new pubkey will be different from the old one - downstream systems may need updates
+
+## Related Skills
+
+- `local-cache-idempotency-fallback`: The base pattern this skill extends
+- Database retry logic for connection resets (separate concern)

--- a/.claude/skills/tests-guard-intentional-workarounds/SKILL.md
+++ b/.claude/skills/tests-guard-intentional-workarounds/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: tests-guard-intentional-workarounds
+description: |
+  Before removing code that looks redundant, wasteful, or "wrong" based on log
+  observations or code review instinct, grep the test suite for tests whose
+  names describe the exact behavior you're about to remove. A test whose title
+  literally describes the "weird" thing (e.g. "calls play() even when player
+  reports playing", "retries even when first call succeeded", "skips cache
+  even when fresh") is a load-bearing workaround, and the production log
+  you're reacting to is probably the workaround working as designed — not a
+  bug. Use when: (1) Tempted to remove a function call that "looks redundant"
+  based on a production log, (2) About to "simplify" a conditional that seems
+  to always take the same branch, (3) Reviewing code and thinking "why would
+  anyone write this?", (4) A log line shows a state that seems impossible or
+  contradictory (e.g. playing=true but positionMs=0 for seconds), (5) CI
+  surfaces a failing test whose name describes exactly what your fix removed.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-05
+---
+
+# Tests Guard Intentional Workarounds
+
+## Problem
+
+You observe a production log line that looks clearly wrong — a function being
+called when its precondition already appears satisfied, a retry firing when
+the first attempt seemed to work, state being set to the value it already
+holds. Instinct says "this is a redundant no-op, I'll remove it." You remove
+it, run local tests (which may even pass if coverage is thin), push to CI,
+and a test fails with a title that describes **exactly the behavior you just
+removed**. The comment on that test explains a subtle platform bug or race
+condition that required the "redundant" call as a workaround.
+
+The log line you reacted to wasn't evidence of a bug. It was evidence of the
+workaround executing correctly for the exact scenario it was designed for.
+
+## Context / Trigger Conditions
+
+Apply this skill's caution when ANY of these hold:
+
+1. **Redundant-looking call**: You're about to wrap a call in `if (!already_X)`
+   or delete it outright because logs show it firing when `X` is already true.
+2. **Impossible state in logs**: Logs show a state combination that seems
+   logically impossible or contradictory (`playing=true` + `positionMs=0` for
+   seconds, `isLoading=false` + data still empty, etc.).
+3. **"Why would anyone write this?"**: Reading code and you can't imagine a
+   reason for a defensive check, extra await, or secondary call.
+4. **Simplifying a conditional**: A branch looks dead because you believe the
+   condition can't be reached, or both branches look identical to you.
+5. **Receiving a failing test**: CI returns a failure with a test title that
+   names exactly the behavior your change removed or modified.
+
+## Solution
+
+Before touching the "redundant" code, run this five-step check:
+
+### Step 1: Grep for tests that assert the exact behavior
+
+Search the test suite for the function name, the state you think is
+redundant, and any synonyms:
+
+```bash
+# Example: considering removing player.play() on rebuffer complete
+grep -rn "player.play" test/ | grep -iE "already|even when|still|twice|redundant"
+grep -rn "rebuffer.*play\|playing.*true.*play" test/
+```
+
+Look specifically for test names containing phrases like:
+- `"even when X"` / `"even if X"`
+- `"still calls Y when Z"`
+- `"twice on Y"` / `"idempotent"`
+- `"after Y"` (especially `"after seek"`, `"after error"`, `"after reconnect"`)
+- `"recovers from"` / `"nudges"` / `"resumes"`
+- The specific state word from your log (`stalled`, `frozen`, `orphan`, `race`)
+
+### Step 2: Read the test comment, not just the assertion
+
+If you find a matching test, **read the comment above the assertion**, not
+just the `expect()` call. The comment almost always explains *why* the
+otherwise-redundant behavior is required. Look for phrases like:
+- "mpv/iOS/Chrome/Safari can X even when Y"
+- "nudge", "kick", "wake up", "unstick"
+- "workaround for", "due to", "race with"
+- Bug tracker references, commit SHAs, PR numbers
+
+### Step 3: Correlate with your production log
+
+Re-read the log line that prompted the "fix" through the lens of the test
+comment. Does the log state match the bug scenario the test describes?
+
+- If the test says "mpv reports playing=true while stalled at positionMs=0"
+  and your log shows `playing=true, positionMs=0`, you are looking at the bug
+  the workaround exists to handle. The workaround is **working**.
+- If the log state doesn't match the test's stated scenario, you may have
+  found a new bug OR a genuinely redundant branch. Proceed carefully.
+
+### Step 4: Preserve behavior, improve observability
+
+If the workaround is load-bearing, don't remove it. Instead:
+- Add or improve the log message so future-you understands the intent
+  (`nudge_stalled_decoder` is clearer than `redundant_play`).
+- Add a code comment referencing the test that guards this behavior
+  (`// See test: "rebuffer recovery calls play() even when playing=true"`).
+- If the volume is noisy, consider downgrading the log level or sampling it,
+  but keep the behavior.
+
+### Step 5: If CI already caught you, revert and learn
+
+If you've already pushed and CI surfaced the guarding test:
+
+1. **Don't "fix" the test to match the new behavior.** The test is the spec.
+2. Revert just the behavior change — keep any unrelated improvements
+   (logging, comments, etc.).
+3. Read the test comment carefully and update your mental model of the system.
+4. Commit the revert with a message that captures the lesson so the next
+   engineer reading git blame understands why the "redundant" call is there.
+
+## Verification
+
+After applying this skill, you should be able to answer:
+
+- [ ] Is there a test whose name describes the behavior I'm about to remove?
+- [ ] If yes, does its comment explain a bug/race/platform quirk that justifies it?
+- [ ] Does the production log I'm reacting to match that bug's scenario?
+- [ ] Can I explain in one sentence *why* the "redundant" behavior exists,
+      with enough detail that a reviewer would agree?
+
+If you can't answer all four, you don't yet know enough to remove the code.
+
+## Example
+
+**Scenario** (real, Flutter + media_kit video player):
+
+Production log from iOS:
+```
+STUTTER_DEBUG rebuffer_auto_play index=48 positionMs=0 playing=true
+```
+
+Instinct: "Why call `player.play()` when `player.state.playing` is already
+true? That's a no-op at best. Let me add `if (!player.state.playing)`."
+
+**Wrong fix applied.** CI fails:
+```
+ - [FAILED] VideoFeedController post-seek rebuffer recovery
+   rebuffer recovery calls play() even when player reports playing
+```
+
+Reading the test (which was already in the repo):
+```dart
+test(
+  'rebuffer recovery calls play() even when player reports playing',
+  () async {
+    // ...
+    // Simulate rebuffer completes while player reports playing=true.
+    // mpv can stall (no frame output) even when playing=true after a
+    // seek, so we always call play() to nudge the decoder.
+    when(() => setup.state.playing).thenReturn(true);
+    // ...
+    verify(setup.player.play).called(greaterThanOrEqualTo(1));
+  },
+);
+```
+
+The test comment documents the exact bug: **mpv's `playing=true` does not
+guarantee frame output after a seek or network hiccup**. The "redundant"
+`play()` call is specifically to unstick the decoder in that state. The
+production log showing `positionMs=0, playing=true` for seconds is the bug
+happening in production — and the workaround is the reason videos recover
+instead of staying frozen.
+
+**Correct response**: Revert the `if (!playing)` guard. Keep it calling
+`play()` unconditionally. If the log is noisy, rename the log tag from
+`rebuffer_auto_play` to `decoder_nudge` to reflect the actual purpose, and
+add a source comment pointing at the test.
+
+## Notes
+
+- This skill is about **code you didn't write**. Your own recent code is
+  unlikely to have a hidden workaround you forgot about.
+- Particularly common in: video/audio playback, network retry paths, browser
+  quirks, GPU/driver workarounds, filesystem race conditions, distributed
+  systems idempotency, animation/layout pipelines.
+- A test whose name contains the phrase *"even when"* or *"even if"* is the
+  single strongest signal that you're looking at a guarded workaround.
+- Conversely, if you *add* a workaround, write the test with a name that
+  literally describes the surprising behavior, so the next engineer (or
+  future-you) gets the warning you wish you'd gotten.
+- Related: `superpowers:verification-before-completion` (don't claim a fix
+  works until you've actually run the test that guards the behavior) and
+  `simplify` (which should also respect this rule — don't simplify away
+  code that a test explicitly asserts).
+
+## References
+
+- Original session: Divine Mobile PR #2737, iOS video stutter debugging,
+  2026-04-05.
+- Related skill: `mock-call-count-retry-fallback` — for the inverse case
+  where adding retry logic breaks test call counts.

--- a/.claude/skills/vine-oembed-metadata-recovery/SKILL.md
+++ b/.claude/skills/vine-oembed-metadata-recovery/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: vine-oembed-metadata-recovery
+description: |
+  Recover Vine video metadata (author, user ID, title, thumbnail) from vine.co oembed endpoint
+  even though the Vine API and pages are dead. Use when: (1) you have Vine shortcode URLs
+  (vine.co/v/XXXXX) and need to identify the creator, (2) the Vine page only shows a loading
+  spinner, (3) archive-api.vineapp.com returns 404, (4) need to map Vine shortcodes to user IDs
+  for cross-referencing against the divine.video database. The oembed endpoint is a still-live
+  metadata oracle for the otherwise-dead Vine platform.
+author: Claude Code
+version: 1.0.0
+date: 2026-03-22
+---
+
+# Vine oEmbed Metadata Recovery
+
+## Problem
+Vine.co pages no longer render content — the SPA shell loads but the backend API
+(`archive-api.vineapp.com`) returns 404, so pages just show a loading spinner. However,
+the **oembed endpoint is still live** and returns structured metadata for any valid Vine URL.
+
+## Context / Trigger Conditions
+- You have Vine URLs in the format `vine.co/v/{shortcode}`
+- The Vine page shows only a loading spinner (SPA shell loads, API calls fail)
+- `archive-api.vineapp.com/timelines/posts/s/{shortcode}` returns 404
+- You need to identify which creator made a specific Vine
+- You need to map Vine shortcodes to Vine user IDs
+
+## Solution
+
+### Single Lookup
+Query the oembed endpoint:
+```
+GET https://vine.co/oembed.json?url=https://vine.co/v/{SHORTCODE}
+```
+
+### Response Fields
+The oembed response provides:
+- **`author_name`** — Vine username (e.g., "Kenrealdihboss")
+- **`author_url`** — Profile URL containing the Vine user ID (e.g., `https://vine.co/u/1306031740015583232`)
+- **`title`** — Post description/caption
+- **`thumbnail_url`** — 480x480 thumbnail (may still resolve on Vine CDN)
+- **`thumbnail_width`** / **`thumbnail_height`** — Always 480x480
+- **`width`** / **`height`** — Embed dimensions (600x600)
+- **`html`** — Iframe embed code
+- **`provider_name`** — "Vine"
+- **`type`** — "video"
+- **`version`** — "1.0"
+- **`cache_age`** — Cache duration in seconds
+
+### Extract User ID
+The Vine numeric user ID is in the `author_url` path:
+```
+author_url: "https://vine.co/u/1306031740015583232"
+→ user_id: 1306031740015583232
+```
+
+### Bulk Recovery Pattern
+If you have a list of Vine shortcodes (from Wayback CDX crawls, social media embeds, etc.):
+
+```python
+import requests
+import time
+
+def get_vine_oembed(shortcode):
+    url = f"https://vine.co/oembed.json?url=https://vine.co/v/{shortcode}"
+    resp = requests.get(url, timeout=10)
+    if resp.status_code == 200:
+        data = resp.json()
+        user_id = data.get("author_url", "").split("/u/")[-1]
+        return {
+            "shortcode": shortcode,
+            "username": data.get("author_name"),
+            "user_id": user_id,
+            "title": data.get("title"),
+            "thumbnail_url": data.get("thumbnail_url"),
+        }
+    return None
+
+# Rate-limit to be respectful
+for shortcode in shortcodes:
+    result = get_vine_oembed(shortcode)
+    if result:
+        print(f"{result['shortcode']} → {result['username']} (ID: {result['user_id']})")
+    time.sleep(0.5)
+```
+
+### Cross-Reference with Database
+Once you have the user ID, look up in the divine.video database:
+```sql
+SELECT * FROM users WHERE id = '1306031740015583232';
+SELECT * FROM outreach_contacts WHERE user_id = '1306031740015583232';
+```
+
+## Verification
+```bash
+curl -s "https://vine.co/oembed.json?url=https://vine.co/v/iLrDJJWn9e6" | python3 -m json.tool
+```
+Should return JSON with `author_name`, `author_url`, `title`, `thumbnail_url`, etc.
+
+## Sources of Vine Shortcodes
+- Wayback Machine CDX API: `http://web.archive.org/cdx/search/cdx?url=vine.co/v/*&output=json`
+- Embedded Vine tweets on Twitter/X
+- Reddit posts linking to vine.co/v/
+- Tumblr embeds (many Vine creators cross-posted)
+- Blog posts and news articles embedding Vines
+
+## Notes
+- The oembed endpoint appears to be served separately from the main Vine API infrastructure,
+  which is why it survived while everything else died
+- Thumbnail CDN URLs from oembed may or may not still resolve — worth checking
+- This works for individual Vine posts but NOT for user profile lookups
+- The `author_url` format `vine.co/u/{numeric_id}` gives you the same user ID used in
+  the divine.video database's `users` and `imported_users` tables
+- Be respectful with rate limits — this endpoint is still running and we don't want to
+  overwhelm it

--- a/.claude/skills/vite-proxy-folder-name-conflict/SKILL.md
+++ b/.claude/skills/vite-proxy-folder-name-conflict/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: vite-proxy-folder-name-conflict
+description: |
+  Fix 404 errors for frontend JS files when using Vite proxy. Use when: (1) Browser shows
+  "Failed to load resource: 404" for JS/JSX files that exist on disk, (2) Vite serves HTML
+  instead of JavaScript for module imports, (3) You have a client folder named "api" (or
+  similar) AND a Vite proxy configured for "/api". The proxy intercepts requests for
+  client-side files when folder names match proxy paths. Applies to Vite, Vite+React,
+  Vite+Vue projects with dev server proxy configuration.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-21
+---
+
+# Vite Proxy Folder Name Conflict
+
+## Problem
+
+Frontend JavaScript/JSX files return 404 errors even though they exist on disk. The browser
+console shows errors like:
+
+```
+usePeople.js:1 Failed to load resource: the server responded with a status of 404 (Not Found)
+useMedia.js:1 Failed to load resource: the server responded with a status of 404 (Not Found)
+```
+
+The files exist at paths like `src/client/api/hooks/usePeople.js`, but Vite returns 404 or
+serves HTML instead of JavaScript.
+
+## Context / Trigger Conditions
+
+This issue occurs when ALL of these conditions are true:
+
+1. **Vite dev server** with proxy configuration in `vite.config.js`:
+   ```javascript
+   server: {
+     proxy: {
+       '/api': {
+         target: 'http://localhost:3001',
+         changeOrigin: true,
+       },
+     },
+   }
+   ```
+
+2. **Client-side folder** with the same name as the proxy path:
+   ```
+   src/client/
+   ├── api/           ← Folder name matches proxy path "/api"
+   │   ├── client.js
+   │   └── hooks/
+   │       ├── usePeople.js
+   │       └── useMedia.js
+   ```
+
+3. **Imports** that resolve to the proxied path:
+   ```javascript
+   // In src/client/pages/Directory.jsx
+   import { usePeople } from '../api/hooks/usePeople.js';
+   // Vite transforms this to: /api/hooks/usePeople.js
+   // This matches the proxy rule and gets sent to backend!
+   ```
+
+## Root Cause
+
+Vite's module resolution transforms relative imports to absolute paths. When you import
+`../api/hooks/usePeople.js` from a page, Vite resolves it to `/api/hooks/usePeople.js`.
+
+The proxy configuration matches paths starting with `/api` and forwards them to the backend
+server. Since `/api/hooks/usePeople.js` starts with `/api`, it gets proxied to the backend
+instead of being served as a static file.
+
+The backend doesn't have a route for `/api/hooks/usePeople.js`, so it returns 404.
+
+## Solution
+
+**Option 1: Rename the client folder (Recommended)**
+
+Rename the conflicting folder to something that won't match the proxy path:
+
+```bash
+# Rename api to services (or lib, helpers, etc.)
+mv src/client/api src/client/services
+
+# Update all imports
+find src/client -name "*.jsx" -o -name "*.js" | xargs sed -i '' 's|from.*['"'"'"]\.\.\/api|from "../services|g'
+```
+
+**Option 2: Use a different proxy path**
+
+Change the proxy path to something more specific:
+
+```javascript
+// vite.config.js
+server: {
+  proxy: {
+    '/api/v1': {  // More specific path
+      target: 'http://localhost:3001',
+      changeOrigin: true,
+    },
+  },
+}
+```
+
+**Option 3: Configure proxy to exclude certain patterns**
+
+Use a custom function to exclude certain paths:
+
+```javascript
+server: {
+  proxy: {
+    '/api': {
+      target: 'http://localhost:3001',
+      changeOrigin: true,
+      bypass: (req) => {
+        // Don't proxy requests for JS/TS files
+        if (req.url.match(/\.(js|jsx|ts|tsx|mjs)$/)) {
+          return req.url;
+        }
+      },
+    },
+  },
+}
+```
+
+## Verification
+
+After applying the fix:
+
+1. Clear Vite's cache: `rm -rf node_modules/.vite`
+2. Restart the dev server: `npm run dev`
+3. Check browser console - 404 errors should be gone
+4. Verify the app loads and API calls still work
+
+Test both:
+- Frontend file serving: `curl http://localhost:5173/services/hooks/usePeople.js` should return JavaScript
+- API proxying: `curl http://localhost:5173/api/people` should return JSON from backend
+
+## Example
+
+**Before (broken):**
+```
+src/client/
+├── api/                    ← Conflicts with proxy
+│   └── hooks/
+│       └── usePeople.js
+├── pages/
+│   └── Directory.jsx       ← import from '../api/hooks/usePeople.js'
+
+vite.config.js:
+  proxy: { '/api': 'http://localhost:3001' }
+
+Result: Browser gets 404 for usePeople.js
+```
+
+**After (fixed):**
+```
+src/client/
+├── services/               ← Renamed to avoid conflict
+│   └── hooks/
+│       └── usePeople.js
+├── pages/
+│   └── Directory.jsx       ← import from '../services/hooks/usePeople.js'
+
+vite.config.js:
+  proxy: { '/api': 'http://localhost:3001' }  ← Unchanged
+
+Result: Frontend files served correctly, API still proxied
+```
+
+## Notes
+
+- This issue is not specific to React—it affects any Vite project with proxies
+- Common conflicting folder names: `api`, `graphql`, `socket`, `ws`
+- The issue only manifests in development (Vite dev server); production builds don't have this problem
+- If using TypeScript path aliases, ensure they also avoid proxy path conflicts
+- Always clear Vite's cache (`node_modules/.vite`) after changing folder structure
+
+## Related Issues
+
+- Similar issues can occur with other dev servers (webpack-dev-server, Create React App)
+- If using a monorepo, check proxy configs in both root and package-level configs

--- a/.claude/skills/wayback-api-archive-recovery/SKILL.md
+++ b/.claude/skills/wayback-api-archive-recovery/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: wayback-api-archive-recovery
+description: |
+  Recover data from archived REST APIs using Wayback Machine. Use when: (1) Recovering
+  data from defunct services like Vine, Twitter, or other platforms, (2) Need to find
+  which API endpoints were archived vs which require authentication, (3) Building data
+  recovery pipelines from web.archive.org. Covers CDX API queries to discover archived
+  endpoints, understanding what gets archived (public) vs what doesn't (authenticated),
+  and extracting embedded JSON from archived web pages as a fallback.
+author: Claude Code
+version: 1.0.0
+date: 2025-01-20
+---
+
+# Wayback Machine API Archive Recovery
+
+## Problem
+When recovering data from defunct services, you need to know which API endpoints were
+archived by the Wayback Machine, and how to access them. Not all endpoints are archived -
+authenticated endpoints typically aren't captured.
+
+## Context / Trigger Conditions
+- Recovering data from a shut-down service (Vine, old Twitter API, defunct platforms)
+- Building an archive crawler for digital preservation
+- Need to reconstruct engagement data (comments, likes, followers) from archives
+- Getting empty results when trying to fetch archived API endpoints
+
+## Solution
+
+### Step 1: Discover What Was Archived
+
+Use the CDX API to search for archived endpoints:
+
+```bash
+# Find all archived endpoints under a path prefix
+curl "https://web.archive.org/cdx/search/cdx?url=vine.co/api/posts/&matchType=prefix&output=json&fl=original,timestamp&filter=statuscode:200&limit=100"
+
+# Check total pages available
+curl "https://web.archive.org/cdx/search/cdx?url=vine.co/api/&matchType=prefix&showNumPages=true"
+```
+
+Key CDX parameters:
+- `matchType=prefix` - Match URL prefixes with wildcards
+- `fl=original,timestamp` - Select which fields to return
+- `filter=statuscode:200` - Only successful captures
+- `collapse=urlkey` - Deduplicate by URL
+- `limit=N` - Cap results
+
+### Step 2: Understand What Gets Archived
+
+**Typically archived (public endpoints):**
+- Comment lists: `/api/posts/{id}/comments`
+- User profiles: `/api/users/profiles/{id}`
+- Timelines: `/api/timelines/users/{id}`
+- Public feeds: `/api/timelines/promoted`
+
+**Typically NOT archived (require authentication):**
+- Like lists: `/api/posts/{id}/likes`
+- Follower/following lists: `/api/users/{id}/followers`
+- Private data: DMs, settings, notifications
+
+### Step 3: Fetch Archived API Responses
+
+Use the `id_` modifier to get raw JSON without the Wayback toolbar:
+
+```bash
+# Without id_ - may return HTML wrapper
+curl "https://web.archive.org/web/20161209032217/https://vine.co/api/posts/123/comments"
+
+# With id_ - returns raw JSON
+curl "https://web.archive.org/web/20161209032217id_/https://vine.co/api/posts/123/comments"
+```
+
+### Step 4: Extract Embedded Data as Fallback
+
+When API endpoints weren't archived, check if data was embedded in archived web pages:
+
+```python
+# Many SPAs embed initial data in script tags
+import re
+import json
+
+html = fetch_archived_page(url)
+
+# Look for embedded JSON (common patterns)
+patterns = [
+    r'window\.POST_DATA\s*=\s*({.*?});',      # Vine
+    r'window\.__INITIAL_STATE__\s*=\s*({.*?});',  # Redux apps
+    r'<script type="application/json"[^>]*>({.*?})</script>',
+]
+
+for pattern in patterns:
+    match = re.search(pattern, html, re.DOTALL)
+    if match:
+        data = json.loads(match.group(1))
+```
+
+**Caveat:** Embedded data is often partial (e.g., only first 3 comments rendered).
+
+### Step 5: Infer Missing Data from Interactions
+
+When follower/following lists aren't available, infer relationships:
+
+```python
+# If A commented on B's post → A probably follows B
+inferred_follows.append({
+    'follower': commenter_id,
+    'followee': post_creator_id,
+    'inference_type': 'commented_on_post',
+    'confidence': 0.7
+})
+
+# If A mentioned @B → A probably follows B
+# If A and B mutually commented → bidirectional follow (collaborators)
+```
+
+## Verification
+
+1. CDX query returns results with status 200
+2. Fetching with `id_` modifier returns valid JSON
+3. Parsing embedded data produces expected structure
+
+## Example
+
+```python
+import urllib.request
+import json
+
+def find_archived_endpoints(base_url):
+    """Find all archived API endpoints for a service."""
+    cdx_url = f"https://web.archive.org/cdx/search/cdx?url={base_url}&matchType=prefix&output=json&fl=original,timestamp&filter=statuscode:200"
+
+    with urllib.request.urlopen(cdx_url, timeout=60) as resp:
+        data = json.loads(resp.read())
+
+    # Skip header row, extract unique URLs
+    endpoints = {}
+    for row in data[1:]:
+        url, timestamp = row[0], row[1]
+        if url not in endpoints:
+            endpoints[url] = timestamp
+
+    return endpoints
+
+def fetch_archived_json(url, timestamp):
+    """Fetch archived JSON using id_ modifier."""
+    archive_url = f"https://web.archive.org/web/{timestamp}id_/{url}"
+
+    with urllib.request.urlopen(archive_url, timeout=30) as resp:
+        return json.loads(resp.read())
+
+# Usage
+endpoints = find_archived_endpoints("vine.co/api/posts/")
+print(f"Found {len(endpoints)} archived endpoints")
+
+# Filter to comment endpoints
+comments = {k: v for k, v in endpoints.items() if '/comments' in k}
+```
+
+## Notes
+
+- Wayback Machine rate limits requests - add delays (1+ second) between fetches
+- Archived timestamps vary - same endpoint may have captures from different dates
+- Paginated APIs: check for `page`, `offset`, `cursor` parameters in archived URLs
+- Some archives return 302 redirects - follow them or check for "stale" archives
+- The CDX API itself can be slow for large result sets - use pagination
+
+## References
+- [Wayback Machine CDX API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server)
+- [Internet Archive APIs](https://archive.org/developers/)

--- a/.claude/skills/wayback-cdx-cloud-ip-workaround/SKILL.md
+++ b/.claude/skills/wayback-cdx-cloud-ip-workaround/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: wayback-cdx-cloud-ip-workaround
+description: |
+  Fix Wayback Machine CDX API returning empty results or timing out from cloud/datacenter
+  IPs (Cloud Run, AWS Lambda, GCE, etc.) while working fine locally. Use when:
+  (1) CDX queries timeout or return 0 bytes from Cloud Run/cloud functions but work from
+  local machine, (2) urllib.request.urlopen times out for web.archive.org from server,
+  (3) Wayback Machine CDX silently returns empty from datacenter IPs with no HTTP error,
+  (4) Need to run CDX-dependent scripts on Cloud Run or similar cloud compute.
+  Workaround: fetch locally, upload to cloud storage, import on cloud compute.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-20
+---
+
+# Wayback CDX API: Cloud/Datacenter IP Workaround
+
+## Problem
+The Wayback Machine CDX API (`web.archive.org/cdx/search/cdx`) silently refuses to
+serve data to requests from cloud provider IP ranges (Google Cloud Run, AWS, GCE, etc.).
+There is no HTTP error code — requests either timeout or return 0 bytes. The same
+queries work perfectly from residential/local IPs.
+
+## Context / Trigger Conditions
+- CDX API returns empty (0 bytes) or times out from Cloud Run, Lambda, GCE, etc.
+- Same query via curl on local machine returns expected data
+- No HTTP error codes (not 429, not 403) — just empty or timeout
+- Other external APIs (Common Crawl, Arctic Shift, Arquivo.pt) work fine from the same cloud instance
+- Even with VPC connector + static IP configured, CDX still fails
+- Increasing timeouts and retries doesn't help
+
+## Solution
+
+### The Pattern: Local Fetch → Cloud Storage → Cloud Import
+
+Since CDX won't respond to cloud IPs, split the workflow:
+
+1. **Fetch locally**: Run CDX queries from your local machine, save results to a file
+2. **Upload to cloud storage**: `gsutil cp` the file to GCS (or S3, etc.)
+3. **Import on cloud**: Have your Cloud Run job read from cloud storage instead of CDX
+
+### Implementation
+
+**Step 1: Local fetch script**
+```python
+# Run this locally — CDX works from residential IPs
+import urllib.request, urllib.parse
+
+CDX = 'https://web.archive.org/cdx/search/cdx'
+results = set()
+resume_key = None
+
+while True:
+    params = {
+        'url': 'example.com/path/*',
+        'output': 'text',
+        'fl': 'original',
+        'filter': 'statuscode:200',
+        'limit': '10000',
+        'showResumeKey': 'true',
+    }
+    if resume_key:
+        params['resumeKey'] = resume_key
+
+    url = f"{CDX}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={'User-Agent': 'MyBot/0.1'})
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        raw = resp.read().decode('utf-8', errors='replace')
+
+    parts = raw.rstrip().rsplit('\n\n', 1)
+    data_lines = parts[0].strip().split('\n')
+    resume_key = parts[1].strip() if len(parts) == 2 else None
+
+    for line in data_lines:
+        results.add(process_line(line))  # Extract what you need
+
+    if not resume_key or len(data_lines) < 10000:
+        break
+    time.sleep(3)
+
+# Save to file
+with open('/tmp/results.txt', 'w') as f:
+    for item in sorted(results):
+        f.write(f'{item}\n')
+```
+
+**Step 2: Upload to GCS**
+```bash
+gsutil cp /tmp/results.txt gs://my-bucket/imports/results.txt
+```
+
+**Step 3: Cloud Run job with --from-gcs flag**
+```python
+def load_from_gcs(gcs_path: str) -> set[str]:
+    """Load IDs from a GCS text file."""
+    import subprocess
+    result = subprocess.run(
+        ["gsutil", "cp", gcs_path, "/tmp/results.txt"],
+        capture_output=True, text=True, timeout=120
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gsutil failed: {result.stderr}")
+
+    items = set()
+    with open("/tmp/results.txt") as f:
+        for line in f:
+            items.add(line.strip())
+    return items
+
+# In main():
+parser.add_argument("--from-gcs", type=str, default=None,
+                    help="Import from GCS file instead of CDX")
+
+if args.from_gcs:
+    items = load_from_gcs(args.from_gcs)
+else:
+    items = fetch_from_cdx(delay=args.delay)
+```
+
+**Step 4: Deploy with --from-gcs**
+```bash
+gcloud run jobs deploy my-job \
+    --args="-m,my_module,--from-gcs,gs://my-bucket/imports/results.txt" \
+    ...
+```
+
+## Verification
+- Local fetch completes successfully with expected data volume
+- File uploads to GCS without errors
+- Cloud Run job reads from GCS and imports to database
+- `gsutil ls -l gs://my-bucket/imports/results.txt` shows expected file size
+
+## Example
+Real-world case: Fetching 312,427 vine IDs from Wayback CDX oEmbed captures.
+- CDX failed from Cloud Run (4 attempts over multiple deploys, all returning 0 bytes)
+- Local fetch completed in ~4 minutes with resumeKey pagination
+- Uploaded 3.6MB text file to GCS
+- Cloud Run imported 170,108 new IDs from GCS in ~10 minutes
+
+## Notes
+- This affects `web.archive.org` specifically. Other CDX servers (index.commoncrawl.org) work fine from cloud IPs
+- The Internet Archive may whitelist specific IPs on request — contact them if you have a legitimate archival use case
+- Even with a whitelisted static IP via VPC connector, the CDX API may still not respond (whitelisting may apply to download, not CDX)
+- `collapse=urlkey` and `matchType=prefix` are more likely to fail than simple wildcard queries, but even wildcards fail from cloud IPs
+- This workaround adds a manual step (local fetch + upload) but is reliable and only needs to be done once per data source
+- For frequently-changing data, consider scheduling the local fetch via cron and automating the GCS upload
+
+## References
+- Wayback CDX API: https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server
+- Related skill: wayback-cdx-wildcard-pagination (for the pagination aspect)

--- a/.claude/skills/wayback-cdx-wildcard-pagination/SKILL.md
+++ b/.claude/skills/wayback-cdx-wildcard-pagination/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: wayback-cdx-wildcard-pagination
+description: |
+  Fix empty results when paginating Wayback Machine CDX API with wildcard URL queries.
+  Use when: (1) CDX query with url=foo/* and page=0 returns empty/0 bytes but works without
+  page parameter, (2) CDX pagination returns no data for wildcard prefix searches,
+  (3) Need to paginate large CDX result sets using wildcard URL matching.
+  Covers showResumeKey, offset, and page parameter incompatibilities.
+author: Claude Code
+version: 1.0.0
+date: 2026-02-20
+---
+
+# Wayback CDX API: Wildcard Query Pagination
+
+## Problem
+The Wayback Machine CDX API's `page=N` pagination parameter returns **empty results**
+when combined with wildcard URL queries (`url=domain.com/path/*`), even though the
+same query without `page=` returns data. This causes scripts to incorrectly report
+"no results found" when there are actually hundreds of thousands of results.
+
+## Context / Trigger Conditions
+- CDX query with `url=*.example.com/*` or `url=example.com/path/*` and `page=0` returns 0 bytes
+- Same query without `page=` parameter returns expected data
+- Using `web.archive.org/cdx/search/cdx` API endpoint
+- `matchType=prefix` + `collapse=urlkey` + `page=N` combination also fails silently
+- Script works with `limit=5` but fails when adding `page=0`
+
+## Solution
+
+### Option 1: Use `showResumeKey=true` (Recommended)
+The most reliable pagination method. CDX appends a base64 resume token after a blank
+line separator in the response.
+
+```python
+resume_key = None
+while True:
+    params = {
+        'url': 'example.com/path/*',
+        'output': 'text',
+        'fl': 'original',
+        'filter': 'statuscode:200',
+        'limit': '10000',
+        'showResumeKey': 'true',
+    }
+    if resume_key:
+        params['resumeKey'] = resume_key
+
+    data = fetch_cdx(params)
+    if not data:
+        break
+
+    # Resume key is after the last blank line
+    parts = data.rstrip().rsplit('\n\n', 1)
+    if len(parts) == 2:
+        data_lines = parts[0].strip().split('\n')
+        resume_key = parts[1].strip()
+    else:
+        data_lines = parts[0].strip().split('\n')
+        resume_key = None
+
+    # Process data_lines...
+
+    if not resume_key or len(data_lines) < limit:
+        break
+```
+
+### Option 2: Use `offset=N`
+Works but less efficient for very large result sets.
+
+```python
+offset = 0
+limit = 10000
+while True:
+    params = {
+        'url': 'example.com/path/*',
+        'output': 'text',
+        'fl': 'original',
+        'limit': str(limit),
+        'offset': str(offset),
+    }
+    data = fetch_cdx(params)
+    lines = data.strip().split('\n')
+    if not lines or not lines[0]:
+        break
+    offset += len(lines)
+```
+
+### What NOT to do
+```python
+# THIS RETURNS EMPTY for wildcard queries:
+params = {
+    'url': 'example.com/path/*',
+    'page': '0',        # <-- INCOMPATIBLE with wildcard
+    'limit': '10000',
+}
+
+# THIS ALSO FAILS from some IPs:
+params = {
+    'url': 'example.com/path/',
+    'matchType': 'prefix',
+    'collapse': 'urlkey',
+    'page': '0',
+}
+```
+
+## Verification
+- Query with `showResumeKey=true` and no `page=` param returns data
+- Response ends with a blank line followed by a base64 token (the resume key)
+- Subsequent request with `resumeKey=<token>` returns the next page
+
+## Example
+Fetching all vine.co/oembed/* URLs (690K+ captures, 312K unique vine IDs):
+```bash
+# This works:
+curl "https://web.archive.org/cdx/search/cdx?url=vine.co/oembed/*&output=text&fl=original&limit=10000&showResumeKey=true"
+
+# This returns empty:
+curl "https://web.archive.org/cdx/search/cdx?url=vine.co/oembed/*&output=text&fl=original&limit=10000&page=0"
+```
+
+## Notes
+- `page=N` works fine for non-wildcard queries (e.g., exact URL lookups)
+- The `showResumeKey` approach is server-side cursor-based, more efficient than offset
+- Keep `limit` at 10000 or less to avoid timeouts, especially from cloud IPs
+- Always add `time.sleep(3-5)` between pages to be polite to the CDX server
+- The CDX API has no official documentation for this incompatibility
+
+## References
+- CDX API informal docs: https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server
+- CDX pagination: The `page` API was designed for the pywb CDX server and may not be fully compatible with all query modes on the production Wayback CDX

--- a/.claude/skills/wayback-indirect-asset-recovery/SKILL.md
+++ b/.claude/skills/wayback-indirect-asset-recovery/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: wayback-indirect-asset-recovery
+description: |
+  Recover assets (images, videos, data) that weren't directly archived by Wayback Machine
+  by crawling archived pages that reference them. Use when: (1) Direct asset URL returns
+  404/503 from Wayback, (2) Asset was hosted on CDN that Wayback didn't crawl, (3) You
+  have the page URL but not the asset URL, (4) Recovering avatars, thumbnails, or embedded
+  media from defunct services. The key insight: pages often got archived even when their
+  assets didn't - extract URLs from archived HTML, then try alternative fetch methods.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-28
+---
+
+# Wayback Indirect Asset Recovery
+
+## Problem
+When archiving content from defunct services, direct asset URLs (images, videos, avatars)
+often return 404/503 from Wayback Machine even when the pages referencing them were archived.
+The assets themselves may not have been crawled, but their URLs exist in archived HTML.
+
+## Context / Trigger Conditions
+- Direct Wayback URL for asset returns 404 or 503
+- You have a profile/page URL but not the asset URL
+- Recovering media from defunct services (Vine, Tumblr, defunct startups)
+- Wayback has the page but not the embedded assets
+- CDN-hosted assets that weren't in Wayback's crawl scope
+
+## Solution
+
+### Step 1: Fetch the Archived Page
+```python
+import requests
+import re
+
+session = requests.Session()
+session.headers['User-Agent'] = 'YourCrawler/0.1 (archival research)'
+
+# Fetch archived profile/page
+page_url = f"https://web.archive.org/web/20170110/https://example.com/user/{username}"
+resp = session.get(page_url, timeout=20, allow_redirects=True)
+```
+
+### Step 2: Extract Asset URLs from HTML
+```python
+# Try multiple patterns - pages structure varies
+patterns = [
+    # Open Graph image
+    (r'og:image["\s]+content="([^"]+)"', 'og:image'),
+    # JSON data in page
+    (r'"avatarUrl"\s*:\s*"([^"]+)"', 'JSON avatarUrl'),
+    (r'"imageUrl"\s*:\s*"([^"]+)"', 'JSON imageUrl'),
+    # CDN URLs
+    (r'(https?://[^"\s]+cdn\.[^"\s]+\.(jpg|png|mp4))', 'CDN URL'),
+    # S3 URLs
+    (r'(https?://[^"\s]+\.s3\.amazonaws\.com/[^"\s]+)', 'S3 URL'),
+]
+
+for pattern, name in patterns:
+    match = re.search(pattern, html)
+    if match:
+        asset_url = match.group(1).replace('&amp;', '&')
+        break
+```
+
+### Step 3: Handle Wayback-Wrapped URLs
+URLs extracted from archived pages are often already Wayback URLs:
+```python
+# If URL is already wrapped, convert im_ to id_ for raw content
+if 'web.archive.org/web/' in asset_url:
+    # Replace /web/TIMESTAMP/ or /web/TIMESTAMPim_/ with /web/TIMESTAMPid_/
+    download_url = re.sub(r'/web/(\d+)(im_)?/', r'/web/\1id_/', asset_url)
+else:
+    # Wrap raw URL in Wayback
+    download_url = f"https://web.archive.org/web/{timestamp}id_/{asset_url}"
+```
+
+### Step 4: Fallback Methods if Wayback Fails
+If Wayback returns 404/503 for the asset, try alternatives:
+
+```python
+# Extract original CDN URL
+cdn_match = re.search(r'(https?://[^/]+cdn\.[^"\s]+)', asset_url)
+if cdn_match:
+    original_url = cdn_match.group(1)
+
+    # Method 1: Try live CDN via IP (if DNS is dead but servers live)
+    # See: dead-cdn-dns-bypass skill
+
+    # Method 2: Try different Wayback timestamps
+    for ts in ['20170110', '20160601', '20150601']:
+        alt_url = f"https://web.archive.org/web/{ts}id_/{original_url}"
+        resp = session.get(alt_url, timeout=30)
+        if resp.status_code == 200:
+            break
+
+    # Method 3: Check if asset exists on successor platform
+    # (e.g., user migrated to Twitter/TikTok with same username)
+```
+
+## Verification
+1. Check HTTP 200 response from final download URL
+2. Validate content-type matches expected type
+3. Verify file magic bytes (JPEG: `\xff\xd8\xff`, PNG: `\x89PNG`)
+4. Confirm file size > minimum threshold
+
+## Example: Recovering Vine Avatars
+
+```python
+def recover_avatar_from_profile(vanity_url: str, user_id: str, session) -> bool:
+    """Recover avatar by crawling archived Vine profile."""
+    timestamps = ['20170110', '20161201', '20160601', '20150601']
+
+    for ts in timestamps:
+        # Fetch archived profile page
+        profile_url = f"https://web.archive.org/web/{ts}/https://vine.co/{vanity_url}"
+        resp = session.get(profile_url, timeout=20)
+
+        if resp.status_code != 200:
+            continue
+
+        # Extract avatar URL from page
+        match = re.search(r'og:image["\s]+content="([^"]+)"', resp.text)
+        if not match:
+            match = re.search(r'"avatarUrl"\s*:\s*"([^"]+)"', resp.text)
+
+        if match:
+            avatar_url = match.group(1).replace('&amp;', '&')
+
+            # Convert to raw content URL
+            if 'web.archive.org/web/' in avatar_url:
+                download_url = re.sub(r'/web/(\d+)(im_)?/', r'/web/\1id_/', avatar_url)
+            else:
+                download_url = f"https://web.archive.org/web/{ts}id_/{avatar_url}"
+
+            # Download
+            img_resp = session.get(download_url, timeout=30)
+            if img_resp.status_code == 200 and len(img_resp.content) > 100:
+                # Validate and save
+                if img_resp.content[:3] == b'\xff\xd8\xff':  # JPEG
+                    save_avatar(user_id, img_resp.content, 'jpg')
+                    return True
+
+    return False
+```
+
+**Result**: Recovered avatars for 95% of top Vine creators (including Logan Paul, Nash Grier,
+Lele Pons) whose direct avatar URLs weren't archived.
+
+## Notes
+
+- **Wayback im_ vs id_ modifiers**: `im_` returns image with Wayback toolbar, `id_` returns raw bytes
+- **Rate limiting**: Respect Wayback's servers - add 1-2 second delays between requests
+- **Multiple timestamps**: Try several archive dates - some may have the asset, others may not
+- **HTML entity decoding**: Always decode `&amp;` to `&` in extracted URLs
+- **Redirect handling**: Use `allow_redirects=True` - Wayback often redirects to nearest snapshot
+
+## Related Skills
+
+- `dead-cdn-dns-bypass` - For when CDN DNS is dead but servers still respond
+- `wayback-api-archive-recovery` - For discovering what was archived via CDX API
+- `wayback-machine-raw-content-id-modifier` - For fetching raw content without Wayback wrapper

--- a/.claude/skills/wayback-machine-raw-content-id-modifier/SKILL.md
+++ b/.claude/skills/wayback-machine-raw-content-id-modifier/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: wayback-machine-raw-content-id-modifier
+description: |
+  Fix JSON parse errors when fetching archived API responses from Wayback Machine. Use when:
+  (1) Getting "Expecting value: line 1 column 1 (char 0)" JSON decode errors from archived URLs,
+  (2) Wayback returns HTML instead of expected JSON/raw content, (3) Crawling archived REST APIs
+  or JSON endpoints from web.archive.org. The `id_` modifier returns raw content without the
+  Wayback toolbar wrapper.
+author: Claude Code
+version: 1.0.0
+date: 2026-01-20
+---
+
+# Wayback Machine Raw Content with id_ Modifier
+
+## Problem
+When fetching archived JSON API endpoints from the Wayback Machine, you get HTML-wrapped
+content with the Wayback toolbar instead of the raw JSON response. This causes JSON parse
+errors like "Expecting value: line 1 column 1 (char 0)" because the response starts with
+`<!DOCTYPE html>` instead of valid JSON.
+
+## Context / Trigger Conditions
+- Fetching archived API endpoints from `web.archive.org/web/{timestamp}/{url}`
+- JSON parsing fails with "Expecting value: line 1 column 1 (char 0)"
+- Response content starts with HTML instead of expected JSON
+- Crawling archived REST APIs, JSON feeds, or any non-HTML content from Wayback
+- Using Python `json.loads()`, `response.json()`, or similar JSON parsing
+
+## Solution
+Add `id_` after the timestamp in the Wayback URL to get raw content:
+
+**Default (HTML-wrapped):**
+```
+https://web.archive.org/web/20170112012313/https://vine.co/api/users/profiles/123
+```
+
+**Raw content (add `id_`):**
+```
+https://web.archive.org/web/20170112012313id_/https://vine.co/api/users/profiles/123
+```
+
+### Code Fix Pattern
+```python
+# BEFORE (broken - returns HTML)
+url = f"https://web.archive.org/web/{timestamp}/https://example.com/api/data"
+
+# AFTER (works - returns raw JSON)
+url = f"https://web.archive.org/web/{timestamp}id_/https://example.com/api/data"
+```
+
+### Other Wayback Modifiers
+- `id_` - Raw/identity (no modifications, returns original content)
+- `if_` - Iframe embed mode
+- `js_` - JavaScript rewriting mode
+- `cs_` - CSS rewriting mode
+- `im_` - Image mode
+
+## Verification
+1. Test the URL with curl to see actual response:
+   ```bash
+   # Without id_ - shows HTML with Wayback toolbar
+   curl -s "https://web.archive.org/web/20170112012313/https://example.com/api/data" | head -5
+
+   # With id_ - shows raw JSON
+   curl -s "https://web.archive.org/web/20170112012313id_/https://example.com/api/data" | head -5
+   ```
+
+2. Verify JSON parsing works:
+   ```python
+   import json
+   import urllib.request
+
+   url = f"https://web.archive.org/web/{timestamp}id_/{api_url}"
+   with urllib.request.urlopen(url) as resp:
+       data = json.loads(resp.read())  # Should work now
+   ```
+
+## Example
+Crawling archived Vine API profiles:
+
+```python
+WAYBACK_BASE = "https://web.archive.org/web"
+
+def fetch_profile(user_id: str, timestamp: str):
+    # Use id_ modifier to get raw JSON instead of HTML-wrapped content
+    url = f"{WAYBACK_BASE}/{timestamp}id_/https://vine.co/api/users/profiles/{user_id}"
+
+    with urllib.request.urlopen(url) as resp:
+        data = json.loads(resp.read())
+        return data['data']  # Now works correctly
+```
+
+## Notes
+- The `id_` modifier works for any content type, not just JSON (images, CSS, JS, etc.)
+- Some archived content may still fail if it was never properly captured
+- CDX API queries (for finding archived URLs) don't need the modifier
+- Rate limit requests to archive.org (5+ seconds between requests recommended)
+- Empty responses (0 bytes) indicate the archive entry exists but content wasn't captured
+
+## References
+- [Wayback Machine URL Modifiers](https://archive.org/help/wayback-api/)
+- [CDX Server API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,24 +9,36 @@
 
 ## Worktree-First Task Workflow
 
-- Start every new task from `main`, not from whatever branch or worktree happens to be open.
-- Sync `main` first: `git fetch origin`, `git switch main`, then `git pull --ff-only origin main`.
-- Create a dedicated worktree before making changes. Prefer `.worktrees/` for repo-local worktrees.
-- Use a fresh branch rooted from `main`, for example: `git worktree add .worktrees/<task-name> -b <branch-name> main`.
+> See `.claude/rules/agent_workflow.md` for detailed rationale and forbidden patterns. The bullets below are the operational summary.
+
+- Start every new task in a **new worktree branched from `origin/main`** — never from local `main` (often stale), never from another branch or worktree.
+- Fetch first, then create the worktree:
+  - `git fetch origin`
+  - `git worktree add .worktrees/<task-name> -b <branch-name> origin/main`
 - Keep one task per worktree. Do not mix unrelated fixes, reviews, or experiments in the same tree.
 - If the current checkout is dirty, do not start new work there. Commit it, stash it intentionally, or discard it intentionally first.
+- **Rebase onto fresh `origin/main` before every push**, even on a branch you've already pushed:
+  - `git fetch origin && git rebase origin/main`
+  - `git push --force-with-lease` (never `--force` without `--lease`)
+- Never merge `main` into a feature branch — always rebase.
 
 ## PR Guardrails
 
 - Every PR title must use Conventional Commit format: `type(scope): summary` or `docs: summary` for docs-only PRs.
 - Set the semantic title when creating the PR. Do not rely on editing it afterward.
 - If a PR title must be fixed after opening, rerun the `semantic_pr` workflow because title edits do not reliably retrigger it.
+- **Every PR targets `main`. Never stack PRs.** When features are interdependent, ship them as **one combined PR** with clearly delineated commits and a description that calls out each feature separately. Never `gh pr create --base <other-branch>`.
 - A task is not complete if the intended changes are still uncommitted.
 - Stage only the files that belong to the task. Avoid broad staging when the worktree contains unrelated changes.
 - End each task with a clean `git status` except for changes that are explicitly still in progress and clearly called out.
 - Commit the completed work on the task branch before handoff.
 - Open a pull request for that branch once the change is ready for review. Do not leave finished work sitting only in a local branch or worktree.
-- Keep commits and PRs focused and reviewable. If a task grows, split it into multiple commits or follow-up PRs.
+- Keep PRs focused and reviewable. If two pieces of work are *truly independent*, split them into separate PRs each targeting `main`. If they depend on each other, **combine them into one PR** rather than splitting and stacking.
+
+## No Technical Debt, No Failing Tests
+
+- Do not accumulate technical debt. Fix issues in the PR that touches them; do not defer with TODOs, follow-up issues, skipped tests, or commented-out code. The only acceptable TODO is a transitional-code TODO with a tracking-issue link (see `.claude/rules/code_style.md`).
+- **`origin/main` always passes.** Any failing test on a feature branch is caused by that branch's diff. Never claim flakiness, never `@Skip` to silence a failure, never push red "to see what CI says." Run affected tests + `flutter analyze` before every push. See `.claude/rules/agent_workflow.md` for the diagnostic recipe when a test fails.
 
 ## Architecture And State Management
 


### PR DESCRIPTION
Closes #3989

## Summary

Mirrors agent workflow rules and the personal skill library into the
repo so every contributor (human or agent) gets the same playbook,
instead of relying on per-user `~/.claude/` setup.

Two clean commits:

1. **Workflow rules** (`97e56cc03`) — codifies four non-negotiables in
   `.claude/rules/agent_workflow.md`, with the operational summary
   threaded into `AGENTS.md` and `self_review_checklist.md` at the
   gates where each rule applies:
   - **Always start in a new worktree branched from `origin/main`**
     (not local `main`, which can be stale).
   - **Always rebase onto fresh `origin/main` before every push**
     (`git fetch origin && git rebase origin/main && git push --force-with-lease`).
   - **Never stack PRs** — every PR targets `main`. Combine
     dependent features into one bigger PR with delineated commits,
     never `--base <other-branch>`.
   - **No technical debt** — fix issues in the PR that touches them;
     no deferral via `// TODO`, `@Skip`, or commented-out code
     (transitional TODOs with tracking-issue links remain allowed
     per `code_style.md`).
   - **Failing tests are never acceptable and always your fault.**
     `origin/main` always passes, so any red test on a feature
     branch is caused by that branch's diff. No "flaky," no `@Skip`
     to silence, no "let's see what CI says."

2. **Shared skill library** (`4fd866eb0`) — adds 109 skills covering
   Flutter / Dart / Riverpod / BLoC patterns, Nostr protocol gotchas,
   divine-specific operational knowledge, and cross-domain debugging
   (clickhouse, postgres, fastly, cloud-run, gcs, wayback, etc.).
   Each skill activates only when its trigger criteria match the
   current task, so irrelevant skills stay quiet. Long-term these may
   move into a shared Claude Code plugin marketplace so they install
   once and propagate across all `divine-*` repos; for now this is the
   simpler answer.

## Why now

Recent reviews surfaced repeated friction from PR stacking, deferred
TODOs, and pushing red tests. Putting the rules in the repo (not just
in one person's agent memory) makes the expectation visible to
everyone, and the skill library means agents working in this repo for
any teammate get the accumulated bug-fix knowledge instead of
rediscovering it each time.

## Test plan

- [ ] CI green (no `.dart` files touched; format/analyze/codegen are
      no-ops for this PR).
- [ ] `find .claude/skills -name SKILL.md | wc -l` shows the expected
      skill count after merge.
- [ ] Open Claude Code in this repo and confirm the new skills surface
      in the available-skills list.
- [ ] Verify `AGENTS.md` and `.claude/rules/self_review_checklist.md`
      both reference `agent_workflow.md` consistently at every gate
      (start of task, before commit, before PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)