### PR TITLE
chore: ignore local dev artifacts and add Zapstore notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,23 @@ logs/
 *.swp
 *.swo
 .claude/worktrees/
+.claude/scheduled_tasks.lock
+
+# Orphan golden tests for missing lib/screens/live/ — preserved on disk, ignored
+mobile/test/goldens/screens/live/
+
+# Local-only zsp publish config (per-machine APK paths)
+mobile/zapstore.yaml
+
+# Superpowers local scratch (not docs/superpowers/)
+.superpowers/
+
+# Playwright MCP scratch output
+**/.playwright-mcp/
+
+# Local exploration / debug captures
+explore-layout-snapshot.md
+explore-layout.png
+search-route-console.txt
+search-route-network.txt
+search-route-snapshot.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,14 @@
 - User-installed CAs are not trusted in any build. If you need to proxy-debug with Charles or mitmproxy, add a single `<certificates src="user" />` line to `<trust-anchors>` in `mobile/android/app/src/main/res/xml/network_security_config.xml` in your working copy and don't commit it; CI's transport-security guard will block any commit that re-enables user-CA trust. (For iOS, plist-edit `NSAppTransportSecurity` similarly and revert before commit.)
 - If you add a new exception to either native config, update `mobile/scripts/check_native_transport_security.sh` so the guard recognises the allowance.
 
+## Zapstore Publishing Notes
+
+- Do not complicate Zapstore publish handoff. Let Rabble run `zsp` directly unless explicitly asked to wrap or automate it.
+- Never ask Rabble to paste an `nsec` into chat or into a shell command that would land in history.
+- If `zsp` selects the wrong release, stop and fix the release source/version issue before signing. Do not continue to preview/sign.
+- Divine `1.0.9` was a GitHub prerelease, so `zsp` selected `1.0.8` unless `--pre-release` was passed or a local APK/config path forced the exact APK.
+- Before telling Rabble to sign, verify the `zsp` fetch output shows the intended APK version, for example `Version: 1.0.9 (...)`.
+
 ## Clean Workspace Expectations
 
 - Do not leave untracked or modified files around after a task unless they are part of the intentional diff.

--- a/docs/superpowers/plans/2026-04-09-mobile-ci-parallelization.md
+++ b/docs/superpowers/plans/2026-04-09-mobile-ci-parallelization.md
@@ -1,0 +1,386 @@
+# Mobile CI Parallelization Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce GitHub Actions PR wall-clock time for `Mobile CI` by splitting static checks into parallel jobs and sharding Flutter tests across multiple runners while preserving full PR coverage.
+
+**Architecture:** Keep the existing `Mobile CI` workflow name and trigger behavior, but replace the single serial `build` job with parallel jobs for generated files, formatting, analysis, and a matrix-based test job. Put test sharding logic in a small repo script so the workflow stays readable and shard behavior is deterministic and easy to tune from 4 shards to a higher count later.
+
+**Tech Stack:** GitHub Actions, Ubuntu runners, Flutter 3.41.4, Dart, Bash
+
+---
+
+## File Structure
+
+**Modify**
+- `.github/workflows/mobile_ci.yaml`
+
+**Create**
+- `mobile/scripts/ci/run_flutter_test_shard.sh`
+
+**Why this structure**
+- Keep workflow orchestration in `.github/workflows/mobile_ci.yaml`.
+- Move shard selection logic into a script so shard behavior can be tested locally and changed without turning the workflow file into shell soup.
+- Avoid broader CI refactors for now. The smallest reviewable change is one workflow file plus one helper script.
+
+## Chunk 1: Add Deterministic Test Sharding Helper
+
+### Task 1: Create the shard runner script
+
+**Files:**
+- Create: `mobile/scripts/ci/run_flutter_test_shard.sh`
+- Verify: `mobile/scripts/ci/run_flutter_test_shard.sh`
+
+- [ ] **Step 1: Create the script file with strict shell settings**
+
+Create `mobile/scripts/ci/run_flutter_test_shard.sh` with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <shard-index> <shard-count>" >&2
+  exit 64
+fi
+
+shard_index="$1"
+shard_count="$2"
+
+if ! [[ "$shard_index" =~ ^[0-9]+$ ]] || ! [[ "$shard_count" =~ ^[0-9]+$ ]]; then
+  echo "shard index and shard count must be integers" >&2
+  exit 64
+fi
+
+if (( shard_count < 1 )); then
+  echo "shard count must be >= 1" >&2
+  exit 64
+fi
+
+if (( shard_index < 0 || shard_index >= shard_count )); then
+  echo "shard index must be between 0 and shard_count - 1" >&2
+  exit 64
+fi
+
+mapfile -t test_files < <(
+  find test -type f -name '*_test.dart' \
+    ! -path 'test/integration/*' \
+    | LC_ALL=C sort
+)
+
+selected_files=()
+for i in "${!test_files[@]}"; do
+  if (( i % shard_count == shard_index )); then
+    selected_files+=("${test_files[$i]}")
+  fi
+done
+
+echo "Shard ${shard_index}/${shard_count}"
+echo "Selected ${#selected_files[@]} test files"
+
+if (( ${#selected_files[@]} == 0 )); then
+  echo "No test files selected for this shard"
+  exit 0
+fi
+
+printf '%s\n' "${selected_files[@]}"
+
+flutter test --exclude-tags integration "${selected_files[@]}"
+```
+
+- [ ] **Step 2: Make the script executable**
+
+Run:
+
+```bash
+chmod +x mobile/scripts/ci/run_flutter_test_shard.sh
+```
+
+Expected: command exits successfully with no output.
+
+- [ ] **Step 3: Verify shard selection works for shard 0**
+
+Run:
+
+```bash
+cd mobile
+scripts/ci/run_flutter_test_shard.sh 0 4
+```
+
+Expected:
+- The script prints `Shard 0/4`
+- It lists a non-zero number of `*_test.dart` files
+- It starts running only that shard’s tests
+
+Stop the run after confirming file selection if the full test execution is too slow during this spot check.
+
+- [ ] **Step 4: Verify shard selection works for the last shard**
+
+Run:
+
+```bash
+cd mobile
+scripts/ci/run_flutter_test_shard.sh 3 4
+```
+
+Expected:
+- The script prints `Shard 3/4`
+- It lists a different subset of test files
+- It exits successfully or starts running only that shard’s tests
+
+- [ ] **Step 5: Commit the helper script**
+
+```bash
+git add mobile/scripts/ci/run_flutter_test_shard.sh
+git commit -m "ci: add Flutter test shard runner"
+```
+
+## Chunk 2: Split Mobile CI into Parallel Jobs
+
+### Task 2: Replace the serial workflow with parallel jobs
+
+**Files:**
+- Modify: `.github/workflows/mobile_ci.yaml`
+- Use: `mobile/scripts/ci/run_flutter_test_shard.sh`
+
+- [ ] **Step 1: Keep workflow triggers and top-level concurrency unchanged**
+
+Preserve:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Expected: PR coverage remains identical to today.
+
+- [ ] **Step 2: Replace the single `build` job with four parallel job groups**
+
+Restructure `.github/workflows/mobile_ci.yaml` into:
+- `generated-files`
+- `format`
+- `analyze`
+- `tests` (matrix)
+
+Each job should:
+- use `runs-on: ubuntu-latest`
+- set `defaults.run.working-directory: mobile/`
+- run `actions/checkout@v4`
+- run `subosito/flutter-action@v2` with:
+
+```yaml
+with:
+  flutter-version: "3.41.4"
+  channel: "stable"
+  cache: true
+```
+
+- run `flutter pub get`
+
+Expected: jobs can run independently without cross-job artifacts.
+
+- [ ] **Step 3: Move generated file verification into its own job**
+
+Use the existing command unchanged inside `generated-files`:
+
+```yaml
+- name: Verify generated files are up-to-date
+  run: |
+    dart run build_runner build --delete-conflicting-outputs
+    if [ -n "$(git status --porcelain)" ]; then
+      echo "⚠️ Generated files are out of date. Please run 'dart run build_runner build' and commit the changes."
+      git diff --name-only
+      exit 1
+    fi
+```
+
+Expected: generator-backed regressions still fail PRs, but no longer block format/analyze/test from starting.
+
+- [ ] **Step 4: Move formatting into its own job**
+
+Add a `format` job using:
+
+```yaml
+- name: Check formatting
+  run: dart format --output=none --set-exit-if-changed lib test integration_test
+```
+
+Expected: formatting failures come back independently from test/analyze failures.
+
+- [ ] **Step 5: Move analysis into its own job**
+
+Add an `analyze` job using:
+
+```yaml
+- name: Analyze code
+  run: flutter analyze lib test integration_test
+```
+
+Expected: analyzer failures are reported separately and sooner.
+
+- [ ] **Step 6: Add a 4-shard test matrix**
+
+Create a `tests` job with:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    shard_index: [0, 1, 2, 3]
+    shard_count: [4]
+```
+
+Use names like:
+
+```yaml
+name: Tests (shard ${{ matrix.shard_index + 1 }}/${{ matrix.shard_count }})
+```
+
+Run:
+
+```yaml
+- name: Run Flutter test shard
+  run: scripts/ci/run_flutter_test_shard.sh ${{ matrix.shard_index }} ${{ matrix.shard_count }}
+```
+
+Expected:
+- test workload is split across 4 runners
+- one failing shard does not cancel the other 3
+- overall PR wall-clock time is driven by the slowest shard rather than the full serial test suite
+
+- [ ] **Step 7: Keep integration-tag behavior unchanged**
+
+Do not add integration tests to this workflow. Preserve the current exclusion behavior via:
+
+```bash
+flutter test --exclude-tags integration
+```
+
+Expected: no surprise expansion in scope or runtime.
+
+- [ ] **Step 8: Validate the workflow YAML**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import yaml
+from pathlib import Path
+
+path = Path(".github/workflows/mobile_ci.yaml")
+with path.open() as fh:
+    yaml.safe_load(fh)
+print("yaml ok")
+PY
+```
+
+Expected: `yaml ok`
+
+- [ ] **Step 9: Review the final workflow shape**
+
+Run:
+
+```bash
+sed -n '1,260p' .github/workflows/mobile_ci.yaml
+```
+
+Expected:
+- one workflow
+- four top-level jobs
+- test matrix with four shards
+- no accidental trigger or permission changes
+
+- [ ] **Step 10: Commit the workflow split**
+
+```bash
+git add .github/workflows/mobile_ci.yaml
+git commit -m "ci: parallelize mobile CI checks"
+```
+
+## Chunk 3: Verification and Rollout
+
+### Task 3: Verify locally and in GitHub Actions
+
+**Files:**
+- Verify: `.github/workflows/mobile_ci.yaml`
+- Verify: `mobile/scripts/ci/run_flutter_test_shard.sh`
+
+- [ ] **Step 1: Run shard script smoke checks locally**
+
+Run:
+
+```bash
+cd mobile
+scripts/ci/run_flutter_test_shard.sh 0 4
+scripts/ci/run_flutter_test_shard.sh 1 4
+```
+
+Expected:
+- both commands select files
+- neither crashes from argument parsing or empty selections
+
+- [ ] **Step 2: Run the non-test local checks once before opening the PR**
+
+Run:
+
+```bash
+cd mobile
+dart run build_runner build --delete-conflicting-outputs
+dart format --output=none --set-exit-if-changed lib test integration_test
+flutter analyze lib test integration_test
+```
+
+Expected: commands pass, or any failures are fixed before PR.
+
+- [ ] **Step 3: Open the PR and inspect Actions timing**
+
+After pushing, verify in GitHub Actions that:
+- `generated-files`, `format`, `analyze`, and all 4 `tests` shards start in parallel
+- no shard is starved waiting on another job
+- total PR wall-clock time is meaningfully lower than the previous ~20 minutes
+
+Expected:
+- wall-clock time should trend closer to the longest single lane rather than the sum of all lanes
+
+- [ ] **Step 4: Capture follow-up tuning data**
+
+Record:
+- total workflow wall-clock time
+- longest test shard duration
+- shortest test shard duration
+- generated-files duration
+
+Expected: enough data to decide whether to stay at 4 shards or increase to 6 or 8 later.
+
+- [ ] **Step 5: If shard imbalance is severe, schedule a follow-up**
+
+If one shard is much slower than the others, create a follow-up task to:
+- increase shard count from 4 to 6 or 8, or
+- change shard assignment logic from simple modulo to duration-aware buckets
+
+Do not expand scope in this PR unless imbalance is catastrophic.
+
+- [ ] **Step 6: Final commit and push hygiene**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only the intended workflow/script changes are present before final push.
+
+## Notes for Execution
+
+- Optimize for developer wall-clock time, not minimum CI minutes.
+- Avoid adding new workflow triggers, path filters, or conditional skips in this change.
+- Keep the initial shard count at 4. It is the lowest-complexity parallel step that should produce a noticeable drop in PR wait time.
+- Do not bundle unrelated CI refactors into this work.
+

--- a/docs/superpowers/plans/2026-04-11-pr-2983-blossom-package-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-11-pr-2983-blossom-package-review-fixes.md
@@ -1,0 +1,492 @@
+# PR #2983 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the should-fix findings from the code review of divinevideo/divine-mobile#2983 ("refactor: extract blossom_upload_service into its own package") without regressing the package boundary or existing behavior.
+
+**Architecture:** Work on the PR author's branch `refactor/extract-blossom-upload-service` in an isolated worktree. Each task is a self-contained commit that leaves `flutter test` and `flutter analyze` green. The package boundary (no `openvine/` / `nostr_sdk` / `firebase_performance` imports in `mobile/packages/blossom_upload_service/lib/`) is a hard invariant — every task verifies it.
+
+**Tech Stack:** Flutter (managed via `mise`), `flutter_bloc`, `mockito`, `very_good_analysis`, `very_good_workflows` CI template, Hive, GitHub Actions.
+
+**Scope — in this plan:**
+- Task 1: Measure and raise `min_coverage` for the new package's CI workflow
+- Task 2: Deduplicate the ~4,500 lines of near-identical test files between `mobile/test/services/` and `mobile/packages/blossom_upload_service/test/src/`
+- Task 3: Decide the fate of the `currentNpub` field on `BlossomAuthProvider` (remove or cover with a test)
+- Task 4: Document the transitive `flutter:` SDK dependency in `pubspec.yaml`
+
+**Scope — explicitly deferred** (separate follow-up PR, not in this plan):
+- Introducing a `BlossomServerConfig` interface to lift `SharedPreferences` out of the package (nit #4 in review). Bigger refactor, deserves its own plan.
+- Re-adding emoji glyphs to log lines (nit #5). Cosmetic; only revisit if log dashboards actually key on them.
+
+**Ground rules:**
+- Work in a worktree; never edit main directly (memory: `feedback_always_use_worktrees`).
+- Follow TDD — write or adjust the failing test before changing production code where applicable.
+- Commit at the end of each task so the PR history is reviewable.
+- Never truncate Nostr IDs in code, logs, tests, or debug output (project rule).
+- Do NOT run destructive git commands (no `reset --hard`, no `branch -D`) — ask the user first if needed.
+
+---
+
+## Chunk 1: Setup and Task 1 (CI coverage)
+
+### Task 0: Worktree and branch setup
+
+**Files:**
+- No code changes in this task.
+
+- [ ] **Step 1: Create an isolated worktree off the PR branch**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git fetch origin refactor/extract-blossom-upload-service
+git worktree add ../divine-mobile-pr2983 refactor/extract-blossom-upload-service
+cd ../divine-mobile-pr2983
+```
+
+Expected: new directory `../divine-mobile-pr2983` checked out on `refactor/extract-blossom-upload-service`.
+
+- [ ] **Step 2: Install git hooks and pub dependencies**
+
+```bash
+cd mobile && mise run setup_hooks && mise exec -- flutter pub get
+cd packages/blossom_upload_service && mise exec -- flutter pub get
+```
+
+Expected: `.git/hooks/pre-commit` and `pre-push` present; both `pub get` commands succeed with no errors.
+
+- [ ] **Step 3: Baseline verification that the branch is green**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter analyze lib test integration_test
+cd packages/blossom_upload_service
+mise exec -- flutter analyze
+mise exec -- flutter test
+```
+
+Expected:
+- `flutter analyze lib test integration_test` from `mobile/`: 0 issues.
+- `flutter analyze` from the package: 0 issues.
+- `flutter test` from the package: 42 pass, 3 skipped.
+
+If any of the above fails, stop and surface to the user — do not start task work on a broken baseline.
+
+---
+
+### Task 1: Raise `min_coverage` on the package CI workflow
+
+**Context:** `.github/workflows/blossom_upload_service.yaml:27` sets `min_coverage: 40`. The project memory rule is "100% test coverage required", and peer package workflows use 80–98 (e.g. `media_cache: 98`, `comments_repository: 80`, `nostr_client: 82`). We will measure the current achieved coverage for the package, then pin `min_coverage` just below it so future regressions are caught without immediately breaking CI.
+
+**Files:**
+- Modify: `.github/workflows/blossom_upload_service.yaml:27`
+
+- [ ] **Step 1: Measure actual coverage for the package**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile/packages/blossom_upload_service
+mise exec -- flutter test --coverage
+```
+
+Expected: `coverage/lcov.info` is created. If `lcov` is installed, generate a summary:
+
+```bash
+mise exec -- lcov --summary coverage/lcov.info 2>/dev/null || \
+  awk -F: '/^LF:/ {lf+=$2} /^LH:/ {lh+=$2} END {printf "lines: %d/%d = %.1f%%\n", lh, lf, (lh/lf)*100}' coverage/lcov.info
+```
+
+Record the percentage (call it `ACTUAL`). It will almost certainly be well above 40 — probably 80–95% given 42 tests against ~2,500 lines of source.
+
+- [ ] **Step 2: Decide the new floor**
+
+Rule: `new_min_coverage = floor(ACTUAL - 2)` clamped to a whole number. The 2-point buffer absorbs small innocuous changes. Examples: actual 92.3 → min 90; actual 78.8 → min 76.
+
+If `ACTUAL < 70`, do NOT silently raise the floor. Instead, flag to the user that the package is under-tested, note it in the PR comment thread, and leave `min_coverage` at 40 for this PR — covering the package back up is out of scope and belongs in a separate test-backfill plan.
+
+- [ ] **Step 3: Update the workflow**
+
+Edit `.github/workflows/blossom_upload_service.yaml:27` — change `min_coverage: 40` to `min_coverage: <new value>`.
+
+- [ ] **Step 4: Sanity-check the workflow still parses**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/blossom_upload_service.yaml'))" \
+  && echo "workflow YAML parses"
+```
+
+Expected: `workflow YAML parses`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+git add .github/workflows/blossom_upload_service.yaml
+git commit -m "ci(blossom_upload_service): raise min_coverage floor to match reality"
+```
+
+---
+
+## Chunk 2: Task 2 (Test deduplication)
+
+**Context:** After the move, six near-identical test files exist:
+
+| App-level copy | Package copy | Lines (app / package) |
+|---|---|---|
+| `mobile/test/services/blossom_upload_service_test.dart` | `mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart` | ~2,265 / ~2,253 |
+| `mobile/test/services/blossom_auth_service_test.dart` | `mobile/packages/blossom_upload_service/test/src/blossom_auth_service_test.dart` | large |
+| `mobile/test/services/blossom_upload_proofmode_test.dart` | `mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart` | large |
+
+The CI-parallelization goal (parent issue #2890) is undermined if every edit has to land twice, and the copies will drift. The package tests are the canonical location; the app-level copies should be either deleted or reduced to a tiny adapter-wiring smoke test that protects `_BlossomAuthAdapter` and `_FirebasePerformanceAdapter` in `mobile/lib/providers/app_providers.dart`.
+
+**Strategy:** Before deleting anything, confirm the package copies cover every test group in the app copies. If any app-level test exercises the adapter (i.e. calls through `AuthService` or `PerformanceMonitoringService`), that test belongs in `mobile/test/` because it exercises app-level glue. Anything else is pure package logic and is redundant.
+
+### Task 2: Deduplicate blossom test files
+
+**Files:**
+- Delete: `mobile/test/services/blossom_upload_service_test.dart` (partial — keep only adapter-wiring tests, if any)
+- Delete: `mobile/test/services/blossom_auth_service_test.dart` (partial — same rule)
+- Delete: `mobile/test/services/blossom_upload_proofmode_test.dart` (partial — same rule)
+- Possibly create: `mobile/test/providers/app_providers_blossom_adapter_test.dart`
+
+- [ ] **Step 1: Diff the three pairs to confirm equivalence**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+diff -u test/services/blossom_upload_service_test.dart \
+        packages/blossom_upload_service/test/src/blossom_upload_service_test.dart > /tmp/diff_upload.txt
+diff -u test/services/blossom_auth_service_test.dart \
+        packages/blossom_upload_service/test/src/blossom_auth_service_test.dart > /tmp/diff_auth.txt
+diff -u test/services/blossom_upload_proofmode_test.dart \
+        packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart > /tmp/diff_proofmode.txt
+wc -l /tmp/diff_upload.txt /tmp/diff_auth.txt /tmp/diff_proofmode.txt
+```
+
+Expected: each diff is small (mostly just import paths flipping between `package:openvine/...` and `package:blossom_upload_service/...`).
+
+- [ ] **Step 2: Classify each `group(...)` in each app-level file**
+
+For each `group(...)` or top-level `test(...)` in the app-level files, decide:
+- (A) **Pure package logic** — mocks `Dio` / `http.Client`, tests `BlossomUploadService` or `BlossomAuthService` in isolation. → delete from app.
+- (B) **Adapter-wiring** — instantiates the real `AuthService`, real `PerformanceMonitoringService`, or the Riverpod provider graph, and proves the adapter forwards correctly. → keep in app, move to `mobile/test/providers/app_providers_blossom_adapter_test.dart`.
+- (C) **Depends on something `openvine/` only has** (e.g. `VideoPublishService`, `UploadManager`, Hive boxes with app-owned types). → keep in app, at current path.
+
+Do this classification pass from the diff output, not by re-reading both files. If a group exists in both files and the only delta is the import line, it's category (A).
+
+- [ ] **Step 3: If there are any category (B) tests, write the failing adapter test first**
+
+If step 2 found adapter-wiring tests worth keeping, extract them into a new file `mobile/test/providers/app_providers_blossom_adapter_test.dart`. Run the new file in isolation to confirm it fails (because it doesn't exist yet) and then compiles:
+
+```bash
+mise exec -- flutter test test/providers/app_providers_blossom_adapter_test.dart
+```
+
+Expected: RED the first time (either "file not found" or a real failing test), then GREEN after you fill it in.
+
+If there are no category (B) tests, skip this step.
+
+- [ ] **Step 4: Delete category (A) test groups from the three app-level files**
+
+Use `Edit` to surgically remove only the redundant `group(...)` blocks. Do NOT blanket-delete the files unless every group in them is category (A) — if the entire file is category (A), delete the whole file.
+
+Likely outcome: all three app-level files are entirely category (A) and get deleted in full.
+
+- [ ] **Step 5: Verify both test surfaces still pass**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter test test/ 2>&1 | tail -5
+cd packages/blossom_upload_service
+mise exec -- flutter test 2>&1 | tail -5
+```
+
+Expected:
+- Package: 42 pass, 3 skipped (unchanged from baseline).
+- App: total count drops by roughly the number of tests removed. No new failures.
+
+- [ ] **Step 6: Verify nothing else was importing the deleted files**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+grep -rn "test/services/blossom_upload_service_test\|test/services/blossom_auth_service_test\|test/services/blossom_upload_proofmode_test" mobile/ || echo "no stale references"
+```
+
+Expected: `no stale references`.
+
+- [ ] **Step 7: Analyzer sanity check**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter analyze lib test integration_test
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+git add -A mobile/test mobile/packages/blossom_upload_service/test
+git commit -m "test(blossom_upload_service): remove app-level test duplicates after package extraction"
+```
+
+---
+
+## Chunk 3: Task 3 and Task 4
+
+### Task 3: Resolve the unused `currentNpub` field on `BlossomAuthProvider`
+
+**Context:** `mobile/packages/blossom_upload_service/lib/src/blossom_auth_provider.dart:29` declares `String? get currentNpub;`. The review found it's only forwarded through `BlossomAuthService.currentUserPubkey` (`blossom_auth_service.dart:220`) and that getter has no in-package callers. It's either dead weight on the contract or it's silently required by an app-level caller.
+
+**Before deleting anything, verify.** The field might be part of the public API that app-level code depends on, in which case the right move is to add a test that exercises it, not to remove it.
+
+**Files:**
+- Modify: `mobile/packages/blossom_upload_service/lib/src/blossom_auth_provider.dart`
+- Modify: `mobile/packages/blossom_upload_service/lib/src/blossom_auth_service.dart`
+- Modify: `mobile/lib/providers/app_providers.dart` (the `_BlossomAuthAdapter` class)
+- Possibly modify: `mobile/packages/blossom_upload_service/test/src/blossom_auth_service_test.dart`
+
+- [ ] **Step 1: Search for every consumer of `currentNpub` and `currentUserPubkey`**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+grep -rn "currentNpub\|currentUserPubkey" mobile/lib mobile/test mobile/integration_test mobile/packages/blossom_upload_service
+```
+
+Record every hit. Expected hits include:
+- The interface declaration
+- The `BlossomAuthService` getter
+- The adapter in `app_providers.dart`
+- Possibly test files
+
+- [ ] **Step 2: Decide path A or path B based on findings**
+
+- **Path A — remove the field.** Pick this if the ONLY consumers are the interface itself, the adapter, and the unused package getter. No production code actually reads the value.
+- **Path B — cover the field with a test.** Pick this if any production call site in `mobile/lib/` or any integration test reads `currentUserPubkey` or `currentNpub` and expects a real value.
+
+State your decision explicitly as a comment at the top of the task before proceeding.
+
+- [ ] **Step 3A: If Path A, remove the field**
+
+1. Delete the `currentNpub` getter from `blossom_auth_provider.dart` (the 3 lines of doc + declaration).
+2. Delete the `currentUserPubkey` getter from `blossom_auth_service.dart`.
+3. Delete the `currentNpub` override in `_BlossomAuthAdapter` in `app_providers.dart`.
+4. Re-run both analyzers and both test surfaces:
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile/packages/blossom_upload_service
+mise exec -- flutter analyze && mise exec -- flutter test
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter analyze lib test integration_test
+mise exec -- flutter test test/providers test/services 2>&1 | tail -5
+```
+
+Expected: all green. If analyzer finds an unknown override or unknown method, you missed a consumer from step 1 — restore the field, re-run step 1 with a wider grep (including `.g.dart`, `.mocks.dart`, generated files), and pivot to Path B.
+
+- [ ] **Step 3B: If Path B, add a direct test**
+
+Add a test to `mobile/packages/blossom_upload_service/test/src/blossom_auth_service_test.dart` that:
+- Constructs a `BlossomAuthService` with a fake `BlossomAuthProvider` whose `currentNpub` returns a full npub (never truncate).
+- Asserts `service.currentUserPubkey` forwards the exact npub.
+- Asserts `null` is forwarded when the provider returns `null`.
+
+Example shape:
+
+```dart
+group('currentUserPubkey', () {
+  test('forwards currentNpub from the provider', () {
+    const npub = 'npub1exampleexampleexampleexampleexampleexampleexampleexampleexampleexample';
+    final provider = _FakeAuthProvider(currentNpub: npub, isAuthenticated: true);
+    final service = BlossomAuthService(authProvider: provider);
+    expect(service.currentUserPubkey, equals(npub));
+  });
+
+  test('returns null when the provider has no active user', () {
+    final provider = _FakeAuthProvider(currentNpub: null, isAuthenticated: false);
+    final service = BlossomAuthService(authProvider: provider);
+    expect(service.currentUserPubkey, isNull);
+  });
+});
+```
+
+Run the new test:
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile/packages/blossom_upload_service
+mise exec -- flutter test --plain-name "currentUserPubkey"
+```
+
+Expected: 2 pass.
+
+- [ ] **Step 4: Verify the package still has no leaks**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+grep -rn "package:openvine/\|package:nostr_sdk/\|package:firebase_performance/" mobile/packages/blossom_upload_service/lib || echo "package boundary intact"
+```
+
+Expected: `package boundary intact`.
+
+- [ ] **Step 5: Commit**
+
+Pick one message, depending on which path you took:
+
+```bash
+# Path A
+git add mobile/packages/blossom_upload_service mobile/lib/providers/app_providers.dart
+git commit -m "refactor(blossom_upload_service): drop unused currentNpub from auth interface"
+
+# Path B
+git add mobile/packages/blossom_upload_service/test
+git commit -m "test(blossom_upload_service): cover BlossomAuthService.currentUserPubkey forwarding"
+```
+
+---
+
+### Task 4: Document the transitive `flutter:` SDK dependency
+
+**Context:** `mobile/packages/blossom_upload_service/pubspec.yaml` declares `flutter: sdk: flutter` but the package's `lib/` has zero direct Flutter imports (the grep passes clean). The Flutter SDK is only pulled in transitively by `flutter_test` and `image_metadata_stripper`. A future reader will wonder why it's there and might innocently delete it. A one-line comment prevents that.
+
+**Files:**
+- Modify: `mobile/packages/blossom_upload_service/pubspec.yaml`
+
+- [ ] **Step 1: Add an explanatory comment above the `flutter:` entry**
+
+Locate the `dependencies:` block in `mobile/packages/blossom_upload_service/pubspec.yaml` and add, immediately above the `flutter:` SDK line:
+
+```yaml
+  # Required transitively by flutter_test (dev) and image_metadata_stripper.
+  # The lib/ sources do NOT import dart:ui or any flutter/* package — the
+  # package is a pure Dart data layer. Do not remove without first confirming
+  # both transitive deps are gone.
+  flutter:
+    sdk: flutter
+```
+
+- [ ] **Step 2: Confirm `pub get` still resolves**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile/packages/blossom_upload_service
+mise exec -- flutter pub get
+```
+
+Expected: resolves cleanly, no errors.
+
+- [ ] **Step 3: Re-verify the package boundary claim in the comment**
+
+```bash
+grep -rn "package:flutter/\|dart:ui" mobile/packages/blossom_upload_service/lib || echo "no flutter imports in lib/"
+```
+
+Expected: `no flutter imports in lib/`. If this fails, the comment is a lie — delete the comment and surface the finding to the user before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+git add mobile/packages/blossom_upload_service/pubspec.yaml
+git commit -m "docs(blossom_upload_service): explain transitive flutter SDK dependency"
+```
+
+---
+
+## Chunk 4: Final verification and handoff
+
+### Task 5: End-to-end verification
+
+- [ ] **Step 1: Fresh `pub get` and codegen check**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter pub get
+cd packages/blossom_upload_service
+mise exec -- flutter pub get
+```
+
+Expected: both resolve. If any `build_runner` inputs were touched (none expected in this plan), also run:
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+```
+
+- [ ] **Step 2: Full analyzer sweep**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter analyze lib test integration_test
+cd packages/blossom_upload_service
+mise exec -- flutter analyze
+```
+
+Expected: 0 issues from both.
+
+- [ ] **Step 3: Full test sweep for affected surfaces**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile/packages/blossom_upload_service
+mise exec -- flutter test
+cd /Users/rabble/code/divine/divine-mobile-pr2983/mobile
+mise exec -- flutter test test/providers test/services test/models test/blocs 2>&1 | tail -10
+```
+
+Expected:
+- Package: 42 pass, 3 skipped, OR (42 + new count from Path B) pass, 3 skipped.
+- App: all blossom-related suites green. Total count reduced by the deduplicated tests from Task 2.
+
+- [ ] **Step 4: Re-run the package boundary check one last time**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+grep -rn "package:openvine/\|package:nostr_sdk/\|package:firebase_performance/\|package:flutter/\|dart:ui" mobile/packages/blossom_upload_service/lib || echo "boundary intact"
+```
+
+Expected: `boundary intact`.
+
+- [ ] **Step 5: Push to the PR branch and update the PR**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile-pr2983
+git log --oneline origin/refactor/extract-blossom-upload-service..HEAD
+```
+
+Review the commit list — should be 3 or 4 commits matching the tasks above. Then push:
+
+```bash
+git push origin refactor/extract-blossom-upload-service
+```
+
+**STOP HERE if the PR author is not rabble.** Since PR #2983 is authored by `realmeylisdev`, pushing directly to their branch may require explicit permission. Before pushing, confirm with the user whether to:
+- (a) push directly to the fork branch (requires write access),
+- (b) open a follow-up PR targeting the same branch,
+- (c) post the commits as suggested changes in the PR review instead.
+
+Default: (c). Do not push without explicit user approval.
+
+- [ ] **Step 6: Post a PR comment summarizing the changes**
+
+Use `gh pr comment 2983 --repo divinevideo/divine-mobile --body-file -` with a short note linking each commit to its review finding. Example body:
+
+```markdown
+Addressed should-fix findings from review:
+
+- `ci: raise min_coverage to N` — Task 1 in plan
+- `test: remove app-level test duplicates` — Task 2
+- `refactor: drop currentNpub` (or `test: cover currentUserPubkey`) — Task 3
+- `docs: explain transitive flutter dep` — Task 4
+
+Deferred to follow-up:
+- `BlossomServerConfig` interface to lift `SharedPreferences` out of the package
+- Decision on whether to restore emoji in log lines
+```
+
+Expected: comment posted.
+
+---
+
+## Remember
+- Never truncate Nostr IDs anywhere (code, logs, tests, debug output).
+- Dark-mode only — no theme work in this plan, but don't introduce `Colors.*` anywhere.
+- Package `lib/` has a hard boundary: no `package:openvine/`, `package:nostr_sdk/`, `package:firebase_performance/`, `package:flutter/`, or `dart:ui` imports. Every task re-verifies this.
+- Commit after each task. Do NOT squash during development.
+- If `min_coverage` measurement shows the package is under 70% covered, STOP Task 1 and surface to user — don't silently accept a low floor.
+- If Task 3 Step 1 turns up a production caller you missed, pivot to Path B without hesitation. Deleting a field that's silently used is worse than keeping dead code.

--- a/docs/superpowers/plans/2026-04-12-l10n-remaining-work.md
+++ b/docs/superpowers/plans/2026-04-12-l10n-remaining-work.md
@@ -1,0 +1,57 @@
+# L10n Remaining Work (Post-PR #2930)
+
+Date: 2026-04-12
+
+## RTL Support (~89 instances)
+
+Zero RTL-aware layout primitives in the codebase. Everything uses physical `left`/`right`.
+
+**Blockers:**
+- `main.dart:576` — `TextDirection.ltr` hardcoded at app root, prevents RTL entirely
+- `divine_ui` package — 7 instances in shared components (app bar, search bar, bottom sheet)
+
+**By category:**
+- EdgeInsets.only(left:/right:): 32 in lib/, 4 in packages/
+- Positioned with asymmetric left/right: ~35
+- Alignment.centerLeft/Right: 13
+- EdgeInsets.fromLTRB asymmetric: 2
+- Hardcoded TextDirection.ltr: 3
+
+**Priority order:** main.dart root → divine_ui → chat bubbles → feed overlay → auth screens
+
+## Date/Time Formatting
+
+**Critical:**
+- TimeFormatter package: "now", "3m", "2h", "Today", "Yesterday" all hardcoded English
+- drafts_tab.dart: `DateFormat('EEEE, MMM d yyyy h:mm a')` hardcoded English pattern
+- creator_analytics_screen.dart: hardcoded ['Mon','Tue',...] day labels and "Xm ago" patterns
+- divine_video_draft.dart: timeAgoString getter returns "Xd ago" etc.
+
+**Fix:** Add ARB keys for relative time patterns, use `DateFormat.yMMMEd(locale)` named constructors
+
+## Number Formatting
+
+**Medium priority:**
+- count_formatter package: hardcoded 'k', 'm' suffixes, '.' decimal separator
+- string_utils.dart: duplicate compact number logic
+- 3 more files with same pattern
+
+**Fix:** Replace with `NumberFormat.compact(locale: locale)` from intl
+
+## ContentLabel.displayName (22 labels)
+
+All 22 content warning labels hardcoded English in the enum. Shown in content filters, account labels, upload flow, video overlays.
+
+**Fix:** Add ARB keys per label, create `ContentLabel.localizedName(BuildContext)` method
+
+## Notification Messages (10 templates)
+
+Client-side notification messages hardcoded: "$actorName liked your video" etc. in notification_event_parser.dart and notification_service_enhanced.dart.
+
+**Fix:** Replace with ARB parameterized strings
+
+## Miscellaneous Hardcoded Strings (~10)
+
+- 'Something went wrong' / 'Try again' in search error state
+- 'Untitled' draft fallback
+- 'None' for empty content warnings/backgrounds

--- a/docs/superpowers/plans/2026-04-17-age-restricted-viewer-auth-parity.md
+++ b/docs/superpowers/plans/2026-04-17-age-restricted-viewer-auth-parity.md
@@ -1,0 +1,307 @@
+# Age-Restricted Viewer Auth Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Divine mobile pooled playback unlock `AgeRestricted` Blossom media by sending accepted viewer auth and retrying playback after age verification.
+
+**Architecture:** `divine-blossom` already accepts either Blossom/BUD-01 `kind 24242` list auth or NIP-98 `kind 27235` HTTP auth for viewer media GET requests. The missing work is in `divine-mobile`: centralize viewer-auth header creation for media requests, teach pooled playback to open authenticated sources, and wire the `401` age-verification retry path to regenerate headers and retry the active player instead of only updating UI state.
+
+**Tech Stack:** Flutter, Riverpod, `video_player`, `media_kit`, pooled_video_player package, Blossom/BUD-01 auth, NIP-98 auth
+
+---
+
+## File Map
+
+- Modify: `mobile/lib/services/blossom_auth_service.dart`
+  Purpose: existing BUD-01 GET auth generation for Blossom blobs.
+- Modify: `mobile/lib/services/nip98_auth_service.dart`
+  Purpose: existing NIP-98 HTTP auth generation for backend-style GET requests.
+- Create: `mobile/lib/services/media_viewer_auth_service.dart`
+  Purpose: single service that chooses accepted viewer auth for media playback requests and returns request headers for a specific media URL/hash.
+- Modify: `mobile/lib/providers/app_providers.dart`
+  Purpose: register the new viewer-auth service and stop duplicating protocol selection logic in widgets.
+- Modify: `mobile/lib/providers/individual_video_providers.dart`
+  Purpose: migrate legacy/non-pooled playback to the shared viewer-auth service so both playback stacks follow the same contract.
+- Modify: `mobile/lib/services/media_auth_interceptor.dart`
+  Purpose: replace direct Blossom-only header creation with shared viewer-auth creation.
+- Modify: `mobile/packages/pooled_video_player/lib/src/models/video_item.dart`
+  Purpose: carry optional per-source request headers or an auth descriptor into pooled playback.
+- Modify: `mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart`
+  Purpose: open pooled player sources with headers, classify `401`, and retry the current source after auth is refreshed.
+- Modify: `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart`
+  Purpose: on Verify Age, invoke the real auth+retry flow instead of only resetting UI status.
+- Modify: `mobile/lib/screens/feed/feed_video_overlay.dart`
+  Purpose: same fix for the non-fullscreen pooled overlay path.
+- Modify: `mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart`
+  Purpose: expose the pooled retry/auth affordance clearly once the retry path is real.
+- Test: `mobile/test/services/media_viewer_auth_service_test.dart`
+  Purpose: protocol-selection and header-generation coverage.
+- Test: `mobile/test/services/media_auth_interceptor_test.dart`
+  Purpose: verify age-check + auth-header generation behavior.
+- Test: `mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart`
+  Purpose: verify pooled playback opens sources with auth headers and retries after `401`.
+- Test: `mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
+  Purpose: verify Verify Age triggers auth generation and retry for pooled fullscreen playback.
+
+## Chunk 1: Shared Viewer Auth Contract
+
+### Task 1: Lock the server contract into a client-facing service
+
+**Files:**
+- Create: `mobile/lib/services/media_viewer_auth_service.dart`
+- Modify: `mobile/lib/providers/app_providers.dart`
+- Test: `mobile/test/services/media_viewer_auth_service_test.dart`
+
+- [ ] **Step 1: Write the failing service tests**
+
+Add tests that prove:
+- when a SHA-256 blob hash is known, the service prefers Blossom/BUD-01 and returns `Authorization: Nostr ...`
+- when no hash is available but a full media URL is available, the service can return NIP-98 auth for `GET <url>`
+- when the user is unauthenticated, the service returns `null`
+- the service never returns both protocols at once for one request
+
+- [ ] **Step 2: Run the focused test file and verify it fails**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/services/media_viewer_auth_service_test.dart`
+
+Expected: FAIL because `MediaViewerAuthService` does not exist yet.
+
+- [ ] **Step 3: Implement `MediaViewerAuthService`**
+
+Implement a focused service that:
+- accepts `sha256Hash`, `url`, `method`
+- uses `BlossomAuthService.createGetAuthHeader(...)` when a blob hash is known
+- falls back to `Nip98AuthService.createAuthToken(url: ..., method: HttpMethod.get)` when hash-based Blossom auth is not possible
+- returns `Map<String, String>?` shaped exactly for playback callers, e.g. `{'Authorization': ...}`
+
+Do not add age-verification UI logic here. This service only chooses and creates viewer identity proof for media GET requests.
+
+- [ ] **Step 4: Register the new provider**
+
+Add a provider in `app_providers.dart` that composes:
+- `authServiceProvider`
+- `blossomAuthServiceProvider`
+- `nip98AuthServiceProvider`
+
+- [ ] **Step 5: Re-run the service tests**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/services/media_viewer_auth_service_test.dart`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git add mobile/lib/services/media_viewer_auth_service.dart mobile/lib/providers/app_providers.dart mobile/test/services/media_viewer_auth_service_test.dart
+git commit -m "feat(mobile): add shared viewer media auth service"
+```
+
+## Chunk 2: Unify Existing Auth Callers
+
+### Task 2: Move legacy playback and interceptor code onto the shared service
+
+**Files:**
+- Modify: `mobile/lib/providers/individual_video_providers.dart`
+- Modify: `mobile/lib/services/media_auth_interceptor.dart`
+- Test: `mobile/test/services/media_auth_interceptor_test.dart`
+
+- [ ] **Step 1: Write failing interceptor tests**
+
+Add tests that prove:
+- `handleUnauthorizedMedia(...)` verifies age access and returns viewer auth headers from the new service
+- it prefers hash-based Blossom auth when the blob hash is known
+- it returns `null` when verification is denied
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/services/media_auth_interceptor_test.dart`
+
+Expected: FAIL because the interceptor still depends on `BlossomAuthService` directly.
+
+- [ ] **Step 3: Replace direct Blossom auth calls in `MediaAuthInterceptor`**
+
+Refactor `MediaAuthInterceptor` so it depends on `MediaViewerAuthService`, not `BlossomAuthService`. Keep the existing age-verification behavior unchanged.
+
+- [ ] **Step 4: Migrate legacy controller header generation**
+
+Update `individual_video_providers.dart` so:
+- `_computeAuthHeadersSync`
+- `_generateAuthHeadersAsync`
+- `_cacheVideoWithAuth`
+
+all call the shared viewer-auth service instead of duplicating Blossom-only request construction.
+
+The legacy path must keep working exactly as before for hash-based Blossom URLs while gaining NIP-98 fallback if only the final URL is available.
+
+- [ ] **Step 5: Re-run focused tests**
+
+Run:
+- `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/services/media_auth_interceptor_test.dart`
+- `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/providers/individual_video_providers_test.dart`
+
+Expected: PASS. If the second file does not exist, add focused coverage near the existing provider tests before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git add mobile/lib/providers/individual_video_providers.dart mobile/lib/services/media_auth_interceptor.dart mobile/test/services/media_auth_interceptor_test.dart
+git commit -m "refactor(mobile): share viewer auth across legacy media playback"
+```
+
+## Chunk 3: Make Pooled Playback Auth-Capable
+
+### Task 3: Add per-source auth headers to the pooled player package
+
+**Files:**
+- Modify: `mobile/packages/pooled_video_player/lib/src/models/video_item.dart`
+- Modify: `mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart`
+- Test: `mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart`
+
+- [ ] **Step 1: Write failing pooled controller tests**
+
+Add tests that prove:
+- a pooled `VideoItem` can carry request headers for media open
+- `VideoFeedController` passes those headers into `player.open(...)`
+- a `401` classified as `ageRestricted` can be retried after the item’s headers are refreshed
+
+- [ ] **Step 2: Run the pooled controller tests and verify they fail**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile/packages/pooled_video_player && flutter test test/controllers/video_feed_controller_test.dart`
+
+Expected: FAIL because `VideoItem` has only a URL and the controller currently calls `player.open(Media(source), play: false)` with no header support.
+
+- [ ] **Step 3: Extend the pooled playback source model**
+
+Add a minimal, explicit representation for an authenticated source. Either:
+- extend `VideoItem` with optional `requestHeaders`, or
+- introduce a small `PlaybackSource` model and use it inside the controller.
+
+Keep the public API narrow: a video may have a URL plus optional headers for that URL.
+
+- [ ] **Step 4: Teach `VideoFeedController` to open authenticated media**
+
+Update `_openWithFallbacks(...)` so it opens `Media(...)` with request headers when present.
+
+Before writing code, verify the exact `media_kit` `Media` constructor API used by the current pinned package version and use the supported header field name. Do not invent a parameter.
+
+- [ ] **Step 5: Add a public retry/update hook**
+
+Expose the smallest controller API needed for the app layer to:
+- replace the current video’s headers after age verification
+- retry loading the current index without requiring a full screen rebuild
+
+Keep the API at the controller boundary, not in widgets.
+
+- [ ] **Step 6: Re-run pooled controller tests**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile/packages/pooled_video_player && flutter test test/controllers/video_feed_controller_test.dart`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git add mobile/packages/pooled_video_player/lib/src/models/video_item.dart mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+git commit -m "feat(pooled): support authenticated media sources"
+```
+
+## Chunk 4: Wire Verify Age into Real Pooled Retry
+
+### Task 4: Make pooled fullscreen/feed retry with auth instead of only changing UI state
+
+**Files:**
+- Modify: `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart`
+- Modify: `mobile/lib/screens/feed/feed_video_overlay.dart`
+- Modify: `mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart`
+- Test: `mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
+
+- [ ] **Step 1: Write failing UI flow tests**
+
+Add tests that prove:
+- when pooled playback reports `PlaybackStatus.ageRestricted`, tapping Verify Age triggers the auth flow
+- successful verification updates the active pooled item with viewer auth headers
+- the active item is retried after auth refresh
+- failed verification does not retry
+
+- [ ] **Step 2: Run the focused fullscreen/feed tests and verify they fail**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
+
+Expected: FAIL because `_verifyAgeForVideo` and `_verifyAge` only call `verifyAdultContentAccess(...)` and reset playback status.
+
+- [ ] **Step 3: Replace the fake pooled retry path**
+
+Refactor:
+- `pooled_fullscreen_video_feed_screen.dart::_verifyAgeForVideo`
+- `feed_video_overlay.dart::_verifyAge`
+
+so they:
+- resolve the active media URL/hash
+- ask `MediaViewerAuthService` or `MediaAuthInterceptor` for viewer auth headers
+- update the active pooled controller item
+- call the new controller retry hook
+
+Do not leave “set playback status to ready” as the only effect.
+
+- [ ] **Step 4: Keep the pooled error overlay behavior aligned**
+
+Ensure `PooledVideoErrorOverlay` still shows age-restricted messaging, but the retry action now reflects the actual pooled retry flow. If Verify Age remains a separate overlay action, keep the button labeling and state transitions consistent.
+
+- [ ] **Step 5: Re-run focused tests**
+
+Run: `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git add mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+git commit -m "fix(feed): retry pooled age-gated playback with viewer auth"
+```
+
+## Chunk 5: End-to-End Verification and Contract Update
+
+### Task 5: Verify both stacks and document the contract
+
+**Files:**
+- Modify: `mobile/docs/superpowers/specs/2026-04-05-moderated-content-filter-design.md` (or the nearest current spec documenting pooled age-gated behavior)
+- Optionally modify: `mobile/docs/PRODUCTION_CHECKLIST.md`
+
+- [ ] **Step 1: Add or update docs**
+
+Document the protocol split explicitly:
+- Blossom/BUD-01 and NIP-98 are both accepted by `divine-blossom` for viewer media GET requests
+- mobile legacy and pooled playback now share a single viewer-auth policy
+- backend API auth remains NIP-98; upload/delete management remains Blossom auth where required
+
+- [ ] **Step 2: Run focused package/app tests**
+
+Run:
+- `cd /Users/rabble/code/divine/divine-mobile/mobile/packages/pooled_video_player && flutter test test/controllers/video_feed_controller_test.dart`
+- `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/services/media_viewer_auth_service_test.dart`
+- `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/services/media_auth_interceptor_test.dart`
+- `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run targeted static analysis**
+
+Run:
+- `cd /Users/rabble/code/divine/divine-mobile/mobile && flutter analyze lib/services lib/screens/feed lib/providers`
+- `cd /Users/rabble/code/divine/divine-mobile/mobile/packages/pooled_video_player && flutter analyze lib`
+
+Expected: PASS or only pre-existing warnings unrelated to this change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git add mobile/docs/superpowers/specs/2026-04-05-moderated-content-filter-design.md mobile/docs/PRODUCTION_CHECKLIST.md
+git commit -m "docs(mobile): record viewer auth contract for age-gated playback"
+```
+

--- a/docs/superpowers/plans/2026-04-26-open-pr-bug-and-l10n-cleanup.md
+++ b/docs/superpowers/plans/2026-04-26-open-pr-bug-and-l10n-cleanup.md
@@ -1,0 +1,802 @@
+# Open-PR Bug and L10n Cleanup — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land code-level fixes on eight already-open PRs (five bugs, three l10n sweeps) without expanding into the design / product / external-blocker work those PRs also need.
+
+**Architecture:** Each PR fix is independent. For every PR: create a worktree off the PR's branch, read intent (PR description + linked issue + spec), read affected code end-to-end, reproduce the defect, fix, regression test, l10n codegen if ARB touched, push to the PR branch, comment on the PR. Sequential, in the order security → correctness → UX → infra → l10n.
+
+**Tech Stack:** Flutter / Dart (BLoC, Riverpod legacy), Kotlin (Android host), Swift (iOS host), Python (CI tooling), GitHub Actions YAML, ARB for l10n.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-open-pr-bug-and-l10n-cleanup-design.md`
+
+---
+
+## Conventions used by every task
+
+- All `flutter` / `dart` / `mise` commands run from `mobile/` unless stated.
+- Worktree path convention: `~/code/divine/divine-mobile-worktrees/pr-<NUM>-<slug>`.
+- After ARB changes, run l10n codegen and commit generated files.
+- After Dart code changes that affect generated outputs (Riverpod / Freezed / Mockito / JSON / Drift), run
+  `dart run build_runner build --delete-conflicting-outputs` and commit generated files.
+- Before any push, run `cd mobile && mise exec -- flutter analyze lib test` and the targeted tests.
+- Commit messages use the project's convention (`fix:`, `chore:`, `feat:` prefixes; reference the PR number).
+- Push directly to the PR's branch. If push to a fork is rejected, fall back to opening a new PR targeting the original PR's branch and link both.
+- After push, leave a PR comment summarizing what changed and why. Use `gh pr comment <NUM>`.
+
+## File-level responsibilities (by task)
+
+| PR | Responsibility | Files |
+|---|---|---|
+| #3301 | Stop logging Zendesk uploadToken | `mobile/android/app/src/main/kotlin/.../MainActivity.kt:591`, `mobile/ios/Runner/AppDelegate.swift:433` |
+| #3433 | Serialize cross-type comment vote events | `mobile/lib/blocs/comments/comments_bloc.dart`, `mobile/lib/blocs/comments/comments_event.dart`, regression test under `mobile/test/blocs/comments/` |
+| #3430 | Version-token guard for like/repost optimistic settle | `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart`, `mobile/lib/blocs/video_interactions/video_interactions_state.dart`, regression test under `mobile/test/blocs/video_interactions/` |
+| #3407 | Drive `_isTrimmingLayer` from current state | `mobile/lib/screens/video_editor/widgets/video_editor_canvas.dart`, widget test under `mobile/test/screens/video_editor/` if feasible |
+| #3440 | Queue fairness in iOS QA slot allocator | `.github/workflows/mobile_ios_qa_allocate.yml`, `scripts/ios_qa_slots.py`, test under `scripts/test_ios_qa_slots.py` |
+| #3375 | L10n sweep for invites screen | `mobile/lib/screens/invites/invites_screen.dart`, `mobile/lib/l10n/app_en.arb`, generated l10n |
+| #3177 | L10n sweep for retry strings | files flagged by review (publish primitives + repost retry feedback), `mobile/lib/l10n/app_en.arb`, generated l10n |
+| #2878 | L10n sweep for C2PA import UI | C2PA import flow widgets, `mobile/lib/l10n/app_en.arb`, generated l10n |
+
+---
+
+## Task 1: PR #3301 — stop logging Zendesk `uploadToken`
+
+**Files:**
+- Modify: `mobile/android/app/src/main/kotlin/.../MainActivity.kt:591`
+- Modify: `mobile/ios/Runner/AppDelegate.swift:433`
+
+- [ ] **Step 1: Set up worktree off the PR branch**
+
+```bash
+gh pr checkout 3301 --detach
+git fetch origin pull/3301/head:pr-3301
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3301-stop-token-logging pr-3301
+cd ~/code/divine/divine-mobile-worktrees/pr-3301-stop-token-logging
+```
+
+- [ ] **Step 2: Read PR intent and original code**
+
+```bash
+gh pr view 3301 --json title,body,files
+gh pr view 3301 --json comments,reviews
+```
+
+Read `MainActivity.kt:580-610` and `AppDelegate.swift:420-450` to confirm what the log statements look like and why they were added.
+
+- [ ] **Step 3: Grep for any other `uploadToken` log sites**
+
+```bash
+git grep -nE 'uploadToken' -- 'mobile/android' 'mobile/ios'
+git grep -nE '(Log\.|os_log|print\().*upload[_ ]?token' -- 'mobile/android' 'mobile/ios'
+```
+
+Note all hits.
+
+- [ ] **Step 4: Remove or redact `uploadToken` from log statements**
+
+In `MainActivity.kt:591`, replace the log statement so the token value is not interpolated. Add a one-line Kotlin comment immediately above:
+
+```kotlin
+// Do not log uploadToken: short-lived Zendesk secure-download credential.
+```
+
+In `AppDelegate.swift:433`, do the equivalent in Swift (`// Do not log uploadToken: short-lived Zendesk secure-download credential.`). If the token was the only purpose of the log line, delete the line.
+
+- [ ] **Step 5: Verify nothing else logs the token**
+
+```bash
+git grep -nE 'uploadToken' -- 'mobile/android' 'mobile/ios'
+```
+
+Expected: only the comment lines you just added (or no hits if you deleted the lines). No remaining log statements include `uploadToken`.
+
+- [ ] **Step 6: Run analyzer**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test
+```
+
+Expected: no new analyzer warnings (these are native files, but analyze still passes for the Dart side).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/android mobile/ios
+git commit -m "fix(zendesk): stop logging uploadToken (PR #3301)"
+```
+
+- [ ] **Step 8: Push and comment on PR**
+
+```bash
+git push origin HEAD:$(gh pr view 3301 --json headRefName -q .headRefName)
+gh pr comment 3301 --body "Removed uploadToken from log statements in MainActivity.kt and AppDelegate.swift. Tokens are short-lived Zendesk secure-download credentials and should not appear in device logs."
+```
+
+If push fails (fork without write access), open a new PR targeting the PR branch instead and link it in the comment.
+
+---
+
+## Task 2: PR #3433 — serialize cross-type comment vote events
+
+**Files:**
+- Modify: `mobile/lib/blocs/comments/comments_bloc.dart` (handlers at :77 and :78)
+- Modify: `mobile/lib/blocs/comments/comments_event.dart` (event shape)
+- Test: `mobile/test/blocs/comments/comments_bloc_test.dart`
+
+- [ ] **Step 1: Worktree + read intent**
+
+```bash
+gh pr checkout 3433 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3433-vote-race pr-3433
+cd ~/code/divine/divine-mobile-worktrees/pr-3433-vote-race
+gh pr view 3433 --json title,body,files,reviews
+```
+
+Read `comments_bloc.dart` end-to-end, focusing on lines 60-120. Identify:
+- The two handlers at :77 (upvote) and :78 (downvote)
+- The transformer used (currently `droppable()`)
+- The state fields they touch (likely `votes`, `commentVoteCounts`)
+
+- [ ] **Step 2: Write a failing bloc test for the rapid up→down→up race**
+
+In `mobile/test/blocs/comments/comments_bloc_test.dart`, add a test that:
+
+```dart
+blocTest<CommentsBloc, CommentsState>(
+  'serializes opposite votes on the same comment',
+  setUp: () {
+    // Stub the repository: upvote takes 50ms, downvote takes 10ms
+    when(() => repository.upvote(any(), any())).thenAnswer((_) async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    when(() => repository.downvote(any(), any())).thenAnswer((_) async {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    });
+  },
+  build: () => CommentsBloc(repository: repository),
+  act: (bloc) async {
+    bloc.add(const CommentVoteRequested(commentId: 'c1', vote: Vote.up));
+    await Future<void>.delayed(Duration.zero);
+    bloc.add(const CommentVoteRequested(commentId: 'c1', vote: Vote.down));
+  },
+  verify: (_) {
+    verifyInOrder([
+      () => repository.upvote('c1', any()),
+      () => repository.downvote('c1', any()),
+    ]);
+  },
+);
+```
+
+- [ ] **Step 3: Run the test and confirm failure**
+
+```bash
+cd mobile && mise exec -- flutter test test/blocs/comments/comments_bloc_test.dart --plain-name "serializes opposite votes"
+```
+
+Expected: FAIL because (a) `CommentVoteRequested` doesn't exist yet, or (b) ordering is not guaranteed.
+
+- [ ] **Step 4: Replace the two events with a single `CommentVoteRequested`**
+
+In `comments_event.dart`, add:
+
+```dart
+enum Vote { up, down, none }
+
+class CommentVoteRequested extends CommentsEvent {
+  const CommentVoteRequested({required this.commentId, required this.vote});
+  final String commentId;
+  final Vote vote;
+
+  @override
+  List<Object?> get props => [commentId, vote];
+}
+```
+
+Keep the old `CommentUpvoteRequested` / `CommentDownvoteRequested` events deprecated only if they have external callers; otherwise remove them.
+
+- [ ] **Step 5: Replace the two handlers with one sequential handler**
+
+In `comments_bloc.dart`, register a single handler with `sequential()` transformer:
+
+```dart
+on<CommentVoteRequested>(_onVoteRequested, transformer: sequential());
+```
+
+Implement `_onVoteRequested` to dispatch to repository based on `event.vote`. Handler must serialize per (commentId, vote) by virtue of `sequential()` running events in FIFO order.
+
+If finer-grained per-`commentId` concurrency is needed (different comments can vote simultaneously), use a custom transformer that groups by `commentId`:
+
+```dart
+EventTransformer<E> _serializePerComment<E extends CommentsEvent>(
+  String Function(E) keyOf,
+) {
+  return (events, mapper) => events
+      .groupBy(keyOf)
+      .flatMap((group) => group.asyncExpand(mapper));
+}
+```
+
+(If `groupBy`/`flatMap` aren't available, document the simpler `sequential()` choice and move on.)
+
+Update call sites that previously dispatched `CommentUpvoteRequested` / `CommentDownvoteRequested` to dispatch `CommentVoteRequested` with the appropriate `Vote`. Remove the `voteInProgressCommentId` state field and any UI guards that referenced it.
+
+- [ ] **Step 6: Re-run the failing test**
+
+```bash
+cd mobile && mise exec -- flutter test test/blocs/comments/comments_bloc_test.dart --plain-name "serializes opposite votes"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the full comments bloc test file**
+
+```bash
+cd mobile && mise exec -- flutter test test/blocs/comments/comments_bloc_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run analyze**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test
+```
+
+Expected: no new warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mobile/lib/blocs/comments mobile/test/blocs/comments
+git commit -m "fix(comments): serialize cross-type vote events to prevent race (PR #3433)"
+```
+
+- [ ] **Step 10: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 3433 --json headRefName -q .headRefName)
+gh pr comment 3433 --body "Replaced two droppable upvote/downvote handlers with a single CommentVoteRequested handled with sequential transformer, preventing opposite votes on the same comment from interleaving. Added a bloc test that drives up→down on one comment and verifies repository calls happen in order."
+```
+
+---
+
+## Task 3: PR #3430 — version-token guard for like/repost optimistic settle
+
+**Files:**
+- Modify: `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart` (around :204)
+- Modify: `mobile/lib/blocs/video_interactions/video_interactions_state.dart`
+- Test: `mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart`
+
+- [ ] **Step 1: Worktree + read intent**
+
+```bash
+gh pr checkout 3430 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3430-like-repost-race pr-3430
+cd ~/code/divine/divine-mobile-worktrees/pr-3430-like-repost-race
+gh pr view 3430 --json title,body,files,reviews
+```
+
+Read the bloc and state classes. Identify:
+- The fire-and-forget call site at `:204`
+- How settle (relay confirmation) currently flows back into state
+- Existing fields (`likedVideoIds`, `repostedVideoIds`, count maps)
+
+- [ ] **Step 2: Write a failing bloc test for out-of-order settle**
+
+```dart
+blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+  'discards stale settle for a video whose toggle has been superseded',
+  setUp: () {
+    final controller1 = Completer<void>();
+    final controller2 = Completer<void>();
+    var call = 0;
+    when(() => repo.publishLike(any())).thenAnswer((_) {
+      call++;
+      return call == 1 ? controller1.future : controller2.future;
+    });
+  },
+  build: () => VideoInteractionsBloc(repository: repo),
+  act: (bloc) async {
+    bloc.add(const ToggleLike('vid1'));   // optimistic: liked=true
+    await Future<void>.delayed(Duration.zero);
+    bloc.add(const ToggleLike('vid1'));   // optimistic: liked=false
+    await Future<void>.delayed(Duration.zero);
+    controller2.complete();               // second publish settles first
+    await Future<void>.delayed(Duration.zero);
+    controller1.complete();               // first publish settles late
+  },
+  verify: (bloc) {
+    expect(bloc.state.isLiked('vid1'), isFalse);
+  },
+);
+```
+
+- [ ] **Step 3: Run and confirm failure**
+
+```bash
+cd mobile && mise exec -- flutter test test/blocs/video_interactions/video_interactions_bloc_test.dart --plain-name "discards stale settle"
+```
+
+Expected: FAIL — final state shows liked=true because the late settle from publish #1 overwrote the latest user state.
+
+- [ ] **Step 4: Add per-(videoId, action) version token to state**
+
+In `video_interactions_state.dart`:
+
+```dart
+// Increments on each user toggle. Settle events carry the token captured
+// at dispatch time; out-of-order settles whose token != current are dropped.
+final Map<(String, InteractionAction), int> _toggleTokens;
+
+int tokenFor(String videoId, InteractionAction action) =>
+    _toggleTokens[(videoId, action)] ?? 0;
+```
+
+Make `copyWith` accept an updated token map.
+
+- [ ] **Step 5: Capture token on dispatch, check on settle**
+
+In the `ToggleLike` / `ToggleRepost` handlers around `:204`:
+
+```dart
+final token = state.tokenFor(event.videoId, action) + 1;
+emit(state.copyWith(/* optimistic update */, withToken: (event.videoId, action, token)));
+
+try {
+  await _repository.publishLike(event.videoId);
+  if (state.tokenFor(event.videoId, action) != token) {
+    return; // user toggled again; this settle is stale.
+  }
+  emit(state.copyWith(/* confirmed */));
+} catch (e, s) {
+  if (state.tokenFor(event.videoId, action) != token) return;
+  addError(e, s);
+  emit(state.copyWith(/* rollback */, status: ...failure));
+}
+```
+
+Replace fire-and-forget with awaited publish under a `sequential()` transformer keyed by videoId if available, but the token guard alone is sufficient for correctness; the sequential transformer is an additional safety net if you choose to add it.
+
+- [ ] **Step 6: Re-run the failing test**
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the full video_interactions bloc test file**
+
+```bash
+cd mobile && mise exec -- flutter test test/blocs/video_interactions
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run analyze + codegen if state class uses Freezed**
+
+```bash
+cd mobile && mise exec -- dart run build_runner build --delete-conflicting-outputs
+cd mobile && mise exec -- flutter analyze lib test
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mobile/lib/blocs/video_interactions mobile/test/blocs/video_interactions
+git commit -m "fix(video-interactions): version-token guard for like/repost settle (PR #3430)"
+```
+
+- [ ] **Step 10: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 3430 --json headRefName -q .headRefName)
+gh pr comment 3430 --body "Added per-(videoId, action) version token to VideoInteractionsState. Each ToggleLike/ToggleRepost increments the token; the publish awaits its result and only emits the confirmed/rollback state if its captured token still matches the current state. Out-of-order settles from rapid taps are dropped. Bloc test added for two-tap reversed-resolution scenario."
+```
+
+---
+
+## Task 4: PR #3407 — drive `_isTrimmingLayer` from current state
+
+**Files:**
+- Modify: `mobile/lib/screens/video_editor/widgets/video_editor_canvas.dart:779`
+- Test: `mobile/test/screens/video_editor/widgets/video_editor_canvas_test.dart` (if widget test feasible)
+
+- [ ] **Step 1: Worktree + read intent**
+
+```bash
+gh pr checkout 3407 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3407-trim-flag pr-3407
+cd ~/code/divine/divine-mobile-worktrees/pr-3407-trim-flag
+gh pr view 3407 --json title,body,files,reviews
+```
+
+Read `video_editor_canvas.dart` around `:740-820` to understand:
+- Where `_isTrimmingLayer` is set
+- What `previous.trimmingItemId` vs `current.trimmingItemId` look like at the relevant transition
+- Why the suppression matters (player position updates fight the gesture)
+
+- [ ] **Step 2: Resolve any merge conflicts on the PR branch**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+If conflicts, resolve them, run `flutter analyze`, and continue. Stop and report if conflicts are non-trivial — the spec excludes hard conflicts from scope.
+
+- [ ] **Step 3: Try to write a widget test**
+
+Goal: a widget test that drives the editor through trim-start → trim-drag → trim-end and asserts `_isTrimmingLayer` is `false` at the end. If the flag isn't directly observable, assert on a downstream observable (e.g., player position update count).
+
+If the widget test is not feasible without a real video player, skip the test step and document this as a manual-QA item.
+
+- [ ] **Step 4: Change `_isTrimmingLayer` source**
+
+Replace the line at `:779`:
+
+```dart
+// Was: final isTrimmingLayer = previous.trimmingItemId != null;
+final isTrimmingLayer = current.trimmingItemId != null;
+```
+
+Trace the surrounding `BlocListener<...>(listenWhen: ..., listener: (context, state) { ... })` block to confirm `current` is in scope. If not, refactor the closure so the flag is recomputed from the current state on every relevant emit.
+
+- [ ] **Step 5: Verify trim-end clears the flag deterministically**
+
+Walk through the BLoC: when the user releases the trim handle, the bloc emits a state with `trimmingItemId == null`. Confirm the listener fires for that emit and `isTrimmingLayer` becomes `false`. Add a comment above the line:
+
+```dart
+// Source from current state, not the previous transition value: a transition
+// to trimmingItemId == null must clear the flag, and reading from `previous`
+// keeps the prior non-null id and leaves the flag stuck.
+```
+
+- [ ] **Step 6: Run analyze + targeted tests**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test
+cd mobile && mise exec -- flutter test test/screens/video_editor
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/lib/screens/video_editor mobile/test/screens/video_editor
+git commit -m "fix(video-editor): clear _isTrimmingLayer from current state (PR #3407)"
+```
+
+- [ ] **Step 8: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 3407 --json headRefName -q .headRefName)
+gh pr comment 3407 --body "Source _isTrimmingLayer from current state.trimmingItemId; reading from previous left the flag stuck true after the trim-end transition because previous still pointed at the active trim item. <Note widget test status>. Flagging device QA: please confirm the live preview no longer continues suppressing position updates after releasing a trim handle."
+```
+
+---
+
+## Task 5: PR #3440 — queue fairness in iOS QA slot allocator
+
+**Files:**
+- Modify: `.github/workflows/mobile_ios_qa_allocate.yml:174-185`
+- Modify: `scripts/ios_qa_slots.py:662-664`
+- Test: `scripts/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Worktree + read intent**
+
+```bash
+gh pr checkout 3440 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3440-queue-fairness pr-3440
+cd ~/code/divine/divine-mobile-worktrees/pr-3440-queue-fairness
+gh pr view 3440 --json title,body,files,reviews
+```
+
+Read the workflow YAML and the allocator script. Understand:
+- What "occupied" vs "queued" mean in `ios_qa_slots.py`
+- Why the workflow's changed-file context check only runs for the target PR
+- The allocator's selection algorithm for the next PR to fill a freed slot
+
+- [ ] **Step 2: Write a unit test for the unfairness scenario**
+
+In `scripts/test_ios_qa_slots.py`:
+
+```python
+def test_older_queued_pr_is_not_jumped():
+    state = {
+        "occupied": {"slot-a": {"pr": 100, "queued_at": "2026-04-26T10:00:00Z"}},
+        "queued":   [{"pr": 200, "queued_at": "2026-04-26T11:00:00Z"}],
+    }
+    # New PR 300 arrives at 12:00.
+    new_state = allocate(state, new_pr=300, now="2026-04-26T12:00:00Z", free_slots=[])
+    # Expected: 200 is still ahead of 300 in queue
+    assert [p["pr"] for p in new_state["queued"]] == [200, 300]
+
+def test_freed_slot_goes_to_oldest_queued():
+    state = {
+        "occupied": {},
+        "queued":   [{"pr": 200}, {"pr": 300}, {"pr": 100}],  # by queued_at ascending
+    }
+    new_state = allocate(state, free_slots=["slot-a"])
+    assert new_state["occupied"]["slot-a"]["pr"] == 200
+```
+
+(Field names are illustrative — adapt to the actual data shape in `ios_qa_slots.py`.)
+
+- [ ] **Step 3: Run and confirm failure**
+
+```bash
+cd scripts && python -m pytest test_ios_qa_slots.py::test_older_queued_pr_is_not_jumped -v
+```
+
+Expected: FAIL because the current allocator drops the queued PR list across runs.
+
+- [ ] **Step 4: Persist queued PRs across runs**
+
+In `ios_qa_slots.py:662-664`, change the persistence call so the saved blob contains both `occupied` and `queued` lists. Restore both on the next run. Sort `queued` by `queued_at` ascending whenever it is mutated. When a slot frees, allocate it to the head of `queued` before considering any newly-arrived PR.
+
+- [ ] **Step 5: Run changed-file context for non-target PRs in the workflow**
+
+In `mobile_ios_qa_allocate.yml:174-185`, remove (or invert) the conditional that skips the context-fetch step for non-target PRs. Each PR in the queue must be checked for relevant file changes, not only the one currently being scheduled.
+
+- [ ] **Step 6: Re-run tests**
+
+```bash
+cd scripts && python -m pytest test_ios_qa_slots.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Lint workflow YAML**
+
+```bash
+yamllint .github/workflows/mobile_ios_qa_allocate.yml || true
+```
+
+(Don't block on lint warnings; just note them.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/ios_qa_slots.py scripts/test_ios_qa_slots.py .github/workflows/mobile_ios_qa_allocate.yml
+git commit -m "fix(ci): preserve queued PRs in iOS QA slot allocator (PR #3440)"
+```
+
+- [ ] **Step 9: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 3440 --json headRefName -q .headRefName)
+gh pr comment 3440 --body "Allocator now persists queued PR list across runs and runs changed-file context check for all PRs, not only the target. Added unit tests covering the case where a newer PR could previously jump an older queued PR and the case where a freed slot is filled from the head of the queue."
+```
+
+---
+
+## Task 6: PR #3375 — l10n sweep for invites screen
+
+**Files:**
+- Modify: `mobile/lib/screens/invites/invites_screen.dart` (lines 37, 85, 100, 187, 235, 256 plus any others)
+- Modify: `mobile/lib/l10n/app_en.arb`
+- Generated: `mobile/lib/l10n/app_localizations*.dart` (codegen output)
+- Test: any existing `mobile/test/screens/invites/...` widget tests that match literal strings
+
+- [ ] **Step 1: Worktree + read intent**
+
+```bash
+gh pr checkout 3375 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3375-invites-l10n pr-3375
+cd ~/code/divine/divine-mobile-worktrees/pr-3375-invites-l10n
+gh pr view 3375 --json title,body,files,reviews
+```
+
+- [ ] **Step 2: Identify all hardcoded strings**
+
+```bash
+grep -nE "Text\\(['\"]|Snackbar\\b|tooltip:" mobile/lib/screens/invites/invites_screen.dart
+```
+
+Confirm the lines flagged in review (37, 85, 100, 187, 235, 256) plus any others.
+
+- [ ] **Step 3: Add ARB keys**
+
+In `mobile/lib/l10n/app_en.arb`, add one key per string. Use snake-case ish camel keys (`invitesAwardedTitle`, `invitesEmptyStateMessage`, etc.) following the file's existing convention. Add `@key` metadata blocks with descriptions.
+
+- [ ] **Step 4: Run l10n codegen**
+
+```bash
+cd mobile && mise exec -- flutter gen-l10n
+```
+
+Expected: regenerated `app_localizations*.dart` files. Confirm no errors.
+
+- [ ] **Step 5: Replace hardcoded strings with `AppLocalizations.of(context)!.<key>`**
+
+Update each call site in `invites_screen.dart`. Add the import if missing:
+
+```dart
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+```
+
+(Or whatever import path the rest of the codebase uses — match existing files.)
+
+- [ ] **Step 6: Update widget tests that referenced literal strings**
+
+```bash
+grep -rnE "(Awarded|invite|Invite)" mobile/test/screens/invites/ || true
+```
+
+Update `find.text(...)` / `expect(find.text(...))` calls to read from the same ARB key, e.g. via a test helper or by pumping a `MaterialApp` with `AppLocalizations.delegate` and asserting on the resolved string.
+
+- [ ] **Step 7: Analyze and run tests**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test
+cd mobile && mise exec -- flutter test test/screens/invites
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mobile/lib/screens/invites mobile/lib/l10n mobile/test/screens/invites
+git commit -m "chore(l10n): localize invites screen strings (PR #3375)"
+```
+
+- [ ] **Step 9: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 3375 --json headRefName -q .headRefName)
+gh pr comment 3375 --body "Moved hardcoded strings in invites_screen.dart through app_en.arb and ran l10n codegen. Updated widget tests that referenced literal strings."
+```
+
+---
+
+## Task 7: PR #3177 — l10n sweep for retry strings
+
+**Files:**
+- Modify: files surfaced by review for retry user-facing strings (publish primitives + repost retry feedback)
+- Modify: `mobile/lib/l10n/app_en.arb`
+- Generated: `mobile/lib/l10n/app_localizations*.dart`
+
+- [ ] **Step 1: Worktree + read review comments to enumerate strings**
+
+```bash
+gh pr checkout 3177 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-3177-retry-l10n pr-3177
+cd ~/code/divine/divine-mobile-worktrees/pr-3177-retry-l10n
+gh pr view 3177 --json reviews,comments,title,body,files
+```
+
+Make a list of every hardcoded user-facing retry string flagged in review.
+
+- [ ] **Step 2: Add ARB keys for each**
+
+Add to `app_en.arb` with descriptive keys (`retryPublishFailedMessage`, `retryRepostQueuedMessage`, etc.). Include `@key` metadata.
+
+- [ ] **Step 3: Run codegen**
+
+```bash
+cd mobile && mise exec -- flutter gen-l10n
+```
+
+- [ ] **Step 4: Replace each hardcoded string with the localized lookup**
+
+Edit each call site identified in step 1.
+
+- [ ] **Step 5: Analyze and run targeted tests**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test
+cd mobile && mise exec -- flutter test <test paths for affected files>
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib mobile/test
+git commit -m "chore(l10n): localize retry user-facing strings (PR #3177)"
+```
+
+- [ ] **Step 7: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 3177 --json headRefName -q .headRefName)
+gh pr comment 3177 --body "Moved retry-related user-facing strings (publish primitives + repost retry feedback) through app_en.arb and ran codegen. Other review comments (unused nostr_client method, result type consistency) are out of scope for this commit and remain open."
+```
+
+---
+
+## Task 8: PR #2878 — l10n sweep for C2PA import UI
+
+**Files:**
+- Modify: C2PA import flow widgets (TBD — discover during step 2)
+- Modify: `mobile/lib/l10n/app_en.arb`
+- Generated: `mobile/lib/l10n/app_localizations*.dart`
+
+- [ ] **Step 1: Worktree + read intent**
+
+```bash
+gh pr checkout 2878 --detach
+git worktree add ~/code/divine/divine-mobile-worktrees/pr-2878-c2pa-l10n pr-2878
+cd ~/code/divine/divine-mobile-worktrees/pr-2878-c2pa-l10n
+gh pr view 2878 --json reviews,comments,title,body,files
+```
+
+- [ ] **Step 2: Locate C2PA import widgets and enumerate hardcoded strings**
+
+```bash
+grep -rnE "Text\\(['\"]" mobile/lib --include='*.dart' | grep -i 'c2pa\\|import\\|verified' || true
+```
+
+Cross-reference with the PR diff to confirm the widgets owned by this PR.
+
+- [ ] **Step 3: Add ARB keys**
+
+Add to `app_en.arb` with import-flow-prefixed keys (`videoImportVerifiedTitle`, `videoImportFailedMessage`, etc.) and metadata.
+
+- [ ] **Step 4: Run codegen**
+
+```bash
+cd mobile && mise exec -- flutter gen-l10n
+```
+
+- [ ] **Step 5: Replace hardcoded strings**
+
+Edit each call site. Do **not** touch `video_import_service.dart:102` `proofManifestJson` issue — that is a separate defect outside this scope.
+
+- [ ] **Step 6: Analyze and run targeted tests**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test
+cd mobile && mise exec -- flutter test <relevant test paths>
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/lib mobile/test
+git commit -m "chore(l10n): localize C2PA import UI strings (PR #2878)"
+```
+
+- [ ] **Step 8: Push and comment**
+
+```bash
+git push origin HEAD:$(gh pr view 2878 --json headRefName -q .headRefName)
+gh pr comment 2878 --body "Moved C2PA import UI strings through app_en.arb. The proofManifestJson issue at video_import_service.dart:102 and the merge conflicts are out of scope for this commit and remain open."
+```
+
+---
+
+## Task 9: Cross-PR cleanup
+
+- [ ] **Step 1: Confirm no `uploadToken` log statements anywhere on `main`**
+
+```bash
+git fetch origin main
+git switch -d origin/main
+git grep -nE 'uploadToken' -- 'mobile/android' 'mobile/ios'
+```
+
+If any hits exist on `main` (independent of #3301), surface them and ask the user whether to file a follow-up.
+
+- [ ] **Step 2: Summarize results to user**
+
+Report: PRs where push succeeded; PRs where push fell back to a new PR; any flagged blockers (e.g. #3407 needing device QA, #3440 lint warnings).
+
+- [ ] **Step 3: Remove all temporary worktrees**
+
+```bash
+for d in ~/code/divine/divine-mobile-worktrees/pr-*; do
+  git worktree remove "$d" || true
+done
+```
+
+- [ ] **Step 4: Mark all tasks complete and stop**
+
+Do not extend scope to the out-of-scope PRs without explicit user approval.
+
+---
+
+## Notes for the executor
+
+- Trust the spec, not assumptions. If a PR's actual code differs from the sketch in this plan (e.g. line numbers shifted, helpers renamed), **read the current code and adapt**. Do not paste the snippets in this plan verbatim if they don't match the file's reality.
+- If a step's "expected" outcome doesn't match reality, stop and investigate. Don't paper over a failing test by changing the assertion.
+- L10n codegen output is committed alongside ARB changes. Don't push without it.
+- Keep commits focused per task. One commit per PR is the target; two if there's a clean separation between fix and tests.
+- If you encounter merge conflicts that are not trivial (more than rebase-noise), stop and surface to the user — those are out of scope per the spec.

--- a/docs/superpowers/plans/2026-05-04-video-comments-revival.md
+++ b/docs/superpowers/plans/2026-05-04-video-comments-revival.md
@@ -1,0 +1,1487 @@
+# Video Comments Revival Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Revive the half-shipped "post a video as a reply to a video" feature behind a `videoReplies` feature flag (default off), including the missing inline display of video comments in the comments sheet, without merging the stale `feat/video-comments-clean` branch (521 commits behind main).
+
+> **2026-05-04 amendment:** Pre-flight verification (see Chunk 0) revealed that the comments sheet on main does NOT render video comments inline — `comment_item.dart` is text-only. The profile tab's `ProfileCommentsState.videoReplies` ships with display, but the in-feed comments sheet does not. Without inline display, a flag-on user posts a video reply and sees nothing appear in the very sheet they posted into. Display work has therefore been folded into this plan as Chunk 5; subsequent chunks renumbered.
+
+**Architecture:** Reuse the existing recorder, editor, and clip pipeline unchanged. A `VideoReplyCubit` (state: `VideoReplyContext?`) provided at the app root holds the reply intent across navigation. At editor confirmation, a small `VideoReplyPublisher` reads the cubit and either hands off to `VideoCommentPublishService` (Blossom upload → NIP-92 imeta → Kind 1111 comment via `CommentsRepository`) or returns false so the editor falls through to the existing metadata-screen → Kind 34236 path. The editor itself stays unaware of replies.
+
+**State management policy:** Per CLAUDE.md, new code is BLoC/Cubit; Riverpod is legacy only. The recorder (`video_recorder_provider.dart`) and editor (`video_editor_provider.dart`) are existing Riverpod and we deliberately do NOT migrate them in this plan — that is a separate effort. The seam between them and the new Cubit-based reply state is at the **widget/screen layer**, where `context` can read both `Ref` (via `ConsumerStatefulWidget`) and `BlocProvider`. The new code path (cubit, service, publisher, comment-input wiring) is 100% BLoC/Cubit and `RepositoryProvider`-injected; no new Riverpod providers are added.
+
+**Tech Stack:** Flutter, `flutter_bloc` + `bloc_test` (all new code), Riverpod (read-only interop with the legacy recorder/editor at the widget layer), Nostr (NIP-22 Kind 1111 comments + NIP-92 imeta video metadata), Blossom (CDN/storage).
+
+---
+
+## Non-Goals (explicitly out of scope)
+
+To prevent scope creep:
+
+- **No new editor UI for replies.** No "replying to @user" banner, no shorter duration cap, no different post-button label. The editor is identical to a normal post until the moment of publish.
+- **No metadata screen for replies.** Captions/hashtags/collaborators are not added to video replies in this iteration. We intentionally skip the metadata screen on the reply path. (If product later wants this, the divergence point is documented and tested.)
+- ~~**No display work in this plan.**~~ **Display work IS in this plan** (Chunk 5). The Comment model on main has `videoUrl`, `thumbnailUrl`, `hasVideo`, etc., but `comment_item.dart` does not branch on those fields. We add a `CommentVideoPlayer` widget and a render branch in `CommentItem`. The profile tab's video-reply rendering remains as it is — out of scope for this plan.
+- **No backend changes.** Funnelcake / relay already accept Kind 1111 with imeta tags.
+
+## Debt Rules (must hold throughout)
+
+These are the rules called out before approving the work. Every reviewer should check the implementation against them:
+
+1. **`VideoReplyCubit` must be cleared on every exit path** — back button, cancel from recorder, cancel from editor, app resume to a non-reply route. Not just on successful publish. There MUST be a regression test for "start reply → cancel → start normal post → cubit state is null."
+2. **No bloat in `video_editor_provider.dart`.** The editor decides "I have a rendered clip"; it must not know about Kind 1111 vs 34236. Routing the rendered clip is `VideoReplyPublisher`'s job (a thin class), and the actual upload+publish is `VideoCommentPublishService`'s job.
+3. **One repository method, extended.** `CommentsRepository.postComment()` gains optional video-metadata params and emits NIP-92 imeta tags inline. No parallel `postVideoComment()` method.
+4. **The flag has an exit criterion.** PR description must state "remove flag once X% rollout stable for 2 weeks." Open a tracking issue at PR time.
+5. **Tests are written fresh against current main.** Do not port the stale tests from `feat/video-comments-clean`. Reference them only for intent.
+6. **Skipping the metadata screen for replies is an explicit tested behavior**, not an accident.
+7. **No new Riverpod providers.** All new state lives in a Cubit; all new services are injected via `RepositoryProvider` or constructor. The legacy recorder/editor Riverpod code stays untouched — interop happens only at the widget/screen layer.
+
+---
+
+## File Structure
+
+### New Files
+
+| Path | Responsibility |
+|---|---|
+| `mobile/lib/models/video_reply_context.dart` | Plain immutable data class: `rootEventId`, `rootEventKind`, `rootAuthorPubkey`, `rootAddressableId`, `parentCommentId?`, `parentAuthorPubkey?`. No behavior. |
+| `mobile/lib/blocs/video_reply/video_reply_cubit.dart` | `Cubit<VideoReplyContext?>` with explicit `start(VideoReplyContext)` and `clear()` methods. Provided at the app root so it survives navigation between comments sheet → recorder → editor. |
+| `mobile/lib/services/video_comment_publish_service.dart` | Stateless service: takes a rendered clip path + reply context + comment text → uploads to Blossom → builds NIP-92 imeta → calls `CommentsRepository.postComment()`. Owns the publish flow end-to-end. Plain Dart class, no Riverpod, injected via constructor. |
+| `mobile/lib/services/video_reply_publisher.dart` | Thin class (~40 lines) called from the editor's "Done" handler. Constructor-injected with `VideoReplyCubit`, `VideoCommentPublishService`, and a `Future<String?> Function() getRenderedClipPath` callback that lets the caller (a `ConsumerStatefulWidget`) bridge to the legacy Riverpod editor without leaking `Ref` into this class. Returns `Future<bool>` — `true` if it consumed the clip; `false` means proceed to metadata screen. |
+| `mobile/packages/comments_repository/lib/src/models/video_comment_media.dart` | Optional value type passed to `postComment()`: `url`, `sha256`, `mimeType`, `dimWidth`, `dimHeight`, `durationSeconds`, `thumbnailUrl?`, `blurhash?`. Pure data. |
+| `mobile/lib/screens/comments/widgets/comment_video_player.dart` | Inline video player for a comment item. Takes the comment's video URL, thumbnail, blurhash, and dimensions and renders a tap-to-play preview. Reuses the project's existing video-player primitives (verify exact widget in pre-flight — likely the same player used elsewhere for inline playback). Constrained aspect ratio matching the comment's `videoDimensions`. |
+
+### Modified Files
+
+| Path | Change |
+|---|---|
+| `mobile/lib/features/feature_flags/models/feature_flag.dart` | Add `videoReplies('Video Replies', 'Allow recording and posting video replies in comments')` enum entry. |
+| `mobile/lib/features/feature_flags/services/build_configuration.dart` | Add switch case `case FeatureFlag.videoReplies: return const bool.fromEnvironment('FF_VIDEO_REPLIES');` plus the env-key mapping case. Default `false`. |
+| `mobile/packages/comments_repository/lib/src/comments_repository.dart` | `postComment()` gains optional `VideoCommentMedia? video` parameter. When present, adds NIP-92 `imeta` tag to the Kind 1111 event. |
+| `mobile/packages/comments_repository/lib/comments_repository.dart` | Export `VideoCommentMedia` from barrel. |
+| `mobile/lib/screens/comments/widgets/comment_input.dart` | Add optional `VoidCallback? onVideoReply`. When non-null, render a video-reply icon next to send. |
+| `mobile/lib/screens/comments/widgets/comment_item.dart` | Branch on `comment.hasVideo`: when true, render `CommentVideoPlayer` above (or in place of) the existing text content; when false, render exactly as today. (Confirmed text-only on main as of pre-flight.) |
+| `mobile/lib/screens/comments/comments_screen.dart` (or its caller — see pre-flight findings) | Read the flag; if on, pass `onVideoReply` that calls `context.read<VideoReplyCubit>().start(...)`, dismisses the sheet, and pushes the recorder route. The sheet is opened via `CommentsScreen.show(context, video)` from `pooled_fullscreen_video_feed_screen.dart:649` — wire the recorder navigation in the `whenComplete` of that call (or directly from the callback if simpler). |
+| `mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart:721` | At the existing `await context.push(VideoMetadataScreen.path)` site, first call `VideoReplyPublisher.handleEditorDone()`. If it returns `true`, do not push the metadata screen. The publisher is read via `context.read<VideoReplyPublisher>()`; the rendered-clip callback bridges to the Riverpod editor via `ref.read(videoEditorProvider).state.finalRenderedClip`. |
+| `mobile/lib/screens/video_recorder_screen.dart` | In `dispose()` and the cancel handler, call `context.read<VideoReplyCubit>().clear()` to satisfy debt rule #1. The Riverpod recorder *notifier* itself is NOT modified — clearing happens at the screen widget layer where both `Ref` and `BlocProvider` are reachable. |
+| `mobile/lib/main.dart` (root `MultiRepositoryProvider` at line 1590, `MultiBlocProvider` at line 1632 — verified in pre-flight) | Provide `VideoReplyCubit` (under `MultiBlocProvider`) and `VideoCommentPublishService` (under `MultiRepositoryProvider`) at the root so they survive navigation. |
+
+### Test Files (mirror)
+
+- `mobile/test/models/video_reply_context_test.dart`
+- `mobile/test/blocs/video_reply/video_reply_cubit_test.dart` (uses `bloc_test`)
+- `mobile/test/services/video_comment_publish_service_test.dart`
+- `mobile/test/services/video_reply_publisher_test.dart`
+- `mobile/packages/comments_repository/test/src/comments_repository_video_test.dart`
+- `mobile/test/screens/comments/widgets/comment_input_video_reply_test.dart`
+- `mobile/test/screens/comments/widgets/comment_video_player_test.dart`
+- `mobile/test/screens/comments/widgets/comment_item_video_render_test.dart`
+- `mobile/test/screens/comments/comments_screen_video_reply_entry_test.dart`
+- `mobile/test/features/feature_flags/video_replies_flag_test.dart`
+
+---
+
+## Pre-Flight Verification Findings (2026-05-04)
+
+Recorded so the rest of the plan and any subsequent reviewers can rely on these:
+
+| Plan assumption | Verified location on `origin/main` |
+|---|---|
+| `FeatureFlag` enum | `mobile/lib/features/feature_flags/models/feature_flag.dart:4` |
+| `CommentsRepository.postComment` | `mobile/packages/comments_repository/lib/src/comments_repository.dart:215` |
+| Editor "Done" → metadata push | `mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart:721` (`await context.push(VideoMetadataScreen.path)`) |
+| Editor rendered-clip accessor | `videoEditorProvider`'s state exposes `finalRenderedClip` (see `video_editor_provider.dart:96, 849, 917`) |
+| Comments sheet entry | `CommentsScreen.show(context, video)` (modal, used at `pooled_fullscreen_video_feed_screen.dart:649`) |
+| `VideoMetadataScreen` location | `mobile/lib/screens/video_metadata/video_metadata_screen.dart` |
+| Recorder screen | `mobile/lib/screens/video_recorder_screen.dart` |
+| App-root providers | `mobile/lib/main.dart` — `MultiRepositoryProvider` at line 1590, `MultiBlocProvider` at line 1632 |
+| Pre-existing `videoReplies` display | Profile only: `mobile/lib/blocs/profile_comments/profile_comments_state.dart:27` (NOT comments sheet) |
+| Comment model video fields | `comment.dart:61` `videoUrl`, `:64` `thumbnailUrl`, `:76` `hasVideo` getter |
+
+**Outstanding setup item:** The fresh worktree at `/Users/rabble/code/divine/divine-mobile-video-comments` does NOT have git hooks installed. Run `mise run setup_hooks` from `mobile/` before the first commit.
+
+---
+
+## Chunk 0: Pre-Flight & Worktree Setup
+
+### Task 0.1: Create worktree
+
+**Files:** none
+
+- [ ] **Step 1: Create the worktree off `main`**
+
+```bash
+cd /Users/rabble/code/divine/divine-mobile
+git fetch origin main
+git worktree add ../divine-mobile-video-comments -b feat/video-comments-revival origin/main
+cd ../divine-mobile-video-comments/mobile
+```
+
+- [ ] **Step 2: Verify hooks installed**
+
+Run: `mise run setup_hooks`
+Expected: pre-commit and pre-push hooks present in `.git/hooks/`.
+
+- [ ] **Step 3: Get dependencies**
+
+Run: `flutter pub get`
+Expected: success.
+
+### Task 0.2: Verify current-state assumptions
+
+This branch was 521 commits behind main when researched. Verify the file paths still match before writing code; correct them in the plan if they have moved.
+
+- [ ] **Step 1: Confirm feature-flag enum location**
+
+Run: `grep -rn "enum FeatureFlag" mobile/lib/features/feature_flags/`
+Expected: hits in `models/feature_flag.dart`. If file has moved, update plan.
+
+- [ ] **Step 2: Confirm `CommentsRepository.postComment` signature**
+
+Run: `grep -n "Future.*postComment" mobile/packages/comments_repository/lib/src/comments_repository.dart`
+Expected: a method that builds and publishes a Kind 1111 event with NIP-22 threading tags. Read it end-to-end before extending.
+
+- [ ] **Step 3: Locate the editor "Done" handler**
+
+Run: `grep -rn "_handleDone\|onDone\|onConfirm" mobile/lib/screens/video_editor/`
+Expected: a single confirm path on the editor canvas. Note its file:line for Chunk 6.
+
+- [ ] **Step 4: Confirm comments screen still uses a modal/bottom-sheet pattern with `whenComplete`**
+
+Run: `grep -n "whenComplete\|showModalBottomSheet" mobile/lib/screens/comments/comments_screen.dart`
+Expected: a modal dismissal hook we can use for "after sheet closed, navigate to recorder if reply context set." If the comments screen has been migrated off a modal pattern, the entry-point wiring in Chunk 5 needs to move to wherever the comment input now lives.
+
+- [x] **Step 5: Confirm the comments screen does NOT need new display widgets** *(resolved 2026-05-04)*
+
+Run: `grep -rn "videoReplies\|VideoCommentPlayer" mobile/lib/screens/comments/`
+Result on `origin/main` at `c5ed3eadd`: **no display for video comments in the comments sheet.** The profile tab renders video replies, the comments sheet does not. Display work has been folded into Chunk 5 of this plan (decision: 2026-05-04).
+
+---
+
+## Chunk 1: Feature Flag Wiring
+
+Foundation for everything else. Ship this commit first; nothing else activates until it's in place.
+
+### Task 1.1: Add `videoReplies` enum entry
+
+**Files:**
+- Modify: `mobile/lib/features/feature_flags/models/feature_flag.dart`
+- Test: `mobile/test/features/feature_flags/video_replies_flag_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:divine_mobile/features/feature_flags/models/feature_flag.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FeatureFlag.videoReplies', () {
+    test('exists and has descriptive metadata', () {
+      const flag = FeatureFlag.videoReplies;
+      expect(flag.displayName, equals('Video Replies'));
+      expect(flag.description, contains('video'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/feature_flags/video_replies_flag_test.dart`
+Expected: FAIL — `videoReplies` is not a member of FeatureFlag.
+
+- [ ] **Step 3: Add the enum entry**
+
+In `mobile/lib/features/feature_flags/models/feature_flag.dart`, add to the enum body:
+
+```dart
+videoReplies(
+  'Video Replies',
+  'Allow recording and posting video replies in comments',
+),
+```
+
+Place it alphabetically or grouped with other camera/video flags — match the file's existing convention.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/feature_flags/video_replies_flag_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/features/feature_flags/models/feature_flag.dart mobile/test/features/feature_flags/video_replies_flag_test.dart
+git commit -m "feat(feature-flags): add videoReplies flag enum entry"
+```
+
+### Task 1.2: Wire env var in BuildConfiguration
+
+**Files:**
+- Modify: `mobile/lib/features/feature_flags/services/build_configuration.dart`
+- Test: append to `mobile/test/features/feature_flags/video_replies_flag_test.dart`
+
+- [ ] **Step 1: Add the failing test**
+
+```dart
+test('BuildConfiguration default for videoReplies is false', () {
+  expect(
+    BuildConfiguration.getDefault(FeatureFlag.videoReplies),
+    isFalse,
+  );
+});
+
+test('BuildConfiguration env key for videoReplies is FF_VIDEO_REPLIES', () {
+  expect(
+    BuildConfiguration.getEnvironmentKey(FeatureFlag.videoReplies),
+    equals('FF_VIDEO_REPLIES'),
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/feature_flags/video_replies_flag_test.dart`
+Expected: FAIL — switch is not exhaustive / case missing.
+
+- [ ] **Step 3: Add the switch cases**
+
+In `build_configuration.dart`, add cases mirroring the existing pattern:
+
+```dart
+case FeatureFlag.videoReplies:
+  return const bool.fromEnvironment('FF_VIDEO_REPLIES');
+```
+
+And in `getEnvironmentKey`:
+
+```dart
+case FeatureFlag.videoReplies:
+  return 'FF_VIDEO_REPLIES';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/feature_flags/video_replies_flag_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/features/feature_flags/services/build_configuration.dart mobile/test/features/feature_flags/video_replies_flag_test.dart
+git commit -m "feat(feature-flags): wire FF_VIDEO_REPLIES env var"
+```
+
+---
+
+## Chunk 2: Reply Context Model + Cubit
+
+### Task 2.1: `VideoReplyContext` model
+
+**Files:**
+- Create: `mobile/lib/models/video_reply_context.dart`
+- Test: `mobile/test/models/video_reply_context_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:divine_mobile/models/video_reply_context.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('VideoReplyContext', () {
+    test('values are equatable', () {
+      const a = VideoReplyContext(
+        rootEventId: 'a' * 64,
+        rootEventKind: 34236,
+        rootAuthorPubkey: 'b' * 64,
+        rootAddressableId: '34236:${'b' * 64}:dtag',
+      );
+      const b = VideoReplyContext(
+        rootEventId: 'a' * 64,
+        rootEventKind: 34236,
+        rootAuthorPubkey: 'b' * 64,
+        rootAddressableId: '34236:${'b' * 64}:dtag',
+      );
+      expect(a, equals(b));
+    });
+
+    test('parent fields default to null for top-level reply', () {
+      const ctx = VideoReplyContext(
+        rootEventId: 'a' * 64,
+        rootEventKind: 34236,
+        rootAuthorPubkey: 'b' * 64,
+        rootAddressableId: '34236:${'b' * 64}:dtag',
+      );
+      expect(ctx.parentCommentId, isNull);
+      expect(ctx.parentAuthorPubkey, isNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/models/video_reply_context_test.dart`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Implement the model**
+
+```dart
+import 'package:equatable/equatable.dart';
+
+class VideoReplyContext extends Equatable {
+  const VideoReplyContext({
+    required this.rootEventId,
+    required this.rootEventKind,
+    required this.rootAuthorPubkey,
+    required this.rootAddressableId,
+    this.parentCommentId,
+    this.parentAuthorPubkey,
+  });
+
+  final String rootEventId;
+  final int rootEventKind;
+  final String rootAuthorPubkey;
+  final String rootAddressableId;
+  final String? parentCommentId;
+  final String? parentAuthorPubkey;
+
+  @override
+  List<Object?> get props => [
+        rootEventId,
+        rootEventKind,
+        rootAuthorPubkey,
+        rootAddressableId,
+        parentCommentId,
+        parentAuthorPubkey,
+      ];
+}
+```
+
+Per CLAUDE.md: never truncate Nostr IDs.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/models/video_reply_context_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/models/video_reply_context.dart mobile/test/models/video_reply_context_test.dart
+git commit -m "feat(models): add VideoReplyContext"
+```
+
+### Task 2.2: `VideoReplyCubit` with explicit clear
+
+**Files:**
+- Create: `mobile/lib/blocs/video_reply/video_reply_cubit.dart`
+- Test: `mobile/test/blocs/video_reply/video_reply_cubit_test.dart`
+
+Per CLAUDE.md, all new state is BLoC/Cubit. This cubit is provided at the app root (Task 2.3) so reply intent persists across the comments-sheet → recorder → editor navigation. State is `VideoReplyContext?` — null means "no reply in progress."
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_mobile/blocs/video_reply/video_reply_cubit.dart';
+import 'package:divine_mobile/models/video_reply_context.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+VideoReplyContext _ctx() => const VideoReplyContext(
+      rootEventId: 'a' * 64,
+      rootEventKind: 34236,
+      rootAuthorPubkey: 'b' * 64,
+      rootAddressableId: '34236:${'b' * 64}:dtag',
+    );
+
+void main() {
+  group(VideoReplyCubit, () {
+    test('initial state is null', () {
+      expect(VideoReplyCubit().state, isNull);
+    });
+
+    blocTest<VideoReplyCubit, VideoReplyContext?>(
+      'start emits the context',
+      build: VideoReplyCubit.new,
+      act: (cubit) => cubit.start(_ctx()),
+      expect: () => [_ctx()],
+    );
+
+    blocTest<VideoReplyCubit, VideoReplyContext?>(
+      'clear emits null after a context was set',
+      build: VideoReplyCubit.new,
+      act: (cubit) => cubit
+        ..start(_ctx())
+        ..clear(),
+      expect: () => [_ctx(), isNull],
+    );
+
+    blocTest<VideoReplyCubit, VideoReplyContext?>(
+      'regression: start → clear → no further emissions before next start; '
+      'subsequent normal-post flow does NOT see leftover context',
+      build: VideoReplyCubit.new,
+      act: (cubit) => cubit
+        ..start(_ctx())
+        ..clear(),
+      verify: (cubit) => expect(cubit.state, isNull),
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/blocs/video_reply/video_reply_cubit_test.dart`
+Expected: FAIL — cubit does not exist.
+
+- [ ] **Step 3: Implement the cubit**
+
+```dart
+import 'package:bloc/bloc.dart';
+import 'package:divine_mobile/models/video_reply_context.dart';
+
+class VideoReplyCubit extends Cubit<VideoReplyContext?> {
+  VideoReplyCubit() : super(null);
+
+  void start(VideoReplyContext context) => emit(context);
+  void clear() => emit(null);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/blocs/video_reply/video_reply_cubit_test.dart`
+Expected: PASS — including the regression test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/blocs/video_reply mobile/test/blocs/video_reply
+git commit -m "feat(video-reply): add VideoReplyCubit with clear semantics"
+```
+
+### Task 2.3: Provide `VideoReplyCubit` at app root
+
+**Files:**
+- Modify: app-root provider widget (verify in Task 0.2 — typically `mobile/lib/main.dart` or a top-level `App` widget that owns `MultiBlocProvider`).
+
+This is a structural change so the cubit survives navigation between comments → recorder → editor. Without this step the cubit would be re-created at each screen and reply intent would not propagate.
+
+- [ ] **Step 1: Locate the existing root `MultiBlocProvider`** (or equivalent). Add an entry:
+
+```dart
+BlocProvider<VideoReplyCubit>(
+  create: (_) => VideoReplyCubit(),
+),
+```
+
+- [ ] **Step 2: Smoke-test that the app still launches**
+
+Run: `cd mobile && flutter run -d <device>` (or `flutter test integration_test/app_smoke_test.dart` if one exists)
+Expected: app launches without provider-not-found errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/main.dart # or wherever providers live
+git commit -m "feat(app): provide VideoReplyCubit at root"
+```
+
+---
+
+## Chunk 3: Repository Layer — Extend `postComment` with Optional Imeta
+
+### Task 3.1: `VideoCommentMedia` value type
+
+**Files:**
+- Create: `mobile/packages/comments_repository/lib/src/models/video_comment_media.dart`
+- Modify: `mobile/packages/comments_repository/lib/src/models/models.dart` (barrel)
+- Modify: `mobile/packages/comments_repository/lib/comments_repository.dart` (top-level barrel)
+- Test: `mobile/packages/comments_repository/test/src/models/video_comment_media_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:comments_repository/comments_repository.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VideoCommentMedia', () {
+    test('builds NIP-92 imeta tag values', () {
+      const media = VideoCommentMedia(
+        url: 'https://blossom.example/abc.mp4',
+        sha256: 'd' * 64,
+        mimeType: 'video/mp4',
+        dimWidth: 720,
+        dimHeight: 1280,
+        durationSeconds: 6,
+        thumbnailUrl: 'https://blossom.example/abc.jpg',
+        blurhash: 'LKO2?U%2Tw=w',
+      );
+      final values = media.toImetaTagValues();
+      expect(values, contains('url https://blossom.example/abc.mp4'));
+      expect(values, contains('x ${'d' * 64}'));
+      expect(values, contains('m video/mp4'));
+      expect(values, contains('dim 720x1280'));
+      expect(values, contains('image https://blossom.example/abc.jpg'));
+      expect(values, contains('blurhash LKO2?U%2Tw=w'));
+    });
+
+    test('omits optional values when absent', () {
+      const media = VideoCommentMedia(
+        url: 'https://blossom.example/abc.mp4',
+        sha256: 'd' * 64,
+        mimeType: 'video/mp4',
+        dimWidth: 720,
+        dimHeight: 1280,
+        durationSeconds: 6,
+      );
+      final values = media.toImetaTagValues();
+      expect(values.any((v) => v.startsWith('image ')), isFalse);
+      expect(values.any((v) => v.startsWith('blurhash ')), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/comments_repository && dart test test/src/models/video_comment_media_test.dart`
+Expected: FAIL — type not defined.
+
+- [ ] **Step 3: Implement the value type**
+
+```dart
+import 'package:equatable/equatable.dart';
+
+class VideoCommentMedia extends Equatable {
+  const VideoCommentMedia({
+    required this.url,
+    required this.sha256,
+    required this.mimeType,
+    required this.dimWidth,
+    required this.dimHeight,
+    required this.durationSeconds,
+    this.thumbnailUrl,
+    this.blurhash,
+  });
+
+  final String url;
+  final String sha256;
+  final String mimeType;
+  final int dimWidth;
+  final int dimHeight;
+  final int durationSeconds;
+  final String? thumbnailUrl;
+  final String? blurhash;
+
+  /// NIP-92 imeta tag values: each entry is a "key value" string,
+  /// laid out per the spec.
+  List<String> toImetaTagValues() {
+    return [
+      'url $url',
+      'x $sha256',
+      'm $mimeType',
+      'dim ${dimWidth}x$dimHeight',
+      'duration $durationSeconds',
+      if (thumbnailUrl != null) 'image $thumbnailUrl',
+      if (blurhash != null) 'blurhash $blurhash',
+    ];
+  }
+
+  @override
+  List<Object?> get props => [
+        url,
+        sha256,
+        mimeType,
+        dimWidth,
+        dimHeight,
+        durationSeconds,
+        thumbnailUrl,
+        blurhash,
+      ];
+}
+```
+
+Verify the exact NIP-92 field names against `mcp__nostrbook__read_nip` for NIP-92 if there is any doubt — do not guess.
+
+- [ ] **Step 4: Update barrels**
+
+```dart
+// models.dart
+export 'video_comment_media.dart';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd mobile/packages/comments_repository && dart test test/src/models/video_comment_media_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/packages/comments_repository/lib mobile/packages/comments_repository/test/src/models
+git commit -m "feat(comments-repository): add VideoCommentMedia value type"
+```
+
+### Task 3.2: Extend `postComment` to accept optional video metadata
+
+**Files:**
+- Modify: `mobile/packages/comments_repository/lib/src/comments_repository.dart`
+- Test: `mobile/packages/comments_repository/test/src/comments_repository_video_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+import 'package:comments_repository/comments_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart'; // adjust per actual import
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+VideoCommentMedia _media() => const VideoCommentMedia(
+      url: 'https://blossom.example/abc.mp4',
+      sha256: 'd' * 64,
+      mimeType: 'video/mp4',
+      dimWidth: 720,
+      dimHeight: 1280,
+      durationSeconds: 6,
+    );
+
+void main() {
+  late _MockNostrClient client;
+  late CommentsRepository repo;
+
+  setUp(() {
+    client = _MockNostrClient();
+    repo = CommentsRepository(nostrClient: client);
+    // Stub publishEvent — exact API depends on current main.
+  });
+
+  group('postComment with video', () {
+    test('without video param, no imeta tag is emitted', () async {
+      await repo.postComment(/* required args */, content: 'hi');
+      final captured = verify(() => client.publishEvent(captureAny()))
+          .captured
+          .single as NostrEvent;
+      expect(
+        captured.tags.any((t) => t.first == 'imeta'),
+        isFalse,
+      );
+    });
+
+    test('with video param, an imeta tag is emitted with NIP-92 fields',
+        () async {
+      await repo.postComment(
+        /* required args */,
+        content: 'check this',
+        video: _media(),
+      );
+      final captured = verify(() => client.publishEvent(captureAny()))
+          .captured
+          .single as NostrEvent;
+      final imeta = captured.tags.firstWhere((t) => t.first == 'imeta');
+      expect(imeta, contains('url https://blossom.example/abc.mp4'));
+      expect(imeta, contains('x ${'d' * 64}'));
+      expect(imeta, contains('dim 720x1280'));
+    });
+
+    test('event kind remains 1111 even when video is present', () async {
+      await repo.postComment(
+        /* required args */,
+        content: 'check this',
+        video: _media(),
+      );
+      final captured = verify(() => client.publishEvent(captureAny()))
+          .captured
+          .single as NostrEvent;
+      expect(captured.kind, equals(1111));
+    });
+  });
+}
+```
+
+The exact `postComment` argument list and `NostrClient.publishEvent` shape must be read from the current main file before writing. Adjust the test to match.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mobile/packages/comments_repository && dart test test/src/comments_repository_video_test.dart`
+Expected: FAIL — `video` parameter not defined.
+
+- [ ] **Step 3: Extend the method**
+
+In `comments_repository.dart`, add a parameter:
+
+```dart
+Future<Comment> postComment({
+  // ... existing params unchanged ...
+  required String content,
+  VideoCommentMedia? video,
+}) async {
+  final tags = <List<String>>[
+    // ... existing NIP-22 threading tags unchanged ...
+    if (video != null) ['imeta', ...video.toImetaTagValues()],
+  ];
+  // ... rest of existing implementation unchanged ...
+}
+```
+
+The `imeta` tag form (`['imeta', 'url ...', 'x ...', ...]`) is per NIP-92.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mobile/packages/comments_repository && dart test`
+Expected: PASS — including all *existing* tests (we did not change non-video behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/comments_repository
+git commit -m "feat(comments-repository): postComment accepts optional video imeta"
+```
+
+---
+
+## Chunk 4: Publish Service + Reply Publisher
+
+### Task 4.1: `VideoCommentPublishService`
+
+**Files:**
+- Create: `mobile/lib/services/video_comment_publish_service.dart`
+- Test: `mobile/test/services/video_comment_publish_service_test.dart`
+
+The service is **the only place that knows about both Blossom and `CommentsRepository`**. The editor must not. The publisher (next task) must not. Plain Dart class, no Riverpod, no BLoC — pure constructor injection so it's trivially mockable.
+
+- [ ] **Step 1: Write failing tests**
+
+Tests to cover:
+1. Successful path: render path + reply context → uploads file → calls `postComment` with the resulting `VideoCommentMedia`.
+2. Blossom upload failure → throws `VideoCommentPublishException`; `postComment` is never called.
+3. Comment publish failure → throws `VideoCommentPublishException` with the underlying error chained.
+4. The `CommentsRepository.postComment` call uses the reply context's `rootEventId`/`rootAuthorPubkey`/`rootAddressableId`/`rootEventKind` in NIP-22 root tags.
+
+Use `mocktail` mocks for `BlossomUploadService` and `CommentsRepository`. Patterns are visible in existing service tests.
+
+- [ ] **Step 2: Run tests — all should FAIL** (file doesn't exist).
+
+- [ ] **Step 3: Implement the service**
+
+Outline only — fill in concrete types from the existing `BlossomUploadService` and `CommentsRepository` APIs:
+
+```dart
+class VideoCommentPublishService {
+  VideoCommentPublishService({
+    required BlossomUploadService blossom,
+    required CommentsRepository commentsRepository,
+  })  : _blossom = blossom,
+        _commentsRepository = commentsRepository;
+
+  final BlossomUploadService _blossom;
+  final CommentsRepository _commentsRepository;
+
+  Future<Comment> publish({
+    required String renderedFilePath,
+    required VideoReplyContext replyContext,
+    required String content,
+  }) async {
+    final uploaded = await _blossom.upload(File(renderedFilePath));
+    final media = VideoCommentMedia(
+      url: uploaded.url,
+      sha256: uploaded.sha256,
+      mimeType: uploaded.mimeType,
+      dimWidth: uploaded.width,
+      dimHeight: uploaded.height,
+      durationSeconds: uploaded.durationSeconds,
+      thumbnailUrl: uploaded.thumbnailUrl,
+      blurhash: uploaded.blurhash,
+    );
+    return _commentsRepository.postComment(
+      // map root* and parent* fields from replyContext
+      content: content,
+      video: media,
+    );
+  }
+}
+
+class VideoCommentPublishException implements Exception {
+  VideoCommentPublishException(this.message, {this.cause});
+  final String message;
+  final Object? cause;
+  @override
+  String toString() => 'VideoCommentPublishException: $message';
+}
+```
+
+- [ ] **Step 4: Run tests — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/video_comment_publish_service.dart mobile/test/services/video_comment_publish_service_test.dart
+git commit -m "feat(services): add VideoCommentPublishService (Blossom + Kind 1111)"
+```
+
+### Task 4.2: `VideoReplyPublisher`
+
+**Files:**
+- Create: `mobile/lib/services/video_reply_publisher.dart`
+- Test: `mobile/test/services/video_reply_publisher_test.dart`
+
+Thin seam between editor and publish service. Reading this file should make the entire reply path obvious to a future maintainer. **No `Ref` here** — the publisher takes the cubit, the service, and a callback the caller uses to bridge to the legacy Riverpod editor for the rendered clip. This keeps the publisher trivially unit-testable with plain mocks (no `ProviderContainer`).
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_mobile/blocs/video_reply/video_reply_cubit.dart';
+import 'package:divine_mobile/models/video_reply_context.dart';
+import 'package:divine_mobile/services/video_comment_publish_service.dart';
+import 'package:divine_mobile/services/video_reply_publisher.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockService extends Mock implements VideoCommentPublishService {}
+class _MockCubit extends MockCubit<VideoReplyContext?>
+    implements VideoReplyCubit {}
+
+VideoReplyContext _ctx() => const VideoReplyContext(
+      rootEventId: 'a' * 64,
+      rootEventKind: 34236,
+      rootAuthorPubkey: 'b' * 64,
+      rootAddressableId: '34236:${'b' * 64}:dtag',
+    );
+
+void main() {
+  late _MockCubit cubit;
+  late _MockService service;
+
+  setUp(() {
+    cubit = _MockCubit();
+    service = _MockService();
+  });
+
+  group(VideoReplyPublisher, () {
+    test('with no reply context, returns false; service not called', () async {
+      when(() => cubit.state).thenReturn(null);
+      final publisher = VideoReplyPublisher(
+        cubit: cubit,
+        service: service,
+        getRenderedClipPath: () async => '/tmp/clip.mp4',
+      );
+      expect(await publisher.handleEditorDone(), isFalse);
+      verifyNever(() => service.publish(
+            renderedFilePath: any(named: 'renderedFilePath'),
+            replyContext: any(named: 'replyContext'),
+            content: any(named: 'content'),
+          ));
+    });
+
+    test('with reply context, publishes and clears cubit, returns true',
+        () async {
+      when(() => cubit.state).thenReturn(_ctx());
+      when(() => service.publish(
+            renderedFilePath: any(named: 'renderedFilePath'),
+            replyContext: any(named: 'replyContext'),
+            content: any(named: 'content'),
+          )).thenAnswer((_) async => /* a Comment fixture */);
+      final publisher = VideoReplyPublisher(
+        cubit: cubit,
+        service: service,
+        getRenderedClipPath: () async => '/tmp/clip.mp4',
+      );
+      expect(await publisher.handleEditorDone(), isTrue);
+      verify(() => cubit.clear()).called(1);
+    });
+
+    test(
+      'on publish failure, cubit is STILL cleared and the error rethrown '
+      '(debt rule #1)',
+      () async {
+        when(() => cubit.state).thenReturn(_ctx());
+        when(() => service.publish(
+              renderedFilePath: any(named: 'renderedFilePath'),
+              replyContext: any(named: 'replyContext'),
+              content: any(named: 'content'),
+            )).thenThrow(Exception('blossom down'));
+        final publisher = VideoReplyPublisher(
+          cubit: cubit,
+          service: service,
+          getRenderedClipPath: () async => '/tmp/clip.mp4',
+        );
+        await expectLater(publisher.handleEditorDone(), throwsException);
+        verify(() => cubit.clear()).called(1);
+      },
+    );
+
+    test('returns false if rendered clip path is null', () async {
+      when(() => cubit.state).thenReturn(_ctx());
+      final publisher = VideoReplyPublisher(
+        cubit: cubit,
+        service: service,
+        getRenderedClipPath: () async => null,
+      );
+      expect(await publisher.handleEditorDone(), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run tests — should FAIL.**
+
+- [ ] **Step 3: Implement**
+
+```dart
+import 'package:divine_mobile/blocs/video_reply/video_reply_cubit.dart';
+import 'package:divine_mobile/services/video_comment_publish_service.dart';
+
+typedef GetRenderedClipPath = Future<String?> Function();
+
+class VideoReplyPublisher {
+  VideoReplyPublisher({
+    required VideoReplyCubit cubit,
+    required VideoCommentPublishService service,
+    required GetRenderedClipPath getRenderedClipPath,
+  })  : _cubit = cubit,
+        _service = service,
+        _getRenderedClipPath = getRenderedClipPath;
+
+  final VideoReplyCubit _cubit;
+  final VideoCommentPublishService _service;
+  final GetRenderedClipPath _getRenderedClipPath;
+
+  /// Returns `true` iff the publisher consumed the rendered clip
+  /// (caller should NOT proceed to the metadata screen).
+  Future<bool> handleEditorDone() async {
+    final replyContext = _cubit.state;
+    if (replyContext == null) return false;
+
+    final clipPath = await _getRenderedClipPath();
+    if (clipPath == null) return false;
+
+    try {
+      await _service.publish(
+        renderedFilePath: clipPath,
+        replyContext: replyContext,
+        content: '', // Phase 1: no caption on replies.
+      );
+    } finally {
+      _cubit.clear();
+    }
+    return true;
+  }
+}
+```
+
+The `getRenderedClipPath` callback is the only seam to the legacy Riverpod editor. The widget that constructs `VideoReplyPublisher` (or wires it via `RepositoryProvider`) supplies a callback that does `ref.read(videoEditorProvider).finalRenderedClipPath`. Confirm that exact accessor against current main in Task 0.2.
+
+- [ ] **Step 4: Run tests — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/video_reply_publisher.dart mobile/test/services/video_reply_publisher_test.dart
+git commit -m "feat(services): add VideoReplyPublisher seam (BLoC-aware, no Ref)"
+```
+
+### Task 4.3: Provide service + publisher via `RepositoryProvider`
+
+**Files:**
+- Modify: app-root provider widget (same one as Task 2.3)
+
+`VideoCommentPublishService` needs `BlossomUploadService` and `CommentsRepository` from existing repository providers. `VideoReplyPublisher` needs the cubit (already provided via `BlocProvider`), the service, and the rendered-clip callback. Because the callback must close over `Ref` for the legacy editor, the publisher is constructed inside the editor screen (a `ConsumerStatefulWidget`) rather than at the app root — see Chunk 6.
+
+- [ ] **Step 1: Add `RepositoryProvider<VideoCommentPublishService>` at root**
+
+```dart
+RepositoryProvider<VideoCommentPublishService>(
+  create: (context) => VideoCommentPublishService(
+    blossom: context.read<BlossomUploadService>(),
+    commentsRepository: context.read<CommentsRepository>(),
+  ),
+),
+```
+
+- [ ] **Step 2: Smoke-test that the app still launches.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(app): provide VideoCommentPublishService at root"
+```
+
+---
+
+## Chunk 5: Comment Display — Render Video Comments Inline
+
+This chunk is independent of the publish path; it ships even with the flag off (no-op when no video comments exist on a given video). It lands the missing display side so that, once Chunk 7 ships and a user posts a video reply, it actually appears in the very sheet they posted from.
+
+> **Reuse existing primitives.** Do not invent a new video-player engine. Verify which inline player the rest of the app uses (`mobile/lib/widgets/video_player_subtitle_layer.dart` and `mobile/lib/widgets/web_video_player.dart` both exist; the feed item likely uses a higher-level wrapper). The implementer should pick the smallest existing primitive that supports tap-to-play with a thumbnail+blurhash placeholder, and only fall back to `package:video_player` directly if the existing wrappers don't fit. If unsure, **stop and ask** rather than reinvent.
+
+### Task 5.1: `CommentVideoPlayer` widget
+
+**Files:**
+- Create: `mobile/lib/screens/comments/widgets/comment_video_player.dart`
+- Test: `mobile/test/screens/comments/widgets/comment_video_player_test.dart`
+
+- [ ] **Step 1: Write failing widget tests**
+
+```dart
+testWidgets(
+  'shows thumbnail + play overlay before tap',
+  (tester) async {
+    await tester.pumpWidget(_wrap(const CommentVideoPlayer(
+      videoUrl: 'https://blossom.example/abc.mp4',
+      thumbnailUrl: 'https://blossom.example/abc.jpg',
+      aspectRatio: 9 / 16,
+    )));
+    expect(find.byKey(const Key('comment-video-thumbnail')), findsOneWidget);
+    expect(find.byKey(const Key('comment-video-play-overlay')), findsOneWidget);
+    expect(find.byKey(const Key('comment-video-player-surface')), findsNothing);
+  },
+);
+
+testWidgets(
+  'tapping the thumbnail switches to the player surface',
+  (tester) async {
+    await tester.pumpWidget(_wrap(const CommentVideoPlayer(
+      videoUrl: 'https://blossom.example/abc.mp4',
+      thumbnailUrl: 'https://blossom.example/abc.jpg',
+      aspectRatio: 9 / 16,
+    )));
+    await tester.tap(find.byKey(const Key('comment-video-thumbnail')));
+    await tester.pump();
+    expect(find.byKey(const Key('comment-video-player-surface')), findsOneWidget);
+  },
+);
+
+testWidgets(
+  'respects the supplied aspectRatio (no fixed height)',
+  (tester) async {
+    await tester.pumpWidget(_wrap(const SizedBox(
+      width: 200,
+      child: CommentVideoPlayer(
+        videoUrl: 'https://blossom.example/abc.mp4',
+        thumbnailUrl: 'https://blossom.example/abc.jpg',
+        aspectRatio: 16 / 9,
+      ),
+    )));
+    final box = tester.getSize(find.byKey(const Key('comment-video-thumbnail')));
+    expect(box.width / box.height, closeTo(16 / 9, 0.01));
+  },
+);
+```
+
+`_wrap` should provide a MaterialApp with VineTheme so the player renders against the dark theme used by the comments sheet.
+
+- [ ] **Step 2: Run — should FAIL.**
+
+- [ ] **Step 3: Implement the widget**
+
+Outline:
+
+```dart
+class CommentVideoPlayer extends StatefulWidget {
+  const CommentVideoPlayer({
+    super.key,
+    required this.videoUrl,
+    required this.thumbnailUrl,
+    required this.aspectRatio,
+    this.blurhash,
+  });
+
+  final String videoUrl;
+  final String? thumbnailUrl;
+  final double aspectRatio;
+  final String? blurhash;
+
+  @override
+  State<CommentVideoPlayer> createState() => _CommentVideoPlayerState();
+}
+```
+
+- Initial state: thumbnail (use `VineCachedImage` per CLAUDE.md UI rules) with a centered play icon (`DivineIcon`).
+- On tap: switch to a video surface (the existing app primitive — verify which one) and start playback.
+- Use `AspectRatio(aspectRatio: ...)` rather than fixed `SizedBox(height:)` so it survives system text scaling per `accessibility.md`.
+- Include `Semantics(label: 'Video reply, tap to play', button: true, ...)` on the tap target per `accessibility.md`.
+- Dispose any controller in `dispose()` per `performance.md`.
+
+If no existing wrapper fits cleanly, stop and ask before pulling `package:video_player` in directly.
+
+- [ ] **Step 4: Run — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/screens/comments/widgets/comment_video_player.dart mobile/test/screens/comments/widgets/comment_video_player_test.dart
+git commit -m "feat(comments): add inline CommentVideoPlayer for video comments"
+```
+
+### Task 5.2: Render `CommentVideoPlayer` from `CommentItem` when `hasVideo`
+
+**Files:**
+- Modify: `mobile/lib/screens/comments/widgets/comment_item.dart`
+- Test: `mobile/test/screens/comments/widgets/comment_item_video_render_test.dart`
+
+- [ ] **Step 1: Write failing widget tests**
+
+```dart
+testWidgets(
+  'text-only comment renders no CommentVideoPlayer (regression)',
+  (tester) async {
+    final comment = _textComment(content: 'just text');
+    await tester.pumpWidget(_wrap(CommentItem(comment: comment, /* required deps */)));
+    expect(find.byType(CommentVideoPlayer), findsNothing);
+    expect(find.text('just text'), findsOneWidget);
+  },
+);
+
+testWidgets(
+  'video comment renders CommentVideoPlayer above the text content',
+  (tester) async {
+    final comment = _videoComment(
+      videoUrl: 'https://blossom.example/abc.mp4',
+      thumbnailUrl: 'https://blossom.example/abc.jpg',
+      content: 'caption',
+    );
+    await tester.pumpWidget(_wrap(CommentItem(comment: comment, /* required deps */)));
+    expect(find.byType(CommentVideoPlayer), findsOneWidget);
+    expect(find.text('caption'), findsOneWidget);
+  },
+);
+
+testWidgets(
+  'video comment with empty content still renders the player',
+  (tester) async {
+    final comment = _videoComment(
+      videoUrl: 'https://blossom.example/abc.mp4',
+      thumbnailUrl: 'https://blossom.example/abc.jpg',
+      content: '',
+    );
+    await tester.pumpWidget(_wrap(CommentItem(comment: comment, /* required deps */)));
+    expect(find.byType(CommentVideoPlayer), findsOneWidget);
+  },
+);
+```
+
+`_textComment` / `_videoComment` are local fixture helpers built with the existing `Comment` constructor.
+
+- [ ] **Step 2: Run — should FAIL.**
+
+- [ ] **Step 3: Add the render branch**
+
+Inside `_CommentItemState.build` (or wherever the comment body is laid out), insert above the existing text widget:
+
+```dart
+if (widget.comment.hasVideo)
+  CommentVideoPlayer(
+    videoUrl: widget.comment.videoUrl!,
+    thumbnailUrl: widget.comment.thumbnailUrl,
+    aspectRatio: _aspectRatioFor(widget.comment), // helper, e.g. 9/16 default
+    blurhash: widget.comment.videoBlurhash,
+  ),
+```
+
+The aspect ratio helper should prefer `comment.videoDimensions` when available, default to `9 / 16` when not (vertical video is the dominant orientation in this app). Confirm field names against the current `Comment` model before writing.
+
+- [ ] **Step 4: Run — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/screens/comments/widgets/comment_item.dart mobile/test/screens/comments/widgets/comment_item_video_render_test.dart
+git commit -m "feat(comments): render video comments inline in CommentItem"
+```
+
+---
+
+## Chunk 6: Comment-Side Entry Point
+
+### Task 6.1: Add `onVideoReply` to `CommentInput`
+
+**Files:**
+- Modify: `mobile/lib/screens/comments/widgets/comment_input.dart`
+- Test: `mobile/test/screens/comments/widgets/comment_input_video_reply_test.dart`
+
+- [ ] **Step 1: Write failing widget test**
+
+```dart
+testWidgets(
+  'video reply icon is hidden when onVideoReply is null',
+  (tester) async {
+    await tester.pumpWidget(_wrap(const CommentInput()));
+    expect(find.byKey(const Key('comment-input-video-reply')), findsNothing);
+  },
+);
+
+testWidgets(
+  'video reply icon is shown and tappable when onVideoReply is non-null',
+  (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      _wrap(CommentInput(onVideoReply: () => tapped = true)),
+    );
+    await tester.tap(find.byKey(const Key('comment-input-video-reply')));
+    expect(tapped, isTrue);
+  },
+);
+```
+
+- [ ] **Step 2: Run — should FAIL.**
+
+- [ ] **Step 3: Add the optional callback + icon**
+
+```dart
+class CommentInput extends StatelessWidget {
+  const CommentInput({super.key, this.onVideoReply});
+  final VoidCallback? onVideoReply;
+  // ... in build, render the icon next to send only when non-null
+}
+```
+
+Use `DivineIcon` and `VineTheme` per CLAUDE.md UI rules. Provide a `tooltip: 'Record a video reply'` for accessibility.
+
+- [ ] **Step 4: Run — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/screens/comments/widgets/comment_input.dart mobile/test/screens/comments/widgets/comment_input_video_reply_test.dart
+git commit -m "feat(comments): optional onVideoReply callback on CommentInput"
+```
+
+### Task 6.2: Wire the entry point in `CommentsScreen`
+
+**Files:**
+- Modify: `mobile/lib/screens/comments/comments_screen.dart`
+- Test: `mobile/test/screens/comments/comments_screen_video_reply_entry_test.dart`
+
+- [ ] **Step 1: Write failing widget tests**
+
+```dart
+testWidgets(
+  'when videoReplies flag is OFF, no video reply icon is rendered',
+  (tester) async { /* override flag service to return false */ },
+);
+
+testWidgets(
+  'when flag is ON, tapping the icon sets reply context, '
+  'closes the sheet, and pushes the recorder route',
+  (tester) async {
+    /* override flag service to true; pump screen */
+    /* tap icon; assert provider state; assert router.push called */
+  },
+);
+```
+
+- [ ] **Step 2: Run — should FAIL.**
+
+- [ ] **Step 3: Wire the callback**
+
+In `CommentsScreen`:
+
+1. Read the flag via the existing `featureFlagProvider` / `FeatureFlagService` pattern (match what other screens do).
+2. If `isEnabled(FeatureFlag.videoReplies)`, pass `onVideoReply: () { ... }` to `CommentInput`.
+3. The handler:
+   - Calls `context.read<VideoReplyCubit>().start(VideoReplyContext(...))` with the parent video's full Nostr id (no truncation), kind, pubkey, addressable id (`30000+:pubkey:dtag`).
+   - Closes the sheet (`Navigator.of(context).pop()`).
+   - In the sheet's `whenComplete` (in whatever caller opens the sheet), if `context.read<VideoReplyCubit>().state` is non-null, `router.push(VideoRecorderScreen.path)`.
+
+If the comments screen no longer uses a modal pattern (verified in Task 0.2), wire the recorder navigation directly from the callback instead of via `whenComplete`.
+
+- [ ] **Step 4: Run — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/screens/comments mobile/test/screens/comments
+git commit -m "feat(comments): wire video reply entry behind videoReplies flag"
+```
+
+---
+
+## Chunk 7: Editor Confirm — Single Decision Point
+
+### Task 7.1: Branch on reply context at editor "Done"
+
+**Files:**
+- Modify: `mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart` (verified in pre-flight; the `await context.push(VideoMetadataScreen.path)` is at line 721 on `origin/main` at `c5ed3eadd`)
+- Test: `mobile/test/widgets/video_editor/main_editor/video_editor_canvas_reply_branch_test.dart`
+
+This is the ONLY file in the editor that learns about replies. Per debt rule #2, do not put any reply logic in `video_editor_provider.dart`.
+
+- [ ] **Step 1: Write failing widget tests**
+
+```dart
+testWidgets(
+  'normal flow: with no reply context, "Done" pushes the metadata screen',
+  (tester) async { /* ... */ },
+);
+
+testWidgets(
+  'reply flow: with reply context, "Done" calls publisher and '
+  'does NOT push the metadata screen',
+  (tester) async {
+    /* Provide a stubbed VideoReplyPublisher whose handleEditorDone
+       returns Future.value(true). Verify the metadata screen never
+       appears in the navigator stack. */
+  },
+);
+
+testWidgets(
+  'reply flow regression: after publisher succeeds, '
+  'VideoReplyCubit state is null',
+  (tester) async { /* ... */ },
+);
+```
+
+- [ ] **Step 2: Run — should FAIL.**
+
+- [ ] **Step 3: Modify `_handleDone` (or equivalent)**
+
+The editor screen is a `ConsumerStatefulWidget` (legacy Riverpod). It constructs the publisher locally so the rendered-clip callback can read `Ref` without leaking it into the publisher class:
+
+```dart
+Future<void> _handleDone() async {
+  final publisher = VideoReplyPublisher(
+    cubit: context.read<VideoReplyCubit>(),
+    service: context.read<VideoCommentPublishService>(),
+    getRenderedClipPath: () async =>
+        ref.read(videoEditorProvider).finalRenderedClipPath,
+  );
+  final consumed = await publisher.handleEditorDone();
+  if (consumed) {
+    if (!mounted) return;
+    context.go(HomeRoute.path); // or whichever post-publish destination
+    return;
+  }
+  // existing path
+  context.push(VideoMetadataScreen.path);
+}
+```
+
+This is the only place `Ref` and `BlocProvider` mix — and it is intentional: it is the documented seam between the legacy editor and the new BLoC-based reply state.
+
+- [ ] **Step 4: Run — should PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/screens/video_editor mobile/test/screens/video_editor
+git commit -m "feat(video-editor): dispatch reply path at confirm; metadata otherwise"
+```
+
+---
+
+## Chunk 8: Lifecycle Hardening
+
+Debt rule #1 has the highest regression risk. Each exit path needs an explicit clear and a test.
+
+### Task 8.1: Clear reply context on recorder cancel/dispose
+
+**Files:**
+- Modify: `mobile/lib/screens/video_recorder_screen.dart` (the *screen widget*, NOT the Riverpod notifier)
+- Test: `mobile/test/screens/video_recorder/video_recorder_screen_reply_clear_test.dart`
+
+The legacy Riverpod recorder *notifier* is not modified — clearing happens at the screen widget layer where both `Ref` and `BlocProvider` are reachable. This avoids polluting Riverpod-only code with BLoC dependencies.
+
+- [ ] **Step 1: Failing widget test** — pump `VideoRecorderScreen` wrapped with a `BlocProvider<VideoReplyCubit>` whose state is set to a non-null context, simulate cancel/back, then assert `cubit.state == null`.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: In the screen's `dispose()` and the cancel button handler, call:**
+
+```dart
+context.read<VideoReplyCubit>().clear();
+```
+
+In `dispose()` use `context.read` carefully — if the screen is being torn down because the `BlocProvider` itself was popped, the cubit may already be unavailable. Guard with a try/catch or store a captured reference in `didChangeDependencies()`:
+
+```dart
+late VideoReplyCubit _replyCubit;
+@override
+void didChangeDependencies() {
+  super.didChangeDependencies();
+  _replyCubit = context.read<VideoReplyCubit>();
+}
+@override
+void dispose() {
+  _replyCubit.clear();
+  super.dispose();
+}
+```
+
+- [ ] **Step 4: Run — PASS.**
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(recorder): clear VideoReplyCubit on screen dispose/cancel"
+```
+
+### Task 8.2: Clear reply context on editor cancel
+
+**Files:**
+- Modify: editor screen cancel handler (verify location — same `ConsumerStatefulWidget` as Chunk 6)
+- Test: matching widget test
+
+- [ ] Same five-step TDD cycle, using the captured-`VideoReplyCubit` pattern from 7.1.
+- [ ] **Commit:**
+
+```bash
+git commit -m "fix(video-editor): clear VideoReplyCubit on cancel"
+```
+
+### Task 8.3: Integration test for the regression scenario
+
+**Files:**
+- Test: `mobile/integration_test/video_reply_lifecycle_test.dart` (or a widget test if integration_test setup is heavy for this)
+
+- [ ] **Step 1:** Write a test that drives: open comments → tap video reply (flag forced on) → enter recorder → press cancel → open the standard recorder via the home tab → assert `VideoReplyCubit.state` is null AND assert that completing the flow publishes a Kind 34236 event, NOT a Kind 1111 with imeta.
+- [ ] **Step 2:** Run — should FAIL until 7.1/7.2 are merged. (Sanity check: temporarily comment out the clear in 7.1; the test should fail. Restore.)
+- [ ] **Step 3:** Run with clears in place — PASS.
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "test(video-comments): regression test for reply→cancel→normal post"
+```
+
+---
+
+## Chunk 9: Final Polish & PR
+
+### Task 9.1: Run the full local CI suite
+
+- [ ] `cd mobile && flutter analyze lib test integration_test`
+- [ ] `cd mobile && dart format --output=none --set-exit-if-changed lib test integration_test`
+- [ ] `cd mobile && flutter test`
+- [ ] `cd mobile/packages/comments_repository && dart test`
+- [ ] If any codegen inputs were touched: `cd mobile && dart run build_runner build --delete-conflicting-outputs` and commit any generated changes.
+
+### Task 9.2: PR with explicit flag exit criterion
+
+Per debt rule #4, the PR description must state when the flag will be removed.
+
+- [ ] Push the branch and open a PR with this body skeleton:
+
+```markdown
+## Summary
+Revives the half-shipped video-replies feature behind `FF_VIDEO_REPLIES` (default off). Reuses the existing recorder/editor; only the publish path diverges (Kind 1111 + NIP-92 imeta vs. Kind 34236).
+
+## Feature flag exit criterion
+Remove the `videoReplies` enum entry, env var, and dispatcher branch once the flag has been at 100% for two weeks with no regression in the comments funnel and no >0.5% lift in publish errors. Tracked in: <issue link>.
+
+## Test plan
+- [ ] With FF_VIDEO_REPLIES=false (default), the comments sheet shows no video-reply icon and the recorder/editor behave exactly as today.
+- [ ] With FF_VIDEO_REPLIES=true, tapping the icon opens the recorder, recording + editing → "Done" publishes a Kind 1111 comment with imeta tags via Blossom, and lands in the feed (no metadata screen).
+- [ ] Reply→cancel→normal-post path produces a Kind 34236 (regression).
+- [ ] Pre-commit and pre-push hooks pass.
+```
+
+- [ ] Open a tracking issue for the flag-removal exit criterion and link it in the PR.
+
+---
+
+## Plan complete
+
+**Saved to:** `docs/superpowers/plans/2026-05-04-video-comments-revival.md`
+
+Ready to execute?

--- a/docs/superpowers/specs/2026-04-20-funnelcake-notifications-api-changes.md
+++ b/docs/superpowers/specs/2026-04-20-funnelcake-notifications-api-changes.md
@@ -1,0 +1,145 @@
+# Funnelcake notifications API — changes required
+
+**Date:** 2026-04-20
+**Owner:** rabble (mobile), funnelcake backend team
+**Status:** Proposal — needs backend sign-off before mobile implementation
+**Related mobile work:** `docs/superpowers/specs/2026-04-20-notifications-redesign-design.md` *(to be written)*
+
+---
+
+## Background
+
+Mobile notifications have four user-visible bugs:
+
+1. Rows say "your video" instead of the actual video title.
+2. Tapping a comment/reply notification doesn't scroll to the specific comment.
+3. Rows misattribute context — "X replied to your video" when X replied to your comment, or on someone else's video.
+4. A week-old event can render as "2h ago."
+
+Before writing any backend, we audited the live OpenAPI spec at `https://relay.divine.video/openapi.json` against the mobile client's expectations. This report covers what funnelcake needs to add, what it already has (and mobile is not using correctly), and open questions.
+
+---
+
+## What the API already returns (for reference)
+
+`GET /api/users/{pubkey}/notifications` — response item shape per `openapi.json`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `source_pubkey` | string | Actor pubkey |
+| `source_event_id` | string | Nostr event id that triggered the notification |
+| `source_kind` | int | Nostr kind of that event |
+| `source_created_at` | int32 (unix s) | **Nostr event's `created_at`** |
+| `referenced_event_id` | string | Event being acted on (video, comment, etc.) |
+| `notification_type` | string | `reaction` \| `reply` \| `repost` \| `mention` \| `follow` \| `zap` |
+| `created_at` | int32 (unix s) | Notification row's ingest/insertion time |
+| `read` | int | `0` unread, `1` read |
+
+**Bug #4 (stale timestamps) is not a backend bug.** `source_created_at` is already returned. The mobile package DTO (`packages/funnelcake_api_client/.../relay_notification.dart`) fails to parse it, and the mapper falls back to `created_at` (the row's insertion time), which is arbitrarily later than the Nostr event. **Fix is mobile-only.** No action required from funnelcake for bug #4.
+
+---
+
+## Changes required for funnelcake
+
+Three additive fields on each notification object. All are optional so older clients continue to work. One optional clarification to `notification_type`'s enumerated values.
+
+### 1. `referenced_event_title` — string, nullable
+
+The title of the referenced event, when that event is a kind 34236 video. For other referenced event kinds (or when no title tag is present), return `null`.
+
+```json
+{
+  "referenced_event_id": "abc123…",
+  "referenced_event_title": "Best Post Ever"
+}
+```
+
+**Why:** Mobile renders "**{actor}** liked your video **{title}**" per the redesigned row. Without this, the client would need a second round-trip to fetch each referenced video and extract its `title` tag. Funnelcake already has the referenced event indexed and can project the title at query time.
+
+**Edge cases:** Referenced event is a comment (kind 1 / 1111) and not a video — `null`. Video has no `title` tag — `null`. Title is empty string — `null`.
+
+---
+
+### 2. `reply_context` — string enum, nullable
+
+Populated only on `notification_type: "reply"`. Classifies the e-tag chain so the client doesn't have to resolve it.
+
+| Value | Meaning |
+|---|---|
+| `"comment_on_your_video"` | Someone top-level commented on the recipient's video. (If the backend emits this, it should actually use `notification_type: "comment"` — see open question 1 below.) |
+| `"reply_to_your_comment_on_your_video"` | Someone replied to a comment the recipient made on their own video. |
+| `"reply_to_your_comment_on_others_video"` | Someone replied to a comment the recipient made on someone else's video. |
+| `null` | Not a reply, or context couldn't be determined. |
+
+**Why:** Bug #3. The current mobile code distinguishes reply vs comment purely by the server's `notification_type` string, with no way to know whose video the comment chain is on. The backend has the e-tag chain already — single authoritative computation server-side beats every client re-implementing it.
+
+---
+
+### 3. `target_comment_id` — string, nullable
+
+The hex event id of the specific comment the user should scroll to when opening the referenced video's comments sheet.
+
+- For `notification_type: "comment"` (top-level comment on your video), `target_comment_id` == `source_event_id`.
+- For `notification_type: "reply"`, `target_comment_id` == `source_event_id` (the new reply).
+- For other types, `null`.
+
+**Why:** Bug #2. The mobile app navigates to the video and opens the comments sheet, but has no comment id to scroll to — users land at the top of the thread and have to hunt for the comment that triggered the notification.
+
+We could derive this client-side from `source_event_id` when `source_kind` is a comment kind, but funnelcake already knows the answer cleanly and returning it avoids client-side kind-guessing.
+
+---
+
+### 4. Document and emit `notification_type: "comment"`
+
+The mobile client today treats `"comment"` as a distinct type from `"reply"` — top-level comments on your video vs replies in a thread — and the mobile code also accepts `"contact"` as an alias for `"follow"`. The OpenAPI `notification_type` description lists only `reaction | reply | repost | mention | follow | zap`.
+
+Please confirm which enum values funnelcake actually emits today, and:
+
+- If the backend already emits `"comment"` and/or `"contact"`, update the OpenAPI description to list them.
+- If it does not, decide whether to add `"comment"` (so top-level video comments are distinguishable from threaded replies without mobile inspecting e-tags) — mobile needs this split to render the copy correctly.
+
+---
+
+## Summary of required backend work
+
+| Item | Type | Effort estimate (backend) |
+|---|---|---|
+| Add `referenced_event_title` to notification response | Additive | Low — one join/lookup on referenced event, project `title` tag |
+| Add `reply_context` enum to notification response | Additive | Medium — walk e-tag chain to classify, 3 enum values |
+| Add `target_comment_id` to notification response | Additive | Low — copy of `source_event_id` for comment/reply types |
+| Confirm + document emitted `notification_type` values; consider adding `"comment"` | Clarification or additive | Low–medium depending on outcome |
+
+All four are additive — no breaking changes to current clients. Mobile will parse the new fields when present and fall back to existing behavior when absent, so the two sides can ship independently.
+
+---
+
+## Out of scope
+
+The Figma redesign also shows three notification categories funnelcake doesn't emit today. Each is its own product feature and is **not** part of this report. File separately:
+
+- **Moderation: "Your post has been flagged"** — needs a new notification emission path from the moderation pipeline.
+- **Hashtag alerts: "It's time for #highnoon"** — needs a hashtag-subscription system (new product surface, not just a notification type).
+- **List follows: "X followed your list **Best List Ever**"** — needs kind 30000 list-follow events indexed into the notifications stream, with `referenced_event_title` returning the list's `d`-tag label.
+
+Once the three core fields above ship, adding any of these later is purely additive to the same schema.
+
+---
+
+## Open questions for funnelcake team
+
+1. **`notification_type: "comment"`** — does it exist today, or should we add it? (See §4.)
+2. **`referenced_event_id` semantics on reply notifications** — when someone replies to a comment, is `referenced_event_id` the parent comment or the root video? Mobile needs to navigate to the video and scroll to the reply; if `referenced_event_id` currently points at the parent comment, we'd also want a `root_event_id` or `target_video_id` field. Please confirm current behavior.
+3. **Rollout** — can these four fields land in one backend PR, or do they prefer separate deploys? Mobile is fine either way; the client reads them independently.
+4. **Availability SLA** — any constraint on how soon after a Nostr event arrives the title/context/target fields are populated? (We don't want a race where the notification is returned before the referenced event is indexed and the fields are all `null` forever.)
+
+---
+
+## Mobile-side followups (tracked separately; not funnelcake's problem)
+
+Documented here only so the shape of the full fix is clear to reviewers:
+
+- Delete the duplicate `RelayNotification` DTO in `mobile/lib/services/relay_notification_api_service.dart`; keep only `packages/funnelcake_api_client/.../relay_notification.dart` and extend it with the new fields.
+- Parse `source_created_at` in the package DTO and use it as the authoritative `NotificationItem.timestamp` — this fixes bug #4 today without waiting on backend.
+- Thread `target_comment_id` through `PooledFullscreenVideoFeedArgs` into the comments sheet and scroll/highlight.
+- Rebuild the notification row UI per the Figma (type badges, grouped avatars, comment preview snippet, "No activity yet" empty state).
+- All of the above landed TDD-first.

--- a/docs/superpowers/specs/2026-04-26-open-pr-bug-and-l10n-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-26-open-pr-bug-and-l10n-cleanup-design.md
@@ -1,0 +1,211 @@
+# Open-PR Bug and L10n Cleanup — Design
+
+Date: 2026-04-26
+Status: Approved (brainstorming complete)
+
+## Goal
+
+Move eight open PRs forward by addressing concrete, code-level defects and
+localization gaps without expanding scope into the open design / product /
+infra-blocked questions on those same PRs.
+
+This spec is the parent design for eight independent fixes. Each fix gets its
+own implementation plan and worktree.
+
+## Scope (in)
+
+Five behavior bugs:
+
+1. **#3301** — Zendesk attachment `uploadToken` is logged on Android and iOS.
+2. **#3433** — Same-comment upvote and downvote events run as separate droppable
+   handlers, allowing opposite votes to interleave.
+3. **#3430** — Like and repost publishes are fire-and-forget; rapid toggles can
+   settle out of order and restore stale state.
+4. **#3407** — `_isTrimmingLayer` in the video editor canvas is sourced from a
+   `previous` transition value, leaving it stuck `true` after trim end.
+5. **#3440** — iOS QA slot allocator can let a newer PR jump an older queued
+   PR; non-target PRs skip changed-file context.
+
+Three localization sweeps (existing PRs flagged with hardcoded user-facing
+strings):
+
+6. **#3375** — Awarded-invites notification / settings flow.
+7. **#3177** — Retry user-facing strings in publish primitives and repost
+   feedback.
+8. **#2878** — C2PA-verified video import UI.
+
+## Scope (out)
+
+- Resolving non-trivial merge conflicts (handed back to PR authors).
+- Design or product decisions (e.g. #3314 hashtag follow behavior, #2812 live
+  spaces foundations, #3244 list-add UI parity).
+- Drafts blocked on external work (Zendesk secure-download provisioning,
+  manual device QA, etc.).
+- Refactors beyond what each fix strictly requires.
+
+## Constraints
+
+- **No edits on `main`.** Each PR is fixed in its own git worktree off the
+  PR's branch.
+- **Intent first.** For every PR, the PR description, linked issue, and any
+  referenced spec are read before any code is changed. The fix must serve the
+  feature's intent, not redefine it.
+- **L10n is mandatory.** Any user-facing string introduced or modified passes
+  through `lib/l10n/app_en.arb`. Hardcoded strings encountered in adjacent
+  code on a fix are routed through l10n as part of the fix rather than
+  perpetuated. After ARB changes, l10n codegen runs and generated files are
+  committed.
+- **Regression tests.** Each bug fix ships with a test that would have caught
+  the bug. L10n sweeps update existing widget tests that reference moved
+  strings.
+- **No destructive git operations** without explicit user approval.
+
+## Per-PR intent + fix sketch
+
+### #3301 — stop logging Zendesk `uploadToken`
+- **Intent.** Local logging while debugging the upload flow. The token is a
+  short-lived Zendesk secure-download credential; nothing about the feature
+  requires it in logs.
+- **Fix.** Remove `uploadToken` from log statements in
+  `mobile/android/app/src/main/kotlin/.../MainActivity.kt:591` and
+  `mobile/ios/Runner/AppDelegate.swift:433`. Add a one-line comment noting
+  the value must not be logged. Grep for any other call sites.
+- **Verification.** `git grep` shows no `uploadToken` in log lines.
+- **L10n.** None (no UI strings).
+
+### #3433 — serialize cross-type comment vote events
+- **Intent.** Allow a user to toggle and switch between upvote and downvote
+  on a single comment without state desync.
+- **Fix.** Replace the two `droppable()` handlers at
+  `comments_bloc.dart:77` and `:78` with a single `CommentVoteRequested`
+  event carrying a `vote` enum, processed with `sequential()` transformer
+  keyed by `commentId` (or a single combined handler that serializes per
+  comment). The previous `voteInProgressCommentId` removal stays.
+- **Verification.** Bloc test: rapid up → down → up emits the final up state
+  with consistent counts.
+- **L10n.** None.
+
+### #3430 — version-token guard for like/repost optimistic settle
+- **Intent.** Make likes and reposts feel instant with optimistic counts,
+  reconciled when the relay confirms.
+- **Fix.** Track a per-(videoId, action) version token in
+  `VideoInteractionsState`. Each tap increments and captures the token.
+  Settle events carry their originating token; only apply the settle if the
+  token still matches the latest. Stale settles are dropped.
+- **Verification.** Bloc test: simulate two `Toggle` events whose publishes
+  resolve in reverse order; final state matches the latest tap.
+- **L10n.** None.
+
+### #3407 — drive `_isTrimmingLayer` from current state
+- **Intent.** Suppress player position updates while the user is dragging
+  trim handles so the preview doesn't fight the gesture.
+- **Fix.** In `video_editor_canvas.dart:779`, source `_isTrimmingLayer` from
+  the *current* `state.trimmingItemId` rather than the previous transition.
+  Ensure the trim-end transition deterministically resets it. Resolve new
+  merge conflicts before fix work.
+- **Verification.** Widget test if feasible; otherwise flag for device QA.
+- **L10n.** None.
+
+### #3440 — queue fairness in iOS QA slot allocator
+- **Intent.** Allocate iOS QA build slots fairly so PRs are tested in the
+  order they queued.
+- **Fix.** In `.github/workflows/mobile_ios_qa_allocate.yml:174-185`, run
+  the changed-file context check for all PRs in the queue, not only the
+  current target. In `scripts/ios_qa_slots.py:662-664`, preserve the queued
+  PR list across runs (not just occupied slots) so an older queued PR
+  cannot be jumped by a newer one.
+- **Verification.** Unit test for the allocator with mixed queued and
+  occupied state.
+- **L10n.** None.
+
+### #3375 — l10n sweep for `invites_screen.dart`
+- **Intent.** Surface awarded invites in notifications, settings, and the
+  invites screen.
+- **Fix.** Move hardcoded strings at lines 37, 85, 100, 187, 235, 256 (and
+  any others discovered) into `app_en.arb` with descriptive keys. Update any
+  widget tests that reference the literal strings. Run l10n codegen.
+- **Verification.** `flutter analyze` passes; widget tests pass; visual
+  parity confirmed via golden updates only if a golden references one of
+  the moved strings.
+- **L10n.** This is the work.
+
+### #3177 — l10n sweep for retry strings
+- **Intent.** Reliable Nostr publish primitives + NIP-09 deletion migration;
+  retry UX must be localized.
+- **Fix.** Identify retry-related hardcoded strings flagged in review.
+  Move into `app_en.arb` with keys. Wire callers through `AppLocalizations`.
+  Codegen + commit. Address adjacent review comments only when they are
+  trivial and string-related (not API or feature-shape changes).
+- **Verification.** `flutter analyze` + targeted tests pass.
+- **L10n.** This is the work.
+
+### #2878 — l10n sweep for C2PA import UI
+- **Intent.** C2PA-verified video import via the share sheet.
+- **Fix.** Move hardcoded import-flow user-facing strings into
+  `app_en.arb` with keys. Codegen + commit. Do not touch
+  `video_import_service.dart:102` `proofManifestJson` issue (separate
+  defect, out of l10n scope).
+- **Verification.** `flutter analyze` + targeted tests pass.
+- **L10n.** This is the work.
+
+## Order of work
+
+Security → correctness → UX → infra → l10n. Each is independent of the
+others; this is just the recommended sequence:
+
+1. #3301 (security; isolated; fast)
+2. #3433 (correctness; small surface)
+3. #3430 (correctness; more state plumbing)
+4. #3407 (UX; may need device verification)
+5. #3440 (infra; CI / Python)
+6. #3375 (l10n; smallest sweep)
+7. #3177 (l10n; cross-cutting)
+8. #2878 (l10n; import UI)
+
+## Per-PR loop
+
+For each PR:
+
+1. Read PR description, linked issue, original design doc.
+2. Read affected code paths end-to-end on the PR branch (not just the diff).
+3. Reproduce the defect (failing test or stepwise trace).
+4. Fix in a worktree off the PR branch.
+5. Add regression test (bug) or update widget tests (l10n sweep).
+6. Run `cd mobile && mise exec -- flutter analyze lib test`.
+7. Run targeted tests.
+8. If ARB touched: run l10n codegen and commit generated files.
+9. Push commits directly to the PR branch. Fallback: open a follow-up PR
+   targeting the original PR's branch if push to a fork is unavailable.
+10. Comment on the PR linking the fix commit and summarizing what changed
+    and why.
+
+## Risks
+
+- **#3407 reproducibility.** The trim flag bug may not be observable in
+  widget tests; if the fix can't be verified without a device, surface that
+  to the user before pushing.
+- **L10n string drift.** Sweeping strings may collide with concurrent
+  changes in the same files on `main` once those PRs rebase. Each sweep
+  stays inside the PR's branch; rebases stay with the PR author.
+- **PR branch push permissions.** If a PR is from a fork without
+  collaborator-edit access, the fallback path is a new PR targeting that
+  branch. The user is informed if this happens.
+
+## Verification (overall)
+
+Per-PR verification is described above. A final pass after all eight fixes:
+
+- All eight PR branches build (`flutter analyze`).
+- All eight PR branches' targeted tests pass.
+- No remaining `uploadToken` log statements in the repo (#3301 cross-check).
+- L10n ARB files validated by codegen on each affected PR branch.
+
+## Out of scope (explicit)
+
+- The other eight open PRs (#3445, #3445 review, #3314, #3244, #3242,
+  #2812, #2508, #2417, #1907) — each has open design or external blockers
+  that this spec does not attempt to resolve.
+- Refactors of state shape, l10n architecture, or BLoC patterns beyond
+  what each fix needs.
+- Adding new tests to existing passing code paths (focus stays on
+  regression coverage for the bugs being fixed).


### PR DESCRIPTION
Closes #3991

## Summary

Working-tree cleanup so local `main` stays clean. No code changes.

- **`.gitignore`** — hides per-developer scratch:
  - `.claude/scheduled_tasks.lock`
  - `.superpowers/` (local Superpowers scratch dir; `docs/superpowers/` plans/specs are still tracked)
  - `**/.playwright-mcp/` (Playwright MCP capture output)
  - `explore-layout-snapshot.md`, `explore-layout.png`, `search-route-{console,network,snapshot}.{txt,md}` (one-off debug captures)
  - `mobile/zapstore.yaml` (per-machine `zsp` config with local APK paths)
  - `mobile/test/goldens/screens/live/` (orphan golden tests; reference `package:openvine/screens/live/...` which doesn't exist in `mobile/lib/`)
- **`AGENTS.md`** — adds Zapstore Publishing Notes from the recent 1.0.9 publish handoff (don't wrap `zsp`, never paste `nsec`, verify version selection before signing).
- **`docs/superpowers/`** — adds 7 plans + 2 specs that landed during recent work but weren't committed.

## Test plan
- [ ] `git status` is clean on `main` after this merges
- [ ] No code paths affected; CI is docs/config only