### PR TITLE
feat(camera): default new users to back camera

### DIFF
--- a/mobile/lib/providers/video_recorder_provider.dart
+++ b/mobile/lib/providers/video_recorder_provider.dart
@@ -160,7 +160,7 @@ class VideoRecorderNotifier extends Notifier<VideoRecorderProviderState> {
     final savedLensString = prefs.getString(_kLastUsedCameraLensKey);
     final initialLens = savedLensString != null
         ? DivineCameraLens.fromNativeString(savedLensString)
-        : DivineCameraLens.front;
+        : DivineCameraLens.back;
 
     Log.info(
       '📹 Initializing video recorder with quality: ${videoQuality.value}, '

--- a/mobile/test/providers/video_recorder_provider_test.dart
+++ b/mobile/test/providers/video_recorder_provider_test.dart
@@ -721,7 +721,7 @@ void main() {
       expect(mockCamera.currentLens, equals(DivineCameraLens.back));
     });
 
-    test('initialize uses front camera when no saved preference', () async {
+    test('initialize uses back camera when no saved preference', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
 
@@ -742,8 +742,7 @@ void main() {
 
       await container.read(videoRecorderProvider.notifier).initialize();
 
-      // Verify mock camera was initialized with default front lens
-      expect(mockCamera.currentLens, equals(DivineCameraLens.front));
+      expect(mockCamera.currentLens, equals(DivineCameraLens.back));
     });
   });
 


### PR DESCRIPTION
## Summary

For first-time users (no saved lens preference), the recorder now opens with the **back** camera instead of the front-facing selfie lens. Users who have previously used the recorder still get their last-used lens restored.

## Changes

- `mobile/lib/providers/video_recorder_provider.dart`: flip the no-saved-preference fallback from `DivineCameraLens.front` to `DivineCameraLens.back`.
- `mobile/test/providers/video_recorder_provider_test.dart`: update the pinned default-lens test to assert `back` and rename it accordingly.

The lens persistence behaviour added in #1663 is unchanged — only the bootstrap default for a brand-new user changes.

## Test plan

- [x] `flutter analyze lib/providers/video_recorder_provider.dart test/providers/video_recorder_provider_test.dart` — clean
- [x] `flutter test test/providers/video_recorder_provider_test.dart` — 42/42 pass, including `Camera Lens Persistence > initialize uses back camera when no saved preference`
- [ ] Manual: fresh install (or clear `camera_last_used_lens` from SharedPreferences) → opening the recorder shows the rear camera preview
- [ ] Manual: switch to front, close and reopen the recorder → front camera is restored (regression check on the persistence path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)