### PR TITLE
feat(video-recorder): keep screen awake during active recording

### DIFF
--- a/mobile/lib/providers/video_recorder_provider.dart
+++ b/mobile/lib/providers/video_recorder_provider.dart
@@ -30,6 +30,7 @@ import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 /// SharedPreferences key for storing the last used camera lens.
 const _kLastUsedCameraLensKey = 'camera_last_used_lens';
@@ -239,6 +240,7 @@ class VideoRecorderNotifier extends Notifier<VideoRecorderProviderState> {
     await _countdownSoundService?.dispose();
     _countdownSoundService = null;
     await _disableRemoteRecordControl();
+    await WakelockPlus.disable();
     await _cameraService.dispose();
   }
 
@@ -691,6 +693,7 @@ class VideoRecorderNotifier extends Notifier<VideoRecorderProviderState> {
         name: 'VideoRecorderNotifier',
         category: .video,
       );
+      await WakelockPlus.enable();
       clipProvider.startRecording();
     } else {
       Log.warning(
@@ -743,6 +746,7 @@ class VideoRecorderNotifier extends Notifier<VideoRecorderProviderState> {
 
     final videoResult = result ?? await _cameraService.stopRecording();
 
+    await WakelockPlus.disable();
     final clipProvider = ref.read(clipManagerProvider.notifier)
       ..stopRecording();
     final remainingDuration = clipProvider.remainingDuration;

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   desktop_webview_window:
     dependency: transitive
     description:
@@ -2562,21 +2562,21 @@ packages:
     source: hosted
     version: "3.4.4"
   wakelock_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
+      sha256: ddf3db70eaa10c37558ff817519b85d527dbd21034fd5d8e1c2e85f31588f1c1
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.2"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
+      sha256: "14b2e5b9e35c2631e656913c47adecdd71633ae92896a27a64c8f1fcfabc21cc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   watcher:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -126,6 +126,7 @@ dependencies:
   dm_repository:
   video_player: ^2.9.1 # Uses native AVPlayer (iOS/macOS) and ExoPlayer (Android)
   visibility_detector: ^0.4.0+2 # Detect widget visibility for proper video control
+  wakelock_plus: ^1.5.2 # Prevent screen timeout during active video recording
   image: ^4.1.7 # Image processing for GIF generation
   image_picker: ^1.2.0 # For selecting images from gallery or camera
   image_metadata_stripper:

--- a/mobile/test/providers/video_recorder_provider_test.dart
+++ b/mobile/test/providers/video_recorder_provider_test.dart
@@ -26,10 +26,41 @@ import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
 
 import '../mocks/mock_camera_service.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+/// Fake [WakelockPlusPlatformInterface] that records all [toggle] calls.
+class _FakeWakelockPlatform extends WakelockPlusPlatformInterface {
+  final List<bool> toggleCalls = [];
+
+  @override
+  Future<void> toggle({required bool enable}) async {
+    toggleCalls.add(enable);
+  }
+
+  @override
+  Future<bool> get enabled async =>
+      toggleCalls.isNotEmpty && toggleCalls.last;
+}
+
+/// [MockCameraService] variant whose [startRecording] always returns false.
+class _FailingStartCameraService extends MockCameraService {
+  _FailingStartCameraService.create({
+    required super.onUpdateState,
+    required super.onAutoStopped,
+  }) : super.create();
+
+  @override
+  Future<bool> startRecording({
+    Duration? maxDuration,
+    String? outputDirectory,
+  }) async =>
+      false;
+}
 
 /// Helper to set up haptic feedback mock and track calls.
 class HapticFeedbackTracker {
@@ -162,6 +193,15 @@ class NotifierTestSetup {
 }
 
 void main() {
+  // Production code calls WakelockPlus.enable/disable around every recording
+  // session. Install a no-op platform fake for the entire suite so tests that
+  // exercise startRecording / stopRecording don't hit a missing platform
+  // channel. The dedicated 'Wake Lock' group swaps in its own recording fake
+  // on top of this and restores it in tearDown.
+  setUpAll(() {
+    wakelockPlusPlatformInstance = _FakeWakelockPlatform();
+  });
+
   group('VideoRecorderUIState AspectRatio', () {
     test('includes aspectRatio in state', () {
       const state = VideoRecorderProviderState();
@@ -1059,6 +1099,80 @@ void main() {
             const MethodChannel('divine_video_player'),
             null,
           );
+    });
+  });
+
+  group('VideoRecorderNotifier - Wake Lock', () {
+    late _FakeWakelockPlatform fakeWakelock;
+    late WakelockPlusPlatformInterface originalInstance;
+
+    final setup = NotifierTestSetup();
+
+    setUp(() async {
+      originalInstance = wakelockPlusPlatformInstance;
+      fakeWakelock = _FakeWakelockPlatform();
+      wakelockPlusPlatformInstance = fakeWakelock;
+      await setup.setUp();
+    });
+
+    tearDown(() {
+      setup.tearDown();
+      wakelockPlusPlatformInstance = originalInstance;
+    });
+
+    test('enables wake lock when recording starts successfully', () async {
+      await setup.container
+          .read(videoRecorderProvider.notifier)
+          .startRecording();
+
+      expect(fakeWakelock.toggleCalls, equals([true]));
+    });
+
+    test('disables wake lock when recording stops', () async {
+      final notifier =
+          setup.container.read(videoRecorderProvider.notifier);
+      await notifier.startRecording();
+      fakeWakelock.toggleCalls.clear();
+
+      await notifier.stopRecording();
+
+      expect(fakeWakelock.toggleCalls, equals([false]));
+    });
+
+    test('does not enable wake lock when recording fails to start', () async {
+      final failingCamera = _FailingStartCameraService.create(
+        onUpdateState: ({forceCameraRebuild}) {},
+        onAutoStopped: (_) {},
+      );
+      await failingCamera.initialize();
+
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          videoRecorderProvider.overrideWith(
+            () => VideoRecorderNotifier(failingCamera),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(videoRecorderProvider.notifier).initialize();
+
+      await container.read(videoRecorderProvider.notifier).startRecording();
+
+      expect(fakeWakelock.toggleCalls, isEmpty);
+    });
+
+    test('disables wake lock on destroy', () async {
+      final notifier =
+          setup.container.read(videoRecorderProvider.notifier);
+      await notifier.startRecording();
+      fakeWakelock.toggleCalls.clear();
+
+      await notifier.destroy();
+
+      expect(fakeWakelock.toggleCalls, contains(false));
     });
   });
 

--- a/mobile/test/providers/video_recorder_provider_test.dart
+++ b/mobile/test/providers/video_recorder_provider_test.dart
@@ -43,8 +43,7 @@ class _FakeWakelockPlatform extends WakelockPlusPlatformInterface {
   }
 
   @override
-  Future<bool> get enabled async =>
-      toggleCalls.isNotEmpty && toggleCalls.last;
+  Future<bool> get enabled async => toggleCalls.isNotEmpty && toggleCalls.last;
 }
 
 /// [MockCameraService] variant whose [startRecording] always returns false.
@@ -58,8 +57,7 @@ class _FailingStartCameraService extends MockCameraService {
   Future<bool> startRecording({
     Duration? maxDuration,
     String? outputDirectory,
-  }) async =>
-      false;
+  }) async => false;
 }
 
 /// Helper to set up haptic feedback mock and track calls.
@@ -1129,8 +1127,7 @@ void main() {
     });
 
     test('disables wake lock when recording stops', () async {
-      final notifier =
-          setup.container.read(videoRecorderProvider.notifier);
+      final notifier = setup.container.read(videoRecorderProvider.notifier);
       await notifier.startRecording();
       fakeWakelock.toggleCalls.clear();
 
@@ -1165,8 +1162,7 @@ void main() {
     });
 
     test('disables wake lock on destroy', () async {
-      final notifier =
-          setup.container.read(videoRecorderProvider.notifier);
+      final notifier = setup.container.read(videoRecorderProvider.notifier);
       await notifier.startRecording();
       fakeWakelock.toggleCalls.clear();
 


### PR DESCRIPTION

## Description

Adds `wakelock_plus` to prevent the screen from timing out while the user is recording a video.

**Changes:**
- Enable wakelock when `startRecording` succeeds; disable on `stopRecording` and `destroy`
- Tests covering enable on success, disable on stop/destroy, and no-op on failed start
- Global no-op wakelock platform fake in the test suite so existing tests don't hit an unmocked platform channel

Note: I tested this on real devices on both Android and iOS, and it worked perfectly fine. The screen never turned off while recording.


**Related Issue:** Closes #3971


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore