### PR TITLE
chore(release): bump iOS version to 1.0.11

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.10+499
+version: 1.0.11+500
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- bump mobile app version from 1.0.10+499 to 1.0.11+500
- unblocks App Store Connect/TestFlight uploads now that the 1.0.10 train is closed

## Verification
- confirmed diff only updates mobile/pubspec.yaml version
- pre-push checks ran; no Dart files changed, Dart checks skipped