### PR TITLE
fix(feed): pull-to-refresh freshness for New tab + popularNow ordering

### DIFF
--- a/mobile/lib/providers/new_videos_feed_provider.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.dart
@@ -52,11 +52,14 @@ class NewVideosFeed extends _$NewVideosFeed {
     return _loadFirstPage();
   }
 
-  Future<VideoFeedState> _loadFirstPage() async {
+  Future<VideoFeedState> _loadFirstPage({
+    bool bypassRepositoryCache = false,
+  }) async {
     try {
       final videosRepository = ref.read(videosRepositoryProvider);
       final videos = await videosRepository.getNewVideos(
         limit: AppConstants.paginationBatchSize,
+        skipCache: bypassRepositoryCache,
       );
 
       if (!ref.mounted) {
@@ -193,7 +196,7 @@ class NewVideosFeed extends _$NewVideosFeed {
       getCurrentState: () => state,
       isMounted: () => ref.mounted,
       setState: (s) => state = s,
-      fetchFresh: _loadFirstPage,
+      fetchFresh: () => _loadFirstPage(bypassRepositoryCache: true),
     );
   }
 

--- a/mobile/lib/providers/new_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.g.dart
@@ -45,7 +45,7 @@ final class NewVideosFeedProvider
   NewVideosFeed create() => NewVideosFeed();
 }
 
-String _$newVideosFeedHash() => r'5a0b3c8fa9079c035a5b76d0e421dcb7aa21e13f';
+String _$newVideosFeedHash() => r'f8f6d8069e144d5f67e1d7cd8557c8b388389d16';
 
 /// New Videos feed provider - shows newest videos first.
 ///

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -4403,8 +4403,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           eventList.insert(0, videoEvent);
         }
 
-      case SubscriptionType.editorial:
       case SubscriptionType.popularNow:
+        // Chronological feed: live → newest-first, historical → append.
+        // Matches PopularNowFeed downstream sort and Explore expectations;
+        // relay batch order alone is not trustworthy.
+        if (isHistorical) {
+          eventList.add(videoEvent);
+        } else {
+          eventList.insert(0, videoEvent);
+        }
+
+      case SubscriptionType.editorial:
       case SubscriptionType.trending:
         // Editorial/trending: maintain order from server (always append)
         eventList.add(videoEvent);

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -133,8 +133,7 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
   }
 
   Future<void> _refreshNewVideos() async {
-    ref.invalidate(newVideosFeedProvider);
-    await ref.read(newVideosFeedProvider.future);
+    await ref.read(newVideosFeedProvider.notifier).refresh();
   }
 
   void _trackLoadingState() {
@@ -269,11 +268,7 @@ class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
           '🔄 NewVideosTab: Refreshing feed',
           category: LogCategory.video,
         );
-        // Rebuild the provider so the tab can re-query and repopulate even
-        // from an empty-state screen. This mirrors other tab-level refresh
-        // patterns in Explore and keeps pull-to-refresh available here.
-        ref.invalidate(newVideosFeedProvider);
-        await ref.read(newVideosFeedProvider.future);
+        await newVideosFeedNotifier.refresh();
       },
       onLoadMore: () async {
         Log.info('📜 NewVideosTab: Loading more', category: LogCategory.video);

--- a/mobile/test/widgets/new_videos_tab_test.dart
+++ b/mobile/test/widgets/new_videos_tab_test.dart
@@ -45,9 +45,8 @@ void main() {
         ),
       ).thenAnswer((_) async => [_video('popular-video')]);
       when(() => videoEventService.filterVideoList(any())).thenAnswer(
-        (invocation) => List<VideoEvent>.from(
-          invocation.positionalArguments.first as List,
-        ),
+        (invocation) =>
+            List<VideoEvent>.from(invocation.positionalArguments.first as List),
       );
       when(
         () => blocklistRepository.shouldFilterFromFeeds(any()),
@@ -89,6 +88,46 @@ void main() {
           skipCache: any(named: 'skipCache'),
         ),
       );
+    });
+
+    testWidgets('pull-to-refresh bypasses repository cache on retry', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testMaterialApp(
+          additionalOverrides: [
+            appReadyProvider.overrideWithValue(true),
+            videosRepositoryProvider.overrideWithValue(videosRepository),
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              blocklistRepository,
+            ),
+          ],
+          home: const Scaffold(body: NewVideosTab()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final refreshIndicator = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      await refreshIndicator.onRefresh();
+      await tester.pumpAndSettle();
+
+      verify(
+        () => videosRepository.getNewVideos(
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+        ),
+      ).called(1);
+      verify(
+        () => videosRepository.getNewVideos(
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+          skipCache: true,
+        ),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
Closes #3848

## Summary

Three small, independent fixes for the pull-to-refresh staleness in #3848, replacing #3958 (closed) with just the parts that move the needle without institutionalizing the EOSE-spinner-hang pattern that bites elsewhere in the app.

The actual user-visible "60s of stale content on refresh" is upstream (`api.divine.video` Fastly `Cache-Control: public, max-age=60`) and needs a server-side purge mechanism — that's tracked separately and isn't fixable from the client.

## What's in here

- **`NewVideosTab` pull-to-refresh switch** — both `_refreshNewVideos` and the empty-state refresh now call `notifier.refresh()` instead of `ref.invalidate(...) + ref.read(...future)`. The latter silently went through `build()` with `skipCache: false`; `refresh()` takes the SWR path that bypasses the Drift cache.
- **`NewVideosFeed._loadFirstPage` gains `bypassRepositoryCache`**, plumbed into the SWR `fetchFresh` callback so explicit pull-to-refresh actually re-hits `videosRepository.getNewVideos(skipCache: true)`.
- **`SubscriptionType.popularNow` chronological insertion** — split out of the `editorial`/`trending` append-only case in `VideoEventService`. Live events `insert(0)`, historical events `add`, matching `PopularNowFeed`'s newest-first downstream sort and the same shape the `profile`/`hashtag`/`search` cases use.

## What's deliberately NOT in here

- **`waitForSubscriptionRelayIdle`** and the two callsites in `popular_now_feed_provider.dart` / `profile_feed_provider.dart` — dropped. We already have too many screens stuck waiting on EOSE; adding a new primitive for it is the wrong direction. Reactive UI updates via the existing `notifyListeners` plumbing is the right pattern when we want to address this later.
- **`_usingRestApi = true` in `PopularNowFeed.refresh()`** — fully redundant. #3849's sticky-flag fix already shipped on `main` via #3973 with a per-call `funnelcakeAvailableProvider` check at every site, and the equivalent regression test (`popular now re-attempts REST after a transient refresh failure`) is already passing on `main`.

## Test plan

- [x] `flutter test test/widgets/new_videos_tab_test.dart` — new `pull-to-refresh bypasses repository cache on retry` test passes.
- [x] `flutter test test/providers/explore_feed_refresh_retention_test.dart test/providers/profile_feed_pagination_contract_test.dart` — pre-existing tests still pass (20 tests).
- [x] `flutter test test/unit/services/video_event_service_force_refresh_test.dart` — pre-existing tests still pass (2 tests).
- [x] `flutter analyze lib/providers/new_videos_feed_provider.dart lib/widgets/new_videos_tab.dart lib/services/video_event_service.dart test/widgets/new_videos_tab_test.dart` — clean.
- [ ] Manual: Explore → New, pull-to-refresh after publishing a new video; verify the new video appears (within Fastly's 60s TTL).

## Related

- Replaces #3958 (closed).
- Closes the local-cache-and-ordering portion of #3848. The Fastly `max-age=60` on `api.divine.video` is the remaining root cause and should be filed as a funnelcake/CDN ticket.
