### PR TITLE
fix(feed): re-enable pull-to-refresh on the home video feed

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -613,50 +613,117 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                     )
                   : null;
 
-              // Note: RefreshIndicator removed - it conflicts with PageView
-              // scrolling and adds memory overhead. Use the refresh button
-              // instead.
-              return Stack(
-                children: [
-                  if (kIsWeb)
-                    WebVideoFeed(
-                      key: _webFeedKey,
-                      videos: state.videos
-                          .where((v) => v.videoUrl != null)
-                          .toList(),
-                      controllerFactory:
-                          widget.webControllerFactory ??
-                          defaultWebVideoPlayerControllerFactory,
-                      authHeaderProvider: webAuthHeaderProvider,
-                      onActiveVideoChanged: (video, index) {
-                        _currentWebIndex = index;
-                        _pagePosition.value = index.toDouble();
-                        _resumeAutoAdvanceAfterSwipe();
-                      },
-                      onCompleted: (_) => _handleAutoAdvanceCompleted(),
-                      onErrored: _handleWebPlayerErrored,
-                      onRequiresAuth: _handleWebPlayerRequiresAuth,
-                      onNearEnd: (index) {
-                        if (state.hasMore) {
-                          context.read<VideoFeedBloc>().add(
-                            const VideoFeedLoadMoreRequested(),
-                          );
-                        }
-                      },
-                      itemBuilder:
-                          (
-                            context,
-                            video,
-                            index, {
-                            required isActive,
-                            controller,
-                          }) {
+              // Pull-to-refresh: a [RefreshIndicator] wraps the feed and
+              // listens for overscroll notifications from the inner
+              // [PageView]. The default predicate (depth == 0) restricts the
+              // gesture to the outermost scrollable, so inner overlay
+              // scrollables can't trigger a refresh. The PooledVideoFeed
+              // below is given [AlwaysScrollableScrollPhysics] so Android
+              // also produces the start-edge overscroll the indicator needs.
+              return RefreshIndicator(
+                onRefresh: () => _refreshFeed(context),
+                child: Stack(
+                  children: [
+                    if (kIsWeb)
+                      WebVideoFeed(
+                        key: _webFeedKey,
+                        videos: state.videos
+                            .where((v) => v.videoUrl != null)
+                            .toList(),
+                        controllerFactory:
+                            widget.webControllerFactory ??
+                            defaultWebVideoPlayerControllerFactory,
+                        authHeaderProvider: webAuthHeaderProvider,
+                        onActiveVideoChanged: (video, index) {
+                          _currentWebIndex = index;
+                          _pagePosition.value = index.toDouble();
+                          _resumeAutoAdvanceAfterSwipe();
+                        },
+                        onCompleted: (_) => _handleAutoAdvanceCompleted(),
+                        onErrored: _handleWebPlayerErrored,
+                        onRequiresAuth: _handleWebPlayerRequiresAuth,
+                        onNearEnd: (index) {
+                          if (state.hasMore) {
+                            context.read<VideoFeedBloc>().add(
+                              const VideoFeedLoadMoreRequested(),
+                            );
+                          }
+                        },
+                        itemBuilder:
+                            (
+                              context,
+                              video,
+                              index, {
+                              required isActive,
+                              controller,
+                            }) {
+                              final listSources =
+                                  state.listOnlyVideoIds.contains(video.id)
+                                  ? state.videoListSources[video.id]
+                                  : null;
+                              return _WebVideoFeedItem(
+                                video: video,
+                                index: index,
+                                isActive: isActive,
+                                pagePosition: _pagePosition,
+                                contextTitle: state.mode.name,
+                                listSources: listSources,
+                                showAutoButton: autoAdvanceAvailable,
+                                isAutoEnabled: effectiveAutoEnabled,
+                                feedController: null,
+                                onAutoPressed: _toggleAutoAdvance,
+                                onInteracted: _suppressAutoAdvance,
+                              );
+                            },
+                      )
+                    else
+                      KeyedSubtree(
+                        key: ValueKey(state.mode),
+                        child: PooledVideoFeed(
+                          key: _feedKey,
+                          videos: pooledVideos,
+                          maxLoopDuration: VideoEditorConstants.maxDuration,
+                          controller: controller,
+                          // Force always-scrollable physics so Android also
+                          // produces the start-edge OverscrollNotification
+                          // that the wrapping [RefreshIndicator] needs to
+                          // trigger pull-to-refresh from page 0.
+                          physics: const AlwaysScrollableScrollPhysics(
+                            parent: PageScrollPhysics(),
+                          ),
+                          onScrollOffsetChanged: (page) =>
+                              _pagePosition.value = page,
+                          itemBuilder: (context, video, index, {required isActive}) {
+                            final originalEvent = eventsById[video.id];
+                            if (originalEvent == null) {
+                              Log.debug(
+                                'Feed item missing original event: '
+                                'mode=${state.mode.name}, index=$index, '
+                                'videoId=${video.id}, playbackUrl=${video.url}, '
+                                'stateVideoCount=${state.videos.length}',
+                                name: 'VideoFeedPage',
+                                category: LogCategory.video,
+                              );
+                              return const ColoredBox(
+                                color: VineTheme.backgroundColor,
+                              );
+                            }
+                            Log.debug(
+                              'Feed item build: mode=${state.mode.name}, index=$index, '
+                              'eventId=${originalEvent.id}, isActive=$isActive, '
+                              'playbackUrl=${video.url}, originalUrl=${originalEvent.videoUrl}, '
+                              'thumbnailUrl=${originalEvent.thumbnailUrl}',
+                              name: 'VideoFeedPage',
+                              category: LogCategory.video,
+                            );
                             final listSources =
-                                state.listOnlyVideoIds.contains(video.id)
-                                ? state.videoListSources[video.id]
+                                state.listOnlyVideoIds.contains(
+                                  originalEvent.id,
+                                )
+                                ? state.videoListSources[originalEvent.id]
                                 : null;
-                            return _WebVideoFeedItem(
-                              video: video,
+                            return _PooledVideoFeedItem(
+                              video: originalEvent,
                               index: index,
                               isActive: isActive,
                               pagePosition: _pagePosition,
@@ -664,104 +731,73 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                               listSources: listSources,
                               showAutoButton: autoAdvanceAvailable,
                               isAutoEnabled: effectiveAutoEnabled,
-                              feedController: null,
+                              isAutoAdvanceActive: effectiveAutoActive,
                               onAutoPressed: _toggleAutoAdvance,
                               onInteracted: _suppressAutoAdvance,
+                              onAutoAdvanceCompleted:
+                                  _handleAutoAdvanceCompleted,
                             );
                           },
-                    )
-                  else
-                    KeyedSubtree(
-                      key: ValueKey(state.mode),
-                      child: PooledVideoFeed(
-                        key: _feedKey,
-                        videos: pooledVideos,
-                        maxLoopDuration: VideoEditorConstants.maxDuration,
-                        controller: controller,
-                        onScrollOffsetChanged: (page) =>
-                            _pagePosition.value = page,
-                        itemBuilder: (context, video, index, {required isActive}) {
-                          final originalEvent = eventsById[video.id];
-                          if (originalEvent == null) {
-                            Log.debug(
-                              'Feed item missing original event: '
-                              'mode=${state.mode.name}, index=$index, '
-                              'videoId=${video.id}, playbackUrl=${video.url}, '
-                              'stateVideoCount=${state.videos.length}',
-                              name: 'VideoFeedPage',
-                              category: LogCategory.video,
+                          onActiveVideoChanged: (video, index) {
+                            _resumeAutoAdvanceAfterSwipe();
+                            FeedPerformanceTracker().startVideoSwipeTracking(
+                              video.id,
                             );
-                            return const ColoredBox(
-                              color: VineTheme.backgroundColor,
+                            final sourceIndex = state.videos.indexWhere(
+                              (event) => event.id == video.id,
                             );
-                          }
-                          Log.debug(
-                            'Feed item build: mode=${state.mode.name}, index=$index, '
-                            'eventId=${originalEvent.id}, isActive=$isActive, '
-                            'playbackUrl=${video.url}, originalUrl=${originalEvent.videoUrl}, '
-                            'thumbnailUrl=${originalEvent.thumbnailUrl}',
-                            name: 'VideoFeedPage',
-                            category: LogCategory.video,
-                          );
-                          final listSources =
-                              state.listOnlyVideoIds.contains(originalEvent.id)
-                              ? state.videoListSources[originalEvent.id]
-                              : null;
-                          return _PooledVideoFeedItem(
-                            video: originalEvent,
-                            index: index,
-                            isActive: isActive,
-                            pagePosition: _pagePosition,
-                            contextTitle: state.mode.name,
-                            listSources: listSources,
-                            showAutoButton: autoAdvanceAvailable,
-                            isAutoEnabled: effectiveAutoEnabled,
-                            isAutoAdvanceActive: effectiveAutoActive,
-                            onAutoPressed: _toggleAutoAdvance,
-                            onInteracted: _suppressAutoAdvance,
-                            onAutoAdvanceCompleted: _handleAutoAdvanceCompleted,
-                          );
-                        },
-                        onActiveVideoChanged: (video, index) {
-                          _resumeAutoAdvanceAfterSwipe();
-                          FeedPerformanceTracker().startVideoSwipeTracking(
-                            video.id,
-                          );
-                          final sourceIndex = state.videos.indexWhere(
-                            (event) => event.id == video.id,
-                          );
-                          if (sourceIndex != -1) {
-                            final event = state.videos[sourceIndex];
-                            Log.info(
-                              '📺 Feed active video: mode=${state.mode.name}, '
-                              'index=$index, eventId=${event.id}, pubkey=${event.pubkey}, '
-                              'playbackUrl=${video.url}, originalUrl=${event.videoUrl}, '
-                              'thumbnailUrl=${event.thumbnailUrl}',
-                              name: 'VideoFeedPage',
-                              category: LogCategory.video,
-                            );
-                          }
-                        },
-                        onNearEnd: (index) {
-                          // PooledVideoFeed fires this when the user is within
-                          // nearEndThreshold (default 3) of the end, using the
-                          // controller's actual video count (not the BlocBuilder's
-                          // list length, which may differ due to deduplication).
-                          if (state.hasMore) {
-                            context.read<VideoFeedBloc>().add(
-                              const VideoFeedLoadMoreRequested(),
-                            );
-                          }
-                        },
+                            if (sourceIndex != -1) {
+                              final event = state.videos[sourceIndex];
+                              Log.info(
+                                '📺 Feed active video: mode=${state.mode.name}, '
+                                'index=$index, eventId=${event.id}, pubkey=${event.pubkey}, '
+                                'playbackUrl=${video.url}, originalUrl=${event.videoUrl}, '
+                                'thumbnailUrl=${event.thumbnailUrl}',
+                                name: 'VideoFeedPage',
+                                category: LogCategory.video,
+                              );
+                            }
+                          },
+                          onNearEnd: (index) {
+                            // PooledVideoFeed fires this when the user is within
+                            // nearEndThreshold (default 3) of the end, using the
+                            // controller's actual video count (not the BlocBuilder's
+                            // list length, which may differ due to deduplication).
+                            if (state.hasMore) {
+                              context.read<VideoFeedBloc>().add(
+                                const VideoFeedLoadMoreRequested(),
+                              );
+                            }
+                          },
+                        ),
                       ),
-                    ),
-                  const FeedModeSwitch(),
-                ],
+                    const FeedModeSwitch(),
+                  ],
+                ),
               );
             },
           ),
         ),
       ),
+    );
+  }
+
+  /// Dispatches a refresh and resolves when the bloc settles.
+  ///
+  /// The [RefreshIndicator] keeps its spinner visible until the returned
+  /// future completes, so we await the next non-loading state instead of
+  /// resolving immediately on dispatch. If the bloc is disposed before
+  /// settling (e.g. the user leaves the screen mid-refresh) the stream
+  /// closes without matching and [Stream.firstWhere] returns the bloc's
+  /// last known state via `orElse`.
+  Future<void> _refreshFeed(BuildContext context) async {
+    final bloc = context.read<VideoFeedBloc>();
+    bloc.add(const VideoFeedRefreshRequested());
+    await bloc.stream.firstWhere(
+      (s) =>
+          s.status == VideoFeedStatus.success ||
+          s.status == VideoFeedStatus.failure,
+      orElse: () => bloc.state,
     );
   }
 }

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
@@ -38,6 +38,7 @@ class PooledVideoFeed extends StatefulWidget {
     this.nearEndThreshold = 3,
     this.onScrollOffsetChanged,
     this.maxLoopDuration,
+    this.physics,
     super.key,
   });
 
@@ -76,6 +77,16 @@ class PooledVideoFeed extends StatefulWidget {
 
   /// Maximum playback duration before automatically seeking back to zero.
   final Duration? maxLoopDuration;
+
+  /// Optional [ScrollPhysics] for the underlying [PageView].
+  ///
+  /// Defaults to Flutter's default ([PageScrollPhysics]). Pass an
+  /// always-scrollable physics (e.g. wrapping [PageScrollPhysics]) when the
+  /// feed is hosted inside a [RefreshIndicator] so a pull-down at index 0
+  /// produces the overscroll notification the indicator listens for —
+  /// otherwise on platforms that clamp by default (Android), the gesture is
+  /// swallowed before reaching the indicator.
+  final ScrollPhysics? physics;
 
   /// Called continuously as the feed scrolls with the fractional page position.
   ///
@@ -296,6 +307,7 @@ class PooledVideoFeedState extends State<PooledVideoFeed>
         allowImplicitScrolling: true,
         controller: _pageController,
         scrollDirection: widget.scrollDirection,
+        physics: widget.physics,
         onPageChanged: _onPageChanged,
         itemCount: _videoCount,
         itemBuilder: (context, index) {

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
@@ -47,6 +47,7 @@ void main() {
       OnActiveVideoChanged? onActiveVideoChanged,
       void Function(int)? onNearEnd,
       int nearEndThreshold = 3,
+      ScrollPhysics? physics,
     }) {
       return MaterialApp(
         home: Scaffold(
@@ -61,6 +62,7 @@ void main() {
             onActiveVideoChanged: onActiveVideoChanged,
             onNearEnd: onNearEnd,
             nearEndThreshold: nearEndThreshold,
+            physics: physics,
             itemBuilder: (context, video, index, {required isActive}) {
               return ColoredBox(
                 key: Key('video_item_$index'),
@@ -106,6 +108,28 @@ void main() {
 
         final pageView = tester.widget<PageView>(find.byType(PageView));
         expect(pageView.scrollDirection, equals(Axis.horizontal));
+      });
+
+      testWidgets('defaults physics to null (PageView default)', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildFeed());
+
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.physics, isNull);
+      });
+
+      testWidgets('forwards a custom physics to the inner PageView', (
+        tester,
+      ) async {
+        const physics = AlwaysScrollableScrollPhysics(
+          parent: PageScrollPhysics(),
+        );
+
+        await tester.pumpWidget(buildFeed(physics: physics));
+
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.physics, same(physics));
       });
     });
 

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -694,6 +694,7 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(const VideoFeedStarted());
+      registerFallbackValue(const VideoFeedRefreshRequested());
     });
 
     Widget buildSubject(VideoFeedState state) {
@@ -718,6 +719,18 @@ void main() {
       );
     }
 
+    void stubControllerForVideo(VideoEvent video) {
+      when(() => videoFeedController.videoCount).thenReturn(1);
+      when(
+        () => videoFeedController.videos,
+      ).thenReturn([VideoItem(id: video.id, url: video.videoUrl!)]);
+      when(() => videoFeedController.currentIndex).thenReturn(0);
+      when(() => videoFeedController.onPageChanged(any())).thenReturn(null);
+      when(
+        () => videoFeedController.getIndexNotifier(any()),
+      ).thenReturn(ValueNotifier(const VideoIndexState()));
+    }
+
     testWidgets(
       'renders native pooled feed with a GlobalKey for programmatic control',
       (tester) async {
@@ -727,15 +740,7 @@ void main() {
           videos: [testVideo],
         );
 
-        when(() => videoFeedController.videoCount).thenReturn(1);
-        when(
-          () => videoFeedController.videos,
-        ).thenReturn([VideoItem(id: testVideo.id, url: testVideo.videoUrl!)]);
-        when(() => videoFeedController.currentIndex).thenReturn(0);
-        when(() => videoFeedController.onPageChanged(any())).thenReturn(null);
-        when(
-          () => videoFeedController.getIndexNotifier(any()),
-        ).thenReturn(ValueNotifier(const VideoIndexState()));
+        stubControllerForVideo(testVideo);
 
         await tester.pumpWidget(buildSubject(state));
         await tester.pump();
@@ -745,6 +750,63 @@ void main() {
         );
 
         expect(pooledVideoFeed.key, isA<GlobalKey<PooledVideoFeedState>>());
+      },
+    );
+
+    testWidgets(
+      'wraps the loaded feed in a RefreshIndicator that dispatches '
+      'VideoFeedRefreshRequested on pull',
+      (tester) async {
+        final testVideo = createTestVideoEvent();
+        final state = VideoFeedState(
+          status: VideoFeedStatus.success,
+          videos: [testVideo],
+        );
+
+        stubControllerForVideo(testVideo);
+
+        await tester.pumpWidget(buildSubject(state));
+        await tester.pump();
+
+        expect(find.byType(RefreshIndicator), findsOneWidget);
+
+        final indicator = tester.widget<RefreshIndicator>(
+          find.byType(RefreshIndicator),
+        );
+        // _refreshFeed awaits bloc.stream which the mock never emits, so
+        // we don't await — the event is added synchronously.
+        unawaited(indicator.onRefresh());
+        await tester.pump();
+
+        verify(
+          () => videoFeedBloc.add(const VideoFeedRefreshRequested()),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'forces always-scrollable physics so Android produces the start-edge '
+      'overscroll the RefreshIndicator listens for',
+      (tester) async {
+        final testVideo = createTestVideoEvent();
+        final state = VideoFeedState(
+          status: VideoFeedStatus.success,
+          videos: [testVideo],
+        );
+
+        stubControllerForVideo(testVideo);
+
+        await tester.pumpWidget(buildSubject(state));
+        await tester.pump();
+
+        final pooledVideoFeed = tester.widget<PooledVideoFeed>(
+          find.byType(PooledVideoFeed),
+        );
+
+        expect(
+          pooledVideoFeed.physics,
+          isA<AlwaysScrollableScrollPhysics>(),
+        );
       },
     );
   });


### PR DESCRIPTION
Closes #4002

## Summary

The fullscreen `VideoFeedPage` (the main bottom-tab feed users see for For You / Following) had **no manual refresh path** in the success state. Pull-to-refresh was removed long ago citing PageView gesture conflicts, and the "use the refresh button instead" comment in the code referred to a button that only exists on the *error* screen. With feeds backed by REST one-shot fetches (no live push), users could not trigger a refresh without killing the app.

This PR re-wires pull-to-refresh on that surface:

- Wrap the success-state stack in a `RefreshIndicator`. The default notification predicate (`depth == 0`) restricts the gesture to the outermost scrollable, so inner overlay scrollables can't fire it.
- Add a `physics` parameter to `PooledVideoFeed` and pass `AlwaysScrollableScrollPhysics(parent: PageScrollPhysics())` from the home feed so Android also produces the start-edge `OverscrollNotification` the indicator listens for. (Default Android physics clamp at index 0, swallowing the gesture before it reaches the indicator.)
- `onRefresh` dispatches `VideoFeedRefreshRequested` and awaits the next non-loading state via `bloc.stream.firstWhere(orElse: ...)`, so the spinner stays visible until the refresh settles, with a safe fallback if the bloc is disposed mid-refresh.

## Relation to #4000

Complementary, non-overlapping:

- **#4000** fixes the Explore screen's **New tab** pull-to-refresh (Drift cache bypass + popularNow chronological insertion). Touches `new_videos_tab.dart`, `new_videos_feed_provider.dart`, `video_event_service.dart`.
- **This PR** re-enables pull-to-refresh on the **home fullscreen feed**. Touches `video_feed_page.dart` and the `pooled_video_player` package.

Either can land first; no file overlap.

## Test plan

- [x] `flutter test test/screens/feed/video_feed_page_test.dart` — adds three assertions in the *native feed wiring* group: `RefreshIndicator` wraps the loaded feed; pulling dispatches `VideoFeedRefreshRequested`; `PooledVideoFeed` receives `AlwaysScrollableScrollPhysics`.
- [x] `flutter test mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart` — adds two assertions for the new `physics` parameter (default null preserves prior behavior; custom physics is forwarded to the inner `PageView`).
- [x] `flutter test test/screens/feed/ test/blocs/video_feed/ packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart` — 225 tests pass.
- [x] `flutter analyze lib test` — clean.
- [ ] Manual: home feed → pull down at index 0 → spinner appears → new videos load. Verify on Android (clamping default) and iOS (bouncing default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)