### PR TITLE
fix(likes): count reactions on all versions of an edited video

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -238,6 +238,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   // Like count batching - accumulates video IDs and fetches counts in batches
   // to prevent ANR issues from too many concurrent relay requests
   final Map<String, SubscriptionType> _pendingLikeCountVideoIds = {};
+  // Addressable IDs (kind:pubkey:d-tag) for pending like count fetches.
+  // Passed to getLikeCounts so reactions on any version of a replaced video
+  // (different event IDs, same d-tag) are also counted via 'a' tag.
+  final Map<String, String> _pendingLikeCountAddressableIds = {};
   Timer? _likeCountBatchTimer;
   static const Duration _likeCountBatchDebounce = Duration(milliseconds: 150);
   static const int _likeCountBatchMaxSize = 50;
@@ -4553,6 +4557,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // Add to pending batch
     _pendingLikeCountVideoIds[videoEvent.id] = subscriptionType;
 
+    // Track addressable ID so the batch fetch can also query by 'a' tag.
+    // This ensures reactions on any version of a replaced video (e.g. after a
+    // metadata edit that changes the event ID) are included in the count.
+    final addressableId = videoEvent.addressableId;
+    if (addressableId != null) {
+      _pendingLikeCountAddressableIds[videoEvent.id] = addressableId;
+    }
+
     // Cancel existing timer
     _likeCountBatchTimer?.cancel();
 
@@ -4575,7 +4587,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     // Move pending to current batch
     final batch = Map<String, SubscriptionType>.from(_pendingLikeCountVideoIds);
+    final addressableIds = Map<String, String>.from(
+      _pendingLikeCountAddressableIds,
+    );
     _pendingLikeCountVideoIds.clear();
+    _pendingLikeCountAddressableIds.clear();
     _likeCountBatchTimer?.cancel();
 
     final videoIds = batch.keys.toList();
@@ -4587,8 +4603,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
 
     try {
-      // Fetch all like counts in a single batched query
-      final likeCounts = await _likesRepository!.getLikeCounts(videoIds);
+      // Fetch like counts via both 'e' tag (event ID) and 'a' tag (addressable
+      // ID).  The 'a' tag query catches reactions on any previous version of the
+      // video so counts stay accurate after a metadata update.
+      final likeCounts = await _likesRepository!.getLikeCounts(
+        videoIds,
+        addressableIds: addressableIds.isEmpty ? null : addressableIds,
+      );
 
       // Apply counts to each video
       var updatedCount = 0;

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -4554,6 +4554,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // Track addressable ID so the batch fetch can also query by 'a' tag.
     // This ensures reactions on any version of a replaced video (e.g. after a
     // metadata edit that changes the event ID) are included in the count.
+    // Preserve the addressable identity alongside the current event ID so the
+    // batch can count reactions across edited versions of the same video.
     final addressableId = videoEvent.addressableId;
     if (addressableId != null) {
       _pendingLikeCountAddressableIds[videoEvent.id] = addressableId;
@@ -4581,6 +4583,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     // Move pending to current batch
     final batch = Map<String, SubscriptionType>.from(_pendingLikeCountVideoIds);
+    // Snapshot the companion addressable IDs with the same batch boundary as
+    // the event IDs so the relay query stays consistent.
     final addressableIds = Map<String, String>.from(
       _pendingLikeCountAddressableIds,
     );

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1740,11 +1740,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             'event_count',
             eventTotal ?? eventCount,
           );
-          _performanceMonitor.putAttribute(
-            traceName,
-            'completion',
-            completion,
-          );
+          _performanceMonitor.putAttribute(traceName, 'completion', completion);
           unawaited(_performanceMonitor.stopTrace(traceName));
         }
 
@@ -5634,6 +5630,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   @visibleForTesting
   void handleEventForTesting(Event event, SubscriptionType type) {
     _handleNewVideoEvent(event, type);
+  }
+
+  /// Flush the pending like-count batch without waiting for the debounce timer.
+  @visibleForTesting
+  Future<void> flushPendingLikeCountBatchForTesting() {
+    return _executeLikeCountBatchFetch();
   }
 
   /// Run automatic diagnostics when feed fails to load events

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -238,9 +238,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   // Like count batching - accumulates video IDs and fetches counts in batches
   // to prevent ANR issues from too many concurrent relay requests
   final Map<String, SubscriptionType> _pendingLikeCountVideoIds = {};
-  // Addressable IDs (kind:pubkey:d-tag) for pending like count fetches.
-  // Passed to getLikeCounts so reactions on any version of a replaced video
-  // (different event IDs, same d-tag) are also counted via 'a' tag.
+  // Companion map for _pendingLikeCountVideoIds: event ID → addressable ID (kind:pubkey:d-tag).
   final Map<String, String> _pendingLikeCountAddressableIds = {};
   Timer? _likeCountBatchTimer;
   static const Duration _likeCountBatchDebounce = Duration(milliseconds: 150);
@@ -4604,7 +4602,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     try {
       // Fetch like counts via both 'e' tag (event ID) and 'a' tag (addressable
-      // ID).  The 'a' tag query catches reactions on any previous version of the
+      // ID). The 'a' tag query catches reactions on any previous version of the
       // video so counts stay accurate after a metadata update.
       final likeCounts = await _likesRepository!.getLikeCounts(
         videoIds,

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -125,6 +125,8 @@ class CurationRepository {
     // Include addressable IDs so reactions on any version of a replaced
     // video (different event ID, same d-tag) are counted via 'a' tag.
     final videoIds = allVideos.map((v) => v.id).toList();
+    // Keep the event-id keys aligned with getLikeCounts' return shape while
+    // still giving the repository the addressable IDs it needs for edited videos.
     final addressableIds = {
       for (final v in allVideos)
         if (v.addressableId != null) v.id: v.addressableId!,

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -121,9 +121,18 @@ class CurationRepository {
     final sortedByTime = List<VideoEvent>.from(allVideos)
       ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
-    // Sort by reaction count (fetching from LikesRepository)
+    // Sort by reaction count (fetching from LikesRepository).
+    // Include addressable IDs so reactions on any version of a replaced
+    // video (different event ID, same d-tag) are counted via 'a' tag.
     final videoIds = allVideos.map((v) => v.id).toList();
-    final likeCounts = await _likesRepository.getLikeCounts(videoIds);
+    final addressableIds = {
+      for (final v in allVideos)
+        if (v.addressableId != null) v.id: v.addressableId!,
+    };
+    final likeCounts = await _likesRepository.getLikeCounts(
+      videoIds,
+      addressableIds: addressableIds.isEmpty ? null : addressableIds,
+    );
 
     final sortedByReactions = List<VideoEvent>.from(allVideos)
       ..sort((a, b) {

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -126,7 +126,8 @@ class CurationRepository {
     // video (different event ID, same d-tag) are counted via 'a' tag.
     final videoIds = allVideos.map((v) => v.id).toList();
     // Keep the event-id keys aligned with getLikeCounts' return shape while
-    // still giving the repository the addressable IDs it needs for edited videos.
+    // still giving the repository the addressable IDs it needs for edited
+    // videos.
     final addressableIds = {
       for (final v in allVideos)
         if (v.addressableId != null) v.id: v.addressableId!,

--- a/mobile/packages/curation_repository/test/src/curation_repository_divine_team_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_repository_divine_team_test.dart
@@ -36,12 +36,14 @@ Event _videoNostrEvent({
   String pubkey = _zeroPubkey,
   int createdAt = 1234567890,
   String? title,
+  String? dTag,
 }) {
   return Event(
     pubkey,
     34236,
     [
       ['h', 'vine'],
+      if (dTag != null) ['d', dTag],
       if (title != null) ['title', title],
       ['url', 'https://example.com/$id.mp4'],
     ],
@@ -56,9 +58,7 @@ Event _videoNostrEvent({
 void main() {
   setUpAll(() {
     registerFallbackValue(<Filter>[]);
-    registerFallbackValue(
-      Event('0' * 64, 1, <List<String>>[], ''),
-    );
+    registerFallbackValue(Event('0' * 64, 1, <List<String>>[], ''));
     registerFallbackValue(<String>[]);
     registerFallbackValue(
       VideoEvent(
@@ -83,25 +83,46 @@ void main() {
       mockLikesRepository = _MockLikesRepository();
       mockSigner = _MockNostrSigner();
 
+      when(() => mockVideoEventCache.discoveryVideos).thenReturn([]);
+      when(() => mockVideoEventCache.addVideoEvent(any())).thenReturn(null);
       when(
-        () => mockVideoEventCache.discoveryVideos,
-      ).thenReturn([]);
-      when(
-        () => mockVideoEventCache.addVideoEvent(any()),
-      ).thenReturn(null);
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
       when(
         () => mockLikesRepository.getLikeCounts(any()),
+      ).thenAnswer((_) async => {});
+      when(
+        () => mockLikesRepository.getLikeCounts(
+          any(),
+          addressableIds: any(named: 'addressableIds'),
+        ),
       ).thenAnswer((_) async => {});
     });
 
     test(
-      'fetches and caches Divine Team videos from relay',
+      'passes addressable IDs through when sorting Divine Team reactions',
       () async {
-        final controller = StreamController<Event>();
+        final addressableVideo = VideoEvent.fromNostrEvent(
+          _videoNostrEvent(
+            id: 'addressable-video',
+            pubkey: _divineTeamPubkey,
+            title: 'Addressable Divine Video',
+            dTag: 'divine-team-addressable',
+          ),
+        );
+        final legacyVideo = VideoEvent(
+          id: 'legacy-video',
+          pubkey: _divineTeamPubkey,
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          content: 'Legacy video',
+          timestamp: DateTime.now(),
+          title: 'Legacy Divine Video',
+          videoUrl: 'https://example.com/legacy-video.mp4',
+        );
 
         when(
-          () => mockNostrService.subscribe(any()),
-        ).thenAnswer((_) => controller.stream);
+          () => mockVideoEventCache.discoveryVideos,
+        ).thenReturn([addressableVideo, legacyVideo]);
 
         final service = CurationRepository(
           nostrService: mockNostrService,
@@ -111,224 +132,221 @@ void main() {
           divineTeamPubkeys: const [_divineTeamPubkey],
         );
 
-        // Emit a video event
-        controller.add(
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockLikesRepository.getLikeCounts(
+            any(),
+            addressableIds: captureAny(named: 'addressableIds'),
+          ),
+        ).captured;
+
+        final addressableIds = captured.first as Map<String, String>?;
+        expect(addressableIds, isNotNull);
+        expect(addressableIds, hasLength(1));
+        expect(
+          addressableIds![addressableVideo.id],
+          equals(addressableVideo.addressableId),
+        );
+        expect(addressableIds.containsKey(legacyVideo.id), isFalse);
+
+        service.dispose();
+      },
+    );
+
+    test('fetches and caches Divine Team videos from relay', () async {
+      final controller = StreamController<Event>();
+
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => controller.stream);
+
+      final service = CurationRepository(
+        nostrService: mockNostrService,
+        videoEventCache: mockVideoEventCache,
+        likesRepository: mockLikesRepository,
+        signer: mockSigner,
+        divineTeamPubkeys: const [_divineTeamPubkey],
+      );
+
+      // Emit a video event
+      controller.add(
+        _videoNostrEvent(
+          id: 'divine_video_1',
+          pubkey: _divineTeamPubkey,
+          title: 'Divine Team Video',
+        ),
+      );
+
+      // Allow stream processing
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Close the stream
+      await controller.close();
+
+      // Allow completion to settle
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Video should have been added to video event cache
+      verify(
+        () => mockVideoEventCache.addVideoEvent(any()),
+      ).called(greaterThan(0));
+
+      service.dispose();
+    });
+
+    test('handles stream error in Divine Team fetch', () async {
+      final controller = StreamController<Event>();
+
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => controller.stream);
+
+      final service = CurationRepository(
+        nostrService: mockNostrService,
+        videoEventCache: mockVideoEventCache,
+        likesRepository: mockLikesRepository,
+        signer: mockSigner,
+        divineTeamPubkeys: const [_divineTeamPubkey],
+      );
+
+      // Emit an error
+      controller.addError(Exception('Relay error'));
+
+      // Allow stream processing
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Service should not crash
+      expect(service.curationSets, isNotEmpty);
+
+      service.dispose();
+      await controller.close();
+    });
+
+    test('deduplicates videos in editor picks internal cache', () async {
+      final controller = StreamController<Event>();
+
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => controller.stream);
+
+      final service = CurationRepository(
+        nostrService: mockNostrService,
+        videoEventCache: mockVideoEventCache,
+        likesRepository: mockLikesRepository,
+        signer: mockSigner,
+        divineTeamPubkeys: const [_divineTeamPubkey],
+      );
+
+      // Emit the same video twice
+      final videoEvent = _videoNostrEvent(
+        id: 'duplicate_vid',
+        pubkey: _divineTeamPubkey,
+        title: 'Duplicate Video',
+      );
+
+      controller
+        ..add(videoEvent)
+        ..add(videoEvent);
+
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      await controller.close();
+
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // addVideoEvent is called for each stream event
+      // (line 212 is outside the dedup block), but the
+      // internal _editorPicksVideoCache only adds once.
+      // We verify the external cache received both calls.
+      verify(() => mockVideoEventCache.addVideoEvent(any())).called(2);
+
+      // Editor picks should have only 1 unique video
+      final picks = service.getVideosForSetType(CurationSetType.editorsPicks);
+      expect(picks, hasLength(1));
+
+      service.dispose();
+    });
+
+    test('editors picks are sorted by creation time '
+        '(newest first)', () async {
+      final controller = StreamController<Event>();
+
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => controller.stream);
+
+      final service = CurationRepository(
+        nostrService: mockNostrService,
+        videoEventCache: mockVideoEventCache,
+        likesRepository: mockLikesRepository,
+        signer: mockSigner,
+        divineTeamPubkeys: const [_divineTeamPubkey],
+      );
+
+      // Emit videos with different creation times
+      controller
+        ..add(
           _videoNostrEvent(
-            id: 'divine_video_1',
+            id: 'old_vid',
             pubkey: _divineTeamPubkey,
-            title: 'Divine Team Video',
+            title: 'Old',
+            createdAt: 1000,
+          ),
+        )
+        ..add(
+          _videoNostrEvent(
+            id: 'new_vid',
+            pubkey: _divineTeamPubkey,
+            title: 'New',
+            createdAt: 5000,
           ),
         );
 
-        // Allow stream processing
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
+      await Future<void>.delayed(const Duration(milliseconds: 200));
 
-        // Close the stream
-        await controller.close();
+      await controller.close();
 
-        // Allow completion to settle
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
+      await Future<void>.delayed(const Duration(milliseconds: 200));
 
-        // Video should have been added to video event cache
-        verify(
-          () => mockVideoEventCache.addVideoEvent(any()),
-        ).called(greaterThan(0));
+      final picks = service.getVideosForSetType(CurationSetType.editorsPicks);
 
-        service.dispose();
-      },
-    );
+      if (picks.length >= 2) {
+        // Newest should be first
+        expect(picks[0].createdAt, greaterThanOrEqualTo(picks[1].createdAt));
+      }
 
-    test(
-      'handles stream error in Divine Team fetch',
-      () async {
-        final controller = StreamController<Event>();
+      service.dispose();
+    });
 
-        when(
-          () => mockNostrService.subscribe(any()),
-        ).thenAnswer((_) => controller.stream);
-
-        final service = CurationRepository(
-          nostrService: mockNostrService,
-          videoEventCache: mockVideoEventCache,
-          likesRepository: mockLikesRepository,
-          signer: mockSigner,
-          divineTeamPubkeys: const [_divineTeamPubkey],
-        );
-
-        // Emit an error
-        controller.addError(Exception('Relay error'));
-
-        // Allow stream processing
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
-
-        // Service should not crash
-        expect(service.curationSets, isNotEmpty);
-
-        service.dispose();
-        await controller.close();
-      },
-    );
-
-    test(
-      'deduplicates videos in editor picks internal cache',
-      () async {
-        final controller = StreamController<Event>();
-
-        when(
-          () => mockNostrService.subscribe(any()),
-        ).thenAnswer((_) => controller.stream);
-
-        final service = CurationRepository(
-          nostrService: mockNostrService,
-          videoEventCache: mockVideoEventCache,
-          likesRepository: mockLikesRepository,
-          signer: mockSigner,
-          divineTeamPubkeys: const [_divineTeamPubkey],
-        );
-
-        // Emit the same video twice
-        final videoEvent = _videoNostrEvent(
-          id: 'duplicate_vid',
-          pubkey: _divineTeamPubkey,
-          title: 'Duplicate Video',
-        );
-
-        controller
-          ..add(videoEvent)
-          ..add(videoEvent);
-
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
-
-        await controller.close();
-
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
-
-        // addVideoEvent is called for each stream event
-        // (line 212 is outside the dedup block), but the
-        // internal _editorPicksVideoCache only adds once.
-        // We verify the external cache received both calls.
-        verify(
-          () => mockVideoEventCache.addVideoEvent(any()),
-        ).called(2);
-
-        // Editor picks should have only 1 unique video
-        final picks = service.getVideosForSetType(
-          CurationSetType.editorsPicks,
-        );
-        expect(picks, hasLength(1));
-
-        service.dispose();
-      },
-    );
-
-    test(
-      'editors picks are sorted by creation time '
-      '(newest first)',
-      () async {
-        final controller = StreamController<Event>();
-
-        when(
-          () => mockNostrService.subscribe(any()),
-        ).thenAnswer((_) => controller.stream);
-
-        final service = CurationRepository(
-          nostrService: mockNostrService,
-          videoEventCache: mockVideoEventCache,
-          likesRepository: mockLikesRepository,
-          signer: mockSigner,
-          divineTeamPubkeys: const [_divineTeamPubkey],
-        );
-
-        // Emit videos with different creation times
-        controller
-          ..add(
-            _videoNostrEvent(
-              id: 'old_vid',
-              pubkey: _divineTeamPubkey,
-              title: 'Old',
-              createdAt: 1000,
-            ),
-          )
-          ..add(
-            _videoNostrEvent(
-              id: 'new_vid',
-              pubkey: _divineTeamPubkey,
-              title: 'New',
-              createdAt: 5000,
-            ),
-          );
-
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
-
-        await controller.close();
-
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
-
-        final picks = service.getVideosForSetType(
-          CurationSetType.editorsPicks,
-        );
-
-        if (picks.length >= 2) {
-          // Newest should be first
-          expect(
-            picks[0].createdAt,
-            greaterThanOrEqualTo(picks[1].createdAt),
-          );
+    test('handles subscribe throwing during Divine Team '
+        'fetch', () async {
+      // First call returns empty stream (for
+      // constructor init), second call throws
+      var callCount = 0;
+      when(() => mockNostrService.subscribe(any())).thenAnswer((_) {
+        callCount++;
+        if (callCount > 1) {
+          throw Exception('Connection failed');
         }
+        return const Stream<Event>.empty();
+      });
 
-        service.dispose();
-      },
-    );
+      // Should not throw during construction
+      final service = CurationRepository(
+        nostrService: mockNostrService,
+        videoEventCache: mockVideoEventCache,
+        likesRepository: mockLikesRepository,
+        signer: mockSigner,
+        divineTeamPubkeys: const [_divineTeamPubkey],
+      );
 
-    test(
-      'handles subscribe throwing during Divine Team '
-      'fetch',
-      () async {
-        // First call returns empty stream (for
-        // constructor init), second call throws
-        var callCount = 0;
-        when(
-          () => mockNostrService.subscribe(any()),
-        ).thenAnswer((_) {
-          callCount++;
-          if (callCount > 1) {
-            throw Exception('Connection failed');
-          }
-          return const Stream<Event>.empty();
-        });
+      // Allow async to settle
+      await Future<void>.delayed(const Duration(milliseconds: 200));
 
-        // Should not throw during construction
-        final service = CurationRepository(
-          nostrService: mockNostrService,
-          videoEventCache: mockVideoEventCache,
-          likesRepository: mockLikesRepository,
-          signer: mockSigner,
-          divineTeamPubkeys: const [_divineTeamPubkey],
-        );
+      expect(service.curationSets, isNotEmpty);
 
-        // Allow async to settle
-        await Future<void>.delayed(
-          const Duration(milliseconds: 200),
-        );
-
-        expect(service.curationSets, isNotEmpty);
-
-        service.dispose();
-      },
-    );
+      service.dispose();
+    });
   });
 }

--- a/mobile/test/services/video_event_service_like_count_addressable_test.dart
+++ b/mobile/test/services/video_event_service_like_count_addressable_test.dart
@@ -86,6 +86,8 @@ void main() {
         ).captured;
 
         // The captured value is the addressableIds map passed to getLikeCounts.
+        // The map is keyed by current event ID even when the lookup also fans
+        // out across prior edited versions via addressable IDs.
         final addressableIds = captured.first as Map<String, String>?;
         expect(
           addressableIds,

--- a/mobile/test/services/video_event_service_like_count_addressable_test.dart
+++ b/mobile/test/services/video_event_service_like_count_addressable_test.dart
@@ -53,47 +53,30 @@ void main() {
       service.dispose();
     });
 
-    // Fill the batch to the maximum (50) so the flush fires immediately,
-    // avoiding any dependence on the 150 ms debounce timer.
-    sdk.Event makeEvent(String dTag, {int createdAt = 1000}) => sdk.Event(
+    sdk.Event makeEvent(
+      String dTag, {
+      int createdAt = 1000,
+      int kind = NIP71VideoKinds.addressableShortVideo,
+      bool includeDTag = true,
+    }) => sdk.Event(
       pubkey,
-      NIP71VideoKinds.addressableShortVideo,
+      kind,
       [
-        ['d', dTag],
+        if (includeDTag) ['d', dTag],
         ['url', videoUrl],
         ['title', 'Test'],
       ],
       '',
       createdAt: createdAt,
-    );
+    )..id = '$kind-$dTag-$createdAt';
 
     test(
       '_fetchAndUpdateLikeCount populates addressable IDs and passes them to getLikeCounts',
       () async {
-        // Build a batch of 49 non-addressable-interest events to prime the
-        // queue, then add the video under test as the 50th entry.  The 50th
-        // push hits the batch-max threshold and triggers an immediate flush
-        // (no timer).
-        final padEvents = List.generate(
-          49,
-          (i) => makeEvent('pad-vine-$i'),
-        );
-        for (final e in padEvents) {
-          service.handleEventForTesting(e, SubscriptionType.discovery);
-        }
-
-        // The 50th video — kind 34236 with a d-tag — has a non-null
-        // addressableId and is the one we want to verify passes through.
         final targetEvent = makeEvent('target-vine');
-        service.handleEventForTesting(
-          targetEvent,
-          SubscriptionType.discovery,
-        );
+        service.handleEventForTesting(targetEvent, SubscriptionType.discovery);
 
-        // The flush is synchronous up to the await inside
-        // _executeLikeCountBatchFetch.  Pump the event loop so the async
-        // getLikeCounts call completes.
-        await Future<void>.delayed(Duration.zero);
+        await service.flushPendingLikeCountBatchForTesting();
 
         final captured = verify(
           () => mockLikesRepository.getLikeCounts(
@@ -132,22 +115,10 @@ void main() {
       () async {
         const dTag = 'my-special-vine';
 
-        // Fill 49 padding events first, then the target as the 50th to trigger
-        // an immediate flush.
-        for (var i = 0; i < 49; i++) {
-          service.handleEventForTesting(
-            makeEvent('pad-vine-$i'),
-            SubscriptionType.discovery,
-          );
-        }
-
         final targetEvent = makeEvent(dTag);
-        service.handleEventForTesting(
-          targetEvent,
-          SubscriptionType.discovery,
-        );
+        service.handleEventForTesting(targetEvent, SubscriptionType.discovery);
 
-        await Future<void>.delayed(Duration.zero);
+        await service.flushPendingLikeCountBatchForTesting();
 
         final captured = verify(
           () => mockLikesRepository.getLikeCounts(
@@ -166,6 +137,43 @@ void main() {
           equals('${NIP71VideoKinds.addressableShortVideo}:$pubkey:$dTag'),
           reason: 'Addressable ID should be kind:pubkey:d-tag',
         );
+      },
+    );
+
+    test(
+      'non-addressable videos are omitted from the addressableIds batch map',
+      () async {
+        final addressableEvent = makeEvent('addressable-vine');
+        final nonAddressableEvent = makeEvent(
+          'legacy-vine',
+          kind: NIP71VideoKinds.shortVideo,
+          includeDTag: false,
+        );
+
+        service.handleEventForTesting(
+          addressableEvent,
+          SubscriptionType.discovery,
+        );
+        service.handleEventForTesting(
+          nonAddressableEvent,
+          SubscriptionType.discovery,
+        );
+
+        await service.flushPendingLikeCountBatchForTesting();
+
+        final captured = verify(
+          () => mockLikesRepository.getLikeCounts(
+            any(),
+            addressableIds: captureAny(named: 'addressableIds'),
+          ),
+        ).captured;
+
+        final addressableIds = captured.first as Map<String, String>?;
+        final addressableVideo = VideoEvent.fromNostrEvent(addressableEvent);
+
+        expect(addressableIds, isNotNull);
+        expect(addressableIds!.containsKey(addressableVideo.id), isTrue);
+        expect(addressableIds.containsKey(nonAddressableEvent.id), isFalse);
       },
     );
   });

--- a/mobile/test/services/video_event_service_like_count_addressable_test.dart
+++ b/mobile/test/services/video_event_service_like_count_addressable_test.dart
@@ -1,0 +1,172 @@
+// ABOUTME: Tests that VideoEventService passes addressable IDs through to
+// ABOUTME: getLikeCounts so reactions on replaced videos are counted correctly.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' hide NIP71VideoKinds;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' as sdk;
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+class _MockLikesRepository extends Mock implements LikesRepository {}
+
+void main() {
+  group('VideoEventService - like count addressable ID wiring', () {
+    const pubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const videoUrl = 'https://example.com/video.mp4';
+
+    late _MockNostrClient mockNostrClient;
+    late _MockSubscriptionManager mockSubscriptionManager;
+    late _MockLikesRepository mockLikesRepository;
+    late VideoEventService service;
+
+    setUp(() {
+      mockNostrClient = _MockNostrClient();
+      mockSubscriptionManager = _MockSubscriptionManager();
+      mockLikesRepository = _MockLikesRepository();
+
+      when(() => mockNostrClient.isInitialized).thenReturn(true);
+      when(() => mockNostrClient.publicKey).thenReturn('');
+      when(
+        () => mockLikesRepository.getLikeCounts(
+          any(),
+          addressableIds: any(named: 'addressableIds'),
+        ),
+      ).thenAnswer((_) async => {});
+
+      service = VideoEventService(
+        mockNostrClient,
+        subscriptionManager: mockSubscriptionManager,
+      );
+      service.setLikesRepository(mockLikesRepository);
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    // Fill the batch to the maximum (50) so the flush fires immediately,
+    // avoiding any dependence on the 150 ms debounce timer.
+    sdk.Event makeEvent(String dTag, {int createdAt = 1000}) => sdk.Event(
+      pubkey,
+      NIP71VideoKinds.addressableShortVideo,
+      [
+        ['d', dTag],
+        ['url', videoUrl],
+        ['title', 'Test'],
+      ],
+      '',
+      createdAt: createdAt,
+    );
+
+    test(
+      '_fetchAndUpdateLikeCount populates addressable IDs and passes them to getLikeCounts',
+      () async {
+        // Build a batch of 49 non-addressable-interest events to prime the
+        // queue, then add the video under test as the 50th entry.  The 50th
+        // push hits the batch-max threshold and triggers an immediate flush
+        // (no timer).
+        final padEvents = List.generate(
+          49,
+          (i) => makeEvent('pad-vine-$i'),
+        );
+        for (final e in padEvents) {
+          service.handleEventForTesting(e, SubscriptionType.discovery);
+        }
+
+        // The 50th video — kind 34236 with a d-tag — has a non-null
+        // addressableId and is the one we want to verify passes through.
+        final targetEvent = makeEvent('target-vine');
+        service.handleEventForTesting(
+          targetEvent,
+          SubscriptionType.discovery,
+        );
+
+        // The flush is synchronous up to the await inside
+        // _executeLikeCountBatchFetch.  Pump the event loop so the async
+        // getLikeCounts call completes.
+        await Future<void>.delayed(Duration.zero);
+
+        final captured = verify(
+          () => mockLikesRepository.getLikeCounts(
+            any(),
+            addressableIds: captureAny(named: 'addressableIds'),
+          ),
+        ).captured;
+
+        // The captured value is the addressableIds map passed to getLikeCounts.
+        final addressableIds = captured.first as Map<String, String>?;
+        expect(
+          addressableIds,
+          isNotNull,
+          reason:
+              'addressableIds should be non-null for a batch containing a kind 34236 video',
+        );
+
+        final targetVideo = VideoEvent.fromNostrEvent(targetEvent);
+        expect(
+          addressableIds!.containsKey(targetVideo.id),
+          isTrue,
+          reason:
+              'The target video event ID should be present in addressableIds',
+        );
+        expect(
+          addressableIds[targetVideo.id],
+          equals(targetVideo.addressableId),
+          reason:
+              'The addressable ID should be the kind:pubkey:d-tag string from the video',
+        );
+      },
+    );
+
+    test(
+      'addressable ID value has the correct kind:pubkey:d-tag format',
+      () async {
+        const dTag = 'my-special-vine';
+
+        // Fill 49 padding events first, then the target as the 50th to trigger
+        // an immediate flush.
+        for (var i = 0; i < 49; i++) {
+          service.handleEventForTesting(
+            makeEvent('pad-vine-$i'),
+            SubscriptionType.discovery,
+          );
+        }
+
+        final targetEvent = makeEvent(dTag);
+        service.handleEventForTesting(
+          targetEvent,
+          SubscriptionType.discovery,
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        final captured = verify(
+          () => mockLikesRepository.getLikeCounts(
+            any(),
+            addressableIds: captureAny(named: 'addressableIds'),
+          ),
+        ).captured;
+
+        final addressableIds = captured.first as Map<String, String>?;
+        expect(addressableIds, isNotNull);
+
+        final targetVideo = VideoEvent.fromNostrEvent(targetEvent);
+        final aId = addressableIds![targetVideo.id];
+        expect(
+          aId,
+          equals('${NIP71VideoKinds.addressableShortVideo}:$pubkey:$dTag'),
+          reason: 'Addressable ID should be kind:pubkey:d-tag',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
After a metadata update a Kind 34236 video gets a new event ID while keeping the same d-tag. The batch like-count fetch was only querying by 'e' tag (event ID), so reactions on the old event ID were missed and the displayed count reset to zero.

Pass the addressable ID (kind:pubkey:d-tag) alongside each event ID in the batch so getLikeCounts also queries by 'a' tag and takes the max, keeping the count accurate across metadata updates.

<!--- Describe your changes in detail -->

**Related Issue:** Relates to #3948

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore