### PR TITLE
fix(notifications): navigate and display using d-tag (vineId)

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -163,8 +163,17 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     );
 
     switch (notification) {
-      case VideoNotification(:final videoEventId, :final type):
-        await _navigateToVideo(context, videoEventId, notificationKind: type);
+      case VideoNotification(
+        :final videoEventId,
+        :final videoAddressableId,
+        :final type,
+      ):
+        await _navigateToVideo(
+          context,
+          videoEventId,
+          videoAddressableId: videoAddressableId,
+          notificationKind: type,
+        );
       case ActorNotification(:final actor, :final type):
         switch (type) {
           case NotificationKind.follow:
@@ -186,60 +195,72 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
   Future<void> _navigateToVideo(
     BuildContext context,
-    String targetId, {
+    String videoEventId, {
+    String? videoAddressableId,
     NotificationKind? notificationKind,
   }) async {
     Log.info(
-      'Navigating to video from notification: $targetId',
+      'Navigating to video from notification: '
+      'addressable=$videoAddressableId eventId=$videoEventId',
       name: 'NotificationsView',
       category: LogCategory.ui,
     );
 
     final videoEventService = ref.read(videoEventServiceProvider);
-    final nostrService = ref.read(nostrServiceProvider);
     final videosRepository = ref.read(videosRepositoryProvider);
 
-    // Resolve the target event ID to a video event ID.
-    final resolver = NotificationTargetResolver(
-      videoEventService: videoEventService,
-      nostrService: nostrService,
-    );
-    final resolvedVideoEventId = await resolver
-        .resolveVideoEventIdFromNotificationTarget(targetId);
+    // For like/repost notifications the referenced video is always owned by
+    // the current user.  Use the stable NIP-33 addressable ID when available —
+    // it survives metadata updates because it's keyed on (kind:pubkey:d-tag)
+    // rather than the mutable event hash.
+    //
+    // For comment/reply notifications the videoEventId is the comment event,
+    // not the video — the resolver walks the E/e tags up to the root video.
+    final isComment =
+        notificationKind == NotificationKind.comment ||
+        notificationKind == NotificationKind.reply;
 
-    if (!context.mounted) return;
+    // Resolve the navigation target.
+    String routeId;
+    if (videoAddressableId != null &&
+        videoAddressableId.isNotEmpty &&
+        !isComment) {
+      // Stable path: addressable ID works even after a metadata update.
+      routeId = videoAddressableId;
+    } else if (isComment) {
+      // Comment path: walk E/e tags to find the root video event ID.
+      final resolved = await NotificationTargetResolver(
+        videoEventService: videoEventService,
+        nostrService: ref.read(nostrServiceProvider),
+      ).resolveVideoEventIdFromNotificationTarget(videoEventId);
 
-    if (resolvedVideoEventId == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Video not found')));
-      return;
+      if (!context.mounted) return;
+
+      if (resolved == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Video not found'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+        return;
+      }
+      routeId = resolved;
+    } else {
+      // Fallback: no addressable ID available, use raw event ID.
+      routeId = videoEventId;
     }
 
-    // Notification entry should use the same hydrated fetch path as feed and
-    // deep-link routes so fullscreen stats don't regress to zero.
-    var video = await videosRepository.fetchVideoWithStats(
-      resolvedVideoEventId,
-    );
-    if (!context.mounted) return;
-
-    // Keep a defensive fallback for the rare case where the repository misses
-    // but the event is still available directly from the service / relay.
-    video ??= videoEventService.getVideoById(resolvedVideoEventId);
-    if (video == null) {
-      try {
-        final event = await nostrService.fetchEventById(resolvedVideoEventId);
-        if (!context.mounted) return;
-        if (event != null) {
-          video = VideoEvent.fromNostrEvent(event);
-        }
-      } catch (e) {
-        Log.error(
-          'Failed to fetch video from Nostr: $e',
-          name: 'NotificationsView',
-          category: LogCategory.ui,
-        );
-      }
+    VideoEvent? video;
+    try {
+      video = await videosRepository.fetchVideoWithStatsForRouteId(routeId);
+      if (!context.mounted) return;
+    } catch (e) {
+      Log.error(
+        'Failed to fetch video: $e',
+        name: 'NotificationsView',
+        category: LogCategory.ui,
+      );
     }
 
     if (!context.mounted) return;
@@ -264,19 +285,13 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       return;
     }
 
-    final shouldAutoOpenComments =
-        notificationKind == NotificationKind.comment ||
-        notificationKind == NotificationKind.reply;
-    final videoForNav = video;
-
     context.push(
       PooledFullscreenVideoFeedScreen.path,
       extra: PooledFullscreenVideoFeedArgs(
-        videosStream: Stream.value([videoForNav]),
+        videosStream: Stream.value([video]),
         initialIndex: 0,
         contextTitle: 'From Notification',
-
-        autoOpenComments: shouldAutoOpenComments,
+        autoOpenComments: isComment,
       ),
     );
   }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -209,22 +209,16 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     final videoEventService = ref.read(videoEventServiceProvider);
     final videosRepository = ref.read(videosRepositoryProvider);
 
-    // For like/repost notifications the referenced video is always owned by
-    // the current user.  Use the stable NIP-33 addressable ID when available —
-    // it survives metadata updates because it's keyed on (kind:pubkey:d-tag)
-    // rather than the mutable event hash.
-    //
-    // For comment/reply notifications the videoEventId is the comment event,
-    // not the video — the resolver walks the E/e tags up to the root video.
+    // Use the stable NIP-33 addressable ID whenever the notification payload
+    // includes one. It survives metadata updates because it's keyed on
+    // (kind:pubkey:d-tag) rather than the mutable event hash.
     final isComment =
         notificationKind == NotificationKind.comment ||
         notificationKind == NotificationKind.reply;
 
     // Resolve the navigation target.
     String routeId;
-    if (videoAddressableId != null &&
-        videoAddressableId.isNotEmpty &&
-        !isComment) {
+    if (videoAddressableId != null && videoAddressableId.isNotEmpty) {
       // Stable path: addressable ID works even after a metadata update.
       routeId = videoAddressableId;
     } else if (isComment) {

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -16,6 +16,8 @@ class RelayNotification {
     this.content,
     this.isReferencedVideo = false,
     this.referencedVideoTitle,
+    this.referencedVideoThumbnail,
+    this.referencedDTag,
   });
 
   /// Parses a notification payload from the FunnelCake API.
@@ -27,6 +29,18 @@ class RelayNotification {
     final videoTitle =
         referencedVideoMap?['title'] as String? ??
         json['referenced_event_title'] as String?;
+
+    // d_tag is the stable vineId for the referenced video. It is sent in two
+    // places by the server — prefer referenced_video.d_tag, fall back to the
+    // top-level referenced_d_tag field.
+    final rawDTag =
+        referencedVideoMap?['d_tag'] as String? ??
+        json['referenced_d_tag'] as String?;
+
+    final rawThumbnail =
+        referencedVideoMap?['thumbnail'] as String? ??
+        json['referenced_event_thumbnail'] as String?;
+
     return RelayNotification(
       id: json['id'] as String? ?? '',
       sourcePubkey: json['source_pubkey'] as String? ?? '',
@@ -43,6 +57,12 @@ class RelayNotification {
       referencedVideoTitle: (videoTitle != null && videoTitle.isNotEmpty)
           ? videoTitle
           : null,
+      referencedVideoThumbnail:
+          (rawThumbnail != null && rawThumbnail.isNotEmpty)
+          ? rawThumbnail
+          : null,
+      referencedDTag:
+          (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
     );
   }
 
@@ -82,6 +102,18 @@ class RelayNotification {
   /// with a non-empty title. `null` for non-video targets or untitled
   /// videos.
   final String? referencedVideoTitle;
+
+  /// Thumbnail URL of the referenced video, when the server includes it in
+  /// `referenced_video.thumbnail`. Stable — does not depend on event ID.
+  final String? referencedVideoThumbnail;
+
+  /// The `d` tag (vineId) of the referenced video.
+  ///
+  /// Populated from `referenced_video.d_tag` or the top-level
+  /// `referenced_d_tag` field when the server includes it. Together with the
+  /// notification recipient's pubkey this forms the NIP-33 addressable
+  /// coordinate (`34236:pubkey:d-tag`) which is stable across metadata edits.
+  final String? referencedDTag;
 
   /// Stable dedup key -- falls back to sourceEventId if id is empty.
   String get dedupeKey => id.isNotEmpty ? id : sourceEventId;

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -61,8 +61,7 @@ class RelayNotification {
           (rawThumbnail != null && rawThumbnail.isNotEmpty)
           ? rawThumbnail
           : null,
-      referencedDTag:
-          (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
+      referencedDTag: (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
     );
   }
 

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -123,6 +123,166 @@ void main() {
         },
       );
 
+      test('parses d_tag from referenced_video.d_tag', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'referenced_video': {
+            'title': 'My vine',
+            'thumbnail': 'https://example.com/thumb.jpg',
+            'd_tag': 'vine-stable-id',
+          },
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.referencedDTag, equals('vine-stable-id'));
+        expect(
+          notification.referencedVideoThumbnail,
+          equals('https://example.com/thumb.jpg'),
+        );
+      });
+
+      test(
+        'falls back to top-level referenced_d_tag when '
+        'referenced_video is absent',
+        () {
+          final json = {
+            'id': 'notif_123',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 7,
+            'referenced_event_id': '55667788' * 8,
+            'referenced_d_tag': 'top-level-dtag',
+            'notification_type': 'reaction',
+            'created_at': 1712345678,
+            'read': false,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(notification.referencedDTag, equals('top-level-dtag'));
+          expect(notification.isReferencedVideo, isFalse);
+        },
+      );
+
+      test(
+        'prefers referenced_video.d_tag over top-level referenced_d_tag',
+        () {
+          final json = {
+            'id': 'notif_123',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 7,
+            'referenced_event_id': '55667788' * 8,
+            'referenced_video': {
+              'title': 'My vine',
+              'd_tag': 'nested-dtag',
+            },
+            'referenced_d_tag': 'top-level-dtag',
+            'notification_type': 'reaction',
+            'created_at': 1712345678,
+            'read': false,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(notification.referencedDTag, equals('nested-dtag'));
+        },
+      );
+
+      test('treats empty referenced_d_tag as null', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'referenced_d_tag': '',
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.referencedDTag, isNull);
+      });
+
+      test('parses thumbnail from referenced_video.thumbnail', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'referenced_video': {
+            'thumbnail': 'https://cdn.example.com/thumb.jpg',
+          },
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(
+          notification.referencedVideoThumbnail,
+          equals('https://cdn.example.com/thumb.jpg'),
+        );
+      });
+
+      test(
+        'falls back to referenced_event_thumbnail when '
+        'referenced_video is absent',
+        () {
+          final json = {
+            'id': 'notif_123',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 7,
+            'referenced_event_id': '55667788' * 8,
+            'referenced_event_thumbnail':
+                'https://cdn.example.com/fallback.jpg',
+            'notification_type': 'reaction',
+            'created_at': 1712345678,
+            'read': false,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(
+            notification.referencedVideoThumbnail,
+            equals('https://cdn.example.com/fallback.jpg'),
+          );
+          expect(notification.isReferencedVideo, isFalse);
+        },
+      );
+
+      test('treats empty referenced_video.thumbnail as null thumbnail', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'referenced_video': {'thumbnail': ''},
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.referencedVideoThumbnail, isNull);
+      });
+
       test('treats empty referenced_video.title as null title', () {
         final json = {
           'id': 'notif_123',

--- a/mobile/packages/models/lib/src/video_notification.dart
+++ b/mobile/packages/models/lib/src/video_notification.dart
@@ -21,6 +21,7 @@ class VideoNotification extends NotificationItem {
     super.isRead,
     this.videoThumbnailUrl,
     this.videoTitle,
+    this.videoAddressableId,
   }) : assert(
          type == NotificationKind.like ||
              type == NotificationKind.likeComment ||
@@ -37,7 +38,16 @@ class VideoNotification extends NotificationItem {
        super(targetEventId: videoEventId);
 
   /// The Nostr event id of the video that was acted on.
+  ///
+  /// May become stale after a metadata update (NIP-33 replacement).
+  /// Prefer [videoAddressableId] for navigation when available.
   final String videoEventId;
+
+  /// The NIP-33 addressable ID (`34236:pubkey:d-tag`) of the video.
+  ///
+  /// Stable across metadata updates. Use this for navigation instead of
+  /// [videoEventId] whenever it is non-null.
+  final String? videoAddressableId;
 
   /// Thumbnail URL of the referenced video, if available.
   final String? videoThumbnailUrl;
@@ -57,6 +67,7 @@ class VideoNotification extends NotificationItem {
     String? id,
     NotificationKind? type,
     String? videoEventId,
+    String? videoAddressableId,
     String? videoThumbnailUrl,
     String? videoTitle,
     List<ActorInfo>? actors,
@@ -68,6 +79,7 @@ class VideoNotification extends NotificationItem {
       id: id ?? this.id,
       type: type ?? this.type,
       videoEventId: videoEventId ?? this.videoEventId,
+      videoAddressableId: videoAddressableId ?? this.videoAddressableId,
       videoThumbnailUrl: videoThumbnailUrl ?? this.videoThumbnailUrl,
       videoTitle: videoTitle ?? this.videoTitle,
       actors: actors ?? this.actors,
@@ -82,6 +94,7 @@ class VideoNotification extends NotificationItem {
     id,
     type,
     videoEventId,
+    videoAddressableId,
     videoThumbnailUrl,
     videoTitle,
     actors,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -299,7 +299,7 @@ class NotificationRepository {
           .map((n) => n.referencedDTag)
           .firstWhere((d) => d != null, orElse: () => null);
       final addressableId = dTag != null && dTag.isNotEmpty
-          ? '34236:$_userPubkey:$dTag'
+          ? '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag'
           : null;
       // Prefer thumbnail from the notification payload — it comes directly from
       // the server and is stable even after a metadata update (unlike the stats
@@ -403,7 +403,7 @@ class NotificationRepository {
       final video = videosById[referenced];
       final dTag = raw.referencedDTag;
       final addressableId = dTag != null && dTag.isNotEmpty
-          ? '34236:$_userPubkey:$dTag'
+          ? '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag'
           : null;
       return VideoNotification(
         id: raw.dedupeKey,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -292,13 +292,33 @@ class NotificationRepository {
           .map((n) => _buildActor(n.sourcePubkey, profiles))
           .toList();
       final video = videosById[entry.key.eventId];
+      // Build the stable NIP-33 addressable ID from the d_tag returned by the
+      // server and the current user's pubkey (all video notifications are for
+      // videos owned by this user, so _userPubkey is always the right author).
+      final dTag = group
+          .map((n) => n.referencedDTag)
+          .firstWhere((d) => d != null, orElse: () => null);
+      final addressableId = dTag != null && dTag.isNotEmpty
+          ? '34236:$_userPubkey:$dTag'
+          : null;
+      // Prefer thumbnail from the notification payload — it comes directly from
+      // the server and is stable even after a metadata update (unlike the stats
+      // lookup which uses the mutable event ID and may 404 post-edit).
+      final thumbnailFromNotif = group
+          .map((n) => n.referencedVideoThumbnail)
+          .firstWhere((t) => t != null && t.isNotEmpty, orElse: () => null);
+      final titleFromNotif = group
+          .map((n) => n.referencedVideoTitle)
+          .firstWhere((t) => t != null && t.isNotEmpty, orElse: () => null);
       result.add(
         VideoNotification(
           id: group.first.dedupeKey,
           type: entry.key.kind,
           videoEventId: entry.key.eventId,
-          videoThumbnailUrl: _nonEmpty(video?.thumbnail),
-          videoTitle: _nonEmpty(video?.title),
+          videoAddressableId: addressableId,
+          videoThumbnailUrl:
+              _nonEmpty(thumbnailFromNotif) ?? _nonEmpty(video?.thumbnail),
+          videoTitle: _nonEmpty(titleFromNotif) ?? _nonEmpty(video?.title),
           actors: actors,
           totalCount: group.length,
           timestamp: group.first.createdAt,
@@ -381,12 +401,19 @@ class NotificationRepository {
     if (isVideoAnchored) {
       if (referenced == null || referenced.isEmpty) return null;
       final video = videosById[referenced];
+      final dTag = raw.referencedDTag;
+      final addressableId = dTag != null && dTag.isNotEmpty
+          ? '34236:$_userPubkey:$dTag'
+          : null;
       return VideoNotification(
         id: raw.dedupeKey,
         type: kind,
         videoEventId: referenced,
-        videoThumbnailUrl: _nonEmpty(video?.thumbnail),
-        videoTitle: _nonEmpty(video?.title),
+        videoAddressableId: addressableId,
+        videoThumbnailUrl: _nonEmpty(raw.referencedVideoThumbnail) ??
+            _nonEmpty(video?.thumbnail),
+        videoTitle:
+            _nonEmpty(raw.referencedVideoTitle) ?? _nonEmpty(video?.title),
         actors: [actor],
         totalCount: 1,
         timestamp: raw.createdAt,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -410,7 +410,8 @@ class NotificationRepository {
         type: kind,
         videoEventId: referenced,
         videoAddressableId: addressableId,
-        videoThumbnailUrl: _nonEmpty(raw.referencedVideoThumbnail) ??
+        videoThumbnailUrl:
+            _nonEmpty(raw.referencedVideoThumbnail) ??
             _nonEmpty(video?.thumbnail),
         videoTitle:
             _nonEmpty(raw.referencedVideoTitle) ?? _nonEmpty(video?.title),

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -524,9 +524,11 @@ class _VideoGroupKey {
   final NotificationKind kind;
 
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes, private value object
   bool operator ==(Object other) =>
       other is _VideoGroupKey && other.eventId == eventId && other.kind == kind;
 
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes, private value object
   int get hashCode => Object.hash(eventId, kind);
 }

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -411,7 +411,8 @@ void main() {
 
     group('video-anchored grouping', () {
       test(
-        '5 likes on same video become 1 $VideoNotification with totalCount 5 and 3 actors',
+        '5 likes on same video become 1 $VideoNotification '
+        'with totalCount 5 and 3 actors',
         () async {
           stubNotifications([
             for (var i = 0; i < 5; i++)
@@ -469,7 +470,8 @@ void main() {
       );
 
       test(
-        'likes + comments on same video become 2 ${VideoNotification}s differing by kind',
+        'likes + comments on same video become 2 ${VideoNotification}s '
+        'differing by kind',
         () async {
           stubNotifications([
             makeNotification(

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -82,6 +82,7 @@ void main() {
     DateTime? createdAt,
     bool read = false,
     String? referencedEventId = 'video_default',
+    String? referencedDTag,
     String? content,
     bool isReferencedVideo = true,
   }) {
@@ -94,6 +95,7 @@ void main() {
       createdAt: createdAt ?? DateTime(2025),
       read: read,
       referencedEventId: referencedEventId,
+      referencedDTag: referencedDTag,
       content: content,
       isReferencedVideo: isReferencedVideo,
     );
@@ -439,6 +441,73 @@ void main() {
           // Newest first — pub_0 had the latest createdAt.
           expect(item.actors.first.displayName, equals('Actor0'));
           expect(item.videoEventId, equals('video_x'));
+        },
+      );
+
+      test(
+        'grouped video notifications build addressable id from '
+        'user pubkey and d-tag',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'l1',
+              sourcePubkey: 'pub_a',
+              referencedEventId: 'video_x',
+              referencedDTag: 'vine-id',
+            ),
+            makeNotification(
+              id: 'l2',
+              sourcePubkey: 'pub_b',
+              referencedEventId: 'video_x',
+              referencedDTag: 'vine-id',
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(
+            item.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:'
+              '$userPubkey:vine-id',
+            ),
+          );
+        },
+      );
+
+      test(
+        'grouped video notifications leave addressable id null when d-tag '
+        'is null or empty',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'l1',
+              sourcePubkey: 'pub_a',
+              referencedEventId: 'video_x',
+              referencedDTag: '',
+            ),
+            makeNotification(
+              id: 'l2',
+              sourcePubkey: 'pub_b',
+              referencedEventId: 'video_x',
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(item.videoAddressableId, isNull);
         },
       );
 
@@ -994,6 +1063,7 @@ void main() {
         int sourceKind = 7,
         String notificationType = 'reaction',
         String? referencedEventId = 'video_x',
+        String? referencedDTag,
         bool isReferencedVideo = true,
       }) {
         return RelayNotification(
@@ -1005,6 +1075,7 @@ void main() {
           createdAt: DateTime(2025),
           read: false,
           referencedEventId: referencedEventId,
+          referencedDTag: referencedDTag,
           isReferencedVideo: isReferencedVideo,
         );
       }
@@ -1030,6 +1101,46 @@ void main() {
           expect(video.videoTitle, equals('T'));
         },
       );
+
+      test(
+        'builds addressable id from user pubkey and d-tag for realtime '
+        'video notifications',
+        () async {
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          });
+          stubVideoStats(
+            'video_x',
+            makeVideoStats(id: 'video_x', thumbnail: 'thumb', title: 'T'),
+          );
+
+          final result = await repository.enrichOne(
+            raw(referencedDTag: 'vine-id'),
+          );
+
+          expect(result, isA<VideoNotification>());
+          final video = result! as VideoNotification;
+          expect(
+            video.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:'
+              '$userPubkey:vine-id',
+            ),
+          );
+        },
+      );
+
+      test('leaves addressable id null when realtime d-tag is empty', () async {
+        stubProfiles({
+          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+        });
+
+        final result = await repository.enrichOne(raw(referencedDTag: ''));
+
+        expect(result, isA<VideoNotification>());
+        final video = result! as VideoNotification;
+        expect(video.videoAddressableId, isNull);
+      });
 
       test('returns null for like with null referencedEventId', () async {
         stubProfiles({

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1682,6 +1682,17 @@ class _VideoRouteCandidate {
       );
     }
 
+    // Raw NIP-33 addressable coordinate: "kind:pubkey:d-tag"
+    // Produced by VideoNotification.videoAddressableId for stable notification
+    // navigation. AId.fromString validates the format and extracts the d-tag.
+    final aid = AId.fromString(trimmed);
+    if (aid != null && NIP71VideoKinds.isVideoKind(aid.kind)) {
+      return _VideoRouteCandidate(
+        addressableId: trimmed,
+        stableId: aid.dTag,
+      );
+    }
+
     return _VideoRouteCandidate(stableId: trimmed);
   }
 }

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6613,7 +6613,8 @@ void main() {
               'd695f6b60119d9521934a691347d9f78'
               'e8770b56da16bb255ee77ac112b4c1f6';
           const author =
-              '4bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+              '4bf0c63fcb93463407af97a5e5ee64fa'
+              '883d107ef9e558472c4eb9aaaefa459d';
           const dTag = 'my-vine-id';
           // Raw addressable coordinate as produced by
           // VideoNotification.videoAddressableId — no bech32 encoding.
@@ -6635,8 +6636,9 @@ void main() {
             funnelcakeApiClient: mockFunnelcakeClient,
           );
 
-          final result =
-              await repo.fetchVideoWithStatsForRouteId(rawAddressableId);
+          final result = await repo.fetchVideoWithStatsForRouteId(
+            rawAddressableId,
+          );
 
           expect(result, isNotNull);
           expect(result!.id, equals(eventId));

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6607,6 +6607,54 @@ void main() {
       });
 
       test(
+        'resolves raw kind:pubkey:d-tag addressable IDs via addressable lookup',
+        () async {
+          const eventId =
+              'd695f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
+          const author =
+              '4bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+          const dTag = 'my-vine-id';
+          // Raw addressable coordinate as produced by
+          // VideoNotification.videoAddressableId — no bech32 encoding.
+          const rawAddressableId = '34236:$author:$dTag';
+          final event = _createVideoEventWithDTag(
+            id: eventId,
+            pubkey: author,
+            dTag: dTag,
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result =
+              await repo.fetchVideoWithStatsForRouteId(rawAddressableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.vineId, equals(dTag));
+
+          // Verify the relay was queried by author + d-tag, not by event ID.
+          final captured =
+              verify(
+                    () => mockNostrClient.queryEvents(captureAny()),
+                  ).captured.single
+                  as List<Filter>;
+          expect(captured, hasLength(1));
+          expect(captured.single.authors, equals([author]));
+          expect(captured.single.d, equals([dTag]));
+        },
+      );
+
+      test(
         'resolves plain stable IDs from local storage before relay',
         () async {
           const eventId =

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -8,17 +8,30 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
 import 'package:openvine/notifications/widgets/notification_empty_state.dart';
 import 'package:openvine/notifications/widgets/notification_list_item.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 class _MockNotificationFeedBloc
     extends MockBloc<NotificationFeedEvent, NotificationFeedState>
     implements NotificationFeedBloc {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 /// Pumps [NotificationsView] inside the required providers.
 Future<void> _pumpView(
@@ -40,6 +53,68 @@ Future<void> _pumpView(
     ),
   );
 }
+
+Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
+  WidgetTester tester,
+  NotificationFeedBloc bloc, {
+  required VideoEventService videoEventService,
+  required NostrClient nostrClient,
+  required VideosRepository videosRepository,
+}) async {
+  final capturedArgs = <PooledFullscreenVideoFeedArgs>[];
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(
+          body: NotificationsView(),
+        ),
+      ),
+      GoRoute(
+        path: PooledFullscreenVideoFeedScreen.path,
+        builder: (context, state) {
+          capturedArgs.add(state.extra! as PooledFullscreenVideoFeedArgs);
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        videoEventServiceProvider.overrideWithValue(videoEventService),
+        nostrServiceProvider.overrideWithValue(nostrClient),
+        videosRepositoryProvider.overrideWithValue(videosRepository),
+      ],
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: ThemeData.dark(),
+        routerConfig: router,
+        builder: (context, child) => BlocProvider<NotificationFeedBloc>.value(
+          value: bloc,
+          child: child ?? const SizedBox.shrink(),
+        ),
+      ),
+    ),
+  );
+
+  return capturedArgs;
+}
+
+VideoEvent _video(String id) => VideoEvent(
+  id: id,
+  pubkey: 'pubkey_$id',
+  createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
+  timestamp: DateTime(2026),
+  content: 'content',
+  title: 'title',
+  videoUrl: 'https://example.com/$id.mp4',
+  thumbnailUrl: 'https://example.com/$id.jpg',
+);
 
 void main() {
   group(NotificationsView, () {
@@ -194,6 +269,73 @@ void main() {
           () => mockBloc.add(NotificationFeedItemTapped('n1')),
         ).called(1);
       });
+
+      testWidgets(
+        'comment notification fetches by addressable id and opens comments',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const staleVideoEventId = 'stale_video_event';
+          const addressableId =
+              '34236:'
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+              ':vine-id';
+          final resolvedVideo = _video('replacement_video_event');
+
+          when(
+            () => videoService.getVideoById(staleVideoEventId),
+          ).thenReturn(null);
+          when(
+            () => nostrClient.fetchEventById(staleVideoEventId),
+          ).thenAnswer((_) async => null);
+          when(
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).thenAnswer((_) async => resolvedVideo);
+          when(
+            () => videoService.shouldHideVideo(resolvedVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                VideoNotification(
+                  id: 'comment-notification',
+                  type: NotificationKind.comment,
+                  videoEventId: staleVideoEventId,
+                  videoAddressableId: addressableId,
+                  actors: const [
+                    ActorInfo(pubkey: 'actor_pubkey', displayName: 'Alice'),
+                  ],
+                  totalCount: 1,
+                  timestamp: DateTime(2026),
+                ),
+              ],
+            ),
+          );
+
+          final capturedArgs = await _pumpRoutedView(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verify(
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).called(1);
+          expect(capturedArgs, hasLength(1));
+          final args = capturedArgs.single;
+          expect(args.autoOpenComments, isTrue);
+          final videos = await args.videosStream.first;
+          expect(videos.single.id, resolvedVideo.id);
+        },
+      );
     });
 
     group('kindFilter', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
After a video metadata update the event ID changes (NIP-33 replacement)but the d-tag (vineId) stays the same. Notifications stored the old event ID, causing 'Video not found' on tap and a blank thumbnail because the stats lookup 404'd on the stale ID.

- Parse referenced_d_tag and referenced_video.thumbnail from the notification API response into RelayNotification
- Build the stable NIP-33 coordinate (34236:pubkey:d-tag) in NotificationRepository using the known user pubkey + d_tag
- Add videoAddressableId to VideoNotification and use it as the primary navigation target in _navigateToVideo
- Teach _VideoRouteCandidate.parse to handle raw kind:pubkey:d-tag strings so fetchVideoWithStatsForRouteId resolves them correctly
- Use referenced_video.thumbnail directly so the thumbnail stays visible even when the event ID-based stats lookup returns 404

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3948

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore