### PR TITLE
fix(android): satisfy network security lint

### DIFF
--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -15,8 +15,8 @@
          The Dart-side source of truth for the emulator-host loopback is
          `localHost` in mobile/lib/models/environment_config.dart. -->
     <domain-config cleartextTrafficPermitted="true">
-        <domain>10.0.2.2</domain>
-        <domain>localhost</domain>
-        <domain>127.0.0.1</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Closes #4009

## Summary
- add explicit includeSubdomains="false" to Android loopback-only network security domains
- fixes release lint failure in :app:lintVitalRelease for network_security_config.xml

## Verification
- reproduced the Codemagic failure locally with flutter build apk --release: :app:lintVitalRelease failed on missing includeSubdomains for 10.0.2.2, localhost, and 127.0.0.1
- reran flutter build apk --release after the fix; lintVitalRelease no longer failed and the build advanced to :app:packageRelease
- local build then stopped at release signing because local SigningConfig lacks storeFile; Codemagic has the signing config
- git merge-base --is-ancestor origin/main HEAD
- pre-push checks passed; no Dart files changed, Dart checks skipped