### PR TITLE
fix(captions): strip leaked LLM prompt directives from transcripts

### DIFF
--- a/mobile/lib/providers/subtitle_providers.dart
+++ b/mobile/lib/providers/subtitle_providers.dart
@@ -11,6 +11,7 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/subtitle_service.dart';
+import 'package:openvine/services/transcript_sanitizer.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'subtitle_providers.g.dart';
@@ -51,6 +52,45 @@ Uri? _parseHttpSubtitleUrl(String? textTrackRef) {
   return uri;
 }
 
+/// Parses VTT and strips leaked LLM prompt directives from each cue.
+///
+/// Single funnel for all four subtitle sources (REST embedded, direct HTTP,
+/// Blossom, relay). The transcription pipeline occasionally appends prompt
+/// scaffolding to cue text (#3737); sanitization is content-level domain
+/// logic and lives at this composition layer rather than in the VTT parser.
+List<SubtitleCue> _parseAndSanitize(String vtt) {
+  final raw = SubtitleService.parseVtt(vtt);
+  final cleaned = <SubtitleCue>[];
+  var truncated = 0;
+  var dropped = 0;
+
+  for (final cue in raw) {
+    final sanitized = TranscriptSanitizer.sanitize(cue.text);
+    if (sanitized == null || sanitized.isEmpty) {
+      dropped++;
+      continue;
+    }
+    if (sanitized != cue.text) {
+      truncated++;
+      cleaned.add(
+        SubtitleCue(start: cue.start, end: cue.end, text: sanitized),
+      );
+    } else {
+      cleaned.add(cue);
+    }
+  }
+
+  if (truncated > 0 || dropped > 0) {
+    developer.log(
+      'Sanitized leaked prompt directives from cues '
+      '(truncated=$truncated, dropped=$dropped)',
+      name: 'subtitleCues',
+    );
+  }
+
+  return cleaned;
+}
+
 Future<List<SubtitleCue>?> _fetchBlossomSubtitles({
   required http.Client client,
   required SubtitlePollDelay delay,
@@ -62,7 +102,7 @@ Future<List<SubtitleCue>?> _fetchBlossomSubtitles({
     final response = await client.get(vttUrl);
 
     if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
-      return SubtitleService.parseVtt(response.body);
+      return _parseAndSanitize(response.body);
     }
 
     if (response.statusCode == 202) {
@@ -109,7 +149,7 @@ Future<List<SubtitleCue>> subtitleCues(
 }) async {
   // Fast path: REST API already embedded the VTT content
   if (textTrackContent != null && textTrackContent.isNotEmpty) {
-    return SubtitleService.parseVtt(textTrackContent);
+    return _parseAndSanitize(textTrackContent);
   }
 
   final directSubtitleUrl = _parseHttpSubtitleUrl(textTrackRef);
@@ -118,7 +158,7 @@ Future<List<SubtitleCue>> subtitleCues(
     try {
       final response = await client.get(directSubtitleUrl);
       if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
-        return SubtitleService.parseVtt(response.body);
+        return _parseAndSanitize(response.body);
       }
     } catch (e) {
       developer.log(
@@ -176,7 +216,7 @@ Future<List<SubtitleCue>> subtitleCues(
   );
 
   if (events.isEmpty) return [];
-  return SubtitleService.parseVtt(events.first.content);
+  return _parseAndSanitize(events.first.content);
 }
 
 /// Tracks global subtitle visibility (CC on/off).

--- a/mobile/lib/providers/subtitle_providers.g.dart
+++ b/mobile/lib/providers/subtitle_providers.g.dart
@@ -119,7 +119,7 @@ final class SubtitleCuesProvider
   }
 }
 
-String _$subtitleCuesHash() => r'2fe38ed9a65de84798b6903ab9c7bb8aaf36b8e7';
+String _$subtitleCuesHash() => r'7da3f43b8359e99d0a97bbb8e5c2c29316c26fff';
 
 /// Fetches subtitle cues for a video, using the fastest available path.
 ///

--- a/mobile/lib/services/subtitle_service.dart
+++ b/mobile/lib/services/subtitle_service.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Service for parsing WebVTT subtitle content into cue objects.
 // ABOUTME: Handles VTT parsing and generation for the subtitle pipeline.
-
-import 'package:openvine/services/transcript_sanitizer.dart';
+// ABOUTME: Pure format handling — content-level filtering (e.g. stripping
+// ABOUTME: leaked AI prompts) lives in the subtitleCues provider, not here.
 
 /// A single subtitle cue with timing and text.
 class SubtitleCue {
@@ -54,18 +54,13 @@ class SubtitleService {
             i++;
           }
           if (textLines.isNotEmpty) {
-            final sanitized = TranscriptSanitizer.sanitize(
-              textLines.join('\n'),
+            cues.add(
+              SubtitleCue(
+                start: timing.$1,
+                end: timing.$2,
+                text: textLines.join('\n'),
+              ),
             );
-            if (sanitized != null && sanitized.isNotEmpty) {
-              cues.add(
-                SubtitleCue(
-                  start: timing.$1,
-                  end: timing.$2,
-                  text: sanitized,
-                ),
-              );
-            }
           }
         } else {
           i++;

--- a/mobile/lib/services/subtitle_service.dart
+++ b/mobile/lib/services/subtitle_service.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Service for parsing WebVTT subtitle content into cue objects.
 // ABOUTME: Handles VTT parsing and generation for the subtitle pipeline.
 
+import 'package:openvine/services/transcript_sanitizer.dart';
+
 /// A single subtitle cue with timing and text.
 class SubtitleCue {
   const SubtitleCue({
@@ -52,13 +54,18 @@ class SubtitleService {
             i++;
           }
           if (textLines.isNotEmpty) {
-            cues.add(
-              SubtitleCue(
-                start: timing.$1,
-                end: timing.$2,
-                text: textLines.join('\n'),
-              ),
+            final sanitized = TranscriptSanitizer.sanitize(
+              textLines.join('\n'),
             );
+            if (sanitized != null && sanitized.isNotEmpty) {
+              cues.add(
+                SubtitleCue(
+                  start: timing.$1,
+                  end: timing.$2,
+                  text: sanitized,
+                ),
+              );
+            }
           }
         } else {
           i++;

--- a/mobile/lib/services/transcript_sanitizer.dart
+++ b/mobile/lib/services/transcript_sanitizer.dart
@@ -15,6 +15,12 @@
 ///
 /// This is a server-side defect, but until upstream fixes propagate, the
 /// client must not surface those phrases as captions.
+///
+// TODO(divinevideo/divine-funnelcake#343): Retire this client sanitizer
+// once funnelcake (1) refuses to serve polluted VTTs (E1) and (2) ships
+// constrained-decoding in the transcription post-processor (D). User-signed
+// Kind 39307 events bypass funnelcake — a narrow client defense may stay
+// for that path even after backend lands.
 class TranscriptSanitizer {
   /// Phrases that signal AI prompt instructions leaking into a caption.
   ///

--- a/mobile/lib/services/transcript_sanitizer.dart
+++ b/mobile/lib/services/transcript_sanitizer.dart
@@ -45,9 +45,11 @@ class TranscriptSanitizer {
   /// Returns [text] with any trailing leaked prompt directive removed, or
   /// `null` if the entire string is prompt content with nothing real to keep.
   ///
-  /// Truncation point is the last sentence terminator (`.`, `!`, `?`) before
-  /// the earliest matched marker. If no terminator precedes the marker, the
-  /// whole string is dropped.
+  /// Truncation prefers the last sentence terminator (`.`, `!`, `?`) before
+  /// the earliest matched marker. When no terminator precedes the marker
+  /// (e.g. trailing-off speech, multi-line cues without punctuation), falls
+  /// back to truncating at the marker boundary so real content is preserved.
+  /// Returns `null` only when the recovered prefix is empty after trimming.
   static String? sanitize(String text) {
     if (text.isEmpty) return text;
 
@@ -69,11 +71,10 @@ class TranscriptSanitizer {
     final beforeMarker = text.substring(0, earliestMarkerIndex);
     final lastSentenceEnd = _lastSentenceTerminator(beforeMarker);
 
-    if (lastSentenceEnd == -1) {
-      return null;
-    }
-
-    final truncated = text.substring(0, lastSentenceEnd + 1).trim();
+    final cutoff = lastSentenceEnd >= 0
+        ? lastSentenceEnd + 1
+        : earliestMarkerIndex;
+    final truncated = text.substring(0, cutoff).trim();
     return truncated.isEmpty ? null : truncated;
   }
 

--- a/mobile/lib/services/transcript_sanitizer.dart
+++ b/mobile/lib/services/transcript_sanitizer.dart
@@ -1,0 +1,87 @@
+// ABOUTME: Strips leaked AI prompt instructions from transcript/caption text.
+// ABOUTME: Defense-in-depth for upstream transcription pipelines that
+// ABOUTME: occasionally concatenate prompt scaffolding into cue text.
+
+/// Sanitizes transcript text against leaked LLM prompt instructions.
+///
+/// The upstream transcription pipeline can concatenate prompt scaffolding
+/// (instructions about producing JSON output, schema directives, etc.) into
+/// the actual transcribed cue text — see issue #3737, where a vine
+/// transcript ended with
+///
+///   "... a single JSON array. Do not include any extra text outside of the
+///   JSON string. When producing JSON you must follow the schema provided
+///   in the context."
+///
+/// This is a server-side defect, but until upstream fixes propagate, the
+/// client must not surface those phrases as captions.
+class TranscriptSanitizer {
+  /// Phrases that signal AI prompt instructions leaking into a caption.
+  ///
+  /// Each entry is matched case-insensitively as a substring. Phrases were
+  /// chosen to be highly specific to LLM-output directives — they are
+  /// extremely unlikely to appear in conversational speech that captions
+  /// typically transcribe.
+  static const List<String> _promptMarkers = [
+    'a single json array',
+    'a single json object',
+    'do not include any extra text',
+    'outside of the json',
+    'follow the schema provided',
+    'schema provided in the context',
+    'when producing json',
+    'when producing the json',
+    'you must follow the schema',
+    'as a json array',
+    'as a json object',
+    'respond with a json',
+    'respond only with json',
+    'output only json',
+    'output a json',
+    'return a json',
+    'return only json',
+  ];
+
+  /// Returns [text] with any trailing leaked prompt directive removed, or
+  /// `null` if the entire string is prompt content with nothing real to keep.
+  ///
+  /// Truncation point is the last sentence terminator (`.`, `!`, `?`) before
+  /// the earliest matched marker. If no terminator precedes the marker, the
+  /// whole string is dropped.
+  static String? sanitize(String text) {
+    if (text.isEmpty) return text;
+
+    final lower = text.toLowerCase();
+    var earliestMarkerIndex = -1;
+
+    for (final marker in _promptMarkers) {
+      final idx = lower.indexOf(marker);
+      if (idx >= 0 &&
+          (earliestMarkerIndex == -1 || idx < earliestMarkerIndex)) {
+        earliestMarkerIndex = idx;
+      }
+    }
+
+    if (earliestMarkerIndex == -1) {
+      return text;
+    }
+
+    final beforeMarker = text.substring(0, earliestMarkerIndex);
+    final lastSentenceEnd = _lastSentenceTerminator(beforeMarker);
+
+    if (lastSentenceEnd == -1) {
+      return null;
+    }
+
+    final truncated = text.substring(0, lastSentenceEnd + 1).trim();
+    return truncated.isEmpty ? null : truncated;
+  }
+
+  static int _lastSentenceTerminator(String text) {
+    for (var i = text.length - 1; i >= 0; i--) {
+      final c = text[i];
+      if (c == '.' || c == '!' || c == '?') return i;
+    }
+    return -1;
+  }
+}

--- a/mobile/test/providers/subtitle_providers_test.dart
+++ b/mobile/test/providers/subtitle_providers_test.dart
@@ -457,6 +457,132 @@ void main() {
       expect(cues, isEmpty);
     });
   });
+
+  group('subtitleCues prompt-leak sanitization (#3737)', () {
+    test(
+      'strips leaked LLM directives from embedded textTrackContent',
+      () async {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        // Verbatim VTT served by media.divine.video for the issue's video.
+        const pollutedVtt =
+            'WEBVTT\n'
+            '\n'
+            '1\n'
+            '00:00:00.000 --> 00:00:01.000\n'
+            'And I promise you, if I get elected, freedom is the only '
+            "option. Well, that's not really freedom now, is it, you "
+            'freaking idiot? a single JSON array. Do not include any '
+            'extra text outside of the JSON string. When producing '
+            'JSON you must follow the schema provided in the context.\n';
+
+        final cues = await container.read(
+          subtitleCuesProvider(
+            videoId: 'test-id',
+            textTrackContent: pollutedVtt,
+          ).future,
+        );
+
+        expect(cues, hasLength(1));
+        expect(
+          cues[0].text,
+          equals(
+            'And I promise you, if I get elected, freedom is the only '
+            "option. Well, that's not really freedom now, is it, you "
+            'freaking idiot?',
+          ),
+        );
+      },
+    );
+
+    test('strips leaked LLM directives from Blossom-served VTT', () async {
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      const pollutedVtt =
+          'WEBVTT\n'
+          '\n'
+          '1\n'
+          '00:00:00.000 --> 00:00:01.000\n'
+          'Hello world. a single JSON array. Do not include any extra '
+          'text outside of the JSON.\n';
+
+      when(() => mockHttpClient.get(any())).thenAnswer(
+        (_) async => http.Response(pollutedVtt, 200),
+      );
+
+      final cues = await container.read(
+        subtitleCuesProvider(videoId: 'test-id', sha256: 'abc123').future,
+      );
+
+      expect(cues, hasLength(1));
+      expect(cues[0].text, equals('Hello world.'));
+    });
+
+    test('strips leaked LLM directives from relay-served VTT', () async {
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      when(
+        () => mockNostrClient.queryEvents(
+          any(),
+          tempRelays: any(named: 'tempRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          Event(
+            testPubkey,
+            39307,
+            [
+              ['d', 'subtitles:test-vine-id'],
+              ['m', 'text/vtt'],
+            ],
+            'WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\n'
+            'Real line! When producing JSON you must follow the schema.\n',
+            createdAt: 1757385263,
+          ),
+        ],
+      );
+
+      final cues = await container.read(
+        subtitleCuesProvider(
+          videoId: 'test-id',
+          textTrackRef: '39307:$testPubkey:subtitles:test-vine-id',
+        ).future,
+      );
+
+      expect(cues, hasLength(1));
+      expect(cues[0].text, equals('Real line!'));
+    });
+
+    test('drops cue whose entire text is prompt content', () async {
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      const pollutedVtt =
+          'WEBVTT\n'
+          '\n'
+          '1\n'
+          '00:00:00.000 --> 00:00:01.000\n'
+          'a single JSON array do not include any extra text\n'
+          '\n'
+          '2\n'
+          '00:00:01.000 --> 00:00:02.000\n'
+          'Real caption.\n';
+
+      final cues = await container.read(
+        subtitleCuesProvider(
+          videoId: 'test-id',
+          textTrackContent: pollutedVtt,
+        ).future,
+      );
+
+      expect(cues, hasLength(1));
+      expect(cues[0].text, equals('Real caption.'));
+      expect(cues[0].start, equals(1000));
+    });
+  });
 }
 
 /// Fake Notifier that returns a pre-configured mock NostrClient.

--- a/mobile/test/services/subtitle_service_test.dart
+++ b/mobile/test/services/subtitle_service_test.dart
@@ -90,49 +90,26 @@ void main() {
         expect(cues[0].text, equals('Valid cue'));
       });
 
-      test('strips leaked LLM prompt directives from cue text (#3737)', () {
-        const vtt =
-            'WEBVTT\n'
-            '\n'
-            '1\n'
-            '00:00:00.000 --> 00:00:01.000\n'
-            'And I promise you, if I get elected, freedom is the only '
-            "option. Well, that's not really freedom now, is it, you "
-            'freaking idiot? a single JSON array. Do not include any '
-            'extra text outside of the JSON string. When producing '
-            'JSON you must follow the schema provided in the context.\n';
+      test(
+        'returns cue text verbatim — no content filtering at this layer',
+        () {
+          // Content-level filtering (e.g. stripping leaked LLM prompts) lives
+          // in the subtitleCues provider, not in the parser. See #3737.
+          const vtt =
+              'WEBVTT\n'
+              '\n'
+              '00:00:00.000 --> 00:00:01.000\n'
+              'a single JSON array do not include any extra text\n';
 
-        final cues = SubtitleService.parseVtt(vtt);
+          final cues = SubtitleService.parseVtt(vtt);
 
-        expect(cues, hasLength(1));
-        expect(
-          cues[0].text,
-          equals(
-            'And I promise you, if I get elected, freedom is the only '
-            "option. Well, that's not really freedom now, is it, you "
-            'freaking idiot?',
-          ),
-        );
-      });
-
-      test('drops cue whose text is entirely prompt content', () {
-        const vtt =
-            'WEBVTT\n'
-            '\n'
-            '1\n'
-            '00:00:00.000 --> 00:00:01.000\n'
-            'a single JSON array do not include any extra text\n'
-            '\n'
-            '2\n'
-            '00:00:01.000 --> 00:00:02.000\n'
-            'Real caption.\n';
-
-        final cues = SubtitleService.parseVtt(vtt);
-
-        expect(cues, hasLength(1));
-        expect(cues[0].text, equals('Real caption.'));
-        expect(cues[0].start, equals(1000));
-      });
+          expect(cues, hasLength(1));
+          expect(
+            cues[0].text,
+            equals('a single JSON array do not include any extra text'),
+          );
+        },
+      );
     });
 
     group('generateVtt', () {

--- a/mobile/test/services/subtitle_service_test.dart
+++ b/mobile/test/services/subtitle_service_test.dart
@@ -89,6 +89,50 @@ void main() {
         expect(cues, hasLength(1));
         expect(cues[0].text, equals('Valid cue'));
       });
+
+      test('strips leaked LLM prompt directives from cue text (#3737)', () {
+        const vtt =
+            'WEBVTT\n'
+            '\n'
+            '1\n'
+            '00:00:00.000 --> 00:00:01.000\n'
+            'And I promise you, if I get elected, freedom is the only '
+            "option. Well, that's not really freedom now, is it, you "
+            'freaking idiot? a single JSON array. Do not include any '
+            'extra text outside of the JSON string. When producing '
+            'JSON you must follow the schema provided in the context.\n';
+
+        final cues = SubtitleService.parseVtt(vtt);
+
+        expect(cues, hasLength(1));
+        expect(
+          cues[0].text,
+          equals(
+            'And I promise you, if I get elected, freedom is the only '
+            "option. Well, that's not really freedom now, is it, you "
+            'freaking idiot?',
+          ),
+        );
+      });
+
+      test('drops cue whose text is entirely prompt content', () {
+        const vtt =
+            'WEBVTT\n'
+            '\n'
+            '1\n'
+            '00:00:00.000 --> 00:00:01.000\n'
+            'a single JSON array do not include any extra text\n'
+            '\n'
+            '2\n'
+            '00:00:01.000 --> 00:00:02.000\n'
+            'Real caption.\n';
+
+        final cues = SubtitleService.parseVtt(vtt);
+
+        expect(cues, hasLength(1));
+        expect(cues[0].text, equals('Real caption.'));
+        expect(cues[0].start, equals(1000));
+      });
     });
 
     group('generateVtt', () {

--- a/mobile/test/services/transcript_sanitizer_test.dart
+++ b/mobile/test/services/transcript_sanitizer_test.dart
@@ -1,0 +1,119 @@
+// ABOUTME: Tests for TranscriptSanitizer.
+// ABOUTME: Pins behavior against the leaked-prompt example from issue #3737
+// ABOUTME: and guards against false positives on conversational speech.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/transcript_sanitizer.dart';
+
+void main() {
+  group(TranscriptSanitizer, () {
+    group('sanitize', () {
+      test('passes through normal speech unchanged', () {
+        const text = 'Hello world, this is a regular caption.';
+        expect(TranscriptSanitizer.sanitize(text), equals(text));
+      });
+
+      test('passes through empty string unchanged', () {
+        expect(TranscriptSanitizer.sanitize(''), equals(''));
+      });
+
+      test('strips trailing leaked LLM prompt from issue #3737', () {
+        // Verbatim cue text from the bug report.
+        const polluted =
+            'And I promise you, if I get elected, freedom is the only '
+            "option. Well, that's not really freedom now, is it, you "
+            'freaking idiot? a single JSON array. Do not include any extra '
+            'text outside of the JSON string. When producing JSON you must '
+            'follow the schema provided in the context.';
+
+        const expected =
+            'And I promise you, if I get elected, freedom is the only '
+            "option. Well, that's not really freedom now, is it, you "
+            'freaking idiot?';
+
+        expect(TranscriptSanitizer.sanitize(polluted), equals(expected));
+      });
+
+      test('strips "do not include any extra text" directive', () {
+        const polluted =
+            'This is real content. Do not include any extra text outside '
+            'of the JSON.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('This is real content.'),
+        );
+      });
+
+      test('strips "follow the schema provided in the context" directive', () {
+        const polluted =
+            'Real transcribed line! follow the schema provided in the '
+            'context.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('Real transcribed line!'),
+        );
+      });
+
+      test('matches markers case-insensitively', () {
+        const polluted =
+            'Hello there. A SINGLE JSON ARRAY. Do Not Include Any Extra '
+            'Text outside of the JSON.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('Hello there.'),
+        );
+      });
+
+      test('returns null when entire text is prompt content', () {
+        const onlyPrompt =
+            'a single JSON array do not include any extra text outside '
+            'of the JSON';
+        expect(TranscriptSanitizer.sanitize(onlyPrompt), isNull);
+      });
+
+      test('returns null when no sentence terminator precedes marker', () {
+        const noTerminator =
+            'and then a single JSON array do not include any extra text';
+        expect(TranscriptSanitizer.sanitize(noTerminator), isNull);
+      });
+
+      test('truncates at the earliest marker among multiple', () {
+        const polluted =
+            'Real content here. When producing JSON you must follow the '
+            'schema. Do not include any extra text outside of the JSON.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('Real content here.'),
+        );
+      });
+
+      test('keeps multi-sentence content before marker', () {
+        const polluted =
+            'First sentence. Second sentence! Third sentence? a single '
+            'JSON array.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('First sentence. Second sentence! Third sentence?'),
+        );
+      });
+
+      test('handles "respond with a json" variant', () {
+        const polluted =
+            'Hello world. Respond with a JSON object containing the '
+            'transcription.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('Hello world.'),
+        );
+      });
+
+      test('handles "output only json" variant', () {
+        const polluted = 'Hello world. Output only JSON without commentary.';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('Hello world.'),
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/services/transcript_sanitizer_test.dart
+++ b/mobile/test/services/transcript_sanitizer_test.dart
@@ -64,17 +64,39 @@ void main() {
         );
       });
 
-      test('returns null when entire text is prompt content', () {
+      test('returns null when text starts with a prompt marker', () {
         const onlyPrompt =
             'a single JSON array do not include any extra text outside '
             'of the JSON';
         expect(TranscriptSanitizer.sanitize(onlyPrompt), isNull);
       });
 
-      test('returns null when no sentence terminator precedes marker', () {
-        const noTerminator =
-            'and then a single JSON array do not include any extra text';
-        expect(TranscriptSanitizer.sanitize(noTerminator), isNull);
+      test(
+        'falls back to marker-boundary truncation when no terminator precedes',
+        () {
+          // Real content has no sentence terminator (trailing-off speech, or
+          // a multi-line cue with line 1 ending mid-thought). Recover the
+          // pre-marker fragment instead of dropping the whole cue.
+          const noTerminator =
+              'and then a single JSON array do not include any extra text';
+          expect(
+            TranscriptSanitizer.sanitize(noTerminator),
+            equals('and then'),
+          );
+        },
+      );
+
+      test('strips marker on second line of multi-line cue', () {
+        // Cues join lines with \n. If the marker appears on line 2 and line 1
+        // ends without punctuation, fallback truncation should still recover
+        // line 1.
+        const polluted =
+            'Hello there\n'
+            'a single JSON array do not include any extra text';
+        expect(
+          TranscriptSanitizer.sanitize(polluted),
+          equals('Hello there'),
+        );
       });
 
       test('truncates at the earliest marker among multiple', () {


### PR DESCRIPTION
## Summary

Closes #3737.

The upstream transcription pipeline occasionally concatenates LLM prompt scaffolding onto the actual transcribed text, which then ships in the VTT served from `media.divine.video/{sha256}/vtt`. The reported video's VTT, fetched verbatim:

```
WEBVTT

1
00:00:00.000 --> 00:00:01.000
And I promise you, if I get elected, freedom is the only option. Well, that's not really freedom now, is it, you freaking idiot? a single JSON array. Do not include any extra text outside of the JSON string. When producing JSON you must follow the schema provided in the context.
```

The bolded tail is leaked LLM directives, not anything the speaker said.

The real fix lives in the transcription pipeline (out of scope for this repo). This PR is defense-in-depth on the client so already-published videos stop surfacing those phrases.

- Add `TranscriptSanitizer` (`mobile/lib/services/transcript_sanitizer.dart`) — case-insensitive substring matcher against a small set of LLM-output directive phrases ("a single JSON array", "do not include any extra text", "follow the schema provided in the context", "when producing JSON", "respond with a JSON", etc.). On match, truncates the cue at the last sentence terminator before the earliest marker; if no terminator precedes the marker, drops the cue.
- Wire it into `SubtitleService.parseVtt` so all four subtitle paths (REST embedded, Blossom, direct HTTP, relay event) flow through the sanitizer automatically.
- Pin behavior with the verbatim issue text in tests.

## Test plan
- [x] `flutter test test/services/transcript_sanitizer_test.dart` — 12 cases incl. issue #3737 verbatim
- [x] `flutter test test/services/subtitle_service_test.dart` — preserves existing parseVtt behavior + 2 new sanitizer integration cases
- [x] `flutter test test/providers/subtitle_providers_test.dart` — 15 existing cases still green
- [x] `flutter analyze lib/services/transcript_sanitizer.dart lib/services/subtitle_service.dart test/services/transcript_sanitizer_test.dart test/services/subtitle_service_test.dart` — clean
- [x] `dart format` — clean
- [ ] Manual: confirm captions on https://divine.video/video/4ad97fcf5fee46f7cf4b794b355e6fb0ee08c0e35d80098b926cf2441ba582e3 no longer show the trailing prompt directives in mobile