### PR TITLE
fix(settings): accept lowercase input for deletion confirmation

### DIFF
--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -147,7 +147,8 @@ Future<void> showDeleteAllContentWarningDialog({
             ),
           ),
           ElevatedButton(
-            onPressed: confirmationController.text == requiredText
+            onPressed:
+                confirmationController.text.trim().toUpperCase() == requiredText
                 ? () {
                     context.pop();
                     onConfirm();

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -1,0 +1,141 @@
+// ABOUTME: Tests for the delete account confirmation dialog
+// ABOUTME: Verifies that the DELETE confirmation is case-insensitive and trims whitespace
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/widgets/delete_account_dialog.dart';
+
+/// Minimal router wrapper so [context.pop()] works inside the dialog.
+Widget _wrapWithRouter(Widget child) {
+  final router = GoRouter(
+    routes: [GoRoute(path: '/', builder: (_, state) => child)],
+  );
+  return MaterialApp.router(routerConfig: router);
+}
+
+Future<void> _showDialog(WidgetTester tester, {VoidCallback? onConfirm}) async {
+  await tester.pumpWidget(
+    _wrapWithRouter(
+      Builder(
+        builder: (context) => Scaffold(
+          body: ElevatedButton(
+            key: const Key('open'),
+            onPressed: () => showDeleteAllContentWarningDialog(
+              context: context,
+              onConfirm: onConfirm ?? () {},
+            ),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.byKey(const Key('open')));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('showDeleteAllContentWarningDialog – confirmation input', () {
+    testWidgets('empty string keeps Delete button disabled', (tester) async {
+      await _showDialog(tester);
+
+      // Button should be disabled (onPressed == null → tapping does nothing)
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('wrong word keeps Delete button disabled', (tester) async {
+      await _showDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'confirm');
+      await tester.pump();
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('exact uppercase DELETE enables the button', (tester) async {
+      await _showDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'DELETE');
+      await tester.pump();
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('lowercase delete enables the button', (tester) async {
+      await _showDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'delete');
+      await tester.pump();
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('mixed case Delete enables the button', (tester) async {
+      await _showDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'Delete');
+      await tester.pump();
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('DELETE with trailing whitespace enables the button', (
+      tester,
+    ) async {
+      await _showDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'DELETE ');
+      await tester.pump();
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('delete with leading whitespace enables the button', (
+      tester,
+    ) async {
+      await _showDialog(tester);
+
+      await tester.enterText(find.byType(TextField), ' delete');
+      await tester.pump();
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('tapping enabled button calls onConfirm', (tester) async {
+      var called = false;
+      await _showDialog(tester, onConfirm: () => called = true);
+
+      await tester.enterText(find.byType(TextField), 'delete');
+      await tester.pump();
+
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, 'Delete All Content'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(called, isTrue);
+    });
+  });
+}


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Keyboard autocapitalization is a hint, not enforcement. Samsung keyboards, predictive text, voice input, and paste all insert lowercase 'delete', making the button appear permanently unresponsive

Change the comparison to trim() + toUpperCase() so any casing of the word is accepted while preserving the destructive-action friction.

Add widget tests covering empty, wrong word, uppercase, lowercase, mixed-case, leading/trailing whitespace, and confirmed tap cases.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3858

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore