### PR TITLE
fix(video): restore fullscreen engagement stats

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -221,6 +221,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     var video = await videosRepository.fetchVideoWithStats(
       resolvedVideoEventId,
     );
+    if (!context.mounted) return;
 
     // Keep a defensive fallback for the rare case where the repository misses
     // but the event is still available directly from the service / relay.
@@ -228,6 +229,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     if (video == null) {
       try {
         final event = await nostrService.fetchEventById(resolvedVideoEventId);
+        if (!context.mounted) return;
         if (event != null) {
           video = VideoEvent.fromNostrEvent(event);
         }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -142,10 +142,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
                             _onItemTap(context, notification),
                         onProfileTap: (pubkey) =>
                             _navigateToProfile(context, pubkey),
-                        onFollowBack: (pubkey) =>
-                            context.read<NotificationFeedBloc>().add(
-                              NotificationFeedFollowBack(pubkey),
-                            ),
+                        onFollowBack: (pubkey) => context
+                            .read<NotificationFeedBloc>()
+                            .add(NotificationFeedFollowBack(pubkey)),
                       ),
                     ),
           };
@@ -165,11 +164,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
     switch (notification) {
       case VideoNotification(:final videoEventId, :final type):
-        await _navigateToVideo(
-          context,
-          videoEventId,
-          notificationKind: type,
-        );
+        await _navigateToVideo(context, videoEventId, notificationKind: type);
       case ActorNotification(:final actor, :final type):
         switch (type) {
           case NotificationKind.follow:
@@ -202,6 +197,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
     final videoEventService = ref.read(videoEventServiceProvider);
     final nostrService = ref.read(nostrServiceProvider);
+    final videosRepository = ref.read(videosRepositoryProvider);
 
     // Resolve the target event ID to a video event ID.
     final resolver = NotificationTargetResolver(
@@ -214,16 +210,21 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     if (!context.mounted) return;
 
     if (resolvedVideoEventId == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Video not found')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Video not found')));
       return;
     }
 
-    // Get video from video event service.
-    var video = videoEventService.getVideoById(resolvedVideoEventId);
+    // Notification entry should use the same hydrated fetch path as feed and
+    // deep-link routes so fullscreen stats don't regress to zero.
+    var video = await videosRepository.fetchVideoWithStats(
+      resolvedVideoEventId,
+    );
 
-    // If not found in cache, try fetching from Nostr.
+    // Keep a defensive fallback for the rare case where the repository misses
+    // but the event is still available directly from the service / relay.
+    video ??= videoEventService.getVideoById(resolvedVideoEventId);
     if (video == null) {
       try {
         final event = await nostrService.fetchEventById(resolvedVideoEventId);
@@ -322,11 +323,7 @@ class _FailureBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(
-            Icons.error_outline,
-            size: 64,
-            color: VineTheme.lightText,
-          ),
+          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
           const SizedBox(height: 16),
           const Text(
             'Failed to load notifications',
@@ -379,9 +376,7 @@ class _NotificationList extends StatelessWidget {
           return const Padding(
             padding: EdgeInsets.all(16),
             child: Center(
-              child: CircularProgressIndicator(
-                color: VineTheme.vineGreen,
-              ),
+              child: CircularProgressIndicator(color: VineTheme.vineGreen),
             ),
           );
         }

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -201,6 +201,16 @@ class ProfileFeed extends _$ProfileFeed {
       if (leftVideo.rawTags['views'] != rightVideo.rawTags['views']) {
         return false;
       }
+      if (leftVideo.originalLikes != rightVideo.originalLikes) return false;
+      if (leftVideo.originalComments != rightVideo.originalComments) {
+        return false;
+      }
+      if (leftVideo.originalReposts != rightVideo.originalReposts) {
+        return false;
+      }
+      if (leftVideo.nostrLikeCount != rightVideo.nostrLikeCount) {
+        return false;
+      }
     }
     return true;
   }
@@ -656,6 +666,10 @@ class ProfileFeed extends _$ProfileFeed {
       return video.copyWith(
         rawTags: mergedTags,
         originalLoops: stats.loops ?? video.originalLoops,
+        originalLikes: video.originalLikes ?? stats.reactions,
+        originalComments: video.originalComments ?? stats.comments,
+        originalReposts: video.originalReposts ?? stats.reposts,
+        nostrLikeCount: video.nostrLikeCount ?? 0,
       );
     }).toList();
     return hydrated;
@@ -719,13 +733,15 @@ class ProfileFeed extends _$ProfileFeed {
           video.rawTags['views'] != null ||
           video.originalLikes != null ||
           video.originalComments != null ||
-          video.originalReposts != null) {
+          video.originalReposts != null ||
+          video.nostrLikeCount != null) {
         _metadataCache[video.id.toLowerCase()] = _VideoMetadataCache(
           originalLoops: video.originalLoops,
           views: video.rawTags['views'],
           originalLikes: video.originalLikes,
           originalComments: video.originalComments,
           originalReposts: video.originalReposts,
+          nostrLikeCount: video.nostrLikeCount,
         );
       }
     }
@@ -743,6 +759,7 @@ class ProfileFeed extends _$ProfileFeed {
         originalLikes: cached.originalLikes,
         originalComments: cached.originalComments,
         originalReposts: cached.originalReposts,
+        nostrLikeCount: cached.nostrLikeCount,
       );
     }).toList();
   }
@@ -755,6 +772,7 @@ class ProfileFeed extends _$ProfileFeed {
     int? originalLikes,
     int? originalComments,
     int? originalReposts,
+    int? nostrLikeCount,
   }) {
     final currentViews = video.rawTags['views'];
     final shouldApply =
@@ -762,7 +780,8 @@ class ProfileFeed extends _$ProfileFeed {
         (currentViews == null && views != null) ||
         (video.originalLikes == null && originalLikes != null) ||
         (video.originalComments == null && originalComments != null) ||
-        (video.originalReposts == null && originalReposts != null);
+        (video.originalReposts == null && originalReposts != null) ||
+        (video.nostrLikeCount == null && nostrLikeCount != null);
 
     if (!shouldApply) return video;
 
@@ -774,6 +793,7 @@ class ProfileFeed extends _$ProfileFeed {
       originalLikes: video.originalLikes ?? originalLikes,
       originalComments: video.originalComments ?? originalComments,
       originalReposts: video.originalReposts ?? originalReposts,
+      nostrLikeCount: video.nostrLikeCount ?? nostrLikeCount,
     );
   }
 
@@ -1080,6 +1100,7 @@ class _VideoMetadataCache {
     this.originalLikes,
     this.originalComments,
     this.originalReposts,
+    this.nostrLikeCount,
   });
 
   final int? originalLoops;
@@ -1087,4 +1108,5 @@ class _VideoMetadataCache {
   final int? originalLikes;
   final int? originalComments;
   final int? originalReposts;
+  final int? nostrLikeCount;
 }

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'f8606985db746c3f71d554faef261c5fdbe23055';
+String _$profileFeedHash() => r'802733be8b9a6d5ab6c4930677d862398f7c1a59';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -222,7 +222,12 @@ class VideosRepository {
         .where(
           (video) =>
               video.id.isNotEmpty &&
-              (video.originalLoops == null || video.rawTags['views'] == null),
+              (video.originalLoops == null ||
+                  video.rawTags['views'] == null ||
+                  video.originalLikes == null ||
+                  video.originalComments == null ||
+                  video.originalReposts == null ||
+                  video.nostrLikeCount == null),
         )
         .toList();
     if (videosNeedingStats.isEmpty) return videos;
@@ -248,6 +253,14 @@ class VideosRepository {
 
         return video.copyWith(
           originalLoops: stats.loops ?? video.originalLoops,
+          originalLikes: video.originalLikes ?? stats.reactions,
+          originalComments: video.originalComments ?? stats.comments,
+          originalReposts: video.originalReposts ?? stats.reposts,
+          // REST reaction totals already include the Nostr portion for the
+          // fullscreen entry paths that rely on this hydration. Seeding
+          // nostrLikeCount to 0 preserves totalLikes while still telling the
+          // interactions bloc it has an initial count to display.
+          nostrLikeCount: video.nostrLikeCount ?? 0,
           rawTags: video.rawTags['views'] == null && stats.views != null
               ? {...video.rawTags, 'views': stats.views.toString()}
               : video.rawTags,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6154,46 +6154,53 @@ void main() {
         expect(result, isNull);
       });
 
-      test('merges loop count from bulk-stats into returned video', () async {
-        const eventId = 'abc123';
-        final nostrEvent = _createVideoEvent(
-          id: eventId,
-          pubkey: 'pubkey-1',
-          videoUrl: 'https://example.com/video.mp4',
-          createdAt: 1739350000,
-        );
+      test(
+        'merges engagement metadata from bulk-stats into returned video',
+        () async {
+          const eventId = 'abc123';
+          final nostrEvent = _createVideoEvent(
+            id: eventId,
+            pubkey: 'pubkey-1',
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+          );
 
-        when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => [nostrEvent]);
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [nostrEvent]);
 
-        when(
-          () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
-        ).thenAnswer(
-          (_) async => const BulkVideoStatsResponse(
-            stats: {
-              eventId: BulkVideoStatsEntry(
-                eventId: eventId,
-                reactions: 0,
-                comments: 0,
-                reposts: 0,
-                loops: 42,
-                views: 100,
-              ),
-            },
-          ),
-        );
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+          ).thenAnswer(
+            (_) async => const BulkVideoStatsResponse(
+              stats: {
+                eventId: BulkVideoStatsEntry(
+                  eventId: eventId,
+                  reactions: 7,
+                  comments: 5,
+                  reposts: 3,
+                  loops: 42,
+                  views: 100,
+                ),
+              },
+            ),
+          );
 
-        final repo = VideosRepository(
-          nostrClient: mockNostrClient,
-          funnelcakeApiClient: mockFunnelcakeClient,
-        );
-        final result = await repo.fetchVideoWithStats(eventId);
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+          final result = await repo.fetchVideoWithStats(eventId);
 
-        expect(result, isNotNull);
-        expect(result!.originalLoops, equals(42));
-        expect(result.rawTags['views'], equals('100'));
-      });
+          expect(result, isNotNull);
+          expect(result!.originalLoops, equals(42));
+          expect(result.rawTags['views'], equals('100'));
+          expect(result.originalLikes, equals(7));
+          expect(result.originalComments, equals(5));
+          expect(result.originalReposts, equals(3));
+          expect(result.nostrLikeCount, equals(0));
+        },
+      );
 
       test(
         'returns video without stats when Funnelcake is unavailable',
@@ -6300,9 +6307,9 @@ void main() {
             createdAt: 1739350000,
           );
 
-          when(() => mockLocalStorage.getEventsByIds([eventId])).thenAnswer(
-            (_) async => [event],
-          );
+          when(
+            () => mockLocalStorage.getEventsByIds([eventId]),
+          ).thenAnswer((_) async => [event]);
 
           final repo = VideosRepository(
             nostrClient: mockNostrClient,
@@ -6356,58 +6363,52 @@ void main() {
         },
       );
 
-      test(
-        'falls back to stable-id lookup when a 64-char hex route is not an '
-        'event id',
-        () async {
-          const hexStableId =
-              'cdb77b012caba00133fc071b568e334b27'
-              '9947f09d30df0ce819aedcd777b749';
-          const eventId =
-              'd695f6b60119d9521934a691347d9f78e8'
-              '770b56da16bb255ee77ac112b4c1f6';
-          const author =
-              '5bf0c63fcb93463407af97a5e5ee64fa88'
-              '3d107ef9e558472c4eb9aaaefa459d';
-          final event = _createVideoEvent(
-            id: eventId,
-            pubkey: author,
-            videoUrl: 'https://example.com/video.mp4',
-            createdAt: 1739350000,
-            extraTags: [
-              ['d', hexStableId],
-            ],
-          );
+      test('falls back to stable-id lookup when a 64-char hex route is not an '
+          'event id', () async {
+        const hexStableId =
+            'cdb77b012caba00133fc071b568e334b27'
+            '9947f09d30df0ce819aedcd777b749';
+        const eventId =
+            'd695f6b60119d9521934a691347d9f78e8'
+            '770b56da16bb255ee77ac112b4c1f6';
+        const author =
+            '5bf0c63fcb93463407af97a5e5ee64fa88'
+            '3d107ef9e558472c4eb9aaaefa459d';
+        final event = _createVideoEvent(
+          id: eventId,
+          pubkey: author,
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: 1739350000,
+          extraTags: [
+            ['d', hexStableId],
+          ],
+        );
 
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
-            invocation,
-          ) async {
-            final filters =
-                invocation.positionalArguments.single as List<Filter>;
-            final filter = filters.single;
-            if (filter.ids?.contains(hexStableId) ?? false) {
-              return <Event>[];
-            }
-            if (filter.d?.contains(hexStableId) ?? false) {
-              return [event];
-            }
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments.single as List<Filter>;
+          final filter = filters.single;
+          if (filter.ids?.contains(hexStableId) ?? false) {
             return <Event>[];
-          });
+          }
+          if (filter.d?.contains(hexStableId) ?? false) {
+            return [event];
+          }
+          return <Event>[];
+        });
 
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(
-            hexStableId,
-          );
+        final result = await repo.fetchVideoWithStatsForRouteId(hexStableId);
 
-          expect(result, isNotNull);
-          expect(result!.id, equals(eventId));
-          expect(result.stableId, equals(hexStableId));
-        },
-      );
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+        expect(result.stableId, equals(hexStableId));
+      });
 
       test(
         'falls back to stable-id lookup for acceptable legacy video kinds',
@@ -6454,9 +6455,7 @@ void main() {
             funnelcakeApiClient: mockFunnelcakeClient,
           );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(
-            hexStableId,
-          );
+          final result = await repo.fetchVideoWithStatsForRouteId(hexStableId);
 
           expect(result, isNotNull);
           expect(result!.id, equals(eventId));
@@ -6464,53 +6463,50 @@ void main() {
         },
       );
 
-      test(
-        'falls back to Funnelcake route lookup when relay misses shared '
-        'stable ID',
-        () async {
-          const stableId =
-              'e96357668c72c8923340b0ecf4bfacea'
-              '505172c4190e9953e603124c67175f3b';
-          const eventId =
-              'e46ff7d0d71d6c8114b58728afa43f08'
-              'd6286fd9a704683af799fd8f855586c2';
-          final relayMissThenApiHit = Event.fromJson({
-            'id': eventId,
-            'pubkey':
-                '076c979382b90f5d3a2b21f95e1ee86b'
-                '6033f14c92e79b7fad3fe1f1073f4886',
-            'created_at': 1777868006,
-            'kind': 34236,
-            'tags': [
-              ['d', stableId],
-              ['url', 'https://media.divine.video/$stableId'],
-              ['title', 'Divine team swag'],
-            ],
-            'content': 'Divine team swag!',
-            'sig': 'sig',
-          });
+      test('falls back to Funnelcake route lookup when relay misses shared '
+          'stable ID', () async {
+        const stableId =
+            'e96357668c72c8923340b0ecf4bfacea'
+            '505172c4190e9953e603124c67175f3b';
+        const eventId =
+            'e46ff7d0d71d6c8114b58728afa43f08'
+            'd6286fd9a704683af799fd8f855586c2';
+        final relayMissThenApiHit = Event.fromJson({
+          'id': eventId,
+          'pubkey':
+              '076c979382b90f5d3a2b21f95e1ee86b'
+              '6033f14c92e79b7fad3fe1f1073f4886',
+          'created_at': 1777868006,
+          'kind': 34236,
+          'tags': [
+            ['d', stableId],
+            ['url', 'https://media.divine.video/$stableId'],
+            ['title', 'Divine team swag'],
+          ],
+          'content': 'Divine team swag!',
+          'sig': 'sig',
+        });
 
-          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => <Event>[],
-          );
-          when(
-            () => mockFunnelcakeClient.getVideoEvent(stableId),
-          ).thenAnswer((_) async => relayMissThenApiHit);
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => <Event>[]);
+        when(
+          () => mockFunnelcakeClient.getVideoEvent(stableId),
+        ).thenAnswer((_) async => relayMissThenApiHit);
 
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+        final result = await repo.fetchVideoWithStatsForRouteId(stableId);
 
-          expect(result, isNotNull);
-          expect(result!.id, equals(eventId));
-          expect(result.stableId, equals(stableId));
-          verify(() => mockFunnelcakeClient.getVideoEvent(stableId)).called(1);
-        },
-      );
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+        expect(result.stableId, equals(stableId));
+        verify(() => mockFunnelcakeClient.getVideoEvent(stableId)).called(1);
+      });
 
       test('returns blocked-author videos for direct route lookups', () async {
         const stableId =
@@ -6530,9 +6526,9 @@ void main() {
           ],
         );
 
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [blockedEvent],
-        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [blockedEvent]);
 
         final repo = VideosRepository(
           nostrClient: mockNostrClient,

--- a/mobile/test/providers/profile_feed_provider_test.dart
+++ b/mobile/test/providers/profile_feed_provider_test.dart
@@ -220,15 +220,35 @@ void main() {
       });
 
       test(
+        'cached metadata rehydrates engagement counts onto relay profile videos',
+        () {
+          final relayVideo = createTestVideo(
+            'id1',
+            'pubkey1',
+            'stable1',
+            baseTime,
+          );
+
+          final hydrated = ProfileFeed.applyCachedMetadataForVideo(
+            relayVideo,
+            originalLikes: 12,
+            originalComments: 4,
+            originalReposts: 2,
+            nostrLikeCount: 0,
+          );
+
+          expect(hydrated.originalLikes, equals(12));
+          expect(hydrated.originalComments, equals(4));
+          expect(hydrated.originalReposts, equals(2));
+          expect(hydrated.nostrLikeCount, equals(0));
+        },
+      );
+
+      test(
         'sequence comparison treats views-only metadata changes as updates',
         () {
           final stale = [
-            createTestVideo(
-              'id1',
-              'pubkey1',
-              'stable1',
-              baseTime,
-            ),
+            createTestVideo('id1', 'pubkey1', 'stable1', baseTime),
           ];
           final enriched = [
             createTestVideo(
@@ -246,24 +266,33 @@ void main() {
         },
       );
 
+      test('sequence comparison treats originalLoops changes as updates', () {
+        final stale = [createTestVideo('id1', 'pubkey1', 'stable1', baseTime)];
+        final enriched = [
+          createTestVideo(
+            'id1',
+            'pubkey1',
+            'stable1',
+            baseTime,
+          ).copyWith(originalLoops: 100),
+        ];
+
+        expect(ProfileFeed.sameVideoSequenceForMerge(stale, enriched), isFalse);
+      });
+
       test(
-        'sequence comparison treats originalLoops changes as updates',
+        'sequence comparison treats engagement-only metadata changes as updates',
         () {
           final stale = [
-            createTestVideo(
-              'id1',
-              'pubkey1',
-              'stable1',
-              baseTime,
-            ),
+            createTestVideo('id1', 'pubkey1', 'stable1', baseTime),
           ];
           final enriched = [
-            createTestVideo(
-              'id1',
-              'pubkey1',
-              'stable1',
-              baseTime,
-            ).copyWith(originalLoops: 100),
+            createTestVideo('id1', 'pubkey1', 'stable1', baseTime).copyWith(
+              originalLikes: 12,
+              originalComments: 4,
+              originalReposts: 2,
+              nostrLikeCount: 0,
+            ),
           ];
 
           expect(

--- a/mobile/test/screens/notifications_navigation_test.dart
+++ b/mobile/test/screens/notifications_navigation_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -14,6 +15,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_notifications_provider.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/notifications_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/notification_list_item.dart';
@@ -55,10 +57,18 @@ void main() {
     required VideoEventService videoEventService,
     required NostrClient nostrClient,
     required VideosRepository videosRepository,
+    GoRouter? router,
   }) {
     final mockInviteCubit = _MockInviteStatusCubit();
     when(() => mockInviteCubit.state).thenReturn(const InviteStatusState());
     when(mockInviteCubit.load).thenAnswer((_) async {});
+    final home = BlocProvider<InviteStatusCubit>.value(
+      value: mockInviteCubit,
+      child: const Scaffold(
+        body: NotificationsScreen(skipInitialBootstrapForTesting: true),
+      ),
+    );
+
     return ProviderScope(
       overrides: [
         relayNotificationsProvider.overrideWith(notifierFactory),
@@ -66,16 +76,21 @@ void main() {
         nostrServiceProvider.overrideWithValue(nostrClient),
         videosRepositoryProvider.overrideWithValue(videosRepository),
       ],
-      child: MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: BlocProvider<InviteStatusCubit>.value(
-          value: mockInviteCubit,
-          child: const Scaffold(
-            body: NotificationsScreen(skipInitialBootstrapForTesting: true),
-          ),
-        ),
-      ),
+      child: router == null
+          ? MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: home,
+            )
+          : MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+              builder: (context, child) => BlocProvider<InviteStatusCubit>.value(
+                value: mockInviteCubit,
+                child: child ?? const SizedBox.shrink(),
+              ),
+            ),
     );
   }
 
@@ -102,12 +117,99 @@ void main() {
   ], 'comment body');
 
   group('NotificationsScreen Navigation', () {
+    testWidgets('hydrated repository fetch pushes fullscreen video route', (
+      WidgetTester tester,
+    ) async {
+      final mockVideoService = _MockVideoEventService();
+      final mockNostrClient = _MockNostrClient();
+      final mockVideosRepository = _MockVideosRepository();
+      final resolvedVideo = video('video_root_1');
+      when(
+        () => mockVideoService.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
+
+      when(
+        () => mockVideoService.getVideoById('comment_event_1'),
+      ).thenReturn(null);
+      when(
+        () => mockNostrClient.fetchEventById('comment_event_1'),
+      ).thenAnswer((_) async => commentEvent(rootVideoId: 'video_root_1'));
+      when(
+        () => mockVideosRepository.fetchVideoWithStats('video_root_1'),
+      ).thenAnswer((_) async => resolvedVideo);
+      when(
+        () => mockVideoService.shouldHideVideo(resolvedVideo),
+      ).thenReturn(false);
+
+      PooledFullscreenVideoFeedArgs? capturedArgs;
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const Scaffold(
+              body: NotificationsScreen(skipInitialBootstrapForTesting: true),
+            ),
+          ),
+          GoRoute(
+            path: PooledFullscreenVideoFeedScreen.path,
+            builder: (context, state) {
+              capturedArgs = state.extra! as PooledFullscreenVideoFeedArgs;
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      final notifier = _MockRelayNotifications([
+        NotificationModel(
+          id: 'notif-comment',
+          type: NotificationType.comment,
+          actorPubkey: 'a' * 64,
+          actorName: 'Commenter',
+          message: 'commented on your video',
+          timestamp: DateTime.now(),
+          targetEventId: 'comment_event_1',
+        ),
+      ]);
+
+      await tester.pumpWidget(
+        buildScreen(
+          () => notifier,
+          videoEventService: mockVideoService,
+          nostrClient: mockNostrClient,
+          videosRepository: mockVideosRepository,
+          router: router,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(NotificationListItem).first);
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockVideosRepository.fetchVideoWithStats('video_root_1'),
+      ).called(1);
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.initialIndex, 0);
+      expect(capturedArgs!.contextTitle, 'From Notification');
+      expect(capturedArgs!.autoOpenComments, isTrue);
+
+      final videos = await capturedArgs!.videosStream.first;
+      expect(videos, hasLength(1));
+      expect(videos.single.id, resolvedVideo.id);
+    });
+
     testWidgets('comment target id resolves to parent video', (
       WidgetTester tester,
     ) async {
       final mockVideoService = _MockVideoEventService();
       final mockNostrClient = _MockNostrClient();
       final mockVideosRepository = _MockVideosRepository();
+      when(
+        () => mockVideoService.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
 
       final resolvedVideo = video('video_root_1');
 
@@ -168,6 +270,9 @@ void main() {
       final mockVideoService = _MockVideoEventService();
       final mockNostrClient = _MockNostrClient();
       final mockVideosRepository = _MockVideosRepository();
+      when(
+        () => mockVideoService.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
 
       when(() => mockVideoService.getVideoById(any())).thenReturn(null);
       when(

--- a/mobile/test/screens/notifications_navigation_test.dart
+++ b/mobile/test/screens/notifications_navigation_test.dart
@@ -86,10 +86,11 @@ void main() {
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
               routerConfig: router,
-              builder: (context, child) => BlocProvider<InviteStatusCubit>.value(
-                value: mockInviteCubit,
-                child: child ?? const SizedBox.shrink(),
-              ),
+              builder: (context, child) =>
+                  BlocProvider<InviteStatusCubit>.value(
+                    value: mockInviteCubit,
+                    child: child ?? const SizedBox.shrink(),
+                  ),
             ),
     );
   }


### PR DESCRIPTION
Closes #4014

## Summary
- route notification video opens through the hydrated repository fetch path instead of a raw event path
- hydrate fullscreen/profile entry videos with loops, views, likes, comments, reposts, and initial like counts from bulk stats
- treat engagement-only metadata changes as meaningful profile feed updates so fullscreen stats refresh correctly

## Testing
- flutter test test/screens/notifications_navigation_test.dart
- flutter test packages/videos_repository/test/src/videos_repository_test.dart --plain-name "fetchVideoWithStats"
- flutter test test/providers/profile_feed_provider_test.dart
- flutter analyze lib/notifications/view/notifications_view.dart lib/providers/profile_feed_provider.dart test/providers/profile_feed_provider_test.dart test/screens/notifications_navigation_test.dart
- flutter analyze lib/src/videos_repository.dart test/src/videos_repository_test.dart
