### PR TITLE
fix(reports): use environment relay for content reports

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1976,15 +1976,17 @@ CurationRepository curationRepository(Ref ref) {
 // Legacy ExploreVideoManager removed - functionality replaced by pure Riverpod video providers
 
 /// Content reporting service for NIP-56 compliance
-@riverpod
+@Riverpod(keepAlive: true)
 Future<ContentReportingService> contentReportingService(Ref ref) async {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
+  final env = ref.read(currentEnvironmentProvider);
   final service = ContentReportingService(
     nostrService: nostrService,
     authService: authService,
     prefs: prefs,
+    moderationRelayUrl: env.relayUrl,
   );
 
   // Initialize the service to enable reporting

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1976,12 +1976,12 @@ CurationRepository curationRepository(Ref ref) {
 // Legacy ExploreVideoManager removed - functionality replaced by pure Riverpod video providers
 
 /// Content reporting service for NIP-56 compliance
-@Riverpod(keepAlive: true)
+@riverpod
 Future<ContentReportingService> contentReportingService(Ref ref) async {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
-  final env = ref.read(currentEnvironmentProvider);
+  final env = ref.watch(currentEnvironmentProvider);
   final service = ContentReportingService(
     nostrService: nostrService,
     authService: authService,

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -3921,7 +3921,7 @@ final class ContentReportingServiceProvider
         argument: null,
         retry: null,
         name: r'contentReportingServiceProvider',
-        isAutoDispose: false,
+        isAutoDispose: true,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -3942,7 +3942,7 @@ final class ContentReportingServiceProvider
 }
 
 String _$contentReportingServiceHash() =>
-    r'b246ddd7f795dcf5adb837e3530bbc21c2c14fa8';
+    r'5f32ae82aae7471e3e3dd008a011607def6bc149';
 
 /// Lists state notifier - manages curated lists state
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -3921,7 +3921,7 @@ final class ContentReportingServiceProvider
         argument: null,
         retry: null,
         name: r'contentReportingServiceProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -94,18 +94,17 @@ class ContentReportingService {
     required NostrClient nostrService,
     required AuthService authService,
     required SharedPreferences prefs,
+    required String moderationRelayUrl,
   }) : _nostrService = nostrService,
        _authService = authService,
-       _prefs = prefs {
+       _prefs = prefs,
+       _moderationRelayUrl = moderationRelayUrl {
     _loadReportHistory();
   }
   final NostrClient _nostrService;
   final AuthService _authService;
   final SharedPreferences _prefs;
-
-  // Divine moderation relay for reports
-  static const String moderationRelayUrl =
-      'wss://relay.divine.video'; // Divine moderation relay
+  final String _moderationRelayUrl;
   static const String reportsStorageKey = 'content_reports_history';
 
   final List<ContentReport> _reportHistory = [];
@@ -181,7 +180,7 @@ class ContentReportingService {
 
       final sentEvent = await _nostrService.publishEvent(
         reportEvent,
-        targetRelays: [moderationRelayUrl],
+        targetRelays: [_moderationRelayUrl],
       );
       if (sentEvent is! PublishSuccess) {
         Log.error(

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -631,7 +631,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       await stagingService.reportContent(
         eventId: 'evt_relay',

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -70,6 +70,7 @@ void main() {
         nostrService: mockNostrService,
         authService: mockAuthService,
         prefs: prefs,
+        moderationRelayUrl: 'wss://relay.divine.video',
       );
 
       await service.initialize();
@@ -92,6 +93,7 @@ void main() {
           nostrService: mockNostrService,
           authService: mockAuthService,
           prefs: prefs,
+          moderationRelayUrl: 'wss://relay.divine.video',
         );
 
         await uninitializedService.initialize();
@@ -107,6 +109,7 @@ void main() {
         nostrService: mockNostrService,
         authService: mockAuthService,
         prefs: prefs,
+        moderationRelayUrl: 'wss://relay.divine.video',
       );
 
       final result = await uninitializedService.reportContent(
@@ -539,6 +542,7 @@ void main() {
         nostrService: mockNostrService,
         authService: mockAuthService,
         prefs: prefs,
+        moderationRelayUrl: 'wss://relay.divine.video',
       );
       await service.initialize();
     });
@@ -581,6 +585,65 @@ void main() {
           kind: EventKind.report,
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+        ),
+      ).called(1);
+
+      verify(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: ['wss://relay.divine.video'],
+        ),
+      ).called(1);
+    });
+
+    test('publishes report to the configured moderation relay', () async {
+      const customRelay = 'wss://relay.staging.dvines.org';
+      SharedPreferences.setMockInitialValues({});
+      final testPrefs = await SharedPreferences.getInstance();
+      final stagingService = ContentReportingService(
+        nostrService: mockNostrService,
+        authService: mockAuthService,
+        prefs: testPrefs,
+        moderationRelayUrl: customRelay,
+      );
+      await stagingService.initialize();
+
+      final reportEvent = Event(
+        testPublicKey,
+        EventKind.report,
+        [],
+        'test',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      reportEvent.id = 'test_id';
+      reportEvent.sig = 'test_sig';
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      await stagingService.reportContent(
+        eventId: 'evt_relay',
+        authorPubkey: 'author_relay',
+        reason: ContentFilterReason.other,
+        details: 'relay routing test',
+      );
+
+      verify(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: [customRelay],
         ),
       ).called(1);
     });
@@ -747,6 +810,7 @@ void main() {
         nostrService: mockNostrService,
         authService: mockAuthService,
         prefs: prefs,
+        moderationRelayUrl: 'wss://relay.divine.video',
       );
       await service.initialize(); // This is what the provider now does
 


### PR DESCRIPTION
## Summary

- Content reports (Kind 1984) were hardcoded to `wss://relay.divine.video`, ignoring the app's environment configuration
- Reports now target the relay from `EnvironmentConfig.relayUrl`, so staging/test builds send reports to the correct environment relay
- `ContentReportingService` accepts `moderationRelayUrl` as a constructor parameter instead of using a static constant
- The reporting provider remains auto-dispose and now watches `currentEnvironmentProvider`, so it stays aligned with runtime environment changes without caching a stale relay URL or stale initialization state

## Known limitation

This fix routes reports to the environment's default relay, which solves the single-relay staging/test case. When connected to multiple relays, reports still go to the environment default rather than the relay the reported content was fetched from. A full fix would thread `Event.sources` from the nostr SDK through `VideoEvent` into `reportContent()`. See #4019 for details.

## Test plan

- [x] Staging build sends Kind 1984 reports to `wss://relay.staging.dvines.org`
- [x] Production build continues to send reports to `wss://relay.divine.video`
- [x] `flutter test --no-pub test/services/content_reporting_service_test.dart`
- [x] `flutter test --no-pub test/widgets/report_content_dialog_test.dart`
- [x] `flutter analyze`

Relates to #4019