### PR TITLE
fix(profile): preserve verified NIP-05 handle on profile edits

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -377,10 +377,18 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         ? null
         : event.externalNip05?.trim().toLowerCase();
 
-    // Explicitly clear NIP-05 when in divine mode with no username. Without
-    // this flag, saveProfileEvent would silently preserve the existing NIP-05
-    // from currentProfile.rawData even though the user opted out of both modes.
-    final clearNip05 = !isExternal && username == null;
+    // Only clear NIP-05 when the user explicitly removes a verified handle
+    // they were known to have: their initialUsername or initialExternalNip05
+    // was loaded by the editor and they are now opting out of it.
+    //
+    // When both are null the editor never loaded the user's existing NIP-05
+    // (e.g. relay race returning an older Kind 0, stale cache). Treating that
+    // as an opt-out would silently destroy a verified handle the user never
+    // intended to remove — exactly the bug that caused #4012.
+    final clearNip05 =
+        !isExternal &&
+        username == null &&
+        (state.initialUsername != null || state.initialExternalNip05 != null);
     final picture = (event.picture?.trim().isEmpty ?? true)
         ? null
         : event.picture;

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -517,11 +517,20 @@ class ProfileRepository {
         nip05 ??
         (username != null ? '_@${username.toLowerCase()}.divine.video' : null);
 
+    // Funnelcake REST API profiles have rawData: {} but nip05 populated on
+    // the object. Fall back to the field so a profile round-trip through the
+    // REST API doesn't silently drop the verified handle from the Kind 0.
+    final existingNip05 =
+        (currentProfile?.rawData.containsKey('nip05') ?? false)
+        ? null // rawData has it; the spread below carries it through
+        : currentProfile?.nip05;
+    final effectiveNip05 = resolvedNip05 ?? existingNip05;
+
     final profileContent = {
       if (currentProfile != null) ...currentProfile.rawData,
       'display_name': displayName,
       'about': about,
-      'nip05': ?resolvedNip05,
+      'nip05': ?effectiveNip05,
       'picture': picture,
       'banner': banner,
     };

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1597,6 +1597,80 @@ void main() {
         });
 
         test(
+          'preserves nip05 from currentProfile.nip05 when rawData is empty '
+          '(Funnelcake REST API profile with rawData: {})',
+          () async {
+            // Funnelcake profiles have rawData: {} but nip05 on the object.
+            // saveProfileEvent must fall back to the field so editing bio/photo
+            // doesn't silently strip the verified divine.video handle.
+            final funnelcakeProfile = UserProfile(
+              pubkey: testPubkey,
+              displayName: 'Old Name',
+              nip05: '_@ike.divine.video',
+              rawData: const {}, // empty — simulates fromUserProfileFound
+              createdAt: DateTime.now(),
+              eventId: 'rest-$testPubkey',
+            );
+
+            when(() => mockProfileEvent.content).thenReturn(
+              jsonEncode({
+                'display_name': 'New Name',
+                'nip05': '_@ike.divine.video',
+              }),
+            );
+
+            await profileRepository.saveProfileEvent(
+              displayName: 'New Name',
+              currentProfile: funnelcakeProfile,
+            );
+
+            verify(
+              () => mockNostrClient.sendProfile(
+                profileContent: {
+                  'display_name': 'New Name',
+                  'nip05': '_@ike.divine.video',
+                  'about': null,
+                  'picture': null,
+                  'banner': null,
+                },
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
+          'clearNip05 removes nip05 even when sourced from Funnelcake profile '
+          '(rawData: {} but nip05 field set)',
+          () async {
+            final funnelcakeProfile = UserProfile(
+              pubkey: testPubkey,
+              displayName: 'Old Name',
+              nip05: '_@ike.divine.video',
+              rawData: const {},
+              createdAt: DateTime.now(),
+              eventId: 'rest-$testPubkey',
+            );
+
+            await profileRepository.saveProfileEvent(
+              displayName: 'New Name',
+              clearNip05: true,
+              currentProfile: funnelcakeProfile,
+            );
+
+            verify(
+              () => mockNostrClient.sendProfile(
+                profileContent: {
+                  'display_name': 'New Name',
+                  'about': null,
+                  'picture': null,
+                  'banner': null,
+                },
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
           'clearNip05 is a no-op when a new nip05 is also provided',
           () async {
             final currentProfile = await createCurrentProfile({

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -218,7 +218,44 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'passes clearNip05: true when no username in divine mode',
+          'passes clearNip05: false when no username and initialUsername is null '
+          '(profile not loaded — must not destroy an unloaded NIP-05)',
+          setUp: () {
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                picture: testPicture,
+                clearNip05: false,
+              ),
+            ).thenAnswer((_) async => createTestProfile());
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+            ),
+          ),
+          verify: (_) {
+            verify(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                picture: testPicture,
+                clearNip05: false,
+              ),
+            ).called(1);
+          },
+        );
+
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'passes clearNip05: true when user explicitly removes a known username',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
@@ -233,14 +270,20 @@ void main() {
             ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-            ),
-          ),
+          // Dispatch InitialUsernameSet first so the bloc knows the user had
+          // 'testuser' — then saving with no username is an explicit removal.
+          act: (bloc) async {
+            bloc.add(const InitialUsernameSet(testUsername));
+            await Future<void>.delayed(Duration.zero);
+            bloc.add(
+              const ProfileSaved(
+                pubkey: testPubkey,
+                displayName: testDisplayName,
+                about: testAbout,
+                picture: testPicture,
+              ),
+            );
+          },
           verify: (_) {
             verify(
               () => mockProfileRepository.saveProfileEvent(

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -229,7 +229,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
-                clearNip05: false,
+                clearNip05: any(named: 'clearNip05'),
               ),
             ).thenAnswer((_) async => createTestProfile());
           },
@@ -248,7 +248,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
-                clearNip05: false,
+                clearNip05: any(named: 'clearNip05', that: isFalse),
               ),
             ).called(1);
           },


### PR DESCRIPTION
## Summary

- **BLoC fix**: `clearNip05` is only `true` when the editor *knows* the user had a handle (`initialUsername` or `initialExternalNip05` was loaded) and they explicitly removed it. An empty username field that was never populated (relay race, stale cache) no longer counts as an opt-out.
- **Repository fix**: Fall back to `currentProfile.nip05` when `rawData` is empty (Funnelcake REST API profile), so the verified handle is preserved on a profile round-trip through the REST API.

Fixes #4021. Closes #4012.

## Root Cause

When a user edited their bio or photo, `ProfileEditorBloc._saveProfile` set `clearNip05 = true` whenever the username text field was empty — even if the field was empty because the profile **never loaded the username** (a faster relay returned a stale Kind 0 without `nip05`, beating the one that had it). This triggered `profileContent.remove('nip05')`, stripping the verified handle from the published Kind 0 and breaking the name-server pairing permanently.

## Test Plan

- [x] `flutter test test/blocs/profile_editor/profile_editor_bloc_test.dart` — all 59 tests pass, including two new tests:
  - `passes clearNip05: false when no username and initialUsername is null` (the bug case)
  - `passes clearNip05: true when user explicitly removes a known username` (the intentional opt-out case)
- [x] `flutter test packages/profile_repository/test/src/profile_repository_test.dart` — all 174 tests pass, including two new tests for the Funnelcake rawData fallback
- [x] `flutter analyze` — no issues
- [ ] Manual: open Edit Profile, edit bio/photo without touching username, save — verify `nip05` is still present in the published Kind 0 (check relay or app logs)
- [ ] Manual: open Edit Profile, clear the username field, save — verify `nip05` is absent (explicit opt-out still works)