### PR TITLE
fix(video-player): use native Apple loop playback

### DIFF
--- a/docs/superpowers/plans/2026-05-06-seamless-video-looping.md
+++ b/docs/superpowers/plans/2026-05-06-seamless-video-looping.md
@@ -1,0 +1,71 @@
+# Seamless Video Looping Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the Apple playback gap caused by manual end-of-item loop replay.
+
+**Architecture:** Android already uses native ExoPlayer repeat mode and remains unchanged. iOS and macOS should use `AVQueuePlayer` with `AVPlayerLooper` when looping is enabled, while non-looping completion still uses the existing completed-state path.
+
+**Tech Stack:** Flutter package tests, Swift AVFoundation, iOS/macOS native plugin code.
+
+---
+
+### Task 1: Add Apple Looping Contract Test
+
+**Files:**
+- Modify: `mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test for both Apple platform files that expects `AVPlayerLooper`, `AVQueuePlayer`, and no manual `player?.seek(to: .zero)` inside looping completion handling.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test packages/divine_video_player/test/src/apple_threading_contract_test.dart`
+
+Expected: FAIL because current iOS/macOS loop code does not use `AVPlayerLooper`.
+
+### Task 2: Implement Apple Native Looping
+
+**Files:**
+- Modify: `mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift`
+- Modify: `mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift`
+
+- [ ] **Step 1: Add Apple looper state**
+
+Use `AVQueuePlayer` for `player` and add `private var playerLooper: AVPlayerLooper?`.
+
+- [ ] **Step 2: Create or clear the looper when clips/looping change**
+
+After a player item is installed, if `isLooping` is true, create `AVPlayerLooper(player: queuePlayer, templateItem: playerItem)`. If looping is false, clear the looper.
+
+- [ ] **Step 3: Remove manual loop replay**
+
+Update `playerDidFinish()` so looping playback does not seek to zero and replay. It should only handle non-looping completion.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `flutter test packages/divine_video_player/test`
+
+Expected: PASS.
+
+### Task 3: Verify and Commit
+
+**Files:**
+- Check: `git diff`
+- Check: `git status --short`
+
+- [ ] **Step 1: Run analyze for the package**
+
+Run from `mobile/packages/divine_video_player`: `flutter analyze`
+
+Expected: No issues.
+
+- [ ] **Step 2: Commit**
+
+Stage only the spec, plan, test, and Swift files. Commit with:
+
+```bash
+git commit -m "fix(video-player): use native Apple loop playback"
+```
+

--- a/docs/superpowers/specs/2026-05-06-seamless-video-looping-design.md
+++ b/docs/superpowers/specs/2026-05-06-seamless-video-looping-design.md
@@ -1,0 +1,23 @@
+# Seamless Video Looping
+
+**Date:** 2026-05-06
+**Status:** Approved
+
+## Problem
+
+Users report a visible or audible gap when short videos loop. The Apple native player currently waits for `AVPlayerItemDidPlayToEndTime`, then seeks to zero and calls `play()` again. That restart happens only after the item has ended, so it can create a loop boundary gap.
+
+Android already uses ExoPlayer `REPEAT_MODE_ALL`, which is the native repeat path for queued media.
+
+## Design
+
+Keep Android unchanged.
+
+On iOS and macOS, replace manual end-notification loop replay with `AVQueuePlayer` plus `AVPlayerLooper`. Apple documents `AVPlayerLooper` as the AVFoundation API for looping media content through a queue player by inserting replica items. That lets the next loop iteration be queued before the current one ends.
+
+When looping is disabled, Apple playback should preserve the current behavior: send `completed`, pause/deactivate audio overlays, and keep normal end-of-item state updates.
+
+## Testing
+
+Add a native contract test that inspects the Apple Swift sources and fails if loop handling still uses manual end-notification seek/replay instead of `AVPlayerLooper`. Run the focused `divine_video_player` package tests from `mobile/`.
+

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import Flutter
 
-/// Wraps a single AVPlayer fed by an `AVMutableComposition` that
+/// Wraps a single AVQueuePlayer fed by an `AVMutableComposition` that
 /// stitches multiple clips into a seamless timeline.
 ///
 /// Communicates with Dart via per-player MethodChannel/EventChannel.
@@ -11,9 +11,12 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private let methodChannel: FlutterMethodChannel
     private let eventChannel: FlutterEventChannel
 
-    private var player: AVPlayer?
+    private var player: AVQueuePlayer?
+    private var playerLooper: AVPlayerLooper?
+    private var templateItem: AVPlayerItem?
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
+    private var currentItemObservation: NSKeyValueObservation?
     private var statusObservation: NSKeyValueObservation?
     /// One-shot KVO that defers `preroll(atRate:)` until `player.status`
     /// is `.readyToPlay`; calling earlier throws `NSInvalidArgumentException`.
@@ -162,7 +165,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     throw CompositionError.invalidRenderSize
                 }
                 playerItem.videoComposition = avComposition
-                self.textureOutput?.attach(to: playerItem)
+                self.templateItem = playerItem
 
                 let startPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value ?? 0
                 let startTime = startPositionMs > 0
@@ -170,15 +173,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     : CMTime.zero
 
                 if let existing = self.player {
-                    existing.replaceCurrentItem(with: playerItem)
+                    self.configureQueue(with: playerItem)
                     await existing.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
                     self.textureOutput?.forceRefresh(for: startTime)
                 } else {
-                    let newPlayer = AVPlayer(playerItem: playerItem)
+                    let newPlayer = AVQueuePlayer()
                     self.player = newPlayer
                     self.textureOutput?.attachPlayer(newPlayer)
                     self.addTimeObserver()
-                    self.observeStatus()
+                    self.observeCurrentItem()
+                    self.configureQueue(with: playerItem)
                     if startPositionMs > 0 {
                         await newPlayer.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
                     }
@@ -190,7 +194,6 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 // preroll throws before status reaches .readyToPlay.
                 self.safePreroll(at: startTime)
 
-                self.observeEnd(for: self.player!.currentItem!)
                 self.currentStatus = "ready"
                 self.sendStateUpdate()
                 result(nil)
@@ -355,6 +358,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return
         }
         isLooping = loop
+        rebuildQueueForLoopingChange()
         result(nil)
     }
 
@@ -389,7 +393,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         audioOverlayManager.pauseAndDeactivateAll()
         // Pause and clear media so the surface goes blank.
         player?.pause()
-        player?.replaceCurrentItem(with: nil)
+        playerLooper = nil
+        templateItem = nil
+        player?.removeAllItems()
         clipOffsets = []
         clipDurations = []
         clipCount = 0
@@ -458,6 +464,36 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
     }
 
+    private func configureQueue(with item: AVPlayerItem) {
+        guard let player else { return }
+        playerLooper = nil
+        player.removeAllItems()
+        if isLooping {
+            playerLooper = AVPlayerLooper(player: player, templateItem: item)
+        } else {
+            player.insert(item, after: nil)
+        }
+        attachCurrentItemOutputs()
+    }
+
+    private func rebuildQueueForLoopingChange() {
+        guard let player, let item = templateItem else { return }
+        let resumeTime = player.currentTime()
+        let shouldResume = player.rate > 0
+        currentStatus = "ready"
+        configureQueue(with: item)
+        player.seek(to: resumeTime, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
+            guard let self else { return }
+            self.textureOutput?.forceRefresh(for: resumeTime)
+            self.syncAudioOverlays()
+            if shouldResume {
+                self.player?.play()
+                self.player?.rate = Float(self.speed)
+                self.audioOverlayManager.resumeActive(speed: self.speed)
+            }
+        }
+    }
+
     /// Calls `AVPlayer.preroll(atRate:)` only when the player is ready;
     /// otherwise defers via a one-shot KVO on `status`. No-op while
     /// `player.rate != 0` (preroll is only useful when paused).
@@ -491,8 +527,26 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
     }
 
-    private func observeStatus() {
-        statusObservation = player?.currentItem?.observe(
+    private func observeCurrentItem() {
+        currentItemObservation = player?.observe(
+            \.currentItem,
+            options: [.new]
+        ) { [weak self] _, _ in
+            self?.attachCurrentItemOutputs()
+        }
+        attachCurrentItemOutputs()
+    }
+
+    private func attachCurrentItemOutputs() {
+        guard let item = player?.currentItem else { return }
+        textureOutput?.attach(to: item)
+        observeStatus(for: item)
+        observeEnd(for: item)
+    }
+
+    private func observeStatus(for item: AVPlayerItem) {
+        statusObservation?.invalidate()
+        statusObservation = item.observe(
             \.status,
             options: [.new]
         ) { [weak self] item, _ in
@@ -525,16 +579,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     }
 
     @objc private func playerDidFinish() {
-        if isLooping {
-            player?.seek(to: .zero)
-            player?.play()
-            player?.rate = Float(speed)
-            syncAudioOverlays()
-        } else {
-            audioOverlayManager.pauseAndDeactivateAll()
-            currentStatus = "completed"
-            sendStateUpdate()
-        }
+        guard !isLooping else { return }
+        audioOverlayManager.pauseAndDeactivateAll()
+        currentStatus = "completed"
+        sendStateUpdate()
     }
 
     // MARK: - State broadcasting
@@ -693,13 +741,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         statusObservation?.invalidate()
         statusObservation = nil
+        currentItemObservation?.invalidate()
+        currentItemObservation = nil
         pendingPrerollObservation?.invalidate()
         pendingPrerollObservation = nil
         NotificationCenter.default.removeObserver(self)
         textureOutput?.dispose()
         textureOutput = nil
+        playerLooper = nil
         player?.pause()
-        player?.replaceCurrentItem(with: nil)
+        player?.removeAllItems()
         player = nil
         audioOverlayManager.disposeAll()
         eventSink = nil

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import FlutterMacOS
 
-/// Wraps a single AVPlayer fed by an `AVMutableComposition` that
+/// Wraps a single AVQueuePlayer fed by an `AVMutableComposition` that
 /// stitches multiple clips into a seamless timeline (macOS).
 ///
 /// Communicates with Dart via per-player MethodChannel/EventChannel.
@@ -11,9 +11,12 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private let methodChannel: FlutterMethodChannel
     private let eventChannel: FlutterEventChannel
 
-    private var player: AVPlayer?
+    private var player: AVQueuePlayer?
+    private var playerLooper: AVPlayerLooper?
+    private var templateItem: AVPlayerItem?
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
+    private var currentItemObservation: NSKeyValueObservation?
     private var statusObservation: NSKeyValueObservation?
     /// One-shot KVO that defers `preroll(atRate:)` until `player.status`
     /// is `.readyToPlay`; calling earlier throws `NSInvalidArgumentException`.
@@ -159,27 +162,35 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     throw CompositionError.invalidRenderSize
                 }
                 playerItem.videoComposition = avComposition
-                self.textureOutput?.attach(to: playerItem)
+                self.templateItem = playerItem
+
+                let startPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value ?? 0
+                let startTime = startPositionMs > 0
+                    ? CMTime(value: startPositionMs, timescale: 1000)
+                    : CMTime.zero
 
                 if let existing = self.player {
-                    existing.replaceCurrentItem(with: playerItem)
-                    await existing.seek(to: .zero)
-                    self.textureOutput?.forceRefresh(for: .zero)
+                    self.configureQueue(with: playerItem)
+                    await existing.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                    self.textureOutput?.forceRefresh(for: startTime)
                 } else {
-                    let newPlayer = AVPlayer(playerItem: playerItem)
+                    let newPlayer = AVQueuePlayer()
                     self.player = newPlayer
                     self.textureOutput?.attachPlayer(newPlayer)
                     self.addTimeObserver()
-                    self.observeStatus()
-                    self.textureOutput?.forceRefresh(for: .zero)
+                    self.observeCurrentItem()
+                    self.configureQueue(with: playerItem)
+                    if startPositionMs > 0 {
+                        await newPlayer.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                    }
+                    self.textureOutput?.forceRefresh(for: startTime)
                 }
 
-                // Preroll so the texture has a real frame at the start
+                // Preroll so the texture has a real frame at startTime
                 // even while paused. Deferred via safePreroll because
                 // preroll throws before status reaches .readyToPlay.
-                self.safePreroll(at: .zero)
+                self.safePreroll(at: startTime)
 
-                self.observeEnd(for: self.player!.currentItem!)
                 self.currentStatus = "ready"
                 self.sendStateUpdate()
                 result(nil)
@@ -333,6 +344,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return
         }
         isLooping = loop
+        rebuildQueueForLoopingChange()
         result(nil)
     }
 
@@ -365,7 +377,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         audioOverlayManager.pauseAndDeactivateAll()
         // Pause and clear media so the surface goes blank.
         player?.pause()
-        player?.replaceCurrentItem(with: nil)
+        playerLooper = nil
+        templateItem = nil
+        player?.removeAllItems()
         clipOffsets = []
         clipDurations = []
         clipCount = 0
@@ -462,8 +476,56 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
     }
 
-    private func observeStatus() {
-        statusObservation = player?.currentItem?.observe(
+    private func configureQueue(with item: AVPlayerItem) {
+        guard let player else { return }
+        playerLooper = nil
+        player.removeAllItems()
+        if isLooping {
+            playerLooper = AVPlayerLooper(player: player, templateItem: item)
+        } else {
+            player.insert(item, after: nil)
+        }
+        attachCurrentItemOutputs()
+    }
+
+    private func rebuildQueueForLoopingChange() {
+        guard let player, let item = templateItem else { return }
+        let resumeTime = player.currentTime()
+        let shouldResume = player.rate > 0
+        currentStatus = "ready"
+        configureQueue(with: item)
+        player.seek(to: resumeTime, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
+            guard let self else { return }
+            self.textureOutput?.forceRefresh(for: resumeTime)
+            self.syncAudioOverlays()
+            if shouldResume {
+                self.player?.play()
+                self.player?.rate = Float(self.speed)
+                self.audioOverlayManager.resumeActive(speed: self.speed)
+            }
+        }
+    }
+
+    private func observeCurrentItem() {
+        currentItemObservation = player?.observe(
+            \.currentItem,
+            options: [.new]
+        ) { [weak self] _, _ in
+            self?.attachCurrentItemOutputs()
+        }
+        attachCurrentItemOutputs()
+    }
+
+    private func attachCurrentItemOutputs() {
+        guard let item = player?.currentItem else { return }
+        textureOutput?.attach(to: item)
+        observeStatus(for: item)
+        observeEnd(for: item)
+    }
+
+    private func observeStatus(for item: AVPlayerItem) {
+        statusObservation?.invalidate()
+        statusObservation = item.observe(
             \.status,
             options: [.new]
         ) { [weak self] item, _ in
@@ -496,16 +558,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     }
 
     @objc private func playerDidFinish() {
-        if isLooping {
-            player?.seek(to: .zero)
-            player?.play()
-            player?.rate = Float(speed)
-            syncAudioOverlays()
-        } else {
-            audioOverlayManager.pauseAndDeactivateAll()
-            currentStatus = "completed"
-            sendStateUpdate()
-        }
+        guard !isLooping else { return }
+        audioOverlayManager.pauseAndDeactivateAll()
+        currentStatus = "completed"
+        sendStateUpdate()
     }
 
     // MARK: - State broadcasting
@@ -660,14 +716,17 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         statusObservation?.invalidate()
         statusObservation = nil
+        currentItemObservation?.invalidate()
+        currentItemObservation = nil
         pendingPrerollObservation?.invalidate()
         pendingPrerollObservation = nil
         NotificationCenter.default.removeObserver(self)
-        player?.pause()
-        player?.replaceCurrentItem(with: nil)
-        player = nil
         textureOutput?.dispose()
         textureOutput = nil
+        playerLooper = nil
+        player?.pause()
+        player?.removeAllItems()
+        player = nil
         audioOverlayManager.disposeAll()
         eventSink = nil
         methodChannel.setMethodCallHandler(nil)

--- a/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
@@ -18,6 +18,32 @@ void main() {
         expect(source, contains('DispatchQueue.main.async'));
         expect(source, contains('sendStateUpdateOnMain'));
       });
+
+      test('$platform uses native queue-based looping', () {
+        final source = _appleSourceFile(platform).readAsStringSync();
+
+        expect(
+          source,
+          contains('AVQueuePlayer'),
+          reason:
+              'Apple loop playback should use a queue player so the next '
+              'iteration can be prepared before the current one ends.',
+        );
+        expect(
+          source,
+          contains('AVPlayerLooper'),
+          reason:
+              'Manual AVPlayerItemDidPlayToEndTime seek-and-replay loops '
+              'can create an end-of-item playback gap.',
+        );
+        expect(
+          source,
+          isNot(contains('player?.seek(to: .zero)')),
+          reason:
+              'Looping must not restart by seeking after the item has already '
+              'finished.',
+        );
+      });
     }
   });
 }


### PR DESCRIPTION
Closes #4028

## Summary
- replace Apple manual end-notification loop replay with AVQueuePlayer + AVPlayerLooper
- reattach texture/status/end observers as the queue player advances through looper replicas
- add a native contract test to prevent returning to seek-after-end loop playback

## Verification
- flutter test packages/divine_video_player/test/src/apple_threading_contract_test.dart
- flutter test packages/divine_video_player/test
- flutter analyze (from mobile/packages/divine_video_player)
- flutter build macos --debug
- flutter build ios --debug --no-codesign
- pre-push hook analyzer and Apple contract test