### PR TITLE
fix(proofmode): Updated proofModePgpFingerprint to load from 'proofmode' tag

### DIFF
--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -3,6 +3,7 @@
 // Parses video metadata from Nostr events with support for
 // kinds 22, 21, 34236, 34235
 
+import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:meta/meta.dart';
@@ -862,14 +863,40 @@ class VideoEvent {
     return rawTags['device_attestation'];
   }
 
-  /// ProofMode: Get PGP public key fingerprint from tags (NIP-145)
+  /// ProofMode: Get PGP signature from the embedded `proofmode` manifest.
+  ///
+  /// Reads `pgpSignature` from the JSON payload of the `proofmode` tag.
+  /// The standalone `pgp_fingerprint` tag is only published when the
+  /// publisher could derive a fingerprint from a stored public key —
+  /// the manifest's `pgpSignature` field is the load-bearing signal that
+  /// the video was actually PGP-signed.
   String? get proofModePgpFingerprint {
-    return rawTags['pgp_fingerprint'];
+    final signature = proofModeManifestJson?['pgpSignature'];
+    if (signature is String && signature.isNotEmpty) return signature;
+    return null;
   }
 
   /// ProofMode: Get C2PA Manifest Id
   String? get proofModeC2paManifestId {
     return rawTags['c2pa_manifest_id'];
+  }
+
+  /// Parsed `proofmode` tag manifest, or `null` when the tag is missing or
+  /// not a JSON object.
+  ///
+  /// The `proofmode` Nostr tag carries the full `NativeProofData` JSON, so
+  /// it is the source of truth for proof signals (`pgpSignature`,
+  /// `publicKey`, `deviceAttestation`, `c2paManifestId`) that the publisher
+  /// may not have additionally surfaced as standalone tags.
+  Map<String, dynamic>? get proofModeManifestJson {
+    final manifest = proofModeManifest;
+    if (manifest == null || manifest.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(manifest);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
   }
 
   /// User-signed creator binding hint emitted alongside ProofMode metadata.

--- a/mobile/test/utils/proofmode_helpers_test.dart
+++ b/mobile/test/utils/proofmode_helpers_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ProofMode helper utilities
 // ABOUTME: Validates VideoEvent extension methods for extracting verification levels from Nostr tags
 
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/utils/proofmode_helpers.dart';
@@ -102,14 +104,16 @@ void main() {
 
       expect(video.hasProofMode, isTrue);
 
-      // Test with fingerprint only
+      // Test with PGP signature in manifest only
       video = VideoEvent(
         id: 'test6',
         pubkey: 'pubkey6',
         createdAt: DateTime.now().millisecondsSinceEpoch,
         content: 'test video',
         timestamp: DateTime.now(),
-        rawTags: const {'pgp_fingerprint': 'ABC123'},
+        rawTags: {
+          'proofmode': jsonEncode({'pgpSignature': 'SIG-DATA'}),
+        },
       );
 
       expect(video.hasProofMode, isTrue);
@@ -143,18 +147,67 @@ void main() {
       expect(video.proofModeDeviceAttestation, attestation);
     });
 
-    test('extracts PGP fingerprint correctly', () {
-      const fingerprint = 'ABCD1234EFGH5678';
+    test(
+      'extracts PGP signature from proofmode manifest pgpSignature field',
+      () {
+        const signature = '-----BEGIN PGP SIGNATURE-----\n...\n-----END-----';
+        final video = VideoEvent(
+          id: 'test9',
+          pubkey: 'pubkey9',
+          createdAt: DateTime.now().millisecondsSinceEpoch,
+          content: 'test video',
+          timestamp: DateTime.now(),
+          rawTags: {
+            'proofmode': jsonEncode({'pgpSignature': signature}),
+          },
+        );
+
+        expect(video.proofModePgpFingerprint, signature);
+      },
+    );
+
+    test(
+      'returns null when proofmode manifest is missing pgpSignature field',
+      () {
+        final video = VideoEvent(
+          id: 'test10',
+          pubkey: 'pubkey10',
+          createdAt: DateTime.now().millisecondsSinceEpoch,
+          content: 'test video',
+          timestamp: DateTime.now(),
+          rawTags: const {
+            'proofmode': '{"publicKey":"abc"}',
+          },
+        );
+
+        expect(video.proofModePgpFingerprint, isNull);
+      },
+    );
+
+    test('returns null when proofmode tag is absent', () {
       final video = VideoEvent(
-        id: 'test9',
-        pubkey: 'pubkey9',
+        id: 'test11',
+        pubkey: 'pubkey11',
         createdAt: DateTime.now().millisecondsSinceEpoch,
         content: 'test video',
         timestamp: DateTime.now(),
-        rawTags: const {'pgp_fingerprint': fingerprint},
       );
 
-      expect(video.proofModePgpFingerprint, fingerprint);
+      expect(video.proofModePgpFingerprint, isNull);
+    });
+
+    test('returns null when proofmode manifest is malformed JSON', () {
+      final video = VideoEvent(
+        id: 'test12',
+        pubkey: 'pubkey12',
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+        content: 'test video',
+        timestamp: DateTime.now(),
+        rawTags: const {'proofmode': 'not-json'},
+      );
+
+      expect(video.proofModePgpFingerprint, isNull);
+      expect(video.proofModeManifestJson, isNull);
     });
   });
 

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -804,7 +804,7 @@ void main() {
         rawTags: {
           'verification': 'verified_mobile',
           'device_attestation': 'token_abc',
-          'pgp_fingerprint': 'ABCD1234',
+          'proofmode': '{"pgpSignature":"-----BEGIN PGP SIGNATURE-----"}',
         },
       );
       await tester.pumpWidget(
@@ -816,16 +816,17 @@ void main() {
       expect(find.text('PGP signature'), findsOneWidget);
       expect(find.text('C2PA Content Credentials'), findsOneWidget);
       expect(find.text('Proof manifest'), findsOneWidget);
-      // Two passed (device attestation, PGP), two failed (C2PA, manifest).
-      // DivineIcon renders SVGs — find by widget type and icon enum value.
+      // Three passed (device attestation, PGP via manifest, proof manifest),
+      // one failed (C2PA). DivineIcon renders SVGs — find by widget type
+      // and icon enum value.
       final checkIcons = tester
           .widgetList<DivineIcon>(find.byType(DivineIcon))
           .where((w) => w.icon == DivineIconName.checkCircle);
       final failIcons = tester
           .widgetList<DivineIcon>(find.byType(DivineIcon))
           .where((w) => w.icon == DivineIconName.prohibit);
-      expect(checkIcons.length, 2);
-      expect(failIcons.length, 2);
+      expect(checkIcons.length, 3);
+      expect(failIcons.length, 1);
     });
 
     testWidgets('hides when no proof data', (tester) async {


### PR DESCRIPTION

## Description

Addresses #3915 partially by fixing 'pgpSignature' loading via 'proofmode' tags

Updated proofModePgpFingerprint to load from 'proofmode' tag

  String? get proofModePgpFingerprint {
    final signature = proofModeManifestJson?['pgpSignature'];
    if (signature is String && signature.isNotEmpty) return signature;
    return null;
  }

  It reads the proofmode tag, parses the JSON, and returns the pgpSignature value — null if any link in
  that chain is missing/malformed. The standalone pgp_fingerprint tag is no longer consulted. Tests
  updated accordingly.

**Related Issue:** Relates to #3915 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ X ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore