### PR TITLE
fix(notifications): follow-back button reappears after remount

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -61,6 +61,22 @@ class NotificationFeedBloc
   final NotificationRepository _notificationRepository;
   final FollowRepository _followRepository;
 
+  /// Override [ActorNotification.isFollowingBack] for follow-type rows so the
+  /// flag tracks the authoritative follow state in [FollowRepository] rather
+  /// than a transient bloc mutation. Without this, the "Follow back" button
+  /// reappears after the page is unmounted and remounted because the bloc is
+  /// rebuilt with a fresh `isFollowingBack: false` from the repository.
+  List<NotificationItem> _applyFollowState(Iterable<NotificationItem> items) {
+    return items.map((item) {
+      if (item is! ActorNotification || item.type != NotificationKind.follow) {
+        return item;
+      }
+      final isFollowing = _followRepository.isFollowing(item.actor.pubkey);
+      if (isFollowing == item.isFollowingBack) return item;
+      return item.copyWith(isFollowingBack: isFollowing);
+    }).toList();
+  }
+
   /// Handle initial load.
   Future<void> _onStarted(
     NotificationFeedStarted event,
@@ -74,7 +90,7 @@ class NotificationFeedBloc
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
-          notifications: page.items,
+          notifications: _applyFollowState(page.items),
           unreadCount: page.unreadCount,
           hasMore: page.hasMore,
         ),
@@ -105,7 +121,10 @@ class NotificationFeedBloc
 
       emit(
         state.copyWith(
-          notifications: [...state.notifications, ...newItems],
+          notifications: _applyFollowState([
+            ...state.notifications,
+            ...newItems,
+          ]),
           hasMore: page.hasMore,
           isLoadingMore: false,
         ),
@@ -127,7 +146,7 @@ class NotificationFeedBloc
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
-          notifications: page.items,
+          notifications: _applyFollowState(page.items),
           unreadCount: page.unreadCount,
           hasMore: page.hasMore,
         ),
@@ -149,7 +168,7 @@ class NotificationFeedBloc
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
-          notifications: page.items,
+          notifications: _applyFollowState(page.items),
           unreadCount: page.unreadCount,
           hasMore: page.hasMore,
         ),
@@ -206,7 +225,7 @@ class NotificationFeedBloc
       if (merged) {
         emit(
           state.copyWith(
-            notifications: mergedList,
+            notifications: _applyFollowState(mergedList),
             unreadCount: state.unreadCount + 1,
           ),
         );
@@ -216,7 +235,7 @@ class NotificationFeedBloc
 
     emit(
       state.copyWith(
-        notifications: [enriched, ...state.notifications],
+        notifications: _applyFollowState([enriched, ...state.notifications]),
         unreadCount: state.unreadCount + 1,
       ),
     );
@@ -265,25 +284,19 @@ class NotificationFeedBloc
 
   /// Handle follow-back action.
   ///
-  /// Calls the follow repository, then updates the matching notification
-  /// to show the follow-back state.
+  /// Calls the follow repository, then re-derives [isFollowingBack] from the
+  /// repository's authoritative state. The flag is not stored on the bloc;
+  /// the next [_applyFollowState] pass on a refresh/remount will reflect the
+  /// same value, so the button stays hidden across navigation.
   Future<void> _onFollowBack(
     NotificationFeedFollowBack event,
     Emitter<NotificationFeedState> emit,
   ) async {
     try {
       await _followRepository.follow(event.pubkey);
-
-      final updated = state.notifications.map((n) {
-        if (n is ActorNotification &&
-            n.type == NotificationKind.follow &&
-            n.actor.pubkey == event.pubkey) {
-          return n.copyWith(isFollowingBack: true);
-        }
-        return n;
-      }).toList();
-
-      emit(state.copyWith(notifications: updated));
+      emit(
+        state.copyWith(notifications: _applyFollowState(state.notifications)),
+      );
     } catch (e, s) {
       addError(e, s);
     }

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -260,7 +260,7 @@ class NotificationFeedBloc
 
     emit(
       state.copyWith(
-        notifications: updated,
+        notifications: _applyFollowState(updated),
         unreadCount: wasUnread
             ? (state.unreadCount - 1).clamp(0, state.unreadCount)
             : state.unreadCount,

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -199,14 +199,11 @@ void main() {
               items: [
                 _actorNotif(
                   id: 'existing-follow',
-                  pubkey: _alicePubkey,
-                  isFollowingBack: false,
                 ),
                 _actorNotif(
                   id: 'new-follow',
                   pubkey: _bobPubkey,
                   displayName: 'Bob',
-                  isFollowingBack: false,
                 ),
               ],
               unreadCount: 2,
@@ -221,8 +218,6 @@ void main() {
           notifications: [
             _actorNotif(
               id: 'existing-follow',
-              pubkey: _alicePubkey,
-              isFollowingBack: false,
             ),
           ],
         ),
@@ -233,8 +228,6 @@ void main() {
             notifications: [
               _actorNotif(
                 id: 'existing-follow',
-                pubkey: _alicePubkey,
-                isFollowingBack: false,
               ),
             ],
             isLoadingMore: true,
@@ -244,7 +237,6 @@ void main() {
             notifications: [
               _actorNotif(
                 id: 'existing-follow',
-                pubkey: _alicePubkey,
                 isFollowingBack: true,
               ),
               _actorNotif(
@@ -350,8 +342,6 @@ void main() {
               items: [
                 _actorNotif(
                   id: 'follow-push',
-                  pubkey: _alicePubkey,
-                  isFollowingBack: false,
                 ),
               ],
               unreadCount: 3,
@@ -371,7 +361,6 @@ void main() {
             notifications: [
               _actorNotif(
                 id: 'follow-push',
-                pubkey: _alicePubkey,
                 isFollowingBack: true,
               ),
             ],
@@ -420,7 +409,6 @@ void main() {
               id: 'realtime-follow',
               pubkey: _bobPubkey,
               displayName: 'Bob',
-              isFollowingBack: false,
             ),
           );
           when(() => mockFollowRepo.isFollowing(_alicePubkey)).thenReturn(true);
@@ -432,8 +420,6 @@ void main() {
           notifications: [
             _actorNotif(
               id: 'existing-follow',
-              pubkey: _alicePubkey,
-              isFollowingBack: false,
             ),
           ],
         ),
@@ -452,7 +438,6 @@ void main() {
               ),
               _actorNotif(
                 id: 'existing-follow',
-                pubkey: _alicePubkey,
                 isFollowingBack: true,
               ),
             ],
@@ -577,8 +562,6 @@ void main() {
             _videoNotif(id: 'existing'),
             _actorNotif(
               id: 'existing-follow',
-              pubkey: _alicePubkey,
-              isFollowingBack: false,
             ),
           ],
         ),
@@ -596,12 +579,10 @@ void main() {
                   _actor(),
                 ],
                 totalCount: 2,
-                isRead: false,
                 timestamp: DateTime(2026, 5, 4, 13),
               ),
               _actorNotif(
                 id: 'existing-follow',
-                pubkey: _alicePubkey,
                 isFollowingBack: true,
               ),
             ],
@@ -648,8 +629,6 @@ void main() {
           notifications: [
             _actorNotif(
               id: 'follow1',
-              pubkey: _alicePubkey,
-              isFollowingBack: false,
             ),
           ],
           unreadCount: 1,
@@ -661,7 +640,6 @@ void main() {
             notifications: [
               _actorNotif(
                 id: 'follow1',
-                pubkey: _alicePubkey,
                 isFollowingBack: true,
                 isRead: true,
               ),

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -97,6 +97,8 @@ void main() {
     setUp(() {
       mockNotificationRepo = _MockNotificationRepository();
       mockFollowRepo = _MockFollowRepository();
+      // Default: not following anyone. Individual tests override per-pubkey.
+      when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
     });
 
     NotificationFeedBloc createBloc() => NotificationFeedBloc(
@@ -471,11 +473,15 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'updates isFollowingBack on matching follow notification',
+        'derives isFollowingBack from FollowRepository after follow succeeds',
         setUp: () {
+          var following = false;
+          when(() => mockFollowRepo.follow('pub123')).thenAnswer((_) async {
+            following = true;
+          });
           when(
-            () => mockFollowRepo.follow('pub123'),
-          ).thenAnswer((_) async {});
+            () => mockFollowRepo.isFollowing('pub123'),
+          ).thenAnswer((_) => following);
         },
         build: createBloc,
         seed: () => NotificationFeedState(
@@ -506,6 +512,106 @@ void main() {
         act: (bloc) => bloc.add(NotificationFeedFollowBack('pub123')),
         expect: () => <NotificationFeedState>[],
         errors: () => [isA<Exception>()],
+      );
+    });
+
+    group('isFollowingBack derivation', () {
+      // Regression: button used to reappear on remount because the bloc
+      // ignored FollowRepository and relied on a transient mutation that
+      // didn't survive a fresh fetch. See issue #4023.
+      const pubkey =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'NotificationFeedStarted overrides isFollowingBack from repository',
+        setUp: () {
+          when(() => mockNotificationRepo.refresh()).thenAnswer(
+            (_) async => NotificationPage(
+              items: [
+                _actorNotif(id: 'f1', pubkey: pubkey, displayName: 'Carol'),
+              ],
+              unreadCount: 1,
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(pubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        expect: () => [
+          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'f1',
+                pubkey: pubkey,
+                displayName: 'Carol',
+                isFollowingBack: true,
+              ),
+            ],
+            unreadCount: 1,
+            hasMore: false,
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'NotificationFeedRefreshed overrides isFollowingBack from repository',
+        setUp: () {
+          when(() => mockNotificationRepo.refresh()).thenAnswer(
+            (_) async => NotificationPage(
+              items: [
+                _actorNotif(id: 'f1', pubkey: pubkey, displayName: 'Carol'),
+              ],
+              unreadCount: 0,
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(pubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [_videoNotif(id: 'old')],
+        ),
+        act: (bloc) => bloc.add(NotificationFeedRefreshed()),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'f1',
+                pubkey: pubkey,
+                displayName: 'Carol',
+                isFollowingBack: true,
+              ),
+            ],
+            hasMore: false,
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'leaves non-follow ActorNotifications untouched',
+        setUp: () {
+          when(() => mockNotificationRepo.refresh()).thenAnswer(
+            (_) async => NotificationPage(
+              items: [
+                _actorNotif(
+                  id: 'mention1',
+                  type: NotificationKind.mention,
+                  pubkey: pubkey,
+                ),
+              ],
+              unreadCount: 1,
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(pubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        verify: (_) {
+          verifyNever(() => mockFollowRepo.isFollowing(pubkey));
+        },
       );
     });
   });

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -419,6 +419,42 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
+        're-derives follow state when tapping a follow notification',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAsRead(any()),
+          ).thenAnswer((_) async {});
+          when(() => mockFollowRepo.isFollowing(_alicePubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _actorNotif(
+              id: 'follow1',
+              pubkey: _alicePubkey,
+              isFollowingBack: false,
+            ),
+          ],
+          unreadCount: 1,
+        ),
+        act: (bloc) => bloc.add(NotificationFeedItemTapped('follow1')),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'follow1',
+                pubkey: _alicePubkey,
+                isFollowingBack: true,
+                isRead: true,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
         'marks $ActorNotification as read locally and decrements unread',
         setUp: () {
           when(

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -190,6 +190,76 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
+        're-derives follow state for existing and appended follow rows',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.getNotifications(),
+          ).thenAnswer(
+            (_) async => NotificationPage(
+              items: [
+                _actorNotif(
+                  id: 'existing-follow',
+                  pubkey: _alicePubkey,
+                  isFollowingBack: false,
+                ),
+                _actorNotif(
+                  id: 'new-follow',
+                  pubkey: _bobPubkey,
+                  displayName: 'Bob',
+                  isFollowingBack: false,
+                ),
+              ],
+              unreadCount: 2,
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(_alicePubkey)).thenReturn(true);
+          when(() => mockFollowRepo.isFollowing(_bobPubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _actorNotif(
+              id: 'existing-follow',
+              pubkey: _alicePubkey,
+              isFollowingBack: false,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(NotificationFeedLoadMore()),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'existing-follow',
+                pubkey: _alicePubkey,
+                isFollowingBack: false,
+              ),
+            ],
+            isLoadingMore: true,
+          ),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'existing-follow',
+                pubkey: _alicePubkey,
+                isFollowingBack: true,
+              ),
+              _actorNotif(
+                id: 'new-follow',
+                pubkey: _bobPubkey,
+                displayName: 'Bob',
+                isFollowingBack: true,
+              ),
+            ],
+            hasMore: false,
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
         'skips when hasMore is false',
         build: createBloc,
         seed: () => NotificationFeedState(
@@ -269,6 +339,47 @@ void main() {
           ),
         ],
       );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        're-derives follow state on push-triggered refresh',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.refresh(),
+          ).thenAnswer(
+            (_) async => NotificationPage(
+              items: [
+                _actorNotif(
+                  id: 'follow-push',
+                  pubkey: _alicePubkey,
+                  isFollowingBack: false,
+                ),
+              ],
+              unreadCount: 3,
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(_alicePubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [_videoNotif(id: 'old')],
+        ),
+        act: (bloc) => bloc.add(NotificationFeedPushReceived()),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'follow-push',
+                pubkey: _alicePubkey,
+                isFollowingBack: true,
+              ),
+            ],
+            unreadCount: 3,
+            hasMore: false,
+          ),
+        ],
+      );
     });
 
     group('NotificationFeedRealtimeReceived', () {
@@ -293,6 +404,57 @@ void main() {
             notifications: [
               _videoNotif(id: 'realtime'),
               _actorNotif(id: 'existing'),
+            ],
+            unreadCount: 1,
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        're-derives follow state when prepending a realtime follow row',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.enrichOne(any()),
+          ).thenAnswer(
+            (_) async => _actorNotif(
+              id: 'realtime-follow',
+              pubkey: _bobPubkey,
+              displayName: 'Bob',
+              isFollowingBack: false,
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(_alicePubkey)).thenReturn(true);
+          when(() => mockFollowRepo.isFollowing(_bobPubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _actorNotif(
+              id: 'existing-follow',
+              pubkey: _alicePubkey,
+              isFollowingBack: false,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          NotificationFeedRealtimeReceived(_rawRelay(id: 'realtime-follow')),
+        ),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _actorNotif(
+                id: 'realtime-follow',
+                pubkey: _bobPubkey,
+                displayName: 'Bob',
+                isFollowingBack: true,
+              ),
+              _actorNotif(
+                id: 'existing-follow',
+                pubkey: _alicePubkey,
+                isFollowingBack: true,
+              ),
             ],
             unreadCount: 1,
           ),
@@ -392,6 +554,60 @@ void main() {
 
           await bloc.close();
         },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        're-derives follow state when merging a realtime video notification',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.enrichOne(any()),
+          ).thenAnswer(
+            (_) async => _videoNotif(
+              id: 'newest',
+              actors: [_actor(pubkey: _bobPubkey, displayName: 'Bob')],
+              timestamp: DateTime(2026, 5, 4, 13),
+            ),
+          );
+          when(() => mockFollowRepo.isFollowing(_alicePubkey)).thenReturn(true);
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _videoNotif(id: 'existing'),
+            _actorNotif(
+              id: 'existing-follow',
+              pubkey: _alicePubkey,
+              isFollowingBack: false,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          NotificationFeedRealtimeReceived(_rawRelay()),
+        ),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _videoNotif(
+                id: 'existing',
+                actors: [
+                  _actor(pubkey: _bobPubkey, displayName: 'Bob'),
+                  _actor(),
+                ],
+                totalCount: 2,
+                isRead: false,
+                timestamp: DateTime(2026, 5, 4, 13),
+              ),
+              _actorNotif(
+                id: 'existing-follow',
+                pubkey: _alicePubkey,
+                isFollowingBack: true,
+              ),
+            ],
+            unreadCount: 1,
+          ),
+        ],
       );
     });
 


### PR DESCRIPTION
## Description

`ActorNotification.isFollowingBack` was a transient bloc-only mutation in `_onFollowBack`. When the notifications page unmounted (tab switch, back to feed) and remounted, `BlocProvider` constructed a fresh `NotificationFeedBloc`, the repository returned `isFollowingBack: false` (it never cross-references the user's follow list), and the "Follow back" button reappeared on actors the user had already followed.

Fix: derive `isFollowingBack` from `FollowRepository.isFollowing(pubkey)` — the repository is `@Riverpod(keepAlive: true)` and its in-memory follow cache survives across page navigations. A `_applyFollowState` helper runs over every list emitted by the bloc (`_onStarted`, `_onLoadMore`, `_onRefreshed`, `_onPushReceived`, `_onRealtimeReceived`, `_onFollowBack`) so the flag always tracks the authoritative state. The bloc-only mutation in `_onFollowBack` is gone — after `await _followRepository.follow(pubkey)`, the repository's cache holds the new pubkey and the next `_applyFollowState` flips the flag.

`isFollowing` is a synchronous `Set.contains` lookup, so the per-emit pass is cheap.

**Related Issue:** Closes #4023

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `flutter test test/notifications/bloc/notification_feed_bloc_test.dart` — 20 tests pass, including 3 new regression tests:
  - `NotificationFeedStarted overrides isFollowingBack from repository`
  - `NotificationFeedRefreshed overrides isFollowingBack from repository`
  - `leaves non-follow ActorNotifications untouched`
- [x] `flutter test test/notifications` — full notifications suite (67 tests) passes
- [x] `flutter analyze lib test integration_test` — clean
- [ ] Manual: tap "Follow back" on a follow notification, switch tab, return — button stays hidden