### PR TITLE
fix(notifications): rollback mark-all-read on server failure

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -254,13 +254,49 @@ class NotificationFeedBloc
   }
 
   /// Handle mark all as read.
+  ///
+  /// Optimistically flips every notification's `isRead` to `true` and zeros
+  /// the unread count, then awaits the server write. On failure the
+  /// pre-optimistic notifications and unread count are restored so the next
+  /// refresh does not silently regress the badge / row state, and the
+  /// underlying error is forwarded to the bloc error stream.
   Future<void> _onMarkAllRead(
     NotificationFeedMarkAllRead event,
     Emitter<NotificationFeedState> emit,
   ) async {
-    emit(state.copyWith(unreadCount: 0));
+    final hasUnread =
+        state.unreadCount > 0 || state.notifications.any((n) => !n.isRead);
+    if (!hasUnread) return;
 
-    unawaited(_notificationRepository.markAllAsRead());
+    final previousNotifications = state.notifications;
+    final previousUnreadCount = state.unreadCount;
+
+    final updatedNotifications = state.notifications.map((n) {
+      if (n.isRead) return n;
+      return switch (n) {
+        VideoNotification() => n.copyWith(isRead: true),
+        ActorNotification() => n.copyWith(isRead: true),
+      };
+    }).toList();
+
+    emit(
+      state.copyWith(
+        notifications: updatedNotifications,
+        unreadCount: 0,
+      ),
+    );
+
+    try {
+      await _notificationRepository.markAllAsRead();
+    } catch (e, s) {
+      addError(e, s);
+      emit(
+        state.copyWith(
+          notifications: previousNotifications,
+          unreadCount: previousUnreadCount,
+        ),
+      );
+    }
   }
 
   /// Handle follow-back action.

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -441,7 +441,7 @@ void main() {
 
     group('NotificationFeedMarkAllRead', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'sets unread count to 0',
+        'flips every notification to read and zeros unread count on success',
         setUp: () {
           when(
             () => mockNotificationRepo.markAllAsRead(),
@@ -450,16 +450,70 @@ void main() {
         build: createBloc,
         seed: () => NotificationFeedState(
           status: NotificationFeedStatus.loaded,
-          notifications: [_videoNotif()],
+          notifications: [_videoNotif(), _actorNotif()],
           unreadCount: 5,
         ),
         act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
         expect: () => [
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
-            notifications: [_videoNotif()],
+            notifications: [
+              _videoNotif(isRead: true),
+              _actorNotif(isRead: true),
+            ],
           ),
         ],
+        verify: (_) {
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'rolls back optimistic update and forwards error when server fails',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenThrow(Exception('network error'));
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [_videoNotif(), _actorNotif()],
+          unreadCount: 5,
+        ),
+        act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
+        expect: () => [
+          // Optimistic update — rows flipped, count zeroed.
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _videoNotif(isRead: true),
+              _actorNotif(isRead: true),
+            ],
+          ),
+          // Rollback on failure — original rows and count restored so the
+          // next refresh does not silently regress the badge.
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [_videoNotif(), _actorNotif()],
+            unreadCount: 5,
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'no-ops when nothing is unread',
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [_videoNotif(isRead: true)],
+        ),
+        act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
+        expect: () => <NotificationFeedState>[],
+        verify: (_) {
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
+        },
       );
     });
 


### PR DESCRIPTION
Closes #4024.

## Summary
- Optimistically flip every `NotificationItem.isRead` alongside zeroing
  `unreadCount` so notification rows actually clear visually on
  mark-all-read (previously only the count moved, but row backgrounds key
  on the per-row flag).
- `await` the repository call instead of `unawaited(...)`, forward the
  error via `addError`, and roll back to the pre-optimistic notifications
  + count on failure. The next refresh then starts from a consistent
  baseline instead of silently pulling back `read: false` from the server.
- Skip the entire flow when nothing is unread (e.g. tab switches across
  the inbox `TabBarView` re-firing `NotificationFeedMarkAllRead` from each
  tab's `initState`).

## Why
User feedback on the latest main: *"notifications are not going away for
me."* Interpretation #2 from the issue — the optimistic update was
incomplete (the server write was fire-and-forget and the per-row `isRead`
flags were never flipped), so on a transient server failure the next
refresh restored unread state silently.

## Test plan
- [x] `flutter analyze lib/notifications test/notifications/bloc` — clean
- [x] `flutter test test/notifications/bloc/notification_feed_bloc_test.dart` — 19/19 pass, including:
  - `flips every notification to read and zeros unread count on success`
  - `rolls back optimistic update and forwards error when server fails` (the issue's regression pin)
  - `no-ops when nothing is unread`
- [x] `flutter test test/notifications` — 67/67 pass

## Out of scope (per issue)
- Interpretation #1 (notifications staying in the list after viewing) is a
  product/UX gap, not a code defect — separate feature request.
- Interpretation #3 (iOS system push tray clearing on inbox open) is a
  distinct code path; not touched here.
- A snackbar / retry affordance was considered but skipped: mark-all-read
  is auto-fired from `NotificationsView.initState` (and re-fired by each
  inbox tab's `initState`), so a "failed to mark as read" toast would
  surface to a user who never explicitly requested the action. The
  rollback itself is the user-visible signal; `addError` captures the
  failure for Crashlytics. Worth revisiting if/when an explicit
  user-triggered mark-all-read entry point lands.