### PR TITLE
feat(audio): add picker search

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3437,7 +3437,7 @@
   "videoEditorAudioNoSoundsAvailableSubtitle": "Sounds will appear here when creators share audio",
   "videoEditorAudioFailedToLoadTitle": "Failed to load sounds",
   "videoEditorAudioSegmentInstruction": "Select the audio segment for your video",
-  "videoEditorAudioCategoryDivine": "OG Sounds",
+  "videoEditorAudioCategoryDivine": "Divine",
   "videoEditorAudioCategoryCommunity": "Community",
   "videoEditorAudioCategoryFeatured": "Featured",
   "videoEditorAudioCategoryMySounds": "My Sounds",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11355,7 +11355,7 @@ abstract class AppLocalizations {
   /// No description provided for @videoEditorAudioCategoryDivine.
   ///
   /// In en, this message translates to:
-  /// **'OG Sounds'**
+  /// **'Divine'**
   String get videoEditorAudioCategoryDivine;
 
   /// No description provided for @videoEditorAudioCategoryCommunity.

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6432,7 +6432,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Select the audio segment for your video';
 
   @override
-  String get videoEditorAudioCategoryDivine => 'OG Sounds';
+  String get videoEditorAudioCategoryDivine => 'Divine';
 
   @override
   String get videoEditorAudioCategoryCommunity => 'Community';

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_category_bar.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_category_bar.dart
@@ -21,14 +21,19 @@ class AudioCategoryBar extends StatelessWidget {
         spacing: 8,
         children: [
           _Chip(
-            onTap: () => onSelect(.featured),
-            isSelected: category == .featured,
-            label: context.l10n.videoEditorAudioCategoryFeatured,
-          ),
-          _Chip(
             onTap: () => onSelect(.divine),
             isSelected: category == .divine,
             label: context.l10n.videoEditorAudioCategoryDivine,
+          ),
+          _Chip(
+            onTap: () => onSelect(.community),
+            isSelected: category == .community,
+            label: context.l10n.videoEditorAudioCategoryCommunity,
+          ),
+          _Chip(
+            onTap: () => onSelect(.featured),
+            isSelected: category == .featured,
+            label: context.l10n.videoEditorAudioCategoryFeatured,
           ),
           _Chip(
             onTap: () => onSelect(.mySounds),
@@ -81,4 +86,4 @@ class _Chip extends StatelessWidget {
   }
 }
 
-enum AudioCategory { featured, divine, mySounds }
+enum AudioCategory { divine, community, featured, mySounds }

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -7,22 +7,22 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/saved_sounds_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
+import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_category_bar.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_list_tile.dart';
 import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-final _featuredSounds = [
-  AudioEvent.fromBundledSound(
-    VineSound(
-      id: 'wednesday',
-      title: 'Wednesday',
-      assetPath: 'assets/sounds/wednesday.mp3',
-      duration: const Duration(milliseconds: 6269),
-      tags: const ['featured'],
-    ),
+final _featuredVineSounds = [
+  VineSound(
+    id: 'wednesday',
+    title: 'Wednesday',
+    assetPath: 'assets/sounds/wednesday.mp3',
+    duration: const Duration(milliseconds: 6269),
+    tags: const ['featured'],
   ),
 ];
 
@@ -83,9 +83,11 @@ class _AudioSelectionBottomSheetState
     extends ConsumerState<AudioSelectionBottomSheet>
     with SingleTickerProviderStateMixin {
   final _audioService = AudioPlaybackService();
+  final _searchController = TextEditingController();
   String? _loadedSoundId;
   AudioEvent? _selectedItem;
-  AudioCategory _category = .featured;
+  AudioCategory _category = .divine;
+  String _searchQuery = '';
 
   late final _tabController = TabController(
     length: AudioCategory.values.length,
@@ -101,6 +103,7 @@ class _AudioSelectionBottomSheetState
   @override
   void dispose() {
     _audioService.dispose();
+    _searchController.dispose();
     _tabController.dispose();
     super.dispose();
   }
@@ -120,6 +123,21 @@ class _AudioSelectionBottomSheetState
         AudioCategory.values.indexWhere((el) => el == category),
       );
     });
+  }
+
+  void _onSearchChanged(String query) {
+    setState(() {
+      _searchQuery = query.toLowerCase().trim();
+    });
+  }
+
+  List<AudioEvent> _filterAudioEvents(List<AudioEvent> sounds) {
+    if (_searchQuery.isEmpty) return sounds;
+    return sounds.where((sound) {
+      final title = sound.title?.toLowerCase() ?? '';
+      final source = sound.source?.toLowerCase() ?? '';
+      return title.contains(_searchQuery) || source.contains(_searchQuery);
+    }).toList();
   }
 
   Future<void> _togglePlayPause({bool enforcePlay = false}) async {
@@ -236,18 +254,31 @@ class _AudioSelectionBottomSheetState
   @override
   Widget build(BuildContext context) {
     final bundledSoundsAsync = ref.watch(soundLibraryServiceProvider);
+    final nostrSoundsAsync = ref.watch(trendingSoundsProvider);
     final savedSounds = ref.watch(savedSoundsProvider);
 
-    // Convert bundled VineSounds to AudioEvents
-    final bundledSounds =
-        bundledSoundsAsync.whenOrNull(
-          data: (service) {
-            return service.sounds.indexed
-                .map((e) => AudioEvent.fromBundledSound(e.$2, index: e.$1))
-                .toList();
-          },
-        ) ??
-        <AudioEvent>[];
+    final bundledVineSounds =
+        bundledSoundsAsync.whenOrNull(data: (service) => service.sounds) ??
+        <VineSound>[];
+    final filteredBundledVineSounds = _searchQuery.isEmpty
+        ? bundledVineSounds
+        : bundledVineSounds
+              .where((sound) => sound.matchesSearch(_searchQuery))
+              .toList();
+    final bundledSounds = filteredBundledVineSounds.indexed
+        .map((e) => AudioEvent.fromBundledSound(e.$2, index: e.$1))
+        .toList();
+    final featuredSounds =
+        (_searchQuery.isEmpty
+                ? _featuredVineSounds
+                : _featuredVineSounds
+                      .where((sound) => sound.matchesSearch(_searchQuery))
+                      .toList())
+            .indexed
+            .map((e) => AudioEvent.fromBundledSound(e.$2, index: e.$1))
+            .toList();
+    final filteredSavedSounds = _filterAudioEvents(savedSounds);
+    const searchEmptyState = _SearchEmptyState();
 
     return Stack(
       children: [
@@ -255,17 +286,14 @@ class _AudioSelectionBottomSheetState
           crossAxisAlignment: .stretch,
           children: [
             AudioCategoryBar(category: _category, onSelect: _selectCategory),
+            _PickerSearchInput(
+              controller: _searchController,
+              onChanged: _onSearchChanged,
+            ),
             Expanded(
               child: TabBarView(
                 controller: _tabController,
                 children: [
-                  _SoundsContent(
-                    scrollController: widget.scrollController,
-                    sounds: _featuredSounds,
-                    selectedSound: _selectedItem,
-                    audioService: _audioService,
-                    onSelect: _selectSound,
-                  ),
                   _SoundsContent(
                     scrollController: widget.scrollController,
                     sounds: bundledSounds,
@@ -273,16 +301,45 @@ class _AudioSelectionBottomSheetState
                     audioService: _audioService,
                     onSelect: _selectSound,
                   ),
+                  nostrSoundsAsync.when(
+                    data: (nostrSounds) {
+                      return _SoundsContent(
+                        scrollController: widget.scrollController,
+                        sounds: _filterAudioEvents(nostrSounds),
+                        selectedSound: _selectedItem,
+                        audioService: _audioService,
+                        onSelect: _selectSound,
+                        emptyState: _searchQuery.isNotEmpty
+                            ? searchEmptyState
+                            : const _EmptyState(),
+                      );
+                    },
+                    loading: () =>
+                        const Center(child: BrandedLoadingIndicator()),
+                    error: (error, stack) => _ErrorState(error: error),
+                  ),
                   _SoundsContent(
                     scrollController: widget.scrollController,
-                    sounds: savedSounds,
+                    sounds: featuredSounds,
                     selectedSound: _selectedItem,
                     audioService: _audioService,
                     onSelect: _selectSound,
-                    emptyState: _EmptyState(
-                      title: context.l10n.soundsSavedEmptyTitle,
-                      subtitle: context.l10n.soundsSavedEmptyDescription,
-                    ),
+                    emptyState: _searchQuery.isNotEmpty
+                        ? searchEmptyState
+                        : const _EmptyState(),
+                  ),
+                  _SoundsContent(
+                    scrollController: widget.scrollController,
+                    sounds: filteredSavedSounds,
+                    selectedSound: _selectedItem,
+                    audioService: _audioService,
+                    onSelect: _selectSound,
+                    emptyState: _searchQuery.isNotEmpty
+                        ? searchEmptyState
+                        : _EmptyState(
+                            title: context.l10n.soundsSavedEmptyTitle,
+                            subtitle: context.l10n.soundsSavedEmptyDescription,
+                          ),
                   ),
                 ],
               ),
@@ -305,6 +362,41 @@ class _AudioSelectionBottomSheetState
           ),
         ),
       ],
+    );
+  }
+}
+
+class _PickerSearchInput extends StatelessWidget {
+  const _PickerSearchInput({required this.controller, required this.onChanged});
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      color: VineTheme.onPrimary,
+      child: TextField(
+        controller: controller,
+        onChanged: onChanged,
+        style: const TextStyle(color: VineTheme.whiteText),
+        decoration: InputDecoration(
+          hintText: context.l10n.soundsSearchHint,
+          hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
+          prefixIcon: const Icon(Icons.search, color: VineTheme.onSurfaceMuted),
+          filled: true,
+          fillColor: VineTheme.backgroundColor,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: BorderSide.none,
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+        ),
+      ),
     );
   }
 }
@@ -377,10 +469,7 @@ class _SoundsContent extends StatelessWidget {
 }
 
 class _EmptyState extends StatelessWidget {
-  const _EmptyState({
-    this.title,
-    this.subtitle,
-  });
+  const _EmptyState({this.title, this.subtitle});
 
   final String? title;
   final String? subtitle;
@@ -391,11 +480,7 @@ class _EmptyState extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(
-            Icons.music_off,
-            size: 64,
-            color: VineTheme.secondaryText,
-          ),
+          const Icon(Icons.music_off, size: 64, color: VineTheme.secondaryText),
           const SizedBox(height: 16),
           Text(
             title ?? context.l10n.videoEditorAudioNoSoundsAvailableTitle,
@@ -408,6 +493,87 @@ class _EmptyState extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _SearchEmptyState extends StatelessWidget {
+  const _SearchEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(
+            Icons.search_off,
+            size: 64,
+            color: VineTheme.secondaryText,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            context.l10n.soundsNoSoundsFound,
+            style: VineTheme.bodyLargeFont(),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            context.l10n.soundsNoSoundsFoundDescription,
+            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends ConsumerWidget {
+  const _ErrorState({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 64, color: VineTheme.likeRed),
+            const SizedBox(height: 16),
+            Text(
+              context.l10n.videoEditorAudioFailedToLoadTitle,
+              style: VineTheme.bodyLargeFont(),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error.toString(),
+              style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+              textAlign: TextAlign.center,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () {
+                ref.invalidate(trendingSoundsProvider);
+              },
+              icon: const Icon(Icons.refresh),
+              label: Text(context.l10n.commonRetry),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: VineTheme.vineGreen,
+                foregroundColor: VineTheme.backgroundColor,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 12,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/test/widgets/video_editor/audio_editor/audio_category_bar_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_category_bar_test.dart
@@ -23,34 +23,58 @@ void main() {
       );
     }
 
-    testWidgets('renders picker category chips in product order', (
-      tester,
-    ) async {
+    testWidgets('renders all category chips', (tester) async {
       await tester.pumpWidget(
-        buildWidget(category: AudioCategory.featured, onSelect: (_) {}),
+        buildWidget(category: AudioCategory.divine, onSelect: (_) {}),
       );
       await tester.pumpAndSettle();
 
       final l10n = lookupAppLocalizations(const Locale('en'));
-      expect(find.text(l10n.videoEditorAudioCategoryFeatured), findsOneWidget);
       expect(find.text(l10n.videoEditorAudioCategoryDivine), findsOneWidget);
+      expect(find.text(l10n.videoEditorAudioCategoryCommunity), findsOneWidget);
+      expect(find.text(l10n.videoEditorAudioCategoryFeatured), findsOneWidget);
       expect(find.text(l10n.videoEditorAudioCategoryMySounds), findsOneWidget);
-      expect(find.text(l10n.videoEditorAudioCategoryCommunity), findsNothing);
-
-      final featuredLeft = tester.getTopLeft(
-        find.text(l10n.videoEditorAudioCategoryFeatured),
-      );
-      final ogLeft = tester.getTopLeft(
-        find.text(l10n.videoEditorAudioCategoryDivine),
-      );
-      final mySoundsLeft = tester.getTopLeft(
-        find.text(l10n.videoEditorAudioCategoryMySounds),
-      );
-      expect(featuredLeft.dx, lessThan(ogLeft.dx));
-      expect(ogLeft.dx, lessThan(mySoundsLeft.dx));
     });
 
-    testWidgets('calls onSelect with featured when first chip is tapped', (
+    testWidgets('calls onSelect with divine when first chip is tapped', (
+      tester,
+    ) async {
+      AudioCategory? selected;
+      await tester.pumpWidget(
+        buildWidget(
+          category: AudioCategory.community,
+          onSelect: (c) => selected = c,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.videoEditorAudioCategoryDivine));
+      await tester.pumpAndSettle();
+
+      expect(selected, equals(AudioCategory.divine));
+    });
+
+    testWidgets('calls onSelect with community when second chip is tapped', (
+      tester,
+    ) async {
+      AudioCategory? selected;
+      await tester.pumpWidget(
+        buildWidget(
+          category: AudioCategory.divine,
+          onSelect: (c) => selected = c,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+      await tester.pumpAndSettle();
+
+      expect(selected, equals(AudioCategory.community));
+    });
+
+    testWidgets('calls onSelect with featured when third chip is tapped', (
       tester,
     ) async {
       AudioCategory? selected;
@@ -69,32 +93,13 @@ void main() {
       expect(selected, equals(AudioCategory.featured));
     });
 
-    testWidgets('calls onSelect with divine when second chip is tapped', (
+    testWidgets('calls onSelect with mySounds when fourth chip is tapped', (
       tester,
     ) async {
       AudioCategory? selected;
       await tester.pumpWidget(
         buildWidget(
-          category: AudioCategory.featured,
-          onSelect: (c) => selected = c,
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      final l10n = lookupAppLocalizations(const Locale('en'));
-      await tester.tap(find.text(l10n.videoEditorAudioCategoryDivine));
-      await tester.pumpAndSettle();
-
-      expect(selected, equals(AudioCategory.divine));
-    });
-
-    testWidgets('calls onSelect with mySounds when third chip is tapped', (
-      tester,
-    ) async {
-      AudioCategory? selected;
-      await tester.pumpWidget(
-        buildWidget(
-          category: AudioCategory.featured,
+          category: AudioCategory.divine,
           onSelect: (c) => selected = c,
         ),
       );
@@ -111,20 +116,12 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        buildWidget(category: AudioCategory.featured, onSelect: (_) {}),
+        buildWidget(category: AudioCategory.divine, onSelect: (_) {}),
       );
       await tester.pumpAndSettle();
 
       final l10n = lookupAppLocalizations(const Locale('en'));
-      final featuredSemantics = tester.widget<Semantics>(
-        find.ancestor(
-          of: find.text(l10n.videoEditorAudioCategoryFeatured),
-          matching: find.byWidgetPredicate(
-            (w) => w is Semantics && w.properties.selected != null,
-          ),
-        ),
-      );
-      final ogSemantics = tester.widget<Semantics>(
+      final divineSemantics = tester.widget<Semantics>(
         find.ancestor(
           of: find.text(l10n.videoEditorAudioCategoryDivine),
           matching: find.byWidgetPredicate(
@@ -132,9 +129,17 @@ void main() {
           ),
         ),
       );
+      final communitySemantics = tester.widget<Semantics>(
+        find.ancestor(
+          of: find.text(l10n.videoEditorAudioCategoryCommunity),
+          matching: find.byWidgetPredicate(
+            (w) => w is Semantics && w.properties.selected != null,
+          ),
+        ),
+      );
 
-      expect(featuredSemantics.properties.selected, isTrue);
-      expect(ogSemantics.properties.selected, isFalse);
+      expect(divineSemantics.properties.selected, isTrue);
+      expect(communitySemantics.properties.selected, isFalse);
     });
   });
 }

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/saved_sounds_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/services/sound_library_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_category_bar.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_list_tile.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart';
@@ -94,7 +95,7 @@ void main() {
         expect(find.byType(AudioSelectionBottomSheet), findsOneWidget);
       });
 
-      testWidgets('renders picker categories without broken community tab', (
+      testWidgets('renders $AudioCategoryBar with all category chips', (
         tester,
       ) async {
         await tester.pumpWidget(
@@ -105,14 +106,110 @@ void main() {
         final l10n = lookupAppLocalizations(const Locale('en'));
         expect(find.byType(AudioCategoryBar), findsOneWidget);
         expect(find.text(l10n.videoEditorAudioCategoryDivine), findsWidgets);
-        expect(find.text(l10n.videoEditorAudioCategoryCommunity), findsNothing);
+        expect(find.text(l10n.videoEditorAudioCategoryCommunity), findsWidgets);
         expect(find.text(l10n.videoEditorAudioCategoryFeatured), findsWidgets);
         expect(find.text(l10n.videoEditorAudioCategoryMySounds), findsWidgets);
       });
     });
 
+    group('Search', () {
+      testWidgets('filters featured sounds on featured tab', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(trendingSoundsAsync: AsyncValue.data(testSounds)),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.enterText(find.byType(TextField).first, 'wednes');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryFeatured));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Wednesday'), findsOneWidget);
+      });
+
+      testWidgets('filters community sounds on community tab', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(trendingSoundsAsync: AsyncValue.data(testSounds)),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.enterText(find.byType(TextField).first, 'beta');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Beta Song'), findsOneWidget);
+        expect(find.text('Alpha Track'), findsNothing);
+      });
+
+      testWidgets('filters saved sounds on My Sounds tab', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data(testSounds),
+            savedSounds: [
+              _createTestAudioEvent(id: 'saved-1', title: 'Uh Oh'),
+              _createTestAudioEvent(id: 'saved-2', title: 'Victory Lap'),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.enterText(find.byType(TextField).first, 'uh oh');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryMySounds));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Uh Oh'), findsOneWidget);
+        expect(find.text('Victory Lap'), findsNothing);
+      });
+
+      testWidgets('renders search empty state when no tab matches', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data(testSounds),
+            savedSounds: [
+              _createTestAudioEvent(id: 'saved-sound', title: 'Saved Sound'),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.enterText(find.byType(TextField).first, 'not a match');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryMySounds));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.soundsNoSoundsFound), findsOneWidget);
+        expect(find.text(l10n.soundsNoSoundsFoundDescription), findsOneWidget);
+      });
+    });
+
+    group('Loading state', () {
+      testWidgets('renders $BrandedLoadingIndicator on community tab', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(trendingSoundsAsync: const AsyncValue.loading()),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+      });
+    });
+
     group('Empty state', () {
-      testWidgets('opens on featured sounds', (
+      testWidgets('renders empty state when no bundled sounds available', (
         tester,
       ) async {
         await tester.pumpWidget(
@@ -120,22 +217,25 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Wednesday'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoEditorAudioNoSoundsAvailableTitle),
+          findsOneWidget,
+        );
+        expect(find.byIcon(Icons.music_off), findsOneWidget);
       });
 
-      testWidgets('leaves featured list when OG Sounds tab is selected', (
-        tester,
-      ) async {
+      testWidgets('renders featured sounds on featured tab', (tester) async {
         await tester.pumpWidget(
           buildWidget(trendingSoundsAsync: AsyncValue.data(testSounds)),
         );
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        await tester.tap(find.text(l10n.videoEditorAudioCategoryDivine));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryFeatured));
         await tester.pumpAndSettle();
 
-        expect(find.text('Wednesday'), findsNothing);
+        expect(find.text('Wednesday'), findsOneWidget);
       });
 
       testWidgets('renders saved sounds empty state on My Sounds tab', (
@@ -155,8 +255,51 @@ void main() {
       });
     });
 
+    group('Error state', () {
+      testWidgets('renders error state when community fails', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.error(
+              Exception('network error'),
+              StackTrace.current,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.videoEditorAudioFailedToLoadTitle),
+          findsOneWidget,
+        );
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      });
+
+      testWidgets('renders retry button on error state', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.error(
+              Exception('network error'),
+              StackTrace.current,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.commonRetry), findsOneWidget);
+        expect(find.byType(ElevatedButton), findsOneWidget);
+      });
+    });
+
     group('Initial state', () {
-      testWidgets('renders featured $AudioListTile initially', (
+      testWidgets('renders no $AudioListTile while no sounds are loaded', (
         tester,
       ) async {
         await tester.pumpWidget(
@@ -164,7 +307,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.byType(AudioListTile), findsOneWidget);
+        expect(find.byType(AudioListTile), findsNothing);
       });
 
       testWidgets('renders saved sounds on My Sounds tab', (tester) async {


### PR DESCRIPTION
Closes #4036

## Summary
- add a search field to the editor audio picker
- filter Divine, Community, Featured, and My Sounds locally within the active picker flow
- show a no-results state when a tab has no matches for the current query

## Stack
- this PR is related to #4026 and is intentionally stacked on top of it
- base branch: `fix/audio-library-consolidation`
- this PR should merge after #4026
- after #4026 merges, this branch/PR should be retargeted or rebased onto `main` before final merge

## Testing
- flutter analyze lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
- flutter test --no-pub test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
