### PR TITLE
fix(comments): use fast profile lookup for mentions

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -822,6 +822,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
             pubkey: pubkey,
             displayName: displayName,
             picture: profile?.picture,
+            nip05: profile?.nip05,
           ),
         );
       }
@@ -859,6 +860,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
               pubkey: profile.pubkey,
               displayName: name,
               picture: profile.picture,
+              nip05: profile.nip05,
             ),
           );
 

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -839,9 +839,10 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     // Tier 2: Async remote search if <5 local results
     if (suggestions.length < 5 && _profileRepository != null) {
       try {
-        final remoteResults = await _profileRepository.searchUsers(
+        final remoteResults = await _profileRepository.searchUsersFromApi(
           query: query,
           limit: 10,
+          sortBy: 'followers',
         );
 
         // Merge with local results, deduplicating by pubkey

--- a/mobile/lib/blocs/comments/comments_state.dart
+++ b/mobile/lib/blocs/comments/comments_state.dart
@@ -28,6 +28,7 @@ class MentionSuggestion extends Equatable {
     required this.pubkey,
     this.displayName,
     this.picture,
+    this.nip05,
   });
 
   /// The hex public key of the suggested user.
@@ -39,8 +40,11 @@ class MentionSuggestion extends Equatable {
   /// Optional profile picture URL.
   final String? picture;
 
+  /// Optional NIP-05 claim from the profile.
+  final String? nip05;
+
   @override
-  List<Object?> get props => [pubkey, displayName, picture];
+  List<Object?> get props => [pubkey, displayName, picture, nip05];
 }
 
 /// Enum representing the status of the comments loading

--- a/mobile/lib/screens/comments/widgets/mention_overlay.dart
+++ b/mobile/lib/screens/comments/widgets/mention_overlay.dart
@@ -5,9 +5,39 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/comments/comments_bloc.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+
+class MentionNip05Claim {
+  const MentionNip05Claim({required this.pubkey, required this.nip05});
+
+  final String pubkey;
+  final String nip05;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MentionNip05Claim &&
+          runtimeType == other.runtimeType &&
+          pubkey == other.pubkey &&
+          nip05 == other.nip05;
+
+  @override
+  int get hashCode => Object.hash(pubkey, nip05);
+}
+
+// ignore: specify_nonobvious_property_types
+final mentionNip05VerificationProvider =
+    FutureProvider.family<Nip05VerificationStatus, MentionNip05Claim>((
+      ref,
+      claim,
+    ) {
+      final service = ref.watch(nip05VerificationServiceProvider);
+      return service.getVerificationStatus(claim.pubkey, claim.nip05);
+    });
 
 /// Overlay widget showing mention suggestions above the comment input.
 class MentionOverlay extends ConsumerWidget {
@@ -88,7 +118,26 @@ class _MentionSuggestionItem extends ConsumerWidget {
     final displayName =
         suggestion.displayName ?? profile?.displayName ?? profile?.name;
     final picture = suggestion.picture ?? profile?.picture;
+    final rawNip05 = suggestion.nip05 ?? profile?.nip05;
+    final displayNip05 = _displayNip05(rawNip05);
+    final verificationStatus = rawNip05 != null && rawNip05.isNotEmpty
+        ? ref
+              .watch(
+                mentionNip05VerificationProvider(
+                  MentionNip05Claim(
+                    pubkey: suggestion.pubkey,
+                    nip05: rawNip05,
+                  ),
+                ),
+              )
+              .whenOrNull(data: (status) => status)
+        : null;
     final npub = NostrKeyUtils.encodePubKey(suggestion.pubkey);
+    final identifier =
+        verificationStatus == Nip05VerificationStatus.verified &&
+            displayNip05 != null
+        ? displayNip05
+        : npub;
 
     return InkWell(
       onTap: onTap,
@@ -117,7 +166,7 @@ class _MentionSuggestionItem extends ConsumerWidget {
                       overflow: TextOverflow.ellipsis,
                     ),
                   Text(
-                    npub,
+                    identifier,
                     style: VineTheme.bodySmallFont(
                       color: VineTheme.onSurfaceMuted,
                     ),
@@ -132,4 +181,15 @@ class _MentionSuggestionItem extends ConsumerWidget {
       ),
     );
   }
+}
+
+String? _displayNip05(String? nip05) {
+  if (nip05 == null || nip05.isEmpty) return null;
+  if (nip05.startsWith('_@')) return nip05.substring(1);
+
+  if (nip05.endsWith('@divine.video') || nip05.endsWith('@openvine.co')) {
+    return '@${nip05.split('@')[0]}.divine.video';
+  }
+
+  return nip05;
 }

--- a/mobile/lib/screens/comments/widgets/mention_overlay.dart
+++ b/mobile/lib/screens/comments/widgets/mention_overlay.dart
@@ -85,7 +85,9 @@ class _MentionSuggestionItem extends ConsumerWidget {
         .watch(userProfileReactiveProvider(suggestion.pubkey))
         .value;
 
-    final displayName = profile?.displayName ?? profile?.name;
+    final displayName =
+        suggestion.displayName ?? profile?.displayName ?? profile?.name;
+    final picture = suggestion.picture ?? profile?.picture;
     final npub = NostrKeyUtils.encodePubKey(suggestion.pubkey);
 
     return InkWell(
@@ -97,7 +99,8 @@ class _MentionSuggestionItem extends ConsumerWidget {
           children: [
             UserAvatar(
               size: 32,
-              imageUrl: profile?.picture,
+              imageUrl: picture,
+              name: displayName,
               placeholderSeed: suggestion.pubkey,
             ),
             Expanded(

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -787,6 +787,47 @@ class ProfileRepository {
     }
   }
 
+  /// Searches for user profiles via the Funnelcake REST API only.
+  ///
+  /// This is for latency-sensitive typeahead surfaces that should not wait
+  /// for NIP-50 relay search. Results are returned in server order.
+  ///
+  /// [offset] skips results for pagination.
+  /// [sortBy] requests server-side sorting (e.g., 'followers').
+  /// [hasVideos] filters to only users who have published at least one video.
+  /// Returns empty list if query is empty, Funnelcake is unavailable, or the
+  /// REST request fails.
+  Future<List<UserProfile>> searchUsersFromApi({
+    required String query,
+    int limit = 50,
+    int offset = 0,
+    String? sortBy,
+    bool hasVideos = false,
+  }) async {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.isEmpty) return [];
+    if (!(_funnelcakeApiClient?.isAvailable ?? false)) return [];
+
+    try {
+      final restResults = await _funnelcakeApiClient!.searchProfiles(
+        query: trimmedQuery,
+        limit: limit,
+        offset: offset,
+        sortBy: sortBy,
+        hasVideos: hasVideos,
+      );
+      final profiles = restResults.map((result) => result.toUserProfile());
+      return _enrichFromCache(profiles.toList());
+    } on Exception catch (e) {
+      Log.warning(
+        'REST profile search failed: $e',
+        name: 'ProfileRepository.searchUsersFromApi',
+        category: LogCategory.api,
+      );
+      return [];
+    }
+  }
+
   /// Searches for user profiles matching the query.
   ///
   /// Uses a hybrid search approach:

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -2145,6 +2145,55 @@ void main() {
       );
 
       test(
+        'searchUsersFromApi returns empty results when Funnelcake fails',
+        () async {
+          // Arrange
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'ga',
+              limit: 10,
+              offset: any(named: 'offset'),
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenThrow(Exception('REST API error'));
+
+          final repoWithFunnelcake = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          // Act
+          final result = await repoWithFunnelcake.searchUsersFromApi(
+            query: 'ga',
+            limit: 10,
+            sortBy: 'followers',
+          );
+
+          // Assert
+          expect(result, isEmpty);
+          verify(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'ga',
+              limit: 10,
+              offset: any(named: 'offset'),
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockNostrClient.queryUsers(
+              any(),
+              limit: any(named: 'limit'),
+            ),
+          );
+        },
+      );
+
+      test(
         'uses Funnelcake first then WebSocket when both available',
         () async {
           // Arrange

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -2085,6 +2085,66 @@ void main() {
       });
 
       test(
+        'searchUsersFromApi uses Funnelcake only with server sorting',
+        () async {
+          // Arrange
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'ga',
+              limit: 10,
+              offset: any(named: 'offset'),
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ProfileSearchResult(
+                pubkey: 'd' * 64,
+                displayName: 'GaryVee',
+                picture: 'https://example.com/garyvee.jpg',
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              ),
+            ],
+          );
+
+          final repoWithFunnelcake = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          // Act
+          final result = await repoWithFunnelcake.searchUsersFromApi(
+            query: 'ga',
+            limit: 10,
+            sortBy: 'followers',
+          );
+
+          // Assert
+          expect(result, hasLength(1));
+          expect(result.first.displayName, 'GaryVee');
+          expect(result.first.picture, 'https://example.com/garyvee.jpg');
+          verify(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'ga',
+              limit: 10,
+              offset: any(named: 'offset'),
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockNostrClient.queryUsers(
+              any(),
+              limit: any(named: 'limit'),
+            ),
+          );
+        },
+      );
+
+      test(
         'uses Funnelcake first then WebSocket when both available',
         () async {
           // Arrange

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -92,6 +92,15 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => []);
+      when(
+        () => mockProfileRepository.searchUsersFromApi(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+          sortBy: any(named: 'sortBy'),
+          hasVideos: any(named: 'hasVideos'),
+        ),
+      ).thenAnswer((_) async => []);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
 
       // Default stubs for real-time comment watching
@@ -2595,12 +2604,15 @@ void main() {
       );
 
       blocTest<CommentsBloc, CommentsState>(
-        'fetches remote results when fewer than 5 local matches',
+        'fetches REST results sorted by followers when fewer than 5 local matches',
         setUp: () {
           when(
-            () => mockProfileRepository.searchUsers(
-              query: 'rem',
+            () => mockProfileRepository.searchUsersFromApi(
+              query: 'ga',
               limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
             (_) async => [
@@ -2609,14 +2621,14 @@ void main() {
                 rawData: const {},
                 createdAt: DateTime.now(),
                 eventId: validId('event4'),
-                displayName: 'RemoteUser',
+                displayName: 'GaryVee',
               ),
             ],
           );
         },
         build: createBloc,
         seed: () => const CommentsState(status: CommentsStatus.success),
-        act: (bloc) => bloc.add(const MentionSearchRequested('rem')),
+        act: (bloc) => bloc.add(const MentionSearchRequested('ga')),
         expect: () => [
           // Tier 1: no local matches
           isA<CommentsState>().having(
@@ -2634,9 +2646,24 @@ void main() {
               .having(
                 (s) => s.mentionSuggestions.first.displayName,
                 'displayName',
-                'RemoteUser',
+                'GaryVee',
               ),
         ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.searchUsersFromApi(
+              query: 'ga',
+              limit: 10,
+              sortBy: 'followers',
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockProfileRepository.searchUsers(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+            ),
+          );
+        },
       );
 
       blocTest<CommentsBloc, CommentsState>(

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -2622,6 +2622,7 @@ void main() {
                 createdAt: DateTime.now(),
                 eventId: validId('event4'),
                 displayName: 'GaryVee',
+                nip05: 'garyvee@example.com',
               ),
             ],
           );
@@ -2647,6 +2648,11 @@ void main() {
                 (s) => s.mentionSuggestions.first.displayName,
                 'displayName',
                 'GaryVee',
+              )
+              .having(
+                (s) => s.mentionSuggestions.first.nip05,
+                'nip05',
+                'garyvee@example.com',
               ),
         ],
         verify: (_) {
@@ -3689,20 +3695,30 @@ void main() {
         pubkey: 'abc',
         displayName: 'Alice',
         picture: 'pic.jpg',
+        nip05: 'alice@example.com',
       );
       const suggestion2 = MentionSuggestion(
         pubkey: 'abc',
         displayName: 'Alice',
         picture: 'pic.jpg',
+        nip05: 'alice@example.com',
       );
       const suggestion3 = MentionSuggestion(
         pubkey: 'abc',
         displayName: 'Bob',
         picture: 'pic.jpg',
+        nip05: 'alice@example.com',
+      );
+      const suggestion4 = MentionSuggestion(
+        pubkey: 'abc',
+        displayName: 'Alice',
+        picture: 'pic.jpg',
+        nip05: 'alice@elsewhere.example',
       );
 
       expect(suggestion1, equals(suggestion2));
       expect(suggestion1, isNot(equals(suggestion3)));
+      expect(suggestion1, isNot(equals(suggestion4)));
     });
 
     test('treats null and non-null optional fields as unequal', () {

--- a/mobile/test/screens/comments/widgets/mention_overlay_test.dart
+++ b/mobile/test/screens/comments/widgets/mention_overlay_test.dart
@@ -6,8 +6,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/screens/comments/widgets/mention_overlay.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
 
 void main() {
+  const pubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
   testWidgets('renders suggestion display name before profile cache resolves', (
     tester,
   ) async {
@@ -18,8 +22,7 @@ void main() {
             body: MentionOverlay(
               suggestions: const [
                 MentionSuggestion(
-                  pubkey:
-                      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                  pubkey: pubkey,
                   displayName: 'GaryVee',
                 ),
               ],
@@ -31,5 +34,81 @@ void main() {
     );
 
     expect(find.text('GaryVee'), findsOneWidget);
+  });
+
+  testWidgets('shows verified NIP-05 instead of npub when suggestion has one', (
+    tester,
+  ) async {
+    const claim = MentionNip05Claim(
+      pubkey: pubkey,
+      nip05: 'garyvee@example.com',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mentionNip05VerificationProvider(claim).overrideWith(
+            (ref) async => Nip05VerificationStatus.verified,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: MentionOverlay(
+              suggestions: const [
+                MentionSuggestion(
+                  pubkey: pubkey,
+                  displayName: 'GaryVee',
+                  nip05: 'garyvee@example.com',
+                ),
+              ],
+              onSelect: (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('garyvee@example.com'), findsOneWidget);
+    expect(find.textContaining('npub'), findsNothing);
+  });
+
+  testWidgets('falls back to npub when NIP-05 verification fails', (
+    tester,
+  ) async {
+    const claim = MentionNip05Claim(
+      pubkey: pubkey,
+      nip05: 'garyvee@example.com',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mentionNip05VerificationProvider(claim).overrideWith(
+            (ref) async => Nip05VerificationStatus.failed,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: MentionOverlay(
+              suggestions: const [
+                MentionSuggestion(
+                  pubkey: pubkey,
+                  displayName: 'GaryVee',
+                  nip05: 'garyvee@example.com',
+                ),
+              ],
+              onSelect: (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('garyvee@example.com'), findsNothing);
+    expect(find.textContaining('npub'), findsOneWidget);
   });
 }

--- a/mobile/test/screens/comments/widgets/mention_overlay_test.dart
+++ b/mobile/test/screens/comments/widgets/mention_overlay_test.dart
@@ -1,0 +1,35 @@
+// ABOUTME: Tests for comment mention autocomplete overlay rendering
+// ABOUTME: Verifies server suggestion data renders before profile cache catches up
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/comments/comments_bloc.dart';
+import 'package:openvine/screens/comments/widgets/mention_overlay.dart';
+
+void main() {
+  testWidgets('renders suggestion display name before profile cache resolves', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: MentionOverlay(
+              suggestions: const [
+                MentionSuggestion(
+                  pubkey:
+                      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                  displayName: 'GaryVee',
+                ),
+              ],
+              onSelect: (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('GaryVee'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #4039

## Summary
- use Funnelcake REST-only profile search for comment mention autocomplete
- sort remote mention results by followers so high-signal accounts appear for short queries like @ga
- render suggestion display names and avatars immediately instead of waiting for the profile cache

## Verification
- flutter test test/blocs/comments/comments_bloc_test.dart
- flutter test test/src/profile_repository_test.dart (from mobile/packages/profile_repository)
- flutter test test/screens/comments/widgets/mention_overlay_test.dart
- flutter analyze
- pre-push hook: analyzer + changed-file tests (284 passed)