### PR TITLE
fix(collabs): publish accepted invite as video copy

### DIFF
--- a/mobile/lib/constants/collaboration_event_kinds.dart
+++ b/mobile/lib/constants/collaboration_event_kinds.dart
@@ -1,4 +1,0 @@
-// ABOUTME: Nostr event kind constants for Divine collaboration flows.
-// ABOUTME: Kept in sync with Funnelcake collaborator response ingestion.
-
-const int kindCollabResponse = 34238;

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -171,6 +171,9 @@ final collaboratorResponseServiceProvider =
       return CollaboratorResponseService(
         authService: ref.watch(authServiceProvider),
         nostrClient: ref.watch(nostrServiceProvider),
+        loadSourceVideo: ref
+            .watch(videosRepositoryProvider)
+            .fetchVideoWithStatsForRouteId,
       );
     });
 

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -4,9 +4,11 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/collaborator_invite.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
 
 class CollaboratorInviteCard extends StatefulWidget {
@@ -108,41 +110,49 @@ class _CardChrome extends StatelessWidget {
         alignment: isSent
             ? AlignmentDirectional.centerEnd
             : AlignmentDirectional.centerStart,
-        child: Container(
-          constraints: BoxConstraints(
-            maxWidth: MediaQuery.sizeOf(context).width * 0.78,
-          ),
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: VineTheme.surfaceContainerHigh,
-            border: Border.all(color: VineTheme.outlineMuted),
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                l10n.inboxCollabInviteCardTitle,
-                style: VineTheme.labelLargeFont(color: VineTheme.primary),
+        child: Semantics(
+          button: true,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () =>
+                context.push(VideoDetailScreen.pathForId(invite.videoAddress)),
+            child: Container(
+              constraints: BoxConstraints(
+                maxWidth: MediaQuery.sizeOf(context).width * 0.78,
               ),
-              const SizedBox(height: 8),
-              Text(
-                _titleText(),
-                style: VineTheme.titleMediumFont(),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: VineTheme.surfaceContainerHigh,
+                border: Border.all(color: VineTheme.outlineMuted),
+                borderRadius: BorderRadius.circular(16),
               ),
-              const SizedBox(height: 4),
-              Text(
-                l10n.inboxCollabInviteCardRoleLabel(invite.role),
-                style: VineTheme.bodySmallFont(
-                  color: VineTheme.onSurfaceMuted,
-                ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    l10n.inboxCollabInviteCardTitle,
+                    style: VineTheme.labelLargeFont(color: VineTheme.primary),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    _titleText(),
+                    style: VineTheme.titleMediumFont(),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    l10n.inboxCollabInviteCardRoleLabel(invite.role),
+                    style: VineTheme.bodySmallFont(
+                      color: VineTheme.onSurfaceMuted,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  action,
+                ],
               ),
-              const SizedBox(height: 16),
-              action,
-            ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/services/collaborator_response_service.dart
+++ b/mobile/lib/services/collaborator_response_service.dart
@@ -1,11 +1,13 @@
-// ABOUTME: Publishes public collaborator response events.
-// ABOUTME: Acceptance events are the mobile side of confirmed collab semantics.
+// ABOUTME: Publishes collaborator acceptance events.
+// ABOUTME: Acceptance mirrors Connect by copying the source video under the accepter.
 
 import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
-import 'package:openvine/constants/collaboration_event_kinds.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/auth_service.dart';
+
+typedef SourceVideoLoader = Future<VideoEvent?> Function(String videoAddress);
 
 class CollaboratorResponseResult extends Equatable {
   const CollaboratorResponseResult({
@@ -32,33 +34,43 @@ class CollaboratorResponseService {
   const CollaboratorResponseService({
     required AuthService authService,
     required NostrClient nostrClient,
+    SourceVideoLoader? loadSourceVideo,
     this.defaultRelayHint = 'wss://relay.divine.video',
   }) : _authService = authService,
-       _nostrClient = nostrClient;
+       _nostrClient = nostrClient,
+       _loadSourceVideo = loadSourceVideo;
 
   final AuthService _authService;
   final NostrClient _nostrClient;
+  final SourceVideoLoader? _loadSourceVideo;
   final String defaultRelayHint;
 
   Future<CollaboratorResponseResult> acceptInvite(
     CollaboratorInvite invite,
   ) async {
     try {
+      final currentPubkey = _authService.currentPublicKeyHex;
+      if (currentPubkey == null || currentPubkey.isEmpty) {
+        return const CollaboratorResponseResult.failure(
+          'Could not determine collaborator pubkey',
+        );
+      }
+
+      final sourceVideo = await _loadSourceVideo?.call(invite.videoAddress);
+      if (sourceVideo == null) {
+        return const CollaboratorResponseResult.failure(
+          'Could not load source video for collaborator acceptance',
+        );
+      }
+
       final event = await _authService.createAndSignEvent(
-        kind: kindCollabResponse,
-        content: '',
-        tags: [
-          ['d', invite.videoAddress],
-          [
-            'a',
-            invite.videoAddress,
-            invite.relayHint ?? defaultRelayHint,
-            'root',
-          ],
-          ['p', invite.creatorPubkey],
-          ['role', invite.role],
-          ['status', 'accepted'],
-        ],
+        kind: invite.videoKind,
+        content: sourceVideo.content,
+        tags: _buildAcceptanceTags(
+          invite: invite,
+          sourceVideo: sourceVideo,
+          accepterPubkey: currentPubkey,
+        ),
       );
 
       if (event == null) {
@@ -78,5 +90,65 @@ class CollaboratorResponseService {
     } on Object catch (error) {
       return CollaboratorResponseResult.failure(error.toString());
     }
+  }
+
+  List<List<String>> _buildAcceptanceTags({
+    required CollaboratorInvite invite,
+    required VideoEvent sourceVideo,
+    required String accepterPubkey,
+  }) {
+    final relayHint = invite.relayHint ?? defaultRelayHint;
+    final tags =
+        (sourceVideo.nostrEventTags.isNotEmpty
+                ? sourceVideo.nostrEventTags
+                : _fallbackSourceTags(invite: invite, sourceVideo: sourceVideo))
+            .where(
+              (tag) => !_isCollaboratorTagFor(tag, accepterPubkey),
+            )
+            .map(List<String>.from)
+            .toList();
+
+    if (!tags.any((tag) => tag.isNotEmpty && tag[0] == 'd')) {
+      tags.insert(0, ['d', invite.videoDTag]);
+    }
+
+    if (!_hasCollaboratorTag(tags, sourceVideo.pubkey)) {
+      tags.add(['p', sourceVideo.pubkey, '', 'collaborator']);
+    }
+
+    if (sourceVideo.id.isNotEmpty) {
+      tags.add(['e', sourceVideo.id, '', 'source']);
+    }
+    tags.add(['a', invite.videoAddress, relayHint, 'source']);
+
+    return tags;
+  }
+
+  List<List<String>> _fallbackSourceTags({
+    required CollaboratorInvite invite,
+    required VideoEvent sourceVideo,
+  }) {
+    return [
+      ['d', invite.videoDTag],
+      if (sourceVideo.title != null && sourceVideo.title!.trim().isNotEmpty)
+        ['title', sourceVideo.title!.trim()],
+      if (sourceVideo.videoUrl != null &&
+          sourceVideo.videoUrl!.trim().isNotEmpty)
+        ['url', sourceVideo.videoUrl!.trim()],
+      if (sourceVideo.thumbnailUrl != null &&
+          sourceVideo.thumbnailUrl!.trim().isNotEmpty)
+        ['thumb', sourceVideo.thumbnailUrl!.trim()],
+    ];
+  }
+
+  bool _isCollaboratorTagFor(List<String> tag, String pubkey) {
+    return tag.length >= 4 &&
+        tag[0] == 'p' &&
+        tag[1] == pubkey &&
+        tag[3].toLowerCase() == 'collaborator';
+  }
+
+  bool _hasCollaboratorTag(List<List<String>> tags, String pubkey) {
+    return tags.any((tag) => _isCollaboratorTagFor(tag, pubkey));
   }
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -15,7 +15,9 @@ import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 
+import '../../../helpers/go_router.dart';
 import '../../../helpers/test_provider_overrides.dart';
 
 class _MockConversationBloc
@@ -79,7 +81,11 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    Widget buildSubject({ConversationState? state, UserProfile? otherProfile}) {
+    Widget buildSubject({
+      ConversationState? state,
+      UserProfile? otherProfile,
+      MockGoRouter? goRouter,
+    }) {
       final effectiveState = state ?? const ConversationState();
       whenListen(
         mockBloc,
@@ -87,7 +93,7 @@ void main() {
         initialState: effectiveState,
       );
 
-      return testMaterialApp(
+      final app = testMaterialApp(
         mockAuthService: mockAuthService,
         additionalOverrides: [
           fetchUserProfileProvider(
@@ -104,6 +110,9 @@ void main() {
           ),
         ),
       );
+      return goRouter == null
+          ? app
+          : MockGoRouterProvider(goRouter: goRouter, child: app);
     }
 
     group('renders', () {
@@ -254,6 +263,58 @@ void main() {
 
           verify(
             () => mockInviteActionsCubit.acceptInvite(any()),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'opens collaborator invite video when card is tapped',
+        (tester) async {
+          final mockGoRouter = MockGoRouter();
+          when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
+
+          final message = DmMessage(
+            id: '9999999999999999999999999999999999999999999999999999999999999999',
+            conversationId:
+                'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            senderPubkey: otherPubkey,
+            content: 'You were invited to collaborate.',
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            giftWrapId:
+                'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+            tags: const [
+              ['divine', 'collab-invite'],
+              [
+                'a',
+                '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
+                'wss://relay.divine.video',
+              ],
+              ['p', otherPubkey],
+              ['role', 'Collaborator'],
+              ['title', 'Skate loop'],
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                messages: [message],
+              ),
+              goRouter: mockGoRouter,
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.byType(CollaboratorInviteCard));
+          await tester.pump();
+
+          verify(
+            () => mockGoRouter.push(
+              VideoDetailScreen.pathForId(
+                '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
+              ),
+            ),
           ).called(1);
         },
       );

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -1,11 +1,11 @@
-// ABOUTME: Tests public collaborator acceptance response publishing.
-// ABOUTME: Verifies kind 34238 acceptance events match Funnelcake semantics.
+// ABOUTME: Tests collaborator acceptance publishing.
+// ABOUTME: Verifies accept mirrors Connect by publishing an accepter-owned video copy.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
-import 'package:openvine/constants/collaboration_event_kinds.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_response_service.dart';
@@ -27,6 +27,21 @@ void main() {
   late _MockNostrClient nostrClient;
   late CollaboratorResponseService service;
 
+  final sourceVideo = VideoEvent(
+    id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    pubkey: creatorPubkey,
+    createdAt: 1700000000,
+    content: 'A collab video',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+    title: 'Collab Video',
+    nostrEventTags: const [
+      ['d', 'video-d-tag'],
+      ['title', 'Collab Video'],
+      ['p', collaboratorPubkey, 'wss://relay.divine.video', 'collaborator'],
+      ['url', 'https://media.divine.video/video.mp4'],
+    ],
+  );
+
   const invite = CollaboratorInvite(
     messageId: 'message-id',
     videoAddress: videoAddress,
@@ -44,13 +59,15 @@ void main() {
   setUp(() {
     authService = _MockAuthService();
     nostrClient = _MockNostrClient();
+    when(() => authService.currentPublicKeyHex).thenReturn(collaboratorPubkey);
     service = CollaboratorResponseService(
       authService: authService,
       nostrClient: nostrClient,
+      loadSourceVideo: (_) async => sourceVideo,
     );
   });
 
-  test('publishes public collaborator acceptance event', () async {
+  test('publishes accepter-owned collaborator video copy', () async {
     late Event signedEvent;
     when(
       () => authService.createAndSignEvent(
@@ -62,9 +79,9 @@ void main() {
       final tags = invocation.namedArguments[#tags] as List<List<String>>;
       signedEvent = Event(
         collaboratorPubkey,
-        kindCollabResponse,
+        34236,
         tags,
-        '',
+        'A collab video',
       );
       return signedEvent;
     });
@@ -85,52 +102,82 @@ void main() {
       ),
     );
 
-    expect(verification.captured[0], kindCollabResponse);
-    expect(verification.captured[1], '');
+    expect(verification.captured[0], 34236);
+    expect(verification.captured[1], 'A collab video');
     expect(verification.captured[2], [
-      ['d', videoAddress],
-      ['a', videoAddress, 'wss://relay.divine.video', 'root'],
-      ['p', creatorPubkey],
-      ['role', 'Collaborator'],
-      ['status', 'accepted'],
+      ['d', 'video-d-tag'],
+      ['title', 'Collab Video'],
+      ['url', 'https://media.divine.video/video.mp4'],
+      ['p', creatorPubkey, '', 'collaborator'],
+      [
+        'e',
+        'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        '',
+        'source',
+      ],
+      ['a', videoAddress, 'wss://relay.divine.video', 'source'],
     ]);
     verify(() => nostrClient.publishEvent(signedEvent)).called(1);
   });
 
-  test('uses default relay hint when invite has none', () async {
-    late List<List<String>> capturedTags;
-    final inviteWithoutRelay = CollaboratorInvite(
-      messageId: invite.messageId,
-      videoAddress: invite.videoAddress,
-      videoKind: invite.videoKind,
-      creatorPubkey: invite.creatorPubkey,
-      videoDTag: invite.videoDTag,
-      role: invite.role,
+  test(
+    'uses default relay hint for source address when invite has none',
+    () async {
+      late List<List<String>> capturedTags;
+      final inviteWithoutRelay = CollaboratorInvite(
+        messageId: invite.messageId,
+        videoAddress: invite.videoAddress,
+        videoKind: invite.videoKind,
+        creatorPubkey: invite.creatorPubkey,
+        videoDTag: invite.videoDTag,
+        role: invite.role,
+      );
+
+      when(
+        () => authService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
+        return Event(collaboratorPubkey, 34236, capturedTags, 'A collab video');
+      });
+      when(() => nostrClient.publishEvent(any())).thenAnswer(
+        (invocation) async => invocation.positionalArguments.single as Event,
+      );
+
+      final result = await service.acceptInvite(inviteWithoutRelay);
+
+      expect(result.success, isTrue);
+      expect(capturedTags.last, [
+        'a',
+        videoAddress,
+        'wss://relay.divine.video',
+        'source',
+      ]);
+    },
+  );
+
+  test('returns failure when source video cannot be loaded', () async {
+    service = CollaboratorResponseService(
+      authService: authService,
+      nostrClient: nostrClient,
+      loadSourceVideo: (_) async => null,
     );
 
-    when(
+    final result = await service.acceptInvite(invite);
+
+    expect(result.success, isFalse);
+    expect(result.error, contains('source video'));
+    verifyNever(
       () => authService.createAndSignEvent(
         kind: any(named: 'kind'),
         content: any(named: 'content'),
         tags: any(named: 'tags'),
       ),
-    ).thenAnswer((invocation) async {
-      capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-      return Event(collaboratorPubkey, kindCollabResponse, capturedTags, '');
-    });
-    when(() => nostrClient.publishEvent(any())).thenAnswer(
-      (invocation) async => invocation.positionalArguments.single as Event,
     );
-
-    final result = await service.acceptInvite(inviteWithoutRelay);
-
-    expect(result.success, isTrue);
-    expect(capturedTags[1], [
-      'a',
-      videoAddress,
-      'wss://relay.divine.video',
-      'root',
-    ]);
+    verifyNever(() => nostrClient.publishEvent(any()));
   });
 
   test('returns failure when signing fails', () async {


### PR DESCRIPTION
Closes #4041

## Summary
- Match divine-connect's collaboration accept behavior by publishing an accepter-owned Kind 34236 video copy instead of a custom 34238 response event.
- Load the source video through the repository before accepting and preserve its video tags while adding reciprocal collaborator/source tags.
- Make collaborator invite cards tappable so the invite opens the referenced video route, and remove the stale response-kind constant.

## Test Plan
- [x] flutter test --no-pub test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart test/screens/inbox/conversation/conversation_view_test.dart test/screens/inbox/message_requests/request_preview_view_test.dart test/services/collaborator_response_service_test.dart
- [x] flutter analyze lib/services/collaborator_response_service.dart lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart lib/providers/app_providers.dart test/services/collaborator_response_service_test.dart test/screens/inbox/conversation/conversation_view_test.dart
- [x] Pre-push hook: analyzer, generated files, and changed-file tests
- [x] Fetched origin/main; branch contains 24b0844278a6b91554c367850dbd14d8cbc521cc