### PR TITLE
chore(release): bump app version to 1.0.12

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.11+500
+version: 1.0.12+501
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- Bump app version from 1.0.11+500 to 1.0.12+501.

## Test Plan
- [x] git diff --check
- [x] flutter pub get
- [x] pre-push hook: no Dart files changed, skipped checks
- [x] fetched origin/main and verified origin/main is an ancestor of HEAD

Note: direct push to main was rejected by branch protection because Mobile CI is required.