### PR TITLE
fix(profile): unify divine.video username validation across editor and repository

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -13,15 +13,10 @@ import 'package:unified_logger/unified_logger.dart';
 part 'profile_editor_event.dart';
 part 'profile_editor_state.dart';
 
-/// Minimum username length.
-const _minUsernameLength = 3;
-
-/// Maximum username length.
-const _maxUsernameLength = 20;
-
-/// Username format: lowercase letters, numbers, hyphens, underscores, periods.
-/// NIP-05 local parts are lowercase-only (a-z0-9-_.) per spec.
-final _usernamePattern = RegExp(r'^[a-z0-9._-]+$');
+/// Matches [DivineUsernameInvalid.reason] for length failures from
+/// [validateDivineUsername].
+String get _divineUsernameLengthFailureReason =>
+    'Usernames must be $kDivineUsernameMinLength–$kDivineUsernameMaxLength characters';
 
 /// External NIP-05 format: `local-part@domain` per NIP-05 spec.
 /// Local part: a-z0-9-_. (lowercase only).
@@ -130,31 +125,27 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       return;
     }
 
-    if (!_usernamePattern.hasMatch(rawUsername)) {
+    final validation = validateDivineUsername(rawUsername);
+    if (validation case DivineUsernameInvalid(:final reason)) {
+      final isLength = reason == _divineUsernameLengthFailureReason;
       emit(
         state.copyWith(
           username: username,
-          usernameStatus: UsernameStatus.error,
-          usernameError: UsernameValidationError.invalidFormat,
+          usernameStatus: isLength
+              ? UsernameStatus.error
+              : UsernameStatus.invalidFormat,
+          usernameError: isLength
+              ? UsernameValidationError.invalidLength
+              : UsernameValidationError.invalidFormat,
+          usernameFormatMessage: isLength ? null : reason,
         ),
       );
       return;
     }
 
-    // Then check length
-    if (username.length < _minUsernameLength ||
-        username.length > _maxUsernameLength) {
-      emit(
-        state.copyWith(
-          username: username,
-          usernameStatus: UsernameStatus.error,
-          usernameError: UsernameValidationError.invalidLength,
-        ),
-      );
-      return;
-    }
+    final normalized = (validation as DivineUsernameValid).normalized;
 
-    if (state.reservedUsernames.contains(username)) {
+    if (state.reservedUsernames.contains(normalized)) {
       emit(
         state.copyWith(
           username: username,
@@ -166,7 +157,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     // Skip API check if username matches the user's own claimed username
     final initial = state.initialUsername;
-    if (initial != null && username == initial.toLowerCase()) {
+    if (initial != null && normalized == initial.toLowerCase()) {
       emit(
         state.copyWith(username: username, usernameStatus: UsernameStatus.idle),
       );
@@ -181,7 +172,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     );
 
     final result = await _profileRepository.checkUsernameAvailability(
-      username: username,
+      username: normalized,
       currentUserPubkey: _currentUserPubkey,
     );
 
@@ -194,7 +185,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         emit(
           state.copyWith(
             usernameStatus: UsernameStatus.reserved,
-            reservedUsernames: {...state.reservedUsernames, username},
+            reservedUsernames: {...state.reservedUsernames, normalized},
           ),
         );
       case UsernameBurned():
@@ -299,8 +290,14 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     final username = state.username;
     if (username.isEmpty) return;
 
+    final validation = validateDivineUsername(username);
+    if (validation case DivineUsernameInvalid()) {
+      return;
+    }
+    final normalized = (validation as DivineUsernameValid).normalized;
+
     // Remove from local reserved cache so the check runs against the server
-    final updatedReserved = {...state.reservedUsernames}..remove(username);
+    final updatedReserved = {...state.reservedUsernames}..remove(normalized);
 
     emit(
       state.copyWith(
@@ -310,7 +307,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     );
 
     final result = await _profileRepository.checkUsernameAvailability(
-      username: username,
+      username: normalized,
       currentUserPubkey: _currentUserPubkey,
     );
 
@@ -323,7 +320,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         emit(
           state.copyWith(
             usernameStatus: UsernameStatus.reserved,
-            reservedUsernames: {...state.reservedUsernames, username},
+            reservedUsernames: {...state.reservedUsernames, normalized},
           ),
         );
       case UsernameBurned():
@@ -344,7 +341,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         emit(
           state.copyWith(
             usernameStatus: UsernameStatus.reserved,
-            reservedUsernames: {...state.reservedUsernames, username},
+            reservedUsernames: {...state.reservedUsernames, normalized},
           ),
         );
     }
@@ -369,9 +366,13 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     // Bloc decides which NIP-05 value to use based on current mode
     final isExternal = state.nip05Mode == Nip05Mode.external_;
-    final username = isExternal || (event.username?.trim().isEmpty ?? true)
+    final trimmedUsername = event.username?.trim();
+    final username = isExternal || (trimmedUsername?.isEmpty ?? true)
         ? null
-        : event.username;
+        : switch (validateDivineUsername(trimmedUsername!)) {
+            DivineUsernameValid(:final normalized) => normalized,
+            DivineUsernameInvalid() => trimmedUsername,
+          };
     final externalNip05 =
         !isExternal || (event.externalNip05?.trim().isEmpty ?? true)
         ? null

--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -65,7 +65,7 @@ enum UsernameStatus {
   /// Username has been permanently burned and is no longer available.
   burned,
 
-  /// Username has invalid format (e.g. contains dots, underscores).
+  /// Username has invalid format for divine.video (e.g. dots, underscores).
   invalidFormat,
 
   /// Validation error (network or other error).
@@ -76,13 +76,13 @@ enum UsernameStatus {
 ///
 /// The UI layer should map these to localized strings.
 enum UsernameValidationError {
-  /// Username contains invalid characters.
+  /// Username contains invalid characters or hyphen placement.
   ///
-  /// Valid characters: lowercase letters, numbers, hyphens, underscores,
-  /// periods. Per NIP-05, local parts are lowercase-only (a-z0-9-_.).
+  /// Valid characters for a divine.video username are lowercase letters,
+  /// digits, and non-edge hyphens (single DNS label under *.divine.video).
   invalidFormat,
 
-  /// Username length is outside allowed range (3-20 characters).
+  /// Username length is outside allowed range (3–63 characters).
   invalidLength,
 
   /// Failed to check username availability due to network error.

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -409,7 +409,7 @@
     "profileSetupCheckAgain": "እንደገና ያረጋግጡ",
     "profileSetupUsernameBurned": "ይህ የተጠቃሚ ስም ከአሁን በኋላ አይገኝም",
     "profileSetupUsernameInvalidFormat": "ፊደሎች፣ ቁጥሮች እና ሰረዞች ብቻ ይፈቀዳሉ።",
-    "profileSetupUsernameInvalidLength": "የተጠቃሚ ስም 3-20 ቁምፊዎች መሆን አለበት።",
+    "profileSetupUsernameInvalidLength": "የተጠቃሚ ስም 3-63 ቁምፊዎች መሆን አለበት።",
     "profileSetupUsernameNetworkError": "ተገኝነትን ማረጋገጥ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",
     "profileSetupUsernameInvalidFormatGeneric": "የተሳሳተ የተጠቃሚ ስም ቅርጸት",
     "profileSetupUsernameCheckFailed": "ተገኝነትን ማረጋገጥ አልተሳካም።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "تحقّق مجددًا",
     "profileSetupUsernameBurned": "اسم المستخدم هذا لم يعد متاحًا",
     "profileSetupUsernameInvalidFormat": "يُسمح بالأحرف والأرقام والواصلات فقط",
-    "profileSetupUsernameInvalidLength": "يجب أن يتراوح طول اسم المستخدم بين 3 و 20 حرفًا",
+    "profileSetupUsernameInvalidLength": "يجب أن يتراوح طول اسم المستخدم بين 3 و 63 حرفًا",
     "profileSetupUsernameNetworkError": "تعذّر التحقق من التوفر. حاول مرّة أخرى.",
     "profileSetupUsernameInvalidFormatGeneric": "تنسيق اسم المستخدم غير صالح",
     "profileSetupUsernameCheckFailed": "تعذّر التحقق من التوفر",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -387,7 +387,7 @@
     "profileSetupCheckAgain": "Провери пак",
     "profileSetupUsernameBurned": "Това потребителско име вече не е достъпно",
     "profileSetupUsernameInvalidFormat": "Разрешени са само букви, цифри и тирета",
-    "profileSetupUsernameInvalidLength": "Потребителското име трябва да е 3-20 знака",
+    "profileSetupUsernameInvalidLength": "Потребителското име трябва да е 3-63 знака",
     "profileSetupUsernameNetworkError": "Не можем да проверим дали е свободно. Опитай пак.",
     "profileSetupUsernameInvalidFormatGeneric": "Невалиден формат на потребителското име",
     "profileSetupUsernameCheckFailed": "Неуспешна проверка за наличност",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Erneut prüfen",
     "profileSetupUsernameBurned": "Dieser Benutzername ist nicht mehr verfügbar",
     "profileSetupUsernameInvalidFormat": "Nur Buchstaben, Zahlen und Bindestriche sind erlaubt",
-    "profileSetupUsernameInvalidLength": "Benutzername muss 3-20 Zeichen lang sein",
+    "profileSetupUsernameInvalidLength": "Benutzername muss 3-63 Zeichen lang sein",
     "profileSetupUsernameNetworkError": "Verfügbarkeit konnte nicht geprüft werden. Bitte versuch es nochmal.",
     "profileSetupUsernameInvalidFormatGeneric": "Ungültiges Benutzernamen-Format",
     "profileSetupUsernameCheckFailed": "Verfügbarkeit konnte nicht geprüft werden",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -409,7 +409,7 @@
   "profileSetupCheckAgain": "Check again",
   "profileSetupUsernameBurned": "This username is no longer available",
   "profileSetupUsernameInvalidFormat": "Only letters, numbers, and hyphens are allowed",
-  "profileSetupUsernameInvalidLength": "Username must be 3-20 characters",
+  "profileSetupUsernameInvalidLength": "Username must be 3-63 characters",
   "profileSetupUsernameNetworkError": "Could not check availability. Please try again.",
   "profileSetupUsernameInvalidFormatGeneric": "Invalid username format",
   "profileSetupUsernameCheckFailed": "Failed to check availability",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Verificar de nuevo",
     "profileSetupUsernameBurned": "Este nombre de usuario ya no está disponible",
     "profileSetupUsernameInvalidFormat": "Solo se permiten letras, números y guiones",
-    "profileSetupUsernameInvalidLength": "El nombre de usuario tiene que tener entre 3 y 20 caracteres",
+    "profileSetupUsernameInvalidLength": "El nombre de usuario tiene que tener entre 3 y 63 caracteres",
     "profileSetupUsernameNetworkError": "No pudimos verificar la disponibilidad. Probá de nuevo.",
     "profileSetupUsernameInvalidFormatGeneric": "Formato de nombre de usuario inválido",
     "profileSetupUsernameCheckFailed": "No se pudo verificar la disponibilidad",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Vérifier à nouveau",
     "profileSetupUsernameBurned": "Ce nom d'utilisateur n'est plus disponible",
     "profileSetupUsernameInvalidFormat": "Seuls les lettres, chiffres et tirets sont autorisés",
-    "profileSetupUsernameInvalidLength": "Le nom d'utilisateur doit faire 3 à 20 caractères",
+    "profileSetupUsernameInvalidLength": "Le nom d'utilisateur doit faire 3 à 63 caractères",
     "profileSetupUsernameNetworkError": "Impossible de vérifier la disponibilité. Réessaie.",
     "profileSetupUsernameInvalidFormatGeneric": "Format de nom d'utilisateur invalide",
     "profileSetupUsernameCheckFailed": "Échec de la vérification de disponibilité",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Cek ulang",
     "profileSetupUsernameBurned": "Username ini tidak tersedia lagi",
     "profileSetupUsernameInvalidFormat": "Hanya huruf, angka, dan tanda hubung yang diperbolehkan",
-    "profileSetupUsernameInvalidLength": "Username harus 3-20 karakter",
+    "profileSetupUsernameInvalidLength": "Username harus 3-63 karakter",
     "profileSetupUsernameNetworkError": "Tidak bisa mengecek ketersediaan. Silakan coba lagi.",
     "profileSetupUsernameInvalidFormatGeneric": "Format username tidak valid",
     "profileSetupUsernameCheckFailed": "Gagal mengecek ketersediaan",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Controlla di nuovo",
     "profileSetupUsernameBurned": "Questo nome utente non è più disponibile",
     "profileSetupUsernameInvalidFormat": "Sono ammessi solo lettere, numeri e trattini",
-    "profileSetupUsernameInvalidLength": "Il nome utente deve avere da 3 a 20 caratteri",
+    "profileSetupUsernameInvalidLength": "Il nome utente deve avere da 3 a 63 caratteri",
     "profileSetupUsernameNetworkError": "Impossibile verificare la disponibilità. Riprova.",
     "profileSetupUsernameInvalidFormatGeneric": "Formato nome utente non valido",
     "profileSetupUsernameCheckFailed": "Verifica disponibilità fallita",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "もう一回確認",
     "profileSetupUsernameBurned": "このユーザー名はもう使えないよ",
     "profileSetupUsernameInvalidFormat": "使えるのは英数字とハイフンだけだよ",
-    "profileSetupUsernameInvalidLength": "ユーザー名は3〜20文字にしてね",
+    "profileSetupUsernameInvalidLength": "ユーザー名は3〜63文字にしてね",
     "profileSetupUsernameNetworkError": "使えるか確認できなかった。もう一回試してみて。",
     "profileSetupUsernameInvalidFormatGeneric": "ユーザー名の形式が正しくないよ",
     "profileSetupUsernameCheckFailed": "使えるか確認できなかった",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -198,7 +198,7 @@
     "profileSetupCheckAgain": "다시 확인",
     "profileSetupUsernameBurned": "이 사용자명은 더 이상 사용할 수 없어요",
     "profileSetupUsernameInvalidFormat": "문자, 숫자, 하이픈만 쓸 수 있어요",
-    "profileSetupUsernameInvalidLength": "사용자명은 3~20자 사이여야 해요",
+    "profileSetupUsernameInvalidLength": "사용자명은 3~63자 사이여야 해요",
     "profileSetupUsernameNetworkError": "사용 가능 여부를 확인하지 못했어요. 다시 시도해보세요.",
     "profileSetupUsernameInvalidFormatGeneric": "잘못된 사용자명 형식",
     "profileSetupUsernameCheckFailed": "사용 가능 여부 확인에 실패했어요",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Opnieuw controleren",
     "profileSetupUsernameBurned": "Deze gebruikersnaam is niet meer beschikbaar",
     "profileSetupUsernameInvalidFormat": "Alleen letters, cijfers en koppeltekens zijn toegestaan",
-    "profileSetupUsernameInvalidLength": "Gebruikersnaam moet 3-20 tekens zijn",
+    "profileSetupUsernameInvalidLength": "Gebruikersnaam moet 3-63 tekens zijn",
     "profileSetupUsernameNetworkError": "Beschikbaarheid checken mislukt. Probeer opnieuw.",
     "profileSetupUsernameInvalidFormatGeneric": "Ongeldig formaat voor gebruikersnaam",
     "profileSetupUsernameCheckFailed": "Beschikbaarheid checken mislukt",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Sprawdź ponownie",
     "profileSetupUsernameBurned": "Ta nazwa użytkownika nie jest już dostępna",
     "profileSetupUsernameInvalidFormat": "Dozwolone są tylko litery, cyfry i myślniki",
-    "profileSetupUsernameInvalidLength": "Nazwa użytkownika musi mieć 3-20 znaków",
+    "profileSetupUsernameInvalidLength": "Nazwa użytkownika musi mieć od 3 do 63 znaków",
     "profileSetupUsernameNetworkError": "Nie można sprawdzić dostępności. Spróbuj ponownie.",
     "profileSetupUsernameInvalidFormatGeneric": "Nieprawidłowy format nazwy użytkownika",
     "profileSetupUsernameCheckFailed": "Nie udało się sprawdzić dostępności",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Verificar novamente",
     "profileSetupUsernameBurned": "Este nome de usuário não está mais disponível",
     "profileSetupUsernameInvalidFormat": "São permitidos apenas letras, números e hífens",
-    "profileSetupUsernameInvalidLength": "O nome de usuário deve ter de 3 a 20 caracteres",
+    "profileSetupUsernameInvalidLength": "O nome de usuário deve ter de 3 a 63 caracteres",
     "profileSetupUsernameNetworkError": "Não foi possível verificar a disponibilidade. Tente novamente.",
     "profileSetupUsernameInvalidFormatGeneric": "Formato de nome de usuário inválido",
     "profileSetupUsernameCheckFailed": "Falha ao verificar a disponibilidade",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Verifică din nou",
     "profileSetupUsernameBurned": "Acest nume nu mai e disponibil",
     "profileSetupUsernameInvalidFormat": "Sunt permise doar litere, cifre și cratime",
-    "profileSetupUsernameInvalidLength": "Numele trebuie să aibă 3-20 de caractere",
+    "profileSetupUsernameInvalidLength": "Numele trebuie să aibă 3-63 de caractere",
     "profileSetupUsernameNetworkError": "N-am putut verifica disponibilitatea. Încearcă din nou.",
     "profileSetupUsernameInvalidFormatGeneric": "Format invalid de nume",
     "profileSetupUsernameCheckFailed": "N-am putut verifica disponibilitatea",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Kolla igen",
     "profileSetupUsernameBurned": "Det här användarnamnet är inte längre tillgängligt",
     "profileSetupUsernameInvalidFormat": "Endast bokstäver, siffror och bindestreck är tillåtna",
-    "profileSetupUsernameInvalidLength": "Användarnamnet måste vara 3–20 tecken",
+    "profileSetupUsernameInvalidLength": "Användarnamnet måste vara 3–63 tecken",
     "profileSetupUsernameNetworkError": "Kunde inte kolla tillgänglighet. Försök igen.",
     "profileSetupUsernameInvalidFormatGeneric": "Ogiltigt format på användarnamn",
     "profileSetupUsernameCheckFailed": "Kunde inte kolla tillgänglighet",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -358,7 +358,7 @@
     "profileSetupCheckAgain": "Tekrar kontrol et",
     "profileSetupUsernameBurned": "Bu kullanıcı adı artık kullanılamıyor",
     "profileSetupUsernameInvalidFormat": "Sadece harfler, rakamlar ve tire kullanılabilir",
-    "profileSetupUsernameInvalidLength": "Kullanıcı adı 3-20 karakter olmalı",
+    "profileSetupUsernameInvalidLength": "Kullanıcı adı 3-63 karakter olmalı",
     "profileSetupUsernameNetworkError": "Uygunluk kontrol edilemedi. Lütfen tekrar dene.",
     "profileSetupUsernameInvalidFormatGeneric": "Geçersiz kullanıcı adı formatı",
     "profileSetupUsernameCheckFailed": "Uygunluk kontrolü başarısız",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1529,7 +1529,7 @@ abstract class AppLocalizations {
   /// No description provided for @profileSetupUsernameInvalidLength.
   ///
   /// In en, this message translates to:
-  /// **'Username must be 3-20 characters'**
+  /// **'Username must be 3-63 characters'**
   String get profileSetupUsernameInvalidLength;
 
   /// No description provided for @profileSetupUsernameNetworkError.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -800,7 +800,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'የተጠቃሚ ስም 3-20 ቁምፊዎች መሆን አለበት።';
+      'የተጠቃሚ ስም 3-63 ቁምፊዎች መሆን አለበት።';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -802,7 +802,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'يجب أن يتراوح طول اسم المستخدم بين 3 و 20 حرفًا';
+      'يجب أن يتراوح طول اسم المستخدم بين 3 و 63 حرفًا';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -838,7 +838,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Потребителското име трябва да е 3-20 знака';
+      'Потребителското име трябва да е 3-63 знака';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -837,7 +837,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Benutzername muss 3-20 Zeichen lang sein';
+      'Benutzername muss 3-63 Zeichen lang sein';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -827,7 +827,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Username must be 3-20 characters';
+      'Username must be 3-63 characters';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -837,7 +837,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'El nombre de usuario tiene que tener entre 3 y 20 caracteres';
+      'El nombre de usuario tiene que tener entre 3 y 63 caracteres';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -846,7 +846,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Le nom d\'utilisateur doit faire 3 à 20 caractères';
+      'Le nom d\'utilisateur doit faire 3 à 63 caractères';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -810,7 +810,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Username harus 3-20 karakter';
+      'Username harus 3-63 karakter';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -838,7 +838,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Il nome utente deve avere da 3 a 20 caratteri';
+      'Il nome utente deve avere da 3 a 63 caratteri';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -765,7 +765,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileSetupUsernameInvalidFormat => '使えるのは英数字とハイフンだけだよ';
 
   @override
-  String get profileSetupUsernameInvalidLength => 'ユーザー名は3〜20文字にしてね';
+  String get profileSetupUsernameInvalidLength => 'ユーザー名は3〜63文字にしてね';
 
   @override
   String get profileSetupUsernameNetworkError => '使えるか確認できなかった。もう一回試してみて。';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -767,7 +767,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileSetupUsernameInvalidFormat => '문자, 숫자, 하이픈만 쓸 수 있어요';
 
   @override
-  String get profileSetupUsernameInvalidLength => '사용자명은 3~20자 사이여야 해요';
+  String get profileSetupUsernameInvalidLength => '사용자명은 3~63자 사이여야 해요';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -829,7 +829,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Gebruikersnaam moet 3-20 tekens zijn';
+      'Gebruikersnaam moet 3-63 tekens zijn';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -840,7 +840,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Nazwa użytkownika musi mieć 3-63 znaków';
+      'Nazwa użytkownika musi mieć od 3 do 63 znaków';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -840,7 +840,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Nazwa użytkownika musi mieć 3-20 znaków';
+      'Nazwa użytkownika musi mieć 3-63 znaków';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -838,7 +838,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'O nome de usuário deve ter de 3 a 20 caracteres';
+      'O nome de usuário deve ter de 3 a 63 caracteres';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -855,7 +855,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Numele trebuie să aibă 3-20 de caractere';
+      'Numele trebuie să aibă 3-63 de caractere';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -813,7 +813,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Användarnamnet måste vara 3–20 tecken';
+      'Användarnamnet måste vara 3–63 tecken';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -810,7 +810,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get profileSetupUsernameInvalidLength =>
-      'Kullanıcı adı 3-20 karakter olmalı';
+      'Kullanıcı adı 3-63 karakter olmalı';
 
   @override
   String get profileSetupUsernameNetworkError =>

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -2,6 +2,7 @@
 library;
 
 export 'src/blocked_profile_filter.dart';
+export 'src/divine_username_policy.dart';
 export 'src/exceptions.dart';
 export 'src/profile_repository.dart';
 export 'src/username_availability_result.dart';

--- a/mobile/packages/profile_repository/lib/src/divine_username_policy.dart
+++ b/mobile/packages/profile_repository/lib/src/divine_username_policy.dart
@@ -1,0 +1,66 @@
+// ABOUTME: Shared validation for divine.video usernames (single DNS label).
+
+/// Minimum length for a divine.video username (inclusive).
+const kDivineUsernameMinLength = 3;
+
+/// Maximum length for a divine.video username (inclusive, DNS label limit).
+const kDivineUsernameMaxLength = 63;
+
+final _divineUsernameCharacters = RegExp(r'^[a-z0-9-]+$');
+
+/// Result of calling [validateDivineUsername].
+sealed class DivineUsernameValidationResult {
+  const DivineUsernameValidationResult();
+}
+
+/// Successful validation; [normalized] is lowercased and trimmed input.
+final class DivineUsernameValid extends DivineUsernameValidationResult {
+  /// Creates a successful validation result.
+  const DivineUsernameValid({required this.normalized});
+
+  /// Lowercase trimmed username.
+  final String normalized;
+}
+
+/// Failed validation with a human-readable [reason].
+final class DivineUsernameInvalid extends DivineUsernameValidationResult {
+  /// Creates a failed validation result.
+  const DivineUsernameInvalid({required this.reason});
+
+  /// Human-readable failure reason.
+  final String reason;
+}
+
+/// Lowercase and trim without validating (shared normalization helper).
+String normalizeDivineUsernameInput(String input) => input.toLowerCase().trim();
+
+/// Validates a string for use as the label in `_@name.divine.video`.
+///
+/// Order: empty → length → leading/trailing hyphen → allowed character run.
+DivineUsernameValidationResult validateDivineUsername(String input) {
+  final normalized = normalizeDivineUsernameInput(input);
+  if (normalized.isEmpty) {
+    return const DivineUsernameInvalid(reason: 'Username is required');
+  }
+  if (normalized.length < kDivineUsernameMinLength ||
+      normalized.length > kDivineUsernameMaxLength) {
+    return const DivineUsernameInvalid(
+      reason:
+          'Usernames must be '
+          '$kDivineUsernameMinLength–$kDivineUsernameMaxLength characters',
+    );
+  }
+  if (normalized.startsWith('-') || normalized.endsWith('-')) {
+    return const DivineUsernameInvalid(
+      reason: "Usernames can't start or end with a hyphen",
+    );
+  }
+  if (!_divineUsernameCharacters.hasMatch(normalized)) {
+    return const DivineUsernameInvalid(
+      reason:
+          'Only letters, numbers, and hyphens are allowed '
+          '(your username becomes username.divine.video)',
+    );
+  }
+  return DivineUsernameValid(normalized: normalized);
+}

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -575,7 +575,12 @@ class ProfileRepository {
   ///
   /// Returns a [UsernameClaimResult] indicating success or the type of failure.
   Future<UsernameClaimResult> claimUsername({required String username}) async {
-    final normalizedUsername = username.toLowerCase();
+    final validation = validateDivineUsername(username);
+    if (validation case DivineUsernameInvalid(:final reason)) {
+      return UsernameClaimError(reason);
+    }
+
+    final normalizedUsername = (validation as DivineUsernameValid).normalized;
     final payload = jsonEncode({'name': normalizedUsername});
     final authHeader = await _nostrClient.createNip98AuthHeader(
       url: _usernameClaimUrl,
@@ -656,8 +661,10 @@ class ProfileRepository {
   /// Checks if a username is available for registration.
   ///
   /// Queries the NIP-05 endpoint to check if the username is already registered
-  /// on the server. This method does NOT validate username format - format
-  /// validation is the responsibility of the BLoC layer.
+  /// on the server.
+  ///
+  /// This method performs shared client-side validation before making network
+  /// calls so editor and repository behavior stay in sync.
   ///
   /// Returns a [UsernameAvailabilityResult] indicating:
   /// - [UsernameAvailable] if the username is not registered on the server
@@ -668,29 +675,11 @@ class ProfileRepository {
     required String username,
     String? currentUserPubkey,
   }) async {
-    final normalizedUsername = username.toLowerCase().trim();
-
-    // Client-side format validation: usernames become subdomains, so only
-    // lowercase letters, digits, and hyphens are allowed. No dots,
-    // underscores, spaces, or special characters.
-    if (normalizedUsername.isEmpty) {
-      return const UsernameInvalidFormat('Username is required');
+    final validation = validateDivineUsername(username);
+    if (validation case DivineUsernameInvalid(:final reason)) {
+      return UsernameInvalidFormat(reason);
     }
-    if (normalizedUsername.length > 63) {
-      return const UsernameInvalidFormat('Usernames must be 1–63 characters');
-    }
-    if (normalizedUsername.startsWith('-') ||
-        normalizedUsername.endsWith('-')) {
-      return const UsernameInvalidFormat(
-        "Usernames can't start or end with a hyphen",
-      );
-    }
-    if (!RegExp(r'^[a-z0-9-]+$').hasMatch(normalizedUsername)) {
-      return const UsernameInvalidFormat(
-        'Only letters, numbers, and hyphens are allowed '
-        '(your username becomes username.divine.video)',
-      );
-    }
+    final normalizedUsername = (validation as DivineUsernameValid).normalized;
 
     // Server-side check using the name-server API which validates format
     // and checks availability in one call.

--- a/mobile/packages/profile_repository/test/src/divine_username_policy_test.dart
+++ b/mobile/packages/profile_repository/test/src/divine_username_policy_test.dart
@@ -1,85 +1,147 @@
+// ABOUTME: Table-driven tests for divine username policy (#3364 AC).
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 void main() {
+  const hyphenEdgeReason = "Usernames can't start or end with a hyphen";
+  const charsetReason =
+      'Only letters, numbers, and hyphens are allowed '
+      '(your username becomes username.divine.video)';
+  const requiredReason = 'Username is required';
+
+  String lengthFailureReason() =>
+      'Usernames must be $kDivineUsernameMinLength–'
+      '$kDivineUsernameMaxLength characters';
+
   group('validateDivineUsername', () {
-    test('accepts alice', () {
-      final r = validateDivineUsername('alice');
-      expect(r, isA<DivineUsernameValid>());
-      expect((r as DivineUsernameValid).normalized, 'alice');
-    });
+    group('acceptance criteria (#3364 table)', () {
+      final cases =
+          <
+            ({
+              String label,
+              String input,
+              bool valid,
+              String? normalized,
+              String? reason,
+            })
+          >[
+            (
+              label: 'alice',
+              input: 'alice',
+              valid: true,
+              normalized: 'alice',
+              reason: null,
+            ),
+            (
+              label: 'a-b',
+              input: 'a-b',
+              valid: true,
+              normalized: 'a-b',
+              reason: null,
+            ),
+            (
+              label: 'a_b',
+              input: 'a_b',
+              valid: false,
+              normalized: null,
+              reason: charsetReason,
+            ),
+            (
+              label: 'a.b',
+              input: 'a.b',
+              valid: false,
+              normalized: null,
+              reason: charsetReason,
+            ),
+            (
+              label: '-alice',
+              input: '-alice',
+              valid: false,
+              normalized: null,
+              reason: hyphenEdgeReason,
+            ),
+            (
+              label: 'alice-',
+              input: 'alice-',
+              valid: false,
+              normalized: null,
+              reason: hyphenEdgeReason,
+            ),
+            (
+              label: 'two chars',
+              input: 'ab',
+              valid: false,
+              normalized: null,
+              reason: lengthFailureReason(),
+            ),
+            (
+              label: '21 chars (within max)',
+              input: List.filled(21, 'a').join(),
+              valid: true,
+              normalized: List.filled(21, 'a').join(),
+              reason: null,
+            ),
+            (
+              label: '64 chars (over max)',
+              input: List.filled(64, 'a').join(),
+              valid: false,
+              normalized: null,
+              reason: lengthFailureReason(),
+            ),
+            (
+              label: 'min length boundary (3)',
+              input: 'abc',
+              valid: true,
+              normalized: 'abc',
+              reason: null,
+            ),
+            (
+              label: 'max length boundary (63)',
+              input: List.filled(63, 'z').join(),
+              valid: true,
+              normalized: List.filled(63, 'z').join(),
+              reason: null,
+            ),
+            (
+              label: 'trim and lowercase',
+              input: '  Alice  ',
+              valid: true,
+              normalized: 'alice',
+              reason: null,
+            ),
+            (
+              label: 'empty',
+              input: '',
+              valid: false,
+              normalized: null,
+              reason: requiredReason,
+            ),
+            (
+              label: 'whitespace only',
+              input: '   ',
+              valid: false,
+              normalized: null,
+              reason: requiredReason,
+            ),
+          ];
 
-    test('accepts a-b', () {
-      final r = validateDivineUsername('a-b');
-      expect(r, isA<DivineUsernameValid>());
-      expect((r as DivineUsernameValid).normalized, 'a-b');
-    });
-
-    test('rejects a_b', () {
-      final r = validateDivineUsername('a_b');
-      expect(r, isA<DivineUsernameInvalid>());
-    });
-
-    test('rejects a.b', () {
-      final r = validateDivineUsername('a.b');
-      expect(r, isA<DivineUsernameInvalid>());
-    });
-
-    test('rejects -alice', () {
-      final r = validateDivineUsername('-alice');
-      expect(r, isA<DivineUsernameInvalid>());
-      expect(
-        (r as DivineUsernameInvalid).reason,
-        "Usernames can't start or end with a hyphen",
-      );
-    });
-
-    test('rejects alice-', () {
-      final r = validateDivineUsername('alice-');
-      expect(r, isA<DivineUsernameInvalid>());
-      expect(
-        (r as DivineUsernameInvalid).reason,
-        "Usernames can't start or end with a hyphen",
-      );
-    });
-
-    test('rejects 2-char input', () {
-      final r = validateDivineUsername('ab');
-      expect(r, isA<DivineUsernameInvalid>());
-      expect(
-        (r as DivineUsernameInvalid).reason,
-        'Usernames must be $kDivineUsernameMinLength–'
-        '$kDivineUsernameMaxLength characters',
-      );
-    });
-
-    test('accepts 21-char input', () {
-      final name = List.filled(21, 'a').join();
-      final r = validateDivineUsername(name);
-      expect(r, isA<DivineUsernameValid>());
-      expect((r as DivineUsernameValid).normalized, name);
-    });
-
-    test('rejects 64-char input', () {
-      final name = List.filled(64, 'a').join();
-      final r = validateDivineUsername(name);
-      expect(r, isA<DivineUsernameInvalid>());
-      expect(
-        (r as DivineUsernameInvalid).reason,
-        'Usernames must be $kDivineUsernameMinLength–'
-        '$kDivineUsernameMaxLength characters',
-      );
-    });
-
-    test('normalizes case and trims', () {
-      final r = validateDivineUsername('  Alice  ');
-      expect(r, isA<DivineUsernameValid>());
-      expect((r as DivineUsernameValid).normalized, 'alice');
-    });
-
-    test('rejects empty and whitespace-only', () {
-      expect(validateDivineUsername(''), isA<DivineUsernameInvalid>());
-      expect(validateDivineUsername('   '), isA<DivineUsernameInvalid>());
+      for (final c in cases) {
+        test(c.label, () {
+          final r = validateDivineUsername(c.input);
+          if (c.valid) {
+            expect(r, isA<DivineUsernameValid>());
+            expect(
+              (r as DivineUsernameValid).normalized,
+              c.normalized,
+              reason: 'normalized output',
+            );
+          } else {
+            expect(r, isA<DivineUsernameInvalid>());
+            expect((r as DivineUsernameInvalid).reason, c.reason);
+          }
+        });
+      }
     });
   });
 

--- a/mobile/packages/profile_repository/test/src/divine_username_policy_test.dart
+++ b/mobile/packages/profile_repository/test/src/divine_username_policy_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+void main() {
+  group('validateDivineUsername', () {
+    test('accepts alice', () {
+      final r = validateDivineUsername('alice');
+      expect(r, isA<DivineUsernameValid>());
+      expect((r as DivineUsernameValid).normalized, 'alice');
+    });
+
+    test('accepts a-b', () {
+      final r = validateDivineUsername('a-b');
+      expect(r, isA<DivineUsernameValid>());
+      expect((r as DivineUsernameValid).normalized, 'a-b');
+    });
+
+    test('rejects a_b', () {
+      final r = validateDivineUsername('a_b');
+      expect(r, isA<DivineUsernameInvalid>());
+    });
+
+    test('rejects a.b', () {
+      final r = validateDivineUsername('a.b');
+      expect(r, isA<DivineUsernameInvalid>());
+    });
+
+    test('rejects -alice', () {
+      final r = validateDivineUsername('-alice');
+      expect(r, isA<DivineUsernameInvalid>());
+      expect(
+        (r as DivineUsernameInvalid).reason,
+        "Usernames can't start or end with a hyphen",
+      );
+    });
+
+    test('rejects alice-', () {
+      final r = validateDivineUsername('alice-');
+      expect(r, isA<DivineUsernameInvalid>());
+      expect(
+        (r as DivineUsernameInvalid).reason,
+        "Usernames can't start or end with a hyphen",
+      );
+    });
+
+    test('rejects 2-char input', () {
+      final r = validateDivineUsername('ab');
+      expect(r, isA<DivineUsernameInvalid>());
+      expect(
+        (r as DivineUsernameInvalid).reason,
+        'Usernames must be $kDivineUsernameMinLength–'
+        '$kDivineUsernameMaxLength characters',
+      );
+    });
+
+    test('accepts 21-char input', () {
+      final name = List.filled(21, 'a').join();
+      final r = validateDivineUsername(name);
+      expect(r, isA<DivineUsernameValid>());
+      expect((r as DivineUsernameValid).normalized, name);
+    });
+
+    test('rejects 64-char input', () {
+      final name = List.filled(64, 'a').join();
+      final r = validateDivineUsername(name);
+      expect(r, isA<DivineUsernameInvalid>());
+      expect(
+        (r as DivineUsernameInvalid).reason,
+        'Usernames must be $kDivineUsernameMinLength–'
+        '$kDivineUsernameMaxLength characters',
+      );
+    });
+
+    test('normalizes case and trims', () {
+      final r = validateDivineUsername('  Alice  ');
+      expect(r, isA<DivineUsernameValid>());
+      expect((r as DivineUsernameValid).normalized, 'alice');
+    });
+
+    test('rejects empty and whitespace-only', () {
+      expect(validateDivineUsername(''), isA<DivineUsernameInvalid>());
+      expect(validateDivineUsername('   '), isA<DivineUsernameInvalid>());
+    });
+  });
+
+  group('normalizeDivineUsernameInput', () {
+    test('lowercases and trims', () {
+      expect(normalizeDivineUsernameInput('  Foo  '), 'foo');
+    });
+  });
+}

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3436,6 +3436,43 @@ void main() {
         },
       );
 
+      test(
+        'returns server error message when claim returns 400 with JSON error body',
+        () async {
+          when(
+            () => mockNostrClient.createNip98AuthHeader(
+              url: any(named: 'url'),
+              method: any(named: 'method'),
+              payload: any(named: 'payload'),
+            ),
+          ).thenAnswer((_) => Future.value('authHeader'));
+          when(
+            () => mockHttpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) => Future.value(
+              Response('{"error": "Name server rejected claim"}', 400),
+            ),
+          );
+
+          final result = await profileRepository.claimUsername(
+            username: 'validuser',
+          );
+
+          expect(
+            result,
+            isA<UsernameClaimError>().having(
+              (e) => e.message,
+              'message',
+              'Name server rejected claim',
+            ),
+          );
+        },
+      );
+
       test('returns error with default message when server returns '
           'non-200 with unparseable body', () async {
         when(

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3437,7 +3437,8 @@ void main() {
       );
 
       test(
-        'returns server error message when claim returns 400 with JSON error body',
+        'returns server error message when claim returns 400 '
+        'with JSON error body',
         () async {
           when(
             () => mockNostrClient.createNip98AuthHeader(

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3409,30 +3409,30 @@ void main() {
       test(
         'returns validation error for too-short username before request',
         () async {
-        final result = await profileRepository.claimUsername(username: 'ab');
+          final result = await profileRepository.claimUsername(username: 'ab');
 
-        expect(
-          result,
-          isA<UsernameClaimError>().having(
-            (e) => e.message,
-            'message',
-            'Usernames must be 3–63 characters',
-          ),
-        );
-        verifyNever(
-          () => mockNostrClient.createNip98AuthHeader(
-            url: any(named: 'url'),
-            method: any(named: 'method'),
-            payload: any(named: 'payload'),
-          ),
-        );
-        verifyNever(
-          () => mockHttpClient.post(
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-          ),
-        );
+          expect(
+            result,
+            isA<UsernameClaimError>().having(
+              (e) => e.message,
+              'message',
+              'Usernames must be 3–63 characters',
+            ),
+          );
+          verifyNever(
+            () => mockNostrClient.createNip98AuthHeader(
+              url: any(named: 'url'),
+              method: any(named: 'method'),
+              payload: any(named: 'payload'),
+            ),
+          );
+          verifyNever(
+            () => mockHttpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          );
         },
       );
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3406,25 +3406,9 @@ void main() {
         },
       );
 
-      test('returns server error message when server returns '
-          'non-200 with JSON error body', () async {
-        when(
-          () => mockNostrClient.createNip98AuthHeader(
-            url: any(named: 'url'),
-            method: any(named: 'method'),
-            payload: any(named: 'payload'),
-          ),
-        ).thenAnswer((_) => Future.value('authHeader'));
-        when(
-          () => mockHttpClient.post(
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) => Future.value(Response('{"error": "Username too short"}', 400)),
-        );
-
+      test(
+        'returns validation error for too-short username before request',
+        () async {
         final result = await profileRepository.claimUsername(username: 'ab');
 
         expect(
@@ -3432,10 +3416,25 @@ void main() {
           isA<UsernameClaimError>().having(
             (e) => e.message,
             'message',
-            'Username too short',
+            'Usernames must be 3–63 characters',
           ),
         );
-      });
+        verifyNever(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        );
+        verifyNever(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        );
+        },
+      );
 
       test('returns error with default message when server returns '
           'non-200 with unparseable body', () async {
@@ -3642,6 +3641,29 @@ void main() {
 
         expect(result, isA<UsernameInvalidFormat>());
       });
+
+      test(
+        'returns UsernameInvalidFormat for too-short names',
+        () async {
+          final result = await profileRepository.checkUsernameAvailability(
+            username: 'ab',
+          );
+
+          expect(
+            result,
+            isA<UsernameInvalidFormat>().having(
+              (e) => e.reason,
+              'reason',
+              'Usernames must be 3–63 characters',
+            ),
+          );
+          verifyNever(
+            () => mockHttpClient.get(
+              Uri.parse('https://names.divine.video/api/username/check/ab'),
+            ),
+          );
+        },
+      );
 
       test(
         'returns UsernameInvalidFormat for names with underscores',

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -776,11 +776,19 @@ void main() {
       blocTest<ProfileEditorBloc, ProfileEditorState>(
         'emits error status for username too long',
         build: createBloc,
-        act: (bloc) => bloc.add(const UsernameChanged('aaaaaaaaaaaaaaaaaaaaa')),
+        act: (bloc) => bloc.add(
+          UsernameChanged(
+            List.filled(kDivineUsernameMaxLength + 1, 'a').join(),
+          ),
+        ),
         wait: debounceDuration,
         expect: () => [
           isA<ProfileEditorState>()
-              .having((s) => s.username, 'username', 'aaaaaaaaaaaaaaaaaaaaa')
+              .having(
+                (s) => s.username,
+                'username',
+                List.filled(kDivineUsernameMaxLength + 1, 'a').join(),
+              )
               .having(
                 (s) => s.usernameStatus,
                 'usernameStatus',
@@ -805,12 +813,18 @@ void main() {
               .having(
                 (s) => s.usernameStatus,
                 'usernameStatus',
-                UsernameStatus.error,
+                UsernameStatus.invalidFormat,
               )
               .having(
                 (s) => s.usernameError,
                 'usernameError',
                 equals(UsernameValidationError.invalidFormat),
+              )
+              .having(
+                (s) => s.usernameFormatMessage,
+                'usernameFormatMessage',
+                'Only letters, numbers, and hyphens are allowed '
+                    '(your username becomes username.divine.video)',
               ),
         ],
       );

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -830,6 +830,62 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'rejects username with a dot before API (DNS label policy)',
+        build: createBloc,
+        act: (bloc) => bloc.add(const UsernameChanged('mr.')),
+        wait: debounceDuration,
+        expect: () => [
+          isA<ProfileEditorState>()
+              .having((s) => s.username, 'username', 'mr.')
+              .having(
+                (s) => s.usernameStatus,
+                'usernameStatus',
+                UsernameStatus.invalidFormat,
+              )
+              .having(
+                (s) => s.usernameError,
+                'usernameError',
+                equals(UsernameValidationError.invalidFormat),
+              ),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockProfileRepository.checkUsernameAvailability(
+              username: any(named: 'username'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'rejects username with underscore before API (DNS label policy)',
+        build: createBloc,
+        act: (bloc) => bloc.add(const UsernameChanged('my_name')),
+        wait: debounceDuration,
+        expect: () => [
+          isA<ProfileEditorState>()
+              .having((s) => s.username, 'username', 'my_name')
+              .having(
+                (s) => s.usernameStatus,
+                'usernameStatus',
+                UsernameStatus.invalidFormat,
+              )
+              .having(
+                (s) => s.usernameError,
+                'usernameError',
+                equals(UsernameValidationError.invalidFormat),
+              ),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockProfileRepository.checkUsernameAvailability(
+              username: any(named: 'username'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
         'emits [checking, available] when username is available',
         setUp: () {
           when(

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -177,7 +177,7 @@ void main() {
         ),
       );
 
-      expect(find.text('Username must be 3-20 characters'), findsOneWidget);
+      expect(find.text('Username must be 3-63 characters'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Closes **#3364**: `ProfileEditorBloc` and `ProfileRepository` used different divine.video username rules (length, allowed characters, leading/trailing hyphen handling), so users could pass local validation and then fail on check/claim. This PR **single-sources** policy in `profile_repository` and aligns the editor, repository, and user-visible copy.

### Changes (summary)

- **`mobile/packages/profile_repository/lib/src/divine_username_policy.dart`** — `validateDivineUsername`, `normalizeDivineUsernameInput`, constants `kDivineUsernameMinLength` (3) / `kDivineUsernameMaxLength` (63); DNS-label rules: `a-z`, `0-9`, internal hyphens only; same human-readable `reason` strings as before for format/length errors.
- **`mobile/packages/profile_repository/lib/profile_repository.dart`** — exports the policy module.
- **`mobile/packages/profile_repository/lib/src/profile_repository.dart`** — `checkUsernameAvailability` and `claimUsername` call the shared validator before HTTP; doc comment for `checkUsernameAvailability` updated to reflect client-side validation.
- **`mobile/lib/blocs/profile_editor/profile_editor_bloc.dart`** — removed duplicate regex/length constants; `_onUsernameChanged` / `_onUsernameRechecked` / `_saveProfile` use `validateDivineUsername`; API calls use normalized username; length vs format mapping preserved for `UsernameValidationError`.
- **`mobile/lib/blocs/profile_editor/profile_editor_state.dart`** — doc comments for username validation enums updated (3–63, DNS-label semantics).
- **L10n** — all `app_*.arb`: `profileSetupUsernameInvalidLength` updated from 3–20 to **3–63**; `flutter gen-l10n` regenerated under `mobile/lib/l10n/generated/`.
- **Tests**
  - `mobile/packages/profile_repository/test/src/divine_username_policy_test.dart` — table-driven AC cases (#3364) including min/max boundaries.
  - `mobile/packages/profile_repository/test/src/profile_repository_test.dart` — client-side `claimUsername` / `checkUsernameAvailability` short-name behavior; `verifyNever` where appropriate.
  - `mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart` — long username, invalid charset, dot/underscore inputs without API; debounce/flow tests updated.
  - `mobile/test/screens/profile_setup_screen_test.dart` — English length hint expectation.

**Verification (suggested):**

From `mobile/`:

- `flutter analyze`
- `flutter test packages/profile_repository/test/`
- `flutter test test/blocs/profile_editor/profile_editor_bloc_test.dart`
- `flutter test test/screens/profile_setup_screen_test.dart`

**Related issues (context):** #3161, #3152, #1738 (per task file).

Closes #3364

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would change existing functionality for users who relied on the old inconsistent rules)
- [x] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore

_Note: User-visible behavior changes for names that were “valid” in the old editor (e.g. dots/underscores, length 21–63) now match the name-server path consistently._
