### PR TITLE
fix(collabs): publish acceptance response events

### DIFF
--- a/mobile/lib/constants/collaboration_event_kinds.dart
+++ b/mobile/lib/constants/collaboration_event_kinds.dart
@@ -1,0 +1,6 @@
+// ABOUTME: Divine-specific Nostr event kinds for collaboration workflows.
+// ABOUTME: Keeps custom protocol kind values centralized for mobile publishers.
+
+abstract final class CollaborationEventKinds {
+  static const int collaboratorResponse = 34238;
+}

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -172,9 +172,6 @@ final collaboratorResponseServiceProvider =
       return CollaboratorResponseService(
         authService: ref.watch(authServiceProvider),
         nostrClient: ref.watch(nostrServiceProvider),
-        loadSourceVideo: ref
-            .watch(videosRepositoryProvider)
-            .fetchVideoWithStatsForRouteId,
       );
     });
 

--- a/mobile/lib/services/collaborator_response_service.dart
+++ b/mobile/lib/services/collaborator_response_service.dart
@@ -1,13 +1,11 @@
 // ABOUTME: Publishes collaborator acceptance events.
-// ABOUTME: Acceptance mirrors Connect by copying the source video under the accepter.
+// ABOUTME: Acceptance is a collaborator-authored public response to a video address.
 
 import 'package:equatable/equatable.dart';
-import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/constants/collaboration_event_kinds.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/auth_service.dart';
-
-typedef SourceVideoLoader = Future<VideoEvent?> Function(String videoAddress);
 
 class CollaboratorResponseResult extends Equatable {
   const CollaboratorResponseResult({
@@ -34,15 +32,12 @@ class CollaboratorResponseService {
   const CollaboratorResponseService({
     required AuthService authService,
     required NostrClient nostrClient,
-    SourceVideoLoader? loadSourceVideo,
     this.defaultRelayHint = 'wss://relay.divine.video',
   }) : _authService = authService,
-       _nostrClient = nostrClient,
-       _loadSourceVideo = loadSourceVideo;
+       _nostrClient = nostrClient;
 
   final AuthService _authService;
   final NostrClient _nostrClient;
-  final SourceVideoLoader? _loadSourceVideo;
   final String defaultRelayHint;
 
   Future<CollaboratorResponseResult> acceptInvite(
@@ -56,21 +51,10 @@ class CollaboratorResponseService {
         );
       }
 
-      final sourceVideo = await _loadSourceVideo?.call(invite.videoAddress);
-      if (sourceVideo == null) {
-        return const CollaboratorResponseResult.failure(
-          'Could not load source video for collaborator acceptance',
-        );
-      }
-
       final event = await _authService.createAndSignEvent(
-        kind: invite.videoKind,
-        content: sourceVideo.content,
-        tags: _buildAcceptanceTags(
-          invite: invite,
-          sourceVideo: sourceVideo,
-          accepterPubkey: currentPubkey,
-        ),
+        kind: CollaborationEventKinds.collaboratorResponse,
+        content: '',
+        tags: _buildAcceptanceTags(invite),
       );
 
       if (event == null) {
@@ -92,63 +76,14 @@ class CollaboratorResponseService {
     }
   }
 
-  List<List<String>> _buildAcceptanceTags({
-    required CollaboratorInvite invite,
-    required VideoEvent sourceVideo,
-    required String accepterPubkey,
-  }) {
+  List<List<String>> _buildAcceptanceTags(CollaboratorInvite invite) {
     final relayHint = invite.relayHint ?? defaultRelayHint;
-    final tags =
-        (sourceVideo.nostrEventTags.isNotEmpty
-                ? sourceVideo.nostrEventTags
-                : _fallbackSourceTags(invite: invite, sourceVideo: sourceVideo))
-            .where(
-              (tag) => !_isCollaboratorTagFor(tag, accepterPubkey),
-            )
-            .map(List<String>.from)
-            .toList();
-
-    if (!tags.any((tag) => tag.isNotEmpty && tag[0] == 'd')) {
-      tags.insert(0, ['d', invite.videoDTag]);
-    }
-
-    if (!_hasCollaboratorTag(tags, sourceVideo.pubkey)) {
-      tags.add(['p', sourceVideo.pubkey, '', 'collaborator']);
-    }
-
-    if (sourceVideo.id.isNotEmpty) {
-      tags.add(['e', sourceVideo.id, '', 'source']);
-    }
-    tags.add(['a', invite.videoAddress, relayHint, 'source']);
-
-    return tags;
-  }
-
-  List<List<String>> _fallbackSourceTags({
-    required CollaboratorInvite invite,
-    required VideoEvent sourceVideo,
-  }) {
     return [
-      ['d', invite.videoDTag],
-      if (sourceVideo.title != null && sourceVideo.title!.trim().isNotEmpty)
-        ['title', sourceVideo.title!.trim()],
-      if (sourceVideo.videoUrl != null &&
-          sourceVideo.videoUrl!.trim().isNotEmpty)
-        ['url', sourceVideo.videoUrl!.trim()],
-      if (sourceVideo.thumbnailUrl != null &&
-          sourceVideo.thumbnailUrl!.trim().isNotEmpty)
-        ['thumb', sourceVideo.thumbnailUrl!.trim()],
+      ['d', invite.videoAddress],
+      ['a', invite.videoAddress, relayHint, 'root'],
+      ['p', invite.creatorPubkey],
+      ['role', invite.role],
+      ['status', 'accepted'],
     ];
-  }
-
-  bool _isCollaboratorTagFor(List<String> tag, String pubkey) {
-    return tag.length >= 4 &&
-        tag[0] == 'p' &&
-        tag[1] == pubkey &&
-        tag[3].toLowerCase() == 'collaborator';
-  }
-
-  bool _hasCollaboratorTag(List<List<String>> tags, String pubkey) {
-    return tags.any((tag) => _isCollaboratorTagFor(tag, pubkey));
   }
 }

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -1,11 +1,11 @@
 // ABOUTME: Tests collaborator acceptance publishing.
-// ABOUTME: Verifies accept mirrors Connect by publishing an accepter-owned video copy.
+// ABOUTME: Verifies accept publishes a public collaborator response event.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/constants/collaboration_event_kinds.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_response_service.dart';
@@ -26,21 +26,6 @@ void main() {
   late _MockAuthService authService;
   late _MockNostrClient nostrClient;
   late CollaboratorResponseService service;
-
-  final sourceVideo = VideoEvent(
-    id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    pubkey: creatorPubkey,
-    createdAt: 1700000000,
-    content: 'A collab video',
-    timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
-    title: 'Collab Video',
-    nostrEventTags: const [
-      ['d', 'video-d-tag'],
-      ['title', 'Collab Video'],
-      ['p', collaboratorPubkey, 'wss://relay.divine.video', 'collaborator'],
-      ['url', 'https://media.divine.video/video.mp4'],
-    ],
-  );
 
   const invite = CollaboratorInvite(
     messageId: 'message-id',
@@ -63,11 +48,10 @@ void main() {
     service = CollaboratorResponseService(
       authService: authService,
       nostrClient: nostrClient,
-      loadSourceVideo: (_) async => sourceVideo,
     );
   });
 
-  test('publishes accepter-owned collaborator video copy', () async {
+  test('publishes public collaborator acceptance response', () async {
     late Event signedEvent;
     when(
       () => authService.createAndSignEvent(
@@ -79,9 +63,9 @@ void main() {
       final tags = invocation.namedArguments[#tags] as List<List<String>>;
       signedEvent = Event(
         collaboratorPubkey,
-        34236,
+        CollaborationEventKinds.collaboratorResponse,
         tags,
-        'A collab video',
+        '',
       );
       return signedEvent;
     });
@@ -102,20 +86,17 @@ void main() {
       ),
     );
 
-    expect(verification.captured[0], 34236);
-    expect(verification.captured[1], 'A collab video');
+    expect(
+      verification.captured[0],
+      CollaborationEventKinds.collaboratorResponse,
+    );
+    expect(verification.captured[1], '');
     expect(verification.captured[2], [
-      ['d', 'video-d-tag'],
-      ['title', 'Collab Video'],
-      ['url', 'https://media.divine.video/video.mp4'],
-      ['p', creatorPubkey, '', 'collaborator'],
-      [
-        'e',
-        'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-        '',
-        'source',
-      ],
-      ['a', videoAddress, 'wss://relay.divine.video', 'source'],
+      ['d', videoAddress],
+      ['a', videoAddress, 'wss://relay.divine.video', 'root'],
+      ['p', creatorPubkey],
+      ['role', 'Collaborator'],
+      ['status', 'accepted'],
     ]);
     verify(() => nostrClient.publishEvent(signedEvent)).called(1);
   });
@@ -141,7 +122,12 @@ void main() {
         ),
       ).thenAnswer((invocation) async {
         capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
-        return Event(collaboratorPubkey, 34236, capturedTags, 'A collab video');
+        return Event(
+          collaboratorPubkey,
+          CollaborationEventKinds.collaboratorResponse,
+          capturedTags,
+          '',
+        );
       });
       when(() => nostrClient.publishEvent(any())).thenAnswer(
         (invocation) async => invocation.positionalArguments.single as Event,
@@ -150,35 +136,14 @@ void main() {
       final result = await service.acceptInvite(inviteWithoutRelay);
 
       expect(result.success, isTrue);
-      expect(capturedTags.last, [
+      expect(capturedTags[1], [
         'a',
         videoAddress,
         'wss://relay.divine.video',
-        'source',
+        'root',
       ]);
     },
   );
-
-  test('returns failure when source video cannot be loaded', () async {
-    service = CollaboratorResponseService(
-      authService: authService,
-      nostrClient: nostrClient,
-      loadSourceVideo: (_) async => null,
-    );
-
-    final result = await service.acceptInvite(invite);
-
-    expect(result.success, isFalse);
-    expect(result.error, contains('source video'));
-    verifyNever(
-      () => authService.createAndSignEvent(
-        kind: any(named: 'kind'),
-        content: any(named: 'content'),
-        tags: any(named: 'tags'),
-      ),
-    );
-    verifyNever(() => nostrClient.publishEvent(any()));
-  });
 
   test('returns failure when signing fails', () async {
     when(


### PR DESCRIPTION
## Summary
- Publish collaborator acceptances as kind `34238` public response events.
- Stop copying the source video event under the collaborator pubkey.
- Centralize the collaborator response kind constant and update regression coverage.

## How We Know It Works
- The service regression test asserts `acceptInvite` signs `CollaborationEventKinds.collaboratorResponse` (`34238`) with empty content and the expected `d`, `a`, `p`, `role`, and `status` tags.
- The same test asserts the fallback relay hint is used on the root `a` tag when the invite does not provide one.
- The failure-path test asserts signing failures keep the invite from publishing.
- Related DM tests assert the Accept button still calls the response service and persists `accepted` only after publish success.

## Verification
- `flutter test --no-pub test/services/collaborator_response_service_test.dart`
- `flutter test --no-pub test/services/collaborator_response_service_test.dart test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart test/screens/inbox/conversation/conversation_view_test.dart test/screens/inbox/message_requests/request_preview_view_test.dart`
- `flutter analyze`
- Pre-push hook: analyzer, generated files, changed service test