### PR TITLE
fix(profile): filter collaborator-tagged videos from profile feed REST path

### DIFF
--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -290,7 +290,12 @@ class ProfileFeed extends _$ProfileFeed {
         final relayVideos = _relayVideosSnapshot();
         final authorVideos = _mergeVideoLists(
           relayVideos,
-          apiVideos.where((v) => !v.isRepost).toList(),
+          // Guard: only include videos genuinely authored by this user.
+          // The backend /api/users/{pubkey}/videos can incorrectly return
+          // videos where pubkey is tagged as a collaborator (p-tag) rather
+          // than being the event author — this filter prevents those from
+          // appearing in the profile grid.
+          apiVideos.where((v) => !v.isRepost && v.pubkey == userId).toList(),
         );
         _cacheVideoMetadata(authorVideos);
 
@@ -435,7 +440,11 @@ class ProfileFeed extends _$ProfileFeed {
         _nextOffset = result.nextOffset ?? (offset + apiVideos.length);
 
         if (apiVideos.isNotEmpty) {
-          var newVideos = apiVideos.where((v) => !v.isRepost).toList();
+          // Same guard as _refreshFromRestApi: exclude videos where pubkey
+          // doesn't match userId (backend can leak collaborator-tagged events).
+          var newVideos = apiVideos
+              .where((v) => !v.isRepost && v.pubkey == userId)
+              .toList();
 
           // Cache metadata from new videos
           _cacheVideoMetadata(newVideos);

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'802733be8b9a6d5ab6c4930677d862398f7c1a59';
+String _$profileFeedHash() => r'ef9ed4aacd68248181a5032042c7bd964dba5c9b';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///


### PR DESCRIPTION
## Summary

- Videos posted by User A with collaborators tagged appeared in each collaborator's profile Videos grid as if they had posted them
- Root cause: the Funnelcake `/api/users/{pubkey}/videos` endpoint returns events where `pubkey` is a collaborator p-tag, not only events the user authored
- This PR adds a client-side defensive guard (`v.pubkey == userId`) to both REST consumption sites in `ProfileFeedProvider` — the Nostr relay path was already clean

Backend fix tracked in: divinevideo/divine-funnelcake#346

## Reproducing steps

1. User A publishes a video and tags User B (and others) as collaborators
2. Navigate to User B's profile → **Videos** tab
3. **Before this fix:** The video posted by User A appears in User B's Videos grid
4. **After this fix:** The video no longer appears in User B's Videos grid (it correctly only appears in the Collabs tab)

## What changed

`mobile/lib/providers/profile_feed_provider.dart` — two sites:

| Site | Before | After |
|------|--------|-------|
| `_refreshFromRestApi` (initial load) | `apiVideos.where((v) => !v.isRepost)` | `apiVideos.where((v) => !v.isRepost && v.pubkey == userId)` |
| `loadMore` (pagination) | `apiVideos.where((v) => !v.isRepost)` | `apiVideos.where((v) => !v.isRepost && v.pubkey == userId)` |

## Root cause detail

The backend `/api/users/{pubkey}/videos` query matches on collaborator p-tag pubkeys in addition to the event author pubkey. The mobile client was merging those results into the profile feed without checking `video.pubkey == profileOwner`. The Nostr relay path (`subscribeToUserVideos` → `authors: [pubkey]` filter + `_authorBuckets` check) was not affected.

## Test plan

- [x] Existing `profile_feed_provider_test.dart` — all 15 tests pass
- [x] `flutter analyze` — no issues
- [ ] Manual: post a video with collaborators → verify collaborator profiles no longer show it in the Videos tab
- [ ] Manual: verify own profile still shows all authored videos correctly
- [ ] Manual: verify Collabs tab is unaffected (uses separate `getCollabVideos` / `/api/users/{pubkey}/collabs` path)