### PR TITLE
fix(feed): top-align contained fullscreen videos

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -64,6 +64,11 @@ const double _kOverlayDimmedOpacity = 0.5; // opacity while in the dim band
 // e.g. 0.03 → full↔dim transition spans 7 %–13 %, dim↔hidden spans 47 %–53 %.
 const double _kOverlayFadeHalfWidth = 0.03;
 
+@visibleForTesting
+Alignment fullscreenVideoMediaAlignment({required bool isPortrait}) {
+  return isPortrait ? Alignment.center : Alignment.topCenter;
+}
+
 /// Maps [distance] (0–1 fraction scrolled away from an item) to overlay
 /// opacity using smooth linear interpolation around each threshold.
 double _scrollDrivenOpacity(double distance) {
@@ -1365,6 +1370,7 @@ class _FittedVideoPlayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
+    final alignment = fullscreenVideoMediaAlignment(isPortrait: isPortrait);
 
     // Do not set filterQuality to high — on Android the bicubic
     // interpolation causes visible blur on the Texture widget when
@@ -1372,6 +1378,7 @@ class _FittedVideoPlayer extends StatelessWidget {
     return Video(
       controller: videoController,
       fit: boxFit,
+      alignment: alignment,
       controls: null,
       width: videoWidth,
       height: videoHeight,
@@ -1389,6 +1396,7 @@ class _VideoLoadingPlaceholder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
+    final alignment = fullscreenVideoMediaAlignment(isPortrait: isPortrait);
     final url = thumbnailUrl;
 
     return Stack(
@@ -1399,6 +1407,7 @@ class _VideoLoadingPlaceholder extends StatelessWidget {
           Image.network(
             url,
             fit: boxFit,
+            alignment: alignment,
             errorBuilder: (_, _, _) =>
                 const ColoredBox(color: VineTheme.backgroundColor),
           )

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -216,6 +216,22 @@ class _PopCountingObserver extends NavigatorObserver {
 
 void main() {
   group('PooledFullscreenVideoFeedScreen', () {
+    group('fullscreen video media alignment', () {
+      test('top-aligns contained square and landscape videos', () {
+        expect(
+          fullscreenVideoMediaAlignment(isPortrait: false),
+          Alignment.topCenter,
+        );
+      });
+
+      test('keeps portrait videos centered while they cover the viewport', () {
+        expect(
+          fullscreenVideoMediaAlignment(isPortrait: true),
+          Alignment.center,
+        );
+      });
+    });
+
     late MockFullscreenFeedBloc mockBloc;
     late MockVideoFeedController defaultController;
     late MockProfileRepository mockProfileRepository;


### PR DESCRIPTION
Closes #4050

## Summary
- Top-align contained fullscreen video media for square and landscape videos
- Keep portrait fullscreen videos centered while they continue to cover the viewport
- Add tests documenting the alignment policy

## Verification
- git merge-base --is-ancestor origin/main HEAD
- flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
- flutter analyze lib/screens/feed/pooled_fullscreen_video_feed_screen.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
- pre-push hook: full analyze and changed-file test suite