### PR TITLE
feat(router): centralize localized route error handling

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2177,6 +2177,7 @@
     "routeInvalidCategory": "ልክ ያልሆነ ምድብ",
     "routeNoVideosToDisplay": "ምንም የሚታዩ ቪዲዮዎች የሉም",
     "routeInvalidProfileId": "ልክ ያልሆነ የመገለጫ መታወቂያ",
+    "routeUnknownPath": "ያ ገጽ በመተግበሪያው ውስጥ የለም።",
     "routeDefaultListName": "ዝርዝር",
     "supportTitle": "የድጋፍ ማዕከል",
     "supportContactSupport": "ድጋፍን ያነጋግሩ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1869,6 +1869,7 @@
     "routeInvalidCategory": "فئة غير صالحة",
     "routeNoVideosToDisplay": "لا توجد مقاطع فيديو لعرضها",
     "routeInvalidProfileId": "مُعرِّف ملف شخصي غير صالح",
+    "routeUnknownPath": "هذه الصفحة غير متوفرة في التطبيق.",
     "routeDefaultListName": "قائمة",
     "supportTitle": "مركز الدعم",
     "supportContactSupport": "التواصل مع الدعم",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2078,6 +2078,7 @@
     "routeInvalidCategory": "Невалидна категория",
     "routeNoVideosToDisplay": "Няма видеа за показване",
     "routeInvalidProfileId": "Невалиден ID на потребителския профил",
+    "routeUnknownPath": "Тази страница не е налична в приложението.",
     "routeDefaultListName": "Списък",
     "supportTitle": "Център за поддръжка",
     "supportContactSupport": "Свържи се с поддръжката",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Ungültige Kategorie",
     "routeNoVideosToDisplay": "Keine Videos zum Anzeigen",
     "routeInvalidProfileId": "Ungültige Profil-ID",
+    "routeUnknownPath": "Diese Seite gibt es in der App nicht.",
     "routeDefaultListName": "Liste",
     "supportTitle": "Support-Center",
     "supportContactSupport": "Support kontaktieren",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2232,6 +2232,9 @@
   "routeNoVideosToDisplay": "No videos to display",
   "routeInvalidProfileId": "Invalid profile ID",
   "routeUnknownPath": "That page isn’t in the app.",
+  "@routeUnknownPath": {
+    "description": "Body text when navigation hits an unknown route (GoRouter.errorBuilder)."
+  },
   "routeDefaultListName": "List",
   "supportTitle": "Support Center",
   "supportContactSupport": "Contact Support",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2231,6 +2231,7 @@
   "routeInvalidCategory": "Invalid category",
   "routeNoVideosToDisplay": "No videos to display",
   "routeInvalidProfileId": "Invalid profile ID",
+  "routeUnknownPath": "That page isn’t in the app.",
   "routeDefaultListName": "List",
   "supportTitle": "Support Center",
   "supportContactSupport": "Contact Support",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1881,6 +1881,7 @@
     "routeInvalidCategory": "Categoría inválida",
     "routeNoVideosToDisplay": "No hay videos para mostrar",
     "routeInvalidProfileId": "ID de perfil inválido",
+    "routeUnknownPath": "Esa página no está en la app.",
     "routeDefaultListName": "Lista",
     "supportTitle": "Centro de soporte",
     "supportContactSupport": "Contactar a soporte",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1104,6 +1104,7 @@
     "routeInvalidCategory": "Invalid na category",
     "routeNoVideosToDisplay": "Walang video na maipapakita",
     "routeInvalidProfileId": "Invalid na profile ID",
+    "routeUnknownPath": "Wala ang page na iyon sa app.",
     "routeDefaultListName": "Listahan",
     "supportTitle": "Support Center",
     "supportContactSupport": "Makipag-ugnayan sa Support",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Catégorie invalide",
     "routeNoVideosToDisplay": "Aucune vidéo à afficher",
     "routeInvalidProfileId": "ID de profil invalide",
+    "routeUnknownPath": "Cette page n’est pas dans l’app.",
     "routeDefaultListName": "Liste",
     "supportTitle": "Centre d'aide",
     "supportContactSupport": "Contacter le support",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1876,6 +1876,7 @@
     "routeInvalidCategory": "Kategori tidak valid",
     "routeNoVideosToDisplay": "Tidak ada video untuk ditampilkan",
     "routeInvalidProfileId": "ID profil tidak valid",
+    "routeUnknownPath": "Halaman itu tidak ada di aplikasi.",
     "routeDefaultListName": "Daftar",
     "supportTitle": "Pusat Bantuan",
     "supportContactSupport": "Hubungi Dukungan",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Categoria non valida",
     "routeNoVideosToDisplay": "Nessun video da mostrare",
     "routeInvalidProfileId": "ID profilo non valido",
+    "routeUnknownPath": "Quella pagina non è nell’app.",
     "routeDefaultListName": "Lista",
     "supportTitle": "Centro assistenza",
     "supportContactSupport": "Contatta l'assistenza",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1869,6 +1869,7 @@
     "routeInvalidCategory": "無効なカテゴリ",
     "routeNoVideosToDisplay": "表示する動画がないよ",
     "routeInvalidProfileId": "無効なプロフィール ID",
+    "routeUnknownPath": "このページはアプリ内にありません。",
     "routeDefaultListName": "リスト",
     "supportTitle": "サポート",
     "supportContactSupport": "サポートに連絡",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1165,6 +1165,7 @@
     "routeInvalidCategory": "잘못된 카테고리예요",
     "routeNoVideosToDisplay": "표시할 영상이 없어요",
     "routeInvalidProfileId": "잘못된 프로필 ID예요",
+    "routeUnknownPath": "앱에 없는 화면이에요.",
     "routeDefaultListName": "목록",
     "supportTitle": "지원 센터",
     "supportContactSupport": "지원팀 문의",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Ongeldige categorie",
     "routeNoVideosToDisplay": "Geen video's om weer te geven",
     "routeInvalidProfileId": "Ongeldige profiel-ID",
+    "routeUnknownPath": "Die pagina zit niet in de app.",
     "routeDefaultListName": "Lijst",
     "supportTitle": "Supportcentrum",
     "supportContactSupport": "Contact met support",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Nieprawidłowa kategoria",
     "routeNoVideosToDisplay": "Brak filmów do wyświetlenia",
     "routeInvalidProfileId": "Nieprawidłowy ID profilu",
+    "routeUnknownPath": "Tej strony nie ma w aplikacji.",
     "routeDefaultListName": "Lista",
     "supportTitle": "Centrum pomocy",
     "supportContactSupport": "Skontaktuj się z pomocą",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Categoria inválida",
     "routeNoVideosToDisplay": "Nenhum vídeo para exibir",
     "routeInvalidProfileId": "ID de perfil inválido",
+    "routeUnknownPath": "Essa página não existe no app.",
     "routeDefaultListName": "Lista",
     "supportTitle": "Central de suporte",
     "supportContactSupport": "Contatar o suporte",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Categorie invalidă",
     "routeNoVideosToDisplay": "Niciun videoclip de afișat",
     "routeInvalidProfileId": "ID de profil invalid",
+    "routeUnknownPath": "Această pagină nu e în aplicație.",
     "routeDefaultListName": "Listă",
     "supportTitle": "Centru de asistență",
     "supportContactSupport": "Contactează asistența",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1877,6 +1877,7 @@
     "routeInvalidCategory": "Ogiltig kategori",
     "routeNoVideosToDisplay": "Inga videor att visa",
     "routeInvalidProfileId": "Ogiltigt profil-ID",
+    "routeUnknownPath": "Den sidan finns inte i appen.",
     "routeDefaultListName": "Lista",
     "supportTitle": "Supportcenter",
     "supportContactSupport": "Kontakta support",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1876,6 +1876,7 @@
     "routeInvalidCategory": "Geçersiz kategori",
     "routeNoVideosToDisplay": "Gösterilecek video yok",
     "routeInvalidProfileId": "Geçersiz profil kimliği",
+    "routeUnknownPath": "Bu sayfa uygulamada yok.",
     "routeDefaultListName": "Liste",
     "supportTitle": "Destek Merkezi",
     "supportContactSupport": "Destekle İletişime Geç",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7526,7 +7526,7 @@ abstract class AppLocalizations {
   /// **'Invalid profile ID'**
   String get routeInvalidProfileId;
 
-  /// No description provided for @routeUnknownPath.
+  /// Body text when navigation hits an unknown route (GoRouter.errorBuilder).
   ///
   /// In en, this message translates to:
   /// **'That page isn’t in the app.'**

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7526,6 +7526,12 @@ abstract class AppLocalizations {
   /// **'Invalid profile ID'**
   String get routeInvalidProfileId;
 
+  /// No description provided for @routeUnknownPath.
+  ///
+  /// In en, this message translates to:
+  /// **'That page isn’t in the app.'**
+  String get routeUnknownPath;
+
   /// No description provided for @routeDefaultListName.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4179,6 +4179,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get routeInvalidProfileId => 'ልክ ያልሆነ የመገለጫ መታወቂያ';
 
   @override
+  String get routeUnknownPath => 'ያ ገጽ በመተግበሪያው ውስጥ የለም።';
+
+  @override
   String get routeDefaultListName => 'ዝርዝር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4226,6 +4226,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get routeInvalidProfileId => 'مُعرِّف ملف شخصي غير صالح';
 
   @override
+  String get routeUnknownPath => 'هذه الصفحة غير متوفرة في التطبيق.';
+
+  @override
   String get routeDefaultListName => 'قائمة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4315,6 +4315,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get routeInvalidProfileId => 'Невалиден ID на потребителския профил';
 
   @override
+  String get routeUnknownPath => 'Тази страница не е налична в приложението.';
+
+  @override
   String get routeDefaultListName => 'Списък';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4321,6 +4321,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get routeInvalidProfileId => 'Ungültige Profil-ID';
 
   @override
+  String get routeUnknownPath => 'Diese Seite gibt es in der App nicht.';
+
+  @override
   String get routeDefaultListName => 'Liste';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4271,6 +4271,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get routeInvalidProfileId => 'Invalid profile ID';
 
   @override
+  String get routeUnknownPath => 'That page isn’t in the app.';
+
+  @override
   String get routeDefaultListName => 'List';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4314,6 +4314,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get routeInvalidProfileId => 'ID de perfil inválido';
 
   @override
+  String get routeUnknownPath => 'Esa página no está en la app.';
+
+  @override
   String get routeDefaultListName => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4321,6 +4321,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get routeInvalidProfileId => 'Invalid na profile ID';
 
   @override
+  String get routeUnknownPath => 'Wala ang page na iyon sa app.';
+
+  @override
   String get routeDefaultListName => 'Listahan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4331,6 +4331,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get routeInvalidProfileId => 'ID de profil invalide';
 
   @override
+  String get routeUnknownPath => 'Cette page n’est pas dans l’app.';
+
+  @override
   String get routeDefaultListName => 'Liste';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4241,6 +4241,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get routeInvalidProfileId => 'ID profil tidak valid';
 
   @override
+  String get routeUnknownPath => 'Halaman itu tidak ada di aplikasi.';
+
+  @override
   String get routeDefaultListName => 'Daftar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4313,6 +4313,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get routeInvalidProfileId => 'ID profilo non valido';
 
   @override
+  String get routeUnknownPath => 'Quella pagina non è nell’app.';
+
+  @override
   String get routeDefaultListName => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4069,6 +4069,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get routeInvalidProfileId => '無効なプロフィール ID';
 
   @override
+  String get routeUnknownPath => 'このページはアプリ内にありません。';
+
+  @override
   String get routeDefaultListName => 'リスト';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4084,6 +4084,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get routeInvalidProfileId => '잘못된 프로필 ID예요';
 
   @override
+  String get routeUnknownPath => '앱에 없는 화면이에요.';
+
+  @override
   String get routeDefaultListName => '목록';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4284,6 +4284,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get routeInvalidProfileId => 'Ongeldige profiel-ID';
 
   @override
+  String get routeUnknownPath => 'Die pagina zit niet in de app.';
+
+  @override
   String get routeDefaultListName => 'Lijst';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4378,6 +4378,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get routeInvalidProfileId => 'Nieprawidłowy ID profilu';
 
   @override
+  String get routeUnknownPath => 'Tej strony nie ma w aplikacji.';
+
+  @override
   String get routeDefaultListName => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4294,6 +4294,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get routeInvalidProfileId => 'ID de perfil inválido';
 
   @override
+  String get routeUnknownPath => 'Essa página não existe no app.';
+
+  @override
   String get routeDefaultListName => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4394,6 +4394,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get routeInvalidProfileId => 'ID de profil invalid';
 
   @override
+  String get routeUnknownPath => 'Această pagină nu e în aplicație.';
+
+  @override
   String get routeDefaultListName => 'Listă';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4266,6 +4266,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get routeInvalidProfileId => 'Ogiltigt profil-ID';
 
   @override
+  String get routeUnknownPath => 'Den sidan finns inte i appen.';
+
+  @override
   String get routeDefaultListName => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4252,6 +4252,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get routeInvalidProfileId => 'Geçersiz profil kimliği';
 
   @override
+  String get routeUnknownPath => 'Bu sayfa uygulamada yok.';
+
+  @override
   String get routeDefaultListName => 'Liste';
 
   @override

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -444,10 +443,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           // sequence. Pass the value through as-is.
           final tag = st.pathParameters['tag'];
           if (tag == null || tag.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidHashtag)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidHashtag);
           }
           return HashtagFeedScreen(hashtag: tag);
         },
@@ -470,9 +466,8 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           final id = st.pathParameters['id'];
           if (id == null || id.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidConversationId)),
+            return RouteErrorScreen(
+              message: ctx.l10n.routeInvalidConversationId,
             );
           }
           final participantPubkeys = st.extra as List<String>? ?? [];
@@ -499,10 +494,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           final id = st.pathParameters['id'];
           if (id == null || id.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidRequestId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidRequestId);
           }
           // Pubkeys are optional — the page loads them from the DB
           // when not provided (e.g. deep link).
@@ -530,10 +522,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           final listId = st.pathParameters['listId'];
           if (listId == null || listId.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidListId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidListId);
           }
           // Extra data contains listName, videoIds, authorPubkey
           final extra = st.extra as CuratedListRouteExtra?;
@@ -586,13 +575,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) {
           final listId = state.pathParameters['listId'];
           if (listId == null || listId.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(
-                title: context.l10n.peopleListsRouteTitle,
-                showBackButton: true,
-                onBackPressed: context.pop,
-              ),
-              body: Center(child: Text(context.l10n.routeInvalidListId)),
+            return RouteErrorScreen(
+              message: context.l10n.routeInvalidListId,
+              title: context.l10n.peopleListsRouteTitle,
+              showBackButton: true,
             );
           }
           return UserListPeopleScreen(listId: listId);
@@ -610,13 +596,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) {
           final listId = state.pathParameters['listId'];
           if (listId == null || listId.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(
-                title: context.l10n.peopleListsAddPeopleTitle,
-                showBackButton: true,
-                onBackPressed: context.pop,
-              ),
-              body: Center(child: Text(context.l10n.routeInvalidListId)),
+            return RouteErrorScreen(
+              message: context.l10n.routeInvalidListId,
+              title: context.l10n.peopleListsAddPeopleTitle,
+              showBackButton: true,
             );
           }
           return AddPeopleToListScreen(listId: listId);
@@ -926,10 +909,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           final pubkey = st.pathParameters['pubkey'];
           final displayName = st.extra as String?;
           if (pubkey == null || pubkey.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidUserId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidUserId);
           }
           return FollowersScreenRouter(
             pubkey: pubkey,
@@ -945,10 +925,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           final pubkey = st.pathParameters['pubkey'];
           final displayName = st.extra as String?;
           if (pubkey == null || pubkey.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidUserId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidUserId);
           }
           return FollowingScreenRouter(
             pubkey: pubkey,
@@ -963,10 +940,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           final videoId = st.pathParameters['id'];
           if (videoId == null || videoId.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidVideoId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
           }
           return VideoDetailScreen(videoId: videoId);
         },
@@ -978,10 +952,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           final soundId = st.pathParameters['id'];
           if (soundId == null || soundId.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidSoundId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidSoundId);
           }
           // Extra can be an AudioEvent directly or a Map with both
           // sound and sourceVideo (for original sounds).
@@ -1009,10 +980,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           final pubkey = st.pathParameters['pubkey'];
           final video = st.extra as VideoEvent?;
           if (pubkey == null || pubkey.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routerInvalidCreator)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routerInvalidCreator);
           }
           return OriginalSoundDetailScreen(
             creatorPubkey: pubkey,
@@ -1069,10 +1037,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               VideoCategory(name: categoryName ?? '', videoCount: 0);
 
           if (category.name.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidCategory)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidCategory);
           }
 
           return CategoryGalleryScreen(category: category);
@@ -1109,10 +1074,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               onPageChanged: extra.onPageChanged ?? (_) {},
             );
           }
-          return Scaffold(
-            appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-            body: Center(child: Text(ctx.l10n.routeNoVideosToDisplay)),
-          );
+          return RouteErrorScreen(message: ctx.l10n.routeNoVideosToDisplay);
         },
       ),
       // Other user's profile screen (no bottom nav, pushed from feeds/search)
@@ -1123,10 +1085,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           final npub = st.pathParameters['npub'];
           if (npub == null || npub.isEmpty) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeInvalidProfileId)),
-            );
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidProfileId);
           }
           // Extract profile hints from extra (for users without Kind 0 profiles)
           final extra = st.extra as Map<String, String?>?;

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -159,6 +159,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     ],
     // Refresh router when auth state changes
     refreshListenable: authListenable,
+    errorBuilder: (context, state) => RouteErrorScreen(
+      message: context.l10n.routeUnknownPath,
+    ),
     redirect: (context, state) {
       // Rewrite divine.video universal-link URLs to internal paths before the
       // auth/match logic runs. Android delivers the full intent URL (scheme +

--- a/mobile/lib/router/route_error_screen.dart
+++ b/mobile/lib/router/route_error_screen.dart
@@ -1,0 +1,50 @@
+// ABOUTME: Shared full-screen layout for route validation failures and not-found UI.
+// ABOUTME: Keeps DiVineAppBar + body copy consistent before wiring GoRouter.errorBuilder.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Full-screen error state for bad route parameters and (later) unmatched paths.
+///
+/// Matches the previous inline pattern in [GoRoute] builders: [DiVineAppBar] with
+/// [AppLocalizations.routeErrorTitle] and a short [message] in the body.
+class RouteErrorScreen extends StatelessWidget {
+  const RouteErrorScreen({
+    required this.message,
+    this.title,
+    this.showBackButton = false,
+    this.onBackPressed,
+    super.key,
+  });
+
+  /// User-visible explanation, usually from [AppLocalizations] route-related getters.
+  final String message;
+
+  /// App bar title; defaults to [AppLocalizations.routeErrorTitle].
+  final String? title;
+
+  /// When true, shows the leading back control (defaults to [GoRouter.pop] if
+  /// [onBackPressed] is omitted).
+  final bool showBackButton;
+
+  final VoidCallback? onBackPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final VoidCallback? backHandler = !showBackButton
+        ? null
+        : (onBackPressed ?? () => context.pop<void>());
+
+    return Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      appBar: DiVineAppBar(
+        title: title ?? context.l10n.routeErrorTitle,
+        showBackButton: showBackButton,
+        onBackPressed: backHandler,
+      ),
+      body: Center(child: Text(message)),
+    );
+  }
+}

--- a/mobile/lib/router/router.dart
+++ b/mobile/lib/router/router.dart
@@ -2,5 +2,6 @@ export 'app_router.dart';
 export 'app_shell.dart';
 export 'navigator_keys.dart';
 export 'providers/providers.dart';
+export 'route_error_screen.dart';
 export 'routes/routes.dart';
 export 'widgets/widgets.dart';

--- a/mobile/test/router/route_error_routing_test.dart
+++ b/mobile/test/router/route_error_routing_test.dart
@@ -1,0 +1,94 @@
+// ABOUTME: Localized route error UI: unknown paths (errorBuilder) and bad pooled extras
+// ABOUTME: Covers GoRouter.errorBuilder and RouteErrorScreen from app routes (#3371)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(resetNavigationState);
+
+  MockAuthService authenticatedAuth() {
+    final mockAuth = createMockAuthService();
+    when(() => mockAuth.isAuthenticated).thenReturn(true);
+    when(() => mockAuth.currentPublicKeyHex).thenReturn(
+      '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738',
+    );
+    when(() => mockAuth.authState).thenReturn(AuthState.authenticated);
+    when(
+      () => mockAuth.authStateStream,
+    ).thenAnswer((_) => Stream.value(AuthState.authenticated));
+    when(() => mockAuth.hasExpiredOAuthSession).thenReturn(false);
+    return mockAuth;
+  }
+
+  testWidgets('errorBuilder shows RouteErrorScreen for unknown location', (
+    tester,
+  ) async {
+    final strings = AppLocalizationsEn();
+    final container = ProviderContainer(
+      overrides: [authServiceProvider.overrideWithValue(authenticatedAuth())],
+    );
+    addTearDown(container.dispose);
+
+    await _pumpRouter(tester, container);
+
+    container
+        .read(goRouterProvider)
+        .go('/__route_error_smoke_not_in_route_table__');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RouteErrorScreen), findsOneWidget);
+    expect(find.text(strings.routeUnknownPath), findsOneWidget);
+  });
+
+  testWidgets(
+    'pooled fullscreen route without feed args uses RouteErrorScreen with no videos copy',
+    (tester) async {
+      final strings = AppLocalizationsEn();
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authenticatedAuth()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await _pumpRouter(tester, container);
+
+      container.read(goRouterProvider).go(PooledFullscreenVideoFeedScreen.path);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RouteErrorScreen), findsOneWidget);
+      expect(find.text(strings.routeNoVideosToDisplay), findsOneWidget);
+    },
+  );
+}
+
+Future<void> _pumpRouter(
+  WidgetTester tester,
+  ProviderContainer container,
+) async {
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        routerConfig: container.read(goRouterProvider),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
<!--
  PR body draft for divine-mobile branch fix/3371-centralize-localized-route-error-handling
-->

## Description

Centralizes localized “bad route” UX behind a shared screen and wires **GoRouter** so unknown URLs show the same layout as other routing guardrails.

- **`RouteErrorScreen`** (`mobile/lib/router/route_error_screen.dart`) — reusable full-screen scaffold: **VineTheme** background, **`DiVineAppBar`**, localized title (defaults to **`routeErrorTitle`**), **`message`**, optional back affordance (**`showBackButton`**, **`onBackPressed`** with default **`context.pop`**).
- **`GoRouter.errorBuilder`** — **`RouteErrorScreen(message: context.l10n.routeUnknownPath)`** for paths that do not match any route.
- **`app_router.dart`** — all previous inline **`Scaffold`** route-error branches now delegate to **`RouteErrorScreen`**, preserving existing **`context.l10n.*`** strings for invalid IDs, hashtags, pools without data, etc. Removes the stray **`package:divine_ui/divine_ui.dart`** import from the router module (widgets live under **`route_error_screen.dart`**).
- **Localization:** new **`routeUnknownPath`** in **`app_en.arb`** (with **`@routeUnknownPath`** metadata) plus the same key in **all 16 non-English** **`app_*.arb`** files; **`flutter gen-l10n`** outputs updated under **`mobile/lib/l10n/generated/`**.
- **Tests:** **`mobile/test/router/route_error_routing_test.dart`** covers (1) navigation to an unknown path → **`errorBuilder`** shows **`routeUnknownPath`**, (2) **`go`** to pooled fullscreen route without **`extra`** → **`RouteErrorScreen`** with **`routeNoVideosToDisplay`** (stable integration surface; empty path-parameter URLs are not relied on because **go_router** normalizes some segments).
- **Misc:** **`notification_repository`** — drops obsolete **`// ignore: avoid_equals_and_hash_code_on_mutable_classes`** comments on **`_VideoGroupKey`** now that the class is annotated **`@immutable`** (no behavior change).

**Verification (suggested before merge):** `cd mobile && flutter analyze` · `flutter test test/router/route_error_routing_test.dart` · `flutter test test/l10n/arb_consistency_test.dart`

**Related Issue:** Closes #3371

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore