### PR TITLE
fix(explore): keep new feed pagination alive in fullscreen

### DIFF
--- a/mobile/lib/providers/new_videos_feed_provider.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.dart
@@ -1,6 +1,7 @@
 // ABOUTME: New Videos feed provider showing videos sorted by creation time
 // ABOUTME: Uses VideosRepository.getNewVideos so Explore New is distinct from Popular
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -11,6 +12,7 @@ import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/utils/video_nostr_enrichment.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'new_videos_feed_provider.g.dart';
@@ -249,3 +251,52 @@ class NewVideosFeed extends _$NewVideosFeed {
     );
   }
 }
+
+/// Replayable stream bridge for fullscreen New Videos playback.
+///
+/// The fullscreen route can outlive the launching tab widget. Keeping this
+/// bridge at provider scope prevents pagination updates from being tied to a
+/// widget-local StreamController that may be disposed during navigation.
+class NewVideosFullscreenFeedBridge {
+  final BehaviorSubject<List<VideoEvent>> _videosSubject =
+      BehaviorSubject<List<VideoEvent>>();
+  final BehaviorSubject<bool> _hasMoreSubject = BehaviorSubject<bool>();
+
+  Stream<List<VideoEvent>> get videosStream => _videosSubject.stream;
+
+  Stream<bool> get hasMoreStream => _hasMoreSubject.stream;
+
+  void update({required List<VideoEvent> videos, required bool hasMore}) {
+    _videosSubject.add(List<VideoEvent>.unmodifiable(videos));
+    _hasMoreSubject.add(hasMore);
+  }
+
+  void dispose() {
+    _videosSubject.close();
+    _hasMoreSubject.close();
+  }
+}
+
+final newVideosFullscreenFeedBridgeProvider =
+    Provider<NewVideosFullscreenFeedBridge>((ref) {
+      final bridge = NewVideosFullscreenFeedBridge();
+
+      ref.listen<AsyncValue<VideoFeedState>>(
+        newVideosFeedProvider,
+        (previous, next) {
+          final feedState = next.asData?.value;
+          if (feedState == null) return;
+
+          bridge.update(
+            videos: feedState.videos
+                .where((v) => v.isSupportedOnCurrentPlatform)
+                .toList(),
+            hasMore: feedState.hasMoreContent,
+          );
+        },
+        fireImmediately: true,
+      );
+
+      ref.onDispose(bridge.dispose);
+      return bridge;
+    });

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -1,8 +1,6 @@
 // ABOUTME: New Videos tab widget showing recent videos sorted by time
 // ABOUTME: Extracted from ExploreScreen for better separation of concerns
 
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,7 +17,6 @@ import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Tab widget displaying new/recent videos sorted by time.
@@ -202,36 +199,10 @@ class _NewVideosContent extends ConsumerStatefulWidget {
 }
 
 class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
-  late final StreamController<List<VideoEvent>> _videosStreamController;
-  late final StreamController<bool> _hasMoreStreamController;
-
-  @override
-  void initState() {
-    super.initState();
-    _videosStreamController = StreamController<List<VideoEvent>>.broadcast();
-    _hasMoreStreamController = StreamController<bool>.broadcast();
-  }
-
-  @override
-  void dispose() {
-    _videosStreamController.close();
-    _hasMoreStreamController.close();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
-    // Listen to provider changes and push to stream for fullscreen updates
-    ref.listen(newVideosFeedProvider, (previous, next) {
-      if (next.hasValue) {
-        final videos = next.value!.videos
-            .where((v) => v.isSupportedOnCurrentPlatform)
-            .toList();
-        _videosStreamController.add(videos);
-        _hasMoreStreamController.add(next.value!.hasMoreContent);
-      }
-    });
     final newVideosFeedNotifier = ref.read(newVideosFeedProvider.notifier);
+    final fullscreenBridge = ref.read(newVideosFullscreenFeedBridgeProvider);
 
     return ComposableVideoGrid(
       videos: widget.videos,
@@ -249,12 +220,10 @@ class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
         context.push(
           PooledFullscreenVideoFeedScreen.path,
           extra: PooledFullscreenVideoFeedArgs(
-            videosStream: _videosStreamController.stream.startWith(videoList),
+            videosStream: fullscreenBridge.videosStream,
             initialIndex: index,
             onLoadMore: newVideosFeedNotifier.loadMore,
-            hasMoreStream: _hasMoreStreamController.stream.startWith(
-              widget.hasMoreContent,
-            ),
+            hasMoreStream: fullscreenBridge.hasMoreStream,
             removedIdsStream: ref
                 .read(videoEventServiceProvider)
                 .removedVideoIds,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -526,11 +526,9 @@ class _VideoGroupKey {
   final NotificationKind kind;
 
   @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes, private value object
   bool operator ==(Object other) =>
       other is _VideoGroupKey && other.eventId == eventId && other.kind == kind;
 
   @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes, private value object
   int get hashCode => Object.hash(eventId, kind);
 }

--- a/mobile/test/widgets/new_videos_tab_test.dart
+++ b/mobile/test/widgets/new_videos_tab_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/new_videos_feed_provider.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/new_videos_tab.dart';
@@ -129,6 +130,26 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'fullscreen feed bridge replays latest feed after listener attaches',
+      () async {
+        final bridge = NewVideosFullscreenFeedBridge();
+        addTearDown(bridge.dispose);
+
+        final firstPage = [_video('new-video-1')];
+        bridge.update(videos: firstPage, hasMore: true);
+
+        await expectLater(bridge.videosStream, emits(firstPage));
+        await expectLater(bridge.hasMoreStream, emits(true));
+
+        final secondPage = [...firstPage, _video('new-video-2')];
+        bridge.update(videos: secondPage, hasMore: false);
+
+        await expectLater(bridge.videosStream, emits(secondPage));
+        await expectLater(bridge.hasMoreStream, emits(false));
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Fixes #4075

## Summary
- Verified Funnelcake recent feed cursor pagination works in production with before, so the likely break was mobile stream ownership rather than the API.
- Move Explore New fullscreen feed updates into a provider-scoped replay bridge so the fullscreen route keeps receiving appended pages after the launching tab widget is disposed or rebuilt.
- Add coverage that late fullscreen stream subscribers receive the latest New Videos page, and remove two stale analyzer ignore comments from the current base.

## Verification
- flutter test test/widgets/new_videos_tab_test.dart
- flutter test test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
- flutter analyze
- pre-push hook: merge-conflict check, changed-item analyzer, generated-files verification, test/widgets/new_videos_tab_test.dart