### PR TITLE
fix(video-download): evict invalid cache entries and auto-retry after Settings

### DIFF
--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -259,7 +259,15 @@ class WatermarkDownloadService {
         name: _logName,
         category: LogCategory.video,
       );
-      await _mediaCache.removeCachedFile(video.id);
+      try {
+        await _mediaCache.removeCachedFile(video.id);
+      } catch (e) {
+        Log.warning(
+          'Failed to evict invalid cached video file: $e',
+          name: _logName,
+          category: LogCategory.video,
+        );
+      }
     }
 
     // Resolve the playable URL and download

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -69,6 +69,9 @@ class WatermarkDownloadPermissionDenied extends WatermarkDownloadResult {
 /// interrupted download) is evicted and re-fetched.
 const _videoExtensions = <String>{'.mp4', '.mov', '.webm', '.mkv', '.m4v'};
 
+String _redownloadCacheKey(String videoId) =>
+    '$videoId-redownload-${DateTime.now().microsecondsSinceEpoch}';
+
 /// Service that downloads a video, applies a Divine watermark, and saves
 /// the result to the device gallery.
 class WatermarkDownloadService {
@@ -237,6 +240,8 @@ class WatermarkDownloadService {
 
   /// Downloads or retrieves the cached video file.
   Future<File?> _getVideoFile(VideoEvent video) async {
+    var cacheKey = video.id;
+
     // Check cache first — only use it when the file has a recognised video
     // extension.  Stale entries from older app versions (or interrupted
     // downloads) can leave a `.bin` file on disk that ProVideoEditor cannot
@@ -267,6 +272,7 @@ class WatermarkDownloadService {
           name: _logName,
           category: LogCategory.video,
         );
+        cacheKey = _redownloadCacheKey(video.id);
       }
     }
 
@@ -281,7 +287,7 @@ class WatermarkDownloadService {
       return null;
     }
 
-    final file = await _mediaCache.cacheFile(videoUrl, key: video.id);
+    final file = await _mediaCache.cacheFile(videoUrl, key: cacheKey);
 
     return file;
   }

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/watermark_image_generator.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -62,6 +63,11 @@ class WatermarkDownloadPermissionDenied extends WatermarkDownloadResult {
   /// Creates a [WatermarkDownloadPermissionDenied].
   const WatermarkDownloadPermissionDenied();
 }
+
+/// File extensions recognised as playable video files when validating a
+/// previously cached download. Anything else (e.g. a `.bin` file from an
+/// interrupted download) is evicted and re-fetched.
+const _videoExtensions = <String>{'.mp4', '.mov', '.webm', '.mkv', '.m4v'};
 
 /// Service that downloads a video, applies a Divine watermark, and saves
 /// the result to the device gallery.
@@ -231,15 +237,29 @@ class WatermarkDownloadService {
 
   /// Downloads or retrieves the cached video file.
   Future<File?> _getVideoFile(VideoEvent video) async {
-    // Check cache first
+    // Check cache first — only use it when the file has a recognised video
+    // extension.  Stale entries from older app versions (or interrupted
+    // downloads) can leave a `.bin` file on disk that ProVideoEditor cannot
+    // read.  Evicting the bad entry lets the next cacheFile() call perform a
+    // clean network download.
     final cachedFile = _mediaCache.getCachedFileSync(video.id);
     if (cachedFile != null && cachedFile.existsSync()) {
-      Log.debug(
-        'Using cached video file',
+      final ext = p.extension(cachedFile.path).toLowerCase();
+      if (_videoExtensions.contains(ext)) {
+        Log.debug(
+          'Using cached video file',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        return cachedFile;
+      }
+
+      Log.warning(
+        'Cached file has invalid extension "$ext", evicting and re-downloading',
         name: _logName,
         category: LogCategory.video,
       );
-      return cachedFile;
+      await _mediaCache.removeCachedFile(video.id);
     }
 
     // Resolve the playable URL and download

--- a/mobile/lib/widgets/retry_after_settings_on_resume.dart
+++ b/mobile/lib/widgets/retry_after_settings_on_resume.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Shared lifecycle helper for permission settings retries.
+// ABOUTME: Defers retry work until the app resumes after opening Settings.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+typedef RetryAfterSettingsCallback = Future<void> Function();
+
+/// Runs a pending retry after Settings returns the app to the foreground.
+mixin RetryAfterSettingsOnResume<T extends StatefulWidget> on State<T> {
+  RetryAfterSettingsCallback? _pendingSettingsRetry;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(_settingsResumeObserver);
+  }
+
+  late final _SettingsResumeObserver _settingsResumeObserver =
+      _SettingsResumeObserver(_handleResume);
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(_settingsResumeObserver);
+    super.dispose();
+  }
+
+  Future<void> openSettingsAndRetryOnResume({
+    required Future<bool> Function() openSettings,
+    required RetryAfterSettingsCallback retry,
+  }) async {
+    _pendingSettingsRetry = retry;
+
+    try {
+      final opened = await openSettings();
+      if (!opened) {
+        _pendingSettingsRetry = null;
+      }
+    } catch (_) {
+      _pendingSettingsRetry = null;
+      rethrow;
+    }
+  }
+
+  void _handleResume() {
+    final retry = _pendingSettingsRetry;
+    if (retry == null || !mounted) {
+      return;
+    }
+
+    _pendingSettingsRetry = null;
+    unawaited(retry());
+  }
+}
+
+class _SettingsResumeObserver extends WidgetsBindingObserver {
+  _SettingsResumeObserver(this.onResume);
+
+  final VoidCallback onResume;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      onResume();
+    }
+  }
+}

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -232,6 +232,16 @@ class _SaveOriginalProgressSheetState
   Future<void> _openSettings() async {
     final permissionsService = widget.ref.read(permissionsServiceProvider);
     await permissionsService.openAppSettings();
+    // After returning from Settings, retry the download automatically.
+    // The user may have just granted the permission.
+    if (mounted) {
+      setState(() {
+        _result = null;
+        _stage = OriginalSaveStage.downloading;
+        _isProcessing = true;
+      });
+      _startDownload();
+    }
   }
 
   Future<void> _shareFile() async {

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -9,6 +9,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
 import 'package:share_plus/share_plus.dart';
 
 /// Shows a bottom sheet that tracks original video save progress.
@@ -44,8 +45,8 @@ class _SaveOriginalProgressSheet extends StatefulWidget {
       _SaveOriginalProgressSheetState();
 }
 
-class _SaveOriginalProgressSheetState
-    extends State<_SaveOriginalProgressSheet> {
+class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
+    with RetryAfterSettingsOnResume {
   OriginalSaveStage _stage = OriginalSaveStage.downloading;
   WatermarkDownloadResult? _result;
   bool _isProcessing = true;
@@ -231,17 +232,18 @@ class _SaveOriginalProgressSheetState
 
   Future<void> _openSettings() async {
     final permissionsService = widget.ref.read(permissionsServiceProvider);
-    await permissionsService.openAppSettings();
-    // After returning from Settings, retry the download automatically.
-    // The user may have just granted the permission.
-    if (mounted) {
-      setState(() {
-        _result = null;
-        _stage = OriginalSaveStage.downloading;
-        _isProcessing = true;
-      });
-      _startDownload();
-    }
+    await openSettingsAndRetryOnResume(
+      openSettings: permissionsService.openAppSettings,
+      retry: () async {
+        if (!mounted) return;
+        setState(() {
+          _result = null;
+          _stage = OriginalSaveStage.downloading;
+          _isProcessing = true;
+        });
+        await _startDownload();
+      },
+    );
   }
 
   Future<void> _shareFile() async {

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -9,6 +9,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
 import 'package:share_plus/share_plus.dart';
 
 /// Shows a bottom sheet that tracks watermark download progress.
@@ -54,7 +55,8 @@ class _WatermarkDownloadProgressSheet extends StatefulWidget {
 }
 
 class _WatermarkDownloadProgressSheetState
-    extends State<_WatermarkDownloadProgressSheet> {
+    extends State<_WatermarkDownloadProgressSheet>
+    with RetryAfterSettingsOnResume {
   WatermarkDownloadStage _stage = WatermarkDownloadStage.downloading;
   WatermarkDownloadResult? _result;
   bool _isProcessing = true;
@@ -239,17 +241,18 @@ class _WatermarkDownloadProgressSheetState
 
   Future<void> _openSettings() async {
     final permissionsService = widget.ref.read(permissionsServiceProvider);
-    await permissionsService.openAppSettings();
-    // After returning from Settings, retry the download automatically.
-    // The user may have just granted the permission.
-    if (mounted) {
-      setState(() {
-        _result = null;
-        _stage = WatermarkDownloadStage.downloading;
-        _isProcessing = true;
-      });
-      _startDownload();
-    }
+    await openSettingsAndRetryOnResume(
+      openSettings: permissionsService.openAppSettings,
+      retry: () async {
+        if (!mounted) return;
+        setState(() {
+          _result = null;
+          _stage = WatermarkDownloadStage.downloading;
+          _isProcessing = true;
+        });
+        await _startDownload();
+      },
+    );
   }
 
   Future<void> _shareFile() async {

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -240,6 +240,16 @@ class _WatermarkDownloadProgressSheetState
   Future<void> _openSettings() async {
     final permissionsService = widget.ref.read(permissionsServiceProvider);
     await permissionsService.openAppSettings();
+    // After returning from Settings, retry the download automatically.
+    // The user may have just granted the permission.
+    if (mounted) {
+      setState(() {
+        _result = null;
+        _stage = WatermarkDownloadStage.downloading;
+        _isProcessing = true;
+      });
+      _startDownload();
+    }
   }
 
   Future<void> _shareFile() async {

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -182,5 +182,159 @@ void main() {
         );
       });
     });
+
+    group('_getVideoFile (cached file fallback)', () {
+      test(
+        'returns cached file when extension is .mp4 and file exists',
+        () async {
+          final tempDir = await Directory.systemTemp.createTemp(
+            'watermark-ext-test',
+          );
+          final videoFile = File('${tempDir.path}/video.mp4');
+          await videoFile.writeAsBytes(const [1, 2, 3, 4]);
+          addTearDown(() async {
+            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+          });
+
+          when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
+          when(
+            () => mockGallerySave.saveVideoToGallery(any()),
+          ).thenAnswer((_) async => const GallerySaveSuccess());
+
+          final result = await service.downloadOriginal(
+            video: _createTestVideo(),
+            onProgress: (_) {},
+          );
+
+          // File was used — gallery save was called
+          verify(() => mockGallerySave.saveVideoToGallery(any())).called(1);
+          // removeCachedFile must NOT have been called
+          verifyNever(() => mockCache.removeCachedFile(any()));
+          expect(result, isA<WatermarkDownloadSuccess>());
+        },
+      );
+
+      test(
+        'evicts cache and re-downloads when cached file has .bin extension',
+        () async {
+          final tempDir = await Directory.systemTemp.createTemp(
+            'watermark-ext-test',
+          );
+          // Simulate stale download stored as .bin (seen in flutter_cache_manager
+          // when a previous download was interrupted without a Content-Type header)
+          final badFile = File('${tempDir.path}/video.bin');
+          await badFile.writeAsBytes(const [0, 0, 0, 0]);
+
+          final freshFile = File('${tempDir.path}/fresh.mp4');
+          await freshFile.writeAsBytes(const [1, 2, 3, 4]);
+
+          addTearDown(() async {
+            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+          });
+
+          when(() => mockCache.getCachedFileSync(any())).thenReturn(badFile);
+          when(
+            () => mockCache.removeCachedFile(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockCache.cacheFile(any(), key: any(named: 'key')),
+          ).thenAnswer((_) async => freshFile);
+          when(
+            () => mockGallerySave.saveVideoToGallery(any()),
+          ).thenAnswer((_) async => const GallerySaveSuccess());
+
+          await service.downloadOriginal(
+            video: _createTestVideo(),
+            onProgress: (_) {},
+          );
+
+          verify(() => mockCache.removeCachedFile(any())).called(1);
+          verify(
+            () => mockCache.cacheFile(any(), key: any(named: 'key')),
+          ).called(1);
+        },
+      );
+
+      test('evicts cache when cached file has no extension', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'watermark-ext-test',
+        );
+        final badFile = File('${tempDir.path}/video');
+        await badFile.writeAsBytes(const [0, 0, 0, 0]);
+
+        addTearDown(() async {
+          if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+        });
+
+        when(() => mockCache.getCachedFileSync(any())).thenReturn(badFile);
+        when(() => mockCache.removeCachedFile(any())).thenAnswer((_) async {});
+        when(
+          () => mockCache.cacheFile(any(), key: any(named: 'key')),
+        ).thenAnswer((_) async => null);
+
+        final result = await service.downloadOriginal(
+          video: _createTestVideo(),
+          onProgress: (_) {},
+        );
+
+        verify(() => mockCache.removeCachedFile(any())).called(1);
+        expect(result, isA<WatermarkDownloadFailure>());
+      });
+
+      test('accepts .mov cached files without eviction', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'watermark-ext-test',
+        );
+        final movFile = File('${tempDir.path}/video.mov');
+        await movFile.writeAsBytes(const [1, 2, 3, 4]);
+        addTearDown(() async {
+          if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+        });
+
+        when(() => mockCache.getCachedFileSync(any())).thenReturn(movFile);
+        when(
+          () => mockGallerySave.saveVideoToGallery(any()),
+        ).thenAnswer((_) async => const GallerySaveSuccess());
+
+        await service.downloadOriginal(
+          video: _createTestVideo(),
+          onProgress: (_) {},
+        );
+
+        verifyNever(() => mockCache.removeCachedFile(any()));
+      });
+
+      test(
+        'falls back to fresh download when getCachedFileSync returns null',
+        () async {
+          final tempDir = await Directory.systemTemp.createTemp(
+            'watermark-ext-test',
+          );
+          final freshFile = File('${tempDir.path}/fresh.mp4');
+          await freshFile.writeAsBytes(const [1, 2, 3, 4]);
+          addTearDown(() async {
+            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+          });
+
+          when(() => mockCache.getCachedFileSync(any())).thenReturn(null);
+          when(
+            () => mockCache.cacheFile(any(), key: any(named: 'key')),
+          ).thenAnswer((_) async => freshFile);
+          when(
+            () => mockGallerySave.saveVideoToGallery(any()),
+          ).thenAnswer((_) async => const GallerySaveSuccess());
+
+          final result = await service.downloadOriginal(
+            video: _createTestVideo(),
+            onProgress: (_) {},
+          );
+
+          verify(
+            () => mockCache.cacheFile(any(), key: any(named: 'key')),
+          ).called(1);
+          expect(result, isA<WatermarkDownloadSuccess>());
+        },
+      );
+    });
   });
 }

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -284,6 +284,7 @@ void main() {
       test(
         'fresh download continues when invalid cache eviction fails',
         () async {
+          final video = _createTestVideo();
           final tempDir = await Directory.systemTemp.createTemp(
             'watermark-ext-test',
           );
@@ -303,20 +304,36 @@ void main() {
           ).thenThrow(Exception('eviction failed'));
           when(
             () => mockCache.cacheFile(any(), key: any(named: 'key')),
-          ).thenAnswer((_) async => freshFile);
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            return key == video.id ? badFile : freshFile;
+          });
           when(
             () => mockGallerySave.saveVideoToGallery(any()),
           ).thenAnswer((_) async => const GallerySaveSuccess());
 
           final result = await service.downloadOriginal(
-            video: _createTestVideo(),
+            video: video,
             onProgress: (_) {},
           );
 
           verify(() => mockCache.removeCachedFile(any())).called(1);
-          verify(
-            () => mockCache.cacheFile(any(), key: any(named: 'key')),
-          ).called(1);
+          final cacheKey =
+              verify(
+                    () => mockCache.cacheFile(
+                      any(),
+                      key: captureAny(named: 'key'),
+                    ),
+                  ).captured.single
+                  as String;
+          expect(cacheKey, isNot(video.id));
+          expect(cacheKey, startsWith('${video.id}-redownload-'));
+          final savedVideo =
+              verify(
+                    () => mockGallerySave.saveVideoToGallery(captureAny()),
+                  ).captured.single
+                  as EditorVideo;
+          expect(savedVideo.file!.path, freshFile.path);
           expect(result, isA<WatermarkDownloadSuccess>());
         },
       );

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -281,6 +281,46 @@ void main() {
         expect(result, isA<WatermarkDownloadFailure>());
       });
 
+      test(
+        'fresh download continues when invalid cache eviction fails',
+        () async {
+          final tempDir = await Directory.systemTemp.createTemp(
+            'watermark-ext-test',
+          );
+          final badFile = File('${tempDir.path}/video.bin');
+          await badFile.writeAsBytes(const [0, 0, 0, 0]);
+
+          final freshFile = File('${tempDir.path}/fresh.mp4');
+          await freshFile.writeAsBytes(const [1, 2, 3, 4]);
+
+          addTearDown(() async {
+            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+          });
+
+          when(() => mockCache.getCachedFileSync(any())).thenReturn(badFile);
+          when(
+            () => mockCache.removeCachedFile(any()),
+          ).thenThrow(Exception('eviction failed'));
+          when(
+            () => mockCache.cacheFile(any(), key: any(named: 'key')),
+          ).thenAnswer((_) async => freshFile);
+          when(
+            () => mockGallerySave.saveVideoToGallery(any()),
+          ).thenAnswer((_) async => const GallerySaveSuccess());
+
+          final result = await service.downloadOriginal(
+            video: _createTestVideo(),
+            onProgress: (_) {},
+          );
+
+          verify(() => mockCache.removeCachedFile(any())).called(1);
+          verify(
+            () => mockCache.cacheFile(any(), key: any(named: 'key')),
+          ).called(1);
+          expect(result, isA<WatermarkDownloadSuccess>());
+        },
+      );
+
       test('accepts .mov cached files without eviction', () async {
         final tempDir = await Directory.systemTemp.createTemp(
           'watermark-ext-test',

--- a/mobile/test/widgets/save_original_progress_sheet_test.dart
+++ b/mobile/test/widgets/save_original_progress_sheet_test.dart
@@ -208,8 +208,7 @@ void main() {
     });
 
     testWidgets(
-      'Open Settings retries download automatically after returning from '
-      'settings',
+      'Open Settings retries download after app resumes from settings',
       (tester) async {
         when(
           () => mockPermissions.openAppSettings(),
@@ -245,8 +244,20 @@ void main() {
           findsOneWidget,
         );
 
-        // Tap Open Settings → opens settings → returns → retries
         await tester.tap(find.text(l10n.saveOriginalOpenSettings));
+        await tester.pump();
+
+        // openAppSettings() returns when Settings opens, so the sheet should
+        // wait for the app to resume before retrying.
+        expect(callCount, equals(1));
+        expect(
+          find.text(l10n.saveOriginalPhotosAccessNeeded),
+          findsOneWidget,
+        );
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
         await tester.pumpAndSettle();
 
         // Should now show success (retry succeeded)
@@ -260,7 +271,7 @@ void main() {
     );
 
     testWidgets(
-      'Open Settings shows loading indicator while retry is in progress',
+      'Open Settings shows loading indicator while resumed retry is in progress',
       (tester) async {
         when(
           () => mockPermissions.openAppSettings(),
@@ -297,10 +308,22 @@ void main() {
 
         // Tap Open Settings
         await tester.tap(find.text(l10n.saveOriginalOpenSettings));
-        await tester.pump(); // process setState
+        await tester.pump();
+
+        expect(callCount, equals(1));
+        expect(
+          find.text(l10n.saveOriginalPhotosAccessNeeded),
+          findsOneWidget,
+        );
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
 
         // Sheet should be in loading/processing state during retry
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(callCount, equals(2));
       },
     );
   });

--- a/mobile/test/widgets/watermark_download_progress_sheet_test.dart
+++ b/mobile/test/widgets/watermark_download_progress_sheet_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for SaveOriginalProgressSheet widget
-// ABOUTME: Validates UI states for downloading, success, failure, and permission denied
+// ABOUTME: Tests for WatermarkDownloadProgressSheet widget
+// ABOUTME: Validates UI states: loading, success, permission-denied (+ retry), failure
 
 import 'dart:async';
 
@@ -12,7 +12,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
-import 'package:openvine/widgets/save_original_progress_sheet.dart';
+import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 import 'package:permissions_service/permissions_service.dart';
 
 class _MockWatermarkDownloadService extends Mock
@@ -39,7 +39,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(_createTestVideo());
-    registerFallbackValue(OriginalSaveStage.downloading);
+    registerFallbackValue(WatermarkDownloadStage.downloading);
   });
 
   setUp(() {
@@ -64,10 +64,11 @@ void main() {
                 return Scaffold(
                   body: ElevatedButton(
                     onPressed: () {
-                      showSaveOriginalSheet(
+                      showWatermarkDownloadSheet(
                         context: context,
                         ref: ref,
                         video: video,
+                        watermarkText: 'TestUser',
                       );
                     },
                     child: const Text('Show Sheet'),
@@ -81,130 +82,127 @@ void main() {
     );
   }
 
-  group('showSaveOriginalSheet', () {
+  group('showWatermarkDownloadSheet', () {
     testWidgets('shows progress indicator while downloading', (tester) async {
-      // Use a Completer that never completes (no timer involved)
       final neverComplete = Completer<WatermarkDownloadResult>();
 
       when(
-        () => mockService.downloadOriginal(
+        () => mockService.downloadWithWatermark(
           video: any(named: 'video'),
+          watermarkText: any(named: 'watermarkText'),
           onProgress: any(named: 'onProgress'),
         ),
       ).thenAnswer((invocation) {
-        // Simulate being stuck in downloading stage
         final onProgress =
             invocation.namedArguments[#onProgress]
-                as void Function(OriginalSaveStage);
-        onProgress(OriginalSaveStage.downloading);
-        // Never return - stays in processing state (Completer avoids timer)
+                as void Function(WatermarkDownloadStage);
+        onProgress(WatermarkDownloadStage.downloading);
         return neverComplete.future;
       });
 
       await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
-
-      // Open the sheet
       await tester.tap(find.text('Show Sheet'));
       await tester.pump();
 
-      // Should show progress indicator
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.text(l10n.saveOriginalDownloadingVideo), findsOneWidget);
+      expect(
+        find.text(l10n.watermarkDownloadStageDownloading),
+        findsOneWidget,
+      );
       // Prove the widget actually reads from l10n
-      expect(find.text(l10nDe.saveOriginalDownloadingVideo), findsNothing);
+      expect(
+        find.text(l10nDe.watermarkDownloadStageDownloading),
+        findsNothing,
+      );
     });
 
-    testWidgets('shows success state with share button', (tester) async {
+    testWidgets('shows watermarking stage label', (tester) async {
+      final neverComplete = Completer<WatermarkDownloadResult>();
+
       when(
-        () => mockService.downloadOriginal(
+        () => mockService.downloadWithWatermark(
           video: any(named: 'video'),
+          watermarkText: any(named: 'watermarkText'),
           onProgress: any(named: 'onProgress'),
         ),
-      ).thenAnswer((invocation) async {
+      ).thenAnswer((invocation) {
         final onProgress =
             invocation.namedArguments[#onProgress]
-                as void Function(OriginalSaveStage);
-        onProgress(OriginalSaveStage.downloading);
-        onProgress(OriginalSaveStage.saving);
-        return const WatermarkDownloadSuccess('/tmp/video.mp4');
+                as void Function(WatermarkDownloadStage);
+        onProgress(WatermarkDownloadStage.watermarking);
+        return neverComplete.future;
       });
 
       await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
+      await tester.tap(find.text('Show Sheet'));
+      await tester.pump();
 
+      expect(
+        find.text(l10n.watermarkDownloadStageWatermarking),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows success state after completed download', (tester) async {
+      when(
+        () => mockService.downloadWithWatermark(
+          video: any(named: 'video'),
+          watermarkText: any(named: 'watermarkText'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async => const WatermarkDownloadSuccess('/tmp/v.mp4'));
+
+      await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
       await tester.tap(find.text('Show Sheet'));
       await tester.pumpAndSettle();
 
-      // Should show success state
-      expect(find.text(l10n.saveOriginalSavedToCameraRoll), findsOneWidget);
-      expect(find.text(l10n.saveOriginalShare), findsOneWidget);
-      expect(find.text(l10n.saveOriginalDone), findsOneWidget);
+      expect(
+        find.text(l10n.watermarkDownloadSavedToCameraRoll),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.watermarkDownloadShare), findsOneWidget);
+      expect(find.text(l10n.watermarkDownloadDone), findsOneWidget);
     });
 
     testWidgets('shows permission denied state', (tester) async {
       when(
-        () => mockService.downloadOriginal(
+        () => mockService.downloadWithWatermark(
           video: any(named: 'video'),
+          watermarkText: any(named: 'watermarkText'),
           onProgress: any(named: 'onProgress'),
         ),
-      ).thenAnswer((invocation) async {
-        final onProgress =
-            invocation.namedArguments[#onProgress]
-                as void Function(OriginalSaveStage);
-        onProgress(OriginalSaveStage.downloading);
-        return const WatermarkDownloadPermissionDenied();
-      });
+      ).thenAnswer((_) async => const WatermarkDownloadPermissionDenied());
 
       await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
-
       await tester.tap(find.text('Show Sheet'));
       await tester.pumpAndSettle();
 
-      expect(find.text(l10n.saveOriginalPhotosAccessNeeded), findsOneWidget);
-      expect(find.text(l10n.saveOriginalOpenSettings), findsOneWidget);
-      expect(find.text(l10n.saveOriginalNotNow), findsOneWidget);
+      expect(
+        find.text(l10n.watermarkDownloadPhotosAccessNeeded),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.watermarkDownloadOpenSettings), findsOneWidget);
+      expect(find.text(l10n.watermarkDownloadNotNow), findsOneWidget);
     });
 
     testWidgets('shows failure state with reason', (tester) async {
       when(
-        () => mockService.downloadOriginal(
+        () => mockService.downloadWithWatermark(
           video: any(named: 'video'),
+          watermarkText: any(named: 'watermarkText'),
           onProgress: any(named: 'onProgress'),
         ),
-      ).thenAnswer((_) async {
-        return const WatermarkDownloadFailure('Network timeout');
-      });
+      ).thenAnswer(
+        (_) async => const WatermarkDownloadFailure('Network error'),
+      );
 
       await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
-
       await tester.tap(find.text('Show Sheet'));
       await tester.pumpAndSettle();
 
-      expect(find.text(l10n.saveOriginalDownloadFailed), findsOneWidget);
-      expect(find.text('Network timeout'), findsOneWidget);
-      expect(find.text(l10n.saveOriginalDismiss), findsOneWidget);
-    });
-
-    testWidgets('dismiss button closes the sheet', (tester) async {
-      when(
-        () => mockService.downloadOriginal(
-          video: any(named: 'video'),
-          onProgress: any(named: 'onProgress'),
-        ),
-      ).thenAnswer((_) async {
-        return const WatermarkDownloadFailure('Error');
-      });
-
-      await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
-
-      await tester.tap(find.text('Show Sheet'));
-      await tester.pumpAndSettle();
-
-      // Tap dismiss
-      await tester.tap(find.text(l10n.saveOriginalDismiss));
-      await tester.pumpAndSettle();
-
-      // Sheet should be closed
-      expect(find.text(l10n.saveOriginalDownloadFailed), findsNothing);
+      expect(find.text(l10n.watermarkDownloadFailed), findsOneWidget);
+      expect(find.text('Network error'), findsOneWidget);
+      expect(find.text(l10n.watermarkDownloadDismiss), findsOneWidget);
     });
 
     testWidgets(
@@ -215,52 +213,52 @@ void main() {
           () => mockPermissions.openAppSettings(),
         ).thenAnswer((_) async => true);
 
-        // First call: permission denied. Second call (retry): success.
         var callCount = 0;
         when(
-          () => mockService.downloadOriginal(
+          () => mockService.downloadWithWatermark(
             video: any(named: 'video'),
+            watermarkText: any(named: 'watermarkText'),
             onProgress: any(named: 'onProgress'),
           ),
         ).thenAnswer((invocation) async {
           callCount++;
           final onProgress =
               invocation.namedArguments[#onProgress]
-                  as void Function(OriginalSaveStage);
-          onProgress(OriginalSaveStage.downloading);
+                  as void Function(WatermarkDownloadStage);
+          onProgress(WatermarkDownloadStage.downloading);
           if (callCount == 1) {
             return const WatermarkDownloadPermissionDenied();
           }
-          onProgress(OriginalSaveStage.saving);
-          return const WatermarkDownloadSuccess('/tmp/video.mp4');
+          onProgress(WatermarkDownloadStage.saving);
+          return const WatermarkDownloadSuccess('/tmp/v.mp4');
         });
 
         await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
         await tester.tap(find.text('Show Sheet'));
         await tester.pumpAndSettle();
 
-        // Permission denied UI is showing
         expect(
-          find.text(l10n.saveOriginalPhotosAccessNeeded),
+          find.text(l10n.watermarkDownloadPhotosAccessNeeded),
           findsOneWidget,
         );
 
-        // Tap Open Settings → opens settings → returns → retries
-        await tester.tap(find.text(l10n.saveOriginalOpenSettings));
+        await tester.tap(find.text(l10n.watermarkDownloadOpenSettings));
         await tester.pumpAndSettle();
 
-        // Should now show success (retry succeeded)
         expect(
-          find.text(l10n.saveOriginalSavedToCameraRoll),
+          find.text(l10n.watermarkDownloadSavedToCameraRoll),
           findsOneWidget,
         );
-        expect(find.text(l10n.saveOriginalPhotosAccessNeeded), findsNothing);
+        expect(
+          find.text(l10n.watermarkDownloadPhotosAccessNeeded),
+          findsNothing,
+        );
         expect(callCount, equals(2));
       },
     );
 
     testWidgets(
-      'Open Settings shows loading indicator while retry is in progress',
+      'Open Settings shows loading state while retry is in progress',
       (tester) async {
         when(
           () => mockPermissions.openAppSettings(),
@@ -270,16 +268,17 @@ void main() {
         var callCount = 0;
 
         when(
-          () => mockService.downloadOriginal(
+          () => mockService.downloadWithWatermark(
             video: any(named: 'video'),
+            watermarkText: any(named: 'watermarkText'),
             onProgress: any(named: 'onProgress'),
           ),
         ).thenAnswer((invocation) async {
           callCount++;
           final onProgress =
               invocation.namedArguments[#onProgress]
-                  as void Function(OriginalSaveStage);
-          onProgress(OriginalSaveStage.downloading);
+                  as void Function(WatermarkDownloadStage);
+          onProgress(WatermarkDownloadStage.downloading);
           if (callCount == 1) {
             return const WatermarkDownloadPermissionDenied();
           }
@@ -291,17 +290,36 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.text(l10n.saveOriginalPhotosAccessNeeded),
+          find.text(l10n.watermarkDownloadPhotosAccessNeeded),
           findsOneWidget,
         );
 
-        // Tap Open Settings
-        await tester.tap(find.text(l10n.saveOriginalOpenSettings));
-        await tester.pump(); // process setState
+        await tester.tap(find.text(l10n.watermarkDownloadOpenSettings));
+        await tester.pump();
 
-        // Sheet should be in loading/processing state during retry
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
       },
     );
+
+    testWidgets('Dismiss button closes the sheet', (tester) async {
+      when(
+        () => mockService.downloadWithWatermark(
+          video: any(named: 'video'),
+          watermarkText: any(named: 'watermarkText'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer(
+        (_) async => const WatermarkDownloadFailure('Network error'),
+      );
+
+      await tester.pumpWidget(buildTestWidget(video: _createTestVideo()));
+      await tester.tap(find.text('Show Sheet'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.watermarkDownloadDismiss));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.watermarkDownloadFailed), findsNothing);
+    });
   });
 }

--- a/mobile/test/widgets/watermark_download_progress_sheet_test.dart
+++ b/mobile/test/widgets/watermark_download_progress_sheet_test.dart
@@ -206,8 +206,7 @@ void main() {
     });
 
     testWidgets(
-      'Open Settings retries download automatically after returning from '
-      'settings',
+      'Open Settings retries download after app resumes from settings',
       (tester) async {
         when(
           () => mockPermissions.openAppSettings(),
@@ -243,6 +242,19 @@ void main() {
         );
 
         await tester.tap(find.text(l10n.watermarkDownloadOpenSettings));
+        await tester.pump();
+
+        // openAppSettings() returns when Settings opens, so the sheet should
+        // wait for the app to resume before retrying.
+        expect(callCount, equals(1));
+        expect(
+          find.text(l10n.watermarkDownloadPhotosAccessNeeded),
+          findsOneWidget,
+        );
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
         await tester.pumpAndSettle();
 
         expect(
@@ -258,7 +270,7 @@ void main() {
     );
 
     testWidgets(
-      'Open Settings shows loading state while retry is in progress',
+      'Open Settings shows loading state while resumed retry is in progress',
       (tester) async {
         when(
           () => mockPermissions.openAppSettings(),
@@ -297,7 +309,19 @@ void main() {
         await tester.tap(find.text(l10n.watermarkDownloadOpenSettings));
         await tester.pump();
 
+        expect(callCount, equals(1));
+        expect(
+          find.text(l10n.watermarkDownloadPhotosAccessNeeded),
+          findsOneWidget,
+        );
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(callCount, equals(2));
       },
     );
 


### PR DESCRIPTION

## Description
Two separate issues caused silent save failures on the video download sheets:

1. **Stale `.bin` cache entries** — `flutter_cache_manager` occasionally stores interrupted downloads under a `.bin` extension. `ProVideoEditor` cannot read these files, causing the watermark/original-save flow to fail without a clear error.
2. **No retry after Settings** — Tapping "Open Settings" on the permission-denied sheet returned the user to the same blocked state. They had to close the sheet and re-trigger the share flow manually.

**Changes**

- `WatermarkDownloadService._getVideoFile`: checks the cached file's extension against a known-good set (`{.mp4, .mov, .webm, .mkv, .m4v}`). Files with any other extension are evicted and re-downloaded. Extension allowlist extracted into a top-level `const _videoExtensions` set.
- `SaveOriginalProgressSheet._openSettings` / `WatermarkDownloadProgressSheet._openSettings`: after `openAppSettings()` returns, the sheet automatically resets state to downloading and calls `_startDownload()` again.


**Related Issue:** Closes #3920

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore