### PR TITLE
feat(audio): add Wednesday My Dudes to Divine bundle

### DIFF
--- a/mobile/assets/sounds/sounds_manifest.json
+++ b/mobile/assets/sounds/sounds_manifest.json
@@ -197,6 +197,13 @@
       "tags": ["meme", "classic", "profanity"]
     },
     {
+      "id": "wednesday",
+      "title": "Wednesday My Dudes",
+      "assetPath": "assets/sounds/wednesday.mp3",
+      "durationMs": 6269,
+      "tags": ["meme", "classic", "frog"]
+    },
+    {
       "id": "what_da_dog_doing",
       "title": "What Da Dog Doing",
       "assetPath": "assets/sounds/what-what-da-dog-doing.mp3",

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -19,7 +19,7 @@ import 'package:unified_logger/unified_logger.dart';
 final _featuredVineSounds = [
   VineSound(
     id: 'wednesday',
-    title: 'Wednesday',
+    title: 'Wednesday My Dudes',
     assetPath: 'assets/sounds/wednesday.mp3',
     duration: const Duration(milliseconds: 6269),
     tags: const ['featured'],

--- a/mobile/test/services/sound_library_service_test.dart
+++ b/mobile/test/services/sound_library_service_test.dart
@@ -67,6 +67,19 @@ void main() {
       },
     );
 
+    test('real manifest includes Wednesday My Dudes bundled clip', () async {
+      final manifestFile = File('assets/sounds/sounds_manifest.json');
+      final sounds = SoundLibraryService.parseManifest(
+        await manifestFile.readAsString(),
+      );
+
+      final sound = sounds.singleWhere((s) => s.id == 'wednesday');
+
+      expect(sound.title, equals('Wednesday My Dudes'));
+      expect(sound.assetPath, equals('assets/sounds/wednesday.mp3'));
+      expect(sound.duration.inMilliseconds, equals(6269));
+    });
+
     test('searchSounds filters by query', () {
       final sounds = [
         VineSound(

--- a/mobile/test/widgets/library/sounds_tab_test.dart
+++ b/mobile/test/widgets/library/sounds_tab_test.dart
@@ -92,16 +92,19 @@ void main() {
       await pumpSoundsTab(
         tester,
         showAudioPicker: (_) async =>
-            _sound(id: 'wednesday', title: 'Wednesday'),
+            _sound(id: 'wednesday', title: 'Wednesday My Dudes'),
       );
 
       await tester.tap(find.text('Add audio'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Wednesday'), findsOneWidget);
+      expect(find.text('Wednesday My Dudes'), findsOneWidget);
 
       final savedSounds = SavedSoundsService(sharedPreferences).loadSounds();
-      expect(savedSounds.map((sound) => sound.title), contains('Wednesday'));
+      expect(
+        savedSounds.map((sound) => sound.title),
+        contains('Wednesday My Dudes'),
+      );
     });
 
     testWidgets('shows empty state when no sounds have been saved', (

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -250,7 +250,7 @@ void main() {
                 id: 'wednesday',
                 title: 'Wednesday My Dudes',
                 assetPath: 'assets/sounds/wednesday.mp3',
-                duration: Duration(milliseconds: 6269),
+                duration: const Duration(milliseconds: 6269),
                 tags: ['meme', 'classic', 'frog'],
               ),
             ],

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -55,11 +55,12 @@ void main() {
     Widget buildWidget({
       AsyncValue<List<AudioEvent>>? trendingSoundsAsync,
       List<AudioEvent> savedSounds = const [],
+      List<VineSound> bundledSounds = const [],
     }) {
       return ProviderScope(
         overrides: [
           soundLibraryServiceProvider.overrideWith(
-            (_) => SoundLibraryService(),
+            (_) async => _FakeSoundLibraryService(bundledSounds),
           ),
           savedSoundsProvider.overrideWith(
             () => _FakeSavedSoundsNotifier(savedSounds),
@@ -125,7 +126,7 @@ void main() {
         await tester.tap(find.text(l10n.videoEditorAudioCategoryFeatured));
         await tester.pumpAndSettle();
 
-        expect(find.text('Wednesday'), findsOneWidget);
+        expect(find.text('Wednesday My Dudes'), findsOneWidget);
       });
 
       testWidgets('filters community sounds on community tab', (tester) async {
@@ -235,7 +236,29 @@ void main() {
         await tester.tap(find.text(l10n.videoEditorAudioCategoryFeatured));
         await tester.pumpAndSettle();
 
-        expect(find.text('Wednesday'), findsOneWidget);
+        expect(find.text('Wednesday My Dudes'), findsOneWidget);
+      });
+
+      testWidgets('renders bundled Wednesday clip on Divine tab', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data(testSounds),
+            bundledSounds: [
+              VineSound(
+                id: 'wednesday',
+                title: 'Wednesday My Dudes',
+                assetPath: 'assets/sounds/wednesday.mp3',
+                duration: Duration(milliseconds: 6269),
+                tags: ['meme', 'classic', 'frog'],
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Wednesday My Dudes'), findsOneWidget);
       });
 
       testWidgets('renders saved sounds empty state on My Sounds tab', (
@@ -354,4 +377,25 @@ class _FakeSavedSoundsNotifier extends SavedSoundsNotifier {
 
   @override
   List<AudioEvent> build() => _sounds;
+}
+
+class _FakeSoundLibraryService extends SoundLibraryService {
+  _FakeSoundLibraryService(this._bundledSounds);
+
+  final List<VineSound> _bundledSounds;
+
+  @override
+  List<VineSound> get sounds => List.unmodifiable(_bundledSounds);
+
+  @override
+  List<VineSound> get customSounds => const [];
+
+  @override
+  bool get isLoaded => true;
+
+  @override
+  Future<void> loadSounds() async {}
+
+  @override
+  Future<void> loadCustomSounds() async {}
 }


### PR DESCRIPTION
## Summary

- rename the Featured audio picker label from Wednesday to Wednesday My Dudes
- add the same bundled clip to the Divine sound manifest
- cover the Featured and Divine tab behavior with tests

## Why

The Wednesday clip already exists as a bundled asset, but it only appeared in the Featured list and still used the shorter title. This update keeps the clip name consistent and exposes the same asset in the Divine tab without duplicating the underlying file.

Closes #4066

## Validation

- flutter test test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
- flutter test test/services/sound_library_service_test.dart
- flutter test test/widgets/library/sounds_tab_test.dart