### PR TITLE
feat(invites): retry transient consume failures with session preservation

### DIFF
--- a/docs/superpowers/plans/2026-05-06-invite-consume-retry.md
+++ b/docs/superpowers/plans/2026-05-06-invite-consume-retry.md
@@ -1,0 +1,831 @@
+# Invite Consume Retry Implementation Plan
+
+Status: Current
+Validated against: `invite_error_utils.dart`, `EmailVerificationCubit`, `DivineAuthCubit` on 2026-05-06.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retry transient invite consume failures with fresh NIP-98 timestamps, preserving the Keycast session before consume so it survives exhausted retries.
+
+**Architecture:** Add `isRetryable()` and `retryConsume()` static helpers to `InviteErrorUtils`. Replace the existing 409-only retry loop in `EmailVerificationCubit` and the bare consume calls in `DivineAuthCubit` with `retryConsume()`. Persist `KeycastSession` immediately after token exchange, before consume, in both session-based paths.
+
+**Tech Stack:** Dart, Flutter BLoC, `invite_api_client` package, `keycast_flutter` package
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `mobile/lib/utils/invite_error_utils.dart` | Modify | Add `isRetryable()` and `retryConsume()` static methods |
+| `mobile/test/utils/invite_error_utils_test.dart` | Modify | Add tests for `isRetryable()` and `retryConsume()` |
+| `mobile/lib/blocs/email_verification/email_verification_cubit.dart` | Modify | Replace 409 loop with `retryConsume()`, add `session.save()` |
+| `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart` | Modify | Wrap consume calls with `retryConsume()`, add `session.save()` |
+| `mobile/test/blocs/email_verification/email_verification_cubit_test.dart` | Modify | Update retry tests for broader retry behavior |
+| `mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart` | Modify | Add retry and session persistence tests |
+
+---
+
+### Task 1: Add `isRetryable()` and `retryConsume()` to InviteErrorUtils
+
+**Files:**
+- Modify: `mobile/lib/utils/invite_error_utils.dart`
+- Modify: `mobile/test/utils/invite_error_utils_test.dart`
+
+- [ ] **Step 1: Write tests for `isRetryable()`**
+
+Append to the end of `main()` in `mobile/test/utils/invite_error_utils_test.dart`, before the closing `}`:
+
+```dart
+  group('isRetryable', () {
+    test('temporary is retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.clientTimeout),
+        ),
+        isTrue,
+      );
+    });
+
+    test('authFailure is retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.authInvalid, statusCode: 401),
+        ),
+        isTrue,
+      );
+    });
+
+    test('alreadyUsed is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.inviteAlreadyUsed),
+        ),
+        isFalse,
+      );
+    });
+
+    test('invalid is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.inviteNotFound),
+        ),
+        isFalse,
+      );
+    });
+
+    test('creatorFull is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.creatorPageFull),
+        ),
+        isFalse,
+      );
+    });
+
+    test('unknown is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(message: 'something unexpected'),
+        ),
+        isFalse,
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Write tests for `retryConsume()`**
+
+Add `import 'dart:async';` at the top of the test file. Then append another group inside `main()`:
+
+```dart
+  group('retryConsume', () {
+    test('returns result on first success', () async {
+      final result = await InviteErrorUtils.retryConsume(
+        consume: () async =>
+            const InviteConsumeResult(message: 'ok', codesAllocated: 5),
+        log: (_) {},
+      );
+      expect(result.message, 'ok');
+    });
+
+    test('retries on retryable error and succeeds', () async {
+      var calls = 0;
+      final result = await InviteErrorUtils.retryConsume(
+        consume: () async {
+          calls++;
+          if (calls == 1) {
+            throw const InviteApiException(
+              'timeout',
+              code: InviteApiErrorCode.clientTimeout,
+            );
+          }
+          return const InviteConsumeResult(message: 'ok', codesAllocated: 5);
+        },
+        log: (_) {},
+        delay: Duration.zero,
+      );
+      expect(result.message, 'ok');
+      expect(calls, 2);
+    });
+
+    test('rethrows terminal error immediately', () async {
+      var calls = 0;
+      await expectLater(
+        () => InviteErrorUtils.retryConsume(
+          consume: () async {
+            calls++;
+            throw const InviteApiException(
+              'already used',
+              code: InviteApiErrorCode.inviteAlreadyUsed,
+            );
+          },
+          log: (_) {},
+          delay: Duration.zero,
+        ),
+        throwsA(isA<InviteApiException>()),
+      );
+      expect(calls, 1);
+    });
+
+    test('rethrows after exhausting max attempts', () async {
+      var calls = 0;
+      await expectLater(
+        () => InviteErrorUtils.retryConsume(
+          consume: () async {
+            calls++;
+            throw const InviteApiException(
+              'timeout',
+              code: InviteApiErrorCode.clientTimeout,
+            );
+          },
+          log: (_) {},
+          maxAttempts: 3,
+          delay: Duration.zero,
+        ),
+        throwsA(isA<InviteApiException>()),
+      );
+      expect(calls, 3);
+    });
+
+    test('logs warning on each retry', () async {
+      final logs = <String>[];
+      var calls = 0;
+      await InviteErrorUtils.retryConsume(
+        consume: () async {
+          calls++;
+          if (calls <= 2) {
+            throw const InviteApiException(
+              'timeout',
+              code: InviteApiErrorCode.clientTimeout,
+            );
+          }
+          return const InviteConsumeResult(message: 'ok', codesAllocated: 5);
+        },
+        log: logs.add,
+        maxAttempts: 3,
+        delay: Duration.zero,
+      );
+      expect(logs.length, 2);
+      expect(logs[0], contains('attempt 1/3'));
+      expect(logs[1], contains('attempt 2/3'));
+    });
+
+    test('respects maxAttempts parameter', () async {
+      var calls = 0;
+      await expectLater(
+        () => InviteErrorUtils.retryConsume(
+          consume: () async {
+            calls++;
+            throw const InviteApiException(
+              'network',
+              code: InviteApiErrorCode.clientNetworkError,
+            );
+          },
+          log: (_) {},
+          maxAttempts: 2,
+          delay: Duration.zero,
+        ),
+        throwsA(isA<InviteApiException>()),
+      );
+      expect(calls, 2);
+    });
+  });
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd mobile && flutter test test/utils/invite_error_utils_test.dart
+```
+Expected: Compile error — `isRetryable` and `retryConsume` don't exist yet.
+
+- [ ] **Step 4: Implement `isRetryable()` and `retryConsume()`**
+
+In `mobile/lib/utils/invite_error_utils.dart`, add this import at the top:
+
+```dart
+import 'package:invite_api_client/invite_api_client.dart'
+    show InviteApiException, InviteConsumeResult;
+```
+
+Wait — the file already imports `invite_api_client.dart`. We need to add `InviteConsumeResult` to the existing import. Replace the first import with:
+
+```dart
+import 'package:invite_api_client/invite_api_client.dart';
+```
+
+(This is already the case — the barrel export includes `InviteConsumeResult`.)
+
+Add these two methods inside the `InviteErrorUtils` class, after `activationFailureMessage`:
+
+```dart
+  /// Whether the error is worth retrying (fresh NIP-98 timestamp may fix it).
+  static bool isRetryable(InviteApiException error) {
+    final reason = activationFailureReason(error);
+    return reason == InviteActivationFailureReason.temporary ||
+        reason == InviteActivationFailureReason.authFailure;
+  }
+
+  /// Retries [consume] up to [maxAttempts] times on retryable errors.
+  ///
+  /// Each retry generates a fresh NIP-98 timestamp (because the caller
+  /// passes a closure that calls `consumeInviteWith*`, which internally
+  /// calls `_createAuthorizationHeader` with `DateTime.now()`).
+  ///
+  /// Terminal errors are rethrown immediately. On the final attempt,
+  /// any error is rethrown regardless of retryability.
+  static Future<InviteConsumeResult> retryConsume({
+    required Future<InviteConsumeResult> Function() consume,
+    required void Function(String message) log,
+    int maxAttempts = 3,
+    Duration delay = const Duration(seconds: 2),
+  }) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await consume();
+      } on InviteApiException catch (e) {
+        final isLastAttempt = attempt == maxAttempts;
+        if (!isRetryable(e) || isLastAttempt) {
+          rethrow;
+        }
+        log(
+          'Invite consume failed (attempt $attempt/$maxAttempts), '
+          'retrying in ${delay.inMilliseconds}ms: '
+          '${e.message} [code=${e.code}]',
+        );
+        await Future<void>.delayed(delay);
+      }
+    }
+    throw StateError('Unreachable');
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd mobile && flutter test test/utils/invite_error_utils_test.dart
+```
+Expected: All tests PASS (existing + new isRetryable + retryConsume tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/utils/invite_error_utils.dart mobile/test/utils/invite_error_utils_test.dart
+git commit -m "feat(invites): add isRetryable and retryConsume helpers
+
+Classifies temporary and authFailure errors as retryable. retryConsume
+wraps a consume closure with configurable retry count and delay.
+Part of #3795 consume retry work."
+```
+
+---
+
+### Task 2: Replace EmailVerificationCubit 409 loop with `retryConsume()`
+
+**Files:**
+- Modify: `mobile/lib/blocs/email_verification/email_verification_cubit.dart`
+- Modify: `mobile/test/blocs/email_verification/email_verification_cubit_test.dart`
+
+- [ ] **Step 1: Update existing retry tests for broader retry behavior**
+
+In `mobile/test/blocs/email_verification/email_verification_cubit_test.dart`, replace the three retry tests (the test named `'retries invite consumption on 409 conflict and succeeds on retry'`, the test named `'gives up after exhausting retries on persistent 409'`, and the test named `'does NOT retry on non-conflict InviteApiException (e.g. 400)'`) with these updated versions:
+
+```dart
+      test(
+        'retries invite consumption on transient error and succeeds on retry',
+        () {
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isAnonymous).thenReturn(false);
+          when(() => mockOAuth.config).thenReturn(
+            const OAuthConfig(
+              serverUrl: 'https://login.divine.video',
+              clientId: 'client-id',
+              redirectUri: 'divine://auth',
+            ),
+          );
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.complete(testCode));
+          when(
+            () =>
+                mockOAuth.exchangeCode(code: testCode, verifier: testVerifier),
+          ).thenAnswer(
+            (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+          );
+
+          var consumeCallCount = 0;
+          when(
+            () => mockInviteApiClient.consumeInviteWithSession(
+              code: any(named: 'code'),
+              oauthConfig: any(named: 'oauthConfig'),
+              session: any(named: 'session'),
+            ),
+          ).thenAnswer((_) async {
+            consumeCallCount++;
+            if (consumeCallCount == 1) {
+              throw const InviteApiException(
+                'timeout',
+                code: InviteApiErrorCode.clientTimeout,
+              );
+            }
+            return const InviteConsumeResult(
+              message: 'Welcome',
+              codesAllocated: 5,
+            );
+          });
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) async {});
+
+          fakeAsync((fake) {
+            final cubit = buildCubit();
+            cubit.startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+              inviteCode: 'ab12ef34',
+            );
+
+            // Poll fires after 3s; retry waits another 2s.
+            fake.elapse(const Duration(seconds: 8));
+
+            expect(cubit.state.status, EmailVerificationStatus.success);
+            expect(
+              consumeCallCount,
+              equals(2),
+              reason:
+                  'Cubit should retry once on transient error before '
+                  'succeeding.',
+            );
+            verify(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test('gives up after exhausting retries on persistent transient error',
+          () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockOAuth.config).thenReturn(
+          const OAuthConfig(
+            serverUrl: 'https://login.divine.video',
+            clientId: 'client-id',
+            redirectUri: 'divine://auth',
+          ),
+        );
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.complete(testCode));
+        when(
+          () => mockOAuth.exchangeCode(code: testCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+
+        var consumeCallCount = 0;
+        when(
+          () => mockInviteApiClient.consumeInviteWithSession(
+            code: any(named: 'code'),
+            oauthConfig: any(named: 'oauthConfig'),
+            session: any(named: 'session'),
+          ),
+        ).thenAnswer((_) async {
+          consumeCallCount++;
+          throw const InviteApiException(
+            'timeout',
+            code: InviteApiErrorCode.clientTimeout,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+            inviteCode: 'ab12ef34',
+          );
+
+          // Generous elapse so all retries can play out.
+          fake.elapse(const Duration(seconds: 30));
+
+          expect(cubit.state.status, EmailVerificationStatus.failure);
+          expect(
+            consumeCallCount,
+            equals(3),
+            reason: 'Cubit should retry 3 times before giving up.',
+          );
+          verifyNever(() => mockAuthService.signInWithDivineOAuth(any()));
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('does NOT retry on terminal InviteApiException', () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockOAuth.config).thenReturn(
+          const OAuthConfig(
+            serverUrl: 'https://login.divine.video',
+            clientId: 'client-id',
+            redirectUri: 'divine://auth',
+          ),
+        );
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.complete(testCode));
+        when(
+          () => mockOAuth.exchangeCode(code: testCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+
+        var consumeCallCount = 0;
+        when(
+          () => mockInviteApiClient.consumeInviteWithSession(
+            code: any(named: 'code'),
+            oauthConfig: any(named: 'oauthConfig'),
+            session: any(named: 'session'),
+          ),
+        ).thenAnswer((_) async {
+          consumeCallCount++;
+          throw const InviteApiException(
+            'Invite already used',
+            code: InviteApiErrorCode.inviteAlreadyUsed,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+            inviteCode: 'ab12ef34',
+          );
+
+          fake.elapse(const Duration(seconds: 5));
+
+          expect(cubit.state.status, EmailVerificationStatus.failure);
+          expect(
+            consumeCallCount,
+            equals(1),
+            reason: 'Terminal invite errors must not be retried.',
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+```
+
+- [ ] **Step 2: Run tests to verify the updated tests fail**
+
+```bash
+cd mobile && flutter test test/blocs/email_verification/email_verification_cubit_test.dart
+```
+Expected: FAIL — the cubit still uses the old 409-only retry loop, so the transient retry test (which throws `clientTimeout`, not 409) will fail.
+
+- [ ] **Step 3: Replace 409 loop with `retryConsume()` and add `session.save()`**
+
+In `mobile/lib/blocs/email_verification/email_verification_cubit.dart`:
+
+First, add the import for `InviteErrorUtils` if not already present. Check — it's already imported via `package:openvine/utils/invite_error_utils.dart`.
+
+Remove the two constants `_maxConsumeRetries` and `_consumeRetryDelay` (lines 319-326).
+
+Replace `_consumeInviteWithSessionIfNeeded` (the entire method from line 468 to 498) with:
+
+```dart
+  Future<void> _consumeInviteWithSessionIfNeeded(KeycastSession session) async {
+    final inviteCode = _pendingInviteCode;
+    final inviteApiClient = _inviteApiClient;
+    if (inviteCode == null || inviteApiClient == null) {
+      return;
+    }
+
+    await session.save();
+
+    await InviteErrorUtils.retryConsume(
+      consume: () => inviteApiClient.consumeInviteWithSession(
+        code: inviteCode,
+        oauthConfig: _oauthClient.config,
+        session: session,
+      ),
+      log: (message) => Log.warning(
+        message,
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      ),
+    );
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mobile && flutter test test/blocs/email_verification/email_verification_cubit_test.dart
+```
+Expected: All tests PASS. The updated retry tests exercise the new `retryConsume()` path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/blocs/email_verification/email_verification_cubit.dart mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+git commit -m "feat(invites): replace 409 retry loop with retryConsume in EmailVerificationCubit
+
+Broader retry covers timeout, network, and auth errors (not just 409).
+Session saved before consume so it survives exhausted retries.
+Removes _maxConsumeRetries and _consumeRetryDelay constants.
+Part of #3795 consume retry work."
+```
+
+---
+
+### Task 3: Wrap DivineAuthCubit consume calls with `retryConsume()`
+
+**Files:**
+- Modify: `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart`
+- Modify: `mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart`
+
+- [ ] **Step 1: Add retry and session persistence tests for `_exchangeCodeAndLogin`**
+
+In `mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart`, find the test group for sign-in invite consumption (look for the `blocTest` named `'emits invite recovery error when invite activation fails during sign in'`). After that test, add:
+
+```dart
+        blocTest<DivineAuthCubit, DivineAuthState>(
+          'retries invite consumption on transient error during sign in',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult(success: true, code: testCode),
+                testVerifier,
+              ),
+            );
+            when(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            ).thenAnswer(
+              (_) async => const TokenResponse(bunkerUrl: 'bunker://test'),
+            );
+            var consumeCallCount = 0;
+            when(
+              () => mockInviteApiClient.consumeInviteWithSession(
+                code: any(named: 'code'),
+                oauthConfig: any(named: 'oauthConfig'),
+                session: any(named: 'session'),
+              ),
+            ).thenAnswer((_) async {
+              consumeCallCount++;
+              if (consumeCallCount == 1) {
+                throw const InviteApiException(
+                  'timeout',
+                  code: InviteApiErrorCode.clientTimeout,
+                );
+              }
+              return const InviteConsumeResult(
+                message: 'Welcome',
+                codesAllocated: 5,
+              );
+            });
+            when(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).thenAnswer((_) async {});
+          },
+          build: () => buildCubit(inviteCode: 'ab12ef34'),
+          seed: () => const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSignIn: true,
+          ),
+          act: (cubit) => cubit.submit(),
+          expect: () => [
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              isSubmitting: true,
+            ),
+            isA<DivineAuthSuccess>(),
+          ],
+          verify: (_) {
+            verify(
+              () => mockInviteApiClient.consumeInviteWithSession(
+                code: any(named: 'code'),
+                oauthConfig: any(named: 'oauthConfig'),
+                session: any(named: 'session'),
+              ),
+            ).called(2);
+          },
+        );
+```
+
+- [ ] **Step 2: Add retry test for `skipWithAnonymousAccount`**
+
+After the existing `'emits invite recovery error when anonymous invite activation fails'` test, add:
+
+```dart
+      blocTest<DivineAuthCubit, DivineAuthState>(
+        'retries anonymous invite consumption on transient error',
+        setUp: () {
+          var consumeCallCount = 0;
+          when(
+            () => mockInviteApiClient.consumeInviteWithKeyContainer(
+              code: any(named: 'code'),
+              keyContainer: any(named: 'keyContainer'),
+            ),
+          ).thenAnswer((_) async {
+            consumeCallCount++;
+            if (consumeCallCount == 1) {
+              throw const InviteApiException(
+                'network error',
+                code: InviteApiErrorCode.clientNetworkError,
+              );
+            }
+            return const InviteConsumeResult(
+              message: 'Welcome',
+              codesAllocated: 5,
+            );
+          });
+          when(
+            () => mockAuthService.createAnonymousAccountFromKeyContainer(any()),
+          ).thenAnswer((_) async {});
+        },
+        build: () => buildCubit(inviteCode: 'ab12ef34'),
+        seed: () =>
+            const DivineAuthFormState(email: testEmail, password: testPassword),
+        act: (cubit) => cubit.skipWithAnonymousAccount(),
+        expect: () => [
+          const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSkipping: true,
+          ),
+          isA<DivineAuthSuccess>(),
+        ],
+        verify: (_) {
+          verify(
+            () => mockInviteApiClient.consumeInviteWithKeyContainer(
+              code: any(named: 'code'),
+              keyContainer: any(named: 'keyContainer'),
+            ),
+          ).called(2);
+        },
+      );
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd mobile && flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart
+```
+Expected: FAIL — consume is only called once (no retry yet).
+
+- [ ] **Step 4: Add `retryConsume()` to `_consumeInviteWithSessionIfNeeded` with `session.save()`**
+
+In `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart`, replace `_consumeInviteWithSessionIfNeeded` (lines 494-506) with:
+
+```dart
+  Future<void> _consumeInviteWithSessionIfNeeded(KeycastSession session) async {
+    final inviteCode = _inviteCode;
+    final inviteApiClient = _inviteApiClient;
+    if (inviteCode == null || inviteApiClient == null) {
+      return;
+    }
+
+    await session.save();
+
+    await InviteErrorUtils.retryConsume(
+      consume: () => inviteApiClient.consumeInviteWithSession(
+        code: inviteCode,
+        oauthConfig: _oauthClient.config,
+        session: session,
+      ),
+      log: (message) => Log.warning(
+        message,
+        name: 'DivineAuthCubit',
+        category: LogCategory.auth,
+      ),
+    );
+  }
+```
+
+- [ ] **Step 5: Add `retryConsume()` to `skipWithAnonymousAccount`**
+
+In `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart`, in `skipWithAnonymousAccount`, replace the bare `consumeInviteWithKeyContainer` call (lines 435-438):
+
+```dart
+          await inviteApiClient.consumeInviteWithKeyContainer(
+            code: inviteCode,
+            keyContainer: pendingKey,
+          );
+```
+
+with:
+
+```dart
+          await InviteErrorUtils.retryConsume(
+            consume: () => inviteApiClient.consumeInviteWithKeyContainer(
+              code: inviteCode,
+              keyContainer: pendingKey,
+            ),
+            log: (message) => Log.warning(
+              message,
+              name: 'DivineAuthCubit',
+              category: LogCategory.auth,
+            ),
+          );
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd mobile && flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart
+```
+Expected: All tests PASS, including new retry tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/lib/blocs/divine_auth/divine_auth_cubit.dart mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+git commit -m "feat(invites): add consume retry and session persistence to DivineAuthCubit
+
+Both session-based and anonymous consume paths now retry transient
+errors via retryConsume(). Session saved before consume in
+_exchangeCodeAndLogin path. Part of #3795 consume retry work."
+```
+
+---
+
+### Task 4: Final verification and cleanup
+
+- [ ] **Step 1: Run all three test suites**
+
+```bash
+cd mobile && flutter test test/utils/invite_error_utils_test.dart test/blocs/email_verification/email_verification_cubit_test.dart test/blocs/divine_auth/divine_auth_cubit_test.dart
+```
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run invite_api_client package tests**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/
+```
+Expected: All tests PASS (no changes to the package in this PR).
+
+- [ ] **Step 3: Run analyzer**
+
+```bash
+cd mobile && flutter analyze
+```
+Expected: No issues introduced by these changes.
+
+- [ ] **Step 4: Verify the old 409 retry constants are removed**
+
+```bash
+grep -rn "_maxConsumeRetries\|_consumeRetryDelay" mobile/ --include="*.dart"
+```
+Expected: No results. Both constants were removed from `EmailVerificationCubit`.
+
+- [ ] **Step 5: Verify `session.save()` is called before consume in both session paths**
+
+```bash
+grep -A3 "session.save()" mobile/lib/blocs/ -r --include="*.dart"
+```
+Expected: Two occurrences — one in `email_verification_cubit.dart` and one in `divine_auth_cubit.dart`, each followed by `retryConsume`.

--- a/docs/superpowers/plans/2026-05-06-invite-consume-telemetry.md
+++ b/docs/superpowers/plans/2026-05-06-invite-consume-telemetry.md
@@ -1,0 +1,465 @@
+# Invite Consume Telemetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve original exception context through invite activation failures so we can diagnose why consume calls fail.
+
+**Architecture:** Add an `Object? cause` field to `InviteApiException`, thread it through the five wrap/throw sites in `invite_api_client.dart`, and enhance log lines in both cubits to include the cause's `runtimeType`. No changes to classification, retry, or UI.
+
+**Tech Stack:** Dart, Flutter BLoC, `invite_api_client` package
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `mobile/packages/invite_api_client/lib/src/invite_api_exception.dart` | Modify | Add `cause` field |
+| `mobile/packages/invite_api_client/lib/src/invite_api_client.dart` | Modify | Thread `cause` at 5 wrap sites, add `_warningLogger` call |
+| `mobile/lib/blocs/email_verification/email_verification_cubit.dart` | Modify | Enhance log line |
+| `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart` | Modify | Enhance log line |
+| `mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart` | Create | Test `cause` field and `toString()` |
+| `mobile/packages/invite_api_client/test/src/invite_api_client_test.dart` | Modify | Add `cause` assertions to existing error tests |
+
+---
+
+### Task 1: Add `cause` field to `InviteApiException`
+
+**Files:**
+- Modify: `mobile/packages/invite_api_client/lib/src/invite_api_exception.dart`
+- Create: `mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart`
+
+- [ ] **Step 1: Write tests for the `cause` field**
+
+Create `mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:invite_api_client/invite_api_client.dart';
+
+void main() {
+  group('InviteApiException', () {
+    test('cause defaults to null', () {
+      const exception = InviteApiException('test error');
+      expect(exception.cause, isNull);
+    });
+
+    test('preserves cause when provided', () {
+      final cause = TimeoutException('timed out');
+      final exception = InviteApiException(
+        'Request failed',
+        cause: cause,
+      );
+      expect(exception.cause, same(cause));
+    });
+
+    test('toString includes cause runtimeType when present', () {
+      final exception = InviteApiException(
+        'Request failed',
+        code: InviteApiErrorCode.clientTimeout,
+        cause: TimeoutException('timed out'),
+      );
+      final str = exception.toString();
+      expect(str, contains('TimeoutException'));
+    });
+
+    test('toString omits cause when null', () {
+      const exception = InviteApiException(
+        'Request failed',
+        code: InviteApiErrorCode.clientTimeout,
+      );
+      final str = exception.toString();
+      expect(str, isNot(contains('cause')));
+    });
+
+    test('const constructor still works without cause', () {
+      const exception = InviteApiException(
+        'test',
+        statusCode: 401,
+        code: InviteApiErrorCode.authInvalid,
+      );
+      expect(exception.message, 'test');
+      expect(exception.statusCode, 401);
+      expect(exception.cause, isNull);
+    });
+
+    test('preserves SocketException as cause', () {
+      const cause = SocketException('Connection refused');
+      final exception = InviteApiException(
+        'Network error',
+        code: InviteApiErrorCode.clientNetworkError,
+        cause: cause,
+      );
+      expect(exception.cause, isA<SocketException>());
+      expect(exception.cause.toString(), contains('Connection refused'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `mobile/`:
+```bash
+cd mobile && flutter test packages/invite_api_client/test/src/invite_api_exception_test.dart
+```
+Expected: Compile error — `cause` parameter does not exist yet.
+
+- [ ] **Step 3: Add `cause` field to `InviteApiException`**
+
+Replace the full class in `mobile/packages/invite_api_client/lib/src/invite_api_exception.dart` (keep `InviteApiErrorCode` unchanged). The class becomes:
+
+```dart
+class InviteApiException implements Exception {
+  const InviteApiException(
+    this.message, {
+    this.statusCode,
+    this.responseBody,
+    this.code,
+    this.creatorSlug,
+    this.creatorDisplayName,
+    this.cause,
+  });
+
+  final String message;
+  final int? statusCode;
+  final String? responseBody;
+  final String? code;
+  final String? creatorSlug;
+  final String? creatorDisplayName;
+  final Object? cause;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer(
+      'InviteApiException(message: $message, statusCode: $statusCode, '
+      'code: $code',
+    );
+    if (cause != null) {
+      buffer.write(', cause: ${cause.runtimeType}: $cause');
+    }
+    buffer.write(')');
+    return buffer.toString();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/src/invite_api_exception_test.dart
+```
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Run existing package tests to verify no regressions**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/
+```
+Expected: All existing tests PASS (const constructors unaffected since `cause` defaults to null).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/packages/invite_api_client/lib/src/invite_api_exception.dart mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart
+git commit -m "feat(invites): add cause field to InviteApiException
+
+Preserves the original exception through wrap sites so cubits can
+log the underlying failure type. Part of #3795 telemetry work."
+```
+
+---
+
+### Task 2: Thread `cause` through wrap sites
+
+**Files:**
+- Modify: `mobile/packages/invite_api_client/lib/src/invite_api_client.dart`
+- Modify: `mobile/packages/invite_api_client/test/src/invite_api_client_test.dart`
+
+- [ ] **Step 1: Add `cause` assertions to existing error tests**
+
+In `mobile/packages/invite_api_client/test/src/invite_api_client_test.dart`, add `.having` matchers for `cause` to three existing tests:
+
+**Test "surfaces validateCode timeout failures as InviteApiException"** (~line 179): add to the `throwsA` matcher chain:
+
+```dart
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<TimeoutException>(),
+                )
+```
+
+**Test "surfaces validateCode transport failures as InviteApiException"** (~line 211): add to the `throwsA` matcher chain:
+
+```dart
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<SocketException>(),
+                )
+```
+
+**Test "surfaces consumeInvite timeout failures with a structured code"** (~line 467): add to the `throwsA` matcher chain:
+
+```dart
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<TimeoutException>(),
+                )
+```
+
+**Test "surfaces consumeInvite network failures with a structured code"** (~line 499): add to the `throwsA` matcher chain:
+
+```dart
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<SocketException>(),
+                )
+```
+
+**Test "surfaces invite signing failures with a structured auth code"** (~line 529): add to the `throwsA` matcher chain:
+
+```dart
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isNotNull,
+                )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/src/invite_api_client_test.dart
+```
+Expected: FAIL — `cause` is null because wrap sites don't pass it yet.
+
+- [ ] **Step 3: Thread `cause` through `_wrapClientException`**
+
+In `mobile/packages/invite_api_client/lib/src/invite_api_client.dart`, replace `_wrapClientException`:
+
+```dart
+  InviteApiException _wrapClientException({
+    required Object error,
+    required String timeoutMessage,
+    required String failureMessage,
+  }) {
+    if (error is InviteApiException) return error;
+    if (error is TimeoutException) {
+      return InviteApiException(
+        timeoutMessage,
+        code: InviteApiErrorCode.clientTimeout,
+        cause: error,
+      );
+    }
+
+    final code = _isNetworkError(error)
+        ? InviteApiErrorCode.clientNetworkError
+        : InviteApiErrorCode.clientError;
+    return InviteApiException('$failureMessage: $error', code: code, cause: error);
+  }
+```
+
+- [ ] **Step 4: Thread `cause` through `consumeInviteWithKeyContainer` catch**
+
+In the same file, replace the catch block in `consumeInviteWithKeyContainer`:
+
+```dart
+    } catch (error) {
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
+      );
+    }
+```
+
+- [ ] **Step 5: Thread `cause` through `consumeInviteWithSession` catch**
+
+In the same file, replace the catch block in `consumeInviteWithSession`:
+
+```dart
+    } catch (error) {
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
+      );
+    }
+```
+
+- [ ] **Step 6: Thread `cause` through `_createAuthorizationHeader` catch**
+
+In the same file, replace the final catch block in `_createAuthorizationHeader`:
+
+```dart
+    } catch (error) {
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
+      );
+    }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/
+```
+Expected: All tests PASS, including the new `cause` assertions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mobile/packages/invite_api_client/lib/src/invite_api_client.dart mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
+git commit -m "feat(invites): thread cause through exception wrap sites
+
+_wrapClientException, consumeInviteWithSession,
+consumeInviteWithKeyContainer, and _createAuthorizationHeader now
+preserve the original error as InviteApiException.cause. Part of
+#3795 telemetry work."
+```
+
+---
+
+### Task 3: Log signer stage failures via `_warningLogger`
+
+**Files:**
+- Modify: `mobile/packages/invite_api_client/lib/src/invite_api_client.dart`
+
+- [ ] **Step 1: Add `_warningLogger` call to `_createAuthorizationHeader`**
+
+In `mobile/packages/invite_api_client/lib/src/invite_api_client.dart`, in `_createAuthorizationHeader`, update the final catch block:
+
+```dart
+    } catch (error) {
+      _warningLogger?.call(
+        'Auth header construction failed: ${error.runtimeType}: $error',
+      );
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
+      );
+    }
+```
+
+Note: The `_createAuthorizationHeader` catch block is only reachable when a signer's `getPublicKey()` or `signEvent()` throws a non-`InviteApiException` error (e.g., an RPC transport failure from `KeycastRpc`). This path is exercised in production by Keycast bunker relay failures but is difficult to unit test without mocking deep Keycast internals. The `_warningLogger` call lives next to the `throw` that IS tested by "surfaces invite signing failures with a structured auth code" — verified by code review.
+
+- [ ] **Step 2: Run tests to verify no regressions**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/
+```
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+git commit -m "feat(invites): log auth header construction failures
+
+Calls _warningLogger before rethrowing so signer/RPC failures are
+visible in production logs. Part of #3795 telemetry work."
+```
+
+---
+
+### Task 4: Enhance cubit log lines with cause context
+
+**Files:**
+- Modify: `mobile/lib/blocs/email_verification/email_verification_cubit.dart`
+- Modify: `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart`
+
+- [ ] **Step 1: Enhance `EmailVerificationCubit` log line**
+
+In `mobile/lib/blocs/email_verification/email_verification_cubit.dart`, in `_exchangeCodeAndLogin`, replace the `InviteApiException` catch block's log call:
+
+```dart
+      } on InviteApiException catch (e) {
+        Log.error(
+          'Invite activation failed: ${e.message} '
+          '[code=${e.code}, status=${e.statusCode}, '
+          'cause=${e.cause?.runtimeType}: ${e.cause}]',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+```
+
+The rest of the catch block (lines saving `inviteCode`, calling `_cleanup()`, emitting state) stays unchanged.
+
+- [ ] **Step 2: Enhance `DivineAuthCubit` log line**
+
+In `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart`, in `_exchangeCodeAndLogin`, replace the `InviteApiException` catch block's log call:
+
+```dart
+    } on InviteApiException catch (e) {
+      Log.error(
+        'Invite activation failed: ${e.message} '
+        '[code=${e.code}, status=${e.statusCode}, '
+        'cause=${e.cause?.runtimeType}: ${e.cause}]',
+        name: 'DivineAuthCubit',
+        category: LogCategory.auth,
+      );
+```
+
+The rest of the catch block (lines checking `current is DivineAuthFormState`, emitting state) stays unchanged.
+
+- [ ] **Step 3: Run both cubit test suites**
+
+```bash
+cd mobile && flutter test test/blocs/email_verification/email_verification_cubit_test.dart test/blocs/divine_auth/divine_auth_cubit_test.dart
+```
+Expected: All tests PASS. Log output changes don't affect assertions (existing tests don't inspect log strings).
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+cd mobile && flutter test
+```
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/blocs/email_verification/email_verification_cubit.dart mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+git commit -m "feat(invites): log original exception context on consume failure
+
+Both cubits now log error code, HTTP status, and the original
+exception type when invite activation fails. Part of #3795
+telemetry work."
+```
+
+---
+
+### Task 5: Final verification and cleanup
+
+- [ ] **Step 1: Run full package and app test suites**
+
+```bash
+cd mobile && flutter test packages/invite_api_client/test/ && flutter test
+```
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run analyzer**
+
+```bash
+cd mobile && flutter analyze
+```
+Expected: No issues introduced by these changes.
+
+- [ ] **Step 3: Verify const call sites still compile**
+
+Grep to confirm all `const InviteApiException(...)` usages still exist and haven't been broken:
+
+```bash
+grep -rn "const InviteApiException" mobile/ --include="*.dart"
+```
+Expected: Same set of call sites as before (10 occurrences). None needed modification.

--- a/docs/superpowers/plans/2026-05-06-invite-consume-telemetry.md
+++ b/docs/superpowers/plans/2026-05-06-invite-consume-telemetry.md
@@ -1,5 +1,8 @@
 # Invite Consume Telemetry Implementation Plan
 
+Status: Historical
+Validated against: implementation on branch `fix/invite-consume-retry`, 2026-05-06.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Preserve original exception context through invite activation failures so we can diagnose why consume calls fail.

--- a/docs/superpowers/specs/2026-05-06-invite-consume-retry-design.md
+++ b/docs/superpowers/specs/2026-05-06-invite-consume-retry-design.md
@@ -1,0 +1,107 @@
+# Invite Consume Retry Design
+
+PR 2 of 3 for #3795. Adds automatic retry on transient consume failures across all three invite activation paths.
+
+## Problem
+
+After Keycast registration burns the user's email, invite consumption on darshan can fail due to NIP-98 clock skew, network errors, or transient server issues. The user sees an error screen with no recourse. PR 1 added telemetry to identify failure causes. This PR retries consumption automatically before surfacing errors.
+
+## Approach
+
+Retry the `consumeInviteWithSession` / `consumeInviteWithKeyContainer` call up to 3 times on retryable errors. Each retry generates a fresh NIP-98 timestamp via `_createAuthorizationHeader` (which uses `DateTime.now()`), addressing the clock-skew case. Retries are invisible to the user.
+
+For session-based paths, persist the `KeycastSession` to FlutterSecureStorage immediately after token exchange, before consume. This ensures the session survives even if all retries fail.
+
+## Retryable vs Terminal
+
+Use `InviteErrorUtils.classify()` to decide. Two reasons are retryable:
+
+- **`temporary`**: timeout, network error, HTTP 429, 5xx, `storage_error`, `internal_error`, `client_timeout`, `client_network_error`
+- **`authFailure`**: `auth_required`, `auth_invalid`, `auth_expired`, `auth_invalid_binding`, `client_auth_failed` (clock skew lives here)
+
+Terminal (no retry): `alreadyUsed`, `invalid`, `creatorFull`, `unknown`.
+
+Including `authFailure` as retryable is the key bet. Clock skew causes stale NIP-98 timestamps, and a fresh retry fixes that. PR 3 tightens this classification based on telemetry data from PR 1.
+
+## Retry Shape
+
+All three consume paths get the same logic:
+
+- 3 attempts max, 2-second delay between retries
+- On retryable error: log warning with attempt number, delay, retry
+- On terminal error: rethrow immediately
+- On last attempt failure: rethrow (caller handles error state as before)
+- Retries are invisible to the user (no UI changes)
+
+Worst case the user waits ~6 seconds (attempt 1 + 2s + attempt 2 + 2s + attempt 3) before seeing an error. In the success case, most retries resolve on attempt 2.
+
+## Three Consume Paths
+
+| Path | Cubit | Method | Signer | Session persistence |
+|------|-------|--------|--------|---------------------|
+| Post-email-verification | `EmailVerificationCubit` | `consumeInviteWithSession` | `KeycastRpc` | Save before consume |
+| Direct sign-in | `DivineAuthCubit._exchangeCodeAndLogin` | `consumeInviteWithSession` | `KeycastRpc` | Save before consume |
+| Anonymous skip | `DivineAuthCubit.skipWithAnonymousAccount` | `consumeInviteWithKeyContainer` | `LocalNostrSigner` | Not needed (key in memory) |
+
+## Shared Retry Helper
+
+Extract retry logic to a helper in `invite_error_utils.dart` rather than duplicating the loop in three places:
+
+```dart
+static Future<InviteConsumeResult> retryConsume({
+  required Future<InviteConsumeResult> Function() consume,
+  required void Function(String message) log,
+  int maxAttempts = 3,
+  Duration delay = const Duration(seconds: 2),
+})
+```
+
+The helper:
+1. Calls `consume()`
+2. On `InviteApiException`, classifies via `InviteErrorUtils.classify()`
+3. If retryable and not last attempt: log, delay, retry
+4. If terminal or last attempt: rethrow
+
+Both cubits call this wrapper around their `consumeInviteWith*` call.
+
+## Existing 409 Retry Loop
+
+`EmailVerificationCubit._consumeInviteWithSessionIfNeeded` has a 409-only retry loop (3 attempts, 500ms delay). The broader retry **replaces** this. The 409 case is subsumed: a 409 without `user_already_joined` error code classifies as `temporary` via status code fallback in `InviteErrorUtils.classify()`.
+
+The method simplifies to a single `retryConsume()` call, removing the manual loop.
+
+`DivineAuthCubit._consumeInviteWithSessionIfNeeded` has no retry today. It gains retry via the same `retryConsume()` wrapper.
+
+## Session Preservation
+
+`KeycastSession` already has `save()`, `load()`, and `clear()` methods using FlutterSecureStorage (key: `keycast_session`). No new persistence code needed.
+
+In both session-based paths, add `await session.save()` immediately after `KeycastSession.fromTokenResponse(tokenResponse)` and before calling consume. This ensures the session is recoverable if all retries fail. The session is later used by `signInWithDivineOAuth()` regardless, so persisting it early has no downside.
+
+For the anonymous path, the `SecureKeyContainer` is already held in memory for the duration of the try block. Retries reuse it directly. No persistence needed because no Keycast registration has occurred.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `mobile/lib/utils/invite_error_utils.dart` | Add `isRetryable()` and `retryConsume()` static methods |
+| `mobile/lib/blocs/email_verification/email_verification_cubit.dart` | Replace 409 loop with `retryConsume()`, add `session.save()`, remove `_maxConsumeRetries` and `_consumeRetryDelay` constants |
+| `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart` | Wrap both consume calls with `retryConsume()`, add `session.save()` in `_exchangeCodeAndLogin` |
+
+No changes to `invite_api_client`. Retry is at the cubit layer, not the HTTP client layer.
+
+## What This Does NOT Do
+
+- No silent sign-in fallback after exhausting retries
+- No UI changes (error states and messages unchanged)
+- No error classification changes (PR 3 scope)
+- No retry button (retries are automatic and invisible)
+- No persistence for the anonymous path key container
+
+## Testing
+
+- Unit test `isRetryable()` for each `InviteActivationFailureReason`
+- Unit test `retryConsume()`: retries on retryable error, stops on terminal, respects max attempts, rethrows on final failure
+- Update `EmailVerificationCubit` tests to verify retry behavior replaces 409 loop
+- Update `DivineAuthCubit` tests to verify retry on both session and anonymous paths
+- Verify `session.save()` is called before consume in session-based paths

--- a/docs/superpowers/specs/2026-05-06-invite-consume-retry-design.md
+++ b/docs/superpowers/specs/2026-05-06-invite-consume-retry-design.md
@@ -1,5 +1,8 @@
 # Invite Consume Retry Design
 
+Status: Current
+Validated against: `invite_api_client`, `EmailVerificationCubit`, `DivineAuthCubit` on 2026-05-06.
+
 PR 2 of 3 for #3795. Adds automatic retry on transient consume failures across all three invite activation paths.
 
 ## Problem

--- a/docs/superpowers/specs/2026-05-06-invite-consume-telemetry-design.md
+++ b/docs/superpowers/specs/2026-05-06-invite-consume-telemetry-design.md
@@ -1,0 +1,99 @@
+# Invite Consume Telemetry Design
+
+**Goal:** Preserve original exception context through invite activation failures so we can diagnose why consume calls fail and make informed decisions about retry behavior.
+
+**Background:** When `consumeInviteWithSession` fails, the original exception (signer RPC failure, network error, timeout, etc.) is flattened into a generic `InviteApiException` string before the cubit sees it. This makes it impossible to distinguish transient signer failures from permanent errors, blocking informed retry logic. See [#3795](https://github.com/divinevideo/divine-mobile/issues/3795) -- Liz's comment recommends telemetry as the first PR before session preservation or classification changes.
+
+**Scope:** Observability only. No changes to error classification, retry behavior, or UI.
+
+---
+
+## Changes
+
+### 1. Add `cause` field to `InviteApiException`
+
+**File:** `mobile/packages/invite_api_client/lib/src/invite_api_exception.dart`
+
+Add an optional `Object? cause` field that carries the original exception. This follows the Dart convention used by `FormatException` and `HttpException`.
+
+Update `toString()` to include the cause's `runtimeType` when present.
+
+The constructor gains a named `cause` parameter. All existing call sites pass `null` implicitly (no breaking change).
+
+### 2. Thread `cause` through wrap sites in `invite_api_client.dart`
+
+**File:** `mobile/packages/invite_api_client/lib/src/invite_api_client.dart`
+
+The following wrap/throw sites already have the original error in scope. Pass it as `cause`:
+
+| Location | Current behavior | Change |
+|----------|-----------------|--------|
+| `_wrapClientException` (TimeoutException branch) | Discards original | Pass `error` as `cause` |
+| `_wrapClientException` (network/generic branch) | Embeds in message string | Pass `error` as `cause` |
+| `_createAuthorizationHeader` final catch block | Embeds in message string | Pass `error` as `cause` |
+| `consumeInviteWithSession` catch block | Discards original | Pass `error` as `cause` |
+| `consumeInviteWithKeyContainer` catch block | Discards original | Pass `error` as `cause` |
+
+`_requestFailed` does NOT need `cause` -- it wraps HTTP responses, not exceptions.
+
+### 3. Log original exception context before classification
+
+**Files:**
+- `mobile/lib/blocs/email_verification/email_verification_cubit.dart` -- `_exchangeCodeAndLogin` InviteApiException catch block
+- `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart` -- `_exchangeCodeAndLogin` InviteApiException catch block
+
+Enhance existing `Log.error` calls to include structured fields:
+
+```dart
+Log.error(
+  'Invite activation failed: ${e.message} '
+  '[code=${e.code}, status=${e.statusCode}, '
+  'cause=${e.cause?.runtimeType}: ${e.cause}]',
+  name: '...',
+  category: LogCategory.auth,
+);
+```
+
+This logs: the error code (for classification), the HTTP status (for server errors), and the original exception type + message (for signer/network/timeout diagnosis).
+
+### 4. Log signer stage failures in `_createAuthorizationHeader`
+
+**File:** `mobile/packages/invite_api_client/lib/src/invite_api_client.dart`
+
+The auth header construction has three distinct failure points: `getPublicKey()`, `signEvent()`, and event serialization. The existing catch block at line ~435 flattens all three into `"Failed to authenticate invite request: $error"`.
+
+Add the `_warningLogger` call before rethrowing to capture which stage failed:
+
+```dart
+_warningLogger?.call(
+  'Auth header construction failed: ${error.runtimeType}: $error',
+);
+```
+
+This uses the existing `_warningLogger` callback (already wired to `Log.warning` in production) without adding a direct logging dependency to the API client package.
+
+---
+
+## What this enables
+
+After this PR ships and runs in production for a release cycle, we'll have data to answer:
+
+- What fraction of consume failures are signer RPC errors vs network vs timeout vs auth rejection?
+- Are `unknown`-classified failures actually a specific typed exception we should handle?
+- Is retry worthwhile, and for which failure types?
+
+That data informs PR 2 (session preservation + consume retry) and PR 3 (classification tightening).
+
+---
+
+## Testing
+
+- Unit test: `InviteApiException` with `cause` field roundtrips correctly, `toString()` includes cause type
+- Unit test: `_wrapClientException` preserves cause for TimeoutException, network errors, and generic errors
+- Existing cubit tests continue to pass (cause is optional, defaults to null)
+- No new UI tests needed (no UI changes)
+
+## References
+
+- [#3795](https://github.com/divinevideo/divine-mobile/issues/3795) -- Liz's recommended PR sequence
+- [#3860](https://github.com/divinevideo/divine-mobile/pull/3860) -- Error classification improvement (already merged)

--- a/docs/superpowers/specs/2026-05-06-invite-consume-telemetry-design.md
+++ b/docs/superpowers/specs/2026-05-06-invite-consume-telemetry-design.md
@@ -1,5 +1,8 @@
 # Invite Consume Telemetry Design
 
+Status: Current
+Validated against: `invite_api_client`, `EmailVerificationCubit`, `DivineAuthCubit` on 2026-05-06.
+
 **Goal:** Preserve original exception context through invite activation failures so we can diagnose why consume calls fail and make informed decisions about retry behavior.
 
 **Background:** When `consumeInviteWithSession` fails, the original exception (signer RPC failure, network error, timeout, etc.) is flattened into a generic `InviteApiException` string before the cubit sees it. This makes it impossible to distinguish transient signer failures from permanent errors, blocking informed retry logic. See [#3795](https://github.com/divinevideo/divine-mobile/issues/3795) -- Liz's comment recommends telemetry as the first PR before session preservation or classification changes.

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -453,7 +453,9 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       emit(const DivineAuthSuccess());
     } on InviteApiException catch (e) {
       Log.error(
-        'Anonymous account invite activation failed: ${e.message}',
+        'Anonymous account invite activation failed: ${e.message} '
+        '[code=${e.code}, status=${e.statusCode}, '
+        'cause=${e.cause?.runtimeType}: ${e.cause}]',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -432,9 +432,16 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       if (inviteCode != null && inviteApiClient != null) {
         final pendingKey = await SecureKeyContainer.generate();
         try {
-          await inviteApiClient.consumeInviteWithKeyContainer(
-            code: inviteCode,
-            keyContainer: pendingKey,
+          await InviteErrorUtils.retryConsume(
+            consume: () => inviteApiClient.consumeInviteWithKeyContainer(
+              code: inviteCode,
+              keyContainer: pendingKey,
+            ),
+            log: (message) => Log.warning(
+              message,
+              name: 'DivineAuthCubit',
+              category: LogCategory.auth,
+            ),
           );
           await _authService.createAnonymousAccountFromKeyContainer(pendingKey);
         } finally {
@@ -498,10 +505,19 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       return;
     }
 
-    await inviteApiClient.consumeInviteWithSession(
-      code: inviteCode,
-      oauthConfig: _oauthClient.config,
-      session: session,
+    await session.save();
+
+    await InviteErrorUtils.retryConsume(
+      consume: () => inviteApiClient.consumeInviteWithSession(
+        code: inviteCode,
+        oauthConfig: _oauthClient.config,
+        session: session,
+      ),
+      log: (message) => Log.warning(
+        message,
+        name: 'DivineAuthCubit',
+        category: LogCategory.auth,
+      ),
     );
   }
 

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -334,7 +334,9 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       emit(const DivineAuthSuccess());
     } on InviteApiException catch (e) {
       Log.error(
-        'Invite activation failed: ${e.message}',
+        'Invite activation failed: ${e.message} '
+        '[code=${e.code}, status=${e.statusCode}, '
+        'cause=${e.cause?.runtimeType}: ${e.cause}]',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -316,7 +316,6 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
   /// Delay between exchange retries
   static const _exchangeRetryDelay = Duration(seconds: 2);
 
-
   Future<void> _exchangeCodeAndLogin(String code, String verifier) async {
     for (var attempt = 1; attempt <= _maxExchangeRetries; attempt++) {
       try {

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -386,7 +386,9 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
         return; // Success - exit the retry loop
       } on InviteApiException catch (e) {
         Log.error(
-          'Invite activation failed: ${e.message}',
+          'Invite activation failed: ${e.message} '
+          '[code=${e.code}, status=${e.statusCode}, '
+          'cause=${e.cause?.runtimeType}: ${e.cause}]',
           name: 'EmailVerificationCubit',
           category: LogCategory.auth,
         );

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -316,14 +316,6 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
   /// Delay between exchange retries
   static const _exchangeRetryDelay = Duration(seconds: 2);
 
-  /// Maximum retries for invite consumption when the server returns
-  /// HTTP 409 ("Another consumption is in progress; retry"). The conflict
-  /// happens when the server is briefly serializing concurrent attempts
-  /// for the same invite — clearing in a few hundred ms.
-  static const _maxConsumeRetries = 3;
-
-  /// Delay between invite-consumption retries on 409 conflict.
-  static const _consumeRetryDelay = Duration(milliseconds: 500);
 
   Future<void> _exchangeCodeAndLogin(String code, String verifier) async {
     for (var attempt = 1; attempt <= _maxExchangeRetries; attempt++) {
@@ -472,29 +464,20 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       return;
     }
 
-    for (var attempt = 1; attempt <= _maxConsumeRetries; attempt++) {
-      try {
-        await inviteApiClient.consumeInviteWithSession(
-          code: inviteCode,
-          oauthConfig: _oauthClient.config,
-          session: session,
-        );
-        return;
-      } on InviteApiException catch (e) {
-        final isLastAttempt = attempt == _maxConsumeRetries;
-        if (e.statusCode != 409 || isLastAttempt) {
-          rethrow;
-        }
-        Log.warning(
-          'Invite consumption conflict, retrying in '
-          '${_consumeRetryDelay.inMilliseconds}ms '
-          '(attempt $attempt/$_maxConsumeRetries): ${e.message}',
-          name: 'EmailVerificationCubit',
-          category: LogCategory.auth,
-        );
-        await Future<void>.delayed(_consumeRetryDelay);
-      }
-    }
+    await session.save();
+
+    await InviteErrorUtils.retryConsume(
+      consume: () => inviteApiClient.consumeInviteWithSession(
+        code: inviteCode,
+        oauthConfig: _oauthClient.config,
+        session: session,
+      ),
+      log: (message) => Log.warning(
+        message,
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      ),
+    );
   }
 
   @override

--- a/mobile/lib/utils/invite_error_utils.dart
+++ b/mobile/lib/utils/invite_error_utils.dart
@@ -184,4 +184,36 @@ class InviteErrorUtils {
             'or contact support.';
     }
   }
+
+  /// Whether the error is worth retrying (fresh NIP-98 timestamp may fix it).
+  static bool isRetryable(InviteApiException error) {
+    final reason = activationFailureReason(error);
+    return reason == InviteActivationFailureReason.temporary ||
+        reason == InviteActivationFailureReason.authFailure;
+  }
+
+  static Future<InviteConsumeResult> retryConsume({
+    required Future<InviteConsumeResult> Function() consume,
+    required void Function(String message) log,
+    int maxAttempts = 3,
+    Duration delay = const Duration(seconds: 2),
+  }) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await consume();
+      } on InviteApiException catch (e) {
+        final isLastAttempt = attempt == maxAttempts;
+        if (!isRetryable(e) || isLastAttempt) {
+          rethrow;
+        }
+        log(
+          'Invite consume failed (attempt $attempt/$maxAttempts), '
+          'retrying in ${delay.inMilliseconds}ms: '
+          '${e.message} [code=${e.code}]',
+        );
+        await Future<void>.delayed(delay);
+      }
+    }
+    throw StateError('Unreachable');
+  }
 }

--- a/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
@@ -202,6 +202,7 @@ class InviteApiClient {
       throw InviteApiException(
         'Failed to authenticate invite request: $error',
         code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
       );
     }
 
@@ -224,6 +225,7 @@ class InviteApiClient {
       throw InviteApiException(
         'Failed to authenticate invite request: $error',
         code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
       );
     }
     try {
@@ -438,6 +440,7 @@ class InviteApiClient {
       throw InviteApiException(
         'Failed to authenticate invite request: $error',
         code: InviteApiErrorCode.clientAuthFailed,
+        cause: error,
       );
     }
   }
@@ -452,13 +455,18 @@ class InviteApiClient {
       return InviteApiException(
         timeoutMessage,
         code: InviteApiErrorCode.clientTimeout,
+        cause: error,
       );
     }
 
     final code = _isNetworkError(error)
         ? InviteApiErrorCode.clientNetworkError
         : InviteApiErrorCode.clientError;
-    return InviteApiException('$failureMessage: $error', code: code);
+    return InviteApiException(
+      '$failureMessage: $error',
+      code: code,
+      cause: error,
+    );
   }
 
   InviteApiException _requestFailed({

--- a/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
@@ -437,6 +437,9 @@ class InviteApiClient {
     } on InviteApiException {
       rethrow;
     } catch (error) {
+      _warningLogger?.call(
+        'Auth header construction failed: ${error.runtimeType}: $error',
+      );
       throw InviteApiException(
         'Failed to authenticate invite request: $error',
         code: InviteApiErrorCode.clientAuthFailed,

--- a/mobile/packages/invite_api_client/lib/src/invite_api_exception.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_exception.dart
@@ -33,6 +33,7 @@ class InviteApiException implements Exception {
     this.code,
     this.creatorSlug,
     this.creatorDisplayName,
+    this.cause,
   });
 
   final String message;
@@ -41,9 +42,18 @@ class InviteApiException implements Exception {
   final String? code;
   final String? creatorSlug;
   final String? creatorDisplayName;
+  final Object? cause;
 
   @override
-  String toString() =>
+  String toString() {
+    final buffer = StringBuffer(
       'InviteApiException(message: $message, statusCode: $statusCode, '
-      'code: $code)';
+      'code: $code',
+    );
+    if (cause != null) {
+      buffer.write(', cause: ${cause.runtimeType}: $cause');
+    }
+    buffer.write(')');
+    return buffer.toString();
+  }
 }

--- a/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
@@ -202,6 +202,11 @@ void main() {
                   (error) => error.code,
                   'code',
                   InviteApiErrorCode.clientTimeout,
+                )
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<TimeoutException>(),
                 ),
           ),
         );
@@ -232,6 +237,11 @@ void main() {
                   (error) => error.code,
                   'code',
                   InviteApiErrorCode.clientNetworkError,
+                )
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<SocketException>(),
                 ),
           ),
         );
@@ -490,6 +500,11 @@ void main() {
                   (error) => error.code,
                   'code',
                   InviteApiErrorCode.clientTimeout,
+                )
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<TimeoutException>(),
                 ),
           ),
         );
@@ -520,6 +535,11 @@ void main() {
                   (error) => error.code,
                   'code',
                   InviteApiErrorCode.clientNetworkError,
+                )
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isA<SocketException>(),
                 ),
           ),
         );
@@ -556,6 +576,11 @@ void main() {
                   (error) => error.code,
                   'code',
                   InviteApiErrorCode.clientAuthFailed,
+                )
+                .having(
+                  (error) => error.cause,
+                  'cause',
+                  isNotNull,
                 ),
           ),
         );

--- a/mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart
@@ -52,7 +52,7 @@ void main() {
 
     test('preserves SocketException as cause', () {
       const cause = SocketException('Connection refused');
-      final exception = InviteApiException(
+      const exception = InviteApiException(
         'Network error',
         code: InviteApiErrorCode.clientNetworkError,
         cause: cause,

--- a/mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_api_exception_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:invite_api_client/invite_api_client.dart';
+
+void main() {
+  group('InviteApiException', () {
+    test('cause defaults to null', () {
+      const exception = InviteApiException('test error');
+      expect(exception.cause, isNull);
+    });
+
+    test('preserves cause when provided', () {
+      final cause = TimeoutException('timed out');
+      final exception = InviteApiException(
+        'Request failed',
+        cause: cause,
+      );
+      expect(exception.cause, same(cause));
+    });
+
+    test('toString includes cause runtimeType when present', () {
+      final exception = InviteApiException(
+        'Request failed',
+        code: InviteApiErrorCode.clientTimeout,
+        cause: TimeoutException('timed out'),
+      );
+      final str = exception.toString();
+      expect(str, contains('TimeoutException'));
+    });
+
+    test('toString omits cause when null', () {
+      const exception = InviteApiException(
+        'Request failed',
+        code: InviteApiErrorCode.clientTimeout,
+      );
+      final str = exception.toString();
+      expect(str, isNot(contains('cause')));
+    });
+
+    test('const constructor still works without cause', () {
+      const exception = InviteApiException(
+        'test',
+        statusCode: 401,
+        code: InviteApiErrorCode.authInvalid,
+      );
+      expect(exception.message, 'test');
+      expect(exception.statusCode, 401);
+      expect(exception.cause, isNull);
+    });
+
+    test('preserves SocketException as cause', () {
+      const cause = SocketException('Connection refused');
+      final exception = InviteApiException(
+        'Network error',
+        code: InviteApiErrorCode.clientNetworkError,
+        cause: cause,
+      );
+      expect(exception.cause, isA<SocketException>());
+      expect(exception.cause.toString(), contains('Connection refused'));
+    });
+  });
+}

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -467,6 +467,80 @@ void main() {
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
+          'retries invite consumption on transient error during sign in',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult(success: true, code: testCode),
+                testVerifier,
+              ),
+            );
+            when(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            ).thenAnswer(
+              (_) async => const TokenResponse(bunkerUrl: 'bunker://test'),
+            );
+            var consumeCallCount = 0;
+            when(
+              () => mockInviteApiClient.consumeInviteWithSession(
+                code: any(named: 'code'),
+                oauthConfig: any(named: 'oauthConfig'),
+                session: any(named: 'session'),
+              ),
+            ).thenAnswer((_) async {
+              consumeCallCount++;
+              if (consumeCallCount == 1) {
+                throw const InviteApiException(
+                  'timeout',
+                  code: InviteApiErrorCode.clientTimeout,
+                );
+              }
+              return const InviteConsumeResult(
+                message: 'Welcome',
+                codesAllocated: 5,
+              );
+            });
+            when(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).thenAnswer((_) async {});
+          },
+          build: () => buildCubit(inviteCode: 'ab12ef34'),
+          seed: () => const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSignIn: true,
+          ),
+          act: (cubit) => cubit.submit(),
+          expect: () => [
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              isSubmitting: true,
+            ),
+            isA<DivineAuthSuccess>(),
+          ],
+          verify: (_) {
+            verify(
+              () => mockInviteApiClient.consumeInviteWithSession(
+                code: any(named: 'code'),
+                oauthConfig: any(named: 'oauthConfig'),
+                session: any(named: 'session'),
+              ),
+            ).called(2);
+          },
+        );
+
+        blocTest<DivineAuthCubit, DivineAuthState>(
           'emits general error when login returns unsuccessful result',
           setUp: () {
             when(
@@ -1403,6 +1477,54 @@ void main() {
           verifyNever(
             () => mockAuthService.createAnonymousAccountFromKeyContainer(any()),
           );
+        },
+      );
+
+      blocTest<DivineAuthCubit, DivineAuthState>(
+        'retries anonymous invite consumption on transient error',
+        setUp: () {
+          var consumeCallCount = 0;
+          when(
+            () => mockInviteApiClient.consumeInviteWithKeyContainer(
+              code: any(named: 'code'),
+              keyContainer: any(named: 'keyContainer'),
+            ),
+          ).thenAnswer((_) async {
+            consumeCallCount++;
+            if (consumeCallCount == 1) {
+              throw const InviteApiException(
+                'network error',
+                code: InviteApiErrorCode.clientNetworkError,
+              );
+            }
+            return const InviteConsumeResult(
+              message: 'Welcome',
+              codesAllocated: 5,
+            );
+          });
+          when(
+            () => mockAuthService.createAnonymousAccountFromKeyContainer(any()),
+          ).thenAnswer((_) async {});
+        },
+        build: () => buildCubit(inviteCode: 'ab12ef34'),
+        seed: () =>
+            const DivineAuthFormState(email: testEmail, password: testPassword),
+        act: (cubit) => cubit.skipWithAnonymousAccount(),
+        expect: () => [
+          const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSkipping: true,
+          ),
+          isA<DivineAuthSuccess>(),
+        ],
+        verify: (_) {
+          verify(
+            () => mockInviteApiClient.consumeInviteWithKeyContainer(
+              code: any(named: 'code'),
+              keyContainer: any(named: 'keyContainer'),
+            ),
+          ).called(2);
         },
       );
 

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -213,14 +213,8 @@ void main() {
         });
       });
 
-      // Regression: server returns 409 "Another consumption is in progress;
-      // retry" when invite consumption races (e.g. user double-taps the
-      // verification link or the polling timer hits the same code twice).
-      // The server message literally tells the client to retry, but the
-      // cubit used to give up immediately, leaving the user stuck on the
-      // verify-email screen.
       test(
-        'retries invite consumption on 409 conflict and succeeds on retry',
+        'retries invite consumption on transient error and succeeds on retry',
         () {
           when(() => mockAuthService.isRegistered).thenReturn(false);
           when(() => mockAuthService.isAuthenticated).thenReturn(false);
@@ -253,8 +247,8 @@ void main() {
             consumeCallCount++;
             if (consumeCallCount == 1) {
               throw const InviteApiException(
-                'Another consumption is in progress; retry',
-                statusCode: 409,
+                'timeout',
+                code: InviteApiErrorCode.clientTimeout,
               );
             }
             return const InviteConsumeResult(
@@ -275,16 +269,16 @@ void main() {
               inviteCode: 'ab12ef34',
             );
 
-            // Poll fires after 3s; retry waits another ~500ms.
-            fake.elapse(const Duration(seconds: 5));
+            // Poll fires after 3s; retry waits another 2s.
+            fake.elapse(const Duration(seconds: 8));
 
             expect(cubit.state.status, EmailVerificationStatus.success);
             expect(
               consumeCallCount,
               equals(2),
               reason:
-                  'Cubit should retry once on 409 before considering '
-                  'invite consumption successful.',
+                  'Cubit should retry once on transient error before '
+                  'succeeding.',
             );
             verify(
               () => mockAuthService.signInWithDivineOAuth(any()),
@@ -296,7 +290,8 @@ void main() {
         },
       );
 
-      test('gives up after exhausting retries on persistent 409', () {
+      test('gives up after exhausting retries on persistent transient error',
+          () {
         when(() => mockAuthService.isRegistered).thenReturn(false);
         when(() => mockAuthService.isAuthenticated).thenReturn(false);
         when(() => mockOAuth.config).thenReturn(
@@ -325,8 +320,8 @@ void main() {
         ).thenAnswer((_) async {
           consumeCallCount++;
           throw const InviteApiException(
-            'Another consumption is in progress; retry',
-            statusCode: 409,
+            'timeout',
+            code: InviteApiErrorCode.clientTimeout,
           );
         });
 
@@ -345,10 +340,8 @@ void main() {
           expect(cubit.state.status, EmailVerificationStatus.failure);
           expect(
             consumeCallCount,
-            greaterThan(1),
-            reason:
-                'Cubit should retry at least once on 409 before giving '
-                'up.',
+            equals(3),
+            reason: 'Cubit should retry 3 times before giving up.',
           );
           verifyNever(() => mockAuthService.signInWithDivineOAuth(any()));
 
@@ -357,7 +350,7 @@ void main() {
         });
       });
 
-      test('does NOT retry on non-conflict InviteApiException (e.g. 400)', () {
+      test('does NOT retry on terminal InviteApiException', () {
         when(() => mockAuthService.isRegistered).thenReturn(false);
         when(() => mockAuthService.isAuthenticated).thenReturn(false);
         when(() => mockOAuth.config).thenReturn(
@@ -386,8 +379,8 @@ void main() {
         ).thenAnswer((_) async {
           consumeCallCount++;
           throw const InviteApiException(
-            'Invite is not valid',
-            statusCode: 400,
+            'Invite already used',
+            code: InviteApiErrorCode.inviteAlreadyUsed,
           );
         });
 
@@ -406,7 +399,7 @@ void main() {
           expect(
             consumeCallCount,
             equals(1),
-            reason: 'Non-409 invite errors must not be retried.',
+            reason: 'Terminal invite errors must not be retried.',
           );
 
           cubit.close();

--- a/mobile/test/utils/invite_error_utils_test.dart
+++ b/mobile/test/utils/invite_error_utils_test.dart
@@ -388,7 +388,6 @@ void main() {
             );
           },
           log: (_) {},
-          maxAttempts: 3,
           delay: Duration.zero,
         ),
         throwsA(isA<InviteApiException>()),
@@ -411,7 +410,6 @@ void main() {
           return const InviteConsumeResult(message: 'ok', codesAllocated: 5);
         },
         log: logs.add,
-        maxAttempts: 3,
         delay: Duration.zero,
       );
       expect(logs.length, 2);

--- a/mobile/test/utils/invite_error_utils_test.dart
+++ b/mobile/test/utils/invite_error_utils_test.dart
@@ -270,4 +270,173 @@ void main() {
       expect(message, contains("couldn't activate"));
     });
   });
+
+  group('isRetryable', () {
+    test('temporary is retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.clientTimeout),
+        ),
+        isTrue,
+      );
+    });
+
+    test('authFailure is retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.authInvalid, statusCode: 401),
+        ),
+        isTrue,
+      );
+    });
+
+    test('alreadyUsed is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.inviteAlreadyUsed),
+        ),
+        isFalse,
+      );
+    });
+
+    test('invalid is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.inviteNotFound),
+        ),
+        isFalse,
+      );
+    });
+
+    test('creatorFull is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(code: InviteApiErrorCode.creatorPageFull),
+        ),
+        isFalse,
+      );
+    });
+
+    test('unknown is not retryable', () {
+      expect(
+        InviteErrorUtils.isRetryable(
+          makeException(message: 'something unexpected'),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('retryConsume', () {
+    test('returns result on first success', () async {
+      final result = await InviteErrorUtils.retryConsume(
+        consume: () async =>
+            const InviteConsumeResult(message: 'ok', codesAllocated: 5),
+        log: (_) {},
+      );
+      expect(result.message, 'ok');
+    });
+
+    test('retries on retryable error and succeeds', () async {
+      var calls = 0;
+      final result = await InviteErrorUtils.retryConsume(
+        consume: () async {
+          calls++;
+          if (calls == 1) {
+            throw const InviteApiException(
+              'timeout',
+              code: InviteApiErrorCode.clientTimeout,
+            );
+          }
+          return const InviteConsumeResult(message: 'ok', codesAllocated: 5);
+        },
+        log: (_) {},
+        delay: Duration.zero,
+      );
+      expect(result.message, 'ok');
+      expect(calls, 2);
+    });
+
+    test('rethrows terminal error immediately', () async {
+      var calls = 0;
+      await expectLater(
+        () => InviteErrorUtils.retryConsume(
+          consume: () async {
+            calls++;
+            throw const InviteApiException(
+              'already used',
+              code: InviteApiErrorCode.inviteAlreadyUsed,
+            );
+          },
+          log: (_) {},
+          delay: Duration.zero,
+        ),
+        throwsA(isA<InviteApiException>()),
+      );
+      expect(calls, 1);
+    });
+
+    test('rethrows after exhausting max attempts', () async {
+      var calls = 0;
+      await expectLater(
+        () => InviteErrorUtils.retryConsume(
+          consume: () async {
+            calls++;
+            throw const InviteApiException(
+              'timeout',
+              code: InviteApiErrorCode.clientTimeout,
+            );
+          },
+          log: (_) {},
+          maxAttempts: 3,
+          delay: Duration.zero,
+        ),
+        throwsA(isA<InviteApiException>()),
+      );
+      expect(calls, 3);
+    });
+
+    test('logs warning on each retry', () async {
+      final logs = <String>[];
+      var calls = 0;
+      await InviteErrorUtils.retryConsume(
+        consume: () async {
+          calls++;
+          if (calls <= 2) {
+            throw const InviteApiException(
+              'timeout',
+              code: InviteApiErrorCode.clientTimeout,
+            );
+          }
+          return const InviteConsumeResult(message: 'ok', codesAllocated: 5);
+        },
+        log: logs.add,
+        maxAttempts: 3,
+        delay: Duration.zero,
+      );
+      expect(logs.length, 2);
+      expect(logs[0], contains('attempt 1/3'));
+      expect(logs[1], contains('attempt 2/3'));
+    });
+
+    test('respects maxAttempts parameter', () async {
+      var calls = 0;
+      await expectLater(
+        () => InviteErrorUtils.retryConsume(
+          consume: () async {
+            calls++;
+            throw const InviteApiException(
+              'network',
+              code: InviteApiErrorCode.clientNetworkError,
+            );
+          },
+          log: (_) {},
+          maxAttempts: 2,
+          delay: Duration.zero,
+        ),
+        throwsA(isA<InviteApiException>()),
+      );
+      expect(calls, 2);
+    });
+  });
 }


### PR DESCRIPTION
Closes #4069

## Summary

PR 2 of 3 for #3795 (Liz's prescribed sequence: telemetry → retry → classification tightening).

- Adds `isRetryable()` and `retryConsume()` helpers to `InviteErrorUtils` -- classifies `temporary` and `authFailure` errors as retryable, retries up to 3x with 2s delay
- Replaces the narrow 409-only retry loop in `EmailVerificationCubit` with the broader `retryConsume()` wrapper
- Wraps both `DivineAuthCubit` consume paths (session-based sign-in and anonymous skip) with `retryConsume()`
- Persists `KeycastSession` via `session.save()` before consume in both session-based paths, so the session survives exhausted retries
- Each retry generates a fresh NIP-98 timestamp (via `_createAuthorizationHeader` using `DateTime.now()`), addressing clock-skew failures

**Stacked on #4065 (PR 1: telemetry).** This prescribed sequence is designed to land incrementally -- PR 1 adds observability, PR 2 adds retry, PR 3 tightens classification based on production data. Stacking lets each PR land and ship in order. Retarget to `main` after PR 1 merges.

## Retryable vs terminal

| Classification | Examples | Retried? |
|---|---|---|
| `temporary` | timeout, network, 5xx, 429, storage_error | Yes |
| `authFailure` | clock skew, auth_invalid, client_auth_failed | Yes |
| `alreadyUsed` | invite_already_used, user_already_joined | No |
| `invalid` | not_found, revoked, expired | No |
| `creatorFull` | creator_page_full | No |
| `unknown` | unclassified errors | No |

## Files changed

| File | Change |
|---|---|
| `mobile/lib/utils/invite_error_utils.dart` | Add `isRetryable()` + `retryConsume()` |
| `mobile/lib/blocs/email_verification/email_verification_cubit.dart` | Replace 409 loop, add `session.save()` |
| `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart` | Wrap both consume paths, add `session.save()` |

## Test plan

- [x] `isRetryable()` tested for all 6 failure reasons (48 tests in invite_error_utils_test)
- [x] `retryConsume()` tested: first success, retry+succeed, terminal rethrow, exhausted rethrow, log verification, maxAttempts
- [x] EmailVerificationCubit: transient retry succeeds, exhausted retry fails, terminal error not retried
- [x] DivineAuthCubit: session-based retry on transient error, anonymous path retry on transient error
- [x] All 140 tests pass across 3 test suites
- [x] `flutter analyze` clean (only pre-existing notification_repository infos)
- [ ] Verify retry is invisible to user (no UI changes)
- [ ] Verify session recovery after app kill during retry window

## Spec

Design doc: `docs/superpowers/specs/2026-05-06-invite-consume-retry-design.md`