### PR TITLE
fix(invite): show dash hint after 4th character in code input

### DIFF
--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -804,9 +804,15 @@ class _InviteCodeTextInputFormatter extends TextInputFormatter {
     TextEditingValue newValue,
   ) {
     final normalized = InviteApiClient.normalizeCode(newValue.text);
+    // After the 4th character, show a trailing dash so the user knows
+    // not to type one themselves. Skip when deleting so backspace
+    // isn't trapped by the dash re-appearing.
+    final isDeleting = newValue.text.length < oldValue.text.length;
+    final display =
+        normalized.length == 4 && !isDeleting ? '$normalized-' : normalized;
     return TextEditingValue(
-      text: normalized,
-      selection: TextSelection.collapsed(offset: normalized.length),
+      text: display,
+      selection: TextSelection.collapsed(offset: display.length),
     );
   }
 }

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -808,8 +808,9 @@ class _InviteCodeTextInputFormatter extends TextInputFormatter {
     // not to type one themselves. Skip when deleting so backspace
     // isn't trapped by the dash re-appearing.
     final isDeleting = newValue.text.length < oldValue.text.length;
-    final display =
-        normalized.length == 4 && !isDeleting ? '$normalized-' : normalized;
+    final display = normalized.length == 4 && !isDeleting
+        ? '$normalized-'
+        : normalized;
     return TextEditingValue(
       text: display,
       selection: TextSelection.collapsed(offset: display.length),

--- a/mobile/test/screens/auth/invite_gate_screen_test.dart
+++ b/mobile/test/screens/auth/invite_gate_screen_test.dart
@@ -150,6 +150,28 @@ void main() {
       verify(() => mockInviteApiClient.validateCode('AB12-EF34')).called(1);
     });
 
+    testWidgets('typing the fourth invite character shows dash hint', (
+      tester,
+    ) async {
+      when(() => mockInviteApiClient.getClientConfig()).thenAnswer(
+        (_) async => const InviteClientConfig(
+          mode: OnboardingMode.inviteCodeRequired,
+          supportEmail: 'support@divine.video',
+        ),
+      );
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'ab12');
+      await tester.pump();
+
+      final editableText = tester.widget<EditableText>(
+        find.byType(EditableText),
+      );
+      expect(editableText.controller.text, 'AB12-');
+    });
+
     testWidgets('shows initial recovery error from query params', (
       tester,
     ) async {


### PR DESCRIPTION
Closes #4073

## Summary

- Invite code formatter now shows a trailing dash after the 4th character, hinting to the user that the dash is auto-inserted
- Previously the dash only appeared after the 5th character, causing users to try typing it themselves and get rejected
- Backspace is not trapped by the hint — deleting removes the dash cleanly

Reported by Alice (conference attendee couldn't get past the dash).

## Test plan

- [x] Type 4 characters in invite code field → dash appears immediately
- [x] Type 5th character → code reads `XXXX-Y` as before
- [x] Backspace from `XXXX-` → goes to `XXXX` (not stuck)
- [x] Type dash manually after 4 chars → no double dash, stays `XXXX-`
- [x] Paste full code → formats correctly (no extra trailing dash)
- [x] Submit code → works (trailing dash stripped by normalizeCode)

Verified on local test build.