### PR TITLE
fix(safety): default Divine-hosted-only filter to enabled

### DIFF
--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -33,7 +33,7 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
   bool _isAgeVerified = false;
   bool _isDivineLabelerEnabled = true;
   bool _isPeopleIFollowEnabled = false;
-  bool _showDivineHostedOnly = false;
+  bool _showDivineHostedOnly = true;
 
   @override
   void initState() {
@@ -102,9 +102,7 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
           constraints: const BoxConstraints(maxWidth: 600),
           child: _isLoading
               ? const Center(
-                  child: CircularProgressIndicator(
-                    color: VineTheme.vineGreen,
-                  ),
+                  child: CircularProgressIndicator(color: VineTheme.vineGreen),
                 )
               : ListView(
                   children: [

--- a/mobile/lib/services/divine_host_filter_service.dart
+++ b/mobile/lib/services/divine_host_filter_service.dart
@@ -2,9 +2,13 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Persists the user's preference for only showing Divine-hosted videos.
+///
+/// Defaults to `true` so new installs only see videos served from
+/// `*.divine.video` hosts that we can moderate. Users opt in to the
+/// wider Nostr media-host space by toggling this off in Safety settings.
 class DivineHostFilterService extends ChangeNotifier {
   DivineHostFilterService(this._prefs)
-    : _showDivineHostedOnly = _prefs.getBool(_prefsKey) ?? false;
+    : _showDivineHostedOnly = _prefs.getBool(_prefsKey) ?? true;
 
   static const String _prefsKey = 'show_divine_hosted_only';
 

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -277,22 +277,24 @@ void main() {
       expect(listViewWidth, moreOrLessEquals(600));
     });
 
-    testWidgets('shows Divine-hosted-only toggle and persists changes', (
-      tester,
-    ) async {
-      await tester.pumpWidget(createTestWidget());
-      await tester.pumpAndSettle();
+    testWidgets(
+      'shows Divine-hosted-only toggle enabled by default and persists '
+      'opt-out',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
 
-      expect(find.text('Only show Divine-hosted videos'), findsOneWidget);
-      expect(divineHostFilterService.showDivineHostedOnly, isFalse);
+        expect(find.text('Only show Divine-hosted videos'), findsOneWidget);
+        expect(divineHostFilterService.showDivineHostedOnly, isTrue);
 
-      await tester.tap(
-        find.widgetWithText(SwitchListTile, 'Only show Divine-hosted videos'),
-      );
-      await tester.pumpAndSettle();
+        await tester.tap(
+          find.widgetWithText(SwitchListTile, 'Only show Divine-hosted videos'),
+        );
+        await tester.pumpAndSettle();
 
-      expect(divineHostFilterService.showDivineHostedOnly, isTrue);
-    });
+        expect(divineHostFilterService.showDivineHostedOnly, isFalse);
+      },
+    );
 
     testWidgets(
       'enables People I follow moderation with current following list',

--- a/mobile/test/services/divine_host_filter_service_test.dart
+++ b/mobile/test/services/divine_host_filter_service_test.dart
@@ -4,29 +4,43 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('DivineHostFilterService', () {
-    test('defaults to disabled', () async {
+    test('defaults to enabled when no preference is stored', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
 
       final service = DivineHostFilterService(prefs);
-
-      expect(service.showDivineHostedOnly, isFalse);
-    });
-
-    test('persists enabled state', () async {
-      SharedPreferences.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
-
-      final service = DivineHostFilterService(prefs);
-      await service.setShowDivineHostedOnly(true);
 
       expect(service.showDivineHostedOnly, isTrue);
-
-      final reloaded = DivineHostFilterService(prefs);
-      expect(reloaded.showDivineHostedOnly, isTrue);
     });
 
-    test('notifies listeners when value changes', () async {
+    test(
+      'respects an explicitly disabled preference (opt-in to wider Nostr)',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'show_divine_hosted_only': false,
+        });
+        final prefs = await SharedPreferences.getInstance();
+
+        final service = DivineHostFilterService(prefs);
+
+        expect(service.showDivineHostedOnly, isFalse);
+      },
+    );
+
+    test('persists disabled state across reloads', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      final service = DivineHostFilterService(prefs);
+      await service.setShowDivineHostedOnly(false);
+
+      expect(service.showDivineHostedOnly, isFalse);
+
+      final reloaded = DivineHostFilterService(prefs);
+      expect(reloaded.showDivineHostedOnly, isFalse);
+    });
+
+    test('notifies listeners only when value actually changes', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
 
@@ -34,8 +48,8 @@ void main() {
       var notificationCount = 0;
       service.addListener(() => notificationCount++);
 
-      await service.setShowDivineHostedOnly(true);
-      await service.setShowDivineHostedOnly(true);
+      await service.setShowDivineHostedOnly(false);
+      await service.setShowDivineHostedOnly(false);
 
       expect(notificationCount, 1);
     });


### PR DESCRIPTION
## Summary

- Flip `DivineHostFilterService` default from off → on so new installs (and existing users who never opened the toggle) only see videos served from `*.divine.video` hosts that we can moderate.
- Existing users who explicitly toggled it off keep their stored preference and continue to see the wider Nostr media-host space.
- Toggle still lives at *Settings → Content & Safety* under "Only show Divine-hosted videos" — tapping it off is the explicit opt-in to wider Nostr.

## Why

The filter that hides non-`*.divine.video` media has shipped for a while but defaulted off, which meant new installs and pref-cleared sessions saw outside media hosts (nostr.build, blossom.primal.net, etc.) we don't moderate. Product call: only show Divine-hosted content by default; let users opt in to the wild Nostr world.

## What changed

- `mobile/lib/services/divine_host_filter_service.dart` — `?? false` → `?? true`, plus a short doc comment on the safety-default rationale.
- `mobile/lib/screens/safety_settings_screen.dart` — placeholder `_showDivineHostedOnly` flips to `true` so the pre-load UI matches the new default.
- `mobile/test/services/divine_host_filter_service_test.dart` — renamed "defaults to disabled" → "defaults to enabled", added an explicit-off regression test (proves opt-out is respected), updated persistence + listener tests to exercise the off path.
- `mobile/test/screens/safety_settings_screen_test.dart` — toggle widget test asserts default-on then taps to opt out.

## Test plan

- [x] `flutter test test/services/divine_host_filter_service_test.dart`
- [x] `flutter test test/screens/safety_settings_screen_test.dart`
- [x] `flutter test test/screens/settings/settings_taxonomy_test.dart`
- [x] `flutter analyze` on changed files
- [ ] Manual: fresh install → home feed shows only `*.divine.video` media; Safety settings toggle is on
- [ ] Manual: toggle off → feed includes nostr.build / other hosts; setting persists across restart
- [ ] Manual: existing build with toggle previously set to off → preference is preserved after upgrade (no silent flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)