### PR TITLE
fix(ui): expand gesture hit targets

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -414,6 +414,7 @@ class _EditIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: onCancel,
       child: Padding(
         padding: const EdgeInsetsDirectional.only(
@@ -461,6 +462,7 @@ class _ReplyIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: onCancel,
       child: Padding(
         padding: const EdgeInsetsDirectional.only(

--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -171,6 +171,7 @@ class _OptionTile extends StatelessWidget {
       label: semanticLabel,
       excludeSemantics: true,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(16),

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -95,6 +95,7 @@ class UserProfileTile extends ConsumerWidget {
       label: displayName,
       container: true,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: Container(
           padding: const EdgeInsets.all(16),
@@ -206,6 +207,7 @@ class _FollowButton extends StatelessWidget {
         label: 'Unfollow user$indexSuffix',
         button: true,
         child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: () => _confirmUnfollow(context),
           child: Container(
             width: 48,
@@ -236,22 +238,28 @@ class _FollowButton extends StatelessWidget {
       label: 'Follow user$indexSuffix',
       button: true,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onToggleFollow,
-        child: Container(
-          width: 40,
-          height: 40,
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            color: VineTheme.vineGreen,
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: SvgPicture.asset(
-            DivineIconName.userPlus.assetPath,
-            width: 24,
-            height: 24,
-            colorFilter: const ColorFilter.mode(
-              VineTheme.onPrimary,
-              BlendMode.srcIn,
+        child: SizedBox.square(
+          dimension: 48,
+          child: Center(
+            child: Container(
+              width: 40,
+              height: 40,
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: VineTheme.vineGreen,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: SvgPicture.asset(
+                DivineIconName.userPlus.assetPath,
+                width: 24,
+                height: 24,
+                colorFilter: const ColorFilter.mode(
+                  VineTheme.onPrimary,
+                  BlendMode.srcIn,
+                ),
+              ),
             ),
           ),
         ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -185,6 +185,7 @@ class _ActionCircle extends StatelessWidget {
       button: true,
       label: label,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: SizedBox(
           width: 68,

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -94,6 +94,7 @@ class _FindPeopleItem extends StatelessWidget {
       button: true,
       label: context.l10n.shareFindPeople,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: SizedBox(
           width: _ShareWithSection._itemWidth,
@@ -176,6 +177,7 @@ class _ContactItem extends StatelessWidget {
       button: true,
       label: user.displayName ?? context.l10n.shareContactFallback,
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: isSent ? null : onTap,
         child: SizedBox(
           width: _ShareWithSection._itemWidth,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -95,6 +95,7 @@ class _OriginalSoundSection extends ConsumerWidget {
         button: true,
         label: 'Original sound by $creatorName. Tap to use this sound.',
         child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: () => _navigateToSoundDetail(context, creatorName),
           child: Row(
             spacing: 16,
@@ -189,6 +190,7 @@ class _SoundListItem extends ConsumerWidget {
       button: true,
       label: 'Sound: $soundName by $creatorName. Tap to view details.',
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: () => _navigateToSoundDetail(context),
         child: Row(
           spacing: 16,

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -207,6 +207,45 @@ void main() {
       expect(textField.onSubmitted, isNull);
     });
 
+    testWidgets('cancels reply when tapping the gap before the close icon', (
+      tester,
+    ) async {
+      var cancelled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: CommentInput(
+              controller: controller,
+              replyToDisplayName: 'alice',
+              onCancelReply: () => cancelled = true,
+              onSubmit: () {},
+            ),
+          ),
+        ),
+      );
+
+      final label = find.text('Re: alice');
+      final closeIcon = find.byIcon(Icons.close);
+      expect(label, findsOneWidget);
+      expect(closeIcon, findsOneWidget);
+
+      final labelRect = tester.getRect(label);
+      final closeRect = tester.getRect(closeIcon);
+
+      await tester.tapAt(
+        Offset(
+          (labelRect.right + closeRect.left) / 2,
+          closeRect.center.dy,
+        ),
+      );
+      await tester.pump();
+
+      expect(cancelled, isTrue);
+    });
+
     testWidgets('shows keyboard dismissal control while focused', (
       tester,
     ) async {

--- a/mobile/test/screens/comments/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/comment_options_modal_test.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Widget tests for comment options modal tap targets.
+// ABOUTME: Verifies option rows respond across transparent icon/text gaps.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/screens/comments/widgets/comment_options_modal.dart';
+
+void main() {
+  group(CommentOptionsModal, () {
+    testWidgets('delete option responds when tapping the icon-label gap', (
+      tester,
+    ) async {
+      CommentOptionResult? result;
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return TextButton(
+                    onPressed: () async {
+                      result = await CommentOptionsModal.showForOwnComment(
+                        context,
+                        commentId:
+                            'comment0123456789abcdef0123456789abcdef01234567',
+                        commentContent: 'test comment',
+                      );
+                    },
+                    child: const Text('Open options'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(routerConfig: router),
+      );
+
+      await tester.tap(find.text('Open options'));
+      await tester.pumpAndSettle();
+
+      final deleteText = find.text('Delete');
+      final deleteIcon = find.byType(SvgPicture).last;
+      expect(deleteText, findsOneWidget);
+      expect(deleteIcon, findsOneWidget);
+
+      final textRect = tester.getRect(deleteText);
+      final iconRect = tester.getRect(deleteIcon);
+
+      await tester.tapAt(
+        Offset(
+          (iconRect.right + textRect.left) / 2,
+          textRect.center.dy,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(result, isA<CommentDeleteResult>());
+    });
+  });
+}

--- a/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
+++ b/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
@@ -8,6 +8,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -54,12 +55,44 @@ void main() {
         expect(find.byIcon(Icons.playlist_add), findsOneWidget);
       },
     );
+
+    testWidgets('tile responds when tapping the avatar-name gap', (
+      tester,
+    ) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        _buildSubject(
+          authService: authService,
+          profileListFeaturesEnabled: false,
+          onTap: () => tapped = true,
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final avatar = find.byType(UserAvatar);
+      expect(avatar, findsOneWidget);
+
+      final avatarRect = tester.getRect(avatar);
+
+      await tester.tapAt(
+        Offset(
+          avatarRect.right + 6,
+          avatarRect.center.dy,
+        ),
+      );
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
   });
 }
 
 Widget _buildSubject({
   required _TestAuthService authService,
   required bool profileListFeaturesEnabled,
+  VoidCallback? onTap,
 }) {
   return MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -71,10 +104,11 @@ Widget _buildSubject({
           FeatureFlag.profileListFeatures,
         ).overrideWithValue(profileListFeaturesEnabled),
       ],
-      child: const Scaffold(
+      child: Scaffold(
         body: UserProfileTile(
           pubkey:
               'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          onTap: onTap,
         ),
       ),
     ),

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -22,7 +22,13 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 class _MockVideoSharingService extends Mock implements VideoSharingService {}
 
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeVideoEvent());
+  });
+
   group(ShareActionButton, () {
     const ownPubkey =
         'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
@@ -222,6 +228,52 @@ void main() {
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Share via'), findsOneWidget);
         expect(find.text('Report'), findsOneWidget);
+      });
+
+      testWidgets('copy action responds when tapping the icon-label gap', (
+        tester,
+      ) async {
+        final mockAuth = createMockAuthService();
+        when(
+          () => mockVideoSharingService.generateShareUrl(any()),
+        ).thenReturn('https://divine.video/v/test');
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: Scaffold(body: ShareActionButton(video: testVideo)),
+            additionalOverrides: [
+              videoSharingServiceProvider.overrideWith(
+                (ref) => mockVideoSharingService,
+              ),
+            ],
+            mockAuthService: mockAuth,
+            mockProfileRepository: mockProfileRepository,
+          ),
+        );
+
+        await tester.tap(find.byType(GestureDetector));
+        await tester.pumpAndSettle();
+
+        final copyIcon = find.byWidgetPredicate(
+          (widget) =>
+              widget is DivineIcon && widget.icon == DivineIconName.linkSimple,
+        );
+        final copyLabel = find.text('Copy');
+        expect(copyIcon, findsOneWidget);
+        expect(copyLabel, findsOneWidget);
+
+        final iconRect = tester.getRect(copyIcon);
+        final labelRect = tester.getRect(copyLabel);
+
+        await tester.tapAt(
+          Offset(
+            iconRect.center.dx,
+            (iconRect.bottom + labelRect.top) / 2,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Link to post copied to clipboard'), findsOneWidget);
       });
 
       testWidgets('shows own-video download actions for owned content', (


### PR DESCRIPTION
Closes #4058

## Description

This splits the broader gesture hit-target work out of #4057 so the feed-mode selector fix can stay focused.

These changes make several small interactive rows and icon/text layouts respond across their transparent spacing, not just on the painted child widgets.

Changes:
- add HitTestBehavior.opaque to comment reply/edit cancel affordances
- add HitTestBehavior.opaque to the comment options row
- expand the interactive area for UserProfileTile and its follow button
- add opaque hit behavior to share-sheet action rows and share-with items
- add opaque hit behavior to sound rows in the metadata sounds section
- add regression tests for the affected tap gaps

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore