### PR TITLE
fix(clip-manager): treat post-deletion cleanup as best-effort

### DIFF
--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -414,15 +414,29 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // Guard against provider disposal during the async gap above.
     if (!ref.mounted) return true;
 
-    if (_clips.isEmpty) _clearProviders();
+    // File cleanup is best-effort: the clip is already gone from state and
+    // the autosave above persists that. A failure here (database init
+    // hiccup, missing file, etc.) must not turn this method into a
+    // rejection — callers and tests rely on the state-mutation contract,
+    // not on disk effects.
+    try {
+      if (_clips.isEmpty) _clearProviders();
 
-    // Delete files only if not referenced by drafts or clip library
-    final db = ref.read(databaseProvider);
-    await FileCleanupService.deleteRecordingClipFiles(
-      clip,
-      draftsDao: db.draftsDao,
-      clipsDao: db.clipsDao,
-    );
+      final db = ref.read(databaseProvider);
+      await FileCleanupService.deleteRecordingClipFiles(
+        clip,
+        draftsDao: db.draftsDao,
+        clipsDao: db.clipsDao,
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        '⚠️ Best-effort cleanup after deleting $clipId failed: $e',
+        name: 'ClipManagerNotifier',
+        category: .video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
 
     return true;
   }

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -99,6 +99,33 @@ void main() {
       expect(state.clips.length, equals(1));
     });
 
+    test(
+      'removeClipById resolves true even when post-mutation cleanup throws',
+      () async {
+        // The autosave / database / file-cleanup chain that runs after the
+        // state mutation is best-effort. A test environment without a real
+        // database (or a production environment with a transient disk
+        // failure) must not turn `removeClipById` into a rejected future —
+        // the clip is already gone from state and that contract is what
+        // callers rely on. This test pins that contract.
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video.mp4'),
+          duration: const Duration(seconds: 2),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        final clipId = container.read(clipManagerProvider).clips[0].id;
+
+        final result = await notifier.removeClipById(clipId);
+
+        expect(result, isTrue);
+        expect(container.read(clipManagerProvider).clips, isEmpty);
+      },
+    );
+
     test('selectClip updates selected clip state', () {
       final notifier = container.read(clipManagerProvider.notifier);
 


### PR DESCRIPTION
Closes #4086

## Summary

Fixes a latent fragility in `ClipManagerNotifier.removeClipById` that surfaced as a CI flake on an unrelated PR (#4078). The state-mutation half of the method runs synchronously and is followed by a forced autosave, then cleanup reads `databaseProvider` (real Drift/SQLite) and calls `FileCleanupService.deleteRecordingClipFiles`. Either step can throw — in a test environment that doesn't override `databaseProvider`, or in production if Drift has a transient init hiccup — and that throw rejected the whole future, turning a successful delete into an apparent failure.

After this change, the post-state-mutation cleanup is wrapped in try/catch + Log.error. The contract `removeClipById` actually offers callers — "the clip is removed from state and the change is persisted" — was already satisfied by the time we reach the cleanup section.

## Test Plan
- [x] Added a regression test (`removeClipById resolves true even when post-mutation cleanup throws`) that pins the contract on a setUp with no database override.
- [x] All 29 tests in `clip_manager_provider_test.dart` pass locally.
- [x] `flutter analyze lib test integration_test` clean.
- [x] No production behavior change for happy paths (cleanup still runs, just no longer load-bearing for the future result).

## Background

PR #4078 ("fix(feed): place square videos below fullscreen header") only touches feed widgets but its CI run failed with `ClipManagerProvider deleteClip removes clip from state`. Last 4 Mobile CI runs on `main` are all green and the diff has nothing to do with ClipManager — the test was racing on a side effect that should never have been load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)