### PR TITLE
fix(profile): align loop counts with Funnelcake for profile and id-based tabs

### DIFF
--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/profile_feed_session_cache.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/state/video_feed_state.dart';
+import 'package:openvine/utils/video_event_merge_utils.dart';
 import 'package:openvine/utils/video_nostr_enrichment.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -37,8 +38,9 @@ part 'profile_feed_provider.g.dart';
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
 /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-/// and [mergeRawTagsForVideoMerge] must stay aligned with this policy whenever
-/// merge logic changes.
+/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// Nostr enrichment) must stay aligned with this policy whenever merge logic
+/// changes.
 ///
 /// Usage:
 /// ```dart
@@ -198,36 +200,7 @@ class ProfileFeed extends _$ProfileFeed {
     // secondary-only keys — important for REST-issued analytics such as
     // `views` that Nostr events often omit. Do not invert without re-checking
     // profile engagement parity with the home feed (#3384).
-    final merged = {...secondary, ...primary};
-    // #3384: `views` feeds into [VideoEvent.totalLoops]. A newer relay copy can
-    // carry `0` or an empty value while the REST snapshot holds the API
-    // aggregate — take the higher non-negative parsed count.
-    return _mergeViewsTagPreferMax(merged, primary, secondary);
-  }
-
-  static Map<String, String> _mergeViewsTagPreferMax(
-    Map<String, String> merged,
-    Map<String, String> primary,
-    Map<String, String> secondary,
-  ) {
-    final p = _parseNonNegativeIntTag(primary['views']);
-    final s = _parseNonNegativeIntTag(secondary['views']);
-    if (p == null && s == null) return merged;
-    final m = math.max(p ?? 0, s ?? 0);
-    merged['views'] = m.toString();
-    return merged;
-  }
-
-  static int? _parseNonNegativeIntTag(String? raw) {
-    if (raw == null) return null;
-    final n = raw.replaceAll(',', '').trim();
-    if (n.isEmpty) return null;
-    final asInt = int.tryParse(n);
-    if (asInt != null) return asInt < 0 ? null : asInt;
-    final asDouble = double.tryParse(n);
-    if (asDouble == null) return null;
-    final rounded = asDouble.round();
-    return rounded < 0 ? null : rounded;
+    return mergeVideoRawTagsPrimaryWins(primary, secondary);
   }
 
   /// Combines two nullable engagement ints from relay vs REST duplicates.
@@ -236,8 +209,7 @@ class ProfileFeed extends _$ProfileFeed {
   /// Funnelcake aggregates (#3384). When both are null, returns null.
   @visibleForTesting
   static int? mergeProfileEngagementCount(int? primary, int? secondary) {
-    if (primary == null && secondary == null) return null;
-    return math.max(primary ?? 0, secondary ?? 0);
+    return mergeNullableEngagementMax(primary, secondary);
   }
 
   @visibleForTesting

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -36,8 +36,9 @@ part 'profile_feed_provider.g.dart';
 /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
-/// source. [_mergeVideo] and [mergeRawTagsForVideoMerge] must stay aligned with
-/// this policy whenever merge logic changes.
+/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// and [mergeRawTagsForVideoMerge] must stay aligned with this policy whenever
+/// merge logic changes.
 ///
 /// Usage:
 /// ```dart
@@ -197,7 +198,46 @@ class ProfileFeed extends _$ProfileFeed {
     // secondary-only keys — important for REST-issued analytics such as
     // `views` that Nostr events often omit. Do not invert without re-checking
     // profile engagement parity with the home feed (#3384).
-    return {...secondary, ...primary};
+    final merged = {...secondary, ...primary};
+    // #3384: `views` feeds into [VideoEvent.totalLoops]. A newer relay copy can
+    // carry `0` or an empty value while the REST snapshot holds the API
+    // aggregate — take the higher non-negative parsed count.
+    return _mergeViewsTagPreferMax(merged, primary, secondary);
+  }
+
+  static Map<String, String> _mergeViewsTagPreferMax(
+    Map<String, String> merged,
+    Map<String, String> primary,
+    Map<String, String> secondary,
+  ) {
+    final p = _parseNonNegativeIntTag(primary['views']);
+    final s = _parseNonNegativeIntTag(secondary['views']);
+    if (p == null && s == null) return merged;
+    final m = math.max(p ?? 0, s ?? 0);
+    merged['views'] = m.toString();
+    return merged;
+  }
+
+  static int? _parseNonNegativeIntTag(String? raw) {
+    if (raw == null) return null;
+    final n = raw.replaceAll(',', '').trim();
+    if (n.isEmpty) return null;
+    final asInt = int.tryParse(n);
+    if (asInt != null) return asInt < 0 ? null : asInt;
+    final asDouble = double.tryParse(n);
+    if (asDouble == null) return null;
+    final rounded = asDouble.round();
+    return rounded < 0 ? null : rounded;
+  }
+
+  /// Combines two nullable engagement ints from relay vs REST duplicates.
+  ///
+  /// Uses the higher non-negative value so a newer relay row cannot zero out
+  /// Funnelcake aggregates (#3384). When both are null, returns null.
+  @visibleForTesting
+  static int? mergeProfileEngagementCount(int? primary, int? secondary) {
+    if (primary == null && secondary == null) return null;
+    return math.max(primary ?? 0, secondary ?? 0);
   }
 
   @visibleForTesting
@@ -1001,11 +1041,18 @@ class ProfileFeed extends _$ProfileFeed {
 
   /// Merges two [VideoEvent]s for the same addressable video.
   ///
-  /// Chooses the newer copy as [primary] (by [createdAt], then id). Engagement
-  /// fields and [mergeRawTagsForVideoMerge] must follow the class-level
-  /// **Engagement merge policy** so profile fullscreen matches Funnelcake-backed
-  /// counts from the home feed (#3384).
+  /// Delegates to [mergeTwoProfileVideos] (see class-level engagement policy,
+  /// #3384).
   VideoEvent _mergeVideo(VideoEvent existing, VideoEvent incoming) {
+    return mergeTwoProfileVideos(existing, incoming);
+  }
+
+  /// Same logic as [_mergeVideo], exposed for tests (#3384).
+  @visibleForTesting
+  static VideoEvent mergeTwoProfileVideos(
+    VideoEvent existing,
+    VideoEvent incoming,
+  ) {
     final incomingIsNewer =
         incoming.createdAt > existing.createdAt ||
         (incoming.createdAt == existing.createdAt &&
@@ -1051,10 +1098,22 @@ class ProfileFeed extends _$ProfileFeed {
       group: primary.group ?? secondary.group,
       altText: primary.altText ?? secondary.altText,
       blurhash: primary.blurhash ?? secondary.blurhash,
-      originalLoops: primary.originalLoops ?? secondary.originalLoops,
-      originalLikes: primary.originalLikes ?? secondary.originalLikes,
-      originalComments: primary.originalComments ?? secondary.originalComments,
-      originalReposts: primary.originalReposts ?? secondary.originalReposts,
+      originalLoops: mergeProfileEngagementCount(
+        primary.originalLoops,
+        secondary.originalLoops,
+      ),
+      originalLikes: mergeProfileEngagementCount(
+        primary.originalLikes,
+        secondary.originalLikes,
+      ),
+      originalComments: mergeProfileEngagementCount(
+        primary.originalComments,
+        secondary.originalComments,
+      ),
+      originalReposts: mergeProfileEngagementCount(
+        primary.originalReposts,
+        secondary.originalReposts,
+      ),
       audioEventId: primary.audioEventId ?? secondary.audioEventId,
       audioEventRelay: primary.audioEventRelay ?? secondary.audioEventRelay,
       collaboratorPubkeys: primary.collaboratorPubkeys.isNotEmpty
@@ -1068,7 +1127,10 @@ class ProfileFeed extends _$ProfileFeed {
           : secondary.nostrEventTags,
       authorName: primary.authorName ?? secondary.authorName,
       authorAvatar: primary.authorAvatar ?? secondary.authorAvatar,
-      nostrLikeCount: primary.nostrLikeCount ?? secondary.nostrLikeCount,
+      nostrLikeCount: mergeProfileEngagementCount(
+        primary.nostrLikeCount,
+        secondary.nostrLikeCount,
+      ),
     );
   }
 

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -29,6 +29,16 @@ part 'profile_feed_provider.g.dart';
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
 ///
+/// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+/// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+/// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+/// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+/// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+/// or stale figures while the API reflects current aggregates. When only Nostr
+/// data exists (no REST row, no cache backfill), relay values remain the sole
+/// source. [_mergeVideo] and [mergeRawTagsForVideoMerge] must stay aligned with
+/// this policy whenever merge logic changes.
+///
 /// Usage:
 /// ```dart
 /// final feed = ref.watch(profileFeedProvider(userId));
@@ -182,8 +192,11 @@ class ProfileFeed extends _$ProfileFeed {
     Map<String, String> primary,
     Map<String, String> secondary,
   ) {
-    // Preserve REST-only analytics tags like `views` while still letting the
-    // primary video win on collisions for actual event metadata.
+    // Spread order: secondary first, primary wins on duplicate keys. That keeps
+    // canonical event tags on the newer (primary) copy while still exposing
+    // secondary-only keys — important for REST-issued analytics such as
+    // `views` that Nostr events often omit. Do not invert without re-checking
+    // profile engagement parity with the home feed (#3384).
     return {...secondary, ...primary};
   }
 
@@ -986,6 +999,12 @@ class ProfileFeed extends _$ProfileFeed {
     return _withoutTombstones(merged);
   }
 
+  /// Merges two [VideoEvent]s for the same addressable video.
+  ///
+  /// Chooses the newer copy as [primary] (by [createdAt], then id). Engagement
+  /// fields and [mergeRawTagsForVideoMerge] must follow the class-level
+  /// **Engagement merge policy** so profile fullscreen matches Funnelcake-backed
+  /// counts from the home feed (#3384).
   VideoEvent _mergeVideo(VideoEvent existing, VideoEvent incoming) {
     final incomingIsNewer =
         incoming.createdAt > existing.createdAt ||

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -16,6 +16,18 @@ part of 'profile_feed_provider.dart';
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
 ///
+/// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+/// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+/// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+/// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+/// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+/// or stale figures while the API reflects current aggregates. When only Nostr
+/// data exists (no REST row, no cache backfill), relay values remain the sole
+/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// Nostr enrichment) must stay aligned with this policy whenever merge logic
+/// changes.
+///
 /// Usage:
 /// ```dart
 /// final feed = ref.watch(profileFeedProvider(userId));
@@ -33,6 +45,18 @@ const profileFeedProvider = ProfileFeedFamily._();
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
 ///
+/// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+/// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+/// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+/// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+/// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+/// or stale figures while the API reflects current aggregates. When only Nostr
+/// data exists (no REST row, no cache backfill), relay values remain the sole
+/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// Nostr enrichment) must stay aligned with this policy whenever merge logic
+/// changes.
+///
 /// Usage:
 /// ```dart
 /// final feed = ref.watch(profileFeedProvider(userId));
@@ -47,6 +71,18 @@ final class ProfileFeedProvider
   ///
   /// Strategy: Try Funnelcake REST API first for better performance,
   /// fall back to Nostr subscription if unavailable.
+  ///
+  /// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+  /// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+  /// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+  /// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+  /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+  /// or stale figures while the API reflects current aggregates. When only Nostr
+  /// data exists (no REST row, no cache backfill), relay values remain the sole
+  /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+  /// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+  /// Nostr enrichment) must stay aligned with this policy whenever merge logic
+  /// changes.
   ///
   /// Usage:
   /// ```dart
@@ -89,7 +125,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'ef9ed4aacd68248181a5032042c7bd964dba5c9b';
+String _$profileFeedHash() => r'bfa1e8e2540ce5e41e1a61484f769a2cf5291322';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
@@ -98,6 +134,18 @@ String _$profileFeedHash() => r'ef9ed4aacd68248181a5032042c7bd964dba5c9b';
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
+///
+/// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+/// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+/// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+/// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+/// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+/// or stale figures while the API reflects current aggregates. When only Nostr
+/// data exists (no REST row, no cache backfill), relay values remain the sole
+/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// Nostr enrichment) must stay aligned with this policy whenever merge logic
+/// changes.
 ///
 /// Usage:
 /// ```dart
@@ -131,6 +179,18 @@ final class ProfileFeedFamily extends $Family
   /// Strategy: Try Funnelcake REST API first for better performance,
   /// fall back to Nostr subscription if unavailable.
   ///
+  /// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+  /// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+  /// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+  /// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+  /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+  /// or stale figures while the API reflects current aggregates. When only Nostr
+  /// data exists (no REST row, no cache backfill), relay values remain the sole
+  /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+  /// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+  /// Nostr enrichment) must stay aligned with this policy whenever merge logic
+  /// changes.
+  ///
   /// Usage:
   /// ```dart
   /// final feed = ref.watch(profileFeedProvider(userId));
@@ -151,6 +211,18 @@ final class ProfileFeedFamily extends $Family
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
+///
+/// **Engagement merge policy (#3384):** Lists merge relay snapshots with
+/// Funnelcake REST rows for the same `(pubkey, stableId)`. For counts that
+/// drive the same UX as the home feed ([VideoEvent.totalLoops] and related
+/// engagement fields), **prefer Funnelcake and bulk-stat hydration** over
+/// conflicting static Nostr tag values: relay copies may carry `loops` / zero
+/// or stale figures while the API reflects current aggregates. When only Nostr
+/// data exists (no REST row, no cache backfill), relay values remain the sole
+/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// Nostr enrichment) must stay aligned with this policy whenever merge logic
+/// changes.
 ///
 /// Usage:
 /// ```dart

--- a/mobile/lib/utils/video_event_merge_utils.dart
+++ b/mobile/lib/utils/video_event_merge_utils.dart
@@ -1,0 +1,39 @@
+// ABOUTME: Shared merge helpers for profile and Nostr enrichment code paths
+// ABOUTME: Keeps engagement parity with Funnelcake when relay/Nostr copies
+// ABOUTME: disagree (#3384); no imports from profile_feed to avoid cycles.
+
+import 'dart:math' as math;
+
+/// [primary] wins on duplicate keys after spreading `{...secondary, ...primary}`,
+/// except `views`: the higher parsed non-negative count wins (#3384).
+///
+/// Used by profile relay/REST merge and by Nostr enrichment (#3384).
+Map<String, String> mergeVideoRawTagsPrimaryWins(
+  Map<String, String> primary,
+  Map<String, String> secondary,
+) {
+  final merged = {...secondary, ...primary};
+  final p = _parseNonNegativeIntTag(primary['views']);
+  final s = _parseNonNegativeIntTag(secondary['views']);
+  if (p == null && s == null) return merged;
+  merged['views'] = math.max(p ?? 0, s ?? 0).toString();
+  return merged;
+}
+
+int? _parseNonNegativeIntTag(String? raw) {
+  if (raw == null) return null;
+  final n = raw.replaceAll(',', '').trim();
+  if (n.isEmpty) return null;
+  final asInt = int.tryParse(n);
+  if (asInt != null) return asInt < 0 ? null : asInt;
+  final asDouble = double.tryParse(n);
+  if (asDouble == null) return null;
+  final rounded = asDouble.round();
+  return rounded < 0 ? null : rounded;
+}
+
+/// Higher of two nullable counters; null only when both are null (#3384).
+int? mergeNullableEngagementMax(int? primary, int? secondary) {
+  if (primary == null && secondary == null) return null;
+  return math.max(primary ?? 0, secondary ?? 0);
+}

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show Filter;
+import 'package:openvine/utils/video_event_merge_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Enrich REST API videos with full Nostr event data.
@@ -11,6 +12,12 @@ import 'package:unified_logger/unified_logger.dart';
 /// Nostr event (rawTags for ProofMode/C2PA badges, dimensions, hashtags,
 /// blurhash, etc.). This function fetches the full events from Nostr relays
 /// by ID and merges any missing fields into the REST API videos.
+///
+/// Tag merge uses [mergeVideoRawTagsPrimaryWins] so Nostr wins on metadata
+/// collisions but `views` (and thus [VideoEvent.totalLoops]) takes the
+/// higher parsed count — Nostr must not zero out Funnelcake aggregates (#3384).
+/// Nullable engagement ints use [mergeNullableEngagementMax] for the same
+/// reason as profile relay/REST merge.
 Future<List<VideoEvent>> enrichVideosWithNostrTags(
   List<VideoEvent> videos, {
   required NostrClient nostrService,
@@ -64,9 +71,10 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
         // Check if Nostr event has original Vine metric tags
 
         return video.copyWith(
-          // Merge: keep REST-only keys (e.g. `views` engagement metric that
-          // Nostr events never carry), but let Nostr win on key collisions.
-          rawTags: {...video.rawTags, ...parsed.rawTags},
+          // Merge: Nostr wins on key collisions for canonical event tags;
+          // `views` uses the higher of REST vs Nostr so API aggregates survive
+          // enrichment (#3384) — see [mergeVideoRawTagsPrimaryWins].
+          rawTags: mergeVideoRawTagsPrimaryWins(parsed.rawTags, video.rawTags),
           contentWarningLabels: video.contentWarningLabels.isEmpty
               ? parsed.contentWarningLabels
               : video.contentWarningLabels,
@@ -85,14 +93,24 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
           group: video.group ?? parsed.group,
           altText: video.altText ?? parsed.altText,
           blurhash: video.blurhash ?? parsed.blurhash,
-          // Original Vine metrics: keep Funnelcake values when present
-          // (they include Nostr-era counts), fill from Nostr tags only
-          // when missing. Don't clear existing values — Funnelcake's
-          // aggregates are more accurate than the static Nostr tags.
-          originalLoops: video.originalLoops ?? parsed.originalLoops,
-          originalLikes: video.originalLikes ?? parsed.originalLikes,
-          originalComments: video.originalComments ?? parsed.originalComments,
-          originalReposts: video.originalReposts ?? parsed.originalReposts,
+          // Original metrics: take max so a Nostr zero/static tag cannot wipe
+          // Funnelcake aggregates (same rule as ProfileFeed — #3384).
+          originalLoops: mergeNullableEngagementMax(
+            parsed.originalLoops,
+            video.originalLoops,
+          ),
+          originalLikes: mergeNullableEngagementMax(
+            parsed.originalLikes,
+            video.originalLikes,
+          ),
+          originalComments: mergeNullableEngagementMax(
+            parsed.originalComments,
+            video.originalComments,
+          ),
+          originalReposts: mergeNullableEngagementMax(
+            parsed.originalReposts,
+            video.originalReposts,
+          ),
           audioEventId: video.audioEventId ?? parsed.audioEventId,
           audioEventRelay: video.audioEventRelay ?? parsed.audioEventRelay,
           collaboratorPubkeys: video.collaboratorPubkeys.isEmpty
@@ -104,6 +122,10 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
           nostrEventTags: video.nostrEventTags.isEmpty
               ? parsed.nostrEventTags
               : video.nostrEventTags,
+          nostrLikeCount: mergeNullableEngagementMax(
+            parsed.nostrLikeCount,
+            video.nostrLikeCount,
+          ),
         );
       }
       return video;

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -231,6 +231,9 @@ class VideosRepository {
           (video) =>
               video.id.isNotEmpty &&
               (video.originalLoops == null ||
+                  // Relay-sourced zeroes are frequently stale placeholders;
+                  // treat them as missing so Funnelcake can reconcile counts.
+                  video.originalLoops == 0 ||
                   video.rawTags['views'] == null ||
                   video.originalLikes == null ||
                   video.originalComments == null ||
@@ -666,9 +669,20 @@ class VideosRepository {
   ///
   /// Returns a list of [VideoEvent] in the same order as [eventIds].
   /// Videos that couldn't be found or failed to parse are omitted.
+  ///
+  /// When a Funnelcake API client is configured and available, results are
+  /// merged with that client's bulk video stats endpoint so relay-sourced rows
+  /// (e.g. profile Liked / Saved tabs) get loop and engagement totals like the
+  /// home feed — unless [hydrateBulkStats] is false.
+  ///
+  /// Use [hydrateBulkStats] `false` when the caller will run bulk-stats
+  /// hydration under its own timeout or policy ([fetchVideoWithStats] does
+  /// this so a slow Funnelcake call cannot block indefinitely on the relay
+  /// fetch+hydrate path).
   Future<List<VideoEvent>> getVideosByIds(
     List<String> eventIds, {
     bool cacheResults = false,
+    bool hydrateBulkStats = true,
   }) async {
     if (eventIds.isEmpty) return [];
 
@@ -716,7 +730,10 @@ class VideosRepository {
       if (video != null) videos.add(video);
     }
 
-    return videos;
+    if (!hydrateBulkStats) {
+      return videos;
+    }
+    return _hydrateVideosWithBulkStats(videos);
   }
 
   /// Number of filters to batch in a single relay query.
@@ -746,6 +763,11 @@ class VideosRepository {
   ///
   /// Returns a list of [VideoEvent] in the same order as [addressableIds].
   /// Videos that couldn't be found or failed to parse are omitted.
+  ///
+  /// When a Funnelcake API client is configured and available, results are
+  /// merged with that client's bulk video stats endpoint (same as
+  /// [getVideosByIds]) so repost tabs and other addressable lookups show
+  /// accurate loop counts.
   Future<List<VideoEvent>> getVideosByAddressableIds(
     List<String> addressableIds, {
     bool cacheResults = false,
@@ -827,7 +849,7 @@ class VideosRepository {
       }
     }
 
-    return videos;
+    return _hydrateVideosWithBulkStats(videos);
   }
 
   /// Fetches missing videos from Funnelcake API and adds them to [foundVideos].
@@ -1422,12 +1444,11 @@ class VideosRepository {
   /// Fetches a single video by event ID and enriches it with REST-side stats
   /// (loop counts, view counts) from the Funnelcake bulk-stats endpoint.
   ///
-  /// Strategy:
-  /// 1. Delegates to [getVideosByIds] for the cache→relay lookup and content
-  ///    filtering (same path used by all feed providers).
-  /// 2. Calls [_hydrateVideosWithBulkStats] on the result so the returned
-  ///    [VideoEvent] carries accurate [VideoEvent.originalLoops] and view
-  ///    counts — identical to what home/profile feeds receive.
+  /// Delegates to [getVideosByIds], which runs the cache→relay lookup,
+  /// content filtering, and bulk-stats enrichment when the API client is
+  /// filtering, then runs bulk-stats enrichment in a second step bounded by
+  /// [_statsFetchTimeout] (relay fetch completes first via
+  /// `getVideosByIds(..., hydrateBulkStats: false)`).
   ///
   /// Returns `null` when the event is not found or fails content filtering.
   /// The Funnelcake stats hydration is bounded by [_statsFetchTimeout]: on
@@ -1438,7 +1459,10 @@ class VideosRepository {
   /// feed context: notification taps and `divine.video/video/:id` deep-links.
   Future<VideoEvent?> fetchVideoWithStats(String eventId) async {
     if (eventId.isEmpty) return null;
-    final videos = await getVideosByIds([eventId]);
+    final videos = await getVideosByIds(
+      [eventId],
+      hydrateBulkStats: false,
+    );
     if (videos.isEmpty) return null;
     final hydrated = await _hydrateVideosWithBulkStats(videos).timeout(
       _statsFetchTimeout,
@@ -1464,10 +1488,7 @@ class VideosRepository {
       final videos = await getVideosByAddressableIds([
         candidate.addressableId!,
       ]);
-      if (videos.isNotEmpty) {
-        final hydrated = await _hydrateVideosWithBulkStats(videos);
-        if (hydrated.isNotEmpty) return hydrated.first;
-      }
+      if (videos.isNotEmpty) return videos.first;
     }
 
     if (candidate.stableId != null) {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1444,8 +1444,7 @@ class VideosRepository {
   /// Fetches a single video by event ID and enriches it with REST-side stats
   /// (loop counts, view counts) from the Funnelcake bulk-stats endpoint.
   ///
-  /// Delegates to [getVideosByIds], which runs the cache→relay lookup,
-  /// content filtering, and bulk-stats enrichment when the API client is
+  /// Delegates to [getVideosByIds] for cache→relay lookup and content
   /// filtering, then runs bulk-stats enrichment in a second step bounded by
   /// [_statsFetchTimeout] (relay fetch completes first via
   /// `getVideosByIds(..., hydrateBulkStats: false)`).

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3203,7 +3203,7 @@ void main() {
             when(
               () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
             ).thenAnswer(
-              (_) async => BulkVideoStatsResponse(
+              (_) async => const BulkVideoStatsResponse(
                 stats: {
                   eventId: BulkVideoStatsEntry(
                     eventId: eventId,
@@ -3501,12 +3501,14 @@ void main() {
         test(
           'fills loop counts from bulk stats when relay event has loops: 0',
           () async {
-            const author = '4bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+            const author =
+                '4bf0c63fcb93463407af97a5e5ee64fa'
+                '883d107ef9e558472c4eb9aaaefa459d';
             const dTag = 'reposted-vine';
             const eventId =
-                'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
-            final addressableId =
-                '${EventKind.videoVertical}:$author:$dTag';
+                'b695f6b60119d9521934a691347d9f78'
+                'e8770b56da16bb255ee77ac112b4c1f6';
+            const addressableId = '${EventKind.videoVertical}:$author:$dTag';
             final event = _createVideoEventWithDTag(
               id: eventId,
               pubkey: author,
@@ -3522,7 +3524,7 @@ void main() {
             when(
               () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
             ).thenAnswer(
-              (_) async => BulkVideoStatsResponse(
+              (_) async => const BulkVideoStatsResponse(
                 stats: {
                   eventId: BulkVideoStatsEntry(
                     eventId: eventId,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3176,6 +3176,61 @@ void main() {
         expect(result, hasLength(1));
         expect(result.first.id, equals('safe-video'));
       });
+
+      group('with Funnelcake bulk-stats hydration', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        });
+
+        test(
+          'fills loop counts from bulk stats when relay event has loops: 0',
+          () async {
+            const eventId = 'liked-tab-video-id';
+            final event = _createVideoEvent(
+              id: eventId,
+              pubkey: 'author-pubkey',
+              videoUrl: 'https://example.com/video.mp4',
+              createdAt: 1704067200,
+              loops: 0,
+            );
+
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => [event]);
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+            ).thenAnswer(
+              (_) async => BulkVideoStatsResponse(
+                stats: {
+                  eventId: BulkVideoStatsEntry(
+                    eventId: eventId,
+                    reactions: 1,
+                    comments: 2,
+                    reposts: 3,
+                    loops: 42,
+                  ),
+                },
+              ),
+            );
+
+            final repo = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo.getVideosByIds([eventId]);
+
+            expect(result, hasLength(1));
+            expect(result.single.originalLoops, equals(42));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+            ).called(1);
+          },
+        );
+      });
     });
 
     group('getVideosByAddressableIds', () {
@@ -3433,6 +3488,69 @@ void main() {
 
         expect(result, hasLength(1));
         expect(result.first.vineId, equals('safe-dtag'));
+      });
+
+      group('with Funnelcake bulk-stats hydration', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        });
+
+        test(
+          'fills loop counts from bulk stats when relay event has loops: 0',
+          () async {
+            const author = '4bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+            const dTag = 'reposted-vine';
+            const eventId =
+                'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+            final addressableId =
+                '${EventKind.videoVertical}:$author:$dTag';
+            final event = _createVideoEventWithDTag(
+              id: eventId,
+              pubkey: author,
+              dTag: dTag,
+              videoUrl: 'https://example.com/video.mp4',
+              createdAt: 1704067200,
+              loops: 0,
+            );
+
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => [event]);
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+            ).thenAnswer(
+              (_) async => BulkVideoStatsResponse(
+                stats: {
+                  eventId: BulkVideoStatsEntry(
+                    eventId: eventId,
+                    reactions: 0,
+                    comments: 0,
+                    reposts: 0,
+                    loops: 99,
+                  ),
+                },
+              ),
+            );
+
+            final repo = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo.getVideosByAddressableIds([
+              addressableId,
+            ]);
+
+            expect(result, hasLength(1));
+            expect(result.single.originalLoops, equals(99));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+            ).called(1);
+          },
+        );
       });
 
       group('Funnelcake API fallback', () {

--- a/mobile/test/providers/profile_feed_provider_test.dart
+++ b/mobile/test/providers/profile_feed_provider_test.dart
@@ -188,18 +188,75 @@ void main() {
           'pubkey1',
           'stable1',
           baseTime.subtract(const Duration(seconds: 1)),
-        ).copyWith(rawTags: {'views': '42'});
+        ).copyWith(rawTags: {'d': 'stable1', 'views': '42'});
 
-        final mergedVideo = relayVideo.copyWith(
-          rawTags: ProfileFeed.mergeRawTagsForVideoMerge(
-            relayVideo.rawTags,
-            restVideo.rawTags,
-          ),
-          originalLoops: relayVideo.originalLoops ?? restVideo.originalLoops,
+        final mergedVideo = ProfileFeed.mergeTwoProfileVideos(
+          restVideo,
+          relayVideo,
         );
 
         expect(mergedVideo.rawTags['views'], equals('42'));
         expect(mergedVideo.totalLoops, equals(42));
+      });
+
+      test(
+        'merge takes max views when newer primary overwrote REST with zero',
+        () {
+          final merged = ProfileFeed.mergeRawTagsForVideoMerge(
+            {'d': 'stable1', 'views': '0'},
+            {'views': '42', 'd': 'stable1'},
+          );
+          expect(merged['views'], equals('42'));
+        },
+      );
+
+      test(
+        'merge preserves higher originalLoops when newer relay carries zero',
+        () {
+          final newerRelay = createTestVideo(
+            'id1',
+            'pubkey1',
+            'stable1',
+            baseTime,
+          ).copyWith(originalLoops: 0);
+          final olderRest = createTestVideo(
+            'id2',
+            'pubkey1',
+            'stable1',
+            baseTime.subtract(const Duration(seconds: 1)),
+          ).copyWith(originalLoops: 500);
+
+          final merged = ProfileFeed.mergeTwoProfileVideos(
+            olderRest,
+            newerRelay,
+          );
+
+          expect(merged.originalLoops, equals(500));
+          expect(merged.totalLoops, equals(500));
+        },
+      );
+
+      group('mergeProfileEngagementCount', () {
+        test('returns null when both sources are null', () {
+          expect(ProfileFeed.mergeProfileEngagementCount(null, null), isNull);
+        });
+
+        test('returns the non-null side when the other is null', () {
+          expect(ProfileFeed.mergeProfileEngagementCount(null, 7), equals(7));
+          expect(ProfileFeed.mergeProfileEngagementCount(7, null), equals(7));
+        });
+
+        test('returns the higher count when both are non-null', () {
+          expect(ProfileFeed.mergeProfileEngagementCount(3, 10), equals(10));
+          expect(ProfileFeed.mergeProfileEngagementCount(10, 3), equals(10));
+        });
+
+        test(
+          'treats zero and null so relay zero does not wipe a positive REST',
+          () {
+            expect(ProfileFeed.mergeProfileEngagementCount(0, 42), equals(42));
+          },
+        );
       });
 
       test('cached metadata rehydrates views onto relay profile videos', () {

--- a/mobile/test/utils/video_event_merge_utils_test.dart
+++ b/mobile/test/utils/video_event_merge_utils_test.dart
@@ -14,6 +14,39 @@ void main() {
       expect(merged['k'], equals('rest-only'));
       expect(merged['views'], equals('100'));
     });
+
+    test('leaves merged map unchanged when neither side parses views', () {
+      final merged = mergeVideoRawTagsPrimaryWins(
+        {'d': 'x', 'views': ''},
+        {'d': 'x', 'views': '   '},
+      );
+      expect(merged['views'], equals(''));
+    });
+
+    test('parses comma-separated and fractional views then takes max', () {
+      expect(
+        mergeVideoRawTagsPrimaryWins(
+          {'views': '1,000'},
+          {'views': '999'},
+        )['views'],
+        equals('1000'),
+      );
+      expect(
+        mergeVideoRawTagsPrimaryWins(
+          {'views': '3'},
+          {'views': '12.7'},
+        )['views'],
+        equals('13'),
+      );
+    });
+
+    test('ignores negative parsed counts for max', () {
+      final merged = mergeVideoRawTagsPrimaryWins(
+        {'views': '-1'},
+        {'views': '40'},
+      );
+      expect(merged['views'], equals('40'));
+    });
   });
 
   group('mergeNullableEngagementMax', () {
@@ -21,6 +54,15 @@ void main() {
       expect(mergeNullableEngagementMax(null, null), isNull);
       expect(mergeNullableEngagementMax(0, 9), equals(9));
       expect(mergeNullableEngagementMax(9, 0), equals(9));
+    });
+
+    test('equal non-null values', () {
+      expect(mergeNullableEngagementMax(12, 12), equals(12));
+    });
+
+    test('non-null with null picks present value', () {
+      expect(mergeNullableEngagementMax(null, 7), equals(7));
+      expect(mergeNullableEngagementMax(7, null), equals(7));
     });
   });
 }

--- a/mobile/test/utils/video_event_merge_utils_test.dart
+++ b/mobile/test/utils/video_event_merge_utils_test.dart
@@ -1,0 +1,26 @@
+// ABOUTME: Unit tests for shared profile/enrichment tag merge (#3384).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/video_event_merge_utils.dart';
+
+void main() {
+  group('mergeVideoRawTagsPrimaryWins', () {
+    test('primary wins on ordinary keys; views uses max', () {
+      final merged = mergeVideoRawTagsPrimaryWins(
+        {'d': 'x', 'title': 'Nostr', 'views': '0'},
+        {'d': 'x', 'views': '100', 'k': 'rest-only'},
+      );
+      expect(merged['title'], equals('Nostr'));
+      expect(merged['k'], equals('rest-only'));
+      expect(merged['views'], equals('100'));
+    });
+  });
+
+  group('mergeNullableEngagementMax', () {
+    test('null handling and max with zero', () {
+      expect(mergeNullableEngagementMax(null, null), isNull);
+      expect(mergeNullableEngagementMax(0, 9), equals(9));
+      expect(mergeNullableEngagementMax(9, 0), equals(9));
+    });
+  });
+}

--- a/mobile/test/utils/video_nostr_enrichment_views_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_views_test.dart
@@ -121,6 +121,43 @@ void main() {
       },
     );
 
+    test(
+      'keeps higher originalLoops when Nostr loops tag is zero and REST has count',
+      () async {
+        const pubkey =
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+        final nostrEvent = Event(
+          pubkey,
+          34236,
+          [
+            ['d', 'video-loops-max'],
+            ['url', 'https://example.com/video-loops-max.mp4'],
+            ['title', 'T'],
+            ['m', 'video/mp4'],
+            ['loops', '0'],
+          ],
+          'c',
+          createdAt: 1704067200,
+        );
+        final restVideo = _restVideo(
+          id: nostrEvent.id,
+          originalLoops: 888,
+          extraTags: const {'views': '1'},
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [nostrEvent]);
+
+        final enriched = await enrichVideosWithNostrTags([
+          restVideo,
+        ], nostrService: mockNostrClient);
+
+        expect(enriched.single.originalLoops, equals(888));
+        expect(enriched.single.totalLoops, equals(889));
+      },
+    );
+
     test('Nostr-supplied tags override REST tags on key collision', () async {
       const pubkey =
           'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';

--- a/mobile/test/utils/video_nostr_enrichment_views_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_views_test.dart
@@ -85,6 +85,42 @@ void main() {
       },
     );
 
+    test(
+      'uses higher views when Nostr carries zero and REST has aggregate (#3384)',
+      () async {
+        const pubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        final nostrEvent = Event(
+          pubkey,
+          34236,
+          [
+            ['d', 'video-views-max'],
+            ['url', 'https://example.com/video-views-max.mp4'],
+            ['title', 'T'],
+            ['m', 'video/mp4'],
+            ['views', '0'],
+          ],
+          'c',
+          createdAt: 1704067200,
+        );
+        final restVideo = _restVideo(
+          id: nostrEvent.id,
+          extraTags: const {'views': '34'},
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [nostrEvent]);
+
+        final enriched = await enrichVideosWithNostrTags([
+          restVideo,
+        ], nostrService: mockNostrClient);
+
+        expect(enriched.single.rawTags['views'], equals('34'));
+        expect(enriched.single.totalLoops, equals(34));
+      },
+    );
+
     test('Nostr-supplied tags override REST tags on key collision', () async {
       const pubkey =
           'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Loop and engagement totals could disagree between the home feed and the profile (and other flows that merge relay snapshots with Funnelcake REST rows). Profile tabs and id-based repository lookups sometimes showed zero or stale loop counts even when the API had current aggregates.

This change:

- **Repository (`videos_repository`):** After resolving videos by event id or addressable id, results are passed through `_hydrateVideosWithBulkStats` so bulk Funnelcake stats apply to the same paths used by profile Liked / Saved and similar id-based tabs, not only explicit `fetchVideoWithStats` callers. Bulk hydration is also triggered when `originalLoops` is 0 (treated like missing) so zero placeholders get backfilled when stats exist. `fetchVideoWithStats` and addressable resolution delegate to these paths without a second hydration hop.
- **Profile feed (`profile_feed_provider`):** Documents an explicit engagement merge policy for #3384: when two copies of the same video exist (relay vs REST), nullable engagement fields (`originalLoops`, likes, comments, reposts, `nostrLikeCount`) use the maximum of the two values so a newer relay row cannot wipe Funnelcake aggregates. Raw tag merge uses shared helpers so `views` keeps the higher parsed count when copies disagree (primary wins other keys as before).
- **Nostr enrichment (`video_nostr_enrichment`):** Uses the same shared utilities (`video_event_merge_utils`) so enriching REST videos with full Nostr events does not overwrite REST `views` or numeric engagement with zeros or stale tags.
- **Tests:** Adds coverage for merge helpers, profile duplicate merge, repository bulk hydration for id-based fetches, and enrichment preserving higher `views`.

**Related Issue:** Closes #3384

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore