### PR TITLE
perf(videos): bound stats hydration latency in fetchVideoWithStats

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -32,6 +32,14 @@ const int _defaultLimit = 5;
 /// user-configured personal relays.
 const Duration _relaySearchTimeout = Duration(seconds: 15);
 
+/// Timeout for the Funnelcake bulk-stats hydration phase inside
+/// [VideosRepository.fetchVideoWithStats].
+///
+/// On timeout the method returns the video without hydrated stats rather than
+/// blocking the caller indefinitely. Three seconds is generous enough for
+/// healthy Funnelcake responses while still bounding degraded-service latency.
+const Duration _statsFetchTimeout = Duration(seconds: 3);
+
 /// {@template videos_repository}
 /// Repository for video operations with Nostr.
 ///
@@ -1421,9 +1429,10 @@ class VideosRepository {
   ///    [VideoEvent] carries accurate [VideoEvent.originalLoops] and view
   ///    counts — identical to what home/profile feeds receive.
   ///
-  /// Returns `null` when the event is not found, fails content filtering, or
-  /// the Funnelcake API is unavailable (stats are omitted but the video is
-  /// still returned in that case via the hydration fallback).
+  /// Returns `null` when the event is not found or fails content filtering.
+  /// The Funnelcake stats hydration is bounded by [_statsFetchTimeout]: on
+  /// timeout the video is returned without hydrated stats rather than blocking
+  /// the caller indefinitely.
   ///
   /// Intended for code paths that fetch a single video by ID outside of a
   /// feed context: notification taps and `divine.video/video/:id` deep-links.
@@ -1431,7 +1440,10 @@ class VideosRepository {
     if (eventId.isEmpty) return null;
     final videos = await getVideosByIds([eventId]);
     if (videos.isEmpty) return null;
-    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    final hydrated = await _hydrateVideosWithBulkStats(videos).timeout(
+      _statsFetchTimeout,
+      onTimeout: () => videos,
+    );
     return hydrated.firstOrNull;
   }
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6230,6 +6230,48 @@ void main() {
           expect(result.originalLoops, isNull);
         },
       );
+
+      test(
+        'returns video without stats when stats hydration times out',
+        () {
+          const eventId = 'timeout-event-id';
+          final nostrEvent = _createVideoEvent(
+            id: eventId,
+            pubkey: 'pubkey-1',
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+          );
+
+          return fakeAsync((async) {
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => [nostrEvent]);
+
+            // Funnelcake hangs indefinitely — never completes.
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+            ).thenAnswer((_) => Completer<BulkVideoStatsResponse>().future);
+
+            final repo = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            VideoEvent? result;
+            unawaited(
+              repo.fetchVideoWithStats(eventId).then((v) => result = v),
+            );
+
+            // Advance past the 3-second stats-fetch timeout.
+            async.elapse(const Duration(seconds: 4));
+
+            expect(result, isNotNull);
+            expect(result!.id, equals(eventId));
+            // No stats hydrated — originalLoops should remain null.
+            expect(result!.originalLoops, isNull);
+          });
+        },
+      );
     });
 
     group('fetchVideoWithStatsForRouteId', () {


### PR DESCRIPTION
## Summary

Closes #3835

- Adds a `_statsFetchTimeout` constant (3 s) at the top of `videos_repository.dart`, alongside the existing `_relaySearchTimeout`.
- Wraps the `_hydrateVideosWithBulkStats(videos)` call in `fetchVideoWithStats` with `.timeout(_statsFetchTimeout, onTimeout: () => videos)` — on timeout the unhydrated video is returned immediately instead of blocking the caller.
- Cache/relay lookup is unchanged; only the stats-hydration phase is bounded.
- Adds a `fakeAsync` test that stubs Funnelcake to never resolve, advances time past the timeout, and asserts the unhydrated video is returned.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore