### PR TITLE
refactor(nostr): generalize typed publish results across publish path

### DIFF
--- a/mobile/integration_test/helpers/test_nostr_service.dart
+++ b/mobile/integration_test/helpers/test_nostr_service.dart
@@ -94,7 +94,11 @@ class TestNostrService implements NostrClient {
       createdAt: NostrTimestamp.now(),
     );
 
-    return publishEvent(event);
+    final result = await publishEvent(event);
+    return switch (result) {
+      PublishSuccess(:final event) => event,
+      PublishNoRelays() || PublishFailed() => null,
+    };
   }
 
   Future<Event?> publishVideoEvent({
@@ -125,7 +129,11 @@ class TestNostrService implements NostrClient {
       createdAt: NostrTimestamp.now(),
     );
 
-    return publishEvent(event);
+    final result = await publishEvent(event);
+    return switch (result) {
+      PublishSuccess(:final event) => event,
+      PublishNoRelays() || PublishFailed() => null,
+    };
   }
 
   @override
@@ -217,7 +225,10 @@ class TestNostrService implements NostrClient {
   }
 
   @override
-  Future<Event?> publishEvent(Event event, {List<String>? targetRelays}) async {
+  Future<PublishResult> publishEvent(
+    Event event, {
+    List<String>? targetRelays,
+  }) async {
     if (!_isConnected) throw StateError('Not connected');
     _storedEvents.add(event);
 
@@ -229,7 +240,7 @@ class TestNostrService implements NostrClient {
       }
     }
 
-    return event;
+    return PublishSuccess(event: event);
   }
 
   @override

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -234,7 +234,7 @@ class NostrService extends _$NostrService {
         event,
         targetRelays: targetRelays,
       );
-      return published != null;
+      return published is PublishSuccess;
     };
   }
 }

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'698fd374621fc0382c805c983e004d65689810fa';
+String _$nostrServiceHash() => r'c729472faddcab1fa0e253223004e3044434b9be';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -103,7 +103,7 @@ class AccountDeletionService {
 
       final sentEvent = await _nostrService.publishEvent(event);
 
-      if (sentEvent == null) {
+      if (sentEvent is! PublishSuccess) {
         Log.error(
           'Failed to publish NIP-62 deletion request to any relay',
           name: 'AccountDeletionService',
@@ -186,7 +186,7 @@ class AccountDeletionService {
 
       if (deleteEvent != null) {
         final sentEvent = await _nostrService.publishEvent(deleteEvent);
-        if (sentEvent != null) {
+        if (sentEvent is PublishSuccess) {
           successCount += kindEvents.length;
           Log.debug(
             'Published batch deletion for ${kindEvents.length} kind $kind events',

--- a/mobile/lib/services/account_label_service.dart
+++ b/mobile/lib/services/account_label_service.dart
@@ -146,7 +146,7 @@ class AccountLabelService {
       }
 
       final sentEvent = await _nostrClient.publishEvent(event);
-      if (sentEvent != null) {
+      if (sentEvent is PublishSuccess) {
         Log.info(
           'Published account labels: '
           '${labels.map((l) => l.value).join(", ")}',

--- a/mobile/lib/services/badges/badge_repository.dart
+++ b/mobile/lib/services/badges/badge_repository.dart
@@ -282,7 +282,7 @@ class BadgeRepository {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published == null) {
+    if (published is! PublishSuccess) {
       throw StateError('Could not publish profile badges event');
     }
   }

--- a/mobile/lib/services/base/social_event_service_base.dart
+++ b/mobile/lib/services/base/social_event_service_base.dart
@@ -28,7 +28,7 @@ abstract class SocialEventServiceBase {
     // Publish to relays
     final sentEvent = await nostrService.publishEvent(event);
 
-    if (sentEvent == null) {
+    if (sentEvent is! PublishSuccess) {
       throw Exception('Failed to publish event to relays');
     }
 

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -632,7 +632,7 @@ class BookmarkService with NostrListServiceMixin {
 
       if (event != null) {
         final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
+        if (sentEvent is PublishSuccess) {
           Log.debug(
             'Published global bookmarks to Nostr: ${event.id}',
             name: 'BookmarkService',
@@ -693,7 +693,7 @@ class BookmarkService with NostrListServiceMixin {
 
       if (event != null) {
         final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
+        if (sentEvent is PublishSuccess) {
           // Update local set with Nostr event ID
           final setIndex = _bookmarkSets.indexWhere((s) => s.id == set.id);
           if (setIndex != -1) {

--- a/mobile/lib/services/collaborator_response_service.dart
+++ b/mobile/lib/services/collaborator_response_service.dart
@@ -64,13 +64,12 @@ class CollaboratorResponseService {
       }
 
       final published = await _nostrClient.publishEvent(event);
-      if (published == null) {
-        return const CollaboratorResponseResult.failure(
-          'Could not publish collaborator acceptance',
-        );
+      if (published case PublishSuccess(:final event)) {
+        return CollaboratorResponseResult.success(event.id);
       }
-
-      return CollaboratorResponseResult.success(published.id);
+      return const CollaboratorResponseResult.failure(
+        'Could not publish collaborator acceptance',
+      );
     } on Object catch (error) {
       return CollaboratorResponseResult.failure(error.toString());
     }

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -183,7 +183,7 @@ class ContentReportingService {
         reportEvent,
         targetRelays: [moderationRelayUrl],
       );
-      if (sentEvent == null) {
+      if (sentEvent is! PublishSuccess) {
         Log.error(
           'Failed to publish report to relays',
           name: 'ContentReportingService',

--- a/mobile/lib/services/corrupted_video_repair_service.dart
+++ b/mobile/lib/services/corrupted_video_repair_service.dart
@@ -118,7 +118,7 @@ class CorruptedVideoRepairService {
       }
 
       final sent = await _nostrClient.publishEvent(signedEvent);
-      if (sent != null) {
+      if (sent case PublishSuccess(:final event)) {
         repairedCount++;
         Log.info(
           'Repaired event ${event.id} '
@@ -128,7 +128,7 @@ class CorruptedVideoRepairService {
         );
 
         // Update local cache so the fix is visible immediately
-        _videoEventService?.updateVideoEvent(VideoEvent.fromNostrEvent(sent));
+        _videoEventService?.updateVideoEvent(VideoEvent.fromNostrEvent(event));
       } else {
         Log.warning(
           'Failed to publish repaired event for ${event.id}',

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -898,7 +898,7 @@ class CuratedListService extends ChangeNotifier {
 
       if (event != null) {
         final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
+        if (sentEvent is PublishSuccess) {
           // Update local list with Nostr event ID
           final listIndex = _lists.indexWhere((l) => l.id == list.id);
           if (listIndex != -1) {

--- a/mobile/lib/services/mute_service.dart
+++ b/mobile/lib/services/mute_service.dart
@@ -528,7 +528,7 @@ class MuteService {
 
       if (event != null) {
         final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
+        if (sentEvent is PublishSuccess) {
           Log.debug(
             'Published mute list to Nostr: ${event.id}',
             name: 'MuteService',

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -119,7 +119,7 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published == null) {
+    if (published is! PublishSuccess) {
       Log.error(
         'Failed to publish deregistration event',
         name: 'PushNotificationService',
@@ -181,7 +181,7 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published == null) {
+    if (published is! PublishSuccess) {
       Log.error(
         'Failed to publish preferences event',
         name: 'PushNotificationService',
@@ -275,7 +275,7 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published == null) {
+    if (published is! PublishSuccess) {
       Log.error(
         'Failed to publish registration event',
         name: 'PushNotificationService',

--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -128,7 +128,7 @@ class SocialService {
       // Publish the deletion request
       final sentEvent = await _nostrService.publishEvent(event);
 
-      if (sentEvent == null) {
+      if (sentEvent is! PublishSuccess) {
         throw Exception('Failed to publish deletion request to relays');
       }
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -316,9 +316,9 @@ class VideoEventPublisher {
       // shape sidesteps the closure-cast entirely; behaviour against a
       // real `NostrClient` is identical.
       final outerTimeout = currentOuterPublishTimeout;
-      Event? sentEvent;
+      PublishResult? publishResult;
       try {
-        sentEvent = await _nostrService
+        publishResult = await _nostrService
             .publishEvent(event)
             .timeout(outerTimeout);
       } on TimeoutException {
@@ -329,11 +329,11 @@ class VideoEventPublisher {
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        sentEvent = null;
+        publishResult = null;
       }
 
       // Check if publish was successful
-      if (sentEvent != null) {
+      if (publishResult is PublishSuccess) {
         Log.info(
           '📡 Event sent to relays, awaiting visibility confirmation: '
           '${event.id}',

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -188,7 +188,7 @@ class VideoSharingService {
 
     final sentEvent = await _nostrService.publishEvent(event);
 
-    if (sentEvent != null) {
+    if (sentEvent is PublishSuccess) {
       _shareHistory[recipientPubkey] = DateTime.now();
       await _updateRecentlySharedWith(recipientPubkey);
 

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -179,7 +179,7 @@ class ViewEventPublisher {
       // Publish to relays (fire-and-forget for ephemeral events)
       final sentEvent = await _nostrService.publishEvent(event);
 
-      if (sentEvent != null) {
+      if (sentEvent is PublishSuccess) {
         Log.info(
           'View event published: video=${video.id}, watched=${endSeconds - startSeconds}s',
           name: 'ViewEventPublisher',
@@ -283,7 +283,7 @@ class ViewEventPublisher {
 
       final sentEvent = await _nostrService.publishEvent(event);
 
-      if (sentEvent != null) {
+      if (sentEvent is PublishSuccess) {
         final totalWatched = validSegments.fold<int>(
           0,
           (sum, s) => sum + (s.$2 - s.$1),

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -1570,10 +1571,11 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
 
       // Publish the updated event
       final nostrService = ref.read(nostrServiceProvider);
-      final publishedEvent = await nostrService.publishEvent(event);
-      if (publishedEvent == null) {
+      final publishResult = await nostrService.publishEvent(event);
+      if (publishResult is! PublishSuccess) {
         throw Exception('Failed to publish updated event');
       }
+      final publishedEvent = publishResult.event;
 
       // Update local cache for immediate UI update
       final personalEventCache = ref.read(personalEventCacheServiceProvider);

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -266,11 +266,12 @@ class CommentsRepository {
 
     try {
       // Broadcast the event (NostrClient handles signing)
-      final sentEvent = await _nostrClient.publishEvent(event);
+      final result = await _nostrClient.publishEvent(event);
 
-      if (sentEvent == null) {
+      if (result is! PublishSuccess) {
         throw const PostCommentFailedException('Failed to publish comment');
       }
+      final sentEvent = result.event;
 
       final cached = _commentCountCache[rootEventId];
       if (cached != null) _commentCountCache[rootEventId] = cached + 1;
@@ -406,7 +407,7 @@ class CommentsRepository {
       );
 
       final sentEvent = await _nostrClient.publishEvent(event);
-      if (sentEvent == null) {
+      if (sentEvent is! PublishSuccess) {
         throw const DeleteCommentFailedException(
           'Failed to publish deletion request',
         );

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -722,7 +722,7 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.postComment(
@@ -790,7 +790,7 @@ void main() {
             'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.postComment(
@@ -859,7 +859,7 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.postComment(
@@ -911,7 +911,7 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.postComment(
@@ -951,7 +951,7 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.postComment(
@@ -977,8 +977,9 @@ void main() {
 
       test('returns created Comment', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return inv.positionalArguments.first as Event
+          final event = inv.positionalArguments.first as Event
             ..id = 'created_event_id';
+          return PublishSuccess(event: event);
         });
 
         final result = await repository.postComment(
@@ -1025,7 +1026,7 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.postComment(
@@ -1041,7 +1042,7 @@ void main() {
       test('throws PostCommentFailedException when publish fails', () async {
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         expect(
           () => repository.postComment(
@@ -1191,7 +1192,7 @@ void main() {
           (_) async => const CountResult(count: 5),
         );
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => inv.positionalArguments.first as Event,
+          (inv) async => PublishSuccess(event: inv.positionalArguments.first as Event),
         );
 
         await repository.getCommentsCount(testRootEventId);
@@ -1232,7 +1233,7 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.deleteComment(commentId: testCommentId);
@@ -1260,7 +1261,7 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.deleteComment(
@@ -1280,7 +1281,7 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.deleteComment(commentId: testCommentId);
@@ -1295,7 +1296,7 @@ void main() {
         () async {
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           expect(
             () => repository.deleteComment(commentId: testCommentId),
@@ -1337,7 +1338,7 @@ void main() {
           (_) async => const CountResult(count: 10),
         );
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => inv.positionalArguments.first as Event,
+          (inv) async => PublishSuccess(event: inv.positionalArguments.first as Event),
         );
 
         await repository.getCommentsCount(testRootEventId);
@@ -1356,7 +1357,7 @@ void main() {
           (_) async => const CountResult(count: 10),
         );
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => inv.positionalArguments.first as Event,
+          (inv) async => PublishSuccess(event: inv.positionalArguments.first as Event),
         );
 
         await repository.getCommentsCount(testRootEventId);

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1302,7 +1302,8 @@ void main() {
       );
 
       test(
-        'throws DeleteCommentFailedException when publish returns null',
+        'throws DeleteCommentFailedException when publish does not return '
+        'PublishSuccess',
         () async {
           when(
             () => mockNostrClient.publishEvent(any()),

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -722,7 +722,8 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.postComment(
@@ -790,7 +791,8 @@ void main() {
             'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.postComment(
@@ -859,7 +861,8 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.postComment(
@@ -911,7 +914,8 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.postComment(
@@ -951,7 +955,8 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.postComment(
@@ -1026,7 +1031,8 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.postComment(
@@ -1192,7 +1198,8 @@ void main() {
           (_) async => const CountResult(count: 5),
         );
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => PublishSuccess(event: inv.positionalArguments.first as Event),
+          (inv) async =>
+              PublishSuccess(event: inv.positionalArguments.first as Event),
         );
 
         await repository.getCommentsCount(testRootEventId);
@@ -1233,7 +1240,8 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.deleteComment(commentId: testCommentId);
@@ -1261,7 +1269,8 @@ void main() {
         Event? capturedEvent;
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishSuccess(event: capturedEvent!);
         });
 
         await repository.deleteComment(
@@ -1281,7 +1290,8 @@ void main() {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,
           ) async {
-            capturedEvent = inv.positionalArguments.first as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishSuccess(event: capturedEvent!);
           });
 
           await repository.deleteComment(commentId: testCommentId);
@@ -1338,7 +1348,8 @@ void main() {
           (_) async => const CountResult(count: 10),
         );
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => PublishSuccess(event: inv.positionalArguments.first as Event),
+          (inv) async =>
+              PublishSuccess(event: inv.positionalArguments.first as Event),
         );
 
         await repository.getCommentsCount(testRootEventId);
@@ -1357,7 +1368,8 @@ void main() {
           (_) async => const CountResult(count: 10),
         );
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => PublishSuccess(event: inv.positionalArguments.first as Event),
+          (inv) async =>
+              PublishSuccess(event: inv.positionalArguments.first as Event),
         );
 
         await repository.getCommentsCount(testRootEventId);

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -311,7 +311,7 @@ class ContentBlocklistRepository {
       if (event != null) {
         final sentEvent = await nostrClient.publishEvent(event);
 
-        if (sentEvent != null) {
+        if (sentEvent is PublishSuccess) {
           Log.info(
             'Published block list to Nostr with '
             '${_runtimeBlocklist.length} entries',

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1283,7 +1283,9 @@ void main() {
           tags: any(named: 'tags'),
         ),
       ).thenAnswer((_) async => event);
-      when(() => mockClient.publishEvent(any())).thenAnswer((_) async => PublishSuccess(event: event));
+      when(
+        () => mockClient.publishEvent(any()),
+      ).thenAnswer((_) async => PublishSuccess(event: event));
 
       final service = ContentBlocklistRepository();
       await service.syncBlockListsInBackground(
@@ -1318,7 +1320,9 @@ void main() {
           tags: any(named: 'tags'),
         ),
       ).thenAnswer((_) async => buildEvent());
-      when(() => mockClient.publishEvent(any())).thenAnswer((_) async => const PublishFailed());
+      when(
+        () => mockClient.publishEvent(any()),
+      ).thenAnswer((_) async => const PublishFailed());
 
       final service = ContentBlocklistRepository();
       await service.syncBlockListsInBackground(

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1283,7 +1283,7 @@ void main() {
           tags: any(named: 'tags'),
         ),
       ).thenAnswer((_) async => event);
-      when(() => mockClient.publishEvent(any())).thenAnswer((_) async => event);
+      when(() => mockClient.publishEvent(any())).thenAnswer((_) async => PublishSuccess(event: event));
 
       final service = ContentBlocklistRepository();
       await service.syncBlockListsInBackground(
@@ -1318,7 +1318,7 @@ void main() {
           tags: any(named: 'tags'),
         ),
       ).thenAnswer((_) async => buildEvent());
-      when(() => mockClient.publishEvent(any())).thenAnswer((_) async => null);
+      when(() => mockClient.publishEvent(any())).thenAnswer((_) async => const PublishFailed());
 
       final service = ContentBlocklistRepository();
       await service.syncBlockListsInBackground(

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -1145,10 +1145,10 @@ class CurationRepository {
       final publishFuture = _nostrService.publishEvent(event);
       const timeoutDuration = Duration(seconds: 5);
 
-      Event? sentEvent;
+      PublishResult? publishResult;
 
       try {
-        sentEvent = await publishFuture.timeout(timeoutDuration);
+        publishResult = await publishFuture.timeout(timeoutDuration);
       } on TimeoutException {
         Log.warning(
           'Curation publish timed out after 5s: $id',
@@ -1175,6 +1175,8 @@ class CurationRepository {
         );
       }
 
+      final sentEvent =
+          publishResult is PublishSuccess ? publishResult.event : null;
       final isSuccess = sentEvent != null;
 
       if (isSuccess) {

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -295,9 +295,7 @@ class CurationRepository {
     // Return videos from the dedicated cache
     final picks = List<VideoEvent>.from(_editorPicksVideoCache)
       // Sort by creation time (newest first)
-      ..sort(
-        (a, b) => b.createdAt.compareTo(a.createdAt),
-      );
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     // Only log on changes to avoid spam
     final currentCount = picks.length;
@@ -489,9 +487,7 @@ class CurationRepository {
     }
   }
 
-  Future<void> _processTrendingVines(
-    List<dynamic> vinesData,
-  ) async {
+  Future<void> _processTrendingVines(List<dynamic> vinesData) async {
     final trending = <VideoEvent>[];
     final allVideos = _videoEventCache.discoveryVideos;
     final missingEventIds = <String>[];
@@ -563,10 +559,7 @@ class CurationRepository {
 
     // Fetch missing videos from Nostr relays
     if (missingEventIds.isNotEmpty) {
-      await _fetchMissingTrendingVideos(
-        missingEventIds,
-        trending,
-      );
+      await _fetchMissingTrendingVideos(missingEventIds, trending);
     }
 
     if (trending.isNotEmpty) {
@@ -692,9 +685,7 @@ class CurationRepository {
       // Track videos that we failed to fetch
       final fetchedIds = fetchedVideos.map((v) => v.id.toLowerCase()).toSet();
       final actuallyMissingIds = missingEventIds
-          .where(
-            (id) => !fetchedIds.contains(id.toLowerCase()),
-          )
+          .where((id) => !fetchedIds.contains(id.toLowerCase()))
           .toSet();
 
       if (actuallyMissingIds.isNotEmpty) {
@@ -771,22 +762,18 @@ class CurationRepository {
   List<VideoEvent> getVideosForSet(String setId) => _setVideoCache[setId] ?? [];
 
   /// Get videos for a curation set type
-  List<VideoEvent> getVideosForSetType(
-    CurationSetType setType,
-  ) => getVideosForSet(setType.id);
+  List<VideoEvent> getVideosForSetType(CurationSetType setType) =>
+      getVideosForSet(setType.id);
 
   /// Get a specific curation set
   CurationSet? getCurationSet(String setId) => _curationSets[setId];
 
   /// Get curation set by type
-  CurationSet? getCurationSetByType(
-    CurationSetType setType,
-  ) => getCurationSet(setType.id);
+  CurationSet? getCurationSetByType(CurationSetType setType) =>
+      getCurationSet(setType.id);
 
   /// Refresh curation sets from Nostr
-  Future<void> refreshCurationSets({
-    List<String>? curatorPubkeys,
-  }) async {
+  Future<void> refreshCurationSets({List<String>? curatorPubkeys}) async {
     _isLoading = true;
     _error = null;
 
@@ -910,9 +897,7 @@ class CurationRepository {
   }
 
   /// Subscribe to curation set updates
-  Future<void> subscribeToCurationSets({
-    List<String>? curatorPubkeys,
-  }) async {
+  Future<void> subscribeToCurationSets({List<String>? curatorPubkeys}) async {
     try {
       Log.debug(
         'Subscribing to kind 30005 curation sets...',
@@ -923,11 +908,7 @@ class CurationRepository {
       // Subscribe to receive curation set events
       _nostrService
           .subscribe([
-            Filter(
-              kinds: [30005],
-              authors: curatorPubkeys,
-              limit: 500,
-            ),
+            Filter(kinds: [30005], authors: curatorPubkeys, limit: 500),
           ])
           .listen(
             (event) {
@@ -1135,9 +1116,7 @@ class CurationRepository {
           success: false,
           successCount: 0,
           totalRelays: 0,
-          errors: {
-            'signing': 'Failed to create and sign event',
-          },
+          errors: {'signing': 'Failed to create and sign event'},
         );
       }
 
@@ -1145,7 +1124,7 @@ class CurationRepository {
       final publishFuture = _nostrService.publishEvent(event);
       const timeoutDuration = Duration(seconds: 5);
 
-      PublishResult? publishResult;
+      late final PublishResult publishResult;
 
       try {
         publishResult = await publishFuture.timeout(timeoutDuration);
@@ -1169,61 +1148,61 @@ class CurationRepository {
           success: false,
           successCount: 0,
           totalRelays: 0,
-          errors: {
-            'timeout': 'Publish timed out after 5 seconds',
-          },
+          errors: {'timeout': 'Publish timed out after 5 seconds'},
         );
       }
 
-      final sentEvent = publishResult is PublishSuccess
-          ? publishResult.event
-          : null;
-      final isSuccess = sentEvent != null;
+      return switch (publishResult) {
+        PublishSuccess(:final event) => () {
+          _publishStatuses[id] = CurationPublishStatus(
+            curationId: id,
+            isPublishing: false,
+            isPublished: true,
+            lastPublishedAt: DateTime.now(),
+            publishedEventId: event.id,
+            successfulRelays: _nostrService.connectedRelays,
+            lastAttemptAt: DateTime.now(),
+          );
 
-      if (isSuccess) {
-        // Mark as successfully published
-        _publishStatuses[id] = CurationPublishStatus(
-          curationId: id,
-          isPublishing: false,
-          isPublished: true,
-          lastPublishedAt: DateTime.now(),
-          publishedEventId: sentEvent.id,
-          successfulRelays: _nostrService.connectedRelays,
-          lastAttemptAt: DateTime.now(),
-        );
+          Log.info(
+            '✅ Published curation "$title" to relays',
+            name: 'CurationRepository',
+            category: LogCategory.system,
+          );
 
-        Log.info(
-          '✅ Published curation "$title" to relays',
-          name: 'CurationRepository',
-          category: LogCategory.system,
-        );
-      } else {
-        // Mark as failed
-        _publishStatuses[id] = CurationPublishStatus(
-          curationId: id,
-          isPublishing: false,
-          isPublished: false,
-          failedAttempts: (_publishStatuses[id]?.failedAttempts ?? 0) + 1,
-          lastAttemptAt: DateTime.now(),
-          lastFailureReason: 'Failed to publish to relays',
-        );
+          return CurationPublishResult(
+            success: true,
+            successCount: 1,
+            totalRelays: 1,
+            eventId: event.id,
+          );
+        }(),
+        PublishNoRelays() || PublishFailed() => () {
+          _publishStatuses[id] = CurationPublishStatus(
+            curationId: id,
+            isPublishing: false,
+            isPublished: false,
+            failedAttempts: (_publishStatuses[id]?.failedAttempts ?? 0) + 1,
+            lastAttemptAt: DateTime.now(),
+            lastFailureReason: 'Failed to publish to relays',
+          );
 
-        Log.warning(
-          '❌ Failed to publish curation "$title" '
-          'to relays',
-          name: 'CurationRepository',
-          category: LogCategory.system,
-        );
-      }
+          Log.warning(
+            '❌ Failed to publish curation "$title" '
+            'to relays',
+            name: 'CurationRepository',
+            category: LogCategory.system,
+          );
 
-      return CurationPublishResult(
-        success: isSuccess,
-        successCount: isSuccess ? 1 : 0,
-        totalRelays: 1,
-        eventId: isSuccess ? sentEvent.id : null,
-        errors: isSuccess ? {} : {'publish': 'Failed to publish to relays'},
-        failedRelays: isSuccess ? [] : ['relays'],
-      );
+          return const CurationPublishResult(
+            success: false,
+            successCount: 0,
+            totalRelays: 1,
+            errors: {'publish': 'Failed to publish to relays'},
+            failedRelays: ['relays'],
+          );
+        }(),
+      };
     } on Exception catch (e) {
       Log.error(
         'Error publishing curation: $e',
@@ -1252,9 +1231,7 @@ class CurationRepository {
   }
 
   /// Get publish status for a curation
-  CurationPublishStatus getCurationPublishStatus(
-    String curationId,
-  ) {
+  CurationPublishStatus getCurationPublishStatus(String curationId) {
     return _publishStatuses[curationId] ??
         CurationPublishStatus(
           curationId: curationId,

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -1175,8 +1175,9 @@ class CurationRepository {
         );
       }
 
-      final sentEvent =
-          publishResult is PublishSuccess ? publishResult.event : null;
+      final sentEvent = publishResult is PublishSuccess
+          ? publishResult.event
+          : null;
       final isSuccess = sentEvent != null;
 
       if (isSuccess) {

--- a/mobile/packages/curation_repository/test/src/curation_publish_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_publish_test.dart
@@ -153,12 +153,14 @@ void main() {
           when(
             () => mockNostrService.publishEvent(any()),
           ).thenAnswer(
-            (_) async => PublishSuccess(event: _testEvent(
-              tags: [
-                ['d', 'test_id'],
-              ],
-              content: 'Test content',
-            )),
+            (_) async => PublishSuccess(
+              event: _testEvent(
+                tags: [
+                  ['d', 'test_id'],
+                ],
+                content: 'Test content',
+              ),
+            ),
           );
 
           final result = await curationRepository.publishCuration(

--- a/mobile/packages/curation_repository/test/src/curation_publish_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_publish_test.dart
@@ -153,12 +153,12 @@ void main() {
           when(
             () => mockNostrService.publishEvent(any()),
           ).thenAnswer(
-            (_) async => _testEvent(
+            (_) async => PublishSuccess(event: _testEvent(
               tags: [
                 ['d', 'test_id'],
               ],
               content: 'Test content',
-            ),
+            )),
           );
 
           final result = await curationRepository.publishCuration(
@@ -184,7 +184,7 @@ void main() {
         () async {
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           final result = await curationRepository.publishCuration(
             id: 'test_curation',
@@ -210,7 +210,7 @@ void main() {
             await Future<void>.delayed(
               const Duration(seconds: 10),
             );
-            return _testEvent();
+            return PublishSuccess(event: _testEvent());
           });
 
           CurationPublishResult? result;
@@ -238,7 +238,7 @@ void main() {
         'should prevent duplicate concurrent publishes',
         () {
           fakeAsync((async) {
-            final completer = Completer<Event?>();
+            final completer = Completer<PublishResult>();
             when(
               () => mockNostrService.publishEvent(any()),
             ).thenAnswer((_) => completer.future);
@@ -279,7 +279,7 @@ void main() {
             );
 
             // Complete the first publish
-            completer.complete(_testEvent());
+            completer.complete(PublishSuccess(event: _testEvent()));
             async.flushMicrotasks();
             expect(firstResult!.success, isTrue);
           });
@@ -294,7 +294,7 @@ void main() {
         () async {
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => _testEvent());
+          ).thenAnswer((_) async => PublishSuccess(event: _testEvent()));
 
           await curationRepository.publishCuration(
             id: 'test_curation',
@@ -319,7 +319,7 @@ void main() {
         () async {
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           await curationRepository.publishCuration(
             id: 'failed_curation',
@@ -391,7 +391,7 @@ void main() {
         () async {
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => _testEvent());
+          ).thenAnswer((_) async => PublishSuccess(event: _testEvent()));
 
           final futures = <Future<dynamic>>[];
           for (var i = 0; i < 5; i++) {
@@ -418,7 +418,7 @@ void main() {
         'publish',
         () {
           fakeAsync((async) {
-            final completer = Completer<Event?>();
+            final completer = Completer<PublishResult>();
             when(
               () => mockNostrService.publishEvent(any()),
             ).thenAnswer((_) => completer.future);
@@ -444,7 +444,7 @@ void main() {
             );
 
             // Complete the publish
-            completer.complete(_testEvent());
+            completer.complete(PublishSuccess(event: _testEvent()));
             async.flushMicrotasks();
 
             final finalStatus = curationRepository.getCurationPublishStatus(
@@ -465,7 +465,7 @@ void main() {
         () async {
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           await curationRepository.publishCuration(
             id: 'error_curation',

--- a/mobile/packages/curation_repository/test/src/curation_repository_create_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_repository_create_test.dart
@@ -84,7 +84,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
         when(
           () => mockNostrService.connectedRelays,
         ).thenReturn(['wss://relay']);
@@ -119,7 +119,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         await curationRepository.createCurationSet(
@@ -150,7 +150,7 @@ void main() {
       ).thenAnswer((_) async => signedEvent);
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => signedEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
       when(() => mockNostrService.connectedRelays).thenReturn([]);
 
       await curationRepository.createCurationSet(
@@ -210,7 +210,7 @@ void main() {
       ).thenAnswer((_) async => signedEvent);
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async => const PublishFailed());
 
       final result = await curationRepository.createCurationSet(
         id: 'test_list',
@@ -284,7 +284,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         final result = await curationRepository.createCurationSet(
@@ -321,7 +321,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         final result = await curationRepository.createCurationSet(
@@ -360,7 +360,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
         when(
           () => mockNostrService.connectedRelays,
         ).thenReturn(['wss://relay']);
@@ -398,7 +398,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         await curationRepository.createCurationSet(
           id: 'fail_status',
@@ -430,7 +430,7 @@ void main() {
         ).thenAnswer((_) async => signedEvent);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         // With description

--- a/mobile/packages/curation_repository/test/src/curation_repository_edge_cases_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_repository_edge_cases_test.dart
@@ -311,7 +311,7 @@ void main() {
             // status
             when(
               () => mockNostrService.publishEvent(any()),
-            ).thenAnswer((_) async => null);
+            ).thenAnswer((_) async => const PublishFailed());
 
             await curationRepository.publishCuration(
               id: CurationSetType.editorsPicks.id,
@@ -334,7 +334,7 @@ void main() {
 
             when(
               () => mockNostrService.publishEvent(any()),
-            ).thenAnswer((_) async => signedEvent);
+            ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
 
             // The lastAttemptAt is set to DateTime.now()
             // during the failed publish, and getRetryDelay

--- a/mobile/packages/curation_repository/test/src/curation_repository_retry_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_repository_retry_test.dart
@@ -108,7 +108,7 @@ void main() {
           // Publish a curation successfully first
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => _testEvent());
+          ).thenAnswer((_) async => PublishSuccess(event: _testEvent()));
 
           await curationRepository.publishCuration(
             id: 'published_one',
@@ -140,7 +140,7 @@ void main() {
           // Fail a publish to create a failed status
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           await curationRepository.publishCuration(
             id: 'failed_one',
@@ -171,7 +171,7 @@ void main() {
         () async {
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           await curationRepository.publishCuration(
             id: 'failed_once',

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1243,7 +1243,7 @@ class DmRepository {
 
     final publishResult = await _nostrClient.publishEvent(signed);
     if (publishResult is! PublishSuccess) {
-      return NIP17SendResult.failure('NIP-04 publish returned null');
+      return NIP17SendResult.failure('NIP-04 publish failed');
     }
 
     return NIP17SendResult.success(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1241,14 +1241,14 @@ class DmRepository {
       return NIP17SendResult.failure('NIP-04 sign returned null');
     }
 
-    final published = await _nostrClient.publishEvent(signed);
-    if (published == null) {
+    final publishResult = await _nostrClient.publishEvent(signed);
+    if (publishResult is! PublishSuccess) {
       return NIP17SendResult.failure('NIP-04 publish returned null');
     }
 
     return NIP17SendResult.success(
-      rumorEventId: published.id,
-      messageEventId: published.id,
+      rumorEventId: publishResult.event.id,
+      messageEventId: publishResult.event.id,
       recipientPubkey: recipientPubkey,
     );
   }

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -105,7 +105,7 @@ class NIP17MessageService {
       // Publish the recipient's gift wrap
       final sentEvent = await _nostrService.publishEvent(giftWrapEvent);
 
-      if (sentEvent == null) {
+      if (sentEvent is! PublishSuccess) {
         const errorMsg = 'Message publish failed to relays';
         Log.error(errorMsg, category: LogCategory.system);
         return NIP17SendResult.failure(errorMsg);

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -400,7 +400,7 @@ void main() {
         // Stub publishEvent for the NIP-04 fallback (fire-and-forget)
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         final repository = createRepository();
 
@@ -565,7 +565,7 @@ void main() {
         ).thenAnswer((_) async => null);
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         final repository = createRepository();
 
@@ -649,7 +649,7 @@ void main() {
           ).thenAnswer((_) async {});
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           // First send: conversation does not exist yet → NIP-04
           // fallback fires (safe legacy interop).
@@ -694,7 +694,7 @@ void main() {
           reset(mockNostrClient);
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
           when(
             () => mockConversationsDao.getConversation(
               any(),
@@ -3124,7 +3124,7 @@ void main() {
           // Stub publishEvent for the NIP-04 fallback (fire-and-forget)
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           final repository = createRepository();
 
@@ -3360,7 +3360,7 @@ void main() {
           // Stub publishEvent for the NIP-04 fallback (fire-and-forget)
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           final repository = createRepository();
 
@@ -4150,17 +4150,19 @@ void main() {
           when(
             () => mockNostrClient.publishEvent(any()),
           ).thenAnswer(
-            (_) async => Event.fromJson({
-              'id': _giftWrapEventId,
-              'pubkey': _validPubkeyA,
-              'created_at': 1700000000,
-              'kind': EventKind.directMessage,
-              'tags': [
-                ['p', _validPubkeyB],
-              ],
-              'content': 'encrypted',
-              'sig': 'sig',
-            }),
+            (_) async => PublishSuccess(
+              event: Event.fromJson({
+                'id': _giftWrapEventId,
+                'pubkey': _validPubkeyA,
+                'created_at': 1700000000,
+                'kind': EventKind.directMessage,
+                'tags': [
+                  ['p', _validPubkeyB],
+                ],
+                'content': 'encrypted',
+                'sig': 'sig',
+              }),
+            ),
           );
 
           final repository = createRepository();
@@ -4374,7 +4376,7 @@ void main() {
 
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => _FakeEvent());
+          ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
           when(
             () => mockDirectMessagesDao.markMessageDeleted(
@@ -5851,7 +5853,7 @@ void main() {
 
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => _FakeEvent());
+          ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
           when(
             () => mockDirectMessagesDao.markMessageDeleted(
@@ -5958,7 +5960,7 @@ void main() {
 
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => _FakeEvent());
+          ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
           when(
             () => mockDirectMessagesDao.markMessageDeleted(
@@ -6247,7 +6249,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => _FakeEvent());
+        ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
         final repo = createRepository();
         const replyId =
@@ -6999,7 +7001,7 @@ void main() {
 
           when(
             () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+          ).thenAnswer((_) async => const PublishFailed());
 
           final repo = DmRepository(
             nostrClient: mockNostrClient,

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -51,7 +51,8 @@ void main() {
     group('sendPrivateMessage', () {
       test('returns success with gift wrap event details', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
+          (invocation) async =>
+              PublishSuccess(event: invocation.positionalArguments[0] as Event),
         );
 
         final result = await service.sendPrivateMessage(
@@ -77,7 +78,8 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = invocation.positionalArguments[0] as Event;
+            return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -95,7 +97,8 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = invocation.positionalArguments[0] as Event;
+            return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -149,7 +152,8 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = invocation.positionalArguments[0] as Event;
+            return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -185,7 +189,8 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
+            capturedEvent = invocation.positionalArguments[0] as Event;
+            return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -203,7 +208,8 @@ void main() {
 
       test('uses provided eventKind for the rumor', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
+          (invocation) async =>
+              PublishSuccess(event: invocation.positionalArguments[0] as Event),
         );
 
         final result = await service.sendPrivateMessage(
@@ -228,7 +234,9 @@ void main() {
               callCount++;
               if (callCount == 1) {
                 // Recipient publish succeeds.
-                return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+                return PublishSuccess(
+                  event: invocation.positionalArguments[0] as Event,
+                );
               }
               // Self-wrap publish throws — should be non-fatal.
               throw Exception('self-wrap relay error');

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -51,7 +51,7 @@ void main() {
     group('sendPrivateMessage', () {
       test('returns success with gift wrap event details', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async => invocation.positionalArguments[0] as Event,
+          (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
         );
 
         final result = await service.sendPrivateMessage(
@@ -77,7 +77,7 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
+            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -95,7 +95,7 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
+            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -119,7 +119,7 @@ void main() {
           (invocation) async {
             final event = invocation.positionalArguments[0] as Event;
             capturedEvents.add(event);
-            return event;
+            return PublishSuccess(event: event);
           },
         );
 
@@ -149,7 +149,7 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
+            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -169,7 +169,7 @@ void main() {
       test('returns failure when publish returns null', () async {
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         final result = await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -185,7 +185,7 @@ void main() {
 
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
           (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
+            capturedEvent = invocation.positionalArguments[0] as Event; return PublishSuccess(event: capturedEvent!);
           },
         );
 
@@ -203,7 +203,7 @@ void main() {
 
       test('uses provided eventKind for the rumor', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async => invocation.positionalArguments[0] as Event,
+          (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
         );
 
         final result = await service.sendPrivateMessage(
@@ -228,7 +228,7 @@ void main() {
               callCount++;
               if (callCount == 1) {
                 // Recipient publish succeeds.
-                return invocation.positionalArguments[0] as Event;
+                return PublishSuccess(event: invocation.positionalArguments[0] as Event);
               }
               // Self-wrap publish throws — should be non-fatal.
               throw Exception('self-wrap relay error');
@@ -262,7 +262,7 @@ void main() {
             (invocation) async {
               final event = invocation.positionalArguments[0] as Event;
               capturedEvents.add(event);
-              return event;
+              return PublishSuccess(event: event);
             },
           );
 

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -170,19 +170,22 @@ void main() {
         expect(capturedEvent!.createdAt, lessThan(afterSend));
       });
 
-      test('returns failure when publish returns null', () async {
-        when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => const PublishFailed());
+      test(
+        'returns failure when publish does not return PublishSuccess',
+        () async {
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => const PublishFailed());
 
-        final result = await service.sendPrivateMessage(
-          recipientPubkey: _recipientPubkey,
-          content: 'Test message',
-        );
+          final result = await service.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
 
-        expect(result.success, isFalse);
-        expect(result.error, contains('publish failed'));
-      });
+          expect(result.success, isFalse);
+          expect(result.error, contains('publish failed'));
+        },
+      );
 
       test('includes additional tags in the gift wrap', () async {
         Event? capturedEvent;

--- a/mobile/packages/nostr_client/lib/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/nostr_client.dart
@@ -7,5 +7,6 @@ library;
 
 export 'src/models/models.dart';
 export 'src/nostr_client.dart';
+export 'src/publish_result.dart';
 export 'src/relay_manager.dart';
 export 'src/send_profile_result.dart';

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:meta/meta.dart';
 import 'package:nostr_client/src/models/models.dart';
+import 'package:nostr_client/src/publish_result.dart';
 import 'package:nostr_client/src/relay_manager.dart';
 import 'package:nostr_client/src/send_profile_result.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
@@ -238,8 +239,12 @@ class NostrClient {
   ///   (upsert deletes old record, so rollback would lose data)
   /// - Deletion events (Kind 5): Removes target events from cache on success
   ///
-  /// Returns the sent event if successful, or `null` if failed.
-  Future<Event?> publishEvent(
+  /// Returns a [PublishResult] describing the outcome:
+  /// - [PublishSuccess] — the event was broadcast to at least one relay.
+  /// - [PublishNoRelays] — no relays were connected even after retry.
+  /// - [PublishFailed] — the relay pool was reachable but the SDK send
+  ///   returned null (e.g. a serialisation error).
+  Future<PublishResult> publishEvent(
     Event event, {
     List<String>? targetRelays,
   }) async {
@@ -259,7 +264,7 @@ class NostrClient {
         if (useOptimisticCache) {
           _rollbackCachedEvent(event.id);
         }
-        return null;
+        return const PublishNoRelays();
       }
     }
 
@@ -278,7 +283,7 @@ class NostrClient {
       if (useOptimisticCache) {
         _rollbackCachedEvent(event.id);
       }
-      return null;
+      return const PublishFailed();
     }
 
     // Handle successful send
@@ -292,7 +297,7 @@ class NostrClient {
 
     statisticsObserver?.onEventSent();
 
-    return sentEvent;
+    return PublishSuccess(event: sentEvent);
   }
 
   /// Publishes an event and waits for an `OK` confirmation from at least one
@@ -828,14 +833,15 @@ class NostrClient {
 
   /// Sends a user profile (Kind 0 metadata event).
   ///
-  /// Checks relay connectivity (with retry) before broadcasting. Kind 0 is
-  /// replaceable, so the event is cached only on successful publish.
+  /// Delegates to [publishEvent], which handles relay connectivity checks,
+  /// retry, caching, and statistics. Kind 0 is replaceable, so it is cached
+  /// only on successful publish (not optimistically).
   ///
   /// Returns a [SendProfileResult] that callers can switch exhaustively over:
   /// - [SendProfileSuccess] — the event was broadcast to at least one relay.
   /// - [SendProfileNoRelays] — no relays were connected even after retry.
-  /// - [SendProfileFailed] — the SDK send call returned null for a reason
-  ///   other than empty relay list (e.g. serialisation error).
+  /// - [SendProfileFailed] — the relay pool was reachable but the send
+  ///   returned null (e.g. a serialisation error).
   Future<SendProfileResult> sendProfile({
     required Map<String, dynamic> profileContent,
   }) async {
@@ -846,27 +852,11 @@ class NostrClient {
       jsonEncode(profileContent),
     );
 
-    // Fast-path: check relay connectivity before attempting to send, and
-    // surface the no-relays case as a first-class result variant rather than
-    // returning null and forcing callers to infer from a subsequent
-    // connectedRelays snapshot.
-    if (_relayManager.connectedRelays.isEmpty) {
-      await retryDisconnectedRelays();
-      if (_relayManager.connectedRelays.isEmpty) {
-        return const SendProfileNoRelays();
-      }
-    }
-
-    final sentEvent = await _nostr.sendEvent(event);
-    if (sentEvent == null) {
-      return const SendProfileFailed();
-    }
-
-    // Kind 0 is replaceable — cache on success only (not optimistically).
-    _cacheEvent(sentEvent);
-    statisticsObserver?.onEventSent();
-
-    return SendProfileSuccess(event: sentEvent);
+    return switch (await publishEvent(event)) {
+      PublishSuccess(:final event) => SendProfileSuccess(event: event),
+      PublishNoRelays() => const SendProfileNoRelays(),
+      PublishFailed() => const SendProfileFailed(),
+    };
   }
 
   /// Sends a repost

--- a/mobile/packages/nostr_client/lib/src/publish_result.dart
+++ b/mobile/packages/nostr_client/lib/src/publish_result.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Typed result for publishEvent, distinguishing success from
+// ABOUTME: no-relays and generic send-failure outcomes.
+
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+/// The outcome of a [NostrClient.publishEvent] call.
+///
+/// Callers can switch exhaustively over the three variants rather than
+/// inferring failure reason from a post-failure relay-list snapshot.
+///
+/// See also:
+/// - [PublishSuccess] — the event was accepted and broadcast.
+/// - [PublishNoRelays] — no relays were connected even after retry.
+/// - [PublishFailed] — the relay pool was reachable but the send returned null.
+sealed class PublishResult {
+  const PublishResult();
+}
+
+/// The event was accepted and broadcast to at least one relay.
+final class PublishSuccess extends PublishResult {
+  /// Creates a successful publish result wrapping the sent [event].
+  const PublishSuccess({required this.event});
+
+  /// The signed and sent [Event].
+  final Event event;
+}
+
+/// The publish attempt was aborted before sending because no relays were
+/// connected, even after a reconnection attempt.
+final class PublishNoRelays extends PublishResult {
+  /// Creates a no-relays result.
+  const PublishNoRelays();
+}
+
+/// The relay pool was reachable but the underlying send call returned null —
+/// e.g. the SDK could not serialise or write the frame.
+/// This is distinct from [PublishNoRelays]: at least one relay was
+/// connected, but the send still failed.
+final class PublishFailed extends PublishResult {
+  /// Creates a send-failed result.
+  const PublishFailed();
+}

--- a/mobile/packages/nostr_client/lib/src/publish_result.dart
+++ b/mobile/packages/nostr_client/lib/src/publish_result.dart
@@ -3,7 +3,7 @@
 
 import 'package:nostr_sdk/nostr_sdk.dart';
 
-/// The outcome of a [NostrClient.publishEvent] call.
+/// The outcome of a `NostrClient.publishEvent` call.
 ///
 /// Callers can switch exhaustively over the three variants rather than
 /// inferring failure reason from a post-failure relay-list snapshot.

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -133,7 +133,8 @@ void main() {
 
         final result = await client.publishEvent(event);
 
-        expect(result, equals(event));
+        expect(result, isA<PublishSuccess>());
+        expect((result as PublishSuccess).event, equals(event));
         verify(
           () => mockNostr.sendEvent(
             event,
@@ -163,7 +164,7 @@ void main() {
         ).called(1);
       });
 
-      test('returns null when sendEvent fails', () async {
+      test('returns PublishFailed when sendEvent fails', () async {
         final event = _createTestEvent();
         when(
           () => mockNostr.sendEvent(
@@ -175,7 +176,7 @@ void main() {
 
         final result = await client.publishEvent(event);
 
-        expect(result, isNull);
+        expect(result, isA<PublishFailed>());
       });
 
       test('attempts reconnection when no relays connected', () async {
@@ -200,7 +201,8 @@ void main() {
 
         final result = await client.publishEvent(event);
 
-        expect(result, equals(event));
+        expect(result, isA<PublishSuccess>());
+        expect((result as PublishSuccess).event, equals(event));
         verify(mockRelayManager.retryDisconnectedRelays).called(1);
         verify(
           () => mockNostr.sendEvent(
@@ -209,7 +211,7 @@ void main() {
         ).called(1);
       });
 
-      test('returns null when reconnection fails', () async {
+      test('returns PublishNoRelays when reconnection fails', () async {
         final event = _createTestEvent();
 
         // No relays connected before and after reconnection attempt
@@ -218,7 +220,7 @@ void main() {
 
         final result = await client.publishEvent(event);
 
-        expect(result, isNull);
+        expect(result, isA<PublishNoRelays>());
         verify(mockRelayManager.retryDisconnectedRelays).called(1);
         verifyNever(
           () => mockNostr.sendEvent(
@@ -246,7 +248,8 @@ void main() {
 
         final result = await client.publishEvent(event);
 
-        expect(result, equals(event));
+        expect(result, isA<PublishSuccess>());
+        expect((result as PublishSuccess).event, equals(event));
         verifyNever(mockRelayManager.retryDisconnectedRelays);
         verify(
           () => mockNostr.sendEvent(
@@ -303,7 +306,7 @@ void main() {
 
           final result = await clientWithCache.publishEvent(event);
 
-          expect(result, isNull);
+          expect(result, isA<PublishNoRelays>());
           // Should have optimistically cached the event
           verify(() => mockNostrEventsDao.upsertEvent(event)).called(1);
           // Should have rolled back the cache
@@ -333,7 +336,7 @@ void main() {
 
             final result = await clientWithCache.publishEvent(event);
 
-            expect(result, isNull);
+            expect(result, isA<PublishNoRelays>());
             // Should NOT have optimistically cached (replaceable events)
             verifyNever(() => mockNostrEventsDao.upsertEvent(any()));
             // Should NOT roll back (nothing was cached)
@@ -365,7 +368,8 @@ void main() {
 
           final result = await clientWithCache.publishEvent(event);
 
-          expect(result, equals(event));
+          expect(result, isA<PublishSuccess>());
+          expect((result as PublishSuccess).event, equals(event));
           // Should have optimistically cached
           verify(() => mockNostrEventsDao.upsertEvent(event)).called(1);
           // Should NOT have rolled back (send succeeded)

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -171,7 +171,7 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
 
     try {
       final sent = await _nostrClient.publishEvent(event);
-      if (sent == null) {
+      if (sent is! PublishSuccess) {
         return const PeopleListPublishResult.failed();
       }
       await _cache.markDeleted(
@@ -179,7 +179,7 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
         listId: listId,
         deletedAt: DateTime.now().toUtc(),
       );
-      return PeopleListPublishResult.submitted(eventId: sent.id);
+      return PeopleListPublishResult.submitted(eventId: sent.event.id);
     } on Object catch (error, stackTrace) {
       developer.log(
         'Failed to publish people-list deletion for list $listId',
@@ -261,16 +261,16 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
 
     try {
       final sent = await _nostrClient.publishEvent(event);
-      if (sent == null) {
+      if (sent is! PublishSuccess) {
         return const PeopleListPublishResult.failed();
       }
-      final persisted = list.copyWith(nostrEventId: sent.id);
+      final persisted = list.copyWith(nostrEventId: sent.event.id);
       await _cache.putList(
         ownerPubkey: ownerPubkey,
         list: persisted,
         receivedAt: DateTime.now().toUtc(),
       );
-      return PeopleListPublishResult.submitted(eventId: sent.id);
+      return PeopleListPublishResult.submitted(eventId: sent.event.id);
     } on Object catch (error, stackTrace) {
       developer.log(
         'Failed to publish people-list replacement for list ${list.id}',

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -94,12 +94,14 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: signedEvent(
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-            createdAt: event.createdAt,
-          ));
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -124,7 +126,9 @@ void main() {
       test('does not write to cache when publishEvent returns null', () async {
         final client = _MockNostrClient();
         when(() => client.publicKey).thenReturn(_ownerPubkey);
-        when(() => client.publishEvent(any())).thenAnswer((_) async => const PublishFailed());
+        when(
+          () => client.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
         final repository = buildRepository(nostrClient: client);
 
         final result = await repository.createList(
@@ -161,12 +165,14 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: signedEvent(
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-            createdAt: event.createdAt,
-          ));
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -199,12 +205,14 @@ void main() {
           when(() => client.publicKey).thenReturn(_ownerPubkey);
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
-            return PublishSuccess(event: signedEvent(
-              kind: event.kind,
-              tags: event.tags,
-              content: event.content,
-              createdAt: event.createdAt,
-          ));
+            return PublishSuccess(
+              event: signedEvent(
+                kind: event.kind,
+                tags: event.tags,
+                content: event.content,
+                createdAt: event.createdAt,
+              ),
+            );
           });
           final repository = buildRepository(nostrClient: client);
 
@@ -253,12 +261,14 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: signedEvent(
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-            createdAt: event.createdAt,
-          ));
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -292,12 +302,14 @@ void main() {
           when(() => client.publicKey).thenReturn(_ownerPubkey);
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
-            return PublishSuccess(event: signedEvent(
-              kind: event.kind,
-              tags: event.tags,
-              content: event.content,
-              createdAt: event.createdAt,
-          ));
+            return PublishSuccess(
+              event: signedEvent(
+                kind: event.kind,
+                tags: event.tags,
+                content: event.content,
+                createdAt: event.createdAt,
+              ),
+            );
           });
           final repository = buildRepository(nostrClient: client);
 
@@ -328,12 +340,14 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: signedEvent(
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-            createdAt: event.createdAt,
-          ));
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -379,12 +393,14 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: signedEvent(
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-            createdAt: event.createdAt,
-          ));
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -440,12 +456,14 @@ void main() {
           publishCalls++;
           if (publishCalls == 1) {
             final event = invocation.positionalArguments.first as Event;
-            return PublishSuccess(event: signedEvent(
-              kind: event.kind,
-              tags: event.tags,
-              content: event.content,
-              createdAt: event.createdAt,
-          ));
+            return PublishSuccess(
+              event: signedEvent(
+                kind: event.kind,
+                tags: event.tags,
+                content: event.content,
+                createdAt: event.createdAt,
+              ),
+            );
           }
           return const PublishFailed();
         });
@@ -561,12 +579,14 @@ void main() {
           // Local optimistic write will be far in the future.
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
-            return PublishSuccess(event: signedEvent(
-              kind: event.kind,
-              tags: event.tags,
-              content: event.content,
-              createdAt: event.createdAt,
-          ));
+            return PublishSuccess(
+              event: signedEvent(
+                kind: event.kind,
+                tags: event.tags,
+                content: event.content,
+                createdAt: event.createdAt,
+              ),
+            );
           });
           final repository = buildRepository(nostrClient: client);
 
@@ -954,12 +974,14 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: signedEvent(
-            kind: event.kind,
-            tags: event.tags,
-            content: event.content,
-            createdAt: event.createdAt,
-          ));
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
         });
         final repository = buildRepository(nostrClient: client);
 

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -123,7 +123,9 @@ void main() {
         expect(stored.single.pubkeys, equals(const [_memberA]));
       });
 
-      test('does not write to cache when publishEvent returns null', () async {
+      test(
+        'does not write to cache when publishEvent returns PublishFailed',
+        () async {
         final client = _MockNostrClient();
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(
@@ -141,7 +143,8 @@ void main() {
 
         final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
         expect(stored, isEmpty);
-      });
+        },
+      );
 
       test('returns failed when publishEvent throws', () async {
         final client = _MockNostrClient();
@@ -446,7 +449,10 @@ void main() {
         expect(stored, isEmpty);
       });
 
-      test('does not tombstone locally when publish returns null', () async {
+      test(
+        'does not tombstone locally when publish does not return '
+        'PublishSuccess',
+        () async {
         final client = _MockNostrClient();
         when(() => client.publicKey).thenReturn(_ownerPubkey);
 
@@ -486,7 +492,8 @@ void main() {
         expect(result.status, equals(PeopleListPublishStatus.failed));
         final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
         expect(stored, hasLength(1));
-      });
+        },
+      );
     });
 
     group('syncOwner', () {

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -94,12 +94,12 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return signedEvent(
+          return PublishSuccess(event: signedEvent(
             kind: event.kind,
             tags: event.tags,
             content: event.content,
             createdAt: event.createdAt,
-          );
+          ));
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -124,7 +124,7 @@ void main() {
       test('does not write to cache when publishEvent returns null', () async {
         final client = _MockNostrClient();
         when(() => client.publicKey).thenReturn(_ownerPubkey);
-        when(() => client.publishEvent(any())).thenAnswer((_) async => null);
+        when(() => client.publishEvent(any())).thenAnswer((_) async => const PublishFailed());
         final repository = buildRepository(nostrClient: client);
 
         final result = await repository.createList(
@@ -161,12 +161,12 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return signedEvent(
+          return PublishSuccess(event: signedEvent(
             kind: event.kind,
             tags: event.tags,
             content: event.content,
             createdAt: event.createdAt,
-          );
+          ));
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -199,12 +199,12 @@ void main() {
           when(() => client.publicKey).thenReturn(_ownerPubkey);
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
-            return signedEvent(
+            return PublishSuccess(event: signedEvent(
               kind: event.kind,
               tags: event.tags,
               content: event.content,
               createdAt: event.createdAt,
-            );
+          ));
           });
           final repository = buildRepository(nostrClient: client);
 
@@ -253,12 +253,12 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return signedEvent(
+          return PublishSuccess(event: signedEvent(
             kind: event.kind,
             tags: event.tags,
             content: event.content,
             createdAt: event.createdAt,
-          );
+          ));
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -292,12 +292,12 @@ void main() {
           when(() => client.publicKey).thenReturn(_ownerPubkey);
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
-            return signedEvent(
+            return PublishSuccess(event: signedEvent(
               kind: event.kind,
               tags: event.tags,
               content: event.content,
               createdAt: event.createdAt,
-            );
+          ));
           });
           final repository = buildRepository(nostrClient: client);
 
@@ -328,12 +328,12 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return signedEvent(
+          return PublishSuccess(event: signedEvent(
             kind: event.kind,
             tags: event.tags,
             content: event.content,
             createdAt: event.createdAt,
-          );
+          ));
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -379,12 +379,12 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return signedEvent(
+          return PublishSuccess(event: signedEvent(
             kind: event.kind,
             tags: event.tags,
             content: event.content,
             createdAt: event.createdAt,
-          );
+          ));
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -440,14 +440,14 @@ void main() {
           publishCalls++;
           if (publishCalls == 1) {
             final event = invocation.positionalArguments.first as Event;
-            return signedEvent(
+            return PublishSuccess(event: signedEvent(
               kind: event.kind,
               tags: event.tags,
               content: event.content,
               createdAt: event.createdAt,
-            );
+          ));
           }
-          return null;
+          return const PublishFailed();
         });
         final repository = buildRepository(nostrClient: client);
 
@@ -561,12 +561,12 @@ void main() {
           // Local optimistic write will be far in the future.
           when(() => client.publishEvent(any())).thenAnswer((invocation) async {
             final event = invocation.positionalArguments.first as Event;
-            return signedEvent(
+            return PublishSuccess(event: signedEvent(
               kind: event.kind,
               tags: event.tags,
               content: event.content,
               createdAt: event.createdAt,
-            );
+          ));
           });
           final repository = buildRepository(nostrClient: client);
 
@@ -954,12 +954,12 @@ void main() {
         when(() => client.publicKey).thenReturn(_ownerPubkey);
         when(() => client.publishEvent(any())).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return signedEvent(
+          return PublishSuccess(event: signedEvent(
             kind: event.kind,
             tags: event.tags,
             content: event.content,
             createdAt: event.createdAt,
-          );
+          ));
         });
         final repository = buildRepository(nostrClient: client);
 

--- a/mobile/test/diag/mocktail_timeout_diag_test.dart
+++ b/mobile/test/diag/mocktail_timeout_diag_test.dart
@@ -1,10 +1,13 @@
 // ABOUTME: Pinned regression tests for the mocktail + Future.timeout gotcha.
 // ABOUTME: When mocktail's thenAnswer((_) async => value) infers a non-nullable
-// ABOUTME: Future<T>, .timeout(onTimeout: () => null) throws a runtime TypeError
-// ABOUTME: because Null is not a subtype of FutureOr<T>. Production code in
-// ABOUTME: video_event_publisher.dart sidesteps this by using try/catch on
+// ABOUTME: Future<T>, .timeout(onTimeout: () => fallback) throws a runtime TypeError
+// ABOUTME: because the closure return type is inferred too narrowly. Production code
+// ABOUTME: in video_event_publisher.dart sidesteps this by using try/catch on
 // ABOUTME: TimeoutException; this file locks the gotcha so future contributors
 // ABOUTME: don't reach for onTimeout when stubbing publishEvent in tests.
+// ABOUTME: Note: publishEvent now returns Future<PublishResult> (a non-nullable
+// ABOUTME: sealed class), so the original Event? nullable flavour is gone, but
+// ABOUTME: the try/catch shape remains the preferred pattern.
 
 import 'dart:async';
 
@@ -37,41 +40,41 @@ void main() {
     });
 
     test(
-      'plain mocktail thenAnswer + await returns the stubbed event',
+      'plain mocktail thenAnswer + await returns the stubbed PublishSuccess',
       () async {
+        final stubResult = PublishSuccess(event: event);
         when(
           () => mock.publishEvent(any()),
-        ).thenAnswer((_) async => event);
+        ).thenAnswer((_) async => stubResult);
 
         final result = await mock.publishEvent(event);
 
-        expect(result, equals(event));
+        expect(result, equals(stubResult));
       },
     );
 
     test(
-      'GOTCHA: mocktail thenAnswer((_) async => event) + .timeout(onTimeout: '
-      '() => null) throws TypeError at runtime because the stubbed Future has '
-      'lost the ? nullability of the declared signature',
+      'GOTCHA: mocktail thenAnswer((_) async => value) + .timeout(onTimeout: '
+      '() => fallback) throws TypeError at runtime because the stubbed Future '
+      'has lost nullability of the closure return type',
       () async {
+        final stubResult = PublishSuccess(event: event);
         when(
           () => mock.publishEvent(any()),
-        ).thenAnswer((_) async => event);
+        ).thenAnswer((_) async => stubResult);
 
         await expectLater(
           () async => mock
               .publishEvent(event)
               .timeout(
                 const Duration(seconds: 30),
-                onTimeout: () => null,
+                onTimeout: () => const PublishFailed(),
               ),
-          throwsA(
-            isA<TypeError>().having(
-              (e) => e.toString(),
-              'message',
-              contains("'() => Null' is not a subtype of"),
-            ),
-          ),
+          // With a non-nullable sealed class the TypeError manifests differently
+          // than with Event? — the closure infers its return as PublishFailed,
+          // which is not assignable to the inferred non-nullable PublishSuccess
+          // type that mocktail bakes in.  The safe workaround is try/catch.
+          throwsA(isA<TypeError>()),
           reason:
               'If this assertion starts failing because no error was thrown, '
               'mocktail or Dart fixed the inference and the try/catch '
@@ -84,39 +87,41 @@ void main() {
       'WORKAROUND A: try/catch on TimeoutException avoids the closure-cast '
       'trap (this is the production-code shape)',
       () async {
+        final stubResult = PublishSuccess(event: event);
         when(
           () => mock.publishEvent(any()),
-        ).thenAnswer((_) async => event);
+        ).thenAnswer((_) async => stubResult);
 
-        Event? result;
+        PublishResult? result;
         try {
           result = await mock
               .publishEvent(event)
               .timeout(const Duration(seconds: 30));
         } on TimeoutException {
-          result = null;
+          result = const PublishFailed();
         }
 
-        expect(result, equals(event));
+        expect(result, equals(stubResult));
       },
     );
 
     test(
-      'WORKAROUND B: stubbing with Future<Event?>.value(event) preserves '
-      'nullability so onTimeout: () => null also works',
+      'WORKAROUND B: stubbing with Future<PublishResult>.value(result) '
+      'preserves the declared return type so onTimeout closure also works',
       () async {
+        final stubResult = PublishSuccess(event: event);
         when(
           () => mock.publishEvent(any()),
-        ).thenAnswer((_) => Future<Event?>.value(event));
+        ).thenAnswer((_) => Future<PublishResult>.value(stubResult));
 
         final result = await mock
             .publishEvent(event)
             .timeout(
               const Duration(seconds: 30),
-              onTimeout: () => null,
+              onTimeout: () => const PublishFailed(),
             );
 
-        expect(result, equals(event));
+        expect(result, equals(stubResult));
       },
     );
 
@@ -124,12 +129,13 @@ void main() {
       'sanity: plain Future.value with the right type + .timeout works',
       () async {
         // Confirms the gotcha is mocktail-specific, not a Dart stdlib issue.
-        final source = Future<Event?>.value(event);
+        final stubResult = PublishSuccess(event: event);
+        final source = Future<PublishResult>.value(stubResult);
         final result = await source.timeout(
           const Duration(seconds: 30),
-          onTimeout: () => null,
+          onTimeout: () => const PublishFailed(),
         );
-        expect(result, equals(event));
+        expect(result, equals(stubResult));
       },
     );
   });

--- a/mobile/test/diag/mocktail_timeout_diag_test.dart
+++ b/mobile/test/diag/mocktail_timeout_diag_test.dart
@@ -73,8 +73,18 @@ void main() {
           // With a non-nullable sealed class the TypeError manifests differently
           // than with Event? — the closure infers its return as PublishFailed,
           // which is not assignable to the inferred non-nullable PublishSuccess
-          // type that mocktail bakes in.  The safe workaround is try/catch.
-          throwsA(isA<TypeError>()),
+          // type that mocktail bakes in. The safe workaround is try/catch.
+          throwsA(
+            isA<TypeError>().having(
+              (error) => error.toString(),
+              'message',
+              allOf(
+                contains('PublishFailed'),
+                contains('PublishSuccess'),
+                contains('subtype of'),
+              ),
+            ),
+          ),
           reason:
               'If this assertion starts failing because no error was thrown, '
               'mocktail or Dart fixed the inference and the try/catch '
@@ -83,27 +93,22 @@ void main() {
       },
     );
 
-    test(
-      'WORKAROUND A: try/catch on TimeoutException avoids the closure-cast '
-      'trap (this is the production-code shape)',
-      () async {
-        final stubResult = PublishSuccess(event: event);
-        when(
-          () => mock.publishEvent(any()),
-        ).thenAnswer((_) async => stubResult);
+    test('WORKAROUND A: try/catch on TimeoutException avoids the closure-cast '
+        'trap (this is the production-code shape)', () async {
+      final stubResult = PublishSuccess(event: event);
+      when(() => mock.publishEvent(any())).thenAnswer((_) async => stubResult);
 
-        PublishResult? result;
-        try {
-          result = await mock
-              .publishEvent(event)
-              .timeout(const Duration(seconds: 30));
-        } on TimeoutException {
-          result = const PublishFailed();
-        }
+      PublishResult? result;
+      try {
+        result = await mock
+            .publishEvent(event)
+            .timeout(const Duration(seconds: 30));
+      } on TimeoutException {
+        result = const PublishFailed();
+      }
 
-        expect(result, equals(stubResult));
-      },
-    );
+      expect(result, equals(stubResult));
+    });
 
     test(
       'WORKAROUND B: stubbing with Future<PublishResult>.value(result) '

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -94,7 +94,11 @@ class TestNostrService implements NostrClient {
       createdAt: NostrTimestamp.now(),
     );
 
-    return publishEvent(event);
+    final result = await publishEvent(event);
+    return switch (result) {
+      PublishSuccess(:final event) => event,
+      PublishNoRelays() || PublishFailed() => null,
+    };
   }
 
   Future<Event?> publishVideoEvent({
@@ -125,7 +129,11 @@ class TestNostrService implements NostrClient {
       createdAt: NostrTimestamp.now(),
     );
 
-    return publishEvent(event);
+    final result = await publishEvent(event);
+    return switch (result) {
+      PublishSuccess(:final event) => event,
+      PublishNoRelays() || PublishFailed() => null,
+    };
   }
 
   @override
@@ -217,7 +225,10 @@ class TestNostrService implements NostrClient {
   }
 
   @override
-  Future<Event?> publishEvent(Event event, {List<String>? targetRelays}) async {
+  Future<PublishResult> publishEvent(
+    Event event, {
+    List<String>? targetRelays,
+  }) async {
     if (!_isConnected) throw StateError('Not connected');
     _storedEvents.add(event);
 
@@ -229,7 +240,7 @@ class TestNostrService implements NostrClient {
       }
     }
 
-    return event;
+    return PublishSuccess(event: event);
   }
 
   @override

--- a/mobile/test/screens/profile_setup_relay_confirmation_test.dart
+++ b/mobile/test/screens/profile_setup_relay_confirmation_test.dart
@@ -89,7 +89,7 @@ void main() {
 
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => publishedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
 
         // Mock profile fetches - first two return stale profile, third returns updated
         final staleProfile = UserProfile(
@@ -233,7 +233,7 @@ void main() {
 
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => publishedEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
 
       // Mock profile repository to ALWAYS return stale profile
       final staleProfile = UserProfile(
@@ -330,7 +330,7 @@ void main() {
 
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => publishedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
 
         // Mock profile repository to return updated profile immediately
         final updatedProfile = UserProfile(

--- a/mobile/test/services/account_deletion_flow_test.dart
+++ b/mobile/test/services/account_deletion_flow_test.dart
@@ -76,7 +76,7 @@ void main() {
 
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => mockEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: mockEvent));
 
       when(
         () => mockAuthService.signOut(deleteKeys: true),
@@ -138,7 +138,7 @@ void main() {
       // publishEvent returns null on failure
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async => const PublishFailed());
 
       final deletionService = AccountDeletionService(
         nostrService: mockNostrService,

--- a/mobile/test/services/account_deletion_flow_test.dart
+++ b/mobile/test/services/account_deletion_flow_test.dart
@@ -135,7 +135,7 @@ void main() {
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPublicKey);
       when(() => mockNostrService.hasKeys).thenReturn(true);
 
-      // publishEvent returns null on failure
+      // publishEvent returns PublishFailed on send failure
       when(
         () => mockNostrService.publishEvent(any()),
       ).thenAnswer((_) async => const PublishFailed());

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -228,7 +228,7 @@ void main() {
         ),
       ).thenAnswer((_) async => expectedEvent);
 
-      // publishEvent returns null on failure
+      // publishEvent returns PublishFailed on send failure
       when(
         () => mockNostrService.publishEvent(any()),
       ).thenAnswer((_) async => const PublishFailed());

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -166,7 +166,7 @@ void main() {
 
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => expectedEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: expectedEvent));
 
       // Act
       await expectLater(service.deleteAccount(), completes);
@@ -198,7 +198,7 @@ void main() {
 
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => expectedEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: expectedEvent));
 
         // Act
         final result = await service.deleteAccount();
@@ -231,7 +231,7 @@ void main() {
       // publishEvent returns null on failure
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async => const PublishFailed());
 
       // Act
       final result = await service.deleteAccount();
@@ -305,7 +305,7 @@ void main() {
         ).thenAnswer((_) async => nip62Event);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+        ).thenAnswer((_) async => PublishSuccess(event: nip62Event));
 
         // Act
         await service.deleteAccount();
@@ -364,7 +364,7 @@ void main() {
 
           when(
             () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => nip62Event);
+          ).thenAnswer((_) async => PublishSuccess(event: nip62Event));
 
           // Act
           final result = await service.deleteAccount();
@@ -447,7 +447,7 @@ void main() {
 
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+        ).thenAnswer((_) async => PublishSuccess(event: nip62Event));
 
         // Act
         final result = await service.deleteAccount();
@@ -505,7 +505,7 @@ void main() {
 
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+        ).thenAnswer((_) async => PublishSuccess(event: nip62Event));
 
         // Act
         final result = await service.deleteAccount();
@@ -538,7 +538,7 @@ void main() {
         ).thenAnswer((_) async => nip62Event);
         when(
           () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+        ).thenAnswer((_) async => PublishSuccess(event: nip62Event));
 
         // Act
         final result = await service.deleteAccount();

--- a/mobile/test/services/badges/badge_repository_test.dart
+++ b/mobile/test/services/badges/badge_repository_test.dart
@@ -30,7 +30,9 @@ void main() {
 
       when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
       when(() => nostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.single as Event,
+        ),
       );
 
       repository = BadgeRepository(

--- a/mobile/test/services/badges/badge_repository_test.dart
+++ b/mobile/test/services/badges/badge_repository_test.dart
@@ -30,7 +30,7 @@ void main() {
 
       when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
       when(() => nostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments.single as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
       );
 
       repository = BadgeRepository(

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -70,7 +70,7 @@ void main() {
       return signedEvent;
     });
     when(() => nostrClient.publishEvent(any())).thenAnswer(
-      (_) async => signedEvent,
+      (_) async => PublishSuccess(event: signedEvent),
     );
 
     final result = await service.acceptInvite(invite);
@@ -130,7 +130,7 @@ void main() {
         );
       });
       when(() => nostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments.single as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
       );
 
       final result = await service.acceptInvite(inviteWithoutRelay);

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -130,7 +130,9 @@ void main() {
         );
       });
       when(() => nostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.single as Event,
+        ),
       );
 
       final result = await service.acceptInvite(inviteWithoutRelay);

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -147,7 +147,7 @@ void main() {
             any(),
             targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => reportEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
         // Act
         final result = await service.reportContent(
@@ -203,7 +203,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       const reasons = ContentFilterReason.values;
 
@@ -270,12 +270,12 @@ void main() {
           targetRelays: any(named: 'targetRelays'),
         ),
       ).thenAnswer(
-        (_) async => createTestEvent(
+        (_) async => PublishSuccess(event: createTestEvent(
           pubkey: testPublicKey,
           kind: 1984,
           tags: [],
           content: 'test',
-        ),
+        )),
       );
 
       for (final reason in ContentFilterReason.values) {
@@ -357,7 +357,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       // Act - This should not throw an exception due to missing switch case
       final result = await service.reportContent(
@@ -395,7 +395,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async => const PublishFailed());
 
       // Act
       final result = await service.reportContent(
@@ -437,7 +437,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       // Act
       await service.reportContent(
@@ -565,7 +565,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       await service.reportContent(
         eventId: 'evt_1',
@@ -612,13 +612,13 @@ void main() {
           targetRelays: any(named: 'targetRelays'),
         ),
       ).thenAnswer(
-        (_) async => Event(
+        (_) async => PublishSuccess(event: Event(
           testPublicKey,
           EventKind.report,
           [],
           '',
           createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        ),
+        )),
       );
 
       await service.reportContent(
@@ -691,13 +691,13 @@ void main() {
             targetRelays: any(named: 'targetRelays'),
           ),
         ).thenAnswer(
-          (_) async => Event(
+          (_) async => PublishSuccess(event: Event(
             testPublicKey,
             EventKind.report,
             [],
             '',
             createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          ),
+          )),
         );
 
         await service.reportContent(
@@ -768,7 +768,7 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       // Now reportContent should work
       final result = await service.reportContent(

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -270,12 +270,14 @@ void main() {
           targetRelays: any(named: 'targetRelays'),
         ),
       ).thenAnswer(
-        (_) async => PublishSuccess(event: createTestEvent(
-          pubkey: testPublicKey,
-          kind: 1984,
-          tags: [],
-          content: 'test',
-        )),
+        (_) async => PublishSuccess(
+          event: createTestEvent(
+            pubkey: testPublicKey,
+            kind: 1984,
+            tags: [],
+            content: 'test',
+          ),
+        ),
       );
 
       for (final reason in ContentFilterReason.values) {
@@ -612,13 +614,15 @@ void main() {
           targetRelays: any(named: 'targetRelays'),
         ),
       ).thenAnswer(
-        (_) async => PublishSuccess(event: Event(
-          testPublicKey,
-          EventKind.report,
-          [],
-          '',
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        )),
+        (_) async => PublishSuccess(
+          event: Event(
+            testPublicKey,
+            EventKind.report,
+            [],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ),
       );
 
       await service.reportContent(
@@ -691,13 +695,15 @@ void main() {
             targetRelays: any(named: 'targetRelays'),
           ),
         ).thenAnswer(
-          (_) async => PublishSuccess(event: Event(
-            testPublicKey,
-            EventKind.report,
-            [],
-            '',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          )),
+          (_) async => PublishSuccess(
+            event: Event(
+              testPublicKey,
+              EventKind.report,
+              [],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          ),
         );
 
         await service.reportContent(

--- a/mobile/test/services/curated_list_service_collaboration_test.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.dart
@@ -40,7 +40,9 @@ void main() {
     // Helper to stub publishEvent - call after reset(mockNostr)
     void stubPublishEvent() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
     }
 

--- a/mobile/test/services/curated_list_service_collaboration_test.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.dart
@@ -40,7 +40,7 @@ void main() {
     // Helper to stub publishEvent - call after reset(mockNostr)
     void stubPublishEvent() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
     }
 

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       // Mock subscribeToEvents for relay sync
@@ -159,7 +159,7 @@ void main() {
         when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) {
           final event = invocation.positionalArguments[0] as Event;
           lists.add(event.toCuratedList());
-          return Future.value(event);
+          return Future.value(PublishSuccess(event: event));
         });
 
         // Mock subscription to return collected lists
@@ -480,7 +480,7 @@ void main() {
         when(() => mockNostr.publishEvent(any())).thenAnswer((
           invocation,
         ) async {
-          return invocation.positionalArguments[0] as Event;
+          return PublishSuccess(event: invocation.positionalArguments[0] as Event);
         });
 
         await service.updateList(listId: list.id, name: 'Updated Name');

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -53,7 +53,9 @@ void main() {
 
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       // Mock subscribeToEvents for relay sync
@@ -480,7 +482,9 @@ void main() {
         when(() => mockNostr.publishEvent(any())).thenAnswer((
           invocation,
         ) async {
-          return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+          return PublishSuccess(
+            event: invocation.positionalArguments[0] as Event,
+          );
         });
 
         await service.updateList(listId: list.id, name: 'Updated Name');

--- a/mobile/test/services/curated_list_service_persistence_test.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.dart
@@ -51,7 +51,9 @@ void main() {
       ).thenReturn('test_pubkey_123456789abcdef');
 
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       when(

--- a/mobile/test/services/curated_list_service_persistence_test.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.dart
@@ -51,7 +51,7 @@ void main() {
       ).thenReturn('test_pubkey_123456789abcdef');
 
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       when(

--- a/mobile/test/services/curated_list_service_playlist_test.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.dart
@@ -50,7 +50,9 @@ void main() {
       ).thenReturn('test_pubkey_123456789abcdef');
 
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       when(
@@ -162,7 +164,9 @@ void main() {
         when(() => mockNostr.publishEvent(any())).thenAnswer((
           invocation,
         ) async {
-          return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+          return PublishSuccess(
+            event: invocation.positionalArguments[0] as Event,
+          );
         });
 
         await service.reorderVideos(list.id, ['video_2', 'video_1']);

--- a/mobile/test/services/curated_list_service_playlist_test.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.dart
@@ -50,7 +50,7 @@ void main() {
       ).thenReturn('test_pubkey_123456789abcdef');
 
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       when(
@@ -162,7 +162,7 @@ void main() {
         when(() => mockNostr.publishEvent(any())).thenAnswer((
           invocation,
         ) async {
-          return invocation.positionalArguments[0] as Event;
+          return PublishSuccess(event: invocation.positionalArguments[0] as Event);
         });
 
         await service.reorderVideos(list.id, ['video_2', 'video_1']);

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -54,7 +54,7 @@ void main() {
 
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       // Mock subscribeToEvents for relay sync

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -54,7 +54,9 @@ void main() {
 
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       // Mock subscribeToEvents for relay sync

--- a/mobile/test/services/curated_list_service_video_management_test.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.dart
@@ -40,7 +40,7 @@ void main() {
     // Helper to stub common mocks - call after reset(mockNostr)
     void stubMocks() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       when(
@@ -62,7 +62,7 @@ void main() {
 
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       // Mock subscribeToEvents for relay sync

--- a/mobile/test/services/curated_list_service_video_management_test.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.dart
@@ -40,7 +40,9 @@ void main() {
     // Helper to stub common mocks - call after reset(mockNostr)
     void stubMocks() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       when(
@@ -62,7 +64,9 @@ void main() {
 
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       // Mock subscribeToEvents for relay sync

--- a/mobile/test/services/profile_editing_test.dart
+++ b/mobile/test/services/profile_editing_test.dart
@@ -92,7 +92,7 @@ void main() {
       ).thenAnswer((_) async => mockEvent);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments[0] as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Act
@@ -141,7 +141,7 @@ void main() {
       ).thenAnswer((_) async => mockEvent);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments[0] as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Act
@@ -211,7 +211,7 @@ void main() {
       ).thenAnswer((_) async => mockEvent);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments[0] as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Mock profile repository to cache profile
@@ -335,7 +335,7 @@ void main() {
       ).thenAnswer((_) async => mockEvent2);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments[0] as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Act - simulate concurrent updates

--- a/mobile/test/services/profile_editing_test.dart
+++ b/mobile/test/services/profile_editing_test.dart
@@ -92,7 +92,8 @@ void main() {
       ).thenAnswer((_) async => mockEvent);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        (invocation) async =>
+            PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Act
@@ -141,7 +142,8 @@ void main() {
       ).thenAnswer((_) async => mockEvent);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        (invocation) async =>
+            PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Act
@@ -211,7 +213,8 @@ void main() {
       ).thenAnswer((_) async => mockEvent);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        (invocation) async =>
+            PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Mock profile repository to cache profile
@@ -335,7 +338,8 @@ void main() {
       ).thenAnswer((_) async => mockEvent2);
 
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        (invocation) async =>
+            PublishSuccess(event: invocation.positionalArguments[0] as Event),
       );
 
       // Act - simulate concurrent updates

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -109,7 +109,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(fakeEvent),
-        ).thenAnswer((_) async => fakeEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
 
         final service = buildService();
         await service.register(testPubkey);
@@ -156,7 +156,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => fakeEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
 
         final service = buildService();
         await service.register(testPubkey);
@@ -283,7 +283,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(fakeEvent),
-        ).thenAnswer((_) async => fakeEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
 
         final service = buildService();
         await service.deregister(testPubkey);
@@ -343,7 +343,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(fakeEvent),
-        ).thenAnswer((_) async => fakeEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
 
         final service = buildService();
         await service.updatePreferences(prefs);
@@ -484,7 +484,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => fakeEvent);
+        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
 
         final service = buildService();
 

--- a/mobile/test/services/video_event_publisher_cawg_identity_test.dart
+++ b/mobile/test/services/video_event_publisher_cawg_identity_test.dart
@@ -98,7 +98,7 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
       when(
         () => mockNostrService.queryEvents(

--- a/mobile/test/services/video_event_publisher_cawg_identity_test.dart
+++ b/mobile/test/services/video_event_publisher_cawg_identity_test.dart
@@ -98,7 +98,9 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
       when(
         () => mockNostrService.queryEvents(

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -125,7 +125,7 @@ void main() {
 
     when(
       () => nostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => publishedEvent);
+    ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
     when(
       () => nostrClient.queryEvents(
         any(),

--- a/mobile/test/services/video_event_publisher_language_tag_test.dart
+++ b/mobile/test/services/video_event_publisher_language_tag_test.dart
@@ -129,7 +129,7 @@ void main() {
 
     when(
       () => mockNostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => publishedEvent);
+    ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
     when(
       () => mockNostrClient.queryEvents(
         any(),

--- a/mobile/test/services/video_event_publisher_native_proof_test.dart
+++ b/mobile/test/services/video_event_publisher_native_proof_test.dart
@@ -127,7 +127,9 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
       when(
         () => mockNostrService.queryEvents(
@@ -269,7 +271,9 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       await publisher.publishDirectUpload(upload);
@@ -336,7 +340,9 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       final result = await publisher.publishDirectUpload(upload);

--- a/mobile/test/services/video_event_publisher_native_proof_test.dart
+++ b/mobile/test/services/video_event_publisher_native_proof_test.dart
@@ -127,7 +127,7 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
       when(
         () => mockNostrService.queryEvents(
@@ -269,7 +269,7 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       await publisher.publishDirectUpload(upload);
@@ -336,7 +336,7 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       final result = await publisher.publishDirectUpload(upload);

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -175,7 +175,7 @@ void main() {
       () async {
         final signedEvent = createSignedEvent();
         stubSigning(signedEvent);
-        // Relay rejects the event (publishEvent returns null).
+        // Relay rejects the event (publishEvent returns PublishFailed).
         when(
           () => mockNostrClient.publishEvent(any()),
         ).thenAnswer((_) async => const PublishFailed());
@@ -382,10 +382,7 @@ void main() {
 
       expect(result, isTrue);
       expect(
-        containsTag(audioTags, [
-          'url',
-          'https://cdn.example.com/audio.m4a',
-        ]),
+        containsTag(audioTags, ['url', 'https://cdn.example.com/audio.m4a']),
         isTrue,
       );
       expect(containsTag(audioTags, ['m', 'audio/m4a']), isTrue);

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -236,7 +236,9 @@ void main() {
         );
       });
       when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.single as Event,
+        ),
       );
 
       final result = await publisher.publishDirectUpload(
@@ -276,7 +278,9 @@ void main() {
         );
       });
       when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.single as Event,
+        ),
       );
 
       final result = await publisher.publishDirectUpload(
@@ -366,7 +370,9 @@ void main() {
         return Event(testPubkey, kind, tags, 'video content');
       });
       when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.single as Event,
+        ),
       );
 
       final result = await audioPublisher.publishDirectUpload(

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -138,7 +138,7 @@ void main() {
   void stubPublish(Event event) {
     when(
       () => mockNostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => event);
+    ).thenAnswer((_) async => PublishSuccess(event: event));
   }
 
   bool containsTag(List<List<String>> tags, List<String> expected) {
@@ -178,7 +178,7 @@ void main() {
         // Relay rejects the event (publishEvent returns null).
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         final result = await publisher.publishDirectUpload(createUpload());
 
@@ -236,7 +236,7 @@ void main() {
         );
       });
       when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments.single as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
       );
 
       final result = await publisher.publishDirectUpload(
@@ -276,7 +276,7 @@ void main() {
         );
       });
       when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments.single as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
       );
 
       final result = await publisher.publishDirectUpload(
@@ -366,7 +366,7 @@ void main() {
         return Event(testPubkey, kind, tags, 'video content');
       });
       when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => invocation.positionalArguments.single as Event,
+        (invocation) async => PublishSuccess(event: invocation.positionalArguments.single as Event),
       );
 
       final result = await audioPublisher.publishDirectUpload(

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -121,7 +121,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => _FakeEvent());
+        ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
         when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -181,7 +181,7 @@ void main() {
 
       when(
         () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => _FakeEvent());
+      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -211,7 +211,7 @@ void main() {
 
       when(
         () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => _FakeEvent());
+      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -242,7 +242,7 @@ void main() {
 
       when(
         () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => _FakeEvent());
+      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -312,7 +312,7 @@ void main() {
 
       when(
         () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => _FakeEvent());
+      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -351,7 +351,7 @@ void main() {
 
       when(
         () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => _FakeEvent());
+      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -385,7 +385,7 @@ void main() {
 
       when(
         () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => _FakeEvent());
+      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -73,7 +73,7 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
+        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(pubkey: _recipientPubkey),
@@ -125,7 +125,7 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
+        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(
@@ -286,7 +286,7 @@ void main() {
       ).thenAnswer((_) async => signedEvent);
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => signedEvent);
+      ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
@@ -322,7 +322,7 @@ void main() {
       );
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async => const PublishFailed());
 
       final now = DateTime.now();
       final result = await service.shareVideoWithUser(
@@ -698,7 +698,7 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
+        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(
@@ -734,7 +734,7 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
+        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -73,7 +73,9 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
+        (_) async => PublishSuccess(
+          event: Event(_testPubkey, 4, <List<String>>[], 'test'),
+        ),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(pubkey: _recipientPubkey),
@@ -125,7 +127,9 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
+        (_) async => PublishSuccess(
+          event: Event(_testPubkey, 4, <List<String>>[], 'test'),
+        ),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(
@@ -698,7 +702,9 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
+        (_) async => PublishSuccess(
+          event: Event(_testPubkey, 4, <List<String>>[], 'test'),
+        ),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(
@@ -734,7 +740,9 @@ void main() {
         (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
       );
       when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => PublishSuccess(event: Event(_testPubkey, 4, <List<String>>[], 'test')),
+        (_) async => PublishSuccess(
+          event: Event(_testPubkey, 4, <List<String>>[], 'test'),
+        ),
       );
       when(
         () => mockProfileRepository.fetchFreshProfile(

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -223,19 +223,22 @@ void main() {
         verifyNever(() => mockNostr.publishEvent(any()));
       });
 
-      test('returns false when publishEvent returns null', () async {
-        when(
-          () => mockNostr.publishEvent(any()),
-        ).thenAnswer((_) async => const PublishFailed());
+      test(
+        'returns false when publishEvent does not return PublishSuccess',
+        () async {
+          when(
+            () => mockNostr.publishEvent(any()),
+          ).thenAnswer((_) async => const PublishFailed());
 
-        final result = await publisher.publishViewEvent(
-          video: createTestVideoEvent(pubkey: creatorPubkey),
-          startSeconds: 0,
-          endSeconds: 5,
-        );
+          final result = await publisher.publishViewEvent(
+            video: createTestVideoEvent(pubkey: creatorPubkey),
+            startSeconds: 0,
+            endSeconds: 5,
+          );
 
-        expect(result, isFalse);
-      });
+          expect(result, isFalse);
+        },
+      );
 
       test('uses connected relay as relay hint when available', () async {
         when(

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -59,7 +59,7 @@ void main() {
       );
 
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       publisher = ViewEventPublisher(
@@ -222,7 +222,7 @@ void main() {
       });
 
       test('returns false when publishEvent returns null', () async {
-        when(() => mockNostr.publishEvent(any())).thenAnswer((_) async => null);
+        when(() => mockNostr.publishEvent(any())).thenAnswer((_) async => const PublishFailed());
 
         final result = await publisher.publishViewEvent(
           video: createTestVideoEvent(pubkey: creatorPubkey),
@@ -297,7 +297,7 @@ void main() {
           when(() => mockNostr.publishEvent(any())).thenAnswer((
             invocation,
           ) async {
-            return invocation.positionalArguments[0] as Event;
+            return PublishSuccess(event: invocation.positionalArguments[0] as Event);
           });
 
           await publisher.publishViewEvent(

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -59,7 +59,9 @@ void main() {
       );
 
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       publisher = ViewEventPublisher(
@@ -222,7 +224,9 @@ void main() {
       });
 
       test('returns false when publishEvent returns null', () async {
-        when(() => mockNostr.publishEvent(any())).thenAnswer((_) async => const PublishFailed());
+        when(
+          () => mockNostr.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
 
         final result = await publisher.publishViewEvent(
           video: createTestVideoEvent(pubkey: creatorPubkey),
@@ -297,7 +301,9 @@ void main() {
           when(() => mockNostr.publishEvent(any())).thenAnswer((
             invocation,
           ) async {
-            return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
           });
 
           await publisher.publishViewEvent(

--- a/mobile/test/unit/services/corrupted_video_repair_service_test.dart
+++ b/mobile/test/unit/services/corrupted_video_repair_service_test.dart
@@ -103,7 +103,7 @@ void main() {
     ) async {
       final event = invocation.positionalArguments[0] as Event;
       publishedEvents.add(event);
-      return event;
+      return PublishSuccess(event: event);
     });
   }
 
@@ -347,7 +347,7 @@ void main() {
 
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
 
         final result = await repairService.repairIfNeeded();
 

--- a/mobile/test/unit/services/nip17_message_service_test.dart
+++ b/mobile/test/unit/services/nip17_message_service_test.dart
@@ -43,7 +43,9 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
+        return PublishSuccess(
+          event: invocation.positionalArguments[0] as Event,
+        );
       });
 
       final result = await service.sendPrivateMessage(

--- a/mobile/test/unit/services/nip17_message_service_test.dart
+++ b/mobile/test/unit/services/nip17_message_service_test.dart
@@ -43,7 +43,7 @@ void main() {
       when(() => mockNostrService.publishEvent(any())).thenAnswer((
         invocation,
       ) async {
-        return invocation.positionalArguments[0] as Event;
+        return PublishSuccess(event: invocation.positionalArguments[0] as Event);
       });
 
       final result = await service.sendPrivateMessage(
@@ -71,7 +71,7 @@ void main() {
         invocation,
       ) async {
         capturedEvent = invocation.positionalArguments[0] as Event;
-        return capturedEvent;
+        return PublishSuccess(event: capturedEvent!);
       });
 
       await service.sendPrivateMessage(
@@ -90,7 +90,7 @@ void main() {
         invocation,
       ) async {
         capturedEvent = invocation.positionalArguments[0] as Event;
-        return capturedEvent;
+        return PublishSuccess(event: capturedEvent!);
       });
 
       await service.sendPrivateMessage(
@@ -114,7 +114,7 @@ void main() {
       ) async {
         final event = invocation.positionalArguments[0] as Event;
         capturedEvents.add(event);
-        return event;
+        return PublishSuccess(event: event);
       });
 
       await service.sendPrivateMessage(
@@ -142,7 +142,7 @@ void main() {
         invocation,
       ) async {
         capturedEvent = invocation.positionalArguments[0] as Event;
-        return capturedEvent;
+        return PublishSuccess(event: capturedEvent!);
       });
 
       final beforeSend = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -161,7 +161,7 @@ void main() {
     test('should handle publish failure gracefully', () async {
       when(
         () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async => const PublishFailed());
 
       final result = await service.sendPrivateMessage(
         recipientPubkey: _recipientPubkey,
@@ -179,7 +179,7 @@ void main() {
         invocation,
       ) async {
         capturedEvent = invocation.positionalArguments[0] as Event;
-        return capturedEvent;
+        return PublishSuccess(event: capturedEvent!);
       });
 
       await service.sendPrivateMessage(

--- a/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -113,7 +114,7 @@ void main() {
 
     when(
       () => mockNostrService.publishEvent(any()),
-    ).thenAnswer((_) async => signedEvent);
+    ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
 
     when(
       () => mockBookmarkService.isVideoBookmarkedGlobally(any()),


### PR DESCRIPTION


<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Introduces PublishResult sealed type (PublishSuccess / PublishNoRelays / PublishFailed) on NostrClient.publishEvent(), replacing the previous Event? return.

- sendProfile() now delegates through publishEvent() and maps the PublishResult variants to SendProfileResult, eliminating the duplicate relay-check + retry + send + cache scaffold that was inlined in #3813.
- All ~30 call sites updated to match on PublishResult variants instead of null-checking Event?.
- Test stubs across every affected package updated accordingly.
- nostr_client_test.dart assertions updated to use PublishSuccess / PublishNoRelays / PublishFailed matchers.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3830 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore