### PR TITLE
docs(funnelcake): correct stale totalCount fallback comment

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -227,8 +227,10 @@ class FunnelcakeApiClient {
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
 
-        // X-Total-Count header is the primary source; fall back to envelope
-        // pagination when the header is absent (post-#238 envelope shape).
+        // totalCount comes solely from the X-Total-Count response header.
+        // It is null when the header is absent — the envelope pagination object
+        // does not carry a total count. hasMore and nextOffset (via nextCursor)
+        // do come from the envelope when the v2 shape is used.
         final totalCountHeader = response.headers['x-total-count'];
         final totalCount = totalCountHeader != null
             ? int.tryParse(totalCountHeader)


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
hasMore and nextOffset do come from the envelope (correctly plumbed in PR #3529). The comment now accurately describes the source of each pagination field.

The previous comment claimed totalCount falls back to the v2 envelope pagination when the X-Total-Count header is absent. That fallback never existed - the code sets totalCount to null when the header is missing.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3544

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore