### PR TITLE
fix(l10n): localize feed mode and video author semantic labels

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2043,6 +2043,23 @@
     "feedModeForYou": "ለእርስዎ",
     "feedModeNew": "አዲስ",
     "feedModeFollowing": "እየተከተሉ",
+    "feedModeSemanticLabel": "የፊድ ሁነታ: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "የቪድዮ ፈጣሪ: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "የፈጣሪ ፎቶ",
     "feedForYouEmpty": "የእርስዎ ለአንተ ምግብ ባዶ ነው።\nቪዲዮዎችን ያስሱ እና ለመቅረጽ ፈጣሪዎችን ይከተሉ።",
     "feedFollowingEmpty": "እስካሁን ከምትከተላቸው ሰዎች ምንም ቪዲዮዎች የሉም።\nየሚወዷቸውን ፈጣሪዎች ያግኙ እና ይከተሉዋቸው።",
     "feedLatestEmpty": "እስካሁን ምንም አዲስ ቪዲዮዎች የሉም።\nበቅርቡ ተመልሰው ይመልከቱ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1735,6 +1735,23 @@
     "feedModeForYou": "لك",
     "feedModeNew": "جديد",
     "feedModeFollowing": "المتابَعون",
+    "feedModeSemanticLabel": "وضع الموجز: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "صانع الفيديو: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "صورة رمز صانع المحتوى",
     "feedForYouEmpty": "خلاصة لك فارغة.\nاستكشف المقاطع واتبع صناع المحتوى لتخصيصها.",
     "feedFollowingEmpty": "لا توجد مقاطع بعد من الأشخاص الذين تتابعهم.\nاعثر على صناع محتوى يعجبونك وتابعهم.",
     "feedLatestEmpty": "لا توجد مقاطع جديدة بعد.\nعد لاحقًا.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1944,6 +1944,23 @@
     "feedModeForYou": "За теб",
     "feedModeNew": "Ново",
     "feedModeFollowing": "Следвани",
+    "feedModeSemanticLabel": "Режим на емисията: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Автор на видеото: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Аватар на автора",
     "feedForYouEmpty": "Твоят фийд „За теб“ е празен.\nРазгледай видеа и последвай творци, за да го оформиш.",
     "feedFollowingEmpty": "Още няма видеа от хората, които следваш.\nНамери творци, които ти допадат, и ги последвай.",
     "feedLatestEmpty": "Още няма нови видеа.\nПровери пак скоро.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Für dich",
     "feedModeNew": "Neu",
     "feedModeFollowing": "Abonniert",
+    "feedModeSemanticLabel": "Feed-Modus: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Urheber des Videos: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar des Urhebers",
     "feedForYouEmpty": "Dein Für-dich-Feed ist leer.\nEntdecke Videos und folge Creator:innen, um ihn zu personalisieren.",
     "feedFollowingEmpty": "Noch keine Videos von Personen, denen du folgst.\nFinde Creator:innen, die dir gefallen, und folge ihnen.",
     "feedLatestEmpty": "Noch keine neuen Videos.\nSchau bald wieder vorbei.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2092,21 +2092,28 @@
   "feedModeFollowing": "Following",
   "feedModeSemanticLabel": "Feed mode: {label}",
   "@feedModeSemanticLabel": {
+    "description": "Semantic label for the feed mode row (current mode plus affordance hint). Screen reader only.",
     "placeholders": {
       "label": {
-        "type": "String"
+        "type": "String",
+        "description": "Localized name of the current feed mode (e.g. New, Following)."
       }
     }
   },
   "videoAuthorSemanticLabel": "Video author: {displayName}",
   "@videoAuthorSemanticLabel": {
+    "description": "Semantic label for the video author's display name region. Screen reader only.",
     "placeholders": {
       "displayName": {
-        "type": "String"
+        "type": "String",
+        "description": "Localized or resolved display name of the creator."
       }
     }
   },
   "videoAuthorAvatarSemanticLabel": "Author avatar",
+  "@videoAuthorAvatarSemanticLabel": {
+    "description": "Semantic label for the author's circular profile avatar on feed video metadata. Screen reader only."
+  },
   "feedForYouEmpty": "Your For You feed is empty.\nExplore videos and follow creators to shape it.",
   "feedFollowingEmpty": "No videos from people you follow yet.\nFind creators you like and follow them.",
   "feedLatestEmpty": "No new videos yet.\nCheck back soon.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2090,6 +2090,23 @@
   "feedModeForYou": "For You",
   "feedModeNew": "New",
   "feedModeFollowing": "Following",
+  "feedModeSemanticLabel": "Feed mode: {label}",
+  "@feedModeSemanticLabel": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "videoAuthorSemanticLabel": "Video author: {displayName}",
+  "@videoAuthorSemanticLabel": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
+  "videoAuthorAvatarSemanticLabel": "Author avatar",
   "feedForYouEmpty": "Your For You feed is empty.\nExplore videos and follow creators to shape it.",
   "feedFollowingEmpty": "No videos from people you follow yet.\nFind creators you like and follow them.",
   "feedLatestEmpty": "No new videos yet.\nCheck back soon.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1749,6 +1749,23 @@
     "feedModeForYou": "Para ti",
     "feedModeNew": "Nuevo",
     "feedModeFollowing": "Siguiendo",
+    "feedModeSemanticLabel": "Modo del feed: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Autor del video: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar del autor",
     "feedForYouEmpty": "Tu feed Para ti está vacío.\nExplora videos y sigue a creadores para personalizarlo.",
     "feedFollowingEmpty": "Aún no hay videos de personas que sigues.\nEncuentra creadores que te gusten y síguelos.",
     "feedLatestEmpty": "Aún no hay videos nuevos.\nVuelve pronto.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Pour toi",
     "feedModeNew": "Nouveau",
     "feedModeFollowing": "Abonnements",
+    "feedModeSemanticLabel": "Fil d'actualité : {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Auteur de la vidéo : {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar de l'auteur",
     "feedForYouEmpty": "Ton fil Pour toi est vide.\nExplore des vidéos et abonne-toi à des créateurs pour le personnaliser.",
     "feedFollowingEmpty": "Aucune vidéo des personnes que tu suis pour le moment.\nTrouve des créateurs que tu aimes et abonne-toi à eux.",
     "feedLatestEmpty": "Aucune nouvelle vidéo pour le moment.\nReviens bientôt.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1742,6 +1742,23 @@
     "feedModeForYou": "Untukmu",
     "feedModeNew": "Baru",
     "feedModeFollowing": "Mengikuti",
+    "feedModeSemanticLabel": "Mode feed: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Pembuat video: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar pembuat",
     "feedForYouEmpty": "Feed Untuk Anda kamu kosong.\nJelajahi video dan ikuti kreator untuk membentuknya.",
     "feedFollowingEmpty": "Belum ada video dari orang yang kamu ikuti.\nTemukan kreator yang kamu suka dan ikuti mereka.",
     "feedLatestEmpty": "Belum ada video baru.\nCek lagi sebentar lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Per te",
     "feedModeNew": "Nuovo",
     "feedModeFollowing": "Seguiti",
+    "feedModeSemanticLabel": "Modalità feed: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Autore del video: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar dell'autore",
     "feedForYouEmpty": "Il tuo feed Per te è vuoto.\nEsplora i video e segui i creator per personalizzarlo.",
     "feedFollowingEmpty": "Ancora nessun video dalle persone che segui.\nTrova creator che ti piacciono e seguili.",
     "feedLatestEmpty": "Ancora nessun nuovo video.\nTorna a controllare a breve.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1735,6 +1735,23 @@
     "feedModeForYou": "おすすめ",
     "feedModeNew": "新着",
     "feedModeFollowing": "フォロー中",
+    "feedModeSemanticLabel": "フィードモード: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "動画の作者: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "作者のアバター",
     "feedForYouEmpty": "おすすめフィードはまだ空です。\n動画を見つけてクリエイターをフォローし、あなた向けに育てましょう。",
     "feedFollowingEmpty": "フォロー中の人の動画はまだありません。\n気に入ったクリエイターを見つけてフォローしましょう。",
     "feedLatestEmpty": "新しい動画はまだありません。\nしばらくしてからもう一度確認してください。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1031,6 +1031,23 @@
     "feedModeForYou": "추천",
     "feedModeNew": "최신",
     "feedModeFollowing": "팔로잉",
+    "feedModeSemanticLabel": "피드 모드: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "동영상 작성자: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "작성자 프로필 사진",
     "feedForYouEmpty": "추천 피드가 비어 있어요.\n동영상을 탐색하고 크리에이터를 팔로우해 피드를 만들어보세요.",
     "feedFollowingEmpty": "아직 팔로우한 사람들의 동영상이 없어요.\n마음에 드는 크리에이터를 찾아 팔로우해 보세요.",
     "feedLatestEmpty": "아직 새로운 동영상이 없어요.\n잠시 후 다시 확인해 주세요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Voor jou",
     "feedModeNew": "Nieuw",
     "feedModeFollowing": "Volgend",
+    "feedModeSemanticLabel": "Feedmodus: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Video-auteur: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar van maker",
     "feedForYouEmpty": "Je Voor jou-feed is leeg.\nVerken video's en volg makers om hem vorm te geven.",
     "feedFollowingEmpty": "Nog geen video's van mensen die je volgt.\nVind makers die je leuk vindt en volg ze.",
     "feedLatestEmpty": "Nog geen nieuwe video's.\nKom binnenkort terug.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Dla ciebie",
     "feedModeNew": "Nowe",
     "feedModeFollowing": "Obserwowane",
+    "feedModeSemanticLabel": "Tryb kanału: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Autor filmu: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Awatar autora",
     "feedForYouEmpty": "Twój kanał Dla Ciebie jest pusty.\nOdkrywaj filmy i obserwuj twórców, aby go ukształtować.",
     "feedFollowingEmpty": "Brak filmów od osób, które obserwujesz.\nZnajdź twórców, których lubisz i zacznij ich obserwować.",
     "feedLatestEmpty": "Brak nowych filmów.\nWróć tu wkrótce.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Para você",
     "feedModeNew": "Novo",
     "feedModeFollowing": "Seguindo",
+    "feedModeSemanticLabel": "Modo do feed: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Autor do vídeo: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar do autor",
     "feedForYouEmpty": "Seu feed Para você está vazio.\nExplore vídeos e siga criadores para personalizá-lo.",
     "feedFollowingEmpty": "Ainda não há vídeos das pessoas que você segue.\nEncontre criadores de que goste e siga-os.",
     "feedLatestEmpty": "Ainda não há vídeos novos.\nVolte em breve.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "Pentru tine",
     "feedModeNew": "Nou",
     "feedModeFollowing": "Urmăresc",
+    "feedModeSemanticLabel": "Mod flux: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Autor videoclip: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Avatar autor",
     "feedForYouEmpty": "Feedul tău Pentru tine este gol.\nExplorează videoclipuri și urmărește creatori pentru a-l modela.",
     "feedFollowingEmpty": "Încă nu există videoclipuri de la persoanele pe care le urmărești.\nGăsește creatori care îți plac și urmărește-i.",
     "feedLatestEmpty": "Încă nu există videoclipuri noi.\nRevino curând.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1745,6 +1745,23 @@
     "feedModeForYou": "För dig",
     "feedModeNew": "Nytt",
     "feedModeFollowing": "Följer",
+    "feedModeSemanticLabel": "Flödesläge: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Videoförfattare: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Skapares avatar",
     "feedForYouEmpty": "Ditt För dig-flöde är tomt.\nUtforska videor och följ kreatörer för att forma det.",
     "feedFollowingEmpty": "Inga videor från personer du följer än.\nHitta kreatörer du gillar och följ dem.",
     "feedLatestEmpty": "Inga nya videor än.\nTitta in igen snart.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1742,6 +1742,23 @@
     "feedModeForYou": "Senin için",
     "feedModeNew": "Yeni",
     "feedModeFollowing": "Takip",
+    "feedModeSemanticLabel": "Akış modu: {label}",
+    "@feedModeSemanticLabel": {
+        "placeholders": {
+            "label": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorSemanticLabel": "Video yazarı: {displayName}",
+    "@videoAuthorSemanticLabel": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "videoAuthorAvatarSemanticLabel": "Yazar avatarı",
     "feedForYouEmpty": "Sana Özel akışın boş.\nVideolar keşfet ve içerik üreticileri takip ederek akışını şekillendir.",
     "feedFollowingEmpty": "Takip ettiğin kişilerden henüz video yok.\nBeğendiğin içerik üreticilerini bulup takip et.",
     "feedLatestEmpty": "Henüz yeni video yok.\nYakında tekrar kontrol et.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6972,19 +6972,19 @@ abstract class AppLocalizations {
   /// **'Following'**
   String get feedModeFollowing;
 
-  /// No description provided for @feedModeSemanticLabel.
+  /// Semantic label for the feed mode row (current mode plus affordance hint). Screen reader only.
   ///
   /// In en, this message translates to:
   /// **'Feed mode: {label}'**
   String feedModeSemanticLabel(String label);
 
-  /// No description provided for @videoAuthorSemanticLabel.
+  /// Semantic label for the video author's display name region. Screen reader only.
   ///
   /// In en, this message translates to:
   /// **'Video author: {displayName}'**
   String videoAuthorSemanticLabel(String displayName);
 
-  /// No description provided for @videoAuthorAvatarSemanticLabel.
+  /// Semantic label for the author's circular profile avatar on feed video metadata. Screen reader only.
   ///
   /// In en, this message translates to:
   /// **'Author avatar'**

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6972,6 +6972,24 @@ abstract class AppLocalizations {
   /// **'Following'**
   String get feedModeFollowing;
 
+  /// No description provided for @feedModeSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Feed mode: {label}'**
+  String feedModeSemanticLabel(String label);
+
+  /// No description provided for @videoAuthorSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Video author: {displayName}'**
+  String videoAuthorSemanticLabel(String displayName);
+
+  /// No description provided for @videoAuthorAvatarSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Author avatar'**
+  String get videoAuthorAvatarSemanticLabel;
+
   /// No description provided for @feedForYouEmpty.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3883,6 +3883,19 @@ class AppLocalizationsAm extends AppLocalizations {
   String get feedModeFollowing => 'እየተከተሉ';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'የእርስዎ ለአንተ ምግብ ባዶ ነው።\nቪዲዮዎችን ያስሱ እና ለመቅረጽ ፈጣሪዎችን ይከተሉ።';
 

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3884,16 +3884,16 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'የፊድ ሁነታ: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'የቪድዮ ፈጣሪ: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'የፈጣሪ ፎቶ';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3928,6 +3928,19 @@ class AppLocalizationsAr extends AppLocalizations {
   String get feedModeFollowing => 'المتابَعون';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'خلاصة لك فارغة.\nاستكشف المقاطع واتبع صناع المحتوى لتخصيصها.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3929,16 +3929,16 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'وضع الموجز: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'صانع الفيديو: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'صورة رمز صانع المحتوى';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4015,6 +4015,19 @@ class AppLocalizationsBg extends AppLocalizations {
   String get feedModeFollowing => 'Следвани';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Твоят фийд „За теб“ е празен.\nРазгледай видеа и последвай творци, за да го оформиш.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4016,16 +4016,16 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Режим на емисията: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Автор на видеото: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Аватар на автора';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4019,6 +4019,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get feedModeFollowing => 'Abonniert';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Dein Für-dich-Feed ist leer.\nEntdecke Videos und folge Creator:innen, um ihn zu personalisieren.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4020,16 +4020,16 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Feed-Modus: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Urheber des Videos: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar des Urhebers';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3971,6 +3971,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get feedModeFollowing => 'Following';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4015,6 +4015,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get feedModeFollowing => 'Siguiendo';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Tu feed Para ti está vacío.\nExplora videos y sigue a creadores para personalizarlo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4016,16 +4016,16 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Modo del feed: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Autor del video: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar del autor';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4030,6 +4030,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get feedModeFollowing => 'Abonnements';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Ton fil Pour toi est vide.\nExplore des vidéos et abonne-toi à des créateurs pour le personnaliser.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4031,16 +4031,16 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Fil d\'actualité : $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Auteur de la vidéo : $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar de l\'auteur';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3940,6 +3940,19 @@ class AppLocalizationsId extends AppLocalizations {
   String get feedModeFollowing => 'Mengikuti';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Feed Untuk Anda kamu kosong.\nJelajahi video dan ikuti kreator untuk membentuknya.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3941,16 +3941,16 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Mode feed: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Pembuat video: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar pembuat';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4014,16 +4014,16 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Modalità feed: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Autore del video: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar dell\'autore';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4013,6 +4013,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get feedModeFollowing => 'Seguiti';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Il tuo feed Per te è vuoto.\nEsplora i video e segui i creator per personalizzarlo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3777,16 +3777,16 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'フィードモード: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return '動画の作者: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => '作者のアバター';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3776,6 +3776,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get feedModeFollowing => 'フォロー中';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'おすすめフィードはまだ空です。\n動画を見つけてクリエイターをフォローし、あなた向けに育てましょう。';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3792,16 +3792,16 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return '피드 모드: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return '동영상 작성자: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => '작성자 프로필 사진';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3791,6 +3791,19 @@ class AppLocalizationsKo extends AppLocalizations {
   String get feedModeFollowing => '팔로잉';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       '추천 피드가 비어 있어요.\n동영상을 탐색하고 크리에이터를 팔로우해 피드를 만들어보세요.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3985,16 +3985,16 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Feedmodus: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Video-auteur: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar van maker';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3984,6 +3984,19 @@ class AppLocalizationsNl extends AppLocalizations {
   String get feedModeFollowing => 'Volgend';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Je Voor jou-feed is leeg.\nVerken video\'s en volg makers om hem vorm te geven.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4077,6 +4077,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String get feedModeFollowing => 'Obserwowane';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Twój kanał Dla Ciebie jest pusty.\nOdkrywaj filmy i obserwuj twórców, aby go ukształtować.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4078,16 +4078,16 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Tryb kanału: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Autor filmu: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Awatar autora';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3995,6 +3995,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get feedModeFollowing => 'Seguindo';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Seu feed Para você está vazio.\nExplore vídeos e siga criadores para personalizá-lo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3996,16 +3996,16 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Modo do feed: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Autor do vídeo: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar do autor';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4093,16 +4093,16 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Mod flux: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Autor videoclip: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Avatar autor';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4092,6 +4092,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get feedModeFollowing => 'Urmăresc';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Feedul tău Pentru tine este gol.\nExplorează videoclipuri și urmărește creatori pentru a-l modela.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3968,16 +3968,16 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Flödesläge: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Videoförfattare: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Skapares avatar';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3967,6 +3967,19 @@ class AppLocalizationsSv extends AppLocalizations {
   String get feedModeFollowing => 'Följer';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Ditt För dig-flöde är tomt.\nUtforska videor och följ kreatörer för att forma det.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3950,6 +3950,19 @@ class AppLocalizationsTr extends AppLocalizations {
   String get feedModeFollowing => 'Takip';
 
   @override
+  String feedModeSemanticLabel(String label) {
+    return 'Feed mode: $label';
+  }
+
+  @override
+  String videoAuthorSemanticLabel(String displayName) {
+    return 'Video author: $displayName';
+  }
+
+  @override
+  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+
+  @override
   String get feedForYouEmpty =>
       'Sana Özel akışın boş.\nVideolar keşfet ve içerik üreticileri takip ederek akışını şekillendir.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3951,16 +3951,16 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String feedModeSemanticLabel(String label) {
-    return 'Feed mode: $label';
+    return 'Akış modu: $label';
   }
 
   @override
   String videoAuthorSemanticLabel(String displayName) {
-    return 'Video author: $displayName';
+    return 'Video yazarı: $displayName';
   }
 
   @override
-  String get videoAuthorAvatarSemanticLabel => 'Author avatar';
+  String get videoAuthorAvatarSemanticLabel => 'Yazar avatarı';
 
   @override
   String get feedForYouEmpty =>

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -123,7 +123,7 @@ class _FeedModeContent extends StatelessWidget {
     return Row(
       children: [
         Semantics(
-          label: 'Feed mode: $label',
+          label: context.l10n.feedModeSemanticLabel(label),
           button: true,
           child: GestureDetector(
             behavior: .opaque,

--- a/mobile/lib/widgets/video_feed_item/video_author_info_section.dart
+++ b/mobile/lib/widgets/video_feed_item/video_author_info_section.dart
@@ -90,7 +90,7 @@ class VideoAuthorInfoSection extends ConsumerWidget {
                       identifier: 'video_author_name',
                       container: true,
                       explicitChildNodes: true,
-                      label: 'Video author: $displayName',
+                      label: context.l10n.videoAuthorSemanticLabel(displayName),
                       child: Text(
                         displayName,
                         style: VineTheme.titleSmallFont(),
@@ -200,7 +200,7 @@ class _AuthorAvatar extends StatelessWidget {
             imageUrl: avatarUrl,
             placeholderSeed: pubkey,
             size: 48,
-            semanticLabel: 'Author avatar',
+            semanticLabel: context.l10n.videoAuthorAvatarSemanticLabel,
             onTap: () {
               onInteracted?.call();
               final npub = normalizeToNpub(pubkey);

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1533,7 +1533,9 @@ class VideoOverlayActions extends ConsumerWidget {
                                       imageUrl: avatarUrl,
                                       name: displayName,
                                       size: 48,
-                                      semanticLabel: 'Author avatar',
+                                      semanticLabel: context
+                                          .l10n
+                                          .videoAuthorAvatarSemanticLabel,
                                       onTap: navigateToProfile,
                                     ),
                                     // Follow button positioned at bottom-right of avatar
@@ -1564,8 +1566,10 @@ class VideoOverlayActions extends ConsumerWidget {
                                               identifier: 'video_author_name',
                                               container: true,
                                               explicitChildNodes: true,
-                                              label:
-                                                  'Video author: $displayName',
+                                              label: context.l10n
+                                                  .videoAuthorSemanticLabel(
+                                                    displayName,
+                                                  ),
                                               child: Text(
                                                 displayName,
                                                 style:

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -373,11 +373,6 @@ const _knownUntranslatedDebt = {
   // divine.video/safety" link). Falls back to English in non-English
   // locales until translated.
   'reportLearnMoreAt',
-  // #4063 — feed mode / video author Semantics labels. English ships;
-  // other locales fall back until translators pick these up.
-  'feedModeSemanticLabel',
-  'videoAuthorSemanticLabel',
-  'videoAuthorAvatarSemanticLabel',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -373,6 +373,11 @@ const _knownUntranslatedDebt = {
   // divine.video/safety" link). Falls back to English in non-English
   // locales until translated.
   'reportLearnMoreAt',
+  // #4063 — feed mode / video author Semantics labels. English ships;
+  // other locales fall back until translators pick these up.
+  'feedModeSemanticLabel',
+  'videoAuthorSemanticLabel',
+  'videoAuthorAvatarSemanticLabel',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -233,14 +233,13 @@ void main() {
       // Helper: finds the Semantics widget that wraps the feed-mode
       // GestureDetector by walking up from the visible label text.
       Semantics findFeedModeSemanticsWidget(WidgetTester tester, String label) {
+        final expectedLabel = l10n.feedModeSemanticLabel(label);
         return tester.widget<Semantics>(
           find
               .ancestor(
                 of: find.text(label),
                 matching: find.byWidgetPredicate(
-                  (w) =>
-                      w is Semantics &&
-                      w.properties.label?.startsWith('Feed mode') == true,
+                  (w) => w is Semantics && w.properties.label == expectedLabel,
                 ),
               )
               .first,
@@ -258,10 +257,13 @@ void main() {
           );
           await tester.pumpWidget(createTestWidget());
 
-          final semanticsWidget = findFeedModeSemanticsWidget(tester, 'New');
+          final semanticsWidget = findFeedModeSemanticsWidget(
+            tester,
+            l10n.feedModeNew,
+          );
           expect(
             semanticsWidget.properties.label,
-            equals('Feed mode: ${l10n.feedModeNew}'),
+            equals(l10n.feedModeSemanticLabel(l10n.feedModeNew)),
           );
           expect(semanticsWidget.properties.button, isTrue);
         },
@@ -292,7 +294,9 @@ void main() {
           );
           expect(
             semanticsWidget.properties.label,
-            equals('Feed mode: ${l10n.feedModeFollowing}'),
+            equals(
+              l10n.feedModeSemanticLabel(l10n.feedModeFollowing),
+            ),
           );
         },
       );
@@ -315,7 +319,8 @@ void main() {
                   matching: find.byWidgetPredicate(
                     (w) =>
                         w is Semantics &&
-                        w.properties.label?.startsWith('Feed mode') == true,
+                        w.properties.label ==
+                            l10n.feedModeSemanticLabel(l10n.feedModeNew),
                   ),
                 )
                 .first,

--- a/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
@@ -6,6 +6,12 @@ import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart'
 
 void main() {
   group(ModeratedContentOverlay, () {
+    late AppLocalizations enL10n;
+
+    setUpAll(() {
+      enL10n = lookupAppLocalizations(const Locale('en'));
+    });
+
     Future<void> pumpOverlay(
       WidgetTester tester, {
       required PlaybackStatus status,
@@ -119,7 +125,10 @@ void main() {
       await pumpOverlay(tester, status: PlaybackStatus.forbidden);
 
       // The overlay must NOT show the usual FeedVideoOverlay chrome.
-      expect(find.bySemanticsLabel(RegExp('Video author: .*')), findsNothing);
+      final videoAuthorSemanticsPrefix = RegExp(
+        '^${RegExp.escape(enL10n.videoAuthorSemanticLabel(''))}',
+      );
+      expect(find.bySemanticsLabel(videoAuthorSemanticsPrefix), findsNothing);
       // The description tap target uses an action-oriented label
       // ("Open video details") in FeedVideoOverlay; either that or the
       // older content-echoing label would still indicate chrome leaked

--- a/mobile/test/widgets/video_feed_item/video_author_info_section_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_author_info_section_test.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Semantics regressions for shared author overlay metadata.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/widgets/video_feed_item/video_author_info_section.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+void main() {
+  late VideoEvent video;
+  late AppLocalizations enL10n;
+
+  const testPubkey =
+      'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+  setUpAll(() {
+    enL10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  setUp(() {
+    video = VideoEvent(
+      id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      pubkey: testPubkey,
+      createdAt: 1757385263,
+      content: '',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      videoUrl: 'https://example.com/video.mp4',
+      authorName: 'Semantic Display Name',
+      originalLoops: 0,
+    );
+  });
+
+  testWidgets(
+    'author row Semantics use localized avatar and author templates',
+    (tester) async {
+      final mockNostr = createMockNostrService();
+      when(() => mockNostr.publicKey).thenReturn(testPubkey);
+
+      await tester.pumpWidget(
+        testProviderScope(
+          mockNostrService: mockNostr,
+          additionalOverrides: [
+            userProfileReactiveProvider(testPubkey).overrideWith(
+              (ref) => Stream<UserProfile?>.value(null),
+            ),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoAuthorInfoSection(
+                video: video,
+                hasTextContent: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.bySemanticsLabel(
+          enL10n.videoAuthorSemanticLabel(video.authorName!),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel(enL10n.videoAuthorAvatarSemanticLabel),
+        findsOneWidget,
+      );
+    },
+  );
+}


### PR DESCRIPTION
<!--
    Thanks for contributing!
    Provide a description of your changes below and a general summary in the title
    Please look at the following checklist to ensure that your PR can be accepted quickly:
  -->
  ## Description
  Routes feed-mode and video-author semantics through `AppLocalizations` instead of raw English literals, so VoiceOver/TalkBack get locale-aware strings:
  - **`FeedModeSwitch`:** `Semantics.label` uses `feedModeSemanticLabel` with the already-localized mode title; sheet options stay on existing `feedMode*`
   keys (`feedModeForYou`, etc.).
  - **`VideoAuthorInfoSection` / `VideoFeedItem`:** author name `Semantics.label` uses `videoAuthorSemanticLabel`; avatar uses 
  `videoAuthorAvatarSemanticLabel`.
  Adds the matching entries to **`app_en.arb`** with ICU placeholders and translator-facing **`@…` descriptions**, mirrors keys (with translations and 
  placeholder metadata) across **ship `app_*.arb` locales**, removes the temporary **`_knownUntranslatedDebt`** entries once locales were filled, and 
  regenerates **`lib/l10n/generated/`**.
  Updates and adds widget tests (`feed_mode_switch_test`, `moderated_content_overlay_test`, `video_author_info_section_test`) so expectations follow 
  `lookupAppLocalizations`/templates instead of hardcoded English.
  **Suggested PR title (Conventional Commits):** `fix(l10n): localize feed mode and video author semantic labels`
  **Related Issue:** Closes #4063
  ## Type of Change
  <!--- Put an `x` in all the boxes that apply: -->
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
  - [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] 🧹 Code refactor
  - [ ] ✅ Build configuration change
  - [ ] 📝 Documentation
  - [ ] 🗑️ Chore