### PR TITLE
fix(dm): update NIP-17 publish result handling

### DIFF
--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -126,7 +126,7 @@ class NIP17MessageService {
         );
         if (selfWrapEvent != null) {
           final selfSent = await _nostrService.publishEvent(selfWrapEvent);
-          selfWrapPublished = selfSent != null;
+          selfWrapPublished = selfSent is PublishSuccess;
         }
       } on Object catch (e) {
         Log.error(

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -261,7 +261,7 @@ void main() {
 
       test(
         'returns success with selfWrapPublished=false '
-        'when self-wrap publish returns null',
+        'when self-wrap publish returns PublishFailed',
         () async {
           // Mirrors the silent-failure shape the reviewer flagged on
           // PR #3908: publishEvent returns null with no exception, so
@@ -289,6 +289,41 @@ void main() {
               return const PublishFailed();
             },
           );
+
+          final result = await matchingService.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
+
+          expect(result.success, isTrue);
+          expect(result.rumorEventId, isNotNull);
+          expect(result.selfWrapPublished, isFalse);
+        },
+      );
+
+      test(
+        'returns success with selfWrapPublished=false '
+        'when self-wrap publish returns PublishNoRelays',
+        () async {
+          final signer = LocalNostrSigner(_testPrivateKey);
+          final senderPublicKey = (await signer.getPublicKey())!;
+          final matchingService = NIP17MessageService(
+            signer: signer,
+            senderPublicKey: senderPublicKey,
+            nostrService: mockNostrClient,
+          );
+          var callCount = 0;
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+            invocation,
+          ) async {
+            callCount++;
+            if (callCount == 1) {
+              return PublishSuccess(
+                event: invocation.positionalArguments[0] as Event,
+              );
+            }
+            return const PublishNoRelays();
+          });
 
           final result = await matchingService.sendPrivateMessage(
             recipientPubkey: _recipientPubkey,

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -281,10 +281,12 @@ void main() {
               callCount++;
               if (callCount == 1) {
                 // Recipient publish succeeds.
-                return invocation.positionalArguments[0] as Event;
+                return PublishSuccess(
+                  event: invocation.positionalArguments[0] as Event,
+                );
               }
-              // Self-wrap publish returns null (silent failure).
-              return null;
+              // Self-wrap publish fails silently.
+              return const PublishFailed();
             },
           );
 


### PR DESCRIPTION
## Summary
Fix the DM repository analyzer break on main after `publishEvent()` moved to `PublishResult`.

- treat self-wrap publish success as `PublishSuccess` instead of a stale null check
- update the stale NIP-17 test stub to return `PublishSuccess` / `PublishFailed`

**Related Issue:** Fixes #4104

## Verification
- `flutter analyze lib test` in `mobile/packages/dm_repository`
- `flutter test test/src/nip17_message_service_test.dart`
