### PR TITLE
feat(dm): self-wrap-only recovery for sentPartial sends

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -29,6 +29,10 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     on<ConversationStarted>(_onStarted, transformer: restartable());
     on<ConversationMessageSent>(_onMessageSent, transformer: sequential());
     on<ConversationMessageDeleted>(_onMessageDeleted, transformer: droppable());
+    on<ConversationSelfWrapRecoveryRequested>(
+      _onSelfWrapRecoveryRequested,
+      transformer: sequential(),
+    );
   }
 
   final DmRepository _dmRepository;
@@ -112,6 +116,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         sendStatus: SendStatus.sending,
         messages: [optimisticMessage, ...state.messages],
         clearLastFailedSend: true,
+        clearLastPartialSend: true,
       ),
     );
 
@@ -120,15 +125,12 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       // persisted it locally, but the self-addressed gift wrap did not
       // reach relays. The sender's other devices will not see this
       // message on relay-only restore. Surface as a distinct status so
-      // the UI can offer a retry-sync path without claiming the send
-      // failed (the optimistic stays — the message *was* sent).
-      //
-      // Retrying redispatches the full send via [lastFailedSend], which
-      // double-delivers to the recipient on success. That tradeoff is
-      // accepted here: silent loss of cross-device sync is worse than a
-      // duplicate bubble. The principled fix — a durable outgoing queue
-      // that retries the self-wrap only — is tracked in #3909.
-      var selfWrapPublished = true;
+      // the UI can offer a self-wrap-only retry without re-delivering
+      // to the recipient (the optimistic stays — the message *was*
+      // sent). [lastPartialSend.rumorIds] carries the per-recipient
+      // rumor ids whose self-wrap publish failed, so retrying
+      // republishes only those self-wraps via [recoverSelfWrap].
+      final partialRumorIds = <String>[];
       if (event.recipientPubkeys.length == 1) {
         final result = await _dmRepository.sendMessage(
           recipientPubkey: event.recipientPubkeys.first,
@@ -137,7 +139,9 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         if (!result.success) {
           throw Exception(result.error ?? 'Failed to send message');
         }
-        selfWrapPublished = result.selfWrapPublished!;
+        if (result.selfWrapPublished == false) {
+          partialRumorIds.add(result.rumorEventId!);
+        }
       } else {
         final results = await _dmRepository.sendGroupMessage(
           recipientPubkeys: event.recipientPubkeys,
@@ -148,22 +152,20 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
             results.first.error ?? 'Failed to send group message',
           );
         }
-        // For groups, "self-wrap" is per-recipient. We treat the send as
-        // partial if any successful per-recipient send had its self-wrap
-        // fail, because that recipient's copy will not sync to the
-        // sender's other devices.
-        selfWrapPublished = results
-            .where((r) => r.success)
-            .every((r) => r.selfWrapPublished!);
+        // For groups, "self-wrap" is per-recipient. We collect the rumor
+        // ids of the successful per-recipient sends whose self-wrap
+        // failed — only those rumors need a recovery republish.
+        for (final result in results) {
+          if (result.success && result.selfWrapPublished == false) {
+            partialRumorIds.add(result.rumorEventId!);
+          }
+        }
       }
-      if (!selfWrapPublished) {
+      if (partialRumorIds.isNotEmpty) {
         emit(
           state.copyWith(
             sendStatus: SendStatus.sentPartial,
-            lastFailedSend: FailedSend(
-              content: event.content,
-              recipientPubkeys: event.recipientPubkeys,
-            ),
+            lastPartialSend: PartialSend(rumorIds: partialRumorIds),
           ),
         );
         return;
@@ -181,6 +183,58 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
             content: event.content,
             recipientPubkeys: event.recipientPubkeys,
           ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onSelfWrapRecoveryRequested(
+    ConversationSelfWrapRecoveryRequested event,
+    Emitter<ConversationState> emit,
+  ) async {
+    if (event.rumorIds.isEmpty) return;
+
+    emit(state.copyWith(sendStatus: SendStatus.sending));
+
+    final stillFailing = <String>[];
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    for (final rumorId in event.rumorIds) {
+      try {
+        final result = await _dmRepository.recoverSelfWrap(rumorId: rumorId);
+        if (!result.success) {
+          stillFailing.add(rumorId);
+        }
+      } on Object catch (e, stackTrace) {
+        // recoverSelfWrap can throw on missing/foreign queue rows or a
+        // missing DAO. Treat each thrown rumor as still-failing so the
+        // user can retry — recording the error for telemetry.
+        stillFailing.add(rumorId);
+        lastError = e;
+        lastStackTrace = stackTrace;
+      }
+    }
+
+    if (lastError != null) {
+      addError(lastError, lastStackTrace);
+    }
+
+    if (stillFailing.isEmpty) {
+      emit(
+        state.copyWith(
+          sendStatus: SendStatus.sent,
+          clearLastPartialSend: true,
+        ),
+      );
+    } else {
+      // Reduce lastPartialSend to only the rumors that are still
+      // failing, so a second Retry tap targets exactly those — never
+      // the ones that already recovered.
+      emit(
+        state.copyWith(
+          sendStatus: SendStatus.sentPartial,
+          lastPartialSend: PartialSend(rumorIds: stillFailing),
         ),
       );
     }

--- a/mobile/lib/blocs/dm/conversation/conversation_event.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_event.dart
@@ -37,3 +37,23 @@ class ConversationMessageDeleted extends ConversationEvent {
   @override
   List<Object?> get props => [rumorId];
 }
+
+/// Re-publish only the sender self-addressed gift wraps for rumors
+/// whose recipient publish landed but whose self-wrap did not.
+///
+/// Dispatched by the retry action on the `sentPartial` SnackBar. The
+/// repository's [recoverSelfWrap] never republishes the recipient
+/// wrap, so recipients are not re-delivered to. Carries the affected
+/// [rumorIds] explicitly rather than reading them from state — the
+/// handler stays decoupled from state shape and tests can act on the
+/// event payload alone.
+class ConversationSelfWrapRecoveryRequested extends ConversationEvent {
+  const ConversationSelfWrapRecoveryRequested({required this.rumorIds});
+
+  /// Rumor ids to re-publish self-wraps for. Sourced from
+  /// [PartialSend.rumorIds] in the originating sentPartial state.
+  final List<String> rumorIds;
+
+  @override
+  List<Object?> get props => [rumorIds];
+}

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -14,9 +14,14 @@ enum SendStatus { idle, sending, sent, sentPartial, failed }
 
 /// Snapshot of the most recent send attempt that did not reach the relay.
 ///
-/// Carried in [ConversationState] so the UI can offer a retry action without
-/// re-collecting the input from the user. Cleared on the next send attempt
-/// (success or failure path both replace it).
+/// Carried in [ConversationState] so the UI can offer a full-resend retry
+/// action without re-collecting the input from the user. Cleared on the
+/// next send attempt (success or failure path both replace it).
+///
+/// Distinct from [PartialSend], which carries the rumor ids needed for a
+/// self-wrap-only recovery on a [SendStatus.sentPartial] outcome — that
+/// path must NOT republish to recipients, and so cannot use [content] +
+/// [recipientPubkeys].
 class FailedSend extends Equatable {
   const FailedSend({required this.content, required this.recipientPubkeys});
 
@@ -30,30 +35,65 @@ class FailedSend extends Equatable {
   List<Object?> get props => [content, recipientPubkeys];
 }
 
+/// Snapshot of the rumor ids whose recipient publish landed but whose
+/// self-addressed gift wrap did not, on the most recent send attempt.
+///
+/// Drives the self-wrap-only recovery path: tapping Retry on the
+/// `sentPartial` SnackBar dispatches [ConversationSelfWrapRecoveryRequested]
+/// with [rumorIds], so only the missing self-wraps are republished and
+/// recipients are never re-delivered to. Lives separately from
+/// [FailedSend] because the data the recovery needs (rumor ids) is not
+/// the data a full resend needs (content + recipientPubkeys).
+class PartialSend extends Equatable {
+  const PartialSend({required this.rumorIds});
+
+  /// Rumor event ids whose self-wrap publish did not land. One id for a
+  /// 1:1 partial; one or more ids for a group partial (only the
+  /// per-recipient sends with `selfWrapPublished == false`).
+  final List<String> rumorIds;
+
+  @override
+  List<Object?> get props => [rumorIds];
+}
+
 class ConversationState extends Equatable {
   const ConversationState({
     this.status = ConversationStatus.initial,
     this.messages = const [],
     this.sendStatus = SendStatus.idle,
     this.lastFailedSend,
+    this.lastPartialSend,
   });
 
   final ConversationStatus status;
   final List<DmMessage> messages;
   final SendStatus sendStatus;
 
-  /// The last send attempt that failed and has not yet been retried.
+  /// The last send attempt that failed (recipient never received it) and
+  /// has not yet been retried.
   ///
   /// `null` when the most recent transition was a successful send, when no
   /// send has been attempted, or once the user has retried.
   final FailedSend? lastFailedSend;
+
+  /// The last send attempt that delivered to recipients but failed to
+  /// publish the sender self-addressed gift wrap, paired with the rumor
+  /// ids the recovery path must replay.
+  ///
+  /// `null` outside a [SendStatus.sentPartial] state. The retry SnackBar
+  /// reads this to dispatch [ConversationSelfWrapRecoveryRequested]
+  /// instead of a full [ConversationMessageSent], so recipients are
+  /// never re-delivered to.
+  final PartialSend? lastPartialSend;
 
   ConversationState copyWith({
     ConversationStatus? status,
     List<DmMessage>? messages,
     SendStatus? sendStatus,
     FailedSend? lastFailedSend,
+    PartialSend? lastPartialSend,
     bool clearLastFailedSend = false,
+    bool clearLastPartialSend = false,
   }) {
     return ConversationState(
       status: status ?? this.status,
@@ -62,9 +102,18 @@ class ConversationState extends Equatable {
       lastFailedSend: clearLastFailedSend
           ? null
           : (lastFailedSend ?? this.lastFailedSend),
+      lastPartialSend: clearLastPartialSend
+          ? null
+          : (lastPartialSend ?? this.lastPartialSend),
     );
   }
 
   @override
-  List<Object?> get props => [status, messages, sendStatus, lastFailedSend];
+  List<Object?> get props => [
+    status,
+    messages,
+    sendStatus,
+    lastFailedSend,
+    lastPartialSend,
+  ];
 }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -143,10 +143,19 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
   }
 
   void _onSendOutcome(BuildContext context, ConversationState state) {
-    final lastFailedSend = state.lastFailedSend;
-    if (lastFailedSend == null) return;
+    final isPartial = state.sendStatus == SendStatus.sentPartial;
+    // Pick the retry payload based on which outcome we're recovering
+    // from: failed → full resend (content + recipients), sentPartial →
+    // self-wrap-only recovery (rumor ids). Either side may be null on
+    // an out-of-band emit; bail out rather than show a SnackBar that
+    // does nothing.
+    final partialSend = state.lastPartialSend;
+    final failedSend = state.lastFailedSend;
+    if (isPartial && partialSend == null) return;
+    if (!isPartial && failedSend == null) return;
+
     final l10n = context.l10n;
-    final message = state.sendStatus == SendStatus.sentPartial
+    final message = isPartial
         ? l10n.dmSendPartialMessage
         : l10n.dmSendFailedMessage;
     final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
@@ -156,12 +165,21 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         action: SnackBarAction(
           label: l10n.dmSendFailedRetry,
           onPressed: () {
-            context.read<ConversationBloc>().add(
-              ConversationMessageSent(
-                recipientPubkeys: lastFailedSend.recipientPubkeys,
-                content: lastFailedSend.content,
-              ),
-            );
+            final bloc = context.read<ConversationBloc>();
+            if (isPartial) {
+              bloc.add(
+                ConversationSelfWrapRecoveryRequested(
+                  rumorIds: partialSend!.rumorIds,
+                ),
+              );
+            } else {
+              bloc.add(
+                ConversationMessageSent(
+                  recipientPubkeys: failedSend!.recipientPubkeys,
+                  content: failedSend.content,
+                ),
+              );
+            }
           },
         ),
       ),

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -940,29 +940,11 @@ class DmRepository {
     } else if (outgoingDao != null) {
       // Recipient publish failed before the self-wrap could land, so
       // both wrap statuses remain retryable on the queue row.
-      final errorMessage = result.error ?? 'Unknown publish failure';
-      try {
-        await outgoingDao.markRecipientWrapStatus(
-          id: rumor.id,
-          status: OutgoingWrapStatus.failed,
-          lastError: errorMessage,
-        );
-        await outgoingDao.markSelfWrapStatus(
-          id: rumor.id,
-          status: OutgoingWrapStatus.failed,
-          lastError: errorMessage,
-        );
-      } on Object catch (e, stackTrace) {
-        Log.error(
-          'Failed to mark outgoing_dms row failed for ${rumor.id}: $e',
-          category: LogCategory.system,
-          error: e,
-          stackTrace: stackTrace,
-        );
-        // Don't rethrow — caller already gets the failure result. The
-        // queue row stays in pending/pending; getStillPendingForOwner
-        // will surface it on the next retry sweep.
-      }
+      await _finalizeAfterRecipientFailure(
+        outgoingDao: outgoingDao,
+        rumorId: rumor.id,
+        errorMessage: result.error ?? 'Unknown publish failure',
+      );
     }
 
     return result;
@@ -1142,6 +1124,38 @@ class DmRepository {
     }
   }
 
+  /// Apply the queue-row transition for a failed per-recipient rumor
+  /// publish. Shared between [sendMessage] and [sendGroupMessage] so
+  /// both call sites keep recipient/self wrap failure bookkeeping in
+  /// lockstep.
+  Future<void> _finalizeAfterRecipientFailure({
+    required OutgoingDmsDao outgoingDao,
+    required String rumorId,
+    required String errorMessage,
+  }) async {
+    try {
+      await outgoingDao.markRecipientWrapStatus(
+        id: rumorId,
+        status: OutgoingWrapStatus.failed,
+        lastError: errorMessage,
+      );
+      await outgoingDao.markSelfWrapStatus(
+        id: rumorId,
+        status: OutgoingWrapStatus.failed,
+        lastError: errorMessage,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to mark outgoing_dms row failed for $rumorId: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      // Don't rethrow — caller already gets the failure result. The
+      // queue row stays retryable and the next sweep can pick it up.
+    }
+  }
+
   /// Send a text message to a group conversation.
   ///
   /// Throws [StateError] if the repository has not been initialized.
@@ -1296,28 +1310,11 @@ class DmRepository {
       for (var i = 0; i < rumors.length; i++) {
         final result = results[i];
         if (result.success) continue;
-        final errorMessage = result.error ?? 'Unknown publish failure';
-        try {
-          await outgoingDao.markRecipientWrapStatus(
-            id: rumors[i].id,
-            status: OutgoingWrapStatus.failed,
-            lastError: errorMessage,
-          );
-          await outgoingDao.markSelfWrapStatus(
-            id: rumors[i].id,
-            status: OutgoingWrapStatus.failed,
-            lastError: errorMessage,
-          );
-        } on Object catch (e, stackTrace) {
-          Log.error(
-            'Failed to mark outgoing_dms row failed for ${rumors[i].id}: '
-            '$e',
-            category: LogCategory.system,
-            error: e,
-            stackTrace: stackTrace,
-          );
-          // Don't rethrow — caller already gets the failure result.
-        }
+        await _finalizeAfterRecipientFailure(
+          outgoingDao: outgoingDao,
+          rumorId: rumors[i].id,
+          errorMessage: result.error ?? 'Unknown publish failure',
+        );
       }
     }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -977,12 +977,152 @@ class DmRepository {
     return result;
   }
 
+  /// Re-publish only the sender self-addressed gift wrap for an
+  /// already-sent rumor whose recipient publish landed but whose
+  /// self-wrap did not.
+  ///
+  /// Looks up the queue row for [rumorId] (must have been enqueued by
+  /// [sendMessage] / [sendGroupMessage]), rebuilds the rumor from the
+  /// stored JSON, calls [NIP17MessageService.publishSelfWrap], and
+  /// transitions the queue row by outcome:
+  ///
+  /// - Success: delete the queue row — both wraps have now landed.
+  /// - Failure: mark the self-wrap status [OutgoingWrapStatus.failed]
+  ///   so the row stays retryable.
+  ///
+  /// Returns the underlying [NIP17SendResult] so callers can chain a
+  /// per-rumor recovery and aggregate the result.
+  ///
+  /// Idempotent: if the row's `selfWrapStatus` is already
+  /// [OutgoingWrapStatus.sent] (e.g. a concurrent recovery already
+  /// landed), returns success without republishing.
+  ///
+  /// Throws [StateError] if the repository or its queue DAO are not
+  /// wired in. Throws [ArgumentError] if no row exists for [rumorId]
+  /// or the row belongs to a different account.
+  Future<NIP17SendResult> recoverSelfWrap({required String rumorId}) async {
+    _assertInitialized();
+    final dao = _outgoingDmsDao;
+    if (dao == null) {
+      throw StateError(
+        'recoverSelfWrap requires the outgoing_dms queue DAO; '
+        'wire OutgoingDmsDao into DmRepository before calling.',
+      );
+    }
+    final row = await dao.getById(rumorId);
+    if (row == null) {
+      throw ArgumentError.value(
+        rumorId,
+        'rumorId',
+        'no queued outgoing DM with this id',
+      );
+    }
+    if (row.ownerPubkey != _userPubkey) {
+      throw ArgumentError.value(
+        rumorId,
+        'rumorId',
+        'queue row belongs to a different account',
+      );
+    }
+
+    // Idempotent re-tap: a concurrent recovery already landed. Return
+    // success so the caller's aggregation treats this rumor as done.
+    if (row.selfWrapStatus == OutgoingWrapStatus.sent) {
+      return NIP17SendResult.success(
+        rumorEventId: rumorId,
+        messageEventId: row.selfWrapEventId ?? rumorId,
+        recipientPubkey: _userPubkey,
+      );
+    }
+
+    final Event rumor;
+    try {
+      final json = jsonDecode(row.rumorEventJson) as Map<String, dynamic>;
+      rumor = Event.fromJson(json);
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to parse rumor JSON for $rumorId: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      // Mark the self-wrap status failed so the row surfaces in the
+      // next retry sweep with a record of the parse failure.
+      try {
+        await dao.markSelfWrapStatus(
+          id: rumorId,
+          status: OutgoingWrapStatus.failed,
+          lastError: 'rumor JSON parse failed: $e',
+        );
+      } on Object {
+        // Swallow — caller still gets the failure result below.
+      }
+      return NIP17SendResult.failure('rumor JSON parse failed: $e');
+    }
+
+    final result = await _messageService!.publishSelfWrap(rumorEvent: rumor);
+
+    if (result.success) {
+      // Both wraps have landed. Mirror sendMessage's full-delivery
+      // path: drop the queue row so the retry sweep stops returning it.
+      try {
+        await dao.deleteById(rumorId);
+      } on Object catch (e, stackTrace) {
+        Log.error(
+          'Failed to delete outgoing_dms row $rumorId after self-wrap '
+          'recovery: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        // The publish succeeded; the bookkeeping failure is degraded
+        // state, not a recovery failure. The retry sweep will re-fire
+        // recoverSelfWrap, which will short-circuit via the
+        // already-sent guard above on the next pass — except we have
+        // no easy way to mark sent without re-deleting. The row
+        // staying in `recipient: sent / self: failed` means the next
+        // sweep republishes the self-wrap again, producing a
+        // duplicate self-wrap on relays. Self-wraps to the sender are
+        // idempotent on receive (NIP-17 dedup keys on the rumor id),
+        // so this degraded path is safe — surface it via the log.
+      }
+    } else {
+      try {
+        await dao.markSelfWrapStatus(
+          id: rumorId,
+          status: OutgoingWrapStatus.failed,
+          lastError: result.error ?? 'self-wrap recovery failed',
+        );
+      } on Object catch (e, stackTrace) {
+        Log.error(
+          'Failed to mark outgoing_dms self-wrap failed for $rumorId: '
+          '$e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        // Don't rethrow — caller already gets the failure result.
+      }
+    }
+
+    return result;
+  }
+
   /// Send a text message to a group conversation.
   ///
   /// Throws [StateError] if the repository has not been initialized.
   /// Throws [ArgumentError] if any pubkey in [recipientPubkeys] is not
   /// a 64-character hex string, if [content] is empty, or if
   /// [recipientPubkeys] is empty.
+  ///
+  /// When an [OutgoingDmsDao] is injected, each per-recipient send
+  /// goes through the durable queue with the same atomicity contract
+  /// as [sendMessage]: enqueue a `pending`/`pending` row keyed by the
+  /// per-recipient rumor id, publish, then transition the row by wrap
+  /// outcome (full delivery → row deleted in the same transaction
+  /// that inserts `direct_messages`; partial delivery → recipient
+  /// `sent` + self `failed` so the recovery path can replay only the
+  /// missing self-wraps without re-delivering to recipients).
   Future<List<NIP17SendResult>> sendGroupMessage({
     required List<String> recipientPubkeys,
     required String content,
@@ -1001,6 +1141,11 @@ class DmRepository {
       throw ArgumentError.value(content, 'content', 'must not be empty');
     }
 
+    final participants = [_userPubkey, ...recipientPubkeys]..sort();
+    final conversationId = computeConversationId(participants);
+    final outgoingDao = _outgoingDmsDao;
+
+    final rumors = <Event>[];
     final results = <NIP17SendResult>[];
 
     for (final pubkey in recipientPubkeys) {
@@ -1011,18 +1156,53 @@ class DmRepository {
         if (replyToId != null) ['e', replyToId],
       ];
 
-      final result = await _messageService!.sendPrivateMessage(
+      // Build the rumor up front so the queue row PK matches the rumor
+      // id the relay will see (each recipient gets a distinct rumor —
+      // their p-tag set differs — so queue rows never collide across
+      // a single group send).
+      final rumor = _messageService!.buildRumor(
         recipientPubkey: pubkey,
         content: content,
         additionalTags: additionalTags,
       );
+
+      // Enqueue before publish so an app crash mid-send leaves a
+      // recoverable trace per recipient. Same contract as sendMessage:
+      // no-op when the queue dao isn't wired in (older test fixtures,
+      // NIP-04-only callers).
+      if (outgoingDao != null) {
+        await outgoingDao.enqueue(
+          OutgoingDm(
+            id: rumor.id,
+            conversationId: conversationId,
+            recipientPubkey: pubkey,
+            content: content,
+            createdAt: rumor.createdAt,
+            rumorEventJson: jsonEncode(rumor.toJson()),
+            messageKind: rumor.kind,
+            replyToId: replyToId,
+            recipientWrapStatus: OutgoingWrapStatus.pending,
+            selfWrapStatus: OutgoingWrapStatus.pending,
+            queuedAt: DateTime.now(),
+            ownerPubkey: _userPubkey,
+          ),
+        );
+      }
+
+      final result = await _messageService!.sendRumor(
+        rumorEvent: rumor,
+        recipientPubkey: pubkey,
+      );
+      rumors.add(rumor);
       results.add(result);
     }
 
-    // If at least one send succeeded, persist locally (atomically).
+    // If at least one send succeeded, persist locally (atomically). The
+    // per-recipient queue updates for successful tuples ride inside the
+    // same transaction so a watcher never observes a window where the
+    // message is in neither table — and partial deliveries preserve
+    // the retry row for the recovery path.
     if (results.any((r) => r.success)) {
-      final participants = [_userPubkey, ...recipientPubkeys]..sort();
-      final conversationId = computeConversationId(participants);
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final firstSuccess = results.firstWhere((r) => r.success);
       final localTags = <List<String>>[
@@ -1059,7 +1239,62 @@ class DmRepository {
           ownerPubkey: _userPubkey,
           dmProtocol: existingGroup?.dmProtocol,
         );
+
+        if (outgoingDao != null) {
+          for (var i = 0; i < rumors.length; i++) {
+            final rumor = rumors[i];
+            final result = results[i];
+            if (!result.success) continue;
+            if (result.selfWrapPublished == true) {
+              await outgoingDao.deleteById(rumor.id);
+            } else {
+              await outgoingDao.markRecipientWrapStatus(
+                id: rumor.id,
+                status: OutgoingWrapStatus.sent,
+                eventId: result.messageEventId,
+              );
+              await outgoingDao.markSelfWrapStatus(
+                id: rumor.id,
+                status: OutgoingWrapStatus.failed,
+                lastError: 'Recipient delivered, but self-wrap publish failed',
+              );
+            }
+          }
+        }
       });
+    }
+
+    // Recipient publish failures: mark both wraps failed so the row
+    // stays retryable. Lives outside the success-transaction, mirroring
+    // sendMessage's split: a recipient-failed tuple has nothing to
+    // atomically tie the queue update to (no message row insert).
+    if (outgoingDao != null) {
+      for (var i = 0; i < rumors.length; i++) {
+        final result = results[i];
+        if (result.success) continue;
+        final errorMessage = result.error ?? 'Unknown publish failure';
+        try {
+          await outgoingDao.markRecipientWrapStatus(
+            id: rumors[i].id,
+            status: OutgoingWrapStatus.failed,
+            lastError: errorMessage,
+          );
+          await outgoingDao.markSelfWrapStatus(
+            id: rumors[i].id,
+            status: OutgoingWrapStatus.failed,
+            lastError: errorMessage,
+          );
+        } on Object catch (e, stackTrace) {
+          Log.error(
+            'Failed to mark outgoing_dms row failed for ${rumors[i].id}: '
+            '$e',
+            category: LogCategory.system,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          // Don't rethrow — caller already gets the failure result.
+        }
+      }
     }
 
     return results;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -893,20 +893,11 @@ class DmRepository {
           );
 
           if (outgoingDao != null) {
-            if (result.selfWrapPublished == true) {
-              await outgoingDao.deleteById(rumor.id);
-            } else {
-              await outgoingDao.markRecipientWrapStatus(
-                id: rumor.id,
-                status: OutgoingWrapStatus.sent,
-                eventId: result.messageEventId,
-              );
-              await outgoingDao.markSelfWrapStatus(
-                id: rumor.id,
-                status: OutgoingWrapStatus.failed,
-                lastError: 'Recipient delivered, but self-wrap publish failed',
-              );
-            }
+            await _finalizeAfterRecipientSuccess(
+              outgoingDao: outgoingDao,
+              rumorId: rumor.id,
+              result: result,
+            );
           }
         });
 
@@ -1025,8 +1016,11 @@ class DmRepository {
       );
     }
 
-    // Idempotent re-tap: a concurrent recovery already landed. Return
-    // success so the caller's aggregation treats this rumor as done.
+    // Idempotent re-tap. Reached when a prior recovery attempt's publish
+    // already landed: either a concurrent recovery for this rumor, or
+    // the previous sweep's deleteById threw and the fallback below
+    // marked self_wrap_status=sent. Return success so the caller's
+    // aggregation treats this rumor as done without re-publishing.
     if (row.selfWrapStatus == OutgoingWrapStatus.sent) {
       return NIP17SendResult.success(
         rumorEventId: rumorId,
@@ -1075,16 +1069,30 @@ class DmRepository {
           error: e,
           stackTrace: stackTrace,
         );
-        // The publish succeeded; the bookkeeping failure is degraded
-        // state, not a recovery failure. The retry sweep will re-fire
-        // recoverSelfWrap, which will short-circuit via the
-        // already-sent guard above on the next pass — except we have
-        // no easy way to mark sent without re-deleting. The row
-        // staying in `recipient: sent / self: failed` means the next
-        // sweep republishes the self-wrap again, producing a
-        // duplicate self-wrap on relays. Self-wraps to the sender are
-        // idempotent on receive (NIP-17 dedup keys on the rumor id),
-        // so this degraded path is safe — surface it via the log.
+        // Publish landed but the row is still here. Mark
+        // self_wrap_status=sent with the published event id so the next
+        // recovery sweep short-circuits via the idempotent guard above
+        // instead of republishing the self-wrap.
+        try {
+          await dao.markSelfWrapStatus(
+            id: rumorId,
+            status: OutgoingWrapStatus.sent,
+            eventId: result.messageEventId,
+          );
+        } on Object catch (markError, markStack) {
+          Log.error(
+            'Fallback markSelfWrapStatus(sent) also failed for $rumorId: '
+            '$markError',
+            category: LogCategory.system,
+            error: markError,
+            stackTrace: markStack,
+          );
+          // Both bookkeeping writes failed. The row stays
+          // `recipient: sent / self: failed` and the next sweep
+          // republishes the self-wrap. Self-wraps to the sender are
+          // idempotent on receive (NIP-17 dedup keys on the rumor id),
+          // so the doubly-degraded path is safe — surfaced via logs.
+        }
       }
     } else {
       try {
@@ -1106,6 +1114,32 @@ class DmRepository {
     }
 
     return result;
+  }
+
+  /// Apply the queue-row transition for a successful per-recipient
+  /// rumor publish. Shared between [sendMessage] and [sendGroupMessage]
+  /// so both call sites agree on the partial-vs-full delivery
+  /// bookkeeping. The caller is responsible for invoking this inside
+  /// the same transaction that persists the local message row.
+  Future<void> _finalizeAfterRecipientSuccess({
+    required OutgoingDmsDao outgoingDao,
+    required String rumorId,
+    required NIP17SendResult result,
+  }) async {
+    if (result.selfWrapPublished == true) {
+      await outgoingDao.deleteById(rumorId);
+    } else {
+      await outgoingDao.markRecipientWrapStatus(
+        id: rumorId,
+        status: OutgoingWrapStatus.sent,
+        eventId: result.messageEventId,
+      );
+      await outgoingDao.markSelfWrapStatus(
+        id: rumorId,
+        status: OutgoingWrapStatus.failed,
+        lastError: 'Recipient delivered, but self-wrap publish failed',
+      );
+    }
   }
 
   /// Send a text message to a group conversation.
@@ -1242,23 +1276,13 @@ class DmRepository {
 
         if (outgoingDao != null) {
           for (var i = 0; i < rumors.length; i++) {
-            final rumor = rumors[i];
             final result = results[i];
             if (!result.success) continue;
-            if (result.selfWrapPublished == true) {
-              await outgoingDao.deleteById(rumor.id);
-            } else {
-              await outgoingDao.markRecipientWrapStatus(
-                id: rumor.id,
-                status: OutgoingWrapStatus.sent,
-                eventId: result.messageEventId,
-              );
-              await outgoingDao.markSelfWrapStatus(
-                id: rumor.id,
-                status: OutgoingWrapStatus.failed,
-                lastError: 'Recipient delivered, but self-wrap publish failed',
-              );
-            }
+            await _finalizeAfterRecipientSuccess(
+              outgoingDao: outgoingDao,
+              rumorId: rumors[i].id,
+              result: result,
+            );
           }
         }
       });

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -147,46 +147,16 @@ class NIP17MessageService {
 
       // NIP-17: publish a self-addressed gift wrap so our own sent
       // messages are recoverable from relays after reinstall or data
-      // loss. Three independent failure modes — track them separately
-      // so the result can distinguish recipient-only delivery from
-      // full delivery. Re-publishing the recipient wrap would
-      // double-deliver, so any future retry handling must target only
-      // the self-wrap (see #3909).
-      var selfWrapPublished = false;
-      try {
-        final selfWrapEvent = await _giftWrapBuilder(
-          nostr,
-          rumorEvent,
-          _senderPublicKey,
-        );
-        if (selfWrapEvent == null) {
-          Log.warning(
-            'Self-wrap creation returned null — recipient was '
-            'delivered, but the sender will not see this message on '
-            'other devices or after a reinstall.',
-            category: LogCategory.system,
-          );
-        } else {
-          final published = await _nostrService.publishEvent(selfWrapEvent);
-          if (published is! PublishSuccess) {
-            Log.warning(
-              'Self-wrap publish failed — recipient was '
-              'delivered, but the sender will not see this message on '
-              'other devices or after a reinstall.',
-              category: LogCategory.system,
-            );
-          } else {
-            selfWrapPublished = true;
-          }
-        }
-      } on Object catch (e) {
-        Log.error(
-          'Self-wrap failed (non-fatal): recipient was delivered, but '
-          'the sender will not see this message on other devices or '
-          'after a reinstall: $e',
-          category: LogCategory.system,
-        );
-      }
+      // loss. The recipient already received the message at this
+      // point, so a self-wrap failure must never bubble up — the
+      // helper catches everything and reports the per-wrap status
+      // separately. Re-publishing the recipient wrap would
+      // double-deliver, so the recovery path uses [publishSelfWrap]
+      // to retry only the missing self-wrap.
+      final selfWrapPublished = await _publishSelfWrap(
+        nostr: nostr,
+        rumorEvent: rumorEvent,
+      );
 
       Log.info(
         'Successfully published NIP-17 message '
@@ -207,6 +177,103 @@ class NIP17MessageService {
         stackTrace: stackTrace,
       );
       return NIP17SendResult.failure('Failed to send message: $e');
+    }
+  }
+
+  /// Publish only the sender self-addressed gift wrap for an
+  /// already-sent [rumorEvent].
+  ///
+  /// Used by the recovery path when a previous [sendRumor] delivered
+  /// to the recipient (the recipient kind 1059 wrap landed) but the
+  /// self-addressed wrap did not. Re-running [sendRumor] would publish
+  /// the recipient wrap a second time and double-deliver, so the
+  /// recovery path goes through this method instead. Receiver-side
+  /// dedup keys on the rumor event id, so callers must pass the same
+  /// rumor that was published originally — rebuilding it from the
+  /// queue's `rumor_event_json` preserves the id, minting a fresh
+  /// rumor would not.
+  ///
+  /// Returns [NIP17SendResult.success] on a successful self-wrap
+  /// publish (the `messageEventId` slot carries the rumor id since no
+  /// new recipient-wrap event id is produced on this path) or
+  /// [NIP17SendResult.failure] when the self-wrap could not be built
+  /// or did not reach a relay.
+  Future<NIP17SendResult> publishSelfWrap({required Event rumorEvent}) async {
+    try {
+      Log.info(
+        'Publishing self-addressed NIP-17 gift wrap for rumor recovery',
+        category: LogCategory.system,
+      );
+
+      final nostr = Nostr(_signer, [], _dummyRelayGenerator);
+      await nostr.refreshPublicKey();
+
+      final published = await _publishSelfWrap(
+        nostr: nostr,
+        rumorEvent: rumorEvent,
+      );
+      if (!published) {
+        return const NIP17SendResult.failure('Self-wrap publish failed');
+      }
+      return NIP17SendResult.success(
+        rumorEventId: rumorEvent.id,
+        messageEventId: rumorEvent.id,
+        recipientPubkey: _senderPublicKey,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to publish self-wrap recovery: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return NIP17SendResult.failure('Failed to publish self-wrap: $e');
+    }
+  }
+
+  /// Build and publish the sender self-addressed gift wrap for
+  /// [rumorEvent]. Returns `true` when the wrap reached at least one
+  /// relay.
+  ///
+  /// Catches every error — used by both the happy-path send (where the
+  /// recipient has already received the message and an exception must
+  /// not crash the result) and the recovery path (where an exception
+  /// is just another failure mode the caller surfaces).
+  Future<bool> _publishSelfWrap({
+    required Nostr nostr,
+    required Event rumorEvent,
+  }) async {
+    try {
+      final selfWrapEvent = await _giftWrapBuilder(
+        nostr,
+        rumorEvent,
+        _senderPublicKey,
+      );
+      if (selfWrapEvent == null) {
+        Log.warning(
+          'Self-wrap creation returned null — the sender will not see '
+          'this message on other devices or after a reinstall.',
+          category: LogCategory.system,
+        );
+        return false;
+      }
+      final published = await _nostrService.publishEvent(selfWrapEvent);
+      if (published is! PublishSuccess) {
+        Log.warning(
+          'Self-wrap publish failed — the sender will not see this '
+          'message on other devices or after a reinstall.',
+          category: LogCategory.system,
+        );
+        return false;
+      }
+      return true;
+    } on Object catch (e) {
+      Log.error(
+        'Self-wrap failed (non-fatal): the sender will not see this '
+        'message on other devices or after a reinstall: $e',
+        category: LogCategory.system,
+      );
+      return false;
     }
   }
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8175,6 +8175,102 @@ void main() {
       );
 
       test(
+        'on successful self-wrap publish: when deleteById throws, '
+        'falls back to markSelfWrapStatus(sent, eventId) and still '
+        'returns success',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          when(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: _validPubkeyA,
+            ),
+          );
+          when(
+            () => mockOutgoingDmsDao.deleteById(_rumorEventId),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          // Publish landed → recovery is a success even though the
+          // delete failed.
+          expect(result.success, isTrue);
+
+          // Fallback closes the duplicate-publish hole: marks the row
+          // sent with the published event id so the next sweep
+          // short-circuits via the idempotent already-sent guard
+          // instead of republishing the self-wrap.
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.sent,
+              eventId: _giftWrapEventId2,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'on successful self-wrap publish: when both deleteById AND '
+        'fallback markSelfWrapStatus throw, surfaces success and does '
+        'not rethrow',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          when(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: _validPubkeyA,
+            ),
+          );
+          when(
+            () => mockOutgoingDmsDao.deleteById(_rumorEventId),
+          ).thenThrow(Exception('drift busy'));
+          when(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          ).thenThrow(Exception('drift still busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          // Caller still sees success: publish outcome drives the
+          // return value, not the bookkeeping outcome. Self-wraps are
+          // idempotent on receive (NIP-17 dedup keys), so the
+          // doubly-degraded path is safe.
+          expect(result.success, isTrue);
+        },
+      );
+
+      test(
         'on self-wrap publish failure: marks self_wrap_status failed '
         'and leaves the row queued for the next retry',
         () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7668,6 +7668,682 @@ void main() {
       );
     });
 
+    group('sendGroupMessage with outgoing_dms queue wired in', () {
+      late _MockOutgoingDmsDao mockOutgoingDmsDao;
+
+      setUp(() {
+        mockOutgoingDmsDao = _MockOutgoingDmsDao();
+        when(
+          () => mockOutgoingDmsDao.enqueue(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockOutgoingDmsDao.deleteById(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockOutgoingDmsDao.markRecipientWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockOutgoingDmsDao.markSelfWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+      });
+
+      test(
+        'enqueues a row per recipient and deletes them all on full delivery',
+        () async {
+          // Per-recipient rumor.id differs because additionalTags differ.
+          // The forwarding shim returns whatever NIP17SendResult we
+          // configure here; pin success on both recipients.
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer((inv) async {
+            final recipient = inv.namedArguments[#recipientPubkey] as String;
+            return NIP17SendResult.success(
+              rumorEventId: 'rumor-$recipient',
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'group full delivery',
+          );
+
+          expect(results, hasLength(2));
+          expect(results.every((r) => r.success), isTrue);
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          expect(
+            captured,
+            hasLength(2),
+            reason: 'one queue row per recipient',
+          );
+          final enqueuedB = captured.first as OutgoingDm;
+          final enqueuedC = captured.last as OutgoingDm;
+          expect(enqueuedB.recipientPubkey, equals(_validPubkeyB));
+          expect(enqueuedC.recipientPubkey, equals(_validPubkeyC));
+          expect(
+            enqueuedB.id,
+            isNot(equals(enqueuedC.id)),
+            reason:
+                'each recipient gets its own rumor id; group queue rows '
+                'must not collide',
+          );
+          expect(enqueuedB.recipientWrapStatus, OutgoingWrapStatus.pending);
+          expect(enqueuedB.selfWrapStatus, OutgoingWrapStatus.pending);
+
+          verify(() => mockOutgoingDmsDao.deleteById(enqueuedB.id)).called(1);
+          verify(() => mockOutgoingDmsDao.deleteById(enqueuedC.id)).called(1);
+          // No mark calls fire on a fully-delivered tuple — the row is
+          // dropped atomically with the message persist.
+          verifyNever(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'marks recipient sent + self failed only for the recipients '
+        'whose self-wrap failed, deletes rows for fully-delivered ones',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer((inv) async {
+            final recipient = inv.namedArguments[#recipientPubkey] as String;
+            return NIP17SendResult.success(
+              rumorEventId: 'rumor-$recipient',
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+              // First recipient (B) is fully delivered, second (C) is
+              // partial. The asymmetry pins "scope recovery to only the
+              // affected successful recipient sends" from #4102.
+              selfWrapPublished: recipient == _validPubkeyB,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'group partial delivery',
+          );
+
+          expect(results, hasLength(2));
+          expect(results.every((r) => r.success), isTrue);
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          final enqueuedB = captured.first as OutgoingDm;
+          final enqueuedC = captured.last as OutgoingDm;
+
+          // Recipient B: full delivery → row deleted.
+          verify(() => mockOutgoingDmsDao.deleteById(enqueuedB.id)).called(1);
+          // Recipient C: partial → recipient sent + self failed, row
+          // preserved for recovery.
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: enqueuedC.id,
+              status: OutgoingWrapStatus.sent,
+              eventId: 'wrap-$_validPubkeyC',
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: enqueuedC.id,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'Recipient delivered, but self-wrap publish failed',
+            ),
+          ).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(enqueuedC.id));
+        },
+      );
+
+      test(
+        'marks both wraps failed for a recipient whose recipient '
+        'publish failed, leaves the others on their full-delivery path',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer((inv) async {
+            final recipient = inv.namedArguments[#recipientPubkey] as String;
+            if (recipient == _validPubkeyC) {
+              return const NIP17SendResult.failure('relay rejected');
+            }
+            return NIP17SendResult.success(
+              rumorEventId: 'rumor-$recipient',
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'mixed outcomes',
+          );
+
+          expect(results, hasLength(2));
+          expect(results.where((r) => r.success), hasLength(1));
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          final enqueuedB = captured.first as OutgoingDm;
+          final enqueuedC = captured.last as OutgoingDm;
+
+          verify(() => mockOutgoingDmsDao.deleteById(enqueuedB.id)).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: enqueuedC.id,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay rejected',
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: enqueuedC.id,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay rejected',
+            ),
+          ).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(enqueuedC.id));
+          // The failure path must not be confused with partial — recipient
+          // never received this rumor, so the queue row is retryable in
+          // both wraps, not in self only.
+          verifyNever(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: enqueuedC.id,
+              status: OutgoingWrapStatus.sent,
+              eventId: any(named: 'eventId'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'when all recipients fail: marks every row both-wraps failed '
+        'and never inserts a direct_messages row',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure('all relays down'),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'total failure',
+          );
+
+          expect(results, hasLength(2));
+          expect(results.every((r) => !r.success), isTrue);
+
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: OutgoingWrapStatus.failed,
+              lastError: 'all relays down',
+            ),
+          ).called(2);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: any(named: 'id'),
+              status: OutgoingWrapStatus.failed,
+              lastError: 'all relays down',
+            ),
+          ).called(2);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'queue is opt-in: when no OutgoingDmsDao is injected, '
+        'sendGroupMessage falls back to the direct-write behaviour',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer((inv) async {
+            final recipient = inv.namedArguments[#recipientPubkey] as String;
+            return NIP17SendResult.success(
+              rumorEventId: 'rumor-$recipient',
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository();
+
+          await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'no queue group send',
+          );
+
+          verifyNever(() => mockOutgoingDmsDao.enqueue(any()));
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verifyNever(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          );
+        },
+      );
+    });
+
+    group('recoverSelfWrap', () {
+      late _MockOutgoingDmsDao mockOutgoingDmsDao;
+
+      // A fixed rumor JSON that Event.fromJson can parse — the
+      // recoverSelfWrap path rebuilds the rumor from this payload to
+      // preserve the receiver-side dedup key.
+      final queuedRumorJson = jsonEncode({
+        'id': _rumorEventId,
+        'pubkey': _validPubkeyA,
+        'created_at': 1700000000,
+        'kind': EventKind.privateDirectMessage,
+        'tags': [
+          ['p', _validPubkeyB],
+        ],
+        'content': 'queued message',
+        'sig': '',
+      });
+
+      OutgoingDm queuedRow({
+        OutgoingWrapStatus selfWrapStatus = OutgoingWrapStatus.failed,
+        String ownerPubkey = _validPubkeyA,
+        String? selfWrapEventId,
+      }) {
+        return OutgoingDm(
+          id: _rumorEventId,
+          conversationId: 'conv',
+          recipientPubkey: _validPubkeyB,
+          content: 'queued message',
+          createdAt: 1700000000,
+          rumorEventJson: queuedRumorJson,
+          recipientWrapStatus: OutgoingWrapStatus.sent,
+          selfWrapStatus: selfWrapStatus,
+          queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
+          ownerPubkey: ownerPubkey,
+          recipientWrapEventId: _giftWrapEventId,
+          selfWrapEventId: selfWrapEventId,
+        );
+      }
+
+      setUp(() {
+        mockOutgoingDmsDao = _MockOutgoingDmsDao();
+        when(
+          () => mockOutgoingDmsDao.deleteById(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockOutgoingDmsDao.markSelfWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+      });
+
+      test(
+        'on successful self-wrap publish: deletes the queue row and '
+        'returns success',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          when(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _rumorEventId,
+              recipientPubkey: _validPubkeyA,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isTrue);
+
+          // Critical contract from #4102: recovery must NOT republish
+          // the recipient wrap. Verify by asserting the underlying send
+          // primitives are never called.
+          verifyNever(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          );
+          verifyNever(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          );
+
+          verify(() => mockOutgoingDmsDao.deleteById(_rumorEventId)).called(1);
+          verifyNever(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'on self-wrap publish failure: marks self_wrap_status failed '
+        'and leaves the row queued for the next retry',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          when(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure('relay timeout'),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay timeout',
+            ),
+          ).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+        },
+      );
+
+      test(
+        'idempotent: when the row already shows self_wrap_status sent, '
+        'returns success without re-publishing',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer(
+            (_) async => queuedRow(
+              selfWrapStatus: OutgoingWrapStatus.sent,
+              selfWrapEventId: _giftWrapEventId2,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isTrue);
+          expect(result.messageEventId, equals(_giftWrapEventId2));
+          verifyNever(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          );
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+        },
+      );
+
+      test(
+        'throws ArgumentError when no queue row exists for the rumor id',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(any()),
+          ).thenAnswer((_) async => null);
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          expect(
+            () => repository.recoverSelfWrap(rumorId: _rumorEventId),
+            throwsArgumentError,
+          );
+        },
+      );
+
+      test(
+        'throws ArgumentError when the queue row belongs to a '
+        'different account',
+        () async {
+          when(() => mockOutgoingDmsDao.getById(_rumorEventId)).thenAnswer(
+            (_) async => queuedRow(ownerPubkey: _validPubkeyD),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          expect(
+            () => repository.recoverSelfWrap(rumorId: _rumorEventId),
+            throwsArgumentError,
+          );
+          verifyNever(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'throws StateError when the outgoing_dms DAO is not wired in',
+        () async {
+          final repository = createRepository();
+
+          expect(
+            () => repository.recoverSelfWrap(rumorId: _rumorEventId),
+            throwsStateError,
+          );
+        },
+      );
+
+      test(
+        'on rumor JSON parse failure: marks self_wrap_status failed '
+        'with the parse error and surfaces a failure result',
+        () async {
+          final corruptedRow = OutgoingDm(
+            id: _rumorEventId,
+            conversationId: 'conv',
+            recipientPubkey: _validPubkeyB,
+            content: 'queued message',
+            createdAt: 1700000000,
+            rumorEventJson: 'this is not json',
+            recipientWrapStatus: OutgoingWrapStatus.sent,
+            selfWrapStatus: OutgoingWrapStatus.failed,
+            queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
+            ownerPubkey: _validPubkeyA,
+          );
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => corruptedRow);
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, contains('rumor JSON parse failed'));
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: any(
+                named: 'lastError',
+                that: contains('rumor JSON parse failed'),
+              ),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          );
+        },
+      );
+    });
+
     group(
       '_mergeDuplicateConversations creates canonical row from phantoms',
       () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -181,41 +181,6 @@ void main() {
           content,
         );
       });
-
-      // Forward sendRumor invocations to sendPrivateMessage so the many
-      // existing `when(() => mockMessageService.sendPrivateMessage(...))`
-      // stubs and `verify(() => mockMessageService.sendPrivateMessage(...))`
-      // assertions in this file keep working unchanged after the
-      // refactor that split sendPrivateMessage into buildRumor +
-      // sendRumor. The forwarded call records both invocations on the
-      // mock — sendRumor for new tests that target the split, and
-      // sendPrivateMessage for the legacy assertions.
-      when(
-        () => mockMessageService.sendRumor(
-          rumorEvent: any(named: 'rumorEvent'),
-          recipientPubkey: any(named: 'recipientPubkey'),
-        ),
-      ).thenAnswer((inv) async {
-        final rumorEvent = inv.namedArguments[#rumorEvent] as Event;
-        final recipientPubkey = inv.namedArguments[#recipientPubkey] as String;
-        // additionalTags excludes the leading p-tag that buildRumor
-        // injected, so the legacy verify assertions match the original
-        // caller-supplied tags exactly.
-        final passthroughTags = rumorEvent.tags
-            .where(
-              (tag) =>
-                  !(tag.length >= 2 &&
-                      tag[0] == 'p' &&
-                      tag[1] == recipientPubkey),
-            )
-            .toList();
-        return mockMessageService.sendPrivateMessage(
-          recipientPubkey: recipientPubkey,
-          content: rumorEvent.content,
-          eventKind: rumorEvent.kind,
-          additionalTags: passthroughTags,
-        );
-      });
     });
 
     DmRepository createRepository({
@@ -237,6 +202,40 @@ void main() {
         nip04Decryptor: nip04Decryptor,
         syncState: syncState,
       );
+    }
+
+    List<List<String>> additionalTagsFromRumor(
+      Event rumorEvent,
+      String recipientPubkey,
+    ) {
+      return rumorEvent.tags
+          .where(
+            (tag) =>
+                !(tag.length >= 2 &&
+                    tag[0] == 'p' &&
+                    tag[1] == recipientPubkey),
+          )
+          .map(List<String>.from)
+          .toList();
+    }
+
+    void stubSendRumor(
+      FutureOr<NIP17SendResult> Function(
+        Event rumorEvent,
+        String recipientPubkey,
+      )
+      answer,
+    ) {
+      when(
+        () => mockMessageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+        ),
+      ).thenAnswer((inv) async {
+        final rumorEvent = inv.namedArguments[#rumorEvent] as Event;
+        final recipientPubkey = inv.namedArguments[#recipientPubkey] as String;
+        return answer(rumorEvent, recipientPubkey);
+      });
     }
 
     // -----------------------------------------------------------------
@@ -363,15 +362,9 @@ void main() {
       });
 
       test('sendMessage forwards additional NIP-17 tags', () async {
-        when(
-          () => mockMessageService.sendPrivateMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            eventKind: any(named: 'eventKind'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).thenAnswer(
-          (_) async => const NIP17SendResult.failure('relay unavailable'),
+        stubSendRumor(
+          (rumorEvent, recipientPubkey) async =>
+              const NIP17SendResult.failure('relay unavailable'),
         );
 
         final repository = createRepository();
@@ -396,33 +389,27 @@ void main() {
           additionalTags: inviteTags,
         );
 
-        final captured =
+        final rumorEvent =
             verify(
-                  () => mockMessageService.sendPrivateMessage(
+                  () => mockMessageService.sendRumor(
+                    rumorEvent: captureAny(named: 'rumorEvent'),
                     recipientPubkey: _validPubkeyB,
-                    content: 'Invited you to collaborate',
-                    eventKind: any(named: 'eventKind'),
-                    additionalTags: captureAny(named: 'additionalTags'),
                   ),
                 ).captured.single
-                as List<List<String>>;
+                as Event;
 
-        expect(captured, containsAll(inviteTags));
+        expect(
+          additionalTagsFromRumor(rumorEvent, _validPubkeyB),
+          containsAll(inviteTags),
+        );
       });
 
       test('persists message and conversation on success', () async {
-        when(
-          () => mockMessageService.sendPrivateMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            eventKind: any(named: 'eventKind'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).thenAnswer(
-          (_) async => NIP17SendResult.success(
+        stubSendRumor(
+          (_, recipientPubkey) async => NIP17SendResult.success(
             rumorEventId: _rumorEventId,
             messageEventId: _giftWrapEventId,
-            recipientPubkey: _validPubkeyB,
+            recipientPubkey: recipientPubkey,
           ),
         );
         when(
@@ -529,15 +516,9 @@ void main() {
       });
 
       test('does not persist on send failure', () async {
-        when(
-          () => mockMessageService.sendPrivateMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            eventKind: any(named: 'eventKind'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).thenAnswer(
-          (_) async => const NIP17SendResult.failure('Relay rejected'),
+        stubSendRumor(
+          (rumorEvent, recipientPubkey) async =>
+              const NIP17SendResult.failure('Relay rejected'),
         );
 
         final repository = createRepository();
@@ -577,18 +558,11 @@ void main() {
       });
 
       test('skipNip04Fallback: true suppresses NIP-04 publish', () async {
-        when(
-          () => mockMessageService.sendPrivateMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            eventKind: any(named: 'eventKind'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).thenAnswer(
-          (_) async => NIP17SendResult.success(
+        stubSendRumor(
+          (_, recipientPubkey) async => NIP17SendResult.success(
             rumorEventId: _rumorEventId,
             messageEventId: _giftWrapEventId,
-            recipientPubkey: _validPubkeyB,
+            recipientPubkey: recipientPubkey,
           ),
         );
         when(
@@ -667,18 +641,11 @@ void main() {
       test(
         'second send to same conversation skips NIP-04 fallback (#3663)',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
           when(
@@ -3181,18 +3148,11 @@ void main() {
               'Reason: Spam or Unwanted Content\n'
               'Event: abc123eventid';
 
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: moderationPubkey,
+              recipientPubkey: recipientPubkey,
             ),
           );
           stubDaoInserts();
@@ -3211,11 +3171,9 @@ void main() {
           expect(result.success, isTrue);
 
           verify(
-            () => mockMessageService.sendPrivateMessage(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: moderationPubkey,
-              content: reportContent,
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
             ),
           ).called(1);
 
@@ -3417,18 +3375,11 @@ void main() {
               'ff0011223344556677889900aabbccddeeff'
               '0011223344556677889900aabbcc';
 
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: externalUserPubkey,
+              recipientPubkey: recipientPubkey,
             ),
           );
           stubDaoInserts();
@@ -3447,11 +3398,9 @@ void main() {
           expect(result.success, isTrue);
 
           verify(
-            () => mockMessageService.sendPrivateMessage(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: externalUserPubkey,
-              content: 'Hello from Divine!',
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
             ),
           ).called(1);
         },
@@ -4197,18 +4146,11 @@ void main() {
       test(
         'sends NIP-04 fallback when protocol is unknown',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
           stubDaoInserts();
@@ -4252,11 +4194,9 @@ void main() {
 
           // Verify both NIP-17 and NIP-04 were called
           verify(
-            () => mockMessageService.sendPrivateMessage(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
             ),
           ).called(1);
 
@@ -4272,18 +4212,11 @@ void main() {
           final participants = [_validPubkeyA, _validPubkeyB]..sort();
           final convId = DmRepository.computeConversationId(participants);
 
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
           stubDaoInserts();
@@ -4317,11 +4250,9 @@ void main() {
 
           // NIP-17 was sent
           verify(
-            () => mockMessageService.sendPrivateMessage(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
             ),
           ).called(1);
 
@@ -6257,18 +6188,11 @@ void main() {
 
     group('sendMessage - replyToId', () {
       test('includes reply-to tag when replyToId is provided', () async {
-        when(
-          () => mockMessageService.sendPrivateMessage(
-            recipientPubkey: any(named: 'recipientPubkey'),
-            content: any(named: 'content'),
-            eventKind: any(named: 'eventKind'),
-            additionalTags: any(named: 'additionalTags'),
-          ),
-        ).thenAnswer(
-          (_) async => NIP17SendResult.success(
+        stubSendRumor(
+          (_, recipientPubkey) async => NIP17SendResult.success(
             rumorEventId: _rumorEventId,
             messageEventId: _giftWrapEventId,
-            recipientPubkey: _validPubkeyB,
+            recipientPubkey: recipientPubkey,
           ),
         );
 
@@ -6336,24 +6260,18 @@ void main() {
           replyToId: replyId,
         );
 
-        // Verify the reply-to tag was passed to sendPrivateMessage
-        final captured =
+        final rumorEvent =
             verify(
-                  () => mockMessageService.sendPrivateMessage(
+                  () => mockMessageService.sendRumor(
+                    rumorEvent: captureAny(named: 'rumorEvent'),
                     recipientPubkey: any(named: 'recipientPubkey'),
-                    content: any(named: 'content'),
-                    eventKind: any(named: 'eventKind'),
-                    additionalTags: captureAny(named: 'additionalTags'),
                   ),
                 ).captured.single
-                as List<dynamic>;
+                as Event;
+        final captured = additionalTagsFromRumor(rumorEvent, _validPubkeyB);
         expect(
           captured.any(
-            (tag) =>
-                tag is List &&
-                tag.length == 2 &&
-                tag[0] == 'e' &&
-                tag[1] == replyId,
+            (tag) => tag.length == 2 && tag[0] == 'e' && tag[1] == replyId,
           ),
           isTrue,
         );
@@ -6418,18 +6336,11 @@ void main() {
       test(
         'sends to each recipient and persists group conversation',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
           stubDaoInserts();
@@ -6445,11 +6356,9 @@ void main() {
 
           // Verify sent to each recipient
           verify(
-            () => mockMessageService.sendPrivateMessage(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: any(named: 'recipientPubkey'),
-              content: 'Group hello!',
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
             ),
           ).called(2);
 
@@ -6475,20 +6384,13 @@ void main() {
         'persists when at least one send succeeds (partial failure)',
         () async {
           var callCount = 0;
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer((_) async {
+          stubSendRumor((_, recipientPubkey) async {
             callCount++;
             if (callCount == 1) {
               return NIP17SendResult.success(
                 rumorEventId: _rumorEventId,
                 messageEventId: _giftWrapEventId,
-                recipientPubkey: _validPubkeyB,
+                recipientPubkey: recipientPubkey,
               );
             }
             return const NIP17SendResult.failure('relay timeout');
@@ -6524,15 +6426,9 @@ void main() {
       test(
         'does not persist when all sends fail',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => const NIP17SendResult.failure('relay timeout'),
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async =>
+                const NIP17SendResult.failure('relay timeout'),
           );
 
           final repo = createRepository();
@@ -7009,18 +6905,11 @@ void main() {
             () => mockSigner.encrypt(any(), any()),
           ).thenAnswer((_) async => null);
 
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
 
@@ -7114,18 +7003,11 @@ void main() {
             () => mockSigner.signEvent(any()),
           ).thenAnswer((_) async => null);
 
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
 
@@ -7208,18 +7090,11 @@ void main() {
             participants,
           );
 
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
 
@@ -7407,18 +7282,11 @@ void main() {
         'enqueues a pending row with the rumor id, then deletes it on '
         'full delivery',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
 
@@ -7474,15 +7342,9 @@ void main() {
         'on publish failure: marks both wraps failed with the error '
         'and leaves the row for the retry service',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => const NIP17SendResult.failure('relay unavailable'),
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async =>
+                const NIP17SendResult.failure('relay unavailable'),
           );
 
           final repository = createRepository(
@@ -7556,18 +7418,11 @@ void main() {
         'on partial delivery: persists locally, keeps the queue row, '
         'marks recipient sent, and marks self failed',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
               selfWrapPublished: false,
             ),
           );
@@ -7637,18 +7492,11 @@ void main() {
         'sendMessage falls back to the direct-write behaviour and '
         'never touches the queue',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => NIP17SendResult.success(
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
               rumorEventId: _rumorEventId,
               messageEventId: _giftWrapEventId,
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: recipientPubkey,
             ),
           );
 
@@ -7749,17 +7597,9 @@ void main() {
         'enqueues a row per recipient and deletes them all on full delivery',
         () async {
           // Per-recipient rumor.id differs because additionalTags differ.
-          // The forwarding shim returns whatever NIP17SendResult we
-          // configure here; pin success on both recipients.
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer((inv) async {
-            final recipient = inv.namedArguments[#recipientPubkey] as String;
+          // Pin success on both recipients so both queued rumor ids
+          // take the full-delivery path.
+          stubSendRumor((_, recipient) async {
             return NIP17SendResult.success(
               rumorEventId: 'rumor-$recipient',
               messageEventId: 'wrap-$recipient',
@@ -7820,15 +7660,7 @@ void main() {
         'marks recipient sent + self failed only for the recipients '
         'whose self-wrap failed, deletes rows for fully-delivered ones',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer((inv) async {
-            final recipient = inv.namedArguments[#recipientPubkey] as String;
+          stubSendRumor((_, recipient) async {
             return NIP17SendResult.success(
               rumorEventId: 'rumor-$recipient',
               messageEventId: 'wrap-$recipient',
@@ -7884,15 +7716,7 @@ void main() {
         'marks both wraps failed for a recipient whose recipient '
         'publish failed, leaves the others on their full-delivery path',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer((inv) async {
-            final recipient = inv.namedArguments[#recipientPubkey] as String;
+          stubSendRumor((_, recipient) async {
             if (recipient == _validPubkeyC) {
               return const NIP17SendResult.failure('relay rejected');
             }
@@ -7954,15 +7778,9 @@ void main() {
         'when all recipients fail: marks every row both-wraps failed '
         'and never inserts a direct_messages row',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer(
-            (_) async => const NIP17SendResult.failure('all relays down'),
+          stubSendRumor(
+            (rumorEvent, recipientPubkey) async =>
+                const NIP17SendResult.failure('all relays down'),
           );
 
           final repository = createRepository(
@@ -8024,15 +7842,7 @@ void main() {
         'queue is opt-in: when no OutgoingDmsDao is injected, '
         'sendGroupMessage falls back to the direct-write behaviour',
         () async {
-          when(
-            () => mockMessageService.sendPrivateMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              eventKind: any(named: 'eventKind'),
-              additionalTags: any(named: 'additionalTags'),
-            ),
-          ).thenAnswer((inv) async {
-            final recipient = inv.namedArguments[#recipientPubkey] as String;
+          stubSendRumor((_, recipient) async {
             return NIP17SendResult.success(
               rumorEventId: 'rumor-$recipient',
               messageEventId: 'wrap-$recipient',

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -762,5 +762,179 @@ void main() {
         },
       );
     });
+
+    group('publishSelfWrap', () {
+      // The recovery primitive: re-publish only the sender
+      // self-addressed gift wrap for a rumor whose recipient publish
+      // already landed. The full sendRumor path would publish a second
+      // recipient wrap and double-deliver — these tests pin that
+      // publishSelfWrap never builds or publishes the recipient wrap.
+      late NIP17MessageService realKeyService;
+
+      setUp(() {
+        // Use a sender pubkey derived from the signer so the self-wrap
+        // NIP-44 ECDH actually runs end-to-end (the synthetic
+        // _testPublicKey is not a valid secp256k1 point).
+        realKeyService = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: getPublicKey(_testPrivateKey),
+          nostrService: mockNostrClient,
+        );
+      });
+
+      test(
+        'returns success when the self-wrap publish succeeds and '
+        'never publishes a recipient wrap',
+        () async {
+          final captured = <Event>[];
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async {
+              final event = invocation.positionalArguments[0] as Event;
+              captured.add(event);
+              return PublishSuccess(event: event);
+            },
+          );
+
+          final rumor = realKeyService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'recovery smoke test',
+          );
+
+          final result = await realKeyService.publishSelfWrap(
+            rumorEvent: rumor,
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isTrue);
+          expect(
+            result.rumorEventId,
+            equals(rumor.id),
+            reason:
+                'rumor id must be preserved across recovery — receiver-side '
+                'gift-wrap dedup keys on it',
+          );
+          expect(
+            result.recipientPubkey,
+            equals(getPublicKey(_testPrivateKey)),
+            reason:
+                'recovery republishes a self-addressed wrap; the result '
+                "exposes the sender's pubkey in the recipientPubkey slot",
+          );
+          expect(
+            captured,
+            hasLength(1),
+            reason:
+                'publishSelfWrap must NOT republish the recipient wrap — '
+                'doing so would double-deliver the message',
+          );
+          expect(captured.single.kind, equals(EventKind.giftWrap));
+        },
+      );
+
+      test(
+        'returns failure when the self-wrap publish returns '
+        'PublishFailed without throwing',
+        () async {
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => const PublishFailed());
+
+          final rumor = realKeyService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'PublishFailed path',
+          );
+
+          final result = await realKeyService.publishSelfWrap(
+            rumorEvent: rumor,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, isNotNull);
+          expect(result.selfWrapPublished, isNull);
+          verify(() => mockNostrClient.publishEvent(any())).called(1);
+        },
+      );
+
+      test(
+        'returns failure when the gift-wrap builder returns null',
+        () async {
+          final nullBuilderService = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: getPublicKey(_testPrivateKey),
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async => null,
+          );
+
+          final rumor = nullBuilderService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'null builder path',
+          );
+
+          final result = await nullBuilderService.publishSelfWrap(
+            rumorEvent: rumor,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, isNotNull);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
+        'returns failure when the gift-wrap builder throws',
+        () async {
+          final throwingBuilderService = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: getPublicKey(_testPrivateKey),
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async {
+              throw Exception('builder boom');
+            },
+          );
+
+          final rumor = throwingBuilderService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'throwing builder path',
+          );
+
+          final result = await throwingBuilderService.publishSelfWrap(
+            rumorEvent: rumor,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, isNotNull);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
+        'returns failure when the signer throws during key refresh',
+        () async {
+          final mockSigner = _MockNostrSigner();
+          when(
+            mockSigner.getPublicKey,
+          ).thenThrow(Exception('signer unavailable'));
+
+          final brokenService = NIP17MessageService(
+            signer: mockSigner,
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+          );
+
+          final rumor = realKeyService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'signer-key-failure path',
+          );
+
+          final result = await brokenService.publishSelfWrap(
+            rumorEvent: rumor,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, isNotNull);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+    });
   });
 }

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -335,7 +335,7 @@ void main() {
         );
 
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending with optimistic, sentPartial with lastFailedSend] '
+          'emits [sending with optimistic, sentPartial with lastPartialSend] '
           'when sendMessage succeeds but the self-wrap was not published',
           setUp: () {
             when(
@@ -363,7 +363,9 @@ void main() {
           // DB persist already happened inside DmRepository.sendMessage,
           // so the optimistic stays — stripping it would race with the
           // watchMessages re-emit and cause a brief disappearance.
-          // lastFailedSend is recorded so the UI can offer retry.
+          // lastPartialSend records the rumor id whose self-wrap failed,
+          // so the SnackBar's Retry can recover via the self-wrap-only
+          // path without redelivering to the recipient (#4102).
           expect: () => [
             isA<ConversationState>()
                 .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
@@ -380,14 +382,15 @@ void main() {
                   1,
                 )
                 .having(
+                  (s) => s.lastPartialSend,
+                  'lastPartialSend',
+                  equals(const PartialSend(rumorIds: [sentEventId])),
+                )
+                .having(
                   (s) => s.lastFailedSend,
-                  'lastFailedSend',
-                  equals(
-                    const FailedSend(
-                      content: 'Hello',
-                      recipientPubkeys: [recipientPubkey],
-                    ),
-                  ),
+                  'lastFailedSend stays null on partial — it drives '
+                  'a different recovery path',
+                  isNull,
                 ),
           ],
         );
@@ -482,9 +485,17 @@ void main() {
         );
 
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending, sentPartial] when any successful per-recipient '
-          'sendGroupMessage had its self-wrap unpublished',
+          'emits [sending, sentPartial with only the failing rumor id] '
+          'when one per-recipient sendGroupMessage has self-wrap unpublished',
           setUp: () {
+            // Each per-recipient send produces its own rumor id.
+            // recipient1 fully delivers, recipient2 partial — only the
+            // partial one should land in lastPartialSend.rumorIds, so
+            // the recovery path republishes only that self-wrap.
+            const rumorIdRecipient1 =
+                '7777777777777777777777777777777777777777777777777777777777777777';
+            const rumorIdRecipient2 =
+                '8888888888888888888888888888888888888888888888888888888888888888';
             when(
               () => mockDmRepository.sendGroupMessage(
                 recipientPubkeys: [recipientPubkey, recipientPubkey2],
@@ -493,13 +504,13 @@ void main() {
             ).thenAnswer(
               (_) async => [
                 NIP17SendResult.success(
-                  rumorEventId: sentEventId,
-                  messageEventId: sentEventId,
+                  rumorEventId: rumorIdRecipient1,
+                  messageEventId: rumorIdRecipient1,
                   recipientPubkey: recipientPubkey,
                 ),
                 NIP17SendResult.success(
-                  rumorEventId: sentEventId,
-                  messageEventId: sentEventId,
+                  rumorEventId: rumorIdRecipient2,
+                  messageEventId: rumorIdRecipient2,
                   recipientPubkey: recipientPubkey2,
                   selfWrapPublished: false,
                 ),
@@ -526,14 +537,20 @@ void main() {
                   SendStatus.sentPartial,
                 )
                 .having(
-                  (s) => s.lastFailedSend,
-                  'lastFailedSend',
+                  (s) => s.lastPartialSend,
+                  'lastPartialSend',
                   equals(
-                    const FailedSend(
-                      content: 'Group hello',
-                      recipientPubkeys: [recipientPubkey, recipientPubkey2],
+                    const PartialSend(
+                      rumorIds: [
+                        '8888888888888888888888888888888888888888888888888888888888888888',
+                      ],
                     ),
                   ),
+                )
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend stays null on partial',
+                  isNull,
                 ),
           ],
         );
@@ -1052,6 +1069,191 @@ void main() {
       });
     });
 
+    group(ConversationSelfWrapRecoveryRequested, () {
+      // The principled recovery path for #4102: tapping Retry on a
+      // sentPartial SnackBar must republish only the missing self-wrap
+      // — never the recipient wrap, which would double-deliver.
+      const rumorId1 =
+          '7777777777777777777777777777777777777777777777777777777777777777';
+      const rumorId2 =
+          '8888888888888888888888888888888888888888888888888888888888888888';
+
+      blocTest<ConversationBloc, ConversationState>(
+        'emits [sending, sent] and clears lastPartialSend when every '
+        'recoverSelfWrap returns success',
+        setUp: () {
+          when(
+            () => mockDmRepository.recoverSelfWrap(
+              rumorId: any(named: 'rumorId'),
+            ),
+          ).thenAnswer(
+            (inv) async => NIP17SendResult.success(
+              rumorEventId: inv.namedArguments[#rumorId] as String,
+              messageEventId: inv.namedArguments[#rumorId] as String,
+              recipientPubkey: senderPubkey,
+            ),
+          );
+        },
+        seed: () => const ConversationState(
+          status: ConversationStatus.loaded,
+          sendStatus: SendStatus.sentPartial,
+          lastPartialSend: PartialSend(rumorIds: [rumorId1, rumorId2]),
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const ConversationSelfWrapRecoveryRequested(
+            rumorIds: [rumorId1, rumorId2],
+          ),
+        ),
+        expect: () => [
+          isA<ConversationState>().having(
+            (s) => s.sendStatus,
+            'sendStatus',
+            SendStatus.sending,
+          ),
+          isA<ConversationState>()
+              .having((s) => s.sendStatus, 'sendStatus', SendStatus.sent)
+              .having(
+                (s) => s.lastPartialSend,
+                'lastPartialSend cleared on full recovery',
+                isNull,
+              ),
+        ],
+        verify: (_) {
+          // Every rumor in the event payload was passed to
+          // recoverSelfWrap (with no recipient publish in sight).
+          verify(
+            () => mockDmRepository.recoverSelfWrap(rumorId: rumorId1),
+          ).called(1);
+          verify(
+            () => mockDmRepository.recoverSelfWrap(rumorId: rumorId2),
+          ).called(1);
+          // Pin the no-duplicate-recipient-publish contract from #4102.
+          verifyNever(
+            () => mockDmRepository.sendMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+            ),
+          );
+          verifyNever(
+            () => mockDmRepository.sendGroupMessage(
+              recipientPubkeys: any(named: 'recipientPubkeys'),
+              content: any(named: 'content'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ConversationBloc, ConversationState>(
+        'reduces lastPartialSend.rumorIds to the still-failing rumors '
+        'when one of two recoveries fails',
+        setUp: () {
+          when(
+            () => mockDmRepository.recoverSelfWrap(rumorId: rumorId1),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: rumorId1,
+              messageEventId: rumorId1,
+              recipientPubkey: senderPubkey,
+            ),
+          );
+          when(
+            () => mockDmRepository.recoverSelfWrap(rumorId: rumorId2),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure('relay timeout'),
+          );
+        },
+        seed: () => const ConversationState(
+          status: ConversationStatus.loaded,
+          sendStatus: SendStatus.sentPartial,
+          lastPartialSend: PartialSend(rumorIds: [rumorId1, rumorId2]),
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const ConversationSelfWrapRecoveryRequested(
+            rumorIds: [rumorId1, rumorId2],
+          ),
+        ),
+        expect: () => [
+          isA<ConversationState>().having(
+            (s) => s.sendStatus,
+            'sendStatus',
+            SendStatus.sending,
+          ),
+          isA<ConversationState>()
+              .having(
+                (s) => s.sendStatus,
+                'sendStatus',
+                SendStatus.sentPartial,
+              )
+              .having(
+                (s) => s.lastPartialSend,
+                'lastPartialSend reduced to still-failing ids only',
+                equals(const PartialSend(rumorIds: [rumorId2])),
+              ),
+        ],
+      );
+
+      blocTest<ConversationBloc, ConversationState>(
+        'reports thrown errors via addError and treats the rumor as '
+        'still-failing',
+        setUp: () {
+          when(
+            () => mockDmRepository.recoverSelfWrap(rumorId: rumorId1),
+          ).thenThrow(StateError('queue DAO not wired'));
+        },
+        seed: () => const ConversationState(
+          status: ConversationStatus.loaded,
+          sendStatus: SendStatus.sentPartial,
+          lastPartialSend: PartialSend(rumorIds: [rumorId1]),
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const ConversationSelfWrapRecoveryRequested(rumorIds: [rumorId1]),
+        ),
+        expect: () => [
+          isA<ConversationState>().having(
+            (s) => s.sendStatus,
+            'sendStatus',
+            SendStatus.sending,
+          ),
+          isA<ConversationState>()
+              .having(
+                (s) => s.sendStatus,
+                'sendStatus',
+                SendStatus.sentPartial,
+              )
+              .having(
+                (s) => s.lastPartialSend?.rumorIds,
+                'still-failing rumor preserved on throw',
+                equals([rumorId1]),
+              ),
+        ],
+        errors: () => [isA<StateError>()],
+      );
+
+      blocTest<ConversationBloc, ConversationState>(
+        'is a no-op when rumorIds is empty',
+        seed: () => const ConversationState(
+          status: ConversationStatus.loaded,
+          sendStatus: SendStatus.sentPartial,
+          lastPartialSend: PartialSend(rumorIds: []),
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const ConversationSelfWrapRecoveryRequested(rumorIds: []),
+        ),
+        expect: () => const <ConversationState>[],
+        verify: (_) {
+          verifyNever(
+            () => mockDmRepository.recoverSelfWrap(
+              rumorId: any(named: 'rumorId'),
+            ),
+          );
+        },
+      );
+    });
+
     group('ConversationMessageDeleted', () {
       blocTest<ConversationBloc, ConversationState>(
         'calls deleteMessageForEveryone on the repository',
@@ -1098,9 +1300,49 @@ void main() {
           <DmMessage>[],
           SendStatus.idle,
           null,
+          null,
         ]),
       );
     });
+
+    test('states with different lastPartialSend are not equal', () {
+      expect(
+        const ConversationState(),
+        isNot(
+          equals(
+            const ConversationState(
+              lastPartialSend: PartialSend(rumorIds: [messageId]),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'copyWith carries lastPartialSend forward when not overridden',
+      () {
+        const partial = PartialSend(rumorIds: [messageId]);
+        const seeded = ConversationState(lastPartialSend: partial);
+
+        expect(
+          seeded.copyWith(sendStatus: SendStatus.sending).lastPartialSend,
+          equals(partial),
+        );
+      },
+    );
+
+    test(
+      'copyWith(clearLastPartialSend: true) wipes lastPartialSend',
+      () {
+        const partial = PartialSend(rumorIds: [messageId]);
+        const seeded = ConversationState(lastPartialSend: partial);
+
+        expect(
+          seeded.copyWith(clearLastPartialSend: true).lastPartialSend,
+          isNull,
+        );
+      },
+    );
 
     test('states with different lastFailedSend are not equal', () {
       expect(
@@ -1294,6 +1536,41 @@ void main() {
         expect(
           const ConversationMessageDeleted(rumorId: messageId).props,
           equals([messageId]),
+        );
+      });
+    });
+
+    group(ConversationSelfWrapRecoveryRequested, () {
+      test('supports value equality', () {
+        expect(
+          const ConversationSelfWrapRecoveryRequested(rumorIds: [messageId]),
+          equals(
+            const ConversationSelfWrapRecoveryRequested(rumorIds: [messageId]),
+          ),
+        );
+      });
+
+      test('events with different rumorIds are not equal', () {
+        expect(
+          const ConversationSelfWrapRecoveryRequested(rumorIds: [messageId]),
+          isNot(
+            equals(
+              const ConversationSelfWrapRecoveryRequested(
+                rumorIds: [giftWrapId],
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('props are correct', () {
+        expect(
+          const ConversationSelfWrapRecoveryRequested(
+            rumorIds: [messageId, giftWrapId],
+          ).props,
+          equals([
+            const [messageId, giftWrapId],
+          ]),
         );
       });
     });

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -70,6 +70,9 @@ void main() {
           content: '',
         ),
       );
+      registerFallbackValue(
+        const ConversationSelfWrapRecoveryRequested(rumorIds: <String>[]),
+      );
     });
 
     setUp(() {
@@ -781,9 +784,13 @@ void main() {
       // The recipient-only partial-delivery path: NIP17MessageService
       // returned `success: true, selfWrapPublished: false`, so the bloc
       // emits SendStatus.sentPartial. The UI must show distinct copy
-      // (the message *was* delivered) while still offering retry, so the
-      // sender can attempt to re-publish their self-wrap and restore
-      // cross-device sync. Pinned per PR #3908 review feedback.
+      // (the message *was* delivered) while still offering retry, and
+      // the retry MUST go through the self-wrap-only recovery path so
+      // recipients are not re-delivered to (#4102).
+      const partialRumorId =
+          '7777777777777777777777777777777777777777777777777777777777777777';
+      const partialSend = PartialSend(rumorIds: [partialRumorId]);
+
       testWidgets(
         'shows the partial-delivery SnackBar copy when sendStatus '
         'transitions to sentPartial',
@@ -795,7 +802,7 @@ void main() {
               ConversationState(
                 status: ConversationStatus.loaded,
                 sendStatus: SendStatus.sentPartial,
-                lastFailedSend: failedSend,
+                lastPartialSend: partialSend,
               ),
             ]),
             initialState: const ConversationState(
@@ -834,6 +841,75 @@ void main() {
           );
           expect(find.text(l10n.dmSendFailedMessage), findsNothing);
           expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'tapping Retry on the partial-delivery SnackBar dispatches '
+        'ConversationSelfWrapRecoveryRequested with the rumor ids — '
+        'never ConversationMessageSent (#4102: no duplicate recipient '
+        'publish)',
+        (tester) async {
+          whenListen(
+            mockBloc,
+            Stream<ConversationState>.fromIterable(const [
+              ConversationState(status: ConversationStatus.loaded),
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.sentPartial,
+                lastPartialSend: partialSend,
+              ),
+            ]),
+            initialState: const ConversationState(
+              status: ConversationStatus.loaded,
+            ),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+              ],
+              home: BlocProvider<ConversationBloc>.value(
+                value: mockBloc,
+                child: BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                  child: const ConversationView(
+                    participantPubkeys: [otherPubkey],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          await tester.tap(find.text(l10n.dmSendFailedRetry));
+          await tester.pump();
+
+          final captured = verify(() => mockBloc.add(captureAny())).captured;
+          expect(captured, isNotEmpty);
+          final retryEvent = captured.last;
+          expect(
+            retryEvent,
+            isA<ConversationSelfWrapRecoveryRequested>().having(
+              (e) => e.rumorIds,
+              'rumorIds',
+              equals(const [partialRumorId]),
+            ),
+          );
+          // The pinning contract from #4102: no recipient republish on
+          // partial recovery.
+          expect(
+            captured.whereType<ConversationMessageSent>(),
+            isEmpty,
+            reason:
+                'partial recovery must NOT redispatch ConversationMessageSent '
+                '— that would re-deliver to the recipient',
+          );
         },
       );
     });


### PR DESCRIPTION
## Description

Closes #4102 — the technical-debt follow-up to PR #3908.

When a NIP-17 send delivers to the recipient but the sender's
self-addressed gift wrap fails to publish, `ConversationBloc` emits
`SendStatus.sentPartial`. Tapping Retry on the SnackBar previously
redispatched the full `ConversationMessageSent` path, which republished
the recipient gift wrap and double-delivered the message. NIP-17 self
wraps are independent of recipient wraps — only the missing self wrap
needs to land on retry, never the recipient one. This PR adds the
self-wrap-only recovery primitive plus the matching BLoC event and
SnackBar wiring so Retry-on-`sentPartial` republishes only the sender's
gift wrap, leaving recipients untouched.

**Related Issue:** Closes #4102 (follow-up to #3908)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes

**`NIP17MessageService` (`packages/dm_repository`)**
- New `publishSelfWrap({required Event rumorEvent})`: builds + publishes
  only the sender self-addressed gift wrap for a pre-existing rumor,
  sharing the underlying self-wrap helper with `sendRumor` so the two
  paths agree on null-builder, publish-failure, and exception handling.

**`DmRepository.recoverSelfWrap(rumorId)`**
- Looks up the queue row by `rumorId`, rebuilds the rumor from
  `rumor_event_json` (preserving the receiver-side dedup key), publishes
  via `publishSelfWrap`, then deletes the row on success or marks
  `self_wrap_status: failed` for the next retry sweep.
- Idempotent against an already-sent row, defends against missing rows,
  foreign-owner rows (cross-account safety), corrupted rumor JSON, and a
  missing queue DAO.

**`DmRepository.sendGroupMessage`**
- Refactored to enqueue a queue row per recipient, mirroring
  `sendMessage`, and to write per-recipient outcomes inside the same
  transaction as the local message persist. This is what lets group
  recovery scope to only the affected successful recipient sends — the
  prior implementation shared a single send path with no queue rows, so
  partial group deliveries had nowhere to look up the rumor for replay.

**`ConversationState`**
- New `PartialSend({required List<String> rumorIds})` carries the
  per-recipient rumor ids whose self-wrap failed.
- `lastPartialSend` lives alongside `lastFailedSend` with its own clear
  flag in `copyWith`. The two states drive different recovery paths
  (full resend vs self-wrap-only), so they're tracked independently.

**`ConversationBloc`**
- On `sentPartial`, populates `lastPartialSend` (not `lastFailedSend`)
  with the rumor ids of the partial-self results.
- New `ConversationSelfWrapRecoveryRequested(rumorIds)` event with a
  `sequential()` transformer (same as `ConversationMessageSent`).
- The handler loops `recoverSelfWrap` per id, aggregates outcomes, and
  reduces `lastPartialSend.rumorIds` to only the still-failing ids so a
  second Retry tap targets exactly those.
- Removes the obsolete "TODO #3909" tradeoff comment block — the
  principled fix it described is now in place.

**`ConversationView`**
- `_onSendOutcome`'s SnackBar action branches on `sendStatus`:
  `sentPartial` dispatches `ConversationSelfWrapRecoveryRequested`,
  `failed` keeps dispatching `ConversationMessageSent`.

**l10n**
- No new keys. The existing `dmSendPartialMessage` and
  `dmSendFailedRetry` already exist in all 17 locales (added by PR
  #3908).

## Test plan

Automated:
- [x] `flutter analyze lib test integration_test` — clean.
- [x] `dart format` — no changes.
- [x] `mobile/packages/dm_repository` 217/217 passing (12 new tests:
  5 `publishSelfWrap`, 5 `sendGroupMessage` queue, 7 `recoverSelfWrap`).
- [x] `mobile/test/blocs/dm` + `mobile/test/screens/inbox` 311/311
  passing (4 new self-wrap recovery scenarios + 3 new event-equality
  tests + 3 new state-shape tests + 1 new view-test for retry-dispatch).

Pinning contracts added:
- `recoverSelfWrap` never publishes a recipient wrap (verified via
  `verifyNever(messageService.sendRumor(...))` and
  `verifyNever(messageService.sendPrivateMessage(...))` after recovery).
- `ConversationSelfWrapRecoveryRequested` handler never calls
  `dmRepository.sendMessage` or `sendGroupMessage`.
- View test: tapping Retry on the partial-delivery SnackBar dispatches
  `ConversationSelfWrapRecoveryRequested` (not
  `ConversationMessageSent`).

Manual verification (please confirm during review):
- [ ] Force a self-wrap publish failure on a 1:1 send (e.g. block the
  second `publishEvent` round in a debug build) → SnackBar shows the
  partial-delivery copy → Retry resyncs the self-wrap without sending
  a second bubble to the recipient.
- [ ] Same for a group send where one of the per-recipient self-wraps
  fails → only that one rumor's self-wrap is republished on Retry.
- [ ] After a successful recovery, leave + re-enter the conversation —
  the `outgoing_dms` row for that rumor should be gone.

## Investigation notes

The plan in `tasks/lessons.md` shape, including the architectural
choice to enqueue group sends per-recipient (so partial group recovery
has a queue-row source of truth), was captured in /plan output for
#4102 prior to implementation.