### PR TITLE
fix(notifications): restore PR #3548 row styling and l10n on top of video grouping

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3670,5 +3670,14 @@
     "reportReasonOtherSubtitle": "ከላይ ያልተዘረዘሩ ጥሰቶች",
     "reportLearnMoreAt": "የበለጠ ይወቁ በ",
     "supportLogsSavedTo": "ምዝግቦች ተቀምጠዋል በ {path}",
-    "supportRevealLogsAction": "በአቃፊ ውስጥ አሳይ"
+    "supportRevealLogsAction": "በአቃፊ ውስጥ አሳይ",
+    "notificationsVideoThumbnailFor": "የ{title} ቪዲዮ ድንክዬ",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "የቪዲዮ ድንክዬ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "انتهاكات غير مدرجة أعلاه",
     "reportLearnMoreAt": "اعرف المزيد على",
     "supportLogsSavedTo": "حُفظت السجلات في {path}",
-    "supportRevealLogsAction": "إظهار في المجلد"
+    "supportRevealLogsAction": "إظهار في المجلد",
+    "notificationsVideoThumbnailFor": "صورة مصغرة لفيديو {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "صورة مصغرة للفيديو"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3676,5 +3676,14 @@
     "reportReasonOtherSubtitle": "Нарушения, които не са изброени по-горе",
     "reportLearnMoreAt": "Научи повече на",
     "supportLogsSavedTo": "Логовете са запазени в {path}",
-    "supportRevealLogsAction": "Покажи в папка"
+    "supportRevealLogsAction": "Покажи в папка",
+    "notificationsVideoThumbnailFor": "Миниатюра на видео за {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Миниатюра на видео"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Verstöße, die oben nicht aufgeführt sind",
     "reportLearnMoreAt": "Mehr erfahren unter",
     "supportLogsSavedTo": "Logs gespeichert unter {path}",
-    "supportRevealLogsAction": "Im Ordner anzeigen"
+    "supportRevealLogsAction": "Im Ordner anzeigen",
+    "notificationsVideoThumbnailFor": "Videovorschaubild für {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Videovorschaubild"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2092,6 +2092,19 @@
   "@notificationsViewProfilesSemanticLabel": {
     "description": "Screen-reader label for a grouped notification's avatar stack, which opens the list of involved profiles."
   },
+  "notificationsVideoThumbnailFor": "Video thumbnail for {title}",
+  "@notificationsVideoThumbnailFor": {
+    "description": "Screen-reader label for the video thumbnail on a video-anchored notification row when the video title is known.",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "notificationsVideoThumbnail": "Video thumbnail",
+  "@notificationsVideoThumbnail": {
+    "description": "Screen-reader fallback label for the video thumbnail on a video-anchored notification row when the title is missing."
+  },
   "notificationsLoadingType": "Loading {type} notifications...",
   "@notificationsLoadingType": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Infracciones no listadas arriba",
     "reportLearnMoreAt": "Más información en",
     "supportLogsSavedTo": "Registros guardados en {path}",
-    "supportRevealLogsAction": "Mostrar en carpeta"
+    "supportRevealLogsAction": "Mostrar en carpeta",
+    "notificationsVideoThumbnailFor": "Miniatura del video {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Miniatura del video"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2095,5 +2095,14 @@
     "profileEditGetVerifiedSubtitle": "I-link ang iyong mga social media account para malaman ng mga tao na ikaw talaga ito.",
     "@profileEditGetVerifiedSubtitle": {
         "description": "Subtitle explaining the verified accounts call to action in the profile editor"
-    }
+    },
+    "notificationsVideoThumbnailFor": "Thumbnail ng video para sa {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Thumbnail ng video"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Infractions non listées ci-dessus",
     "reportLearnMoreAt": "En savoir plus sur",
     "supportLogsSavedTo": "Journaux enregistrés dans {path}",
-    "supportRevealLogsAction": "Afficher dans le dossier"
+    "supportRevealLogsAction": "Afficher dans le dossier",
+    "notificationsVideoThumbnailFor": "Miniature de la vidéo {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Miniature de la vidéo"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Pelanggaran yang tidak tercantum di atas",
     "reportLearnMoreAt": "Pelajari lebih lanjut di",
     "supportLogsSavedTo": "Log disimpan ke {path}",
-    "supportRevealLogsAction": "Tampilkan di folder"
+    "supportRevealLogsAction": "Tampilkan di folder",
+    "notificationsVideoThumbnailFor": "Thumbnail video untuk {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Thumbnail video"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Violazioni non elencate sopra",
     "reportLearnMoreAt": "Scopri di più su",
     "supportLogsSavedTo": "Log salvati in {path}",
-    "supportRevealLogsAction": "Mostra nella cartella"
+    "supportRevealLogsAction": "Mostra nella cartella",
+    "notificationsVideoThumbnailFor": "Anteprima del video {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Anteprima del video"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "上記に記載されていない違反",
     "reportLearnMoreAt": "詳しくはこちら",
     "supportLogsSavedTo": "ログを{path}に保存しました",
-    "supportRevealLogsAction": "フォルダで表示"
+    "supportRevealLogsAction": "フォルダで表示",
+    "notificationsVideoThumbnailFor": "{title}の動画サムネイル",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "動画のサムネイル"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2837,5 +2837,14 @@
     "reportReasonOtherSubtitle": "위에 나열되지 않은 위반",
     "reportLearnMoreAt": "자세한 내용은",
     "supportLogsSavedTo": "{path}에 로그 저장됨",
-    "supportRevealLogsAction": "폴더에서 보기"
+    "supportRevealLogsAction": "폴더에서 보기",
+    "notificationsVideoThumbnailFor": "{title} 동영상 썸네일",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "동영상 썸네일"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Overtredingen die hierboven niet staan",
     "reportLearnMoreAt": "Meer info op",
     "supportLogsSavedTo": "Logs opgeslagen in {path}",
-    "supportRevealLogsAction": "Tonen in map"
+    "supportRevealLogsAction": "Tonen in map",
+    "notificationsVideoThumbnailFor": "Videominiatuur van {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Videominiatuur"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Naruszenia niewymienione powyżej",
     "reportLearnMoreAt": "Dowiedz się więcej na",
     "supportLogsSavedTo": "Logi zapisano w {path}",
-    "supportRevealLogsAction": "Pokaż w folderze"
+    "supportRevealLogsAction": "Pokaż w folderze",
+    "notificationsVideoThumbnailFor": "Miniatura wideo dla {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Miniatura wideo"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Violações não listadas acima",
     "reportLearnMoreAt": "Saiba mais em",
     "supportLogsSavedTo": "Logs salvos em {path}",
-    "supportRevealLogsAction": "Mostrar na pasta"
+    "supportRevealLogsAction": "Mostrar na pasta",
+    "notificationsVideoThumbnailFor": "Miniatura do vídeo {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Miniatura do vídeo"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Încălcări care nu sunt listate mai sus",
     "reportLearnMoreAt": "Află mai multe la",
     "supportLogsSavedTo": "Jurnale salvate în {path}",
-    "supportRevealLogsAction": "Arată în dosar"
+    "supportRevealLogsAction": "Arată în dosar",
+    "notificationsVideoThumbnailFor": "Miniatură video pentru {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Miniatură video"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Överträdelser som inte listas ovan",
     "reportLearnMoreAt": "Läs mer på",
     "supportLogsSavedTo": "Loggar sparade i {path}",
-    "supportRevealLogsAction": "Visa i mapp"
+    "supportRevealLogsAction": "Visa i mapp",
+    "notificationsVideoThumbnailFor": "Videominiatyr för {title}",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Videominiatyr"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3541,5 +3541,14 @@
     "reportReasonOtherSubtitle": "Yukarıda listelenmeyen ihlaller",
     "reportLearnMoreAt": "Daha fazla bilgi:",
     "supportLogsSavedTo": "Günlükler {path} konumuna kaydedildi",
-    "supportRevealLogsAction": "Klasörde göster"
+    "supportRevealLogsAction": "Klasörde göster",
+    "notificationsVideoThumbnailFor": "{title} için video küçük resmi",
+    "@notificationsVideoThumbnailFor": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationsVideoThumbnail": "Video küçük resmi"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6980,6 +6980,18 @@ abstract class AppLocalizations {
   /// **'View profiles'**
   String get notificationsViewProfilesSemanticLabel;
 
+  /// Screen-reader label for the video thumbnail on a video-anchored notification row when the video title is known.
+  ///
+  /// In en, this message translates to:
+  /// **'Video thumbnail for {title}'**
+  String notificationsVideoThumbnailFor(String title);
+
+  /// Screen-reader fallback label for the video thumbnail on a video-anchored notification row when the title is missing.
+  ///
+  /// In en, this message translates to:
+  /// **'Video thumbnail'**
+  String get notificationsVideoThumbnail;
+
   /// No description provided for @notificationsLoadingType.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3884,6 +3884,14 @@ class AppLocalizationsAm extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'መገለጫዎችን ይመልከቱ';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return '$type ማሳወቂያዎችን በመጫን ላይ...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3885,11 +3885,11 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'የ$title ቪዲዮ ድንክዬ';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'የቪዲዮ ድንክዬ';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3928,6 +3928,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'عرض الملفات الشخصية';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'جارٍ تحميل إشعارات $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3929,11 +3929,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'صورة مصغرة لفيديو $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'صورة مصغرة للفيديو';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4016,11 +4016,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Миниатюра на видео за $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Миниатюра на видео';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4015,6 +4015,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Преглед на профили';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Зареждат се $type известия...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4020,11 +4020,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Videovorschaubild für $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Videovorschaubild';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4019,6 +4019,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Profile öffnen';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return '$type-Benachrichtigungen werden geladen...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3971,6 +3971,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'View profiles';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Loading $type notifications...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4016,11 +4016,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Miniatura del video $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Miniatura del video';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4015,6 +4015,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Ver perfiles';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Cargando notificaciones de $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4028,6 +4028,14 @@ class AppLocalizationsFil extends AppLocalizations {
       'Tingnan ang mga profile';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Nilo-load ang $type na notifications...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4029,11 +4029,11 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Thumbnail ng video para sa $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Thumbnail ng video';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4031,11 +4031,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Miniature de la vidéo $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Miniature de la vidéo';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4030,6 +4030,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Voir les profils';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Chargement des notifications $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3940,6 +3940,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Lihat profil';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Memuat notifikasi $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3941,11 +3941,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Thumbnail video untuk $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Thumbnail video';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4014,11 +4014,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Anteprima del video $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Anteprima del video';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4013,6 +4013,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Vedi profili';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Caricamento notifiche $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3777,6 +3777,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'プロフィールを開く';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return '$typeの通知を読み込み中...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3778,11 +3778,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return '$titleの動画サムネイル';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => '動画のサムネイル';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3793,11 +3793,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return '$title 동영상 썸네일';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => '동영상 썸네일';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3792,6 +3792,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => '프로필 보기';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return '$type 알림을 불러오는 중...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3984,6 +3984,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Profielen bekijken';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return '$type-meldingen laden...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3985,11 +3985,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Videominiatuur van $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Videominiatuur';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4069,6 +4069,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Zobacz profile';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Wczytywanie powiadomień typu $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4070,11 +4070,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Miniatura wideo dla $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Miniatura wideo';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3995,6 +3995,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Ver perfis';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Carregando notificações de $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3996,11 +3996,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Miniatura do vídeo $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Miniatura do vídeo';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4086,11 +4086,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Miniatură video pentru $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Miniatură video';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4085,6 +4085,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Vezi profilurile';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Se încarcă notificările de tip $type...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3968,11 +3968,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return 'Videominiatyr för $title';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Videominiatyr';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3967,6 +3967,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Visa profiler';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return 'Läser in $type-aviseringar...';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3951,11 +3951,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String notificationsVideoThumbnailFor(String title) {
-    return 'Video thumbnail for $title';
+    return '$title için video küçük resmi';
   }
 
   @override
-  String get notificationsVideoThumbnail => 'Video thumbnail';
+  String get notificationsVideoThumbnail => 'Video küçük resmi';
 
   @override
   String notificationsLoadingType(String type) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3950,6 +3950,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get notificationsViewProfilesSemanticLabel => 'Profilleri görüntüle';
 
   @override
+  String notificationsVideoThumbnailFor(String title) {
+    return 'Video thumbnail for $title';
+  }
+
+  @override
+  String get notificationsVideoThumbnail => 'Video thumbnail';
+
+  @override
   String notificationsLoadingType(String type) {
     return '$type bildirimleri yükleniyor...';
   }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -7,6 +7,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -15,7 +17,6 @@ import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
-import 'package:time_formatter/time_formatter.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// The notification list UI.
@@ -107,7 +108,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
-      color: VineTheme.backgroundColor,
+      color: VineTheme.surfaceContainerHigh,
       child: BlocBuilder<NotificationFeedBloc, NotificationFeedState>(
         builder: (context, state) {
           final visible = _applyFilter(state.notifications);
@@ -252,9 +253,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
       if (resolved == null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Video not found'),
-            duration: Duration(seconds: 2),
+          SnackBar(
+            content: Text(context.l10n.notificationsVideoNotFound),
+            duration: const Duration(seconds: 2),
           ),
         );
         return;
@@ -281,9 +282,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
     if (video == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Video not found'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: Text(context.l10n.notificationsVideoNotFound),
+          duration: const Duration(seconds: 2),
         ),
       );
       return;
@@ -291,9 +292,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
     if (videoEventService.shouldHideVideo(video)) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Video unavailable'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: Text(context.l10n.notificationsVideoUnavailable),
+          duration: const Duration(seconds: 2),
         ),
       );
       return;
@@ -304,7 +305,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       extra: PooledFullscreenVideoFeedArgs(
         videosStream: Stream.value([video]),
         initialIndex: 0,
-        contextTitle: 'From Notification',
+        contextTitle: context.l10n.notificationsFromNotification,
         autoOpenComments: isComment,
       ),
     );
@@ -356,16 +357,19 @@ class _FailureBody extends StatelessWidget {
         children: [
           const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
           const SizedBox(height: 16),
-          const Text(
-            'Failed to load notifications',
-            style: TextStyle(fontSize: 18, color: VineTheme.secondaryText),
+          Text(
+            context.l10n.notificationsFailedToLoad,
+            style: const TextStyle(
+              fontSize: 18,
+              color: VineTheme.secondaryText,
+            ),
           ),
           const SizedBox(height: 16),
           TextButton(
             onPressed: onRetry,
-            child: const Text(
-              'Retry',
-              style: TextStyle(color: VineTheme.vineGreen),
+            child: Text(
+              context.l10n.notificationsRetry,
+              style: const TextStyle(color: VineTheme.vineGreen),
             ),
           ),
         ],
@@ -422,13 +426,13 @@ class _NotificationList extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                 child: Text(
-                  TimeFormatter.formatDateLabel(
+                  LocalizedTimeFormatter.formatDateLabel(
+                    context.l10n,
                     notification.timestamp.millisecondsSinceEpoch ~/ 1000,
+                    locale: Localizations.localeOf(context).toLanguageTag(),
                   ),
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                    color: VineTheme.secondaryText,
+                  style: VineTheme.labelLargeFont(
+                    color: VineTheme.onSurfaceMuted,
                   ),
                 ),
               ),
@@ -444,13 +448,6 @@ class _NotificationList extends StatelessWidget {
                 if (pubkey != null) onFollowBack(pubkey);
               },
             ),
-            if (index < notifications.length - 1)
-              const Divider(
-                height: 1,
-                thickness: 0.5,
-                color: VineTheme.onSurfaceMuted,
-                indent: 72,
-              ),
           ],
         );
       },

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -355,21 +355,22 @@ class _FailureBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.notificationsFailedToLoad,
-            style: const TextStyle(
-              fontSize: 18,
-              color: VineTheme.secondaryText,
-            ),
+            style: VineTheme.bodyLargeFont(color: VineTheme.secondaryText),
           ),
           const SizedBox(height: 16),
           TextButton(
             onPressed: onRetry,
             child: Text(
               context.l10n.notificationsRetry,
-              style: const TextStyle(color: VineTheme.vineGreen),
+              style: VineTheme.labelLargeFont(color: VineTheme.vineGreen),
             ),
           ),
         ],

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -9,8 +9,7 @@ import 'package:openvine/constants/notification_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
-import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
-import 'package:openvine/widgets/notification_type_icon.dart';
+import 'package:openvine/notifications/widgets/notification_leading_type_icon.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Displays a single actor-anchored notification row (follow / mention /
@@ -62,7 +61,7 @@ class ActorNotificationRow extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _LeadingTypeIcon(
+                  NotificationLeadingTypeIcon(
                     type: notification.type,
                     isRead: notification.isRead,
                   ),
@@ -80,24 +79,6 @@ class ActorNotificationRow extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _LeadingTypeIcon extends StatelessWidget {
-  const _LeadingTypeIcon({required this.type, required this.isRead});
-
-  final NotificationKind type;
-  final bool isRead;
-
-  @override
-  Widget build(BuildContext context) {
-    final spec = notificationTypeIconSpec(type);
-    return NotificationTypeIcon(
-      icon: spec.icon,
-      backgroundColor: spec.background,
-      foregroundColor: spec.foreground,
-      showUnreadDot: !isRead,
     );
   }
 }

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -239,14 +239,9 @@ class _CommentQuote extends StatelessWidget {
 
 /// Trailing "Follow back" button on follow-kind rows.
 ///
-/// Sized to match [NotificationConstants.avatarSize] (32px) so the row's
-/// trailing affordance aligns vertically with the leading type icon and
-/// the actor's avatar. [DivineButton]'s `small` variant is 40px tall
-/// (24px titleMediumFont line-height + 8px vertical padding × 2) and
-/// can't be clamped without clipping text, so this is a deliberate
-/// local primitive that mirrors the design-system primary button at a
-/// 32px height. If `divine_ui` ever grows a `DivineButtonSize.tiny`
-/// variant this should swap to it.
+/// Uses [DivineButtonSize.tiny] (32px visible height) so the row's
+/// trailing affordance aligns vertically with the leading 32px type icon
+/// and the actor's 32px avatar.
 class _FollowBackButton extends StatelessWidget {
   const _FollowBackButton({this.onPressed});
 
@@ -254,25 +249,10 @@ class _FollowBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: NotificationConstants.avatarSize,
-      child: Material(
-        color: VineTheme.primary,
-        borderRadius: BorderRadius.circular(16),
-        child: InkWell(
-          onTap: onPressed,
-          borderRadius: BorderRadius.circular(16),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Center(
-              child: Text(
-                context.l10n.notificationFollowBack,
-                style: VineTheme.labelLargeFont(color: VineTheme.onPrimary),
-              ),
-            ),
-          ),
-        ),
-      ),
+    return DivineButton(
+      label: context.l10n.notificationFollowBack,
+      onPressed: onPressed,
+      size: DivineButtonSize.tiny,
     );
   }
 }

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -36,10 +36,6 @@ class ActorNotificationRow extends StatelessWidget {
   /// Called when the Follow back button is tapped (follow kind only).
   final VoidCallback? onFollowBack;
 
-  bool get _showFollowBack =>
-      notification.type == NotificationKind.follow &&
-      !notification.isFollowingBack;
-
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
@@ -74,12 +70,9 @@ class ActorNotificationRow extends StatelessWidget {
                     child: _NotificationContent(
                       notification: notification,
                       onProfileTap: onProfileTap,
+                      onFollowBack: onFollowBack,
                     ),
                   ),
-                  if (_showFollowBack) ...[
-                    const SizedBox(width: 8),
-                    _FollowBackButton(onPressed: onFollowBack),
-                  ],
                 ],
               ),
             ),
@@ -112,10 +105,16 @@ class _NotificationContent extends StatelessWidget {
   const _NotificationContent({
     required this.notification,
     required this.onProfileTap,
+    this.onFollowBack,
   });
 
   final ActorNotification notification;
   final VoidCallback onProfileTap;
+  final VoidCallback? onFollowBack;
+
+  bool get _showFollowBack =>
+      notification.type == NotificationKind.follow &&
+      !notification.isFollowingBack;
 
   bool get _hasComment =>
       notification.commentText != null && notification.commentText!.isNotEmpty;
@@ -126,16 +125,30 @@ class _NotificationContent extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        UserAvatar(
-          imageUrl: notification.actor.pictureUrl,
-          name: notification.actor.displayName,
-          placeholderSeed: notification.actor.pubkey,
-          size: NotificationConstants.avatarSize,
-          cornerRadius: NotificationConstants.avatarCornerRadius,
-          onTap: onProfileTap,
-          semanticLabel: l10n.notificationsViewProfileSemanticLabel(
-            notification.actor.displayName,
-          ),
+        // Avatar + (optional) Follow back share a single row so the avatar
+        // stays anchored to the top-left and the button hugs the right
+        // edge. Keeping the button on this row — instead of as a sibling
+        // of the entire content column — means the message text's width
+        // below doesn't change when the button appears or disappears, so
+        // tapping Follow back never re-wraps the message line.
+        Row(
+          children: [
+            UserAvatar(
+              imageUrl: notification.actor.pictureUrl,
+              name: notification.actor.displayName,
+              placeholderSeed: notification.actor.pubkey,
+              size: NotificationConstants.avatarSize,
+              cornerRadius: NotificationConstants.avatarCornerRadius,
+              onTap: onProfileTap,
+              semanticLabel: l10n.notificationsViewProfileSemanticLabel(
+                notification.actor.displayName,
+              ),
+            ),
+            if (_showFollowBack) ...[
+              const Spacer(),
+              _FollowBackButton(onPressed: onFollowBack),
+            ],
+          ],
         ),
         const SizedBox(height: 8),
         _MessageText(notification: notification),

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -136,7 +136,15 @@ class _NotificationContent extends StatelessWidget {
             ),
             if (_showFollowBack) ...[
               const Spacer(),
-              _FollowBackButton(onPressed: onFollowBack),
+              // Tiny variant (32px visible) so the row's trailing
+              // affordance aligns with the leading 32px type icon and
+              // the actor's 32px avatar — keeping the row's intrinsic
+              // height stable when the button shows / hides.
+              DivineButton(
+                label: l10n.notificationFollowBack,
+                onPressed: onFollowBack,
+                size: DivineButtonSize.tiny,
+              ),
             ],
           ],
         ),
@@ -237,24 +245,4 @@ String _verbFor(AppLocalizations l10n, NotificationKind type) {
     NotificationKind.comment ||
     NotificationKind.repost => '',
   };
-}
-
-/// Trailing "Follow back" button on follow-kind rows.
-///
-/// Uses [DivineButtonSize.tiny] (32px visible height) so the row's
-/// trailing affordance aligns vertically with the leading 32px type icon
-/// and the actor's 32px avatar.
-class _FollowBackButton extends StatelessWidget {
-  const _FollowBackButton({this.onPressed});
-
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return DivineButton(
-      label: context.l10n.notificationFollowBack,
-      onPressed: onPressed,
-      size: DivineButtonSize.tiny,
-    );
-  }
 }

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -40,14 +40,9 @@ class ActorNotificationRow extends StatelessWidget {
       notification.type == NotificationKind.follow &&
       !notification.isFollowingBack;
 
-  bool get _hasComment =>
-      notification.commentText != null && notification.commentText!.isNotEmpty;
-
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final spec = notificationTypeIconSpec(notification.type);
-
     return Material(
       color: VineTheme.surfaceContainerHigh,
       child: Semantics(
@@ -70,37 +65,15 @@ class ActorNotificationRow extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  NotificationTypeIcon(
-                    icon: spec.icon,
-                    backgroundColor: spec.background,
-                    foregroundColor: spec.foreground,
-                    showUnreadDot: !notification.isRead,
+                  _LeadingTypeIcon(
+                    type: notification.type,
+                    isRead: notification.isRead,
                   ),
                   const SizedBox(width: 16),
                   Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        UserAvatar(
-                          imageUrl: notification.actor.pictureUrl,
-                          name: notification.actor.displayName,
-                          placeholderSeed: notification.actor.pubkey,
-                          size: NotificationConstants.avatarSize,
-                          cornerRadius:
-                              NotificationConstants.avatarCornerRadius,
-                          onTap: onProfileTap,
-                          semanticLabel: l10n
-                              .notificationsViewProfileSemanticLabel(
-                                notification.actor.displayName,
-                              ),
-                        ),
-                        const SizedBox(height: 8),
-                        _MessageText(notification: notification),
-                        if (_hasComment) ...[
-                          const SizedBox(height: 4),
-                          _CommentQuote(text: notification.commentText!),
-                        ],
-                      ],
+                    child: _NotificationContent(
+                      notification: notification,
+                      onProfileTap: onProfileTap,
                     ),
                   ),
                   if (_showFollowBack) ...[
@@ -113,6 +86,64 @@ class ActorNotificationRow extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _LeadingTypeIcon extends StatelessWidget {
+  const _LeadingTypeIcon({required this.type, required this.isRead});
+
+  final NotificationKind type;
+  final bool isRead;
+
+  @override
+  Widget build(BuildContext context) {
+    final spec = notificationTypeIconSpec(type);
+    return NotificationTypeIcon(
+      icon: spec.icon,
+      backgroundColor: spec.background,
+      foregroundColor: spec.foreground,
+      showUnreadDot: !isRead,
+    );
+  }
+}
+
+class _NotificationContent extends StatelessWidget {
+  const _NotificationContent({
+    required this.notification,
+    required this.onProfileTap,
+  });
+
+  final ActorNotification notification;
+  final VoidCallback onProfileTap;
+
+  bool get _hasComment =>
+      notification.commentText != null && notification.commentText!.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        UserAvatar(
+          imageUrl: notification.actor.pictureUrl,
+          name: notification.actor.displayName,
+          placeholderSeed: notification.actor.pubkey,
+          size: NotificationConstants.avatarSize,
+          cornerRadius: NotificationConstants.avatarCornerRadius,
+          onTap: onProfileTap,
+          semanticLabel: l10n.notificationsViewProfileSemanticLabel(
+            notification.actor.displayName,
+          ),
+        ),
+        const SizedBox(height: 8),
+        _MessageText(notification: notification),
+        if (_hasComment) ...[
+          const SizedBox(height: 4),
+          _CommentQuote(text: notification.commentText!),
+        ],
+      ],
     );
   }
 }

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -1,19 +1,19 @@
-// ABOUTME: One-row layout for ActorNotification — single avatar with type
-// ABOUTME: badge, message + timestamp, optional Follow back button.
+// ABOUTME: One-row layout for ActorNotification — leading 32x32 type icon,
+// ABOUTME: avatar + bold actor name + verb + inline timestamp, optional
+// ABOUTME: comment quote, optional Follow back button.
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
+import 'package:openvine/constants/notification_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:time_formatter/time_formatter.dart';
-
-const double _avatarSize = 48;
-const double _badgeSize = 20;
-const double _followBackHeight = 32;
+import 'package:openvine/l10n/localized_time_formatter.dart';
+import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
+import 'package:openvine/widgets/notification_type_icon.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 
 /// Displays a single actor-anchored notification row (follow / mention /
-/// system).
+/// likeComment / reply / system).
 class ActorNotificationRow extends StatelessWidget {
   /// Creates an [ActorNotificationRow].
   const ActorNotificationRow({
@@ -46,64 +46,70 @@ class ActorNotificationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final actorName = notification.actor.displayName;
-    final message = switch (notification.type) {
-      NotificationKind.follow => l10n.notificationStartedFollowing(actorName),
-      NotificationKind.mention => l10n.notificationMentionedYou(actorName),
-      NotificationKind.likeComment => l10n.notificationLikedYourComment(
-        actorName,
-      ),
-      NotificationKind.reply =>
-        '$actorName ${l10n.notificationRepliedToYourComment}',
-      NotificationKind.system => l10n.notificationSystemUpdate,
-      NotificationKind.like ||
-      NotificationKind.comment ||
-      NotificationKind.repost => actorName,
-    };
+    final spec = notificationTypeIconSpec(notification.type);
 
     return Material(
-      color: notification.isRead
-          ? VineTheme.backgroundColor
-          : VineTheme.cardBackground,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _AvatarWithBadge(
-                actor: notification.actor,
-                type: notification.type,
-                onProfileTap: onProfileTap,
+      color: VineTheme.surfaceContainerHigh,
+      child: Semantics(
+        button: true,
+        container: true,
+        label: notification.isRead ? null : l10n.notificationsUnreadPrefix,
+        child: InkWell(
+          onTap: onTap,
+          child: DecoratedBox(
+            decoration: const BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: VineTheme.outlineDisabled),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(message, style: VineTheme.bodyMediumFont()),
-                    if (_hasComment) ...[
-                      const SizedBox(height: 4),
-                      _CommentPreview(text: notification.commentText!),
-                    ],
-                    const SizedBox(height: 4),
-                    Text(
-                      TimeFormatter.formatRelativeVerbose(
-                        notification.timestamp.millisecondsSinceEpoch ~/ 1000,
-                      ),
-                      style: VineTheme.bodySmallFont(
-                        color: VineTheme.lightText,
-                      ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 12,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  NotificationTypeIcon(
+                    icon: spec.icon,
+                    backgroundColor: spec.background,
+                    foregroundColor: spec.foreground,
+                    showUnreadDot: !notification.isRead,
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        UserAvatar(
+                          imageUrl: notification.actor.pictureUrl,
+                          name: notification.actor.displayName,
+                          placeholderSeed: notification.actor.pubkey,
+                          size: NotificationConstants.avatarSize,
+                          cornerRadius:
+                              NotificationConstants.avatarCornerRadius,
+                          onTap: onProfileTap,
+                          semanticLabel: l10n
+                              .notificationsViewProfileSemanticLabel(
+                                notification.actor.displayName,
+                              ),
+                        ),
+                        const SizedBox(height: 8),
+                        _MessageText(notification: notification),
+                        if (_hasComment) ...[
+                          const SizedBox(height: 4),
+                          _CommentQuote(text: notification.commentText!),
+                        ],
+                      ],
                     ),
-                    if (_showFollowBack) ...[
-                      const SizedBox(height: 8),
-                      _FollowBackButton(onPressed: onFollowBack),
-                    ],
+                  ),
+                  if (_showFollowBack) ...[
+                    const SizedBox(width: 8),
+                    _FollowBackButton(onPressed: onFollowBack),
                   ],
-                ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),
@@ -111,146 +117,91 @@ class ActorNotificationRow extends StatelessWidget {
   }
 }
 
-class _AvatarWithBadge extends StatelessWidget {
-  const _AvatarWithBadge({
-    required this.actor,
-    required this.type,
-    required this.onProfileTap,
-  });
+class _MessageText extends StatelessWidget {
+  const _MessageText({required this.notification});
 
-  final ActorInfo actor;
-  final NotificationKind type;
-  final VoidCallback onProfileTap;
+  final ActorNotification notification;
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      label: 'View ${actor.displayName} profile',
-      button: true,
-      child: GestureDetector(
-        onTap: onProfileTap,
-        child: SizedBox(
-          width: _avatarSize,
-          height: _avatarSize,
-          child: Stack(
-            children: [
-              ClipOval(
-                child: actor.pictureUrl != null
-                    ? CachedNetworkImage(
-                        imageUrl: actor.pictureUrl!,
-                        width: _avatarSize,
-                        height: _avatarSize,
-                        fit: BoxFit.cover,
-                        placeholder: (context, url) => const _DefaultAvatar(),
-                        errorWidget: (context, url, error) =>
-                            const _DefaultAvatar(),
-                      )
-                    : const _DefaultAvatar(),
-              ),
-              Positioned(
-                right: 0,
-                bottom: 0,
-                child: _TypeBadge(type: type),
-              ),
-            ],
-          ),
+    final l10n = context.l10n;
+    final spans = <InlineSpan>[];
+    final type = notification.type;
+
+    if (type == NotificationKind.system) {
+      spans.add(
+        TextSpan(
+          text: l10n.notificationSystemUpdate,
+          style: VineTheme.bodyMediumFont(),
         ),
+      );
+    } else {
+      spans.add(
+        TextSpan(
+          text: notification.actor.displayName,
+          style: VineTheme.labelLargeFont(),
+        ),
+      );
+      spans.add(
+        TextSpan(
+          text: ' ${_verbFor(l10n, type)}',
+          style: VineTheme.bodyMediumFont(),
+        ),
+      );
+    }
+
+    spans.add(
+      TextSpan(
+        text:
+            ' ${LocalizedTimeFormatter.formatRelative(l10n, notification.timestamp.millisecondsSinceEpoch ~/ 1000)}',
+        style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted55),
       ),
+    );
+
+    return Text.rich(
+      TextSpan(children: spans),
+      textScaler: MediaQuery.textScalerOf(context),
     );
   }
 }
 
-class _DefaultAvatar extends StatelessWidget {
-  const _DefaultAvatar();
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: VineTheme.accentPurple.withValues(alpha: 0.2),
-        shape: BoxShape.circle,
-      ),
-      child: const SizedBox(
-        width: _avatarSize,
-        height: _avatarSize,
-        child: Center(
-          child: Icon(Icons.person, color: VineTheme.accentPurple, size: 24),
-        ),
-      ),
-    );
-  }
+/// Returns just the verb portion (no actor name) for inline composition.
+///
+/// l10n verb keys carry the actor name as a leading `{actorName}`
+/// placeholder. Calling them with an empty string leaves a leading
+/// separator (a space in English, possibly something different in other
+/// locales) — strip it so the caller can prepend its own bold actor name.
+/// `notificationRepliedToYourComment` is already actor-free and used
+/// as-is.
+String _verbFor(AppLocalizations l10n, NotificationKind type) {
+  return switch (type) {
+    NotificationKind.follow => l10n.notificationStartedFollowing('').trimLeft(),
+    NotificationKind.mention => l10n.notificationMentionedYou('').trimLeft(),
+    NotificationKind.likeComment =>
+      l10n.notificationLikedYourComment('').trimLeft(),
+    NotificationKind.reply => l10n.notificationRepliedToYourComment,
+    // System is handled inline in _MessageText. The remaining cases are
+    // unreachable because ActorNotification asserts on type — but
+    // exhaustivity requires them.
+    NotificationKind.system ||
+    NotificationKind.like ||
+    NotificationKind.comment ||
+    NotificationKind.repost => '',
+  };
 }
 
-class _TypeBadge extends StatelessWidget {
-  const _TypeBadge({required this.type});
-
-  final NotificationKind type;
-
-  Color get _backgroundColor {
-    return switch (type) {
-      NotificationKind.like => VineTheme.error,
-      NotificationKind.likeComment => VineTheme.error,
-      NotificationKind.comment => VineTheme.info,
-      NotificationKind.reply => VineTheme.info,
-      NotificationKind.follow => VineTheme.accentPurple,
-      NotificationKind.repost => VineTheme.vineGreen,
-      NotificationKind.mention => VineTheme.warning,
-      NotificationKind.system => VineTheme.lightText,
-    };
-  }
-
-  String get _emoji {
-    return switch (type) {
-      NotificationKind.like => '❤️',
-      NotificationKind.likeComment => '❤️',
-      NotificationKind.comment => '💬',
-      NotificationKind.reply => '↩️',
-      NotificationKind.follow => '👤',
-      NotificationKind.repost => '🔁',
-      NotificationKind.mention => '@',
-      NotificationKind.system => 'ℹ️',
-    };
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: _badgeSize,
-      height: _badgeSize,
-      decoration: BoxDecoration(
-        color: _backgroundColor,
-        shape: BoxShape.circle,
-        border: Border.all(width: 2),
-      ),
-      child: Center(
-        child: Text(
-          _emoji,
-          style: const TextStyle(fontSize: 10),
-        ),
-      ),
-    );
-  }
-}
-
-class _CommentPreview extends StatelessWidget {
-  const _CommentPreview({required this.text});
+class _CommentQuote extends StatelessWidget {
+  const _CommentQuote({required this.text});
 
   final String text;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: VineTheme.cardBackground,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Text(
-        text,
-        style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,
-      ),
+    return Text(
+      '“$text”',
+      style: VineTheme.bodyMediumFont(),
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
     );
   }
 }
@@ -262,20 +213,10 @@ class _FollowBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: _followBackHeight,
-      child: FilledButton(
-        onPressed: onPressed,
-        style: FilledButton.styleFrom(
-          backgroundColor: VineTheme.vineGreen,
-          foregroundColor: VineTheme.onPrimary,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        child: const Text('Follow back'),
-      ),
+    return DivineButton(
+      label: context.l10n.notificationFollowBack,
+      onPressed: onPressed,
+      size: DivineButtonSize.small,
     );
   }
 }

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -237,6 +237,16 @@ class _CommentQuote extends StatelessWidget {
   }
 }
 
+/// Trailing "Follow back" button on follow-kind rows.
+///
+/// Sized to match [NotificationConstants.avatarSize] (32px) so the row's
+/// trailing affordance aligns vertically with the leading type icon and
+/// the actor's avatar. [DivineButton]'s `small` variant is 40px tall
+/// (24px titleMediumFont line-height + 8px vertical padding × 2) and
+/// can't be clamped without clipping text, so this is a deliberate
+/// local primitive that mirrors the design-system primary button at a
+/// 32px height. If `divine_ui` ever grows a `DivineButtonSize.tiny`
+/// variant this should swap to it.
 class _FollowBackButton extends StatelessWidget {
   const _FollowBackButton({this.onPressed});
 
@@ -244,10 +254,25 @@ class _FollowBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DivineButton(
-      label: context.l10n.notificationFollowBack,
-      onPressed: onPressed,
-      size: DivineButtonSize.small,
+    return SizedBox(
+      height: NotificationConstants.avatarSize,
+      child: Material(
+        color: VineTheme.primary,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(16),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Center(
+              child: Text(
+                context.l10n.notificationFollowBack,
+                style: VineTheme.labelLargeFont(color: VineTheme.onPrimary),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -8,6 +8,7 @@ import 'package:models/models.dart';
 import 'package:openvine/constants/notification_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
+import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
 import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -122,6 +123,14 @@ class _NotificationContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    // The trailing relative timestamp anchors to the visual end of the
+    // row. When a comment quote is rendered, the quote owns the
+    // timestamp suffix; without a quote, the timestamp sits at the end
+    // of the message text.
+    final relativeTime = LocalizedTimeFormatter.formatRelative(
+      l10n,
+      notification.timestamp.millisecondsSinceEpoch ~/ 1000,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -151,10 +160,16 @@ class _NotificationContent extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 8),
-        _MessageText(notification: notification),
+        _MessageText(
+          notification: notification,
+          timestamp: _hasComment ? null : relativeTime,
+        ),
         if (_hasComment) ...[
           const SizedBox(height: 4),
-          _CommentQuote(text: notification.commentText!),
+          NotificationCommentQuote(
+            text: notification.commentText!,
+            timestamp: relativeTime,
+          ),
         ],
       ],
     );
@@ -162,9 +177,16 @@ class _NotificationContent extends StatelessWidget {
 }
 
 class _MessageText extends StatelessWidget {
-  const _MessageText({required this.notification});
+  const _MessageText({required this.notification, this.timestamp});
 
   final ActorNotification notification;
+
+  /// When non-empty, appended in muted style at the end of the message.
+  /// Pass `null` (the default) when a [NotificationCommentQuote] sits
+  /// below this widget — the quote renders the timestamp instead, so
+  /// the trailing relative time stays anchored to the visual end of
+  /// the row.
+  final String? timestamp;
 
   @override
   Widget build(BuildContext context) {
@@ -194,13 +216,15 @@ class _MessageText extends StatelessWidget {
       );
     }
 
-    spans.add(
-      TextSpan(
-        text:
-            ' ${LocalizedTimeFormatter.formatRelative(l10n, notification.timestamp.millisecondsSinceEpoch ~/ 1000)}',
-        style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted55),
-      ),
-    );
+    final ts = timestamp;
+    if (ts != null && ts.isNotEmpty) {
+      spans.add(
+        TextSpan(
+          text: ' $ts',
+          style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted55),
+        ),
+      );
+    }
 
     return Text.rich(
       TextSpan(children: spans),
@@ -232,22 +256,6 @@ String _verbFor(AppLocalizations l10n, NotificationKind type) {
     NotificationKind.comment ||
     NotificationKind.repost => '',
   };
-}
-
-class _CommentQuote extends StatelessWidget {
-  const _CommentQuote({required this.text});
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      '“$text”',
-      style: VineTheme.bodyMediumFont(),
-      maxLines: 2,
-      overflow: TextOverflow.ellipsis,
-    );
-  }
 }
 
 /// Trailing "Follow back" button on follow-kind rows.

--- a/mobile/lib/notifications/widgets/notification_comment_quote.dart
+++ b/mobile/lib/notifications/widgets/notification_comment_quote.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Shared comment-quote primitive for notification rows. Renders
+// ABOUTME: the quoted comment text with curly quotes and an optional
+// ABOUTME: muted relative-timestamp suffix appended inline at the end.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+/// Renders a notification's quoted comment beneath the message text.
+///
+/// The text is wrapped in curly quotes and rendered in
+/// [VineTheme.bodyMediumFont]. When [timestamp] is non-empty the
+/// formatted relative time (e.g. `2d`) is appended inline at the end of
+/// the quote in [VineTheme.onSurfaceMuted55] — keeping the timestamp
+/// anchored to the visual end of the row rather than floating between
+/// the message text and the quote, which is what happens when the quote
+/// is rendered as a separate widget below a message that already
+/// includes its own trailing timestamp.
+///
+/// Capped at two lines so a long quote doesn't push the row's intrinsic
+/// height past the rest of the list.
+class NotificationCommentQuote extends StatelessWidget {
+  /// Creates a [NotificationCommentQuote].
+  const NotificationCommentQuote({
+    required this.text,
+    this.timestamp,
+    super.key,
+  });
+
+  /// The quoted comment body. Surrounding curly quotes are added by
+  /// the widget — pass the raw string.
+  final String text;
+
+  /// Optional formatted relative timestamp (e.g. `2d`). When non-null
+  /// and non-empty it's appended inline after the closing curly quote
+  /// in muted styling.
+  final String? timestamp;
+
+  @override
+  Widget build(BuildContext context) {
+    final ts = timestamp;
+    final showTimestamp = ts != null && ts.isNotEmpty;
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(text: '“$text”', style: VineTheme.bodyMediumFont()),
+          if (showTimestamp)
+            TextSpan(
+              text: ' $ts',
+              style: VineTheme.bodyMediumFont(
+                color: VineTheme.onSurfaceMuted55,
+              ),
+            ),
+        ],
+      ),
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}

--- a/mobile/lib/notifications/widgets/notification_leading_type_icon.dart
+++ b/mobile/lib/notifications/widgets/notification_leading_type_icon.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Leading 32×32 type indicator at the start of every notification
+// ABOUTME: row. Looks up the (icon, accent pair) for a NotificationKind via
+// ABOUTME: notificationTypeIconSpec and renders NotificationTypeIcon with
+// ABOUTME: the unread red dot driven by isRead.
+
+import 'package:flutter/widgets.dart';
+import 'package:models/models.dart';
+import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
+import 'package:openvine/widgets/notification_type_icon.dart';
+
+/// Leading type indicator at the start of a notification row.
+///
+/// Combines [notificationTypeIconSpec] (the design contract mapping
+/// [NotificationKind] → accent pair + icon) with [NotificationTypeIcon]
+/// (the rounded-square primitive) so both row variants —
+/// `ActorNotificationRow` and `VideoNotificationRow` — share a single
+/// implementation. The unread red dot is driven by [isRead].
+class NotificationLeadingTypeIcon extends StatelessWidget {
+  /// Creates a [NotificationLeadingTypeIcon].
+  const NotificationLeadingTypeIcon({
+    required this.type,
+    required this.isRead,
+    super.key,
+  });
+
+  /// The notification's kind. Determines which accent pair the icon uses.
+  final NotificationKind type;
+
+  /// Whether the notification has been read. When false, an unread red
+  /// dot overlays the badge's top-right corner.
+  final bool isRead;
+
+  @override
+  Widget build(BuildContext context) {
+    final spec = notificationTypeIconSpec(type);
+    return NotificationTypeIcon(
+      icon: spec.icon,
+      backgroundColor: spec.background,
+      foregroundColor: spec.foreground,
+      showUnreadDot: !isRead,
+    );
+  }
+}

--- a/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
+++ b/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Maps NotificationKind to the (icon, background, foreground)
+// ABOUTME: triple used by the leading 32×32 type indicator on every row.
+//
+// Single source of truth for the design contract. Adding a new
+// NotificationKind is a compile error here — and a regression test in
+// notification_type_icon_spec_test.dart locks the mapping so it can't
+// silently drift again.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/painting.dart';
+import 'package:models/models.dart';
+
+/// Triple (icon, background, foreground) consumed by [NotificationTypeIcon].
+class NotificationTypeIconSpec {
+  const NotificationTypeIconSpec({
+    required this.icon,
+    required this.background,
+    required this.foreground,
+  });
+
+  final DivineIconName icon;
+  final Color background;
+  final Color foreground;
+}
+
+/// Returns the spec for [type] used by both row widgets.
+NotificationTypeIconSpec notificationTypeIconSpec(NotificationKind type) {
+  return switch (type) {
+    NotificationKind.like ||
+    NotificationKind.likeComment => const NotificationTypeIconSpec(
+      icon: DivineIconName.heart,
+      background: VineTheme.accentPinkBackground,
+      foreground: VineTheme.accentPink,
+    ),
+    NotificationKind.follow => const NotificationTypeIconSpec(
+      icon: DivineIconName.user,
+      background: VineTheme.accentLimeBackground,
+      foreground: VineTheme.accentLime,
+    ),
+    NotificationKind.comment ||
+    NotificationKind.reply ||
+    NotificationKind.mention => const NotificationTypeIconSpec(
+      icon: DivineIconName.chat,
+      background: VineTheme.accentVioletBackground,
+      foreground: VineTheme.accentViolet,
+    ),
+    NotificationKind.repost => const NotificationTypeIconSpec(
+      icon: DivineIconName.repeat,
+      background: VineTheme.accentYellowBackground,
+      foreground: VineTheme.accentYellow,
+    ),
+    NotificationKind.system => const NotificationTypeIconSpec(
+      icon: DivineIconName.logo,
+      background: VineTheme.onPrimaryButton,
+      foreground: VineTheme.primary,
+    ),
+  };
+}

--- a/mobile/lib/notifications/widgets/notification_video_thumbnail.dart
+++ b/mobile/lib/notifications/widgets/notification_video_thumbnail.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Right-side 56×56 video thumbnail on a video-anchored notification
+// ABOUTME: row. Renders the cached thumbnail or a card-background placeholder
+// ABOUTME: when the URL is missing.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+/// Diameter of the video thumbnail.
+const double _thumbnailSize = 56;
+
+/// Memory-cache decode width for the thumbnail. Sized for 4× DPI
+/// (`56 × 4 = 224`) so the rendered chip stays sharp on the highest
+/// pixel-density displays we ship to without paying for a full
+/// pre-scaled cache. At 2× / 3× the cache decodes slightly oversized
+/// and the GPU downscales — cheap.
+const int _thumbnailMemCacheWidth = 224;
+
+/// Tap-target wrapper around the 56×56 thumbnail at the right edge of a
+/// `VideoNotificationRow`. Public so tests can locate it via
+/// `find.byType(NotificationVideoThumbnail)` instead of a
+/// hardcoded-string `Key`.
+class NotificationVideoThumbnail extends StatelessWidget {
+  /// Creates a [NotificationVideoThumbnail].
+  const NotificationVideoThumbnail({
+    required this.imageUrl,
+    required this.title,
+    required this.onTap,
+    super.key,
+  });
+
+  /// Cached thumbnail URL. When null, a flat card-background tile shows
+  /// instead so the row's right edge stays a fixed 56×56.
+  final String? imageUrl;
+
+  /// Optional video title — used in the screen-reader label so the
+  /// thumbnail announces "Video thumbnail for {title}" when known.
+  final String? title;
+
+  /// Tap handler — the row body's onTap and the thumbnail's onTap are
+  /// split so a tap on the thumbnail can target a different navigation
+  /// (e.g. open the video) than a tap elsewhere on the row.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Semantics(
+      label: title != null
+          ? l10n.notificationsVideoThumbnailFor(title!)
+          : l10n.notificationsVideoThumbnail,
+      button: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: SizedBox(
+            width: _thumbnailSize,
+            height: _thumbnailSize,
+            child: imageUrl != null
+                ? VineCachedImage(
+                    imageUrl: imageUrl!,
+                    memCacheWidth: _thumbnailMemCacheWidth,
+                  )
+                : const ColoredBox(color: VineTheme.cardBackground),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -1,13 +1,16 @@
-// ABOUTME: One-row layout for VideoNotification — avatar stack on the left,
-// ABOUTME: message + timestamp in the middle, 56x56 video thumbnail on right.
+// ABOUTME: One-row layout for VideoNotification — leading 32x32 type icon,
+// ABOUTME: avatar stack + bold actor name(s) + verb + bold title +
+// ABOUTME: inline timestamp, 56x56 video thumbnail on the right.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
+import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
+import 'package:openvine/widgets/notification_type_icon.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
-import 'package:time_formatter/time_formatter.dart';
 
 /// Diameter of the video thumbnail on the right of the row.
 const double _thumbnailSize = 56;
@@ -20,10 +23,10 @@ const int _thumbnailMemCacheWidth = 200;
 
 /// Displays a single video-anchored notification row.
 ///
-/// Layout: avatar stack (left) → message + relative timestamp (center) →
-/// 56x56 rounded thumbnail (right). Tap targets are split: tap on the
-/// row body fires [onTap] (open the video), tap on the thumbnail fires
-/// [onThumbnailTap], tap on the avatar stack fires [onProfileTap].
+/// Layout: leading 32x32 type icon (left) → avatar stack + message text
+/// (center) → 56x56 rounded thumbnail (right). Tap targets are split: tap
+/// on the row body fires [onTap] (open the video), tap on the thumbnail
+/// fires [onThumbnailTap], tap on the avatar stack fires [onProfileTap].
 class VideoNotificationRow extends StatelessWidget {
   /// Creates a [VideoNotificationRow].
   const VideoNotificationRow({
@@ -49,58 +52,68 @@ class VideoNotificationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final spec = notificationTypeIconSpec(notification.type);
     final overflowCount = notification.totalCount - notification.actors.length;
-    final firstName = notification.actors.first.displayName;
-    final othersCount = notification.totalCount - 1;
-    final message = othersCount <= 0
-        ? _verbWithActor(l10n, notification.type, firstName)
-        : '$firstName ${l10n.notificationAndConnector} '
-              '${l10n.notificationOthersCount(othersCount)} '
-              '${_verb(l10n, notification.type)}';
 
     return Material(
-      color: notification.isRead
-          ? VineTheme.backgroundColor
-          : VineTheme.cardBackground,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              GestureDetector(
-                onTap: onProfileTap,
-                child: NotificationAvatarStack(
-                  actors: notification.actors.take(_maxStackActors).toList(),
-                  overflowCount: overflowCount > 0 ? overflowCount : null,
-                ),
+      color: VineTheme.surfaceContainerHigh,
+      child: Semantics(
+        button: true,
+        container: true,
+        label: notification.isRead ? null : l10n.notificationsUnreadPrefix,
+        child: InkWell(
+          onTap: onTap,
+          child: DecoratedBox(
+            decoration: const BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: VineTheme.outlineDisabled),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(message, style: VineTheme.bodyMediumFont()),
-                    const SizedBox(height: 4),
-                    Text(
-                      TimeFormatter.formatRelativeVerbose(
-                        notification.timestamp.millisecondsSinceEpoch ~/ 1000,
-                      ),
-                      style: VineTheme.bodySmallFont(
-                        color: VineTheme.lightText,
-                      ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 12,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  NotificationTypeIcon(
+                    icon: spec.icon,
+                    backgroundColor: spec.background,
+                    foregroundColor: spec.foreground,
+                    showUnreadDot: !notification.isRead,
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        GestureDetector(
+                          onTap: onProfileTap,
+                          child: NotificationAvatarStack(
+                            actors: notification.actors
+                                .take(_maxStackActors)
+                                .toList(),
+                            overflowCount: overflowCount > 0
+                                ? overflowCount
+                                : null,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        _MessageText(notification: notification),
+                      ],
                     ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(width: 12),
+                  _Thumbnail(
+                    key: const Key('video_notification_thumbnail'),
+                    imageUrl: notification.videoThumbnailUrl,
+                    title: notification.videoTitle,
+                    onTap: onThumbnailTap,
+                  ),
+                ],
               ),
-              const SizedBox(width: 12),
-              _Thumbnail(
-                key: const Key('video_notification_thumbnail'),
-                imageUrl: notification.videoThumbnailUrl,
-                title: notification.videoTitle,
-                onTap: onThumbnailTap,
-              ),
-            ],
+            ),
           ),
         ),
       ),
@@ -108,30 +121,107 @@ class VideoNotificationRow extends StatelessWidget {
   }
 }
 
-/// Builds the localized "{actor} {verb}" string for a single-actor row.
-String _verbWithActor(
-  AppLocalizations l10n,
-  NotificationKind type,
-  String actor,
-) {
+class _MessageText extends StatelessWidget {
+  const _MessageText({required this.notification});
+
+  final VideoNotification notification;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final spans = <InlineSpan>[];
+    final actors = notification.actors;
+    final type = notification.type;
+    final videoTitle = notification.videoTitle;
+    final othersCount = notification.totalCount - 1;
+
+    spans.add(
+      TextSpan(
+        text: actors.first.displayName,
+        style: VineTheme.labelLargeFont(),
+      ),
+    );
+
+    if (othersCount > 0) {
+      spans.add(
+        TextSpan(
+          text: ' ${l10n.notificationAndConnector} ',
+          style: VineTheme.bodyMediumFont(),
+        ),
+      );
+      spans.add(
+        TextSpan(
+          text: l10n.notificationOthersCount(othersCount),
+          style: VineTheme.labelLargeFont(),
+        ),
+      );
+    }
+
+    spans.add(
+      TextSpan(
+        text: ' ${_verbFor(l10n, type)}',
+        style: VineTheme.bodyMediumFont(),
+      ),
+    );
+
+    if (videoTitle != null && _typeShowsTitle(type)) {
+      spans.add(
+        TextSpan(
+          text: ' $videoTitle',
+          style: VineTheme.labelLargeFont(),
+        ),
+      );
+    }
+
+    spans.add(
+      TextSpan(
+        text:
+            ' ${LocalizedTimeFormatter.formatRelative(l10n, notification.timestamp.millisecondsSinceEpoch ~/ 1000)}',
+        style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted55),
+      ),
+    );
+
+    return Text.rich(
+      TextSpan(children: spans),
+      textScaler: MediaQuery.textScalerOf(context),
+    );
+  }
+}
+
+/// Whether the row should append the bold video title after the verb.
+///
+/// `likeComment` is intentionally excluded: comment-likes are routed
+/// through `ActorNotification` and have no associated video title here;
+/// even if the dispatcher routes one to this row, suppressing the title
+/// keeps the message accurate.
+bool _typeShowsTitle(NotificationKind type) {
+  return type == NotificationKind.like ||
+      type == NotificationKind.comment ||
+      type == NotificationKind.repost;
+}
+
+/// Returns just the verb portion (no actor name) for inline composition.
+///
+/// l10n verb keys carry the actor name as a leading `{actorName}`
+/// placeholder. Calling them with an empty string and trimming the leading
+/// separator yields just the verb that the caller can prepend a bold actor
+/// span to.
+String _verbFor(AppLocalizations l10n, NotificationKind type) {
   return switch (type) {
-    NotificationKind.like => l10n.notificationLikedYourVideo(actor),
-    NotificationKind.likeComment => l10n.notificationLikedYourComment(actor),
-    NotificationKind.comment => l10n.notificationCommentedOnYourVideo(actor),
-    NotificationKind.repost => l10n.notificationRepostedYourVideo(actor),
-    // The repository asserts that VideoNotification.type is one of the
-    // four above; the remaining cases satisfy switch exhaustivity only.
+    NotificationKind.like => l10n.notificationLikedYourVideo('').trimLeft(),
+    NotificationKind.likeComment =>
+      l10n.notificationLikedYourComment('').trimLeft(),
+    NotificationKind.comment =>
+      l10n.notificationCommentedOnYourVideo('').trimLeft(),
+    NotificationKind.repost =>
+      l10n.notificationRepostedYourVideo('').trimLeft(),
+    // VideoNotification asserts type ∈ {like, likeComment, comment,
+    // repost}; the remaining cases satisfy switch exhaustivity only.
     NotificationKind.reply ||
     NotificationKind.follow ||
     NotificationKind.mention ||
-    NotificationKind.system => actor,
+    NotificationKind.system => '',
   };
-}
-
-/// Returns just the verb portion (no actor name) for the multi-actor
-/// "{first} and N others {verb}" composition.
-String _verb(AppLocalizations l10n, NotificationKind type) {
-  return _verbWithActor(l10n, type, '').trimLeft();
 }
 
 class _Thumbnail extends StatelessWidget {

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -52,9 +52,6 @@ class VideoNotificationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final spec = notificationTypeIconSpec(notification.type);
-    final overflowCount = notification.totalCount - notification.actors.length;
-
     return Material(
       color: VineTheme.surfaceContainerHigh,
       child: Semantics(
@@ -77,31 +74,15 @@ class VideoNotificationRow extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  NotificationTypeIcon(
-                    icon: spec.icon,
-                    backgroundColor: spec.background,
-                    foregroundColor: spec.foreground,
-                    showUnreadDot: !notification.isRead,
+                  _LeadingTypeIcon(
+                    type: notification.type,
+                    isRead: notification.isRead,
                   ),
                   const SizedBox(width: 16),
                   Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        GestureDetector(
-                          onTap: onProfileTap,
-                          child: NotificationAvatarStack(
-                            actors: notification.actors
-                                .take(_maxStackActors)
-                                .toList(),
-                            overflowCount: overflowCount > 0
-                                ? overflowCount
-                                : null,
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        _MessageText(notification: notification),
-                      ],
+                    child: _NotificationContent(
+                      notification: notification,
+                      onProfileTap: onProfileTap,
                     ),
                   ),
                   const SizedBox(width: 12),
@@ -117,6 +98,57 @@ class VideoNotificationRow extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _LeadingTypeIcon extends StatelessWidget {
+  const _LeadingTypeIcon({required this.type, required this.isRead});
+
+  final NotificationKind type;
+  final bool isRead;
+
+  @override
+  Widget build(BuildContext context) {
+    final spec = notificationTypeIconSpec(type);
+    return NotificationTypeIcon(
+      icon: spec.icon,
+      backgroundColor: spec.background,
+      foregroundColor: spec.foreground,
+      showUnreadDot: !isRead,
+    );
+  }
+}
+
+class _NotificationContent extends StatelessWidget {
+  const _NotificationContent({
+    required this.notification,
+    required this.onProfileTap,
+  });
+
+  final VideoNotification notification;
+  final VoidCallback onProfileTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final overflowCount = notification.totalCount - notification.actors.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Semantics(
+          button: true,
+          label: context.l10n.notificationsViewProfilesSemanticLabel,
+          child: GestureDetector(
+            onTap: onProfileTap,
+            child: NotificationAvatarStack(
+              actors: notification.actors.take(_maxStackActors).toList(),
+              overflowCount: overflowCount > 0 ? overflowCount : null,
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        _MessageText(notification: notification),
+      ],
     );
   }
 }
@@ -238,8 +270,11 @@ class _Thumbnail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Semantics(
-      label: title != null ? 'Video thumbnail for $title' : 'Video thumbnail',
+      label: title != null
+          ? l10n.notificationsVideoThumbnailFor(title!)
+          : l10n.notificationsVideoThumbnail,
       button: true,
       child: GestureDetector(
         onTap: onTap,

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -8,6 +8,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
+import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
 import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -129,15 +130,27 @@ class _NotificationContent extends StatelessWidget {
   final VideoNotification notification;
   final VoidCallback onProfileTap;
 
+  bool get _hasComment =>
+      notification.commentText != null && notification.commentText!.isNotEmpty;
+
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     final overflowCount = notification.totalCount - notification.actors.length;
+    // The trailing relative timestamp anchors to the visual end of the
+    // row. When a comment quote is rendered, it goes after the quote
+    // (NotificationCommentQuote handles that inline). Without a quote,
+    // it sits at the end of the message text.
+    final relativeTime = LocalizedTimeFormatter.formatRelative(
+      l10n,
+      notification.timestamp.millisecondsSinceEpoch ~/ 1000,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Semantics(
           button: true,
-          label: context.l10n.notificationsViewProfilesSemanticLabel,
+          label: l10n.notificationsViewProfilesSemanticLabel,
           child: GestureDetector(
             onTap: onProfileTap,
             child: NotificationAvatarStack(
@@ -147,16 +160,32 @@ class _NotificationContent extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 8),
-        _MessageText(notification: notification),
+        _MessageText(
+          notification: notification,
+          timestamp: _hasComment ? null : relativeTime,
+        ),
+        if (_hasComment) ...[
+          const SizedBox(height: 4),
+          NotificationCommentQuote(
+            text: notification.commentText!,
+            timestamp: relativeTime,
+          ),
+        ],
       ],
     );
   }
 }
 
 class _MessageText extends StatelessWidget {
-  const _MessageText({required this.notification});
+  const _MessageText({required this.notification, this.timestamp});
 
   final VideoNotification notification;
+
+  /// When non-empty, appended in muted style at the end of the message.
+  /// Pass `null` (the default) when a [NotificationCommentQuote] sits
+  /// below this widget — the quote renders the timestamp instead, so it
+  /// stays anchored to the visual end of the row.
+  final String? timestamp;
 
   @override
   Widget build(BuildContext context) {
@@ -205,13 +234,15 @@ class _MessageText extends StatelessWidget {
       );
     }
 
-    spans.add(
-      TextSpan(
-        text:
-            ' ${LocalizedTimeFormatter.formatRelative(l10n, notification.timestamp.millisecondsSinceEpoch ~/ 1000)}',
-        style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted55),
-      ),
-    );
+    final ts = timestamp;
+    if (ts != null && ts.isNotEmpty) {
+      spans.add(
+        TextSpan(
+          text: ' $ts',
+          style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted55),
+        ),
+      );
+    }
 
     return Text.rich(
       TextSpan(children: spans),

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -10,16 +10,10 @@ import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
 import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
 import 'package:openvine/notifications/widgets/notification_leading_type_icon.dart';
-import 'package:openvine/widgets/vine_cached_image.dart';
-
-/// Diameter of the video thumbnail on the right of the row.
-const double _thumbnailSize = 56;
+import 'package:openvine/notifications/widgets/notification_video_thumbnail.dart';
 
 /// Maximum stacked actor avatars before showing the overflow circle.
 const int _maxStackActors = 3;
-
-/// Memory-cache decode width for the thumbnail (~3.5x at 2x DPI).
-const int _thumbnailMemCacheWidth = 200;
 
 /// Displays a single video-anchored notification row.
 ///
@@ -86,8 +80,7 @@ class VideoNotificationRow extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(width: 12),
-                  _Thumbnail(
-                    key: const Key('video_notification_thumbnail'),
+                  NotificationVideoThumbnail(
                     imageUrl: notification.videoThumbnailUrl,
                     title: notification.videoTitle,
                     onTap: onThumbnailTap,
@@ -266,44 +259,4 @@ String _verbFor(AppLocalizations l10n, NotificationKind type) {
     NotificationKind.mention ||
     NotificationKind.system => '',
   };
-}
-
-class _Thumbnail extends StatelessWidget {
-  const _Thumbnail({
-    required this.imageUrl,
-    required this.title,
-    required this.onTap,
-    super.key,
-  });
-
-  final String? imageUrl;
-  final String? title;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    return Semantics(
-      label: title != null
-          ? l10n.notificationsVideoThumbnailFor(title!)
-          : l10n.notificationsVideoThumbnail,
-      button: true,
-      child: GestureDetector(
-        onTap: onTap,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(8),
-          child: SizedBox(
-            width: _thumbnailSize,
-            height: _thumbnailSize,
-            child: imageUrl != null
-                ? VineCachedImage(
-                    imageUrl: imageUrl!,
-                    memCacheWidth: _thumbnailMemCacheWidth,
-                  )
-                : const ColoredBox(color: VineTheme.cardBackground),
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/mobile/lib/notifications/widgets/video_notification_row.dart
+++ b/mobile/lib/notifications/widgets/video_notification_row.dart
@@ -9,8 +9,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
 import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
-import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
-import 'package:openvine/widgets/notification_type_icon.dart';
+import 'package:openvine/notifications/widgets/notification_leading_type_icon.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Diameter of the video thumbnail on the right of the row.
@@ -75,7 +74,7 @@ class VideoNotificationRow extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _LeadingTypeIcon(
+                  NotificationLeadingTypeIcon(
                     type: notification.type,
                     isRead: notification.isRead,
                   ),
@@ -99,24 +98,6 @@ class VideoNotificationRow extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _LeadingTypeIcon extends StatelessWidget {
-  const _LeadingTypeIcon({required this.type, required this.isRead});
-
-  final NotificationKind type;
-  final bool isRead;
-
-  @override
-  Widget build(BuildContext context) {
-    final spec = notificationTypeIconSpec(type);
-    return NotificationTypeIcon(
-      icon: spec.icon,
-      backgroundColor: spec.background,
-      foregroundColor: spec.foreground,
-      showUnreadDot: !isRead,
     );
   }
 }

--- a/mobile/lib/notifications/widgets/widgets.dart
+++ b/mobile/lib/notifications/widgets/widgets.dart
@@ -2,6 +2,7 @@ export 'actor_notification_row.dart';
 export 'notification_avatar_stack.dart';
 export 'notification_comment_quote.dart';
 export 'notification_empty_state.dart';
+export 'notification_leading_type_icon.dart';
 export 'notification_list_item.dart';
 export 'notification_type_icon_spec.dart';
 export 'video_notification_row.dart';

--- a/mobile/lib/notifications/widgets/widgets.dart
+++ b/mobile/lib/notifications/widgets/widgets.dart
@@ -2,4 +2,5 @@ export 'actor_notification_row.dart';
 export 'notification_avatar_stack.dart';
 export 'notification_empty_state.dart';
 export 'notification_list_item.dart';
+export 'notification_type_icon_spec.dart';
 export 'video_notification_row.dart';

--- a/mobile/lib/notifications/widgets/widgets.dart
+++ b/mobile/lib/notifications/widgets/widgets.dart
@@ -1,5 +1,6 @@
 export 'actor_notification_row.dart';
 export 'notification_avatar_stack.dart';
+export 'notification_comment_quote.dart';
 export 'notification_empty_state.dart';
 export 'notification_list_item.dart';
 export 'notification_type_icon_spec.dart';

--- a/mobile/lib/notifications/widgets/widgets.dart
+++ b/mobile/lib/notifications/widgets/widgets.dart
@@ -5,4 +5,5 @@ export 'notification_empty_state.dart';
 export 'notification_leading_type_icon.dart';
 export 'notification_list_item.dart';
 export 'notification_type_icon_spec.dart';
+export 'notification_video_thumbnail.dart';
 export 'video_notification_row.dart';

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -140,7 +140,7 @@ class ConversationTile extends ConsumerWidget {
                             conversation.lastMessageContent!,
                           ),
                           style: VineTheme.bodyMediumFont(
-                            color: VineTheme.onSurfaceMuted,
+                            color: VineTheme.onSurfaceVariant,
                           ),
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -48,7 +48,11 @@ enum DivineButtonType {
 /// area.
 enum DivineButtonSize {
   /// Tiny button: no outer tap-padding, 12px horizontal / 6px vertical
-  /// inner padding, 16px border radius, 14px `labelLargeFont` text,
+  /// inner padding, 12.8px border radius (= 32 × 0.4, matches a 32px
+  /// `UserAvatar`'s rounded square so the button rhymes visually with
+  /// the avatar it usually sits next to), 14px `titleSmallFont` text
+  /// (Bricolage Grotesque 800 — heavier than the Inter `labelLargeFont`
+  /// used elsewhere so the small chip still reads as a primary action),
   /// 20px icon. Visual height and tap target both 32px (deliberately
   /// flush with the avatar / type-icon module so the row's intrinsic
   /// height matches whether the button is present or not).
@@ -216,7 +220,10 @@ class _DivineButtonContent extends StatelessWidget {
   }
 
   double get _borderRadius => switch (size) {
-    DivineButtonSize.tiny => 16,
+    // 32 × 0.4 — same factor `UserAvatar` uses for non-tiny avatars, so
+    // a tiny button sitting next to a 32px avatar shares its corner
+    // curvature exactly.
+    DivineButtonSize.tiny => 12.8,
     DivineButtonSize.small => 16,
     DivineButtonSize.base => 20,
   };
@@ -260,10 +267,13 @@ class _DivineButtonContent extends StatelessWidget {
       );
     }
 
-    // Tiny buttons use the smaller labelLargeFont (14/20) so 6px vertical
-    // padding × 2 + 20px line-height totals exactly 32px.
+    // Tiny buttons use Bricolage `titleSmallFont` (800 14/20/0.1) — same
+    // 14/20 dimensions as `labelLargeFont` so 6px vertical padding × 2
+    // + 20px line-height still totals exactly 32px, but the heavier
+    // weight and brand font keep the small chip reading as a primary
+    // action.
     if (size == DivineButtonSize.tiny) {
-      return VineTheme.labelLargeFont(color: _foregroundColor);
+      return VineTheme.titleSmallFont(color: _foregroundColor);
     }
 
     return VineTheme.titleMediumFont(color: _foregroundColor);

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -37,16 +37,21 @@ enum DivineButtonType {
 
 /// The size of a [DivineButton].
 ///
-/// All sizes have the same 48px total outer height for consistent touch
-/// targets. The [tiny] and [small] variants wrap the visible button in
-/// extra outer padding so the visible chip is shorter while the tap area
-/// stays 48px.
+/// [base] (48px) and [small] (40px visible / 48px tap target) keep a
+/// 48px minimum tap target — small wraps the visible chip in 4px of
+/// outer padding so the tap area stays at 48 even though the chip
+/// renders shorter. [tiny] (32px) explicitly does NOT — its outer
+/// bounds equal its visible bounds so it can sit on the same baseline
+/// as a 32px avatar / type icon without inflating the surrounding row
+/// height. Use [tiny] only where the layout's grid module is the
+/// constraint and the surrounding context can absorb the smaller tap
+/// area.
 enum DivineButtonSize {
-  /// Tiny button: 8px outer padding, 12px horizontal / 6px vertical
+  /// Tiny button: no outer tap-padding, 12px horizontal / 6px vertical
   /// inner padding, 16px border radius, 14px `labelLargeFont` text,
-  /// 20px icon. Visual height 32px, tap target 48px. Use when the
-  /// surrounding layout is built on a 32px module (e.g. a notification
-  /// row aligned with 32px avatars and type icons).
+  /// 20px icon. Visual height and tap target both 32px (deliberately
+  /// flush with the avatar / type-icon module so the row's intrinsic
+  /// height matches whether the button is present or not).
   tiny,
 
   /// Small button: 4px outer padding, 16px horizontal / 8px vertical
@@ -357,15 +362,12 @@ class _DivineButtonContent extends StatelessWidget {
       ),
     );
 
-    // Tiny / small variants: wrap in extra outer padding so the visible
-    // chip is shorter than 48px while the tap target stays 48px.
-    final outerPad = switch (size) {
-      DivineButtonSize.tiny => 8.0, // 32 + 8 + 8 = 48 tap target.
-      DivineButtonSize.small => 4.0, // 40 + 4 + 4 = 48 tap target.
-      DivineButtonSize.base => null,
-    };
-    if (outerPad != null) {
-      button = Padding(padding: EdgeInsets.all(outerPad), child: button);
+    // Small variant only: wrap in extra outer padding so the visible
+    // chip is 40px while the tap target stays at 48px. Tiny deliberately
+    // skips this — its outer == inner == 32px so it can sit flush with a
+    // 32px avatar / type icon without inflating the row's height.
+    if (size == DivineButtonSize.small) {
+      button = Padding(padding: const EdgeInsets.all(4), child: button);
     }
 
     return button;

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -37,16 +37,26 @@ enum DivineButtonType {
 
 /// The size of a [DivineButton].
 ///
-/// Both sizes have the same 48px total outer height for consistent touch
-/// targets. The [small] variant wraps the visible button in 4px padding,
-/// making it appear 40px tall while keeping the 48px tap area.
+/// All sizes have the same 48px total outer height for consistent touch
+/// targets. The [tiny] and [small] variants wrap the visible button in
+/// extra outer padding so the visible chip is shorter while the tap area
+/// stays 48px.
 enum DivineButtonSize {
+  /// Tiny button: 8px outer padding, 12px horizontal / 6px vertical
+  /// inner padding, 16px border radius, 14px `labelLargeFont` text,
+  /// 20px icon. Visual height 32px, tap target 48px. Use when the
+  /// surrounding layout is built on a 32px module (e.g. a notification
+  /// row aligned with 32px avatars and type icons).
+  tiny,
+
   /// Small button: 4px outer padding, 16px horizontal / 8px vertical
-  /// inner padding, 16px border radius. Visual height 40px, tap target 48px.
+  /// inner padding, 16px border radius, 16px `titleMediumFont` text,
+  /// 24px icon. Visual height 40px, tap target 48px.
   small,
 
   /// Base/medium button: 24px horizontal / 12px vertical padding, 20px
-  /// border radius. Total height 48px.
+  /// border radius, 16px `titleMediumFont` text, 24px icon. Total
+  /// height 48px.
   base,
 }
 
@@ -160,8 +170,13 @@ class _DivineButtonContent extends StatelessWidget {
 
   bool get _isEnabled => onPressed != null && !isLoading;
 
-  /// Icon size is 24px for both variants.
-  static const double _iconSize = 24;
+  /// Icon size scales with [size]: tiny uses a smaller 20px icon to fit
+  /// inside the 32px visible chip, small/base use 24px.
+  double get _iconSize => switch (size) {
+    DivineButtonSize.tiny => 20,
+    DivineButtonSize.small => 24,
+    DivineButtonSize.base => 24,
+  };
 
   /// Whether the button has no text label (icon-only mode).
   ///
@@ -174,11 +189,16 @@ class _DivineButtonContent extends StatelessWidget {
     if (_noLabel) {
       // Match DivineIconButton padding for icon-only mode.
       return switch (size) {
+        DivineButtonSize.tiny => const EdgeInsets.all(6),
         DivineButtonSize.small => const EdgeInsets.all(8),
         DivineButtonSize.base => const EdgeInsets.all(12),
       };
     }
     return switch (size) {
+      DivineButtonSize.tiny => const EdgeInsets.symmetric(
+        horizontal: 12,
+        vertical: 6,
+      ),
       DivineButtonSize.small => const EdgeInsets.symmetric(
         horizontal: 16,
         vertical: 8,
@@ -191,6 +211,7 @@ class _DivineButtonContent extends StatelessWidget {
   }
 
   double get _borderRadius => switch (size) {
+    DivineButtonSize.tiny => 16,
     DivineButtonSize.small => 16,
     DivineButtonSize.base => 20,
   };
@@ -232,6 +253,12 @@ class _DivineButtonContent extends StatelessWidget {
         decorationColor: VineTheme.primary,
         decorationThickness: 2,
       );
+    }
+
+    // Tiny buttons use the smaller labelLargeFont (14/20) so 6px vertical
+    // padding × 2 + 20px line-height totals exactly 32px.
+    if (size == DivineButtonSize.tiny) {
+      return VineTheme.labelLargeFont(color: _foregroundColor);
     }
 
     return VineTheme.titleMediumFont(color: _foregroundColor);
@@ -279,6 +306,7 @@ class _DivineButtonContent extends StatelessWidget {
           DivineIcon(
             icon: leadingIcon!,
             color: _foregroundColor,
+            size: _iconSize,
           ),
         if (!_noLabel)
           Flexible(
@@ -294,6 +322,7 @@ class _DivineButtonContent extends StatelessWidget {
           DivineIcon(
             icon: trailingIcon!,
             color: _foregroundColor,
+            size: _iconSize,
           ),
       ],
     );
@@ -328,10 +357,15 @@ class _DivineButtonContent extends StatelessWidget {
       ),
     );
 
-    // Small variant: wrap in 4px padding so the visible button is 40px
-    // tall but the tap target remains 48px.
-    if (size == DivineButtonSize.small) {
-      button = Padding(padding: const EdgeInsets.all(4), child: button);
+    // Tiny / small variants: wrap in extra outer padding so the visible
+    // chip is shorter than 48px while the tap target stays 48px.
+    final outerPad = switch (size) {
+      DivineButtonSize.tiny => 8.0, // 32 + 8 + 8 = 48 tap target.
+      DivineButtonSize.small => 4.0, // 40 + 4 + 4 = 48 tap target.
+      DivineButtonSize.base => null,
+    };
+    if (outerPad != null) {
+      button = Padding(padding: EdgeInsets.all(outerPad), child: button);
     }
 
     return button;

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -187,6 +187,24 @@ void main() {
         );
         expect(divineIcon.size, 24);
       });
+
+      testWidgets('tiny size renders 20px icon', (tester) async {
+        // The 32px visible chip can't fit a 24px icon plus the 6px
+        // padding above and below — tiny scales the icon down to 20px so
+        // 6 + 20 + 6 = 32 exactly.
+        await tester.pumpWidget(
+          buildTestWidget(
+            size: DivineButtonSize.tiny,
+            leadingIcon: DivineIconName.envelope,
+            onPressed: () {},
+          ),
+        );
+
+        final divineIcon = tester.widget<DivineIcon>(
+          find.byType(DivineIcon),
+        );
+        expect(divineIcon.size, 20);
+      });
     });
 
     group('interaction', () {
@@ -294,6 +312,17 @@ void main() {
     });
 
     group('button sizes', () {
+      testWidgets('renders tiny size', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            size: DivineButtonSize.tiny,
+            onPressed: () {},
+          ),
+        );
+
+        expect(find.byType(DivineButton), findsOneWidget);
+      });
+
       testWidgets('renders small size', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(
@@ -314,6 +343,45 @@ void main() {
 
         expect(find.byType(DivineButton), findsOneWidget);
       });
+
+      testWidgets(
+        'tiny visible chip is 32px tall (8px outer × 2 + 32 = 48 tap target)',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              size: DivineButtonSize.tiny,
+              onPressed: () {},
+            ),
+          );
+
+          // The outermost Padding inside the button widget tree owns the
+          // tap-target inflation. For tiny, that's 8px on every side, so
+          // the visible chip's painted box (the AnimatedOpacity that wraps
+          // the Material decoration) is exactly 16px shorter than the
+          // outer DivineButton's painted size.
+          final outerSize = tester.getSize(find.byType(DivineButton));
+          final innerSize = tester.getSize(find.byType(AnimatedOpacity));
+          expect(outerSize.height - innerSize.height, equals(16));
+          expect(innerSize.height, equals(32));
+        },
+      );
+
+      testWidgets(
+        'small visible chip is 40px tall (4px outer × 2 + 40 = 48 tap target)',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              size: DivineButtonSize.small,
+              onPressed: () {},
+            ),
+          );
+
+          final outerSize = tester.getSize(find.byType(DivineButton));
+          final innerSize = tester.getSize(find.byType(AnimatedOpacity));
+          expect(outerSize.height - innerSize.height, equals(8));
+          expect(innerSize.height, equals(40));
+        },
+      );
     });
 
     group('disabled state', () {
@@ -503,6 +571,25 @@ void main() {
     });
 
     group('icon-only mode (empty label)', () {
+      testWidgets('tiny size uses DivineIconButton padding', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: '',
+            leadingIcon: DivineIconName.heart,
+            size: DivineButtonSize.tiny,
+            onPressed: () {},
+          ),
+        );
+
+        expect(find.byType(DivineButton), findsOneWidget);
+        expect(find.byType(DivineIcon), findsOneWidget);
+        expect(find.text(''), findsNothing);
+
+        // Tiny icon-only is 6 + 20 + 6 = 32 visible.
+        final innerSize = tester.getSize(find.byType(AnimatedOpacity));
+        expect(innerSize.height, equals(32));
+      });
+
       testWidgets('small size uses DivineIconButton padding', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -345,7 +345,7 @@ void main() {
       });
 
       testWidgets(
-        'tiny visible chip is 32px tall (8px outer × 2 + 32 = 48 tap target)',
+        'tiny outer == inner == 32px (no tap-padding inflation)',
         (tester) async {
           await tester.pumpWidget(
             buildTestWidget(
@@ -354,14 +354,15 @@ void main() {
             ),
           );
 
-          // The outermost Padding inside the button widget tree owns the
-          // tap-target inflation. For tiny, that's 8px on every side, so
-          // the visible chip's painted box (the AnimatedOpacity that wraps
-          // the Material decoration) is exactly 16px shorter than the
-          // outer DivineButton's painted size.
+          // Tiny intentionally skips the outer tap-padding wrap so its
+          // painted bounds match the 32px module of the avatar / type
+          // icon it usually sits next to. A row that swaps the button in
+          // and out (e.g. a Follow back affordance) keeps the same
+          // intrinsic height because the button never adds height
+          // beyond what the avatar already contributes.
           final outerSize = tester.getSize(find.byType(DivineButton));
           final innerSize = tester.getSize(find.byType(AnimatedOpacity));
-          expect(outerSize.height - innerSize.height, equals(16));
+          expect(outerSize.height, equals(32));
           expect(innerSize.height, equals(32));
         },
       );

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -368,6 +368,54 @@ void main() {
       );
 
       testWidgets(
+        'tiny uses 12.8 corner radius (matches 32px UserAvatar)',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(size: DivineButtonSize.tiny, onPressed: () {}),
+          );
+
+          // The Ink widget owns the decorated background; its border
+          // radius is the source of truth for the chip's corner.
+          final ink = tester.widget<Ink>(find.byType(Ink));
+          final decoration = ink.decoration! as BoxDecoration;
+          final radius = decoration.borderRadius! as BorderRadius;
+          expect(radius.topLeft, equals(const Radius.circular(12.8)));
+        },
+      );
+
+      testWidgets(
+        'tiny uses titleSmallFont (Bricolage Grotesque 800 14/20)',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(size: DivineButtonSize.tiny, onPressed: () {}),
+          );
+
+          final text = tester.widget<Text>(find.text('Test'));
+          // titleSmallFont = Bricolage 800 14/20/0.1.  Bigger weight
+          // than labelLargeFont (Inter 600) so the small chip still
+          // reads as a primary action.
+          expect(text.style?.fontWeight, equals(FontWeight.w800));
+          expect(text.style?.fontSize, equals(14));
+        },
+      );
+
+      testWidgets(
+        'small uses titleMediumFont (Bricolage Grotesque 800 16/24)',
+        (tester) async {
+          // Locks the contract that small / base keep the heavier-feel
+          // titleMediumFont — the tiny→titleSmallFont fork above must
+          // not leak into the other variants.
+          await tester.pumpWidget(
+            buildTestWidget(size: DivineButtonSize.small, onPressed: () {}),
+          );
+
+          final text = tester.widget<Text>(find.text('Test'));
+          expect(text.style?.fontWeight, equals(FontWeight.w800));
+          expect(text.style?.fontSize, equals(16));
+        },
+      );
+
+      testWidgets(
         'small visible chip is 40px tall (4px outer × 2 + 40 = 48 tap target)',
         (tester) async {
           await tester.pumpWidget(

--- a/mobile/packages/models/lib/src/video_notification.dart
+++ b/mobile/packages/models/lib/src/video_notification.dart
@@ -22,6 +22,7 @@ class VideoNotification extends NotificationItem {
     this.videoThumbnailUrl,
     this.videoTitle,
     this.videoAddressableId,
+    this.commentText,
   }) : assert(
          type == NotificationKind.like ||
              type == NotificationKind.likeComment ||
@@ -62,6 +63,13 @@ class VideoNotification extends NotificationItem {
   /// [actors]).
   final int totalCount;
 
+  /// Optional excerpt of the most recent comment when [type] is
+  /// [NotificationKind.comment]. Truncated by the repository so a long
+  /// comment doesn't blow out the row layout. Other kinds (like, repost,
+  /// likeComment) leave this null because they have no associated body
+  /// text.
+  final String? commentText;
+
   /// Returns a copy with the given fields replaced.
   VideoNotification copyWith({
     String? id,
@@ -74,6 +82,7 @@ class VideoNotification extends NotificationItem {
     int? totalCount,
     DateTime? timestamp,
     bool? isRead,
+    String? commentText,
   }) {
     return VideoNotification(
       id: id ?? this.id,
@@ -86,6 +95,7 @@ class VideoNotification extends NotificationItem {
       totalCount: totalCount ?? this.totalCount,
       timestamp: timestamp ?? this.timestamp,
       isRead: isRead ?? this.isRead,
+      commentText: commentText ?? this.commentText,
     );
   }
 
@@ -101,5 +111,6 @@ class VideoNotification extends NotificationItem {
     totalCount,
     timestamp,
     isRead,
+    commentText,
   ];
 }

--- a/mobile/packages/models/test/src/video_notification_test.dart
+++ b/mobile/packages/models/test/src/video_notification_test.dart
@@ -41,6 +41,35 @@ void main() {
           timestamp: timestamp,
         );
       });
+
+      test('exposes optional commentText for comment kind', () {
+        // Comment notifications carry an excerpt of the most recent
+        // comment so the row can quote it under the message text.
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.comment,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          commentText: 'Loved this clip!',
+        );
+
+        expect(notification.commentText, equals('Loved this clip!'));
+      });
+
+      test('commentText defaults to null when not set', () {
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.like,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+        );
+
+        expect(notification.commentText, isNull);
+      });
     });
 
     group('equality', () {
@@ -128,6 +157,22 @@ void main() {
         final updated = original.copyWith(totalCount: 2);
 
         expect(updated.isRead, isTrue);
+      });
+
+      test('preserves commentText when not overridden', () {
+        final original = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.comment,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          commentText: 'Original comment',
+        );
+
+        final updated = original.copyWith(isRead: true);
+
+        expect(updated.commentText, equals('Original comment'));
       });
     });
   });

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -297,6 +297,14 @@ class NotificationRepository {
       final titleFromNotif = group
           .map((n) => n.referencedVideoTitle)
           .firstWhere((t) => t != null && t.isNotEmpty, orElse: () => null);
+      // Carry the most-recent comment text (the same payload the bold
+      // first-actor span shows) so the row can quote it under the message
+      // text. Only meaningful for `comment` kind — likes and reposts have
+      // no body text. Reuses the same length-cap as actor-anchored
+      // comments / replies for layout safety.
+      final commentTextForRow = entry.key.kind == NotificationKind.comment
+          ? _truncateComment(group.first.content, entry.key.kind)
+          : null;
       result.add(
         VideoNotification(
           id: group.first.dedupeKey,
@@ -310,6 +318,7 @@ class NotificationRepository {
           totalCount: group.length,
           timestamp: group.first.createdAt,
           isRead: group.every((n) => n.read),
+          commentText: commentTextForRow,
         ),
       );
     }
@@ -408,6 +417,9 @@ class NotificationRepository {
         totalCount: 1,
         timestamp: raw.createdAt,
         isRead: raw.read,
+        commentText: kind == NotificationKind.comment
+            ? _truncateComment(raw.content, kind)
+            : null,
       );
     }
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -880,8 +880,10 @@ void main() {
       });
 
       test(
-        'comment kind on video is a $VideoNotification (no commentText)',
+        'comment kind on video is a $VideoNotification with commentText',
         () async {
+          // The repository carries the comment body through to the row
+          // so it can quote the most recent comment under the message.
           stubNotifications([
             makeNotification(
               notificationType: 'comment',
@@ -892,7 +894,45 @@ void main() {
           stubProfiles({});
 
           final page = await repository.getNotifications();
-          expect(page.items.single, isA<VideoNotification>());
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.comment));
+          expect(item.commentText, equals('Short comment'));
+        },
+      );
+
+      test(
+        'truncates a long comment on $VideoNotification (50 chars + ellipsis)',
+        () async {
+          final longComment = 'A' * 60;
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: longComment,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          // Reuses _truncateComment: caps at 50 chars and appends "..."
+          // so the row never tries to render an unbounded comment body.
+          expect(item.commentText, equals('${'A' * 50}...'));
+        },
+      );
+
+      test(
+        'like / repost on video leaves commentText null (no body text)',
+        () async {
+          // Default makeNotification is a reaction (kind 7) on a video,
+          // which the repository maps to NotificationKind.like.
+          stubNotifications([makeNotification()]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.commentText, isNull);
         },
       );
     });

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -4,6 +4,7 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,6 +24,8 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
+
+final AppLocalizations _l10n = lookupAppLocalizations(const Locale('en'));
 
 class _MockNotificationFeedBloc
     extends MockBloc<NotificationFeedEvent, NotificationFeedState>
@@ -131,6 +134,23 @@ void main() {
 
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
       });
+
+      testWidgets('outer container uses surfaceContainerHigh background', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(NotificationFeedState());
+
+        await _pumpView(tester, mockBloc);
+
+        final coloredBoxFinder = find
+            .descendant(
+              of: find.byType(NotificationsView),
+              matching: find.byType(ColoredBox),
+            )
+            .first;
+        final coloredBox = tester.widget<ColoredBox>(coloredBoxFinder);
+        expect(coloredBox.color, equals(VineTheme.surfaceContainerHigh));
+      });
     });
 
     group('loading state', () {
@@ -146,15 +166,17 @@ void main() {
     });
 
     group('failure state', () {
-      testWidgets('renders error message and retry button', (tester) async {
+      testWidgets('renders localized error message and retry button', (
+        tester,
+      ) async {
         when(() => mockBloc.state).thenReturn(
           NotificationFeedState(status: NotificationFeedStatus.failure),
         );
 
         await _pumpView(tester, mockBloc);
 
-        expect(find.text('Failed to load notifications'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text(_l10n.notificationsFailedToLoad), findsOneWidget);
+        expect(find.text(_l10n.notificationsRetry), findsOneWidget);
       });
 
       testWidgets('dispatches refresh on retry tap', (tester) async {
@@ -163,7 +185,7 @@ void main() {
         );
 
         await _pumpView(tester, mockBloc);
-        await tester.tap(find.text('Retry'));
+        await tester.tap(find.text(_l10n.notificationsRetry));
         await tester.pump();
 
         verify(() => mockBloc.add(NotificationFeedRefreshed())).called(1);
@@ -230,6 +252,23 @@ void main() {
 
         // One for the bottom loading indicator.
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('does not inject Divider widgets between rows', (
+        tester,
+      ) async {
+        // The row widget owns its bottom border via outlineDisabled; the
+        // list must not add a separate Divider on top of it.
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: testNotifications,
+          ),
+        );
+
+        await _pumpView(tester, mockBloc);
+
+        expect(find.byType(Divider), findsNothing);
       });
 
       testWidgets('dispatches mark all read on screen open', (tester) async {

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/actor_notification_row.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 
 const _alice = ActorInfo(
   pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -144,6 +145,33 @@ void main() {
 
           final button = tester.widget<DivineButton>(find.byType(DivineButton));
           expect(button.size, equals(DivineButtonSize.tiny));
+        },
+      );
+
+      testWidgets(
+        'Follow back button shares its row with the avatar so message '
+        'text width is stable when the button appears / disappears',
+        (tester) async {
+          await _pump(tester, notification: _actor());
+
+          // The Row that holds the avatar must also hold the Follow back
+          // button — they're siblings, not children of separate columns.
+          // If the button were a sibling of the entire content column the
+          // message text below would re-wrap when the button appears or
+          // disappears.
+          final avatarRow = find
+              .ancestor(
+                of: find.byType(UserAvatar),
+                matching: find.byType(Row),
+              )
+              .first;
+          expect(
+            find.descendant(
+              of: avatarRow,
+              matching: find.byType(DivineButton),
+            ),
+            findsOneWidget,
+          );
         },
       );
 

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -2,10 +2,10 @@
 // ABOUTME: likeComment / reply rendering, follow-back button visibility,
 // ABOUTME: and tap callbacks.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
-import 'package:openvine/constants/notification_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/actor_notification_row.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
@@ -138,19 +138,12 @@ void main() {
       });
 
       testWidgets(
-        'Follow back button height matches the avatar / type icon (32px)',
+        'Follow back button uses DivineButtonSize.tiny (32px visible)',
         (tester) async {
           await _pump(tester, notification: _actor());
 
-          // Locate the height-clamping SizedBox that wraps the button.
-          final sizedBoxFinder = find.ancestor(
-            of: find.text(_l10n.notificationFollowBack),
-            matching: find.byWidgetPredicate(
-              (w) =>
-                  w is SizedBox && w.height == NotificationConstants.avatarSize,
-            ),
-          );
-          expect(sizedBoxFinder, findsOneWidget);
+          final button = tester.widget<DivineButton>(find.byType(DivineButton));
+          expect(button.size, equals(DivineButtonSize.tiny));
         },
       );
 

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/constants/notification_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/actor_notification_row.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
@@ -135,6 +136,23 @@ void main() {
 
         expect(find.text(_l10n.notificationFollowBack), findsOneWidget);
       });
+
+      testWidgets(
+        'Follow back button height matches the avatar / type icon (32px)',
+        (tester) async {
+          await _pump(tester, notification: _actor());
+
+          // Locate the height-clamping SizedBox that wraps the button.
+          final sizedBoxFinder = find.ancestor(
+            of: find.text(_l10n.notificationFollowBack),
+            matching: find.byWidgetPredicate(
+              (w) =>
+                  w is SizedBox && w.height == NotificationConstants.avatarSize,
+            ),
+          );
+          expect(sizedBoxFinder, findsOneWidget);
+        },
+      );
 
       testWidgets('no Follow back button when already following back', (
         tester,

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -1,11 +1,13 @@
-// ABOUTME: Tests for ActorNotificationRow — follow / mention / system
-// ABOUTME: rendering, follow-back button visibility, and tap callbacks.
+// ABOUTME: Tests for ActorNotificationRow — follow / mention / system /
+// ABOUTME: likeComment / reply rendering, follow-back button visibility,
+// ABOUTME: and tap callbacks.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/actor_notification_row.dart';
+import 'package:openvine/widgets/notification_type_icon.dart';
 
 const _alice = ActorInfo(
   pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -58,13 +60,18 @@ Future<void> _pump(
 void main() {
   group(ActorNotificationRow, () {
     group('renders', () {
-      testWidgets('"{actor} started following you" for follow', (
+      testWidgets('leading $NotificationTypeIcon for every kind', (
         tester,
       ) async {
         await _pump(tester, notification: _actor());
+        expect(find.byType(NotificationTypeIcon), findsOneWidget);
+      });
+
+      testWidgets('"{actor} started following you" for follow', (tester) async {
+        await _pump(tester, notification: _actor());
 
         expect(
-          find.text(_l10n.notificationStartedFollowing('Alice')),
+          find.textContaining(_l10n.notificationStartedFollowing('Alice')),
           findsOneWidget,
         );
       });
@@ -76,7 +83,7 @@ void main() {
         );
 
         expect(
-          find.text(_l10n.notificationMentionedYou('Alice')),
+          find.textContaining(_l10n.notificationMentionedYou('Alice')),
           findsOneWidget,
         );
       });
@@ -87,7 +94,10 @@ void main() {
           notification: _actor(type: NotificationKind.system),
         );
 
-        expect(find.text(_l10n.notificationSystemUpdate), findsOneWidget);
+        expect(
+          find.textContaining(_l10n.notificationSystemUpdate),
+          findsOneWidget,
+        );
       });
 
       testWidgets('"{actor} liked your comment" for likeComment', (
@@ -99,7 +109,7 @@ void main() {
         );
 
         expect(
-          find.text(_l10n.notificationLikedYourComment('Alice')),
+          find.textContaining(_l10n.notificationLikedYourComment('Alice')),
           findsOneWidget,
         );
       });
@@ -113,7 +123,9 @@ void main() {
         );
 
         expect(
-          find.text('Alice ${_l10n.notificationRepliedToYourComment}'),
+          find.textContaining(
+            'Alice ${_l10n.notificationRepliedToYourComment}',
+          ),
           findsOneWidget,
         );
       });
@@ -121,7 +133,7 @@ void main() {
       testWidgets('Follow back button when not yet following', (tester) async {
         await _pump(tester, notification: _actor());
 
-        expect(find.text('Follow back'), findsOneWidget);
+        expect(find.text(_l10n.notificationFollowBack), findsOneWidget);
       });
 
       testWidgets('no Follow back button when already following back', (
@@ -132,7 +144,7 @@ void main() {
           notification: _actor(isFollowingBack: true),
         );
 
-        expect(find.text('Follow back'), findsNothing);
+        expect(find.text(_l10n.notificationFollowBack), findsNothing);
       });
 
       testWidgets('comment text for mention with commentText', (tester) async {
@@ -144,7 +156,7 @@ void main() {
           ),
         );
 
-        expect(find.text('Hey check this out'), findsOneWidget);
+        expect(find.textContaining('Hey check this out'), findsOneWidget);
       });
     });
 
@@ -173,7 +185,7 @@ void main() {
           onFollowBack: () => tapped = true,
         );
 
-        await tester.tap(find.text('Follow back'));
+        await tester.tap(find.text(_l10n.notificationFollowBack));
         await tester.pump();
 
         expect(tapped, isTrue);

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/actor_notification_row.dart';
+import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
@@ -197,6 +198,45 @@ void main() {
 
         expect(find.textContaining('Hey check this out'), findsOneWidget);
       });
+
+      testWidgets(
+        'renders $NotificationCommentQuote when commentText is set',
+        (tester) async {
+          await _pump(
+            tester,
+            notification: _actor(
+              type: NotificationKind.reply,
+              commentText: 'I guess xd',
+            ),
+          );
+
+          expect(find.byType(NotificationCommentQuote), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'timestamp moves to the quote when commentText is present',
+        (tester) async {
+          // The timestamp must anchor to the visual end of the row, so
+          // when a comment quote sits below the message the trailing
+          // relative time goes inside the quote (not on the message
+          // line). This locks the rendering contract that fixes the
+          // "2d sandwiched between message and quote" layout regression.
+          await _pump(
+            tester,
+            notification: _actor(
+              type: NotificationKind.reply,
+              commentText: 'I guess xd',
+            ),
+          );
+
+          final quoteWidget = tester.widget<NotificationCommentQuote>(
+            find.byType(NotificationCommentQuote),
+          );
+          expect(quoteWidget.timestamp, isNotNull);
+          expect(quoteWidget.timestamp, isNotEmpty);
+        },
+      );
     });
 
     group('interactions', () {

--- a/mobile/test/notifications/widgets/notification_comment_quote_test.dart
+++ b/mobile/test/notifications/widgets/notification_comment_quote_test.dart
@@ -1,0 +1,97 @@
+// ABOUTME: Tests for NotificationCommentQuote — quoted text rendering and
+// ABOUTME: optional inline timestamp suffix.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required String text,
+  String? timestamp,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: NotificationCommentQuote(text: text, timestamp: timestamp),
+      ),
+    ),
+  );
+}
+
+TextSpan? _findSpan(
+  TextSpan root, {
+  required bool Function(TextSpan) matching,
+}) {
+  if (matching(root)) return root;
+  for (final child in root.children ?? const <InlineSpan>[]) {
+    if (child is TextSpan) {
+      final found = _findSpan(child, matching: matching);
+      if (found != null) return found;
+    }
+  }
+  return null;
+}
+
+void main() {
+  group(NotificationCommentQuote, () {
+    testWidgets('wraps text in curly quotes', (tester) async {
+      await _pump(tester, text: 'Hello world');
+
+      expect(find.textContaining('“Hello world”'), findsOneWidget);
+    });
+
+    testWidgets('appends timestamp inline when non-empty', (tester) async {
+      await _pump(tester, text: 'Hello world', timestamp: '2d');
+
+      // The Text.rich concatenates to "“Hello world” 2d" — find.text
+      // matches Text widgets by their concatenated plaintext.
+      expect(find.text('“Hello world” 2d'), findsOneWidget);
+    });
+
+    testWidgets('omits timestamp suffix when null', (tester) async {
+      await _pump(tester, text: 'Hello world');
+
+      expect(find.text('“Hello world”'), findsOneWidget);
+    });
+
+    testWidgets('omits timestamp suffix when empty string', (tester) async {
+      await _pump(tester, text: 'Hello world', timestamp: '');
+
+      expect(find.text('“Hello world”'), findsOneWidget);
+    });
+
+    testWidgets('caps at two lines for long quotes', (tester) async {
+      // A long line will wrap; the widget's own maxLines should clamp.
+      await _pump(
+        tester,
+        text:
+            'This is a very long comment that will wrap to multiple lines '
+            'when rendered in a constrained-width container, and we want to '
+            'make sure the widget caps it at two lines.',
+        timestamp: '5h',
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(richText.maxLines, equals(2));
+      expect(richText.overflow, equals(TextOverflow.ellipsis));
+    });
+
+    testWidgets('timestamp uses muted onSurfaceMuted55', (tester) async {
+      await _pump(tester, text: 'Hi', timestamp: '2d');
+
+      // Walk the rendered RichText's span tree to find the timestamp
+      // suffix. Text.rich wraps our root TextSpan in another span to
+      // apply the ambient text style, so our quote/timestamp children
+      // sit one level deeper than the RichText's top-level children.
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final timestampSpan = _findSpan(
+        richText.text as TextSpan,
+        matching: (span) => span.text == ' 2d',
+      );
+      expect(timestampSpan, isNotNull);
+      expect(timestampSpan!.style?.color, equals(VineTheme.onSurfaceMuted55));
+    });
+  });
+}

--- a/mobile/test/notifications/widgets/notification_leading_type_icon_test.dart
+++ b/mobile/test/notifications/widgets/notification_leading_type_icon_test.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Tests for NotificationLeadingTypeIcon — the shared wrapper
+// ABOUTME: that combines notificationTypeIconSpec with NotificationTypeIcon
+// ABOUTME: for use in both row variants.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/notifications/widgets/notification_leading_type_icon.dart';
+import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
+import 'package:openvine/widgets/notification_type_icon.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required NotificationKind type,
+  required bool isRead,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: NotificationLeadingTypeIcon(type: type, isRead: isRead),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group(NotificationLeadingTypeIcon, () {
+    testWidgets('renders the underlying $NotificationTypeIcon', (tester) async {
+      await _pump(tester, type: NotificationKind.follow, isRead: false);
+
+      expect(find.byType(NotificationTypeIcon), findsOneWidget);
+    });
+
+    testWidgets(
+      'forwards the spec for the given kind to NotificationTypeIcon',
+      (tester) async {
+        await _pump(tester, type: NotificationKind.follow, isRead: true);
+
+        final widget = tester.widget<NotificationTypeIcon>(
+          find.byType(NotificationTypeIcon),
+        );
+        final spec = notificationTypeIconSpec(NotificationKind.follow);
+        expect(widget.icon, equals(spec.icon));
+        expect(widget.backgroundColor, equals(spec.background));
+        expect(widget.foregroundColor, equals(spec.foreground));
+      },
+    );
+
+    testWidgets('shows unread dot when isRead is false', (tester) async {
+      await _pump(tester, type: NotificationKind.like, isRead: false);
+
+      final widget = tester.widget<NotificationTypeIcon>(
+        find.byType(NotificationTypeIcon),
+      );
+      expect(widget.showUnreadDot, isTrue);
+    });
+
+    testWidgets('hides unread dot when isRead is true', (tester) async {
+      await _pump(tester, type: NotificationKind.like, isRead: true);
+
+      final widget = tester.widget<NotificationTypeIcon>(
+        find.byType(NotificationTypeIcon),
+      );
+      expect(widget.showUnreadDot, isFalse);
+    });
+  });
+}

--- a/mobile/test/notifications/widgets/notification_list_item_test.dart
+++ b/mobile/test/notifications/widgets/notification_list_item_test.dart
@@ -9,6 +9,8 @@ import 'package:openvine/notifications/widgets/actor_notification_row.dart';
 import 'package:openvine/notifications/widgets/notification_list_item.dart';
 import 'package:openvine/notifications/widgets/video_notification_row.dart';
 
+final AppLocalizations _l10n = lookupAppLocalizations(const Locale('en'));
+
 const _alice = ActorInfo(
   pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   displayName: 'Alice',
@@ -131,7 +133,7 @@ void main() {
           onFollowBack: () => tapped = true,
         );
 
-        await tester.tap(find.text('Follow back'));
+        await tester.tap(find.text(_l10n.notificationFollowBack));
         await tester.pump();
 
         expect(tapped, isTrue);

--- a/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
+++ b/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
@@ -1,0 +1,76 @@
+// ABOUTME: Locks the NotificationKind → (icon, accent pair) design contract
+// ABOUTME: so a future reskin can't silently drift the row palette.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
+
+void main() {
+  group('notificationTypeIconSpec', () {
+    test('like uses heart on accentPink', () {
+      final spec = notificationTypeIconSpec(NotificationKind.like);
+      expect(spec.icon, equals(DivineIconName.heart));
+      expect(spec.background, equals(VineTheme.accentPinkBackground));
+      expect(spec.foreground, equals(VineTheme.accentPink));
+    });
+
+    test('likeComment shares the heart accent with like', () {
+      final spec = notificationTypeIconSpec(NotificationKind.likeComment);
+      expect(spec.icon, equals(DivineIconName.heart));
+      expect(spec.background, equals(VineTheme.accentPinkBackground));
+      expect(spec.foreground, equals(VineTheme.accentPink));
+    });
+
+    test('follow uses user on accentLime', () {
+      final spec = notificationTypeIconSpec(NotificationKind.follow);
+      expect(spec.icon, equals(DivineIconName.user));
+      expect(spec.background, equals(VineTheme.accentLimeBackground));
+      expect(spec.foreground, equals(VineTheme.accentLime));
+    });
+
+    test('comment uses chat on accentViolet', () {
+      final spec = notificationTypeIconSpec(NotificationKind.comment);
+      expect(spec.icon, equals(DivineIconName.chat));
+      expect(spec.background, equals(VineTheme.accentVioletBackground));
+      expect(spec.foreground, equals(VineTheme.accentViolet));
+    });
+
+    test('reply shares the chat accent with comment', () {
+      final spec = notificationTypeIconSpec(NotificationKind.reply);
+      expect(spec.icon, equals(DivineIconName.chat));
+      expect(spec.background, equals(VineTheme.accentVioletBackground));
+      expect(spec.foreground, equals(VineTheme.accentViolet));
+    });
+
+    test('mention shares the chat accent with comment', () {
+      final spec = notificationTypeIconSpec(NotificationKind.mention);
+      expect(spec.icon, equals(DivineIconName.chat));
+      expect(spec.background, equals(VineTheme.accentVioletBackground));
+      expect(spec.foreground, equals(VineTheme.accentViolet));
+    });
+
+    test('repost uses repeat on accentYellow', () {
+      final spec = notificationTypeIconSpec(NotificationKind.repost);
+      expect(spec.icon, equals(DivineIconName.repeat));
+      expect(spec.background, equals(VineTheme.accentYellowBackground));
+      expect(spec.foreground, equals(VineTheme.accentYellow));
+    });
+
+    test('system uses logo on the primary accent', () {
+      final spec = notificationTypeIconSpec(NotificationKind.system);
+      expect(spec.icon, equals(DivineIconName.logo));
+      expect(spec.background, equals(VineTheme.onPrimaryButton));
+      expect(spec.foreground, equals(VineTheme.primary));
+    });
+
+    test('every NotificationKind is covered by the switch', () {
+      for (final kind in NotificationKind.values) {
+        // Throws if any enum case were missing — the switch is exhaustive
+        // by construction, but this ensures the contract still holds when
+        // a future enum case is added without updating the helper.
+        expect(notificationTypeIconSpec(kind), isA<NotificationTypeIconSpec>());
+      }
+    });
+  });
+}

--- a/mobile/test/notifications/widgets/video_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/video_notification_row_test.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
 import 'package:openvine/notifications/widgets/video_notification_row.dart';
+import 'package:openvine/widgets/notification_type_icon.dart';
 
 const _alice = ActorInfo(
   pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -74,13 +75,20 @@ Future<void> _pump(
 void main() {
   group(VideoNotificationRow, () {
     group('renders', () {
+      testWidgets('leading $NotificationTypeIcon for every kind', (
+        tester,
+      ) async {
+        await _pump(tester, notification: _video());
+        expect(find.byType(NotificationTypeIcon), findsOneWidget);
+      });
+
       testWidgets('actor name and like message when single actor', (
         tester,
       ) async {
         await _pump(tester, notification: _video());
 
         expect(
-          find.text(_l10n.notificationLikedYourVideo('Alice')),
+          find.textContaining(_l10n.notificationLikedYourVideo('Alice')),
           findsOneWidget,
         );
       });
@@ -96,7 +104,7 @@ void main() {
 
         final verb = _l10n.notificationLikedYourVideo('').trimLeft();
         expect(
-          find.text(
+          find.textContaining(
             'Alice ${_l10n.notificationAndConnector} '
             '${_l10n.notificationOthersCount(49)} $verb',
           ),
@@ -111,10 +119,22 @@ void main() {
         );
 
         expect(
-          find.text(_l10n.notificationCommentedOnYourVideo('Alice')),
+          find.textContaining(_l10n.notificationCommentedOnYourVideo('Alice')),
           findsOneWidget,
         );
       });
+
+      testWidgets(
+        'appends video title for like / comment / repost',
+        (tester) async {
+          await _pump(
+            tester,
+            notification: _video(videoTitle: 'My Cool Vine'),
+          );
+
+          expect(find.textContaining('My Cool Vine'), findsOneWidget);
+        },
+      );
 
       testWidgets('thumbnail placeholder when videoThumbnailUrl is null', (
         tester,

--- a/mobile/test/notifications/widgets/video_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/video_notification_row_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
+import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
 import 'package:openvine/notifications/widgets/video_notification_row.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
 
@@ -33,6 +34,7 @@ VideoNotification _video({
   int totalCount = 1,
   String? videoThumbnailUrl,
   String? videoTitle,
+  String? commentText,
   bool isRead = false,
 }) {
   return VideoNotification(
@@ -45,6 +47,7 @@ VideoNotification _video({
     timestamp: DateTime.utc(2026, 5, 4, 12),
     videoThumbnailUrl: videoThumbnailUrl,
     videoTitle: videoTitle,
+    commentText: commentText,
     isRead: isRead,
   );
 }
@@ -133,6 +136,60 @@ void main() {
           );
 
           expect(find.textContaining('My Cool Vine'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'renders $NotificationCommentQuote when commentText is set',
+        (tester) async {
+          await _pump(
+            tester,
+            notification: _video(
+              type: NotificationKind.comment,
+              commentText: 'Loved this clip!',
+            ),
+          );
+
+          // The quote widget renders the body with curly quotes.
+          expect(find.byType(NotificationCommentQuote), findsOneWidget);
+          expect(find.textContaining('Loved this clip!'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'no $NotificationCommentQuote when commentText is null',
+        (tester) async {
+          await _pump(
+            tester,
+            notification: _video(type: NotificationKind.comment),
+          );
+
+          expect(find.byType(NotificationCommentQuote), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'timestamp moves to the quote when commentText is present',
+        (tester) async {
+          // The timestamp must anchor to the visual end of the row, so
+          // when a comment quote is rendered the timestamp goes there
+          // instead of the message line. This test asserts the message
+          // line does NOT carry the timestamp suffix while the quote
+          // does.
+          await _pump(
+            tester,
+            notification: _video(
+              type: NotificationKind.comment,
+              commentText: 'Thanks!',
+            ),
+          );
+
+          final quoteWidget = tester.widget<NotificationCommentQuote>(
+            find.byType(NotificationCommentQuote),
+          );
+          // The widget owns the timestamp suffix.
+          expect(quoteWidget.timestamp, isNotNull);
+          expect(quoteWidget.timestamp, isNotEmpty);
         },
       );
 

--- a/mobile/test/notifications/widgets/video_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/video_notification_row_test.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
 import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
+import 'package:openvine/notifications/widgets/notification_video_thumbnail.dart';
 import 'package:openvine/notifications/widgets/video_notification_row.dart';
 import 'package:openvine/widgets/notification_type_icon.dart';
 
@@ -199,7 +200,7 @@ void main() {
         await _pump(tester, notification: _video());
 
         expect(
-          find.byKey(const Key('video_notification_thumbnail')),
+          find.byType(NotificationVideoThumbnail),
           findsOneWidget,
         );
       });
@@ -243,7 +244,7 @@ void main() {
         );
 
         await tester.tap(
-          find.byKey(const Key('video_notification_thumbnail')),
+          find.byType(NotificationVideoThumbnail),
         );
         await tester.pump();
 

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -129,6 +129,42 @@ void main() {
         expect(find.text('Hey, how are you?'), findsOneWidget);
       });
 
+      testWidgets(
+        'last message preview uses VineTheme.onSurfaceVariant',
+        (tester) async {
+          // PR #3548 picked onSurfaceVariant for the preview; a later
+          // drift slid it back to onSurfaceMuted (one shade darker) and
+          // shipped without anyone catching it. Pin the color so the
+          // same drift can't recur silently.
+          final testProfile = createTestProfile(displayName: 'Alice');
+          final testConversation = createTestConversation(
+            lastMessageContent: 'Hey, how are you?',
+            lastMessageTimestamp: nowUnix,
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => testProfile),
+              ],
+              home: Scaffold(
+                body: ConversationTile(
+                  conversation: testConversation,
+                  currentUserPubkey: currentPubkey,
+                  onTap: () {},
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final preview = tester.widget<Text>(find.text('Hey, how are you?'));
+          expect(preview.style?.color, equals(VineTheme.onSurfaceVariant));
+        },
+      );
+
       // #3662 — the structured collab invite carries a deterministic
       // plaintext fallback ('...Open diVine to review and accept.') so
       // legacy clients can still see something. Inside diVine that copy


### PR DESCRIPTION
Closes #4184

## Description

PR [#3548](https://github.com/divinevideo/divine-mobile/pull/3548) ("new-notifications", merged 2026-04-29) shipped a Figma-aligned notifications redesign: a 32×32 type-icon column with an accent palette, inline `labelLargeFont` emphasis on actor names and titles, an `outlineDisabled` row border, and a localized date section header.

PR [#3944](https://github.com/divinevideo/divine-mobile/pull/3944) (video grouping + thumbnails, 2026-05-05) reimplemented the row from scratch and dropped all of those styles. Subsequent fixes ([#3828](https://github.com/divinevideo/divine-mobile/pull/3828), [#4007](https://github.com/divinevideo/divine-mobile/pull/4007), [#4013](https://github.com/divinevideo/divine-mobile/pull/4013)) further regressed the view container background, the date section header, and several l10n call sites. A separate small drift slipped the inbox conversation-tile preview color from `onSurfaceVariant` to `onSurfaceMuted`.

This PR re-applies the PR #3548 visual language on top of the current sealed-type / grouping / thumbnail functionality. It does not change any behavior introduced by [#3944](https://github.com/divinevideo/divine-mobile/pull/3944), [#3961](https://github.com/divinevideo/divine-mobile/pull/3961), [#3828](https://github.com/divinevideo/divine-mobile/pull/3828), [#4007](https://github.com/divinevideo/divine-mobile/pull/4007), [#4013](https://github.com/divinevideo/divine-mobile/pull/4013), or [#4130](https://github.com/divinevideo/divine-mobile/pull/4130) (replies routing).

The actor row's inline `Text.rich` layout includes a `_verbFor` branch for `NotificationKind.reply` so the verb produced by [#4130](https://github.com/divinevideo/divine-mobile/pull/4130) renders correctly under the new row structure (bold actor span + `notificationRepliedToYourComment` plain span + inline timestamp).

### Notifications screen

<table>
  <tr>
    <th>Main</th>
    <th>This branch</th>
  </tr>
  <tr>
    <td>
      <img width="400" alt="simulator_screenshot_F18AAE26-05D5-459A-B4FE-30002FA7E221" src="https://github.com/user-attachments/assets/12aade95-5459-41cc-ae39-0057611c51ba" />
    </td>
    <td>
      <img width="400" alt="simulator_screenshot_15DB52A2-9314-40EB-8BB2-871BACE09040" src="https://github.com/user-attachments/assets/278099d1-2178-4dbc-8756-7d532879929c" />
    </td>
  </tr>
</table>

**Related Issue:** Relates to [#3548](https://github.com/divinevideo/divine-mobile/pull/3548)

## Type of Change

- [ ] ✨ New feature
- [x] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## What changed

- `ActorNotificationRow` and `VideoNotificationRow` now use `NotificationTypeIcon` with the original `accentPink` / `accentLime` / `accentViolet` / `accentYellow` palette (`likeComment` and `reply` fall into the heart and chat accents respectively).
- Row container restored: uniform `surfaceContainerHigh` background + `outlineDisabled` bottom border. Unread state shows the red dot on the type icon, not a row-level tint.
- `ActorNotificationRow` uses `UserAvatar` (the placeholder-avatar primitive from PR #3548) instead of a hand-rolled `CachedNetworkImage` stack. The Follow back button uses `DivineButton(size: tiny)` and the `notificationFollowBack` l10n key instead of a hand-rolled `FilledButton` with hardcoded `'Follow back'`.
- `_MessageText` restored on both rows: `labelLargeFont` emphasis on actor names and video titles, `bodyMediumFont` verbs, `onSurfaceMuted55` trailing relative timestamp via `LocalizedTimeFormatter.formatRelative`. The actor row's `_verbFor` includes a `reply` branch returning `notificationRepliedToYourComment` directly (no actor-placeholder strip needed) so the bold actor + reply verb render correctly under the new structure.
- Date section header restored: `VineTheme.labelLargeFont(color: onSurfaceMuted)` + `LocalizedTimeFormatter.formatDateLabel`.
- Restored l10n on five snackbar / failure body strings that #3944 / #4007 hardcoded (`notificationsVideoNotFound`, `notificationsVideoUnavailable`, `notificationsFromNotification`, `notificationsFailedToLoad`, `notificationsRetry`).
- Dropped the inline `Divider` between rows; the row's bottom border owns the separation again.
- New `notification_type_icon_spec.dart` helper as the single source of truth for the `NotificationKind` → `(icon, accent pair)` mapping. Locked by a regression test so a future reskin can't silently drift the row palette.
- `ConversationTile` last-message preview color restored to `onSurfaceVariant`, with a regression test pinning the color so the same drift can't recur silently.

`VideoNotificationRow` keeps the 56×56 thumbnail introduced by #3944 — kept as new functionality, not a regression.

## New widget extractions (not restoration)

The diff is sized as a "restoration" but three files in `mobile/lib/notifications/widgets/` are net-new code worth reviewing as such, not as restored content:

- **`notification_comment_quote.dart`** (+59 LOC) — shared primitive for the `"…" 2d` quote-with-trailing-timestamp pattern. Owns the timestamp suffix when a comment quote is present so the trailing relative time stays anchored to the visual end of the row regardless of whether a quote is rendered.
- **`notification_leading_type_icon.dart`** (+43 LOC) — shared wrapper combining `notificationTypeIconSpec` with `NotificationTypeIcon`. Replaces an 11-line private widget that was duplicated byte-for-byte across both row variants.
- **`notification_video_thumbnail.dart`** (+74 LOC) — public extraction of the previously-private `_Thumbnail` inside `VideoNotificationRow`. Content was relocated, not invented; the file is new but the widget itself existed in the merge base. Surfaced so tests can use `find.byType` instead of a magic-string `Key` (per `testing.md` "Prefer Type Over Key").

Each of the three has a focused widget test in `mobile/test/notifications/widgets/`.

## Non-goals (preserved unchanged)

- Sealed split `VideoNotification` / `ActorNotification` and grouping logic ([#3944](https://github.com/divinevideo/divine-mobile/pull/3944)).
- The `kindFilter` parameter (Likes tab still matches both `like` and `likeComment`).
- d-tag / addressable-id navigation ([#4007](https://github.com/divinevideo/divine-mobile/pull/4007)) and the realtime enrichment path ([#3944](https://github.com/divinevideo/divine-mobile/pull/3944)).
- Reply / likeComment tap routing and the model accepting `reply` ([#4130](https://github.com/divinevideo/divine-mobile/pull/4130) — landed on main during the lifetime of this PR; the actor row's reply verb is the only piece restored here so the inline `Text.rich` layout renders the right text).
- Inbox-open badge sync via Riverpod cache ([#4165](https://github.com/divinevideo/divine-mobile/pull/4165)).
- The collab-invite plaintext suppression in `_MessageList` and the `_previewText` replacement in `ConversationTile` ([#3672](https://github.com/divinevideo/divine-mobile/pull/3672)).
- The legacy `mobile/lib/screens/notifications_screen.dart` and `mobile/lib/widgets/notification_list_item.dart` (test-only, dead code in production) — out of scope; deleting them is a separate follow-up.

## Test plan

- [x] `flutter analyze lib test integration_test packages` — clean
- [x] `dart format` — clean
- [x] `flutter test test/notifications/ test/widgets/notification_type_icon_test.dart test/widgets/notification_list_item_test.dart test/screens/inbox/inbox_view_test.dart test/screens/inbox/inbox_page_test.dart test/screens/notifications_screen_test.dart test/screens/notifications_navigation_test.dart test/screens/notifications_refresh_test.dart packages/divine_ui/test/src/button/divine_button_test.dart` — green
- [x] `divine_ui` strict-coverage gate maintained: `divine_button.dart` 121/121 line coverage with the new `DivineButtonSize.tiny` variant
- [ ] Manual: notifications tab matches Figma — accent palette + dot + border (in **dark mode** — Divine is dark-mode only)
- [ ] Manual: a comment-like (`likeComment`) row uses the heart accent
- [ ] Manual: a reply row uses the purple chat-bubble accent + "{actor} replied to your comment"
- [ ] Manual: grouped video like row shows thumbnail and stacked avatar
- [ ] Manual: Follow back button on a follow row uses `DivineButton(size: tiny)` and is flush with the avatar (no row-height jump on tap)
- [ ] Manual: long-press on system row does nothing (kept behavior)
- [ ] Manual: Spanish locale shows localized snackbar copy
- [ ] Manual: inbox conversation list shows preview text in `onSurfaceVariant`
