### PR TITLE
build(ci): add macOS lane for iOS attestation RunnerTests

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -156,7 +156,7 @@ jobs:
     # contract that the Dart-bound payload contains exactly
     # {message, isMainFrame} and no origin host/port/scheme fields).
     # Without this lane, regressions in those types pass CI and ship.
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         working-directory: mobile/
@@ -169,8 +169,9 @@ jobs:
         # which only matches the protocol shape in the iOS 18 SDK.
         # Xcode 15.x's iOS 17.5 SDK declares those as `[String: Any]`,
         # so the dependency fails to compile and the test build never
-        # starts. The default Xcode on macos-14 runners floats and would
-        # silently change the toolchain — pin to a known-good 16.x.
+        # starts. macos-14 caps at Xcode 16.2; macos-15 ships 16.4 as
+        # default, so we run there and pin explicitly so the default
+        # can't drift underneath us.
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16.4"
@@ -205,9 +206,11 @@ jobs:
       - name: 🧪 Run RunnerTests
         # Code signing is disabled because simulator unit tests don't
         # need a provisioning profile; with it on, GitHub-hosted runners
-        # without Apple credentials fail with "no profile". `iPhone 15`
-        # is preinstalled on macos-14; OS=latest is safe because the
-        # tests are pure Swift unit tests with no version-gated APIs.
+        # without Apple credentials fail with "no profile". `iPhone 16`
+        # is the default preinstalled simulator on macos-15 with
+        # Xcode 16.4 (iPhone 15 was dropped from the default set);
+        # OS=latest is safe because the tests are pure Swift unit tests
+        # with no version-gated APIs.
         working-directory: mobile/ios
         run: |
           set -o pipefail
@@ -215,7 +218,7 @@ jobs:
             -workspace Runner.xcworkspace \
             -scheme Runner \
             -only-testing:RunnerTests \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -configuration Debug \
             -resultBundlePath build/RunnerTests.xcresult \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -148,6 +148,82 @@ jobs:
             exit 1
           fi
           echo "✅ VGV tag count OK: current=$current, baseline=$baseline"
+  runner-tests:
+    name: iOS Runner Tests
+    # Gates the security-sensitive Swift code added in #3979:
+    # NostrBridgeAttestationPolicy (single-instance attach/detach state
+    # machine) and FrameAttestingScriptMessageHandler.eventPayload (pinned
+    # contract that the Dart-bound payload contains exactly
+    # {message, isMainFrame} and no origin host/port/scheme fields).
+    # Without this lane, regressions in those types pass CI and ship.
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: mobile/
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🍎 Setup Xcode
+        # Pinned to 15.4: Flutter 3.41.9 is tested up to Xcode 15.x;
+        # Xcode 16 has surfaced sporadic CocoaPods regressions. The
+        # default Xcode on macos-14 runners floats and would silently
+        # change the toolchain.
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.4"
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.9"
+          channel: "stable"
+          cache: true
+      - name: 📥 Precache iOS artifacts
+        run: flutter precache --ios
+      - name: 📦 Install dependencies
+        run: flutter pub get
+      - name: 🔧 Generate iOS Flutter config
+        # `--config-only` writes mobile/ios/Flutter/Generated.xcconfig
+        # which the Podfile reads to resolve FLUTTER_ROOT. Without it,
+        # `pod install` fails. `--config-only` skips Dart compilation;
+        # `--no-codesign` is belt-and-suspenders since this lane never
+        # archives.
+        run: flutter build ios --config-only --no-codesign
+      - name: 🍫 Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            mobile/ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: pods-${{ runner.os }}-${{ hashFiles('mobile/ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
+      - name: 🥘 Install CocoaPods
+        working-directory: mobile/ios
+        run: pod install
+      - name: 🧪 Run RunnerTests
+        # Code signing is disabled because simulator unit tests don't
+        # need a provisioning profile; with it on, GitHub-hosted runners
+        # without Apple credentials fail with "no profile". `iPhone 15`
+        # is preinstalled on macos-14; OS=latest is safe because the
+        # tests are pure Swift unit tests with no version-gated APIs.
+        working-directory: mobile/ios
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -workspace Runner.xcworkspace \
+            -scheme Runner \
+            -only-testing:RunnerTests \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            -configuration Debug \
+            -resultBundlePath build/RunnerTests.xcresult \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            | xcpretty
+      - name: 📤 Upload xcresult on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: RunnerTests.xcresult
+          path: mobile/ios/build/RunnerTests.xcresult
   mobile-ci:
     name: Mobile CI
     if: ${{ always() }}
@@ -157,6 +233,7 @@ jobs:
       - analyze
       - tests
       - vgv-tag-gate
+      - runner-tests
     runs-on: ubuntu-latest
     steps:
       - name: Verify upstream jobs
@@ -166,18 +243,21 @@ jobs:
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
           VGV_TAG_GATE_RESULT: ${{ needs.vgv-tag-gate.result }}
+          RUNNER_TESTS_RESULT: ${{ needs.runner-tests.result }}
         run: |
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
           echo "vgv-tag-gate: ${VGV_TAG_GATE_RESULT}"
+          echo "runner-tests: ${RUNNER_TESTS_RESULT}"
 
           if [[ "${GENERATED_FILES_RESULT}" != "success" || \
                 "${FORMAT_RESULT}" != "success" || \
                 "${ANALYZE_RESULT}" != "success" || \
                 "${TESTS_RESULT}" != "success" || \
-                "${VGV_TAG_GATE_RESULT}" != "success" ]]; then
+                "${VGV_TAG_GATE_RESULT}" != "success" || \
+                "${RUNNER_TESTS_RESULT}" != "success" ]]; then
             echo "One or more Mobile CI jobs failed."
             exit 1
           fi

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -181,6 +181,19 @@ jobs:
           flutter-version: "3.41.9"
           channel: "stable"
           cache: true
+      - name: 📦 Enable Swift Package Manager
+        # c2pa_flutter (declared in pubspec.yaml as a git dependency)
+        # ships a CocoaPods stub whose only Swift file is a `#error`
+        # directive demanding SPM — its podspec exists only to satisfy
+        # Flutter's plugin validation. Locally SPM is enabled by
+        # `flutter config --enable-swift-package-manager`, so pub_get
+        # registers the plugin via FlutterGeneratedPluginSwiftPackage
+        # and `pod install` skips it. CI runners start with SPM off,
+        # so without this step pub_get installs c2pa_flutter as a Pod
+        # and `xcodebuild test` compiles the stub → ** TEST FAILED **.
+        # Setting must happen before any flutter command that touches
+        # iOS plugin setup (pub get, precache, build).
+        run: flutter config --enable-swift-package-manager
       - name: 📥 Precache iOS artifacts
         run: flutter precache --ios
       - name: 📦 Install dependencies

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -163,18 +163,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 🍎 Setup Xcode
-        # Pinned to 16.4: pro_video_editor 1.15.0 declares
-        # `[String: any Sendable]` for AVVideoCompositing's
-        # sourcePixelBufferAttributes / requiredPixelBufferAttributesForRenderContext,
-        # which only matches the protocol shape in the iOS 18 SDK.
-        # Xcode 15.x's iOS 17.5 SDK declares those as `[String: Any]`,
-        # so the dependency fails to compile and the test build never
-        # starts. macos-14 caps at Xcode 16.2; macos-15 ships 16.4 as
-        # default, so we run there and pin explicitly so the default
-        # can't drift underneath us.
+        # Pinned to 26.3: pro_video_editor 1.15.0's
+        # CompositionBuilder.swift references
+        # `AVVideoCompositionLayerInstruction.Configuration`, an iOS 26
+        # SDK type. The reference is runtime-gated by
+        # `if #available(iOS 26.0, *)`, but Swift still type-checks
+        # both branches at compile time, so the type has to exist in
+        # the SDK. Xcode 16.x ships iOS 17/18 SDKs and the build fails
+        # with "type 'AVVideoCompositionLayerInstruction' has no
+        # member 'Configuration'" before tests can run. The same file
+        # also needs the iOS 18 SDK shape (`[String: any Sendable]`)
+        # for AVVideoCompositing — Xcode 26 satisfies both.
+        # macos-15-arm64 ships 26.3 alongside 26.2 / 26.1.1 / 26.0.1
+        # but defaults to 16.4, so the explicit pin is required and
+        # protects against the runner image's default drifting.
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.4"
+          xcode-version: "26.3"
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -163,13 +163,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 🍎 Setup Xcode
-        # Pinned to 15.4: Flutter 3.41.9 is tested up to Xcode 15.x;
-        # Xcode 16 has surfaced sporadic CocoaPods regressions. The
-        # default Xcode on macos-14 runners floats and would silently
-        # change the toolchain.
+        # Pinned to 16.4: pro_video_editor 1.15.0 declares
+        # `[String: any Sendable]` for AVVideoCompositing's
+        # sourcePixelBufferAttributes / requiredPixelBufferAttributesForRenderContext,
+        # which only matches the protocol shape in the iOS 18 SDK.
+        # Xcode 15.x's iOS 17.5 SDK declares those as `[String: Any]`,
+        # so the dependency fails to compile and the test build never
+        # starts. The default Xcode on macos-14 runners floats and would
+        # silently change the toolchain — pin to a known-good 16.x.
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "15.4"
+          xcode-version: "16.4"
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
Closes #4119. Follow-up to #3979.

## Summary

Adds a `runner-tests` job to `.github/workflows/mobile_ci.yaml` that runs the Swift `RunnerTests` suite from #3979 on `macos-14` so regressions in `NostrBridgeAttestationPolicy` or `FrameAttestingScriptMessageHandler.eventPayload` fail CI instead of relying on a contributor remembering to run `xcodebuild test` locally.

## Why

The Nostr bridge attestation work is a security-sensitive boundary. The two types this PR gates are:

- `NostrBridgeAttestationPolicy` — single-instance attach/detach state machine that prevents the per-frame attestation handler from being silently dropped or swapped.
- `FrameAttestingScriptMessageHandler.eventPayload` — pinned contract that the Dart-bound payload contains exactly `{message, isMainFrame}` and never leaks origin host/port/scheme upward.

Without a CI lane these tests are honor-system. This PR makes them required.

## What changed

`.github/workflows/mobile_ci.yaml`:

- New `runner-tests` job on `macos-14` with Xcode `15.4` pinned via `maxim-lobanov/setup-xcode@v1`. Flutter `3.41.9` matches the existing Ubuntu jobs verbatim.
- Steps: `flutter precache --ios` → `flutter pub get` → `flutter build ios --config-only --no-codesign` (writes `Generated.xcconfig` so the Podfile resolves `FLUTTER_ROOT`) → CocoaPods cache keyed on `Podfile.lock` → `pod install` → `xcodebuild test -only-testing:RunnerTests` against an iPhone 15 simulator.
- Code signing is disabled (`CODE_SIGNING_ALLOWED=NO`, `CODE_SIGNING_REQUIRED=NO`) — simulator unit tests don't need a profile.
- On failure the `.xcresult` bundle is uploaded as an artifact for triage.
- `mobile-ci` aggregator now `needs: runner-tests` and exits non-zero if it fails, so the lane becomes transitively required by branch protection without any branch-protection rule change.

No `paths:` filter — runs on every PR to `main`, matching the existing workflow's convention. The cost (~5–7 macOS minutes per PR) is acceptable for a security-critical lane.

## Test plan

- [ ] First run on this PR is green; `runner-tests` and `mobile-ci` both pass.
- [ ] Push a throwaway commit that flips one expected `AttachResult` case in `RunnerTests.swift`; verify `runner-tests` goes red, `mobile-ci` goes red, the other five jobs stay green; revert.
- [ ] Confirm the PR is blocked from merge while red (branch protection on `mobile-ci`).
- [ ] Inspect the failing run's `RunnerTests.xcresult` artifact and verify it opens in Xcode.