### PR TITLE
fix(notifications): wire "liked your comment" + "replied" notification taps

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -174,15 +174,26 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           videoAddressableId: videoAddressableId,
           notificationKind: type,
         );
-      case ActorNotification(:final actor, :final type):
+      case ActorNotification(:final actor, :final type, :final targetEventId):
         switch (type) {
           case NotificationKind.follow:
           case NotificationKind.mention:
             _navigateToProfile(context, actor.pubkey);
+          case NotificationKind.likeComment:
+            // targetEventId is the kind 1111 comment; the resolver
+            // walks its E tag to the root video.
+            if (targetEventId != null && targetEventId.isNotEmpty) {
+              await _navigateToVideo(
+                context,
+                targetEventId,
+                notificationKind: type,
+              );
+            } else {
+              _navigateToProfile(context, actor.pubkey);
+            }
           case NotificationKind.system:
             break;
           case NotificationKind.like:
-          case NotificationKind.likeComment:
           case NotificationKind.comment:
           case NotificationKind.reply:
           case NotificationKind.repost:
@@ -214,7 +225,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     // (kind:pubkey:d-tag) rather than the mutable event hash.
     final isComment =
         notificationKind == NotificationKind.comment ||
-        notificationKind == NotificationKind.reply;
+        notificationKind == NotificationKind.reply ||
+        notificationKind == NotificationKind.likeComment;
 
     // Resolve the navigation target.
     String routeId;

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -180,6 +180,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           case NotificationKind.mention:
             _navigateToProfile(context, actor.pubkey);
           case NotificationKind.likeComment:
+          case NotificationKind.reply:
             // targetEventId is the kind 1111 comment; the resolver
             // walks its E tag to the root video.
             if (targetEventId != null && targetEventId.isNotEmpty) {
@@ -195,7 +196,6 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             break;
           case NotificationKind.like:
           case NotificationKind.comment:
-          case NotificationKind.reply:
           case NotificationKind.repost:
             // Not represented as ActorNotification, but pattern-match
             // exhaustivity requires these.

--- a/mobile/lib/notifications/widgets/actor_notification_row.dart
+++ b/mobile/lib/notifications/widgets/actor_notification_row.dart
@@ -53,10 +53,11 @@ class ActorNotificationRow extends StatelessWidget {
       NotificationKind.likeComment => l10n.notificationLikedYourComment(
         actorName,
       ),
+      NotificationKind.reply =>
+        '$actorName ${l10n.notificationRepliedToYourComment}',
       NotificationKind.system => l10n.notificationSystemUpdate,
       NotificationKind.like ||
       NotificationKind.comment ||
-      NotificationKind.reply ||
       NotificationKind.repost => actorName,
     };
 

--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -22,9 +22,10 @@ class ActorNotification extends NotificationItem {
          type == NotificationKind.follow ||
              type == NotificationKind.mention ||
              type == NotificationKind.system ||
-             type == NotificationKind.likeComment,
+             type == NotificationKind.likeComment ||
+             type == NotificationKind.reply,
          'ActorNotification only supports follow, mention, system, '
-         'likeComment',
+         'likeComment, reply',
        );
 
   /// The actor who triggered this notification.

--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -15,6 +15,7 @@ class ActorNotification extends NotificationItem {
     required this.actor,
     required super.timestamp,
     super.isRead,
+    super.targetEventId,
     this.commentText,
     this.isFollowingBack = false,
   }) : assert(
@@ -44,6 +45,7 @@ class ActorNotification extends NotificationItem {
     bool? isRead,
     String? commentText,
     bool? isFollowingBack,
+    String? targetEventId,
   }) {
     return ActorNotification(
       id: id ?? this.id,
@@ -53,6 +55,7 @@ class ActorNotification extends NotificationItem {
       isRead: isRead ?? this.isRead,
       commentText: commentText ?? this.commentText,
       isFollowingBack: isFollowingBack ?? this.isFollowingBack,
+      targetEventId: targetEventId ?? this.targetEventId,
     );
   }
 
@@ -65,5 +68,6 @@ class ActorNotification extends NotificationItem {
     isRead,
     commentText,
     isFollowingBack,
+    targetEventId,
   ];
 }

--- a/mobile/packages/models/test/src/actor_notification_test.dart
+++ b/mobile/packages/models/test/src/actor_notification_test.dart
@@ -3,10 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   group(ActorNotification, () {
-    final actor = ActorInfo(
-      pubkey: 'a' * 64,
-      displayName: 'Alice',
-    );
+    final actor = ActorInfo(pubkey: 'a' * 64, displayName: 'Alice');
     final timestamp = DateTime.utc(2026, 5, 4, 12);
 
     group('structure', () {
@@ -32,6 +29,18 @@ void main() {
           actor: actor,
           timestamp: timestamp,
         );
+      });
+
+      test('exposes targetEventId for likeComment', () {
+        final notification = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+          targetEventId: 'b' * 64,
+        );
+
+        expect(notification.targetEventId, equals('b' * 64));
       });
     });
 
@@ -99,6 +108,20 @@ void main() {
         final updated = original.copyWith(isFollowingBack: true);
 
         expect(updated.isRead, isTrue);
+      });
+
+      test('preserves targetEventId when not overridden', () {
+        final original = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+          targetEventId: 'c' * 64,
+        );
+
+        final updated = original.copyWith(isRead: true);
+
+        expect(updated.targetEventId, equals('c' * 64));
       });
     });
   });

--- a/mobile/packages/models/test/src/actor_notification_test.dart
+++ b/mobile/packages/models/test/src/actor_notification_test.dart
@@ -42,6 +42,17 @@ void main() {
 
         expect(notification.targetEventId, equals('b' * 64));
       });
+
+      test('accepts reply as an actor-anchored kind', () {
+        // Should not throw the assert.
+        ActorNotification(
+          id: 'n1',
+          type: NotificationKind.reply,
+          actor: actor,
+          timestamp: timestamp,
+          targetEventId: 'd' * 64,
+        );
+      });
     });
 
     group('equality', () {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -334,15 +334,19 @@ class NotificationRepository {
           kind == NotificationKind.repost) {
         continue;
       }
-      // ActorNotification supports follow/mention/system/likeComment;
-      // coerce other kinds (e.g. reply) to system.
+      // ActorNotification supports follow/mention/system/likeComment/reply;
+      // coerce any other kind to system.
       final mapped =
           (kind == NotificationKind.follow ||
               kind == NotificationKind.mention ||
               kind == NotificationKind.system ||
-              kind == NotificationKind.likeComment)
+              kind == NotificationKind.likeComment ||
+              kind == NotificationKind.reply)
           ? kind
           : NotificationKind.system;
+      final isCommentTargeted =
+          mapped == NotificationKind.likeComment ||
+          mapped == NotificationKind.reply;
       result.add(
         ActorNotification(
           id: n.dedupeKey,
@@ -351,9 +355,7 @@ class NotificationRepository {
           timestamp: n.createdAt,
           isRead: n.read,
           commentText: _truncateComment(n.content, kind),
-          targetEventId: mapped == NotificationKind.likeComment
-              ? n.referencedEventId
-              : null,
+          targetEventId: isCommentTargeted ? n.referencedEventId : null,
         ),
       );
     }
@@ -413,9 +415,13 @@ class NotificationRepository {
         (kind == NotificationKind.follow ||
             kind == NotificationKind.mention ||
             kind == NotificationKind.system ||
-            kind == NotificationKind.likeComment)
+            kind == NotificationKind.likeComment ||
+            kind == NotificationKind.reply)
         ? kind
         : NotificationKind.system;
+    final isCommentTargeted =
+        mapped == NotificationKind.likeComment ||
+        mapped == NotificationKind.reply;
     return ActorNotification(
       id: raw.dedupeKey,
       type: mapped,
@@ -423,9 +429,7 @@ class NotificationRepository {
       timestamp: raw.createdAt,
       isRead: raw.read,
       commentText: _truncateComment(raw.content, kind),
-      targetEventId: mapped == NotificationKind.likeComment
-          ? raw.referencedEventId
-          : null,
+      targetEventId: isCommentTargeted ? raw.referencedEventId : null,
     );
   }
 
@@ -469,6 +473,11 @@ class NotificationRepository {
   /// Likes (and zaps) on a non-video target — typically a kind 1111
   /// comment — map to [NotificationKind.likeComment] so the UI can
   /// render "liked your comment" instead of "liked your video".
+  ///
+  /// Replies (kind 1111) split the same way: a reply directly on a video
+  /// is indistinguishable from a comment for the user, so we map it to
+  /// [NotificationKind.comment]. A reply on a non-video (i.e. on one of
+  /// the user's own comments) maps to [NotificationKind.reply].
   static NotificationKind _mapNotificationKind(RelayNotification n) {
     final isReaction = switch (n.notificationType) {
       'reaction' || 'zap' => true,
@@ -480,7 +489,8 @@ class NotificationRepository {
           : NotificationKind.likeComment;
     }
     return switch (n.notificationType) {
-      'reply' => NotificationKind.reply,
+      'reply' =>
+        n.isReferencedVideo ? NotificationKind.comment : NotificationKind.reply,
       'comment' => NotificationKind.comment,
       'repost' => NotificationKind.repost,
       'mention' => NotificationKind.mention,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -73,17 +73,11 @@ class NotificationRepository {
     try {
       final effectiveCursor = cursor ?? _lastCursor;
       final requestUrl = _funnelcakeApiClient
-          .notificationsUri(
-            pubkey: _userPubkey,
-            cursor: effectiveCursor,
-          )
+          .notificationsUri(pubkey: _userPubkey, cursor: effectiveCursor)
           .toString();
 
       final authHeaders = _authHeadersProvider != null
-          ? await _authHeadersProvider(
-              requestUrl,
-              'GET',
-            )
+          ? await _authHeadersProvider(requestUrl, 'GET')
           : <String, String>{};
 
       final response = await _funnelcakeApiClient.getNotifications(
@@ -178,10 +172,7 @@ class NotificationRepository {
       pubkeys: pubkeys,
     );
     final videosFuture = _fetchVideoMetadata(eventIds);
-    final (profiles, videosById) = await (
-      profilesFuture,
-      videosFuture,
-    ).wait;
+    final (profiles, videosById) = await (profilesFuture, videosFuture).wait;
 
     final consolidated = _consolidateFollows(raw);
     final videos = _groupVideoAnchored(consolidated, profiles, videosById);
@@ -210,10 +201,7 @@ class NotificationRepository {
                   .toList();
               if (filtered.isEmpty) return null;
               if (filtered.length == n.actors.length) return n;
-              return n.copyWith(
-                actors: filtered,
-                totalCount: filtered.length,
-              );
+              return n.copyWith(actors: filtered, totalCount: filtered.length);
             }(),
             ActorNotification() => filter(n.actor.pubkey) ? null : n,
           },
@@ -239,15 +227,13 @@ class NotificationRepository {
     List<String> eventIds,
   ) async {
     if (eventIds.isEmpty) return const <String, VideoStats>{};
-    final futures = eventIds.map(
-      (id) async {
-        try {
-          return await _funnelcakeApiClient.getVideoStats(id);
-        } on Object {
-          return null;
-        }
-      },
-    );
+    final futures = eventIds.map((id) async {
+      try {
+        return await _funnelcakeApiClient.getVideoStats(id);
+      } on Object {
+        return null;
+      }
+    });
     final results = await Future.wait(futures);
     final map = <String, VideoStats>{};
     for (var i = 0; i < eventIds.length; i++) {
@@ -365,6 +351,9 @@ class NotificationRepository {
           timestamp: n.createdAt,
           isRead: n.read,
           commentText: _truncateComment(n.content, kind),
+          targetEventId: mapped == NotificationKind.likeComment
+              ? n.referencedEventId
+              : null,
         ),
       );
     }
@@ -392,10 +381,7 @@ class NotificationRepository {
         ? _fetchVideoMetadata([referenced])
         : Future<Map<String, VideoStats>>.value(const {});
 
-    final (profiles, videosById) = await (
-      profilesFuture,
-      videoFuture,
-    ).wait;
+    final (profiles, videosById) = await (profilesFuture, videoFuture).wait;
 
     final actor = _buildActor(raw.sourcePubkey, profiles);
 
@@ -437,6 +423,9 @@ class NotificationRepository {
       timestamp: raw.createdAt,
       isRead: raw.read,
       commentText: _truncateComment(raw.content, kind),
+      targetEventId: mapped == NotificationKind.likeComment
+          ? raw.referencedEventId
+          : null,
     );
   }
 
@@ -465,10 +454,7 @@ class NotificationRepository {
   }
 
   /// Builds an [ActorInfo] from a pubkey and the profile lookup map.
-  ActorInfo _buildActor(
-    String pubkey,
-    Map<String, UserProfile> profiles,
-  ) {
+  ActorInfo _buildActor(String pubkey, Map<String, UserProfile> profiles) {
     final profile = profiles[pubkey];
     return ActorInfo(
       pubkey: pubkey,

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -103,9 +103,8 @@ void main() {
 
   void stubProfiles(Map<String, UserProfile> profiles) {
     when(
-      () => profileRepository.fetchBatchProfiles(
-        pubkeys: any(named: 'pubkeys'),
-      ),
+      () =>
+          profileRepository.fetchBatchProfiles(pubkeys: any(named: 'pubkeys')),
     ).thenAnswer((_) async => profiles);
   }
 
@@ -201,16 +200,11 @@ void main() {
         final signedUri = Uri.parse(signedUrl);
         expect(
           '${signedUri.scheme}://${signedUri.host}${signedUri.path}',
-          equals(
-            'https://api.example.com/api/users/$userPubkey/notifications',
-          ),
+          equals('https://api.example.com/api/users/$userPubkey/notifications'),
         );
         expect(signedUri.queryParameters['limit'], equals('50'));
         expect(signedUri.queryParameters['before'], isNotNull);
-        expect(
-          int.tryParse(signedUri.queryParameters['before']!),
-          isNotNull,
-        );
+        expect(int.tryParse(signedUri.queryParameters['before']!), isNotNull);
         expect(signedMethod, equals('GET'));
       });
 
@@ -280,9 +274,7 @@ void main() {
       });
 
       test('falls back to "Unknown user" for missing profiles', () async {
-        stubNotifications([
-          makeNotification(sourcePubkey: 'unknown_pub'),
-        ]);
+        stubNotifications([makeNotification(sourcePubkey: 'unknown_pub')]);
         stubProfiles({});
 
         final page = await repository.getNotifications();
@@ -412,104 +404,95 @@ void main() {
     });
 
     group('video-anchored grouping', () {
-      test(
-        '5 likes on same video become 1 $VideoNotification '
-        'with totalCount 5 and 3 actors',
-        () async {
-          stubNotifications([
-            for (var i = 0; i < 5; i++)
-              makeNotification(
-                id: 'l$i',
-                sourcePubkey: 'pub_$i',
-                referencedEventId: 'video_x',
-                createdAt: DateTime(2025, 1, 5 - i),
-              ),
-          ]);
-          stubProfiles({
-            for (var i = 0; i < 5; i++)
-              'pub_$i': makeProfile('pub_$i', displayName: 'Actor$i'),
-          });
-
-          final page = await repository.getNotifications();
-
-          expect(page.items, hasLength(1));
-          final item = page.items.single as VideoNotification;
-          expect(item.type, equals(NotificationKind.like));
-          expect(item.totalCount, equals(5));
-          // Cap is 3 actors for the stack.
-          expect(item.actors, hasLength(3));
-          // Newest first — pub_0 had the latest createdAt.
-          expect(item.actors.first.displayName, equals('Actor0'));
-          expect(item.videoEventId, equals('video_x'));
-        },
-      );
-
-      test(
-        'grouped video notifications build addressable id from '
-        'user pubkey and d-tag',
-        () async {
-          stubNotifications([
+      test('5 likes on same video become 1 $VideoNotification '
+          'with totalCount 5 and 3 actors', () async {
+        stubNotifications([
+          for (var i = 0; i < 5; i++)
             makeNotification(
-              id: 'l1',
-              sourcePubkey: 'pub_a',
+              id: 'l$i',
+              sourcePubkey: 'pub_$i',
               referencedEventId: 'video_x',
-              referencedDTag: 'vine-id',
+              createdAt: DateTime(2025, 1, 5 - i),
             ),
-            makeNotification(
-              id: 'l2',
-              sourcePubkey: 'pub_b',
-              referencedEventId: 'video_x',
-              referencedDTag: 'vine-id',
-            ),
-          ]);
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
-          });
+        ]);
+        stubProfiles({
+          for (var i = 0; i < 5; i++)
+            'pub_$i': makeProfile('pub_$i', displayName: 'Actor$i'),
+        });
 
-          final page = await repository.getNotifications();
+        final page = await repository.getNotifications();
 
-          expect(page.items, hasLength(1));
-          final item = page.items.single as VideoNotification;
-          expect(
-            item.videoAddressableId,
-            equals(
-              '${NIP71VideoKinds.addressableShortVideo}:'
-              '$userPubkey:vine-id',
-            ),
-          );
-        },
-      );
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.like));
+        expect(item.totalCount, equals(5));
+        // Cap is 3 actors for the stack.
+        expect(item.actors, hasLength(3));
+        // Newest first — pub_0 had the latest createdAt.
+        expect(item.actors.first.displayName, equals('Actor0'));
+        expect(item.videoEventId, equals('video_x'));
+      });
 
-      test(
-        'grouped video notifications leave addressable id null when d-tag '
-        'is null or empty',
-        () async {
-          stubNotifications([
-            makeNotification(
-              id: 'l1',
-              sourcePubkey: 'pub_a',
-              referencedEventId: 'video_x',
-              referencedDTag: '',
-            ),
-            makeNotification(
-              id: 'l2',
-              sourcePubkey: 'pub_b',
-              referencedEventId: 'video_x',
-            ),
-          ]);
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
-          });
+      test('grouped video notifications build addressable id from '
+          'user pubkey and d-tag', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'l1',
+            sourcePubkey: 'pub_a',
+            referencedEventId: 'video_x',
+            referencedDTag: 'vine-id',
+          ),
+          makeNotification(
+            id: 'l2',
+            sourcePubkey: 'pub_b',
+            referencedEventId: 'video_x',
+            referencedDTag: 'vine-id',
+          ),
+        ]);
+        stubProfiles({
+          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+        });
 
-          final page = await repository.getNotifications();
+        final page = await repository.getNotifications();
 
-          expect(page.items, hasLength(1));
-          final item = page.items.single as VideoNotification;
-          expect(item.videoAddressableId, isNull);
-        },
-      );
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(
+          item.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:vine-id',
+          ),
+        );
+      });
+
+      test('grouped video notifications leave addressable id null when d-tag '
+          'is null or empty', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'l1',
+            sourcePubkey: 'pub_a',
+            referencedEventId: 'video_x',
+            referencedDTag: '',
+          ),
+          makeNotification(
+            id: 'l2',
+            sourcePubkey: 'pub_b',
+            referencedEventId: 'video_x',
+          ),
+        ]);
+        stubProfiles({
+          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+        });
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(item.videoAddressableId, isNull);
+      });
 
       test(
         '5 likes on 5 different videos produce 5 ${VideoNotification}s',
@@ -538,56 +521,48 @@ void main() {
         },
       );
 
-      test(
-        'likes + comments on same video become 2 ${VideoNotification}s '
-        'differing by kind',
-        () async {
-          stubNotifications([
-            makeNotification(
-              id: 'l1',
-              sourcePubkey: 'pub_a',
-              referencedEventId: 'video_x',
-            ),
-            makeNotification(
-              id: 'c1',
-              sourcePubkey: 'pub_b',
-              notificationType: 'comment',
-              sourceKind: 1,
-              referencedEventId: 'video_x',
-              content: 'Cool',
-            ),
-          ]);
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
-          });
+      test('likes + comments on same video become 2 ${VideoNotification}s '
+          'differing by kind', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'l1',
+            sourcePubkey: 'pub_a',
+            referencedEventId: 'video_x',
+          ),
+          makeNotification(
+            id: 'c1',
+            sourcePubkey: 'pub_b',
+            notificationType: 'comment',
+            sourceKind: 1,
+            referencedEventId: 'video_x',
+            content: 'Cool',
+          ),
+        ]);
+        stubProfiles({
+          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+        });
 
-          final page = await repository.getNotifications();
+        final page = await repository.getNotifications();
 
-          expect(page.items, hasLength(2));
-          final kinds = page.items
-              .whereType<VideoNotification>()
-              .map((v) => v.type)
-              .toSet();
-          expect(
-            kinds,
-            equals({NotificationKind.like, NotificationKind.comment}),
-          );
-        },
-      );
+        expect(page.items, hasLength(2));
+        final kinds = page.items
+            .whereType<VideoNotification>()
+            .map((v) => v.type)
+            .toSet();
+        expect(
+          kinds,
+          equals({NotificationKind.like, NotificationKind.comment}),
+        );
+      });
 
       test(
         'video-anchored notification with null referencedEventId is dropped',
         () async {
           stubNotifications([
-            makeNotification(
-              sourcePubkey: 'pub_a',
-              referencedEventId: null,
-            ),
+            makeNotification(sourcePubkey: 'pub_a', referencedEventId: null),
           ]);
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-          });
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
           final page = await repository.getNotifications();
 
@@ -604,9 +579,7 @@ void main() {
               referencedEventId: 'video_x',
             ),
           ]);
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-          });
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
           when(
             () => funnelcakeApiClient.getVideoStats('video_x'),
           ).thenThrow(const FunnelcakeException('boom'));
@@ -622,75 +595,66 @@ void main() {
     });
 
     group('follow consolidation', () {
-      test(
-        '2 follows from same pubkey become 1 $ActorNotification '
-        'with earliest timestamp',
-        () async {
-          final earlier = DateTime(2025);
-          final later = DateTime(2025, 1, 5);
-          stubNotifications([
-            makeNotification(
-              id: 'f1',
-              sourcePubkey: 'follower_pub',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              createdAt: later,
-            ),
-            makeNotification(
-              id: 'f2',
-              sourcePubkey: 'follower_pub',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              createdAt: earlier,
-            ),
-          ]);
-          stubProfiles({
-            'follower_pub': makeProfile(
-              'follower_pub',
-              displayName: 'Follower',
-            ),
-          });
+      test('2 follows from same pubkey become 1 $ActorNotification '
+          'with earliest timestamp', () async {
+        final earlier = DateTime(2025);
+        final later = DateTime(2025, 1, 5);
+        stubNotifications([
+          makeNotification(
+            id: 'f1',
+            sourcePubkey: 'follower_pub',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            createdAt: later,
+          ),
+          makeNotification(
+            id: 'f2',
+            sourcePubkey: 'follower_pub',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            createdAt: earlier,
+          ),
+        ]);
+        stubProfiles({
+          'follower_pub': makeProfile('follower_pub', displayName: 'Follower'),
+        });
 
-          final page = await repository.getNotifications();
+        final page = await repository.getNotifications();
 
-          expect(page.items, hasLength(1));
-          final item = page.items.single as ActorNotification;
-          expect(item.type, equals(NotificationKind.follow));
-          expect(item.timestamp, equals(earlier));
-        },
-      );
+        expect(page.items, hasLength(1));
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.follow));
+        expect(item.timestamp, equals(earlier));
+      });
 
-      test(
-        'follows from different pubkeys are not consolidated',
-        () async {
-          stubNotifications([
-            makeNotification(
-              id: 'f1',
-              sourcePubkey: 'pub_a',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-            ),
-            makeNotification(
-              id: 'f2',
-              sourcePubkey: 'pub_b',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-            ),
-          ]);
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
-          });
+      test('follows from different pubkeys are not consolidated', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'f1',
+            sourcePubkey: 'pub_a',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+          ),
+          makeNotification(
+            id: 'f2',
+            sourcePubkey: 'pub_b',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+          ),
+        ]);
+        stubProfiles({
+          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+        });
 
-          final page = await repository.getNotifications();
+        final page = await repository.getNotifications();
 
-          expect(page.items, hasLength(2));
-        },
-      );
+        expect(page.items, hasLength(2));
+      });
     });
 
     group('comments stay individual when on different videos', () {
@@ -739,20 +703,30 @@ void main() {
         expect(item.type, equals(NotificationKind.like));
       });
 
-      test(
-        'reaction on a non-video target maps to likeComment '
-        '($ActorNotification)',
-        () async {
-          stubNotifications([
-            makeNotification(isReferencedVideo: false),
-          ]);
-          stubProfiles({});
+      test('reaction on a non-video target maps to likeComment '
+          '($ActorNotification)', () async {
+        stubNotifications([makeNotification(isReferencedVideo: false)]);
+        stubProfiles({});
 
-          final page = await repository.getNotifications();
-          final item = page.items.single as ActorNotification;
-          expect(item.type, equals(NotificationKind.likeComment));
-        },
-      );
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.likeComment));
+      });
+
+      test('likeComment carries referencedEventId as targetEventId', () async {
+        stubNotifications([
+          makeNotification(
+            isReferencedVideo: false,
+            referencedEventId: 'comment_event_xyz',
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.likeComment));
+        expect(item.targetEventId, equals('comment_event_xyz'));
+      });
 
       test('reply maps to reply (rendered as $ActorNotification)', () async {
         stubNotifications([
@@ -1083,9 +1057,7 @@ void main() {
       test(
         'returns $VideoNotification for like with non-null referencedEventId',
         () async {
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-          });
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
           stubVideoStats(
             'video_x',
             makeVideoStats(id: 'video_x', thumbnail: 'thumb', title: 'T'),
@@ -1102,38 +1074,31 @@ void main() {
         },
       );
 
-      test(
-        'builds addressable id from user pubkey and d-tag for realtime '
-        'video notifications',
-        () async {
-          stubProfiles({
-            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-          });
-          stubVideoStats(
-            'video_x',
-            makeVideoStats(id: 'video_x', thumbnail: 'thumb', title: 'T'),
-          );
+      test('builds addressable id from user pubkey and d-tag for realtime '
+          'video notifications', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats(
+          'video_x',
+          makeVideoStats(id: 'video_x', thumbnail: 'thumb', title: 'T'),
+        );
 
-          final result = await repository.enrichOne(
-            raw(referencedDTag: 'vine-id'),
-          );
+        final result = await repository.enrichOne(
+          raw(referencedDTag: 'vine-id'),
+        );
 
-          expect(result, isA<VideoNotification>());
-          final video = result! as VideoNotification;
-          expect(
-            video.videoAddressableId,
-            equals(
-              '${NIP71VideoKinds.addressableShortVideo}:'
-              '$userPubkey:vine-id',
-            ),
-          );
-        },
-      );
+        expect(result, isA<VideoNotification>());
+        final video = result! as VideoNotification;
+        expect(
+          video.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:vine-id',
+          ),
+        );
+      });
 
       test('leaves addressable id null when realtime d-tag is empty', () async {
-        stubProfiles({
-          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-        });
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
         final result = await repository.enrichOne(raw(referencedDTag: ''));
 
@@ -1143,21 +1108,15 @@ void main() {
       });
 
       test('returns null for like with null referencedEventId', () async {
-        stubProfiles({
-          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-        });
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
-        final result = await repository.enrichOne(
-          raw(referencedEventId: null),
-        );
+        final result = await repository.enrichOne(raw(referencedEventId: null));
 
         expect(result, isNull);
       });
 
       test('returns $ActorNotification for follow', () async {
-        stubProfiles({
-          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
-        });
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
         final result = await repository.enrichOne(
           raw(
@@ -1171,6 +1130,20 @@ void main() {
         final actor = result! as ActorNotification;
         expect(actor.type, equals(NotificationKind.follow));
         expect(actor.actor.displayName, equals('Alice'));
+      });
+
+      test('returns likeComment with targetEventId when reaction targets a '
+          'non-video event', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+        final result = await repository.enrichOne(
+          raw(referencedEventId: 'comment_evt_id', isReferencedVideo: false),
+        );
+
+        expect(result, isA<ActorNotification>());
+        final actor = result! as ActorNotification;
+        expect(actor.type, equals(NotificationKind.likeComment));
+        expect(actor.targetEventId, equals('comment_evt_id'));
       });
     });
   });

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -728,22 +728,39 @@ void main() {
         expect(item.targetEventId, equals('comment_event_xyz'));
       });
 
-      test('reply maps to reply (rendered as $ActorNotification)', () async {
+      test('reply on a video maps to comment ($VideoNotification)', () async {
         stubNotifications([
-          makeNotification(
-            notificationType: 'reply',
-            sourceKind: 1,
-            referencedEventId: null,
-          ),
+          makeNotification(notificationType: 'reply', sourceKind: 1),
         ]);
         stubProfiles({});
 
         final page = await repository.getNotifications();
-        // Reply is not a video kind — it falls through to actor mapping
-        // and is coerced to system in the ActorNotification.
-        final item = page.items.single as ActorNotification;
-        expect(item.type, equals(NotificationKind.system));
+        // A reply directly on a video is indistinguishable from a comment
+        // for the user, so it lands in the comment grouping path.
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.comment));
       });
+
+      test(
+        'reply on a non-video target maps to reply ($ActorNotification) '
+        'with targetEventId',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'reply',
+              sourceKind: 1,
+              isReferencedVideo: false,
+              referencedEventId: 'parent_comment_id',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.reply));
+          expect(item.targetEventId, equals('parent_comment_id'));
+        },
+      );
 
       test('comment maps to comment', () async {
         stubNotifications([

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -12,6 +12,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
@@ -67,9 +68,7 @@ Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
     routes: [
       GoRoute(
         path: '/',
-        builder: (context, state) => Scaffold(
-          body: NotificationsView(),
-        ),
+        builder: (context, state) => Scaffold(body: NotificationsView()),
       ),
       GoRoute(
         path: PooledFullscreenVideoFeedScreen.path,
@@ -167,9 +166,7 @@ void main() {
         await tester.tap(find.text('Retry'));
         await tester.pump();
 
-        verify(
-          () => mockBloc.add(NotificationFeedRefreshed()),
-        ).called(1);
+        verify(() => mockBloc.add(NotificationFeedRefreshed())).called(1);
       });
     });
 
@@ -247,9 +244,7 @@ void main() {
         // addPostFrameCallback fires after first frame.
         await tester.pump();
 
-        verify(
-          () => mockBloc.add(NotificationFeedMarkAllRead()),
-        ).called(1);
+        verify(() => mockBloc.add(NotificationFeedMarkAllRead())).called(1);
       });
 
       testWidgets('dispatches item tapped on notification tap', (tester) async {
@@ -265,9 +260,80 @@ void main() {
         await tester.tap(find.byType(NotificationListItem).first);
         await tester.pump();
 
+        verify(() => mockBloc.add(NotificationFeedItemTapped('n1'))).called(1);
+      });
+
+      testWidgets('likeComment tap resolves comment to root video and opens '
+          'comments thread', (tester) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const commentEventId = 'comment_1111_event';
+        const rootVideoEventId = 'root_video_event';
+        final resolvedVideo = _video(rootVideoEventId);
+
+        // The comment is not a video — resolver fetches it from relay
+        // and follows its uppercase E tag to the root video.
+        when(() => videoService.getVideoById(commentEventId)).thenReturn(null);
+        when(() => nostrClient.fetchEventById(commentEventId)).thenAnswer((
+          _,
+        ) async {
+          final event = Event(
+            'a' * 64,
+            1111,
+            const [
+              ['E', rootVideoEventId],
+            ],
+            'liked comment text',
+            createdAt: 1700000000,
+          );
+          event.id = commentEventId;
+          return event;
+        });
+        when(
+          () =>
+              videosRepository.fetchVideoWithStatsForRouteId(rootVideoEventId),
+        ).thenAnswer((_) async => resolvedVideo);
+        when(
+          () => videoService.shouldHideVideo(resolvedVideo),
+        ).thenReturn(false);
+
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'lc1',
+                type: NotificationKind.likeComment,
+                actor: ActorInfo(pubkey: 'liker', displayName: 'Liz'),
+                timestamp: DateTime(2026),
+                targetEventId: commentEventId,
+              ),
+            ],
+          ),
+        );
+
+        final capturedArgs = await _pumpRoutedView(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
+
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
+
+        verify(() => nostrClient.fetchEventById(commentEventId)).called(1);
         verify(
-          () => mockBloc.add(NotificationFeedItemTapped('n1')),
+          () =>
+              videosRepository.fetchVideoWithStatsForRouteId(rootVideoEventId),
         ).called(1);
+        expect(capturedArgs, hasLength(1));
+        final args = capturedArgs.single;
+        expect(args.autoOpenComments, isTrue);
+        final videos = await args.videosStream.first;
+        expect(videos.single.id, resolvedVideo.id);
       });
 
       testWidgets(
@@ -389,25 +455,20 @@ void main() {
         expect(find.byType(NotificationListItem), findsNWidgets(5));
       });
 
-      testWidgets(
-        'follow filter renders only follow notifications',
-        (tester) async {
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: mixed,
-            ),
-          );
+      testWidgets('follow filter renders only follow notifications', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: mixed,
+          ),
+        );
 
-          await _pumpView(
-            tester,
-            mockBloc,
-            kindFilter: NotificationKind.follow,
-          );
+        await _pumpView(tester, mockBloc, kindFilter: NotificationKind.follow);
 
-          expect(find.byType(NotificationListItem), findsOneWidget);
-        },
-      );
+        expect(find.byType(NotificationListItem), findsOneWidget);
+      });
 
       testWidgets(
         'like filter also matches likeComment so likes-on-comments appear',
@@ -419,11 +480,7 @@ void main() {
             ),
           );
 
-          await _pumpView(
-            tester,
-            mockBloc,
-            kindFilter: NotificationKind.like,
-          );
+          await _pumpView(tester, mockBloc, kindFilter: NotificationKind.like);
 
           // VideoNotification(like) + ActorNotification(likeComment) = 2.
           expect(find.byType(NotificationListItem), findsNWidgets(2));

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -337,6 +337,81 @@ void main() {
       });
 
       testWidgets(
+        'reply tap resolves target comment to root video and opens '
+        'comments thread',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const parentCommentId = 'parent_comment_id';
+          const rootVideoEventId = 'reply_root_video';
+          final resolvedVideo = _video(rootVideoEventId);
+
+          when(
+            () => videoService.getVideoById(parentCommentId),
+          ).thenReturn(null);
+          when(() => nostrClient.fetchEventById(parentCommentId)).thenAnswer((
+            _,
+          ) async {
+            final event = Event(
+              'a' * 64,
+              1111,
+              const [
+                ['E', rootVideoEventId],
+              ],
+              'parent comment text',
+              createdAt: 1700000000,
+            );
+            event.id = parentCommentId;
+            return event;
+          });
+          when(
+            () => videosRepository.fetchVideoWithStatsForRouteId(
+              rootVideoEventId,
+            ),
+          ).thenAnswer((_) async => resolvedVideo);
+          when(
+            () => videoService.shouldHideVideo(resolvedVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'r1',
+                  type: NotificationKind.reply,
+                  actor: ActorInfo(pubkey: 'replier', displayName: 'Bob'),
+                  timestamp: DateTime(2026),
+                  targetEventId: parentCommentId,
+                ),
+              ],
+            ),
+          );
+
+          final capturedArgs = await _pumpRoutedView(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verify(() => nostrClient.fetchEventById(parentCommentId)).called(1);
+          verify(
+            () => videosRepository.fetchVideoWithStatsForRouteId(
+              rootVideoEventId,
+            ),
+          ).called(1);
+          expect(capturedArgs, hasLength(1));
+          expect(capturedArgs.single.autoOpenComments, isTrue);
+        },
+      );
+
+      testWidgets(
         'comment notification fetches by addressable id and opens comments',
         (tester) async {
           final videoService = _MockVideoEventService();

--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -104,6 +104,20 @@ void main() {
         );
       });
 
+      testWidgets('"{actor} replied to your comment" for reply', (
+        tester,
+      ) async {
+        await _pump(
+          tester,
+          notification: _actor(type: NotificationKind.reply),
+        );
+
+        expect(
+          find.text('Alice ${_l10n.notificationRepliedToYourComment}'),
+          findsOneWidget,
+        );
+      });
+
       testWidgets('Follow back button when not yet following', (tester) async {
         await _pump(tester, notification: _actor());
 


### PR DESCRIPTION
## Description

Two related notification routing bugs.

### Bug 1 — "X liked your comment" tap did nothing

The `_onItemTap` switch in `notifications_view.dart` had `likeComment` in a fallthrough block with the comment *"Not represented as ActorNotification"* — but `ActorNotification`'s assert explicitly accepts `likeComment`. So it fell through to a no-op `break`. And even with the case wired, `ActorNotification` for `likeComment` wasn't carrying the relay's `referenced_event_id` (the kind 1111 comment), so there was nothing to navigate to.

### Bug 2 — Replies showed up as "You have a new update"

Reply notifications (kind 1111 with `notification_type: 'reply'`) were silently coerced to `NotificationKind.system` in the repository's actor-enrichment path because `ActorNotification` didn't accept `reply`. That coercion produced a *"You have a new update"* row with the reply text underneath, no actor name, and a no-op tap.

## Fixes

### Bug 1 — likeComment tap

- **Model** (`actor_notification.dart`) — accept `targetEventId` via `super.targetEventId` (the sealed `NotificationItem` base already declared the field).
- **Repository** (`notification_repository.dart`) — populate `targetEventId` from `RelayNotification.referencedEventId` for `likeComment` in both batch and realtime (`enrichOne`) paths.
- **View** (`notifications_view.dart`) — `likeComment` taps now route through `_navigateToVideo` with the comment-resolver path (walks the kind 1111's `E` tag to the parent video) and `autoOpenComments: true`. Falls back to the actor's profile if `targetEventId` is missing.

### Bug 2 — reply routing

Split the reply path the same way reactions are split:

- `'reply'` on a video → `NotificationKind.comment` (groups under the existing video-anchored comment path; user already understands this as a comment on their video).
- `'reply'` on a non-video (reply to one of the user's own comments) → `NotificationKind.reply` on an `ActorNotification`, with `targetEventId` carrying the parent. Tap routes through the same resolver path as `likeComment`.

Adds `NotificationKind.reply` to `ActorNotification`'s accept-list, renders the row using the existing `notificationRepliedToYourComment` ARB key, reuses the kind-1111 E-tag resolver. No new strings, no new resolver code, no new widgets.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Out of scope

Showing the actual liked-comment text in the row. The relay's `content` field on a kind 7 reaction is just the emoji (`+`/`❤️`), not the comment body. The `_CommentPreview` slot in `ActorNotificationRow` already exists, so when a future change fetches the kind 1111 content (or the relay starts including it) the preview will render automatically.

## Test plan

- [x] `packages/models` — 9 tests pass (3 new for `targetEventId` + reply assert)
- [x] `packages/notification_repository` — 44 tests pass (3 new: likeComment+targetEventId batch & realtime, reply→comment on video, reply→reply on non-video)
- [x] `test/notifications/view` — 16 tests pass (2 new: likeComment tap → resolver → video w/ comments, reply tap → resolver → video w/ comments)
- [x] `test/notifications/widgets` — 78 tests pass (1 new: reply row rendering)
- [x] `test/notifications/bloc` — 27 pass (model field addition didn't break copyWith callers)
- [x] `flutter analyze lib/notifications test/notifications` — clean
- [x] `dart analyze` on `packages/models` and `packages/notification_repository` — clean
- [ ] Manual: tap a `likeComment` notification on device → lands on parent video w/ comments thread
- [ ] Manual: tap a reply-to-your-video → lands on that video w/ comments
- [ ] Manual: tap a reply-to-your-comment → lands on root video w/ comments

## Note on diff size

The pre-commit `dart format` reflowed several pre-existing unrelated lines in `notification_repository.dart` and its test (file was last touched with a different formatter version). The hook would block the commit otherwise. Functional diff is small — search for `targetEventId`, `NotificationKind.reply`, and `isCommentTargeted` for the actual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)