### PR TITLE
feat(profile): show divine.video handles as @user (no domain suffix)

### DIFF
--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -51,10 +51,7 @@ class WelcomeScreen extends ConsumerWidget {
   ).toString();
 
   /// Build a login-options path with optional recovery context prefilled.
-  static String loginOptionsPathWithRecovery({
-    String? email,
-    String? error,
-  }) {
+  static String loginOptionsPathWithRecovery({String? email, String? error}) {
     final queryParameters = <String, String>{};
 
     if (email != null && email.isNotEmpty) {
@@ -361,7 +358,7 @@ class _ReturningUserProfile extends StatelessWidget {
         UserProfile.defaultDisplayNameFor(pubkeyHex);
 
     final identifier =
-        profile?.displayNip05 ?? NostrKeyUtils.truncateNpub(pubkeyHex);
+        profile?.shortDisplayNip05 ?? NostrKeyUtils.truncateNpub(pubkeyHex);
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/mobile/lib/screens/comments/widgets/mention_overlay.dart
+++ b/mobile/lib/screens/comments/widgets/mention_overlay.dart
@@ -124,10 +124,7 @@ class _MentionSuggestionItem extends ConsumerWidget {
         ? ref
               .watch(
                 mentionNip05VerificationProvider(
-                  MentionNip05Claim(
-                    pubkey: suggestion.pubkey,
-                    nip05: rawNip05,
-                  ),
+                  MentionNip05Claim(pubkey: suggestion.pubkey, nip05: rawNip05),
                 ),
               )
               .whenOrNull(data: (status) => status)
@@ -185,10 +182,16 @@ class _MentionSuggestionItem extends ConsumerWidget {
 
 String? _displayNip05(String? nip05) {
   if (nip05 == null || nip05.isEmpty) return null;
-  if (nip05.startsWith('_@')) return nip05.substring(1);
+  if (nip05.startsWith('_@')) {
+    final stripped = nip05.substring(1);
+    final match = RegExp(
+      r'^@([a-z0-9\-_.]+)\.divine\.video$',
+    ).firstMatch(stripped);
+    return match != null ? '@${match.group(1)}' : stripped;
+  }
 
   if (nip05.endsWith('@divine.video') || nip05.endsWith('@openvine.co')) {
-    return '@${nip05.split('@')[0]}.divine.video';
+    return '@${nip05.split('@')[0]}';
   }
 
   return nip05;

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -128,7 +128,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 otherPubkey: otherPubkey,
                 displayName: displayName,
                 imageUrl: profile?.picture,
-                nip05: profile?.displayNip05,
+                nip05: profile?.shortDisplayNip05,
                 onViewProfile: () {
                   final npub = NostrKeyUtils.encodePubKey(otherPubkey);
                   context.push('${OtherProfileScreen.path}/$npub');

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -102,7 +102,7 @@ class _ProfileContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final imageUrl = profile?.picture;
-    final nip05 = profile?.displayNip05;
+    final nip05 = profile?.shortDisplayNip05;
     final followerCount = profile?.followerCount;
     final videoCount = profile?.videoCount;
 

--- a/mobile/lib/screens/search_results/widgets/search_user_tile.dart
+++ b/mobile/lib/screens/search_results/widgets/search_user_tile.dart
@@ -27,7 +27,7 @@ class SearchUserTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final claimedNip05 = profile.displayNip05;
+    final claimedNip05 = profile.shortDisplayNip05;
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref
               .watch(nip05VerificationProvider(profile.pubkey))

--- a/mobile/lib/widgets/clickable_hashtag_text.dart
+++ b/mobile/lib/widgets/clickable_hashtag_text.dart
@@ -285,8 +285,9 @@ class ClickableHashtagText extends ConsumerWidget {
       UserProfile(:final displayName?) when displayName.isNotEmpty =>
         displayName,
       UserProfile(:final name?) when name.isNotEmpty => name,
-      UserProfile(:final displayNip05?) when displayNip05.isNotEmpty =>
-        displayNip05,
+      UserProfile(:final shortDisplayNip05?)
+          when shortDisplayNip05.isNotEmpty =>
+        shortDisplayNip05,
       _ => UserProfile.defaultDisplayNameFor(hexPubkey),
     };
     return profileText.startsWith('@') ? profileText : '@$profileText';

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -193,7 +193,7 @@ class _ResultsList extends StatelessWidget {
                   );
                   return _UserResultTile(
                     user: user,
-                    nip05: profile.nip05,
+                    nip05: profile.shortDisplayNip05,
                     onTap: () => onSelectUser(user),
                   );
                 },
@@ -213,7 +213,7 @@ class _ResultsList extends StatelessWidget {
                   );
                   return _UserResultTile(
                     user: user,
-                    nip05: profile.nip05,
+                    nip05: profile.shortDisplayNip05,
                     onTap: () => onSelectUser(user),
                   );
                 },

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -159,7 +159,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         effectiveProfile?.picture?.isNotEmpty == true ||
         effectiveProfile?.about?.isNotEmpty == true ||
         effectiveProfile?.nip05?.isNotEmpty == true;
-    final nip05 = effectiveProfile?.displayNip05;
+    final nip05 = effectiveProfile?.shortDisplayNip05;
     final about = effectiveProfile?.about;
     final profileColor = effectiveProfile?.profileBackgroundColor;
     final authService = ref.watch(authServiceProvider);
@@ -668,10 +668,7 @@ class _BannerImage extends StatelessWidget {
 /// shimmering indefinitely or collapsing the row (which would shift the
 /// surrounding profile layout).
 class _ProfileStatsRow extends StatefulWidget {
-  const _ProfileStatsRow({
-    required this.userIdHex,
-    this.profileStats,
-  });
+  const _ProfileStatsRow({required this.userIdHex, this.profileStats});
 
   final String userIdHex;
   final ProfileStats? profileStats;
@@ -954,10 +951,8 @@ void _showAvatarLightbox(
     barrierColor: VineTheme.transparent,
     barrierDismissible: true,
     barrierLabel: context.l10n.profileAvatarLightboxBarrierLabel,
-    pageBuilder: (context, _, _) => _AvatarLightbox(
-      imageUrl: imageUrl,
-      userIdHex: userIdHex,
-    ),
+    pageBuilder: (context, _, _) =>
+        _AvatarLightbox(imageUrl: imageUrl, userIdHex: userIdHex),
   );
 }
 

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -354,9 +354,10 @@ class _UserSearchTile extends StatelessWidget {
                   overflow: .ellipsis,
                   style: VineTheme.titleMediumFont(color: textColor),
                 ),
-                if (profile.nip05 != null && profile.nip05!.isNotEmpty)
+                if (profile.shortDisplayNip05 != null &&
+                    profile.shortDisplayNip05!.isNotEmpty)
                   Text(
-                    profile.nip05!,
+                    profile.shortDisplayNip05!,
                     maxLines: 1,
                     overflow: .ellipsis,
                     style: VineTheme.bodyMediumFont(color: textColor),

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -76,7 +76,7 @@ class UserProfileTile extends ConsumerWidget {
     final displayName =
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
 
-    final claimedNip05 = profile?.displayNip05;
+    final claimedNip05 = profile?.shortDisplayNip05;
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref
               .watch(nip05VerificationProvider(pubkey))

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -181,21 +181,26 @@ class UserProfile {
   /// A display handle for the user, prefixed with `@`.
   ///
   /// Prefers NIP-05 identifier, falls back to [name]. Returns an empty
-  /// string when neither is available.
+  /// string when neither is available. Uses [shortDisplayNip05] so
+  /// divine.video users render as `@rabble`, not `@rabble.divine.video`.
   String get handle {
     if (nip05 != null && nip05!.isNotEmpty) {
-      final dn = displayNip05!;
+      final dn = shortDisplayNip05!;
       return dn.startsWith('@') ? dn : '@$dn';
     }
     if (name != null && name!.isNotEmpty) return '@$name';
     return '';
   }
 
-  /// NIP-05 formatted for display.
+  /// NIP-05 formatted for display, full form.
   ///
   /// Normalises all divine.video / openvine.co identifiers to the canonical
   /// `@username.divine.video` form. External identifiers (e.g.
   /// `alice@example.com`) are returned unchanged.
+  ///
+  /// Use this when the domain is meaningful to the user — settings screens,
+  /// the share-video watermark, the NIP-05 editor — so people understand
+  /// what they own. For general UI rendering prefer [shortDisplayNip05].
   String? get displayNip05 {
     if (nip05 == null || nip05!.isEmpty) return null;
     // New subdomain format: _@username.divine.video → @username.divine.video
@@ -204,6 +209,19 @@ class UserProfile {
     final username = divineUsername;
     if (username != null) return '@$username.divine.video';
     // External domain: keep as-is
+    return nip05;
+  }
+
+  /// NIP-05 formatted for display, short form.
+  ///
+  /// Strips the `.divine.video` suffix for divine-owned subdomains so the
+  /// user shows up as `@rabble` instead of `@rabble.divine.video`. External
+  /// identifiers (e.g. `alice@example.com`) are returned unchanged because
+  /// the domain is the user's own and meaningful.
+  String? get shortDisplayNip05 {
+    if (nip05 == null || nip05!.isEmpty) return null;
+    final username = divineUsername;
+    if (username != null) return '@$username';
     return nip05;
   }
 

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -530,6 +530,30 @@ void main() {
 
         expect(profile.handle, isEmpty);
       });
+
+      test('strips .divine.video suffix for subdomain format', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: '_@rabble.divine.video',
+        );
+
+        expect(profile.handle, equals('@rabble'));
+      });
+
+      test('strips divine.video suffix for legacy format', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'rabble@divine.video',
+        );
+
+        expect(profile.handle, equals('@rabble'));
+      });
     });
 
     group('computed properties', () {
@@ -948,6 +972,79 @@ void main() {
         );
 
         expect(profile.displayNip05, isNull);
+      });
+    });
+
+    group('shortDisplayNip05', () {
+      test('returns @user (no suffix) for subdomain format', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: '_@alice.divine.video',
+        );
+
+        expect(profile.shortDisplayNip05, equals('@alice'));
+      });
+
+      test('returns @user (no suffix) for legacy user@divine.video', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'heybob@divine.video',
+        );
+
+        expect(profile.shortDisplayNip05, equals('@heybob'));
+      });
+
+      test('returns @user (no suffix) for legacy user@openvine.co', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'charlie@openvine.co',
+        );
+
+        expect(profile.shortDisplayNip05, equals('@charlie'));
+      });
+
+      test('preserves external NIP-05 unchanged', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'alice@example.com',
+        );
+
+        expect(profile.shortDisplayNip05, equals('alice@example.com'));
+      });
+
+      test('returns null when nip05 is null', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+        );
+
+        expect(profile.shortDisplayNip05, isNull);
+      });
+
+      test('returns null when nip05 is empty', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: '',
+        );
+
+        expect(profile.shortDisplayNip05, isNull);
       });
     });
 

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -413,7 +413,7 @@ void main() {
       final textSpan = text.textSpan! as TextSpan;
       final spans = textSpan.children!.cast<TextSpan>();
       final mentionSpan = spans.firstWhere(
-        (span) => span.text == '@alice.divine.video',
+        (span) => span.text == '@alice',
       );
 
       expect(mentionSpan.recognizer, isA<TapGestureRecognizer>());


### PR DESCRIPTION
## Summary

- For users on `*.divine.video` / `openvine.co`, the handle now renders as `@rabble` instead of `@rabble.divine.video` across the app's display surfaces.
- External NIP-05s (`alice@example.com`) are kept full because the domain *is* the user's identity.
- New `UserProfile.shortDisplayNip05` getter; `UserProfile.handle` switched to use it so every caller going through `.handle` inherits the short form.
- 9 UI surfaces swapped: profile header, comments mention overlay, search user tile, user profile tile, conversation view, message request preview, welcome screen account block, find-people sheet, user-picker sheet, clickable hashtag/mention text.

## Deliberately kept on the long form

These surfaces answer the question "what do I own" and need the full domain:

- `watermark_text_resolver.dart` — share-video watermark needs the full handle so cross-client viewers can find the creator.
- `settings_screen.dart` — own-identity header + account switcher row.
- `nip05_settings_screen.dart` / `nostr_settings_screen.dart` / `profile_setup_screen.dart` — direct NIP-05 editing screens (already used raw `nip05`, untouched).
- `special_profile_checkmark.dart` — matches against full hostname.
- `notification_helpers.dart` — internal username extraction, not a display surface.

## Why short form

The full `@user.divine.video` was visual noise for the default-domain case, which is most of the user base. Telegram/Fragment behave the same way. The verified checkmark already signals "owns a real domain" — encoding it in the visible string twice was redundant.

Trade-off worth noting: cross-client (Damus, Amethyst) still shows `@rabble.divine.video`. If that becomes confusing in mention/search flows, the short form is one getter swap away from being reverted per call site.

## Test plan

- [x] `flutter test packages/models/test/src/user_profile_test.dart` — 101/101 pass, including 6 new `shortDisplayNip05` cases and 2 new `handle` cases for divine.video subdomains.
- [x] `flutter test` on all 12 affected UI test files — 154/154 pass after updating one outdated assertion in `clickable_hashtag_text_test.dart` to expect `@alice` instead of `@alice.divine.video`.
- [x] `flutter analyze` on all 10 changed UI files — clean.
- [ ] Manual: load profile of a `*.divine.video` user → header shows `@rabble`. Load an external NIP-05 user → still shows `alice@example.com`.
- [ ] Manual: settings screen still shows the full `@rabble.divine.video` for the current account.
- [ ] Manual: share a video → watermark still credits the user with the full handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)