### PR TITLE
test(apps): add E2E coverage for iOS frame attestation hop

### DIFF
--- a/mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md
@@ -1,0 +1,273 @@
+# Brainstorm: end-to-end EventChannel coverage for iOS frame attestation
+
+Date: 2026-05-08
+
+Issue: [#4120](https://github.com/divinevideo/divine-mobile/issues/4120)
+Follow-up to: PR [#3979](https://github.com/divinevideo/divine-mobile/pull/3979) (closed
+[#3764](https://github.com/divinevideo/divine-mobile/issues/3764))
+
+## Problem Statement
+
+PR #3979 shipped iOS per-frame origin attestation: a custom
+`WKScriptMessageHandler` reads `WKScriptMessage.frameInfo.isMainFrame` and
+streams `{message, isMainFrame}` to Dart through an `EventChannel`. The Dart
+reaction is unit-tested via the `@visibleForTesting onAttestedEventHandlerReady`
+seam, and the Swift policy + payload shape are pinned by `RunnerTests.swift`.
+**No test exercises the live `WKScriptMessage → Swift handler → EventChannel →
+Dart` hop.** A channel-name typo, payload-key drift, broadcast-stream
+lifecycle bug, or marshaling regression on either side would silently degrade
+defence-in-depth to nonce-only enforcement, and every existing test would
+still be green.
+
+## Constraints
+
+- **iOS-only feature.** The native plugin lives in
+  `mobile/ios/Runner/NostrBridgeAttestationPlugin.swift`. Android keeps its
+  current nonce-only posture (parity tracked separately in #4105). The new test
+  must skip on `!= TargetPlatform.iOS`.
+- **`webview_flutter_wkwebview: ^3.24.1`.** Pigeon definition of
+  `WKScriptMessage` does not include `frameInfo` — that's exactly why the
+  native plugin was needed. The test cannot reach `frameInfo` from Dart; it
+  must let the live `WKWebView` produce the `WKScriptMessage` in flight.
+- **Production routing on iOS uses `loadRequest(uri)`** (the
+  `_BootstrappedSandboxPage` path is gated on Android). The fixture must be
+  loadable as a real URL.
+- **Allowed-origin gate**: `_isAllowedOrigin` requires the loaded page's
+  origin to exactly match an entry in `NostrAppDirectoryEntry.allowedOrigins`.
+  Fixtures need to drive both sides of that.
+- **Bootstrap script is `forMainFrameOnly: true`** — by design. The iframe
+  has no `__divineBridgeNonce` constant; the only available channel is
+  `webkit.messageHandlers.divineSandboxBridge.postMessage(...)` raw. That is
+  exactly the attack vector PR #3979 closes.
+- **`patrol: ^4.2.0` is the integration-test harness.** Existing tests in
+  `mobile/integration_test/` use `patrolTest($)` regardless of whether they
+  use OS-level automation. The new test follows the same convention.
+- **Repo rules**: layered architecture, no error strings in BLoC state, no
+  hardcoded values without a named constant, l10n for any user-visible
+  string. None of these bite hard for a test, but the test fixture should
+  pull constants out (channel names, nonce, pubkey) into named consts.
+
+## Prior Art
+
+- **PR #3979** ships the feature under test. Plugin lives at
+  `mobile/ios/Runner/NostrBridgeAttestationPlugin.swift`. Test seam exposed
+  at `mobile/lib/screens/apps/nostr_app_sandbox_screen.dart:53-54`
+  (`onAttestedEventHandlerReady`) and `:39-58` (`bridgeNonceOverride`,
+  `currentUserPubkeyOverride`, `javaScriptRunnerOverride`,
+  `bridgeServiceOverride`).
+- **`mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart:406-572`**:
+  the `iOS frame attestation` group exercises the Dart-side handler in
+  isolation. It is the contract this E2E test layers above.
+- **`mobile/ios/RunnerTests/RunnerTests.swift`**:
+  `FrameAttestingScriptMessageHandlerTests` pin the dictionary shape;
+  `WebKitContentControllerIntegrationTests` smoke-test the WebKit APIs the
+  plugin depends on. Neither exercises Flutter channels.
+- **`mobile/integration_test/privacy/image_metadata_stripper_test.dart`**:
+  closest existing template for a single-feature, native-plugin integration
+  test driven from Dart. No full app launch.
+- **`mobile/integration_test/secure_key_storage_test.dart`**: another
+  feature-isolated integration test using `patrolTest($)` without app launch.
+- **`mobile/integration_test/helpers/`**: reusable helpers for HTTP, db,
+  navigation, relay, services. None currently bind a local server inside a
+  test process — that pattern is net-new.
+- **`webview_flutter` `WKUserContentController.add(_:name:)`** does not take
+  `forMainFrameOnly` — handlers are reachable from sub-frames by design.
+  The defence is reading `frameInfo.isMainFrame` in the handler, not blocking
+  the post.
+
+## Approaches Explored
+
+### Approach A: in-process `dart:io` HTTP server + `<iframe src="/iframe.html">`
+
+**Description.** The integration test binds an `HttpServer` to
+`127.0.0.1:0`, serves two endpoints from the same origin:
+
+- `GET /` → main HTML. The bootstrap script (installed by the native
+  plugin as `WKUserScript`, document-start, main-frame only) takes care of
+  `window.nostr`; the pigeon's own `addJavaScriptChannel` install aliases
+  `window.divineSandboxBridge → webkit.messageHandlers.divineSandboxBridge`.
+  The main page's body fires
+  `divineSandboxBridge.postMessage(JSON.stringify({id:'main',method:'getPublicKey',args:{},nonce:'<known>'}))`
+  once the alias resolves. The known nonce is supplied via
+  `bridgeNonceOverride`.
+- `GET /iframe.html` → iframe HTML. Inline script:
+  `webkit.messageHandlers.divineSandboxBridge.postMessage(JSON.stringify({id:'frame',method:'getPublicKey',args:{}}))` —
+  no nonce, no bootstrap. Mimics the attack vector from #3764.
+
+The main page contains `<iframe src="/iframe.html"></iframe>` so both frames
+are same-origin (loopback), and `webkit.messageHandlers.divineSandboxBridge`
+is reachable from the iframe.
+
+The fixture `NostrAppDirectoryEntry` carries
+`allowedOrigins: ['http://127.0.0.1:<port>']` and
+`launchUrl: 'http://127.0.0.1:<port>/'`. Pump `NostrAppSandboxScreen`
+inside a `MaterialApp` with `javaScriptRunnerOverride` collecting outbound
+`__divineNostrBridge?.handleResponse(...)` calls into a `List<String>`.
+
+Poll the collector (250 ms ticks, 15 s cap) until two specific response
+payloads land — one for `id: 'main'`, one for `id: 'frame'` — then assert:
+
+- The `frame` response contains `"subframe_rejected"`.
+- The `main` response does NOT contain `"subframe_rejected"`. With a stub
+  bridge service wired, additionally assert `"success":true` and the
+  pubkey echoed back.
+
+**Layers affected.** Integration test only. No production-code change.
+
+**Pros.**
+- Real `WKWebView` produces the real `WKScriptMessage`; the
+  `frameInfo.isMainFrame` value comes from WebKit, not from a test fake.
+- `<iframe src=...>` is the closest analogue to the production attack
+  vector (compromised same-origin asset, XSS into a sub-frame, etc.).
+- Exercises every link in the chain: WKScriptMessageHandler swap,
+  `FrameAttestingScriptMessageHandler.userContentController`, dictionary
+  marshal, `FlutterEventSink`, `EventChannel.receiveBroadcastStream()`,
+  `_handleAttestedEvent`'s map-key reads, `_emitBridgeResponse`.
+- Reuses the existing `javaScriptRunnerOverride` seam — same assertion
+  shape as the unit tests.
+- Single Dart file (plus optional helper). No iOS test target changes.
+
+**Cons.**
+- Net-new pattern: no existing `mobile/integration_test/` test binds a
+  local HTTP server. Slight risk of port-binding flake; mitigated by
+  `bind('127.0.0.1', 0)` and reading the actual port back from
+  `server.port`.
+- Test must run on a device/simulator where loopback HTTP is reachable
+  (it is, on iOS simulators by default). App Transport Security may need
+  an exception for `127.0.0.1` HTTP for device runs.
+
+**Risks / Unknowns.**
+- iOS may rewrite the loopback origin in some way (`http://localhost`
+  vs `http://127.0.0.1`); the fixture must use whichever one
+  `WKWebView` reports back. Local testing confirms which form to embed
+  in `allowedOrigins`.
+- Timing: the main page's `_postMain()` may fire before the alias is
+  available; polling for the alias in the fixture script handles this.
+- The captured-scripts collector relies on `_emitBridgeResponse` running
+  successfully — the `_runJavaScript` override has to succeed, otherwise
+  the production code throws and the test stalls.
+
+**Complexity:** Medium.
+
+### Approach B: in-process HTTP server + `<iframe srcdoc="...">`
+
+**Description.** Same as Approach A, but the iframe is inline:
+`<iframe srcdoc="<script>webkit.messageHandlers.divineSandboxBridge.postMessage(...)</script>"></iframe>`.
+Only one endpoint to serve.
+
+**Pros.**
+- Slightly simpler: one HTML body, one route handler.
+- No risk of iframe failing to load (no second network hop).
+
+**Cons.**
+- WebKit's treatment of `srcdoc` iframes vs same-origin `src=` iframes
+  is subtly different. `srcdoc` iframes inherit the embedder's origin —
+  `frameInfo.isMainFrame` is correctly `false`, so the test is sound —
+  but `webkit.messageHandlers` exposure to `srcdoc` iframes has shifted
+  in past iOS versions. We'd be coupling test reliability to that quirk.
+- Less faithful to the production attack vector. The realistic threat is
+  a compromised same-origin URL, not a `srcdoc` injection.
+
+**Risks / Unknowns.**
+- `srcdoc` script execution and `webkit.messageHandlers` scope on iOS 18+.
+  Could regress unrelated to the fix-under-test.
+
+**Complexity:** Low.
+
+### Approach C: bundled-asset HTML loaded via `loadFlutterAsset` / `file://`
+
+**Description.** Add a fixture HTML pair under
+`mobile/integration_test/fixtures/` (or as test_assets) and load via
+`controller.loadFlutterAsset(...)`. No HTTP server.
+
+**Pros.**
+- No network code in the test.
+- Asset bundle ships with the test binary; no port binding.
+
+**Cons.**
+- `file://` and `flutter-asset://` origins are not real HTTP(S) origins.
+  `_isAllowedOrigin` matches by `Uri.origin`, which returns an empty
+  string for non-HTTP(S) URIs. The production guard would refuse to load
+  the page in the first place.
+- To make this work, the test would either bypass `allowedOrigins`
+  (production-code change ruled out by scope) or override
+  `sandboxBuilder` to skip the WebView entirely — which reduces to the
+  existing unit-test seam.
+- Asset declarations would land in the production `pubspec.yaml`,
+  shipping fixture HTML to end-users.
+
+**Risks / Unknowns.**
+- Doesn't satisfy the issue's intent. Cut.
+
+**Complexity:** Misleadingly low — turns out infeasible without a
+production-code carve-out.
+
+### Approach D: pure native XCUITest layer
+
+**Description.** Add an XCUITest target that loads a real `WKWebView`,
+installs `FrameAttestingScriptMessageHandler` directly, and asserts the
+`FlutterEventSink` is invoked with the right payload via a stub sink.
+
+**Pros.**
+- Native fidelity: no Dart, no `EventChannel` cost.
+
+**Cons.**
+- Issue body is explicit: *"add an integration test using
+  `package:integration_test`"*. XCUITest doesn't satisfy that ask.
+- Doesn't cover the Dart-side reaction (`_handleAttestedEvent`,
+  `_emitBridgeResponse`).
+
+**Complexity:** Low for the native side; ignores half the surface.
+
+## Recommendation
+
+**Approach A** — in-process HTTP server with two same-origin endpoints
+(`/` main + `/iframe.html` subframe).
+
+Why:
+
+1. **Faithfulness to the threat model.** `<iframe src="/iframe.html">`
+   maps directly onto the threat in #3764: a same-origin asset is
+   compromised and posts to `webkit.messageHandlers.divineSandboxBridge`
+   from a sub-frame. `srcdoc` (Approach B) is a less realistic vector
+   and couples to WebKit `srcdoc` quirks.
+2. **Coverage of the live hop.** The live `WKWebView` produces the
+   `WKScriptMessage` with a real `frameInfo`, the native handler
+   receives it, the dictionary is marshaled across the Flutter
+   `EventChannel`, and the Dart reaction runs. Every link the unit test
+   skips is exercised.
+3. **No production-code changes.** All other approaches either touch
+   production guards (Approach C) or fail to satisfy the issue scope
+   (Approach D).
+4. **Reuse over invention.** The assertion mechanic (capture
+   `_runJavaScript` calls into a list and grep response payloads for
+   `subframe_rejected`) is identical to the existing widget test —
+   reviewers already know this shape from
+   `nostr_app_sandbox_screen_test.dart`.
+
+## Open Questions for /plan
+
+- [ ] Confirm whether `WKWebView` reports the loopback origin as
+      `http://127.0.0.1:<port>` or `http://localhost:<port>` after a
+      `loadRequest`. The fixture `allowedOrigins` must use the form
+      WebKit echoes back; otherwise the navigation delegate's allow-list
+      check refuses the page before a single `WKScriptMessage` flows.
+- [ ] Whether to wire a stub `BridgeService` so the main-frame path can
+      be asserted positively (`success: true`). Recommended: yes — a
+      negative assertion ("not subframe_rejected") is weak.
+- [ ] Polling timeout budget: 15 s on a simulator should be ample, may
+      need bumping under CI load.
+- [ ] App Transport Security on physical-device runs (loopback HTTP).
+
+## Prerequisites
+
+- [ ] None blocking. The plugin, the seam, and the patrol harness are
+      already in place.
+
+## Next Step
+
+`/plan https://github.com/divinevideo/divine-mobile/issues/4120` —
+proceed with implementation planning using Approach A. The plan should
+resolve the loopback-origin question (probe with a one-off
+`debugPrint`-driven simulator run if needed) before finalizing the
+fixture.

--- a/mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md
@@ -262,11 +262,17 @@ Why:
   response landed in ~1 s and the `main` response in ~1 s across 3
   consecutive runs. Even with cold caches the slowest tail observed was
   under 2 s.
-- **App Transport Security.** Simulator allows `http://127.0.0.1`
-  without Info.plist changes; the Runner Info.plist is unchanged. Device
-  runs are not exercised by this PR — if a future device-only CI run
-  trips ATS, a test-only `NSAllowsLocalNetworking` carve-out is the
-  expected mitigation (production Info.plist must not change).
+- **App Transport Security.** No Info.plist change is needed for this
+  PR. `mobile/ios/Runner/Info.plist` already declares
+  `NSAllowsLocalNetworking=true` under `NSAppTransportSecurity`, which
+  permits cleartext HTTP/WS to `localhost`, `127.0.0.1`, `::1`,
+  single-label hostnames, and the `.local` TLD on both simulator and
+  device (remote cleartext stays rejected). The fixture's
+  `http://127.0.0.1:<port>` loopback URL is covered by that exemption
+  verbatim, so the test runs identically on simulator and physical-device
+  targets without any test-specific carve-out. The exemption mirrors the
+  loopback domain-config in
+  `android/app/src/main/res/xml/network_security_config.xml`.
 - **Test harness choice.** `testWidgets` against
   `IntegrationTestWidgetsFlutterBinding`, not `patrolTest`. This test
   doesn't need patrol's native automation, and `flutter test

--- a/mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md
@@ -39,9 +39,11 @@ still be green.
   has no `__divineBridgeNonce` constant; the only available channel is
   `webkit.messageHandlers.divineSandboxBridge.postMessage(...)` raw. That is
   exactly the attack vector PR #3979 closes.
-- **`patrol: ^4.2.0` is the integration-test harness.** Existing tests in
-  `mobile/integration_test/` use `patrolTest($)` regardless of whether they
-  use OS-level automation. The new test follows the same convention.
+- **`patrol: ^4.2.0` is the integration-test harness for tests that need
+  OS-level automation** (`auth/`, `lifecycle/`, etc.). Tests that don't need
+  patrol's native side run as plain `testWidgets` against the
+  `IntegrationTestWidgetsFlutterBinding`, executable directly via
+  `flutter test integration_test/...` — the new test follows that pattern.
 - **Repo rules**: layered architecture, no error strings in BLoC state, no
   hardcoded values without a named constant, l10n for any user-visible
   string. None of these bite hard for a test, but the test fixture should
@@ -219,10 +221,10 @@ installs `FrameAttestingScriptMessageHandler` directly, and asserts the
 
 **Complexity:** Low for the native side; ignores half the surface.
 
-## Recommendation
+## Decision
 
 **Approach A** — in-process HTTP server with two same-origin endpoints
-(`/` main + `/iframe.html` subframe).
+(`/` main + `/iframe.html` subframe). Landed in PR #4134.
 
 Why:
 
@@ -245,29 +247,31 @@ Why:
    reviewers already know this shape from
    `nostr_app_sandbox_screen_test.dart`.
 
-## Open Questions for /plan
+## Resolved Questions
 
-- [ ] Confirm whether `WKWebView` reports the loopback origin as
-      `http://127.0.0.1:<port>` or `http://localhost:<port>` after a
-      `loadRequest`. The fixture `allowedOrigins` must use the form
-      WebKit echoes back; otherwise the navigation delegate's allow-list
-      check refuses the page before a single `WKScriptMessage` flows.
-- [ ] Whether to wire a stub `BridgeService` so the main-frame path can
-      be asserted positively (`success: true`). Recommended: yes — a
-      negative assertion ("not subframe_rejected") is weak.
-- [ ] Polling timeout budget: 15 s on a simulator should be ample, may
-      need bumping under CI load.
-- [ ] App Transport Security on physical-device runs (loopback HTTP).
-
-## Prerequisites
-
-- [ ] None blocking. The plugin, the seam, and the patrol harness are
-      already in place.
-
-## Next Step
-
-`/plan https://github.com/divinevideo/divine-mobile/issues/4120` —
-proceed with implementation planning using Approach A. The plan should
-resolve the loopback-origin question (probe with a one-off
-`debugPrint`-driven simulator run if needed) before finalizing the
-fixture.
+- **Loopback origin form.** WKWebView preserves `http://127.0.0.1:<port>`
+  verbatim through `loadRequest` on iPhone 17 Pro / iOS 26.4. The fixture
+  uses the literal IP form in both `launchUrl` and `allowedOrigins`; no
+  rewrite to `localhost` was observed.
+- **Stub `BridgeService`.** Wired for the main-frame test
+  (`bridgeServiceOverride` + private `_FakeAuthProvider` /
+  `_FakeNostrSigner`). The iframe test omits it because rejection
+  happens before `_handleBridgeMessage` runs.
+- **Polling timeout budget.** 15 s is comfortable headroom. On
+  iPhone 17 Pro / iOS 26.4 / Flutter 3.41.4 the `iframe`
+  response landed in ~1 s and the `main` response in ~1 s across 3
+  consecutive runs. Even with cold caches the slowest tail observed was
+  under 2 s.
+- **App Transport Security.** Simulator allows `http://127.0.0.1`
+  without Info.plist changes; the Runner Info.plist is unchanged. Device
+  runs are not exercised by this PR — if a future device-only CI run
+  trips ATS, a test-only `NSAllowsLocalNetworking` carve-out is the
+  expected mitigation (production Info.plist must not change).
+- **Test harness choice.** `testWidgets` against
+  `IntegrationTestWidgetsFlutterBinding`, not `patrolTest`. This test
+  doesn't need patrol's native automation, and `flutter test
+  integration_test/apps/...` is the simplest invocation. Patrol's
+  `PatrolBinding` and the auto-installed `IntegrationTestWidgetsFlutterBinding`
+  conflict when invoked through `flutter test` (assertion failure on
+  binding init), so adopting plain `testWidgets` was the cleaner path
+  rather than introducing the patrol CLI as a new dependency.

--- a/mobile/integration_test/apps/nostr_bridge_frame_attestation_test.dart
+++ b/mobile/integration_test/apps/nostr_bridge_frame_attestation_test.dart
@@ -14,7 +14,6 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
-import 'package:patrol/patrol.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Live channel coverage for `NostrBridgeAttestationPlugin`.
@@ -52,10 +51,9 @@ void main() {
       await server.close(force: true);
     });
 
-    patrolTest(
+    testWidgets(
       'iframe-originated bridge traffic is rejected with subframe_rejected',
-      ($) async {
-        final tester = $.tester;
+      (tester) async {
         if (defaultTargetPlatform != TargetPlatform.iOS) return;
 
         final captured = <String>[];
@@ -84,10 +82,9 @@ void main() {
       },
     );
 
-    patrolTest(
+    testWidgets(
       'main-frame bridge traffic reaches the bridge service',
-      ($) async {
-        final tester = $.tester;
+      (tester) async {
         if (defaultTargetPlatform != TargetPlatform.iOS) return;
 
         SharedPreferences.setMockInitialValues({});

--- a/mobile/integration_test/apps/nostr_bridge_frame_attestation_test.dart
+++ b/mobile/integration_test/apps/nostr_bridge_frame_attestation_test.dart
@@ -1,0 +1,308 @@
+// ABOUTME: End-to-end coverage for the iOS frame attestation channel.
+// ABOUTME: Drives a real WKWebView through the live WKScriptMessage hop.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/signer/nostr_signer.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:patrol/patrol.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Live channel coverage for `NostrBridgeAttestationPlugin`.
+///
+/// The widget tests in `test/screens/apps/nostr_app_sandbox_screen_test.dart`
+/// exercise `_handleAttestedEvent` via the `onAttestedEventHandlerReady`
+/// seam — they prove the Dart-side branching but never traverse the
+/// `WKScriptMessage → FrameAttestingScriptMessageHandler → FlutterEventSink
+/// → EventChannel → broadcast stream → _handleAttestedEvent` hop. A
+/// channel-name typo, payload-key drift, or stream-lifecycle bug on either
+/// side of the channel would silently degrade defence-in-depth to nonce-only
+/// enforcement and leave every existing test green.
+///
+/// This test boots a loopback HTTP server, loads a same-origin main + iframe
+/// pair into the sandbox WebView, and asserts the Dart-observable response
+/// for each frame against captured `_runJavaScript` calls.
+///
+/// iOS-only: the native plugin lives in the Runner target; on every other
+/// platform the early-return is the correct behaviour. Android per-frame
+/// attestation parity is tracked separately (#4105).
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NostrBridge frame attestation E2E', () {
+    late HttpServer server;
+    late String origin;
+
+    setUp(() async {
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      origin = 'http://127.0.0.1:${server.port}';
+      unawaited(server.forEach(_serveFixture));
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+    });
+
+    patrolTest(
+      'iframe-originated bridge traffic is rejected with subframe_rejected',
+      ($) async {
+        final tester = $.tester;
+        if (defaultTargetPlatform != TargetPlatform.iOS) return;
+
+        final captured = <String>[];
+        await _pumpSandbox(
+          tester,
+          origin: origin,
+          capturedScripts: captured,
+        );
+
+        await _pumpUntil(
+          tester,
+          () => captured.any((s) => s.contains('"id":"frame"')),
+        );
+
+        final frameResponse = captured.firstWhere(
+          (s) => s.contains('"id":"frame"'),
+        );
+        expect(
+          frameResponse,
+          contains('subframe_rejected'),
+          reason:
+              'Iframe-originated postMessage must hit the platform-level '
+              'rejection before the nonce gate.',
+        );
+        expect(frameResponse, isNot(contains('"success":true')));
+      },
+    );
+
+    patrolTest(
+      'main-frame bridge traffic reaches the bridge service',
+      ($) async {
+        final tester = $.tester;
+        if (defaultTargetPlatform != TargetPlatform.iOS) return;
+
+        SharedPreferences.setMockInitialValues({});
+        final sharedPreferences = await SharedPreferences.getInstance();
+        final grantStore = NostrAppGrantStore(
+          sharedPreferences: sharedPreferences,
+        );
+        final bridgeService = NostrAppBridgeService(
+          authProvider: _FakeAuthProvider(),
+          policy: NostrAppBridgePolicy(
+            grantStore: grantStore,
+            currentUserPubkey: 'f' * 64,
+          ),
+          signerFactory: _FakeNostrSigner.new,
+        );
+
+        final captured = <String>[];
+        await _pumpSandbox(
+          tester,
+          origin: origin,
+          capturedScripts: captured,
+          bridgeService: bridgeService,
+        );
+
+        await _pumpUntil(
+          tester,
+          () => captured.any((s) => s.contains('"id":"main"')),
+        );
+
+        final mainResponse = captured.firstWhere(
+          (s) => s.contains('"id":"main"'),
+        );
+        expect(mainResponse, isNot(contains('subframe_rejected')));
+        expect(
+          mainResponse,
+          contains('"success":true'),
+          reason:
+              'Main-frame postMessage with a valid nonce must reach the '
+              'bridge service and succeed.',
+        );
+        expect(mainResponse, contains('f' * 64));
+      },
+    );
+  });
+}
+
+const _testNonce = 'test-nonce';
+const _testPubkey =
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+Future<void> _serveFixture(HttpRequest request) async {
+  final path = request.uri.path;
+  if (path == '/' || path == '/index.html') {
+    request.response
+      ..headers.contentType = ContentType.html
+      ..write(_mainPageHtml);
+  } else if (path == '/iframe.html') {
+    request.response
+      ..headers.contentType = ContentType.html
+      ..write(_iframePageHtml);
+  } else {
+    request.response.statusCode = HttpStatus.notFound;
+  }
+  await request.response.close();
+}
+
+const _mainPageHtml =
+    '''
+<!doctype html>
+<html><head></head><body>
+<iframe src="/iframe.html" width="200" height="100"></iframe>
+<script>
+  // The pigeon-managed addJavaScriptChannel installs
+  // window.divineSandboxBridge as an alias for
+  // webkit.messageHandlers.divineSandboxBridge at document-start.
+  // Poll until it is available, then post the main-frame request.
+  function _postMain() {
+    if (typeof divineSandboxBridge === 'undefined') {
+      setTimeout(_postMain, 25);
+      return;
+    }
+    divineSandboxBridge.postMessage(JSON.stringify({
+      id: 'main',
+      method: 'getPublicKey',
+      args: {},
+      nonce: '$_testNonce'
+    }));
+  }
+  _postMain();
+</script>
+</body></html>
+''';
+
+const _iframePageHtml = '''
+<!doctype html>
+<html><body>
+<script>
+  // Iframe attempts to reach the bridge directly via the WebKit message
+  // handler — bypassing window.divineSandboxBridge (which the pigeon
+  // alias only exposes in the main frame). With per-frame attestation
+  // in place the host must reject this with subframe_rejected before
+  // the nonce gate runs.
+  webkit.messageHandlers.divineSandboxBridge.postMessage(JSON.stringify({
+    id: 'frame',
+    method: 'getPublicKey',
+    args: {}
+  }));
+</script>
+</body></html>
+''';
+
+NostrAppDirectoryEntry _fixtureApp(String origin) {
+  final timestamp = DateTime.parse('2026-05-08T00:00:00Z');
+  return NostrAppDirectoryEntry(
+    id: 'test-frame-attestation',
+    slug: 'test-frame-attestation',
+    name: 'Frame Attestation Test',
+    tagline: 'Loopback fixture',
+    description: 'Loopback HTTP fixture for iOS frame attestation E2E.',
+    iconUrl: '$origin/icon.png',
+    launchUrl: '$origin/',
+    allowedOrigins: [origin],
+    allowedMethods: const ['getPublicKey'],
+    allowedSignEventKinds: const [],
+    promptRequiredFor: const [],
+    status: 'approved',
+    sortOrder: 0,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  );
+}
+
+Future<void> _pumpSandbox(
+  WidgetTester tester, {
+  required String origin,
+  required List<String> capturedScripts,
+  NostrAppBridgeService? bridgeService,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: NostrAppSandboxScreen(
+          app: _fixtureApp(origin),
+          bridgeServiceOverride: bridgeService,
+          javaScriptRunnerOverride: (script) async {
+            capturedScripts.add(script);
+          },
+          bridgeNonceOverride: _testNonce,
+          currentUserPubkeyOverride: _testPubkey,
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  Duration interval = const Duration(milliseconds: 250),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail(
+        'Timed out waiting for captured response after ${timeout.inSeconds}s',
+      );
+    }
+    await tester.pump(interval);
+  }
+}
+
+class _FakeAuthProvider implements BridgeAuthProvider {
+  @override
+  String? get currentPublicKeyHex => _testPubkey;
+
+  @override
+  List<BridgeRelay> get userRelays => const [];
+
+  @override
+  Future<BridgeSignedEvent?> createAndSignEvent({
+    required int kind,
+    required String content,
+    required List<List<String>> tags,
+    int? createdAt,
+  }) async {
+    final event = Event(_testPubkey, kind, tags, content, createdAt: createdAt);
+    return BridgeSignedEvent(json: event.toJson());
+  }
+}
+
+class _FakeNostrSigner implements NostrSigner {
+  @override
+  void close() {}
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) async => null;
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) async => null;
+
+  @override
+  Future<String?> getPublicKey() async => _testPubkey;
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() async => null;
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) async => null;
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) async => null;
+
+  @override
+  Future<Event?> signEvent(Event event) async => event;
+}


### PR DESCRIPTION
## Summary

Closes #4120 — follow-up to PR #3979 (iOS per-frame origin attestation).

The existing tests for the frame-attestation channel stop at the
`@visibleForTesting onAttestedEventHandlerReady` seam: widget tests
inject synthetic `Map<String, dynamic>` events into Dart, and Swift
unit tests pin the dictionary shape and policy in isolation. **Nothing
exercises the live `WKScriptMessage → FrameAttestingScriptMessageHandler
→ FlutterEventSink → EventChannel → broadcast stream → _handleAttestedEvent`
hop** — a channel-name typo, payload-key drift, or stream-lifecycle
regression on either side would silently degrade defence-in-depth to
nonce-only enforcement and leave every existing test green.

This PR adds one integration test that drives a real `WKWebView` against
a loopback HTTP fixture with both a main page and a same-origin iframe.

### What it covers

- A loopback `HttpServer.bind(InternetAddress.loopbackIPv4, 0)` serves
  two same-origin endpoints:
  - `GET /` → main HTML that polls for the pigeon-installed
    `window.divineSandboxBridge` alias and posts a request with the
    known `bridgeNonceOverride` once available.
  - `GET /iframe.html` → iframe HTML that calls
    `webkit.messageHandlers.divineSandboxBridge.postMessage(...)` raw,
    no nonce — exactly the attack vector PR #3979 closes.
- The main page contains `<iframe src=\"/iframe.html\">` so both frames
  are same-origin and `webkit.messageHandlers.divineSandboxBridge` is
  reachable from the iframe.
- `NostrAppSandboxScreen` is pumped with the existing seams
  (`javaScriptRunnerOverride`, `bridgeNonceOverride`,
  `currentUserPubkeyOverride`, `bridgeServiceOverride` for the positive
  case). No production-code change.
- A `_pumpUntil` helper polls the captured-scripts list with a 15 s
  cap (real time under `IntegrationTestWidgetsFlutterBinding`).
- `testWidgets` against `IntegrationTestWidgetsFlutterBinding`, runnable
  via `flutter test integration_test/apps/...`. Patrol's `PatrolBinding`
  conflicts with the auto-installed `IntegrationTestWidgetsFlutterBinding`
  under `flutter test`, so plain `testWidgets` is the right tool here —
  this test doesn't need patrol's native automation.

### Assertions

| Test | Asserts |
|------|---------|
| iframe-originated bridge traffic is rejected with `subframe_rejected` | Captured response for `id: 'frame'` contains `subframe_rejected` and not `\"success\":true`. |
| main-frame bridge traffic reaches the bridge service | Captured response for `id: 'main'` does not contain `subframe_rejected`, contains `\"success\":true`, and echoes the test pubkey. |

iOS-only: each `testWidgets` body early-returns on
`defaultTargetPlatform != TargetPlatform.iOS` since the native plugin
lives in the Runner target. Android per-frame attestation parity is
tracked in #4105.

### Approach selection

See the brainstorm doc bundled in this PR
(`mobile/docs/brainstorm/2026-05-08-issue4120-ios-frame-attestation-e2e-test-brainstorm.md`)
for the full comparison and the resolved-questions section. Approach A
(HTTP server + same-origin `<iframe src=...>`) was picked over
`srcdoc` (Approach B), bundled assets (Approach C), and a pure XCUITest
(Approach D) because it (1) matches the production threat model most
faithfully, (2) exercises the entire channel hop end-to-end, and (3)
requires no production-code or Xcode project changes.

## Test plan

- [x] `cd mobile && flutter analyze integration_test/apps/` — clean.
- [x] `cd mobile && dart format integration_test/apps/` — clean.
- [x] **iOS Simulator verification** — iPhone 17 Pro on iOS 26.4,
      Flutter 3.41.4. Three consecutive runs of
      `flutter test integration_test/apps/nostr_bridge_frame_attestation_test.dart -d <udid>`
      all green. Per-test wall time ~1–2 s (well inside the 15 s
      `_pumpUntil` cap).
- [x] **Loopback origin form resolved** — WKWebView preserves
      `http://127.0.0.1:<port>` verbatim through `loadRequest`. The
      fixture uses the literal IP form in both `launchUrl` and
      `allowedOrigins`; no rewrite to `localhost` was observed.
- [x] **Skip behavior** — early-return on `defaultTargetPlatform !=
      TargetPlatform.iOS` keeps the test inert on macOS / Android.

Resolved-questions section in the brainstorm doc (origin form, stubbed
bridge service, polling budget, ATS posture, harness choice) records
the same outcome.

## Type of Change

- [x] 🧪 Test coverage (no production-code change)