### PR TITLE
feat(ui): grow bottom-nav tab hit targets to fill the row

### DIFF
--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -101,60 +101,127 @@ class VineBottomNav extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Container(
+    return ColoredBox(
       color: VineTheme.surfaceBackground,
-      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      // No Container padding remains — the 12 px strips above and below
+      // the icons and the 16 px strips on each side are now all part of
+      // each adjacent tab's hit target (see [_kTopExtraTapHeight],
+      // [_kBottomExtraTapHeight] and [_kHorizontalEdgePad]). The
+      // [SafeArea] still keeps tap targets clear of the iOS home
+      // indicator and Android navigation bar.
       child: SafeArea(
         top: false,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            _IconTabButton(
-              semanticIdentifier: 'home_tab',
-              semanticLabel: context.l10n.navHome,
-              icon: DivineIconName.houseSimple,
-              isSelected: currentIndex == 0,
-              onTap: () => _handleTabTap(context, ref, 0),
-            ),
-            _IconTabButton(
-              semanticIdentifier: 'explore_tab',
-              semanticLabel: context.l10n.navExplore,
-              icon: DivineIconName.search,
-              isSelected: currentIndex == 1,
-              onTap: () => _handleTabTap(context, ref, 1),
-            ),
-            // Camera button in center of bottom nav
-            _CameraButton(
-              onTap: () {
-                Log.info(
-                  '👆 User tapped camera button',
-                  name: 'Navigation',
-                  category: LogCategory.ui,
-                );
-                context.pushToCameraWithPermission();
-              },
-            ),
-            NotificationBadge(
-              count: _inboxUnreadCount(context, ref),
-              child: _IconTabButton(
-                semanticIdentifier: 'inbox_tab',
-                semanticLabel: context.l10n.navInbox,
-                icon: DivineIconName.chat,
-                isSelected: currentIndex == 2,
-                onTap: () => _handleTabTap(context, ref, 2),
-              ),
-            ),
-            _ProfileTabButton(
-              semanticLabel: context.l10n.navProfile,
-              isSelected: currentIndex == 3,
-              onTap: () => _handleTabTap(context, ref, 3),
-            ),
-          ],
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // Each tab claims half of each adjacent inter-icon gap so taps
+            // anywhere closer to a given icon than to its neighbour route
+            // to that tab. Home and Profile additionally absorb the
+            // formerly-reserved [_kHorizontalEdgePad] strip on the screen
+            // edge. Icons stay in the exact visual positions a
+            // `MainAxisAlignment.spaceBetween` row inset by 16 px (the
+            // previous layout) would produce.
+            const iconWidth = kMinInteractiveDimension;
+            const cameraWidth = _kCameraButtonWidth;
+            const totalIconWidth = iconWidth * 4 + cameraWidth;
+            const totalEdgePad = _kHorizontalEdgePad * 2;
+            // 8 half-gaps split the space the inter-icon gaps used to
+            // occupy — same numeric formula as before, derived from
+            // `constraints.maxWidth - totalIconWidth - 2 * 16` since
+            // `maxWidth` is now 32 px wider (no Container padding).
+            final halfGap =
+                ((constraints.maxWidth - totalIconWidth - totalEdgePad) / 8)
+                    .clamp(0.0, double.infinity);
+
+            return Row(
+              children: [
+                _IconTabButton(
+                  semanticIdentifier: 'home_tab',
+                  semanticLabel: context.l10n.navHome,
+                  icon: DivineIconName.houseSimple,
+                  isSelected: currentIndex == 0,
+                  onTap: () => _handleTabTap(context, ref, 0),
+                  tapTargetWidth: _kHorizontalEdgePad + iconWidth + halfGap,
+                  iconAlignment: AlignmentDirectional.centerStart,
+                  edgePadding: const EdgeInsetsDirectional.only(
+                    start: _kHorizontalEdgePad,
+                  ),
+                ),
+                _IconTabButton(
+                  semanticIdentifier: 'explore_tab',
+                  semanticLabel: context.l10n.navExplore,
+                  icon: DivineIconName.search,
+                  isSelected: currentIndex == 1,
+                  onTap: () => _handleTabTap(context, ref, 1),
+                  tapTargetWidth: iconWidth + halfGap * 2,
+                ),
+                // Camera button in center of bottom nav
+                _CameraButton(
+                  tapTargetWidth: cameraWidth + halfGap * 2,
+                  onTap: () {
+                    Log.info(
+                      '👆 User tapped camera button',
+                      name: 'Navigation',
+                      category: LogCategory.ui,
+                    );
+                    context.pushToCameraWithPermission();
+                  },
+                ),
+                _IconTabButton(
+                  semanticIdentifier: 'inbox_tab',
+                  semanticLabel: context.l10n.navInbox,
+                  icon: DivineIconName.chat,
+                  isSelected: currentIndex == 2,
+                  onTap: () => _handleTabTap(context, ref, 2),
+                  tapTargetWidth: iconWidth + halfGap * 2,
+                  badgeCount: _inboxUnreadCount(context, ref),
+                ),
+                _ProfileTabButton(
+                  semanticLabel: context.l10n.navProfile,
+                  isSelected: currentIndex == 3,
+                  onTap: () => _handleTabTap(context, ref, 3),
+                  tapTargetWidth: iconWidth + halfGap + _kHorizontalEdgePad,
+                  iconAlignment: AlignmentDirectional.centerEnd,
+                  edgePadding: const EdgeInsetsDirectional.only(
+                    end: _kHorizontalEdgePad,
+                  ),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );
   }
 }
+
+/// Visible width of the green camera-button pill in the bottom nav.
+const double _kCameraButtonWidth = 72;
+
+/// Extra hit-target height stacked on top of the [kMinInteractiveDimension]
+/// icon row. Equal to the top padding the bottom nav used to reserve, so
+/// the previously-dead strip above the icons now routes taps to the tab
+/// directly above it without moving any icon visually.
+const double _kTopExtraTapHeight = 12;
+
+/// Extra hit-target height stacked below the [kMinInteractiveDimension]
+/// icon row. Equal to the bottom padding the bottom nav used to reserve,
+/// so the previously-dead strip beneath the icons (above the [SafeArea]
+/// inset) now routes taps to the tab directly below it without moving
+/// any icon visually.
+const double _kBottomExtraTapHeight = 12;
+
+/// Total vertical hit-target height per tab. The icon container sits at
+/// the vertical centre of this slot — the top and bottom extras are
+/// equal — so taps both above and below the visible glyph route to the
+/// correct tab.
+const double _kTabSlotHeight =
+    kMinInteractiveDimension + _kTopExtraTapHeight + _kBottomExtraTapHeight;
+
+/// Lateral inset between the screen edge and the visible position of the
+/// outermost icons (Home / Profile). Used to be a [Container] padding;
+/// it is now folded into Home's and Profile's hit targets so taps inside
+/// the previously-reserved 16 px strip route to the adjacent tab.
+const double _kHorizontalEdgePad = 16;
 
 // =============================================================================
 // Tab buttons
@@ -174,6 +241,13 @@ class VineBottomNav extends ConsumerWidget {
 ///
 /// The child gets the 32 %-opacity dim in the unselected state and the
 /// glyph-shaped shadow pair in the selected state. See [_ShadowedNavIcon].
+///
+/// [tapTargetWidth] is the full width the GestureDetector occupies inside
+/// the bottom nav row — usually larger than the 48 px icon container so
+/// taps in the surrounding gap also route to this tab. The icon itself
+/// stays a [kMinInteractiveDimension]-sized box positioned via
+/// [iconAlignment]; the row computes both so icons stay in the exact same
+/// visual positions a `MainAxisAlignment.spaceBetween` row would produce.
 class _IconTabButton extends StatelessWidget {
   const _IconTabButton({
     required this.semanticIdentifier,
@@ -181,6 +255,10 @@ class _IconTabButton extends StatelessWidget {
     required this.icon,
     required this.isSelected,
     required this.onTap,
+    required this.tapTargetWidth,
+    this.iconAlignment = Alignment.center,
+    this.edgePadding = EdgeInsets.zero,
+    this.badgeCount,
   });
 
   final String semanticIdentifier;
@@ -188,9 +266,50 @@ class _IconTabButton extends StatelessWidget {
   final DivineIconName icon;
   final bool isSelected;
   final VoidCallback onTap;
+  final double tapTargetWidth;
+
+  /// Where to place the 48 px icon container inside the slot. Defaults to
+  /// [Alignment.center] so the icon sits at the same vertical position
+  /// it would have had under the previous (smaller) tap target — the
+  /// extra height extends symmetrically above and below the visible
+  /// glyph. Use `centerStart` / `centerEnd` (combined with [edgePadding])
+  /// for the leftmost / rightmost tabs so they hug the row's edge.
+  final AlignmentGeometry iconAlignment;
+
+  /// Horizontal inset between the slot edge and the icon container.
+  /// Non-zero only for Home and Profile, where the slot extends all the
+  /// way to the screen edge but the icon must still sit
+  /// [_kHorizontalEdgePad] in from that edge to match the previous
+  /// visual position. The edge strip itself stays inside the
+  /// [GestureDetector] so taps there route to the tab.
+  final EdgeInsetsGeometry edgePadding;
+
+  /// When non-null, wraps the inner icon container in a [NotificationBadge]
+  /// so the badge stays anchored to the icon's top-right corner rather
+  /// than to the (potentially much wider) tap target. Pass `null` on tabs
+  /// that never show a badge — that keeps `NotificationBadge` out of the
+  /// widget tree entirely so finders downstream still match exactly one
+  /// instance.
+  final int? badgeCount;
 
   @override
   Widget build(BuildContext context) {
+    Widget iconBox = SizedBox.square(
+      dimension: kMinInteractiveDimension,
+      child: Center(
+        child: Opacity(
+          // Figma: unselected tabs render at 32 % opacity; selected stays
+          // at 100 %. No color tint — just dim + shadow toggle.
+          opacity: isSelected ? 1.0 : 0.32,
+          child: _ShadowedNavIcon(icon: icon, showShadow: isSelected),
+        ),
+      ),
+    );
+
+    if (badgeCount != null) {
+      iconBox = NotificationBadge(count: badgeCount!, child: iconBox);
+    }
+
     return Semantics(
       identifier: semanticIdentifier,
       button: true,
@@ -198,15 +317,12 @@ class _IconTabButton extends StatelessWidget {
       child: GestureDetector(
         onTap: onTap,
         behavior: .opaque,
-        child: SizedBox.square(
-          dimension: kMinInteractiveDimension,
-          child: Center(
-            child: Opacity(
-              // Figma: unselected tabs render at 32 % opacity; selected stays
-              // at 100 %. No color tint — just dim + shadow toggle.
-              opacity: isSelected ? 1.0 : 0.32,
-              child: _ShadowedNavIcon(icon: icon, showShadow: isSelected),
-            ),
+        child: SizedBox(
+          width: tapTargetWidth,
+          height: _kTabSlotHeight,
+          child: Padding(
+            padding: edgePadding,
+            child: Align(alignment: iconAlignment, child: iconBox),
           ),
         ),
       ),
@@ -287,11 +403,19 @@ class _ProfileTabButton extends ConsumerWidget {
     required this.semanticLabel,
     required this.isSelected,
     required this.onTap,
+    required this.tapTargetWidth,
+    this.iconAlignment = Alignment.center,
+    this.edgePadding = EdgeInsets.zero,
   });
 
   final String semanticLabel;
   final bool isSelected;
   final VoidCallback onTap;
+  final double tapTargetWidth;
+  final AlignmentGeometry iconAlignment;
+
+  /// See [_IconTabButton.edgePadding].
+  final EdgeInsetsGeometry edgePadding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -303,6 +427,24 @@ class _ProfileTabButton extends ConsumerWidget {
     final imageUrl = profile?.picture;
     final hasAvatar = imageUrl != null && imageUrl.isNotEmpty;
 
+    final iconBox = SizedBox.square(
+      dimension: kMinInteractiveDimension,
+      child: Center(
+        child: hasAvatar
+            ? _ProfileAvatarBox(imageUrl: imageUrl, isSelected: isSelected)
+            // No signed-in avatar: render the same icon-tab treatment
+            // (opacity dim / shadow) as Home / Search / Inbox so the
+            // nav bar still feels uniform until the profile loads.
+            : Opacity(
+                opacity: isSelected ? 1.0 : 0.32,
+                child: _ShadowedNavIcon(
+                  icon: DivineIconName.userCircle,
+                  showShadow: isSelected,
+                ),
+              ),
+      ),
+    );
+
     return Semantics(
       identifier: 'profile_tab',
       button: true,
@@ -310,21 +452,12 @@ class _ProfileTabButton extends ConsumerWidget {
       child: GestureDetector(
         onTap: onTap,
         behavior: .opaque,
-        child: SizedBox.square(
-          dimension: kMinInteractiveDimension,
-          child: Center(
-            child: hasAvatar
-                ? _ProfileAvatarBox(imageUrl: imageUrl, isSelected: isSelected)
-                // No signed-in avatar: render the same icon-tab treatment
-                // (opacity dim / shadow) as Home / Search / Inbox so the
-                // nav bar still feels uniform until the profile loads.
-                : Opacity(
-                    opacity: isSelected ? 1.0 : 0.32,
-                    child: _ShadowedNavIcon(
-                      icon: DivineIconName.userCircle,
-                      showShadow: isSelected,
-                    ),
-                  ),
+        child: SizedBox(
+          width: tapTargetWidth,
+          height: _kTabSlotHeight,
+          child: Padding(
+            padding: edgePadding,
+            child: Align(alignment: iconAlignment, child: iconBox),
           ),
         ),
       ),
@@ -389,9 +522,10 @@ class _ProfileAvatarBox extends StatelessWidget {
 
 /// Camera button in the center of the bottom navigation bar.
 class _CameraButton extends StatelessWidget {
-  const _CameraButton({required this.onTap});
+  const _CameraButton({required this.onTap, required this.tapTargetWidth});
 
   final VoidCallback onTap;
+  final double tapTargetWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -401,15 +535,26 @@ class _CameraButton extends StatelessWidget {
       label: context.l10n.navOpenCamera,
       child: GestureDetector(
         onTap: onTap,
-        child: Container(
-          width: 72,
-          height: 48,
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-          decoration: BoxDecoration(
-            color: VineTheme.cameraButtonGreen,
-            borderRadius: BorderRadius.circular(20),
+        behavior: .opaque,
+        child: SizedBox(
+          width: tapTargetWidth,
+          height: _kTabSlotHeight,
+          // Centered so the visible green pill stays at the same Y
+          // position it had under the previous (smaller) tap target —
+          // the extra height extends symmetrically above and below the
+          // pill into the row's previously-dead top and bottom padding.
+          child: Align(
+            child: Container(
+              width: _kCameraButtonWidth,
+              height: kMinInteractiveDimension,
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+              decoration: BoxDecoration(
+                color: VineTheme.cameraButtonGreen,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: const DivineIcon(icon: .cameraRetro, size: 32),
+            ),
           ),
-          child: const DivineIcon(icon: .cameraRetro, size: 32),
         ),
       ),
     );

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -103,31 +103,25 @@ class VineBottomNav extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return ColoredBox(
       color: VineTheme.surfaceBackground,
-      // No Container padding remains — the 12 px strips above and below
-      // the icons and the 16 px strips on each side are now all part of
-      // each adjacent tab's hit target (see [_kTopExtraTapHeight],
-      // [_kBottomExtraTapHeight] and [_kHorizontalEdgePad]). The
-      // [SafeArea] still keeps tap targets clear of the iOS home
-      // indicator and Android navigation bar.
+      // The bottom nav has no Container padding — all four edges of the
+      // breathing room around the icons are folded into adjacent tab hit
+      // targets (see [_kTopExtraTapHeight], [_kBottomExtraTapHeight],
+      // [_kHorizontalEdgePad]). [SafeArea] still keeps tap targets clear
+      // of the iOS home indicator and Android navigation bar.
       child: SafeArea(
         top: false,
         child: LayoutBuilder(
           builder: (context, constraints) {
-            // Each tab claims half of each adjacent inter-icon gap so taps
-            // anywhere closer to a given icon than to its neighbour route
-            // to that tab. Home and Profile additionally absorb the
-            // formerly-reserved [_kHorizontalEdgePad] strip on the screen
-            // edge. Icons stay in the exact visual positions a
-            // `MainAxisAlignment.spaceBetween` row inset by 16 px (the
-            // previous layout) would produce.
+            // Each tab's slot covers its icon plus half of each adjacent
+            // inter-icon gap, so taps closer to a given icon than to its
+            // neighbour route to that tab. Home and Profile additionally
+            // span the [_kHorizontalEdgePad] strip out to the screen edge.
+            // Icons sit at their Figma-specified positions.
             const iconWidth = kMinInteractiveDimension;
             const cameraWidth = _kCameraButtonWidth;
             const totalIconWidth = iconWidth * 4 + cameraWidth;
             const totalEdgePad = _kHorizontalEdgePad * 2;
-            // 8 half-gaps split the space the inter-icon gaps used to
-            // occupy — same numeric formula as before, derived from
-            // `constraints.maxWidth - totalIconWidth - 2 * 16` since
-            // `maxWidth` is now 32 px wider (no Container padding).
+            // 4 inter-icon gaps × 2 halves = 8.
             final halfGap =
                 ((constraints.maxWidth - totalIconWidth - totalEdgePad) / 8)
                     .clamp(0.0, double.infinity);
@@ -197,30 +191,26 @@ class VineBottomNav extends ConsumerWidget {
 /// Visible width of the green camera-button pill in the bottom nav.
 const double _kCameraButtonWidth = 72;
 
-/// Extra hit-target height stacked on top of the [kMinInteractiveDimension]
-/// icon row. Equal to the top padding the bottom nav used to reserve, so
-/// the previously-dead strip above the icons now routes taps to the tab
-/// directly above it without moving any icon visually.
+/// Extra hit-target height stacked above the [kMinInteractiveDimension]
+/// icon row, so taps in the strip immediately above the visible icons
+/// route to the tab below.
 const double _kTopExtraTapHeight = 12;
 
 /// Extra hit-target height stacked below the [kMinInteractiveDimension]
-/// icon row. Equal to the bottom padding the bottom nav used to reserve,
-/// so the previously-dead strip beneath the icons (above the [SafeArea]
-/// inset) now routes taps to the tab directly below it without moving
-/// any icon visually.
+/// icon row (above the [SafeArea] inset), so taps in the strip
+/// immediately beneath the visible icons route to the tab above.
 const double _kBottomExtraTapHeight = 12;
 
 /// Total vertical hit-target height per tab. The icon container sits at
-/// the vertical centre of this slot — the top and bottom extras are
-/// equal — so taps both above and below the visible glyph route to the
-/// correct tab.
+/// the vertical centre of this slot — top and bottom extras are equal —
+/// so taps both above and below the visible glyph route to the right tab.
 const double _kTabSlotHeight =
     kMinInteractiveDimension + _kTopExtraTapHeight + _kBottomExtraTapHeight;
 
 /// Lateral inset between the screen edge and the visible position of the
-/// outermost icons (Home / Profile). Used to be a [Container] padding;
-/// it is now folded into Home's and Profile's hit targets so taps inside
-/// the previously-reserved 16 px strip route to the adjacent tab.
+/// outermost icons (Home / Profile). Folded into Home's and Profile's hit
+/// targets so taps inside the 16 px strip on the screen edge still route
+/// to the adjacent tab.
 const double _kHorizontalEdgePad = 16;
 
 // =============================================================================
@@ -246,8 +236,7 @@ const double _kHorizontalEdgePad = 16;
 /// the bottom nav row — usually larger than the 48 px icon container so
 /// taps in the surrounding gap also route to this tab. The icon itself
 /// stays a [kMinInteractiveDimension]-sized box positioned via
-/// [iconAlignment]; the row computes both so icons stay in the exact same
-/// visual positions a `MainAxisAlignment.spaceBetween` row would produce.
+/// [iconAlignment].
 class _IconTabButton extends StatelessWidget {
   const _IconTabButton({
     required this.semanticIdentifier,
@@ -269,19 +258,18 @@ class _IconTabButton extends StatelessWidget {
   final double tapTargetWidth;
 
   /// Where to place the 48 px icon container inside the slot. Defaults to
-  /// [Alignment.center] so the icon sits at the same vertical position
-  /// it would have had under the previous (smaller) tap target — the
-  /// extra height extends symmetrically above and below the visible
-  /// glyph. Use `centerStart` / `centerEnd` (combined with [edgePadding])
-  /// for the leftmost / rightmost tabs so they hug the row's edge.
+  /// [Alignment.center] so the icon sits at the slot's centre with equal
+  /// hit-target padding above and below it. Use `centerStart` /
+  /// `centerEnd` (combined with [edgePadding]) for the leftmost /
+  /// rightmost tabs so they hug the row's edge.
   final AlignmentGeometry iconAlignment;
 
   /// Horizontal inset between the slot edge and the icon container.
   /// Non-zero only for Home and Profile, where the slot extends all the
   /// way to the screen edge but the icon must still sit
-  /// [_kHorizontalEdgePad] in from that edge to match the previous
-  /// visual position. The edge strip itself stays inside the
-  /// [GestureDetector] so taps there route to the tab.
+  /// [_kHorizontalEdgePad] in from that edge per the Figma spec. The
+  /// edge strip itself stays inside the [GestureDetector] so taps there
+  /// route to the tab.
   final EdgeInsetsGeometry edgePadding;
 
   /// When non-null, wraps the inner icon container in a [NotificationBadge]
@@ -539,11 +527,10 @@ class _CameraButton extends StatelessWidget {
         child: SizedBox(
           width: tapTargetWidth,
           height: _kTabSlotHeight,
-          // Centered so the visible green pill stays at the same Y
-          // position it had under the previous (smaller) tap target —
-          // the extra height extends symmetrically above and below the
-          // pill into the row's previously-dead top and bottom padding.
-          child: Align(
+          // Centered so the visible pill keeps its on-screen position
+          // even though the slot is taller and wider than the pill —
+          // the extra space all goes to hit-target absorption.
+          child: Center(
             child: Container(
               width: _kCameraButtonWidth,
               height: kMinInteractiveDimension,

--- a/mobile/test/widgets/vine_bottom_nav_test.dart
+++ b/mobile/test/widgets/vine_bottom_nav_test.dart
@@ -136,7 +136,7 @@ void main() {
         expect(exploreRect.width, greaterThan(kMinInteractiveDimension));
 
         // Tap inside the home slot, just to the right of the home icon
-        // (i.e. inside the half-gap that was previously dead space).
+        // (i.e. inside the inter-icon half-gap, not on the icon itself).
         final justPastHomeIcon = Offset(
           homeRect.left + kMinInteractiveDimension + 1,
           homeRect.center.dy,
@@ -149,8 +149,8 @@ void main() {
     );
 
     testWidgets(
-      'tab hit targets extend above the icon row so taps in the former '
-      'top padding strip still route to the tab below',
+      'tab hit targets extend above the icon row so taps in the strip '
+      'above the icons still route to the tab below',
       (tester) async {
         final router = MockGoRouter();
         await pumpSubjectWithRouter(tester, router);
@@ -159,14 +159,13 @@ void main() {
           find.bySemanticsIdentifier('home_tab'),
         );
 
-        // The slot is taller than a bare 48 px icon container — the
-        // previously-reserved top-padding strip is now part of the hit
-        // target.
+        // The slot is taller than a bare 48 px icon container — extra
+        // height above the icon is part of the hit target.
         expect(homeRect.height, greaterThan(kMinInteractiveDimension));
 
-        // Tap 2 px below the slot's top edge (well above where the icon
-        // is drawn). Without the absorbed top padding, this tap would
-        // land in dead space.
+        // Tap 2 px below the slot's top edge — well above where the
+        // icon is drawn. The strip above the icon container is part of
+        // the slot, not dead space.
         await tester.tapAt(homeRect.topLeft + const Offset(8, 2));
         await tester.pump();
 
@@ -176,7 +175,7 @@ void main() {
 
     testWidgets(
       'home and profile slots reach the screen edges so taps in the '
-      'former lateral padding strip still route to the adjacent tab',
+      'edge strip still route to the adjacent tab',
       (tester) async {
         final router = MockGoRouter();
         await pumpSubjectWithRouter(tester, router);
@@ -194,8 +193,8 @@ void main() {
         expect(homeRect.left, navRect.left);
         expect(profileRect.right, navRect.right);
 
-        // Tap 2 px in from the screen's left edge — formerly inside the
-        // 16 px Container padding, now part of the home slot.
+        // Tap 2 px in from the screen's left edge — inside the home
+        // slot's outer edge inset, not on the icon itself.
         await tester.tapAt(
           Offset(navRect.left + 2, homeRect.center.dy),
         );
@@ -206,8 +205,8 @@ void main() {
     );
 
     testWidgets(
-      'tab hit targets extend below the icon row so taps in the former '
-      'bottom padding strip still route to the tab above',
+      'tab hit targets extend below the icon row so taps in the strip '
+      'below the icons still route to the tab above',
       (tester) async {
         final router = MockGoRouter();
         await pumpSubjectWithRouter(tester, router);
@@ -217,16 +216,16 @@ void main() {
           find.bySemanticsIdentifier('home_tab'),
         );
 
-        // The slot's bottom edge meets the bottom nav's bottom edge —
-        // no Container padding remains below the row. (No bottom safe
-        // area inset is applied in the test environment, so the two
-        // are exactly equal.)
+        // The slot's bottom edge meets the bottom nav's bottom edge.
+        // (No bottom safe area inset is applied in the test environment,
+        // so the two are exactly equal — on real devices [SafeArea]
+        // separates them by [MediaQuery.viewPadding.bottom].)
         expect(homeRect.bottom, navRect.bottom);
 
         // Tap 2 px above the slot's bottom edge — well below where the
         // icon is drawn (the icon is centred in a 72 px slot, so its
-        // bottom edge sits 12 px above the slot's bottom). Without the
-        // absorbed bottom padding this tap would land in dead space.
+        // bottom edge sits 12 px above the slot's bottom). The strip
+        // below the icon container is part of the slot.
         await tester.tapAt(
           Offset(homeRect.center.dx, homeRect.bottom - 2),
         );

--- a/mobile/test/widgets/vine_bottom_nav_test.dart
+++ b/mobile/test/widgets/vine_bottom_nav_test.dart
@@ -81,7 +81,7 @@ void main() {
       expect(sizedBoxes, hasLength(4));
     });
 
-    testWidgets('icon and profile tabs use opaque gesture hit behavior', (
+    testWidgets('all five tabs use opaque gesture hit behavior', (
       tester,
     ) async {
       await pumpSubject(tester);
@@ -91,7 +91,10 @@ void main() {
           .where((detector) => detector.behavior == HitTestBehavior.opaque)
           .toList();
 
-      expect(opaqueDetectors, hasLength(4));
+      // Home / Explore / Camera / Inbox / Profile — each owns an opaque
+      // GestureDetector that fills its slice of the row so taps in the
+      // surrounding gap also route to the right tab.
+      expect(opaqueDetectors, hasLength(5));
     });
 
     testWidgets(
@@ -102,9 +105,131 @@ void main() {
         await pumpSubjectWithRouter(tester, router);
 
         final rect = tester.getRect(find.bySemanticsIdentifier('home_tab'));
-        // Tap 2 px inside the top-left corner — the 48×48 hit target must
-        // respond here, not just at the centre where the icon is drawn.
+        // Tap 2 px inside the top-left corner — the hit target must respond
+        // here, not just at the centre where the icon is drawn.
         await tester.tapAt(rect.topLeft + const Offset(2, 2));
+        await tester.pump();
+
+        verify(() => router.go(any())).called(1);
+      },
+    );
+
+    testWidgets(
+      'tab hit targets divide the inter-icon gap so taps just past an '
+      'icon still route to that tab',
+      (tester) async {
+        final router = MockGoRouter();
+        await pumpSubjectWithRouter(tester, router);
+
+        final homeRect = tester.getRect(
+          find.bySemanticsIdentifier('home_tab'),
+        );
+        final exploreRect = tester.getRect(
+          find.bySemanticsIdentifier('explore_tab'),
+        );
+
+        // The two slots must touch (no dead zone between them).
+        expect(homeRect.right, exploreRect.left);
+        // And each must be wider than the bare 48 px icon container —
+        // otherwise the gap was not absorbed.
+        expect(homeRect.width, greaterThan(kMinInteractiveDimension));
+        expect(exploreRect.width, greaterThan(kMinInteractiveDimension));
+
+        // Tap inside the home slot, just to the right of the home icon
+        // (i.e. inside the half-gap that was previously dead space).
+        final justPastHomeIcon = Offset(
+          homeRect.left + kMinInteractiveDimension + 1,
+          homeRect.center.dy,
+        );
+        await tester.tapAt(justPastHomeIcon);
+        await tester.pump();
+
+        verify(() => router.go(any())).called(1);
+      },
+    );
+
+    testWidgets(
+      'tab hit targets extend above the icon row so taps in the former '
+      'top padding strip still route to the tab below',
+      (tester) async {
+        final router = MockGoRouter();
+        await pumpSubjectWithRouter(tester, router);
+
+        final homeRect = tester.getRect(
+          find.bySemanticsIdentifier('home_tab'),
+        );
+
+        // The slot is taller than a bare 48 px icon container — the
+        // previously-reserved top-padding strip is now part of the hit
+        // target.
+        expect(homeRect.height, greaterThan(kMinInteractiveDimension));
+
+        // Tap 2 px below the slot's top edge (well above where the icon
+        // is drawn). Without the absorbed top padding, this tap would
+        // land in dead space.
+        await tester.tapAt(homeRect.topLeft + const Offset(8, 2));
+        await tester.pump();
+
+        verify(() => router.go(any())).called(1);
+      },
+    );
+
+    testWidgets(
+      'home and profile slots reach the screen edges so taps in the '
+      'former lateral padding strip still route to the adjacent tab',
+      (tester) async {
+        final router = MockGoRouter();
+        await pumpSubjectWithRouter(tester, router);
+
+        final navRect = tester.getRect(find.byType(VineBottomNav));
+        final homeRect = tester.getRect(
+          find.bySemanticsIdentifier('home_tab'),
+        );
+        final profileRect = tester.getRect(
+          find.bySemanticsIdentifier('profile_tab'),
+        );
+
+        // Outer edges of Home / Profile slots align with the bottom
+        // nav's left / right edges — no horizontal dead zone.
+        expect(homeRect.left, navRect.left);
+        expect(profileRect.right, navRect.right);
+
+        // Tap 2 px in from the screen's left edge — formerly inside the
+        // 16 px Container padding, now part of the home slot.
+        await tester.tapAt(
+          Offset(navRect.left + 2, homeRect.center.dy),
+        );
+        await tester.pump();
+
+        verify(() => router.go(any())).called(1);
+      },
+    );
+
+    testWidgets(
+      'tab hit targets extend below the icon row so taps in the former '
+      'bottom padding strip still route to the tab above',
+      (tester) async {
+        final router = MockGoRouter();
+        await pumpSubjectWithRouter(tester, router);
+
+        final navRect = tester.getRect(find.byType(VineBottomNav));
+        final homeRect = tester.getRect(
+          find.bySemanticsIdentifier('home_tab'),
+        );
+
+        // The slot's bottom edge meets the bottom nav's bottom edge —
+        // no Container padding remains below the row. (No bottom safe
+        // area inset is applied in the test environment, so the two
+        // are exactly equal.)
+        expect(homeRect.bottom, navRect.bottom);
+
+        // Tap 2 px above the slot's bottom edge — well below where the
+        // icon is drawn (the icon is centred in a 72 px slot, so its
+        // bottom edge sits 12 px above the slot's bottom). Without the
+        // absorbed bottom padding this tap would land in dead space.
+        await tester.tapAt(
+          Offset(homeRect.center.dx, homeRect.bottom - 2),
+        );
         await tester.pump();
 
         verify(() => router.go(any())).called(1);


### PR DESCRIPTION
## Description

Bottom-nav tap targets now fill the entire row instead of just the 48 px icon. Each tab claims half of each adjacent gap, plus the strips above and below the icons, plus (for Home and Profile) the 16 px lateral edge insets. Icons stay at their Figma positions; `SafeArea` keeps the targets clear of the iOS home indicator and Android navigation bar.

## Screenshots

This change is invisible by design — icon positions, spacing, and the green camera pill should be identical before and after. The screenshots below are a regression check, not a redesign showcase.

### Bottom nav (regression check)

<table>
  <tr>
    <th>Main</th>
    <th>This branch</th>
  </tr>
  <tr>
    <td>
      <img width="450" alt="bar-before" src="https://github.com/user-attachments/assets/84f85532-833e-4839-92dc-ec6d61cfbda0" />
    </td>
    <td>
      <img width="450" alt="bar-after" src="https://github.com/user-attachments/assets/8b553087-e98b-41a7-8d42-56deb0122494" />
    </td>
  </tr>
</table>

**Related Issue:** Closes #4137

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [ ] **Direct visual verification** — open Home / Explore / Inbox / Profile screens. Bottom nav looks identical to `main`: same icon positions, same spacing, same green camera pill, same selected-state shadow.
- [ ] **Tap each formerly-dead strip** — tap the 12 px strip directly above each icon, the 12 px strip directly below each icon, the inter-icon gaps, and the 16 px screen-edge strips on Home and Profile. Each tap should route to the nearest tab.
- [ ] **iOS home indicator boundary** — on an iPhone with a home indicator, confirm tapping just above the home indicator still selects a tab and the swipe-up home gesture still works. Tap targets stop at the `SafeArea` inset.
- [ ] **Landscape on notched devices** — in landscape on a notched iPhone, Home / Profile tap targets end at the safe-area inset over the rounded corner / notch, not at the raw screen edge.
- [ ] **Screen reader (VoiceOver / TalkBack)** — each tab's semantic label still describes the action ("Home", "Explore", etc.). Inbox unread badge is still announced when present.
- [ ] **CI green** — Format, Analyze, Tests.