### PR TITLE
fix(sound): cache remote audio previews on iOS

### DIFF
--- a/mobile/lib/blocs/video_editor/audio_timing/audio_timing_cubit.dart
+++ b/mobile/lib/blocs/video_editor/audio_timing/audio_timing_cubit.dart
@@ -7,6 +7,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -27,13 +28,20 @@ class AudioTimingCubit extends Cubit<AudioTimingState> {
   ///
   /// The [sound] is the audio event to edit timing for.
   /// An optional [clipPlayer] can be injected for testing.
-  AudioTimingCubit({required AudioEvent sound, AudioClipPlayer? clipPlayer})
-    : _sound = sound,
-      _clipPlayer = clipPlayer ?? AudioClipPlayer(),
-      super(const AudioTimingState());
+  /// An optional [proVideoEditor] can be injected for testing; defaults to
+  /// [ProVideoEditor.instance].
+  AudioTimingCubit({
+    required AudioEvent sound,
+    AudioClipPlayer? clipPlayer,
+    ProVideoEditor? proVideoEditor,
+  }) : _sound = sound,
+       _clipPlayer = clipPlayer ?? AudioClipPlayer(),
+       _proVideoEditor = proVideoEditor ?? ProVideoEditor.instance,
+       super(const AudioTimingState());
 
   final AudioEvent _sound;
   final AudioClipPlayer _clipPlayer;
+  final ProVideoEditor _proVideoEditor;
   StreamSubscription<void>? _completionSubscription;
 
   static const _logName = 'AudioTimingCubit';
@@ -56,7 +64,13 @@ class AudioTimingCubit extends Cubit<AudioTimingState> {
   /// Should be called once after the cubit is created, typically in
   /// a post-frame callback.
   Future<void> initialize() async {
-    final audioDuration = _sound.duration ?? 0;
+    // Sounds from Nostr sometimes don't carry a duration tag — fall back to
+    // probing the audio source via ProVideoEditor.getMetadata so the timeline
+    // selector still works.
+    var audioDuration = _sound.duration ?? 0;
+    if (audioDuration <= 0) {
+      audioDuration = await _resolveAudioDurationSecs();
+    }
 
     // Restore previous selection offset (normalized 0-1)
     var initialOffset = 0.0;
@@ -126,6 +140,35 @@ class AudioTimingCubit extends Cubit<AudioTimingState> {
   Future<void> _onPlaybackCompleted() async {
     await _clipPlayer.seek(Duration.zero);
     await _clipPlayer.play();
+  }
+
+  /// Resolves the audio duration in seconds via [ProVideoEditor.getMetadata]
+  /// when the [AudioEvent] does not carry a duration value.
+  ///
+  /// Returns 0 if the audio source is unavailable or metadata extraction
+  /// fails.
+  Future<double> _resolveAudioDurationSecs() async {
+    final EditorVideo source;
+    if (_sound.isBundled && _sound.assetPath != null) {
+      source = EditorVideo.asset(_sound.assetPath!);
+    } else if (_sound.url != null && _sound.url!.isNotEmpty) {
+      source = EditorVideo.network(_sound.url!);
+    } else {
+      return 0;
+    }
+
+    try {
+      final metadata = await _proVideoEditor.getMetadata(source);
+      return metadata.duration.inMilliseconds / 1000.0;
+    } catch (e, s) {
+      Log.error(
+        'Failed to resolve audio duration for ${_sound.id}: $e',
+        name: _logName,
+        error: e,
+        stackTrace: s,
+      );
+      return 0;
+    }
   }
 
   /// Loads the selected audio and starts looped playback.

--- a/mobile/lib/providers/saved_sounds_provider.dart
+++ b/mobile/lib/providers/saved_sounds_provider.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 final savedSoundsServiceProvider = Provider<SavedSoundsService>((ref) {
   return SavedSoundsService(ref.watch(sharedPreferencesProvider));
@@ -16,13 +18,25 @@ final savedSoundsProvider =
     );
 
 class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
+  bool _backfillScheduled = false;
+
   @override
   List<AudioEvent> build() {
-    return ref.watch(savedSoundsServiceProvider).loadSounds();
+    final sounds = ref.watch(savedSoundsServiceProvider).loadSounds();
+    if (!_backfillScheduled && sounds.any((s) => (s.duration ?? 0) <= 0)) {
+      // Fire-and-forget backfill for legacy entries that were saved
+      // before SavedSoundsNotifier started persisting durations.
+      _backfillScheduled = true;
+      Future.microtask(_backfillMissingDurations);
+    }
+    return sounds;
   }
 
   Future<SavedSoundSaveResult> saveSound(AudioEvent sound) async {
-    final result = await ref.read(savedSoundsServiceProvider).saveSound(sound);
+    final enriched = await _ensureDuration(sound);
+    final result = await ref
+        .read(savedSoundsServiceProvider)
+        .saveSound(enriched);
     state = ref.read(savedSoundsServiceProvider).loadSounds();
     return result;
   }
@@ -30,5 +44,54 @@ class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
   Future<void> removeSound(String soundId) async {
     await ref.read(savedSoundsServiceProvider).removeSound(soundId);
     state = ref.read(savedSoundsServiceProvider).loadSounds();
+  }
+
+  Future<void> _backfillMissingDurations() async {
+    final current = state;
+    final updated = <AudioEvent>[];
+    var changed = false;
+    for (final sound in current) {
+      if ((sound.duration ?? 0) > 0) {
+        updated.add(sound);
+        continue;
+      }
+      final enriched = await _ensureDuration(sound);
+      if ((enriched.duration ?? 0) > 0) changed = true;
+      updated.add(enriched);
+    }
+    if (!changed) return;
+    await ref.read(savedSoundsServiceProvider).replaceAll(updated);
+    state = updated;
+  }
+
+  /// Probes [ProVideoEditor] for the missing duration so the saved
+  /// entry persists with the correct length. Nostr Kind 1063 events
+  /// frequently omit the `duration` tag.
+  Future<AudioEvent> _ensureDuration(AudioEvent sound) async {
+    if ((sound.duration ?? 0) > 0) return sound;
+
+    final EditorVideo source;
+    if (sound.isBundled && sound.assetPath != null) {
+      source = EditorVideo.asset(sound.assetPath!);
+    } else if (sound.url != null && sound.url!.isNotEmpty) {
+      source = EditorVideo.network(sound.url!);
+    } else {
+      return sound;
+    }
+
+    try {
+      final metadata = await ProVideoEditor.instance.getMetadata(source);
+      final seconds = metadata.duration.inMilliseconds / 1000.0;
+      if (seconds <= 0) return sound;
+      return sound.copyWith(duration: seconds);
+    } catch (e, s) {
+      Log.error(
+        'Failed to resolve duration for saved sound ${sound.id}: $e',
+        name: 'SavedSoundsNotifier',
+        error: e,
+        stackTrace: s,
+      );
+      return sound;
+    }
   }
 }

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -17,6 +17,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/stereo_waveform_painter.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
+import 'package:sound_service/sound_service.dart';
 
 /// Result of the audio timing screen.
 ///
@@ -55,6 +56,7 @@ class VideoAudioEditorTimingScreen extends StatefulWidget {
   const VideoAudioEditorTimingScreen({
     required this.sound,
     this.enableDeleteButton = true,
+    this.clipPlayer,
     super.key,
   });
 
@@ -63,6 +65,9 @@ class VideoAudioEditorTimingScreen extends StatefulWidget {
 
   /// Whether the delete button is shown in the toolbar.
   final bool enableDeleteButton;
+
+  /// Optional audio clip player override for tests.
+  final AudioClipPlayer? clipPlayer;
 
   /// Route name for navigation.
   static const routeName = 'video-audio-timing';
@@ -91,7 +96,10 @@ class _VideoAudioEditorTimingScreenState
     _waveformBloc = SoundWaveformBloc();
     _flingController = AnimationController.unbounded(vsync: this);
     _flingController.addListener(_onFlingUpdate);
-    _audioTimingCubit = AudioTimingCubit(sound: widget.sound);
+    _audioTimingCubit = AudioTimingCubit(
+      sound: widget.sound,
+      clipPlayer: widget.clipPlayer,
+    );
 
     // Delay initialization until after first frame
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -56,7 +56,7 @@ class VideoAudioEditorTimingScreen extends StatefulWidget {
   const VideoAudioEditorTimingScreen({
     required this.sound,
     this.enableDeleteButton = true,
-    this.clipPlayer,
+    @visibleForTesting this.clipPlayer,
     super.key,
   });
 
@@ -67,6 +67,7 @@ class VideoAudioEditorTimingScreen extends StatefulWidget {
   final bool enableDeleteButton;
 
   /// Optional audio clip player override for tests.
+  @visibleForTesting
   final AudioClipPlayer? clipPlayer;
 
   /// Route name for navigation.
@@ -193,7 +194,14 @@ class _VideoAudioEditorTimingScreenState
   Future<void> _confirmSelection() async {
     await _audioTimingCubit.stopPlayback();
     final startOffset = _audioTimingCubit.calculateStartOffset();
-    final updatedSound = widget.sound.copyWith(startOffset: startOffset);
+    // Persist the resolved duration when the source AudioEvent did not
+    // carry one (common for sounds coming from Nostr).
+    final resolvedDuration =
+        widget.sound.duration ?? _audioTimingCubit.state.audioDuration;
+    final updatedSound = widget.sound.copyWith(
+      startOffset: startOffset,
+      duration: resolvedDuration,
+    );
     if (mounted) {
       context.pop<AudioTimingResult>(AudioTimingConfirmed(updatedSound));
     }

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -58,6 +58,10 @@ class SavedSoundsService {
     await _writeSounds(sounds);
   }
 
+  /// Overwrites the persisted list. Used by the notifier after backfilling
+  /// missing fields (e.g. duration) on legacy entries.
+  Future<void> replaceAll(List<AudioEvent> sounds) => _writeSounds(sounds);
+
   Future<void> _writeSounds(List<AudioEvent> sounds) async {
     await _preferences.setString(
       storageKey,

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -13,6 +13,7 @@ import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_category_bar.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_list_tile.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -172,15 +173,24 @@ class _AudioSelectionBottomSheetState
 
     try {
       await _audioService.seek(.zero);
+      var resolvedSound = sound;
       if (shouldReload) {
         await _audioService.stop();
-        await _audioService.loadAudio(sound.url!);
+        final loadedDuration = await _audioService.loadAudio(sound.url!);
         _loadedSoundId = sound.id;
+        // Backfill missing duration so the selection overlay and list
+        // tile can show a correct timestamp for Nostr sounds that don't
+        // carry a duration tag.
+        if (sound.duration == null && loadedDuration != null) {
+          resolvedSound = sound.copyWith(
+            duration: loadedDuration.inMilliseconds / 1000.0,
+          );
+        }
       }
 
       if (mounted) {
         setState(() {
-          _selectedItem = sound;
+          _selectedItem = resolvedSound;
         });
       }
       // Blocks here for the entire duration of playback — only
@@ -222,9 +232,19 @@ class _AudioSelectionBottomSheetState
       return;
     }
 
-    if (_selectedItem!.duration == null ||
-        _selectedItem!.duration! >
-            (VideoEditorConstants.maxDuration.inMilliseconds / 1000)) {
+    var sound = _selectedItem!;
+    if (sound.duration == null) {
+      final resolvedDuration = await _resolveDurationSecs(sound);
+      if (!mounted) return;
+      if (resolvedDuration != null) {
+        sound = sound.copyWith(duration: resolvedDuration);
+        setState(() => _selectedItem = sound);
+      }
+    }
+
+    if (sound.duration == null ||
+        sound.duration! >
+            (VideoEditorConstants.maxDuration.inMilliseconds / 1000.0)) {
       final timingResult = await Navigator.of(context).push<AudioTimingResult>(
         PageRouteBuilder(
           opaque: false,
@@ -232,7 +252,7 @@ class _AudioSelectionBottomSheetState
           transitionsBuilder: (_, animation, _, child) =>
               FadeTransition(opacity: animation, child: child),
           pageBuilder: (_, _, _) => VideoAudioEditorTimingScreen(
-            sound: _selectedItem!,
+            sound: sound,
             enableDeleteButton: false,
           ),
         ),
@@ -247,7 +267,34 @@ class _AudioSelectionBottomSheetState
         }
       }
     } else {
-      context.pop(_selectedItem);
+      context.pop(sound);
+    }
+  }
+
+  /// Resolves the audio duration in seconds via [ProVideoEditor.getMetadata].
+  /// Returns `null` if no source is available or metadata extraction fails.
+  Future<double?> _resolveDurationSecs(AudioEvent sound) async {
+    final assetPath = sound.assetPath;
+    final url = sound.url;
+    if ((assetPath == null || assetPath.isEmpty) &&
+        (url == null || url.isEmpty)) {
+      return null;
+    }
+    try {
+      final metadata = await ProVideoEditor.instance.getMetadata(
+        EditorVideo.autoSource(assetPath: assetPath, networkUrl: url),
+      );
+      final secs = metadata.duration.inMilliseconds / 1000.0;
+      return secs > 0 ? secs : null;
+    } catch (e, s) {
+      Log.error(
+        'Failed to resolve duration for sound ${sound.id}: $e',
+        name: 'AudioSelectionBottomSheet',
+        category: LogCategory.ui,
+        error: e,
+        stackTrace: s,
+      );
+      return null;
     }
   }
 
@@ -447,15 +494,19 @@ class _SoundsContent extends StatelessWidget {
                 onTap: () => onSelect(audio),
               );
             }
+            // Use selectedSound for the selected entry so any duration
+            // backfilled after loading the preview shows up in the
+            // subtitle.
+            final displayAudio = selectedSound ?? audio;
             return StreamBuilder<bool>(
               stream: audioService.playingStream,
               initialData: audioService.isPlaying,
               builder: (context, snapshot) {
                 return AudioListTile(
-                  audio: audio,
+                  audio: displayAudio,
                   isSelected: true,
                   isPlaying: snapshot.data ?? false,
-                  onTap: () => onSelect(audio),
+                  onTap: () => onSelect(displayAudio),
                 );
               },
             );

--- a/mobile/packages/sound_service/lib/src/audio_clip_player.dart
+++ b/mobile/packages/sound_service/lib/src/audio_clip_player.dart
@@ -4,9 +4,15 @@
 
 import 'dart:async';
 import 'dart:developer';
+import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:sound_service/src/audio_source_config.dart';
+
+/// Downloads a remote audio URL to a local file, optionally reusing a cache.
+typedef RemoteAudioFileLoader =
+    Future<File> Function(Uri uri, File? cachedFile, Uri? cachedUri);
 
 /// A player that plays a clipped portion of an audio source.
 ///
@@ -20,11 +26,18 @@ class AudioClipPlayer {
   /// An optional [audioPlayer] can be injected for testing within the
   /// `sound_service` package.
   // coverage:ignore-start
-  AudioClipPlayer({AudioPlayer? audioPlayer})
-    : _audioPlayer = audioPlayer ?? AudioPlayer();
+  AudioClipPlayer({
+    AudioPlayer? audioPlayer,
+    RemoteAudioFileLoader? remoteAudioFileLoader,
+  }) : _audioPlayer = audioPlayer ?? AudioPlayer(),
+       _remoteAudioFileLoader =
+           remoteAudioFileLoader ?? _defaultRemoteAudioFileLoader;
   // coverage:ignore-end
 
   final AudioPlayer _audioPlayer;
+  final RemoteAudioFileLoader _remoteAudioFileLoader;
+  File? _cachedRemoteFile;
+  Uri? _cachedRemoteUri;
 
   /// playing (i.e. reaches the end without being stopped manually).
   ///
@@ -45,11 +58,20 @@ class AudioClipPlayer {
   Future<void> setClip(AudioSourceConfig config) async {
     final UriAudioSource child;
     if (config.isAsset) {
+      await _clearCachedRemoteFile();
       child = AudioSource.asset(config.uri);
     } else if (config.isFile) {
+      await _clearCachedRemoteFile();
       child = AudioSource.file(config.uri);
     } else {
-      child = AudioSource.uri(Uri.parse(config.uri));
+      final cachedFile = await _remoteAudioFileLoader(
+        Uri.parse(config.uri),
+        _cachedRemoteFile,
+        _cachedRemoteUri,
+      );
+      _cachedRemoteFile = cachedFile;
+      _cachedRemoteUri = Uri.parse(config.uri);
+      child = AudioSource.file(cachedFile.path);
     }
 
     final source = ClippingAudioSource(
@@ -85,6 +107,7 @@ class AudioClipPlayer {
   Future<void> dispose() async {
     try {
       await _audioPlayer.dispose();
+      await _clearCachedRemoteFile();
     } on Exception catch (e) {
       log(
         'Error disposing AudioClipPlayer: $e',
@@ -92,5 +115,70 @@ class AudioClipPlayer {
         level: 900,
       );
     }
+  }
+
+  Future<void> _clearCachedRemoteFile() async {
+    final file = _cachedRemoteFile;
+    _cachedRemoteFile = null;
+    _cachedRemoteUri = null;
+    if (file == null) return;
+
+    try {
+      if (file.existsSync()) {
+        file.deleteSync();
+        final parent = file.parent;
+        if (parent.existsSync()) {
+          parent.deleteSync();
+        }
+      }
+    } on Exception catch (e) {
+      log(
+        'Failed to delete cached remote audio file: $e',
+        name: 'AudioClipPlayer',
+        level: 900,
+      );
+    }
+  }
+
+  static Future<File> _defaultRemoteAudioFileLoader(
+    Uri uri,
+    File? cachedFile,
+    Uri? cachedUri,
+  ) async {
+    if (cachedFile != null && cachedUri == uri && cachedFile.existsSync()) {
+      return cachedFile;
+    }
+
+    if (cachedFile != null && cachedFile.existsSync()) {
+      cachedFile.deleteSync();
+      final parent = cachedFile.parent;
+      if (parent.existsSync()) {
+        parent.deleteSync();
+      }
+    }
+
+    final request = await HttpClient().getUrl(uri);
+    final response = await request.close();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to download remote audio (${response.statusCode})',
+        uri: uri,
+      );
+    }
+
+    final bytes = await consolidateHttpClientResponseBytes(response);
+    final tempDir = await Directory.systemTemp.createTemp('sound_clip_');
+    final path = tempDir.uri.resolve(_safeFilenameForUri(uri)).toFilePath();
+    final file = File(path);
+    await file.writeAsBytes(bytes, flush: true);
+    return file;
+  }
+
+  static String _safeFilenameForUri(Uri uri) {
+    final lastSegment = uri.pathSegments.isEmpty
+        ? 'audio_clip'
+        : uri.pathSegments.last;
+    final sanitized = lastSegment.replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
+    return sanitized.isEmpty ? 'audio_clip' : sanitized;
   }
 }

--- a/mobile/packages/sound_service/lib/src/audio_clip_player.dart
+++ b/mobile/packages/sound_service/lib/src/audio_clip_player.dart
@@ -6,9 +6,14 @@ import 'dart:async';
 import 'dart:developer';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:sound_service/src/audio_source_config.dart';
+
+abstract class _RemoteAudioLoaderConfig {
+  static const Duration connectionTimeout = Duration(seconds: 10);
+  static const Duration readTimeout = Duration(seconds: 30);
+  static const int maxBytes = 50 * 1024 * 1024;
+}
 
 /// Downloads a remote audio URL to a local file, optionally reusing a cache.
 typedef RemoteAudioFileLoader =
@@ -107,7 +112,6 @@ class AudioClipPlayer {
   Future<void> dispose() async {
     try {
       await _audioPlayer.dispose();
-      await _clearCachedRemoteFile();
     } on Exception catch (e) {
       log(
         'Error disposing AudioClipPlayer: $e',
@@ -115,6 +119,7 @@ class AudioClipPlayer {
         level: 900,
       );
     }
+    await _clearCachedRemoteFile();
   }
 
   Future<void> _clearCachedRemoteFile() async {
@@ -127,6 +132,9 @@ class AudioClipPlayer {
       if (file.existsSync()) {
         file.deleteSync();
         final parent = file.parent;
+        // Non-recursive on purpose: a custom RemoteAudioFileLoader may place
+        // the cached file in a directory that is shared with unrelated files;
+        // deleteSync() throws (and we swallow) if the parent isn't empty.
         if (parent.existsSync()) {
           parent.deleteSync();
         }
@@ -153,25 +161,51 @@ class AudioClipPlayer {
       cachedFile.deleteSync();
       final parent = cachedFile.parent;
       if (parent.existsSync()) {
-        parent.deleteSync();
+        parent.deleteSync(recursive: true);
       }
     }
 
-    final request = await HttpClient().getUrl(uri);
-    final response = await request.close();
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw HttpException(
-        'Failed to download remote audio (${response.statusCode})',
-        uri: uri,
+    final client = HttpClient()
+      ..connectionTimeout = _RemoteAudioLoaderConfig.connectionTimeout;
+    try {
+      final request = await client.getUrl(uri);
+      final response = await request.close().timeout(
+        _RemoteAudioLoaderConfig.readTimeout,
       );
-    }
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw HttpException(
+          'Failed to download remote audio (${response.statusCode})',
+          uri: uri,
+        );
+      }
 
-    final bytes = await consolidateHttpClientResponseBytes(response);
-    final tempDir = await Directory.systemTemp.createTemp('sound_clip_');
-    final path = tempDir.uri.resolve(_safeFilenameForUri(uri)).toFilePath();
-    final file = File(path);
-    await file.writeAsBytes(bytes, flush: true);
-    return file;
+      final tempDir = await Directory.systemTemp.createTemp('sound_clip_');
+      final path = tempDir.uri.resolve(_safeFilenameForUri(uri)).toFilePath();
+      final file = File(path);
+      final sink = file.openWrite();
+      var written = 0;
+      try {
+        await for (final chunk in response.timeout(
+          _RemoteAudioLoaderConfig.readTimeout,
+        )) {
+          written += chunk.length;
+          if (written > _RemoteAudioLoaderConfig.maxBytes) {
+            throw HttpException(
+              'Remote audio exceeds ${_RemoteAudioLoaderConfig.maxBytes} '
+              'byte limit',
+              uri: uri,
+            );
+          }
+          sink.add(chunk);
+        }
+        await sink.flush();
+      } finally {
+        await sink.close();
+      }
+      return file;
+    } finally {
+      client.close(force: true);
+    }
   }
 
   static String _safeFilenameForUri(Uri uri) {

--- a/mobile/packages/sound_service/lib/src/audio_playback_service.dart
+++ b/mobile/packages/sound_service/lib/src/audio_playback_service.dart
@@ -194,11 +194,10 @@ class AudioPlaybackService {
           name: 'AudioPlaybackService',
         );
       } else {
-        loadedDuration = await _audioPlayer.setUrl(url);
-        log(
-          'Loaded audio from URL: $url',
-          name: 'AudioPlaybackService',
+        loadedDuration = await _audioPlayer.setAudioSource(
+          _networkAudioSource(url),
         );
+        log('Loaded audio from URL: $url', name: 'AudioPlaybackService');
       }
 
       _lastSource = (type: _SourceType.url, value: url);
@@ -224,10 +223,7 @@ class AudioPlaybackService {
     _loadCompleter = Completer<void>();
     try {
       final loadedDuration = await _audioPlayer.setFilePath(filePath);
-      log(
-        'Loaded audio from file: $filePath',
-        name: 'AudioPlaybackService',
-      );
+      log('Loaded audio from file: $filePath', name: 'AudioPlaybackService');
       _lastSource = (type: _SourceType.file, value: filePath);
       return loadedDuration;
     } catch (e) {
@@ -252,24 +248,34 @@ class AudioPlaybackService {
     if (_isDisposed) return null;
     _loadCompleter = Completer<void>();
     try {
-      final UriAudioSource child;
-      if (config.isAsset) {
-        child = AudioSource.asset(config.uri);
-      } else if (config.isFile) {
-        child = AudioSource.file(config.uri);
-      } else {
-        child = AudioSource.uri(Uri.parse(config.uri));
-      }
-
       final AudioSource source;
-      if (config.isClipped) {
+      if (config.isAsset) {
+        final child = AudioSource.asset(config.uri);
+        source = config.isClipped
+            ? ClippingAudioSource(
+                child: child,
+                start: config.start,
+                end: config.end,
+              )
+            : child;
+      } else if (config.isFile) {
+        final child = AudioSource.file(config.uri);
+        source = config.isClipped
+            ? ClippingAudioSource(
+                child: child,
+                start: config.start,
+                end: config.end,
+              )
+            : child;
+      } else if (config.isClipped) {
+        final child = AudioSource.uri(Uri.parse(config.uri));
         source = ClippingAudioSource(
           child: child,
           start: config.start,
           end: config.end,
         );
       } else {
-        source = child;
+        source = _networkAudioSource(config.uri);
       }
 
       final loadedDuration = await _audioPlayer.setAudioSource(source);
@@ -290,6 +296,15 @@ class AudioPlaybackService {
       _loadCompleter?.complete();
       _loadCompleter = null;
     }
+  }
+
+  AudioSource _networkAudioSource(String uri) {
+    final parsedUri = Uri.parse(uri);
+    if (parsedUri.scheme == 'http' || parsedUri.scheme == 'https') {
+      return LockCachingAudioSource(parsedUri);
+    }
+
+    return AudioSource.uri(parsedUri);
   }
 
   /// Starts audio playback.
@@ -401,11 +416,7 @@ class AudioPlaybackService {
         name: 'AudioPlaybackService',
       );
     } catch (e) {
-      log(
-        'Failed to set volume: $e',
-        name: 'AudioPlaybackService',
-        level: 900,
-      );
+      log('Failed to set volume: $e', name: 'AudioPlaybackService', level: 900);
       rethrow;
     }
   }
@@ -527,10 +538,7 @@ class AudioPlaybackService {
         ),
       );
 
-      log(
-        'Reset audio session to default',
-        name: 'AudioPlaybackService',
-      );
+      log('Reset audio session to default', name: 'AudioPlaybackService');
     } on Exception catch (e) {
       log(
         'Failed to reset audio session: $e',
@@ -552,10 +560,7 @@ class AudioPlaybackService {
     await _headphonesConnectedSubject.close();
     await _audioPlayer.dispose();
 
-    log(
-      'AudioPlaybackService disposed',
-      name: 'AudioPlaybackService',
-    );
+    log('AudioPlaybackService disposed', name: 'AudioPlaybackService');
   }
 
   /// Returns `true` if the error is a transient "Loading interrupted" error

--- a/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates setClip, playback controls, completionStream, dispose
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -58,6 +59,66 @@ Future<HttpClientResponse> _okHttpResponse(Invocation _) async =>
 
 Future<HttpClientResponse> _notFoundHttpResponse(Invocation _) async =>
     _FakeHttpClientResponse(HttpStatus.notFound, const []);
+
+/// A `List<int>` that reports an arbitrary [length] without allocating
+/// any backing storage. Used to drive the maxBytes guard in the default
+/// remote audio loader without allocating ~50 MB of real bytes.
+class _FakeOversizedChunk with ListMixin<int> {
+  _FakeOversizedChunk(this._length);
+
+  final int _length;
+
+  @override
+  int get length => _length;
+
+  @override
+  set length(int newLength) => throw UnsupportedError('readonly');
+
+  @override
+  int operator [](int index) => 0;
+
+  @override
+  void operator []=(int index, int value) => throw UnsupportedError('readonly');
+}
+
+/// HTTP response that yields a single fake chunk reporting [byteCount]
+/// bytes. Never materializes the bytes — useful for size-limit tests.
+class _OversizedHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  _OversizedHttpClientResponse(this.byteCount);
+
+  final int byteCount;
+
+  @override
+  int get statusCode => HttpStatus.ok;
+
+  @override
+  int get contentLength => byteCount;
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return Stream<List<int>>.fromIterable([
+      _FakeOversizedChunk(byteCount),
+    ]).listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 Future<HttpClientRequest> Function(Invocation) _httpRequestAnswer(
   HttpClientRequest request,
@@ -435,6 +496,41 @@ void main() {
               createHttpClient: _httpClientFactory(mockHttpClient),
             ),
             throwsA(isA<HttpException>()),
+          );
+        },
+      );
+
+      test(
+        'throws when the default network loader exceeds the byte limit',
+        () async {
+          final mockHttpClient = _MockHttpClient();
+          final mockRequest = _MockHttpClientRequest();
+          when(
+            () => mockHttpClient.getUrl(any()),
+          ).thenAnswer(_httpRequestAnswer(mockRequest));
+          // 50 MiB + 1 byte — exceeds the loader's hard cap.
+          when(mockRequest.close).thenAnswer(
+            (_) async => _OversizedHttpClientResponse(50 * 1024 * 1024 + 1),
+          );
+
+          await expectLater(
+            HttpOverrides.runZoned(
+              () => player.setClip(
+                const AudioSourceConfig.network(
+                  'https://example.com/huge.m4a',
+                  start: Duration.zero,
+                  end: Duration(seconds: 2),
+                ),
+              ),
+              createHttpClient: _httpClientFactory(mockHttpClient),
+            ),
+            throwsA(
+              isA<HttpException>().having(
+                (e) => e.message,
+                'message',
+                contains('byte limit'),
+              ),
+            ),
           );
         },
       );

--- a/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
@@ -11,12 +11,69 @@ import 'package:sound_service/sound_service.dart';
 
 class _MockAudioPlayer extends Mock implements AudioPlayer {}
 
+class _MockHttpClient extends Mock implements HttpClient {}
+
+class _MockHttpClientRequest extends Mock implements HttpClientRequest {}
+
 class _FakeAudioSource extends Fake implements AudioSource {}
+
+class _FakeHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  _FakeHttpClientResponse(this.statusCode, List<int> bytes)
+    : _bytes = List<int>.unmodifiable(bytes);
+
+  @override
+  final int statusCode;
+
+  final List<int> _bytes;
+
+  @override
+  int get contentLength => _bytes.length;
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return Stream<List<int>>.fromIterable([_bytes]).listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<HttpClientResponse> _okHttpResponse(Invocation _) async =>
+    _FakeHttpClientResponse(HttpStatus.ok, const [1, 2, 3, 4]);
+
+Future<HttpClientResponse> _notFoundHttpResponse(Invocation _) async =>
+    _FakeHttpClientResponse(HttpStatus.notFound, const []);
+
+Future<HttpClientRequest> Function(Invocation) _httpRequestAnswer(
+  HttpClientRequest request,
+) {
+  return (_) async => request;
+}
+
+HttpClient Function(SecurityContext?) _httpClientFactory(HttpClient client) {
+  return (_) => client;
+}
 
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeAudioSource());
     registerFallbackValue(Duration.zero);
+    registerFallbackValue(Uri.parse('https://example.com'));
   });
 
   group(AudioClipPlayer, () {
@@ -184,6 +241,207 @@ void main() {
         },
       );
 
+      test(
+        'clears cached remote file when switching away from network audio',
+        () async {
+          late File cachedFile;
+          late File siblingFile;
+          player = AudioClipPlayer(
+            audioPlayer: mockAudioPlayer,
+            remoteAudioFileLoader: (uri, existingFile, existingUri) async {
+              final dir = Directory.systemTemp.createTempSync(
+                'audio_clip_test_',
+              );
+              siblingFile = File('${dir.path}/keep.txt')
+                ..writeAsStringSync('keep', flush: true);
+              return cachedFile = File('${dir.path}/clip.mp3')
+                ..writeAsBytesSync(const [1, 2, 3], flush: true);
+            },
+          );
+
+          await player.setClip(
+            const AudioSourceConfig.network(
+              'https://example.com/audio.mp3',
+              start: Duration(seconds: 1),
+              end: Duration(seconds: 5),
+            ),
+          );
+
+          await player.setClip(
+            const AudioSourceConfig.asset(
+              'assets/sounds/clip.mp3',
+              start: Duration.zero,
+              end: Duration(seconds: 3),
+            ),
+          );
+
+          expect(cachedFile.existsSync(), isFalse);
+          expect(siblingFile.existsSync(), isTrue);
+        },
+      );
+
+      test(
+        'downloads and caches network audio with the default loader',
+        () async {
+          final mockHttpClient = _MockHttpClient();
+          final mockRequest = _MockHttpClientRequest();
+          when(
+            () => mockHttpClient.getUrl(any()),
+          ).thenAnswer(_httpRequestAnswer(mockRequest));
+          when(mockRequest.close).thenAnswer(_okHttpResponse);
+
+          await HttpOverrides.runZoned(
+            () => player.setClip(
+              const AudioSourceConfig.network(
+                'https://example.com/remote clip.m4a',
+                start: Duration.zero,
+                end: Duration(seconds: 2),
+              ),
+            ),
+            createHttpClient: _httpClientFactory(mockHttpClient),
+          );
+
+          final capturedSource =
+              verify(
+                    () => mockAudioPlayer.setAudioSource(captureAny()),
+                  ).captured.single
+                  as ClippingAudioSource;
+          expect(capturedSource.child.uri.scheme, 'file');
+          expect(
+            capturedSource.child.uri.pathSegments.last,
+            'remote_clip.m4a',
+          );
+        },
+      );
+
+      test(
+        'reuses the default cached file for repeated network clips',
+        () async {
+          final mockHttpClient = _MockHttpClient();
+          final mockRequest = _MockHttpClientRequest();
+          when(
+            () => mockHttpClient.getUrl(any()),
+          ).thenAnswer(_httpRequestAnswer(mockRequest));
+          when(mockRequest.close).thenAnswer(_okHttpResponse);
+
+          const uri = 'https://example.com';
+
+          await HttpOverrides.runZoned(
+            () => player.setClip(
+              const AudioSourceConfig.network(
+                uri,
+                start: Duration.zero,
+                end: Duration(seconds: 2),
+              ),
+            ),
+            createHttpClient: _httpClientFactory(mockHttpClient),
+          );
+          await HttpOverrides.runZoned(
+            () => player.setClip(
+              const AudioSourceConfig.network(
+                uri,
+                start: Duration(seconds: 1),
+                end: Duration(seconds: 3),
+              ),
+            ),
+            createHttpClient: _httpClientFactory(mockHttpClient),
+          );
+
+          final capturedSources = verify(
+            () => mockAudioPlayer.setAudioSource(captureAny()),
+          ).captured.cast<ClippingAudioSource>();
+          expect(capturedSources, hasLength(2));
+          expect(
+            capturedSources.first.child.uri.path,
+            capturedSources.last.child.uri.path,
+          );
+          expect(
+            capturedSources.last.child.uri.pathSegments.last,
+            'audio_clip',
+          );
+          verify(() => mockHttpClient.getUrl(any())).called(1);
+        },
+      );
+
+      test(
+        'replaces the default cached file when the network URI changes',
+        () async {
+          final mockHttpClient = _MockHttpClient();
+          final mockRequest = _MockHttpClientRequest();
+          when(
+            () => mockHttpClient.getUrl(any()),
+          ).thenAnswer(_httpRequestAnswer(mockRequest));
+          when(mockRequest.close).thenAnswer(_okHttpResponse);
+
+          await HttpOverrides.runZoned(
+            () => player.setClip(
+              const AudioSourceConfig.network(
+                'https://example.com/first.m4a',
+                start: Duration.zero,
+                end: Duration(seconds: 2),
+              ),
+            ),
+            createHttpClient: _httpClientFactory(mockHttpClient),
+          );
+
+          final firstSource =
+              verify(
+                    () => mockAudioPlayer.setAudioSource(captureAny()),
+                  ).captured.single
+                  as ClippingAudioSource;
+          final firstFile = File(firstSource.child.uri.toFilePath());
+          expect(firstFile.existsSync(), isTrue);
+
+          await HttpOverrides.runZoned(
+            () => player.setClip(
+              const AudioSourceConfig.network(
+                'https://example.com/second.m4a',
+                start: Duration.zero,
+                end: Duration(seconds: 2),
+              ),
+            ),
+            createHttpClient: _httpClientFactory(mockHttpClient),
+          );
+
+          final secondSource =
+              verify(
+                    () => mockAudioPlayer.setAudioSource(captureAny()),
+                  ).captured.last
+                  as ClippingAudioSource;
+          expect(
+            secondSource.child.uri.path,
+            isNot(firstSource.child.uri.path),
+          );
+          expect(firstFile.existsSync(), isFalse);
+        },
+      );
+
+      test(
+        'throws when the default network loader gets a non-success response',
+        () async {
+          final mockHttpClient = _MockHttpClient();
+          final mockRequest = _MockHttpClientRequest();
+          when(
+            () => mockHttpClient.getUrl(any()),
+          ).thenAnswer(_httpRequestAnswer(mockRequest));
+          when(mockRequest.close).thenAnswer(_notFoundHttpResponse);
+
+          await expectLater(
+            HttpOverrides.runZoned(
+              () => player.setClip(
+                const AudioSourceConfig.network(
+                  'https://example.com/missing.m4a',
+                  start: Duration.zero,
+                  end: Duration(seconds: 2),
+                ),
+              ),
+              createHttpClient: _httpClientFactory(mockHttpClient),
+            ),
+            throwsA(isA<HttpException>()),
+          );
+        },
+      );
+
       test('sets asset audio source', () async {
         await player.setClip(
           const AudioSourceConfig.asset(
@@ -256,6 +514,30 @@ void main() {
 
         // Should not throw — error is caught and logged.
         await expectLater(player.dispose(), completes);
+      });
+
+      test('deletes cached remote file during dispose', () async {
+        late File cachedFile;
+        player = AudioClipPlayer(
+          audioPlayer: mockAudioPlayer,
+          remoteAudioFileLoader: (uri, existingFile, existingUri) async {
+            final dir = Directory.systemTemp.createTempSync('audio_clip_test_');
+            return cachedFile = File('${dir.path}/clip.mp3')
+              ..writeAsBytesSync(const [1, 2, 3], flush: true);
+          },
+        );
+
+        await player.setClip(
+          const AudioSourceConfig.network(
+            'https://example.com/audio.mp3',
+            start: Duration.zero,
+            end: Duration(seconds: 2),
+          ),
+        );
+
+        await player.dispose();
+
+        expect(cachedFile.existsSync(), isFalse);
       });
     });
   });

--- a/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
@@ -307,10 +307,7 @@ void main() {
                   ).captured.single
                   as ClippingAudioSource;
           expect(capturedSource.child.uri.scheme, 'file');
-          expect(
-            capturedSource.child.uri.pathSegments.last,
-            'remote_clip.m4a',
-          );
+          expect(capturedSource.child.uri.pathSegments.last, 'remote_clip.m4a');
         },
       );
 
@@ -515,6 +512,39 @@ void main() {
         // Should not throw — error is caught and logged.
         await expectLater(player.dispose(), completes);
       });
+
+      test(
+        'still deletes cached remote file when audio player dispose throws',
+        () async {
+          late File cachedFile;
+          player = AudioClipPlayer(
+            audioPlayer: mockAudioPlayer,
+            remoteAudioFileLoader: (uri, existingFile, existingUri) async {
+              final dir = Directory.systemTemp.createTempSync(
+                'audio_clip_test_',
+              );
+              return cachedFile = File('${dir.path}/clip.mp3')
+                ..writeAsBytesSync(const [1, 2, 3], flush: true);
+            },
+          );
+
+          await player.setClip(
+            const AudioSourceConfig.network(
+              'https://example.com/audio.mp3',
+              start: Duration.zero,
+              end: Duration(seconds: 2),
+            ),
+          );
+
+          when(
+            () => mockAudioPlayer.dispose(),
+          ).thenThrow(Exception('dispose failed'));
+
+          await player.dispose();
+
+          expect(cachedFile.existsSync(), isFalse);
+        },
+      );
 
       test('deletes cached remote file during dispose', () async {
         late File cachedFile;

--- a/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates setClip, playback controls, completionStream, dispose
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart';
@@ -108,6 +109,18 @@ void main() {
 
     group('setClip', () {
       test('sets network audio source', () async {
+        var loaderCallCount = 0;
+        player = AudioClipPlayer(
+          audioPlayer: mockAudioPlayer,
+          remoteAudioFileLoader: (uri, cachedFile, cachedUri) async {
+            loaderCallCount++;
+            final dir = Directory.systemTemp.createTempSync('audio_clip_test_');
+            final file = File('${dir.path}/clip.mp3')
+              ..writeAsBytesSync(const [1, 2, 3], flush: true);
+            return file;
+          },
+        );
+
         await player.setClip(
           const AudioSourceConfig.network(
             'https://example.com/audio.mp3',
@@ -116,8 +129,60 @@ void main() {
           ),
         );
 
-        verify(() => mockAudioPlayer.setAudioSource(any())).called(1);
+        final capturedSource =
+            verify(
+                  () => mockAudioPlayer.setAudioSource(captureAny()),
+                ).captured.single
+                as ClippingAudioSource;
+        expect(capturedSource.child.uri.scheme, 'file');
+        expect(loaderCallCount, 1);
       });
+
+      test(
+        'reuses cached file for repeated network clips from same URI',
+        () async {
+          File? cachedFile;
+          var loaderCallCount = 0;
+          player = AudioClipPlayer(
+            audioPlayer: mockAudioPlayer,
+            remoteAudioFileLoader: (uri, existingFile, existingUri) async {
+              loaderCallCount++;
+              if (existingFile != null &&
+                  existingUri == uri &&
+                  existingFile.existsSync()) {
+                return existingFile;
+              }
+
+              final dir = Directory.systemTemp.createTempSync(
+                'audio_clip_test_',
+              );
+              cachedFile = File('${dir.path}/clip.mp3');
+              cachedFile!.writeAsBytesSync(const [1, 2, 3], flush: true);
+              return cachedFile!;
+            },
+          );
+
+          const source = AudioSourceConfig.network(
+            'https://example.com/audio.mp3',
+            start: Duration(seconds: 1),
+            end: Duration(seconds: 5),
+          );
+
+          await player.setClip(source);
+          await player.setClip(
+            const AudioSourceConfig.network(
+              'https://example.com/audio.mp3',
+              start: Duration(seconds: 2),
+              end: Duration(seconds: 6),
+            ),
+          );
+
+          verify(() => mockAudioPlayer.setAudioSource(any())).called(2);
+          expect(loaderCallCount, 2);
+          expect(cachedFile, isNotNull);
+          expect(cachedFile!.existsSync(), isTrue);
+        },
+      );
 
       test('sets asset audio source', () async {
         await player.setClip(

--- a/mobile/packages/sound_service/test/src/audio_playback_service_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_playback_service_test.dart
@@ -5,8 +5,10 @@
 // but no stable alternative exists. Tracked: github.com/ryanheise/audio_session
 // ignore_for_file: experimental_member_use
 import 'dart:async';
+import 'dart:io';
 
 import 'package:audio_session/audio_session.dart' as audio_session;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:mocktail/mocktail.dart';
@@ -29,13 +31,27 @@ class _FakeAudioDevice extends Fake implements audio_session.AudioDevice {
 }
 
 void main() {
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+
   setUpAll(() {
     TestWidgetsFlutterBinding.ensureInitialized();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+          if (call.method == 'getTemporaryDirectory') {
+            return Directory.systemTemp.path;
+          }
+          return null;
+        });
     registerFallbackValue(_FakeAudioSource());
     registerFallbackValue(Duration.zero);
     registerFallbackValue('');
     registerFallbackValue(0.0);
     registerFallbackValue(_FakeAudioSessionConfig());
+  });
+
+  tearDownAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
   });
 
   group(AudioPlaybackService, () {
@@ -86,7 +102,7 @@ void main() {
     test('loadAudio loads audio from URL', () async {
       const testUrl = 'https://example.com/audio.aac';
       when(
-        () => mockPlayer.setUrl(testUrl),
+        () => mockPlayer.setAudioSource(any()),
       ).thenAnswer((_) async => const Duration(seconds: 10));
 
       service = AudioPlaybackService(
@@ -95,7 +111,10 @@ void main() {
       );
       final duration = await service.loadAudio(testUrl);
 
-      verify(() => mockPlayer.setUrl(testUrl)).called(1);
+      final capturedSource =
+          verify(() => mockPlayer.setAudioSource(captureAny())).captured.single
+              as AudioSource;
+      expect(capturedSource, isA<LockCachingAudioSource>());
       expect(duration, const Duration(seconds: 10));
     });
 
@@ -145,7 +164,10 @@ void main() {
         const AudioSourceConfig.network('https://example.com/audio.mp3'),
       );
 
-      verify(() => mockPlayer.setAudioSource(any())).called(1);
+      final capturedSource =
+          verify(() => mockPlayer.setAudioSource(captureAny())).captured.single
+              as AudioSource;
+      expect(capturedSource, isA<LockCachingAudioSource>());
       expect(duration, const Duration(seconds: 20));
     });
 
@@ -413,7 +435,7 @@ void main() {
 
     test('loadAudio rethrows on error', () async {
       when(
-        () => mockPlayer.setUrl(any()),
+        () => mockPlayer.setAudioSource(any()),
       ).thenThrow(Exception('Network error'));
 
       service = AudioPlaybackService(
@@ -495,9 +517,7 @@ void main() {
     });
 
     test('seek rethrows on error', () async {
-      when(
-        () => mockPlayer.seek(any()),
-      ).thenThrow(Exception('Seek failed'));
+      when(() => mockPlayer.seek(any())).thenThrow(Exception('Seek failed'));
 
       service = AudioPlaybackService(
         audioPlayer: mockPlayer,
@@ -576,7 +596,7 @@ void main() {
       'play retries and succeeds after Loading interrupted with URL source',
       () async {
         when(
-          () => mockPlayer.setUrl(any()),
+          () => mockPlayer.setAudioSource(any()),
         ).thenAnswer((_) async => const Duration(seconds: 10));
 
         var playCallCount = 0;
@@ -600,10 +620,6 @@ void main() {
     test(
       'play rethrows after Loading interrupted when reload also fails',
       () async {
-        when(
-          () => mockPlayer.setUrl(any()),
-        ).thenAnswer((_) async => const Duration(seconds: 10));
-
         var playCallCount = 0;
         when(() => mockPlayer.play()).thenAnswer((_) async {
           if (playCallCount++ == 0) {
@@ -611,10 +627,10 @@ void main() {
           }
         });
 
-        // Reload (setUrl) throws on the second call
-        var setUrlCallCount = 0;
-        when(() => mockPlayer.setUrl(any())).thenAnswer((_) async {
-          if (setUrlCallCount++ > 0) throw Exception('Reload failed');
+        // Reload throws on the second load attempt.
+        var setSourceCallCount = 0;
+        when(() => mockPlayer.setAudioSource(any())).thenAnswer((_) async {
+          if (setSourceCallCount++ > 0) throw Exception('Reload failed');
           return const Duration(seconds: 10);
         });
 
@@ -680,30 +696,27 @@ void main() {
       },
     );
 
-    test(
-      'seek retries and succeeds after Loading interrupted',
-      () async {
-        when(
-          () => mockPlayer.setUrl(any()),
-        ).thenAnswer((_) async => const Duration(seconds: 10));
+    test('seek retries and succeeds after Loading interrupted', () async {
+      when(
+        () => mockPlayer.setAudioSource(any()),
+      ).thenAnswer((_) async => const Duration(seconds: 10));
 
-        var seekCallCount = 0;
-        when(() => mockPlayer.seek(any())).thenAnswer((_) async {
-          if (seekCallCount++ == 0) {
-            throw Exception('Loading interrupted');
-          }
-        });
+      var seekCallCount = 0;
+      when(() => mockPlayer.seek(any())).thenAnswer((_) async {
+        if (seekCallCount++ == 0) {
+          throw Exception('Loading interrupted');
+        }
+      });
 
-        service = AudioPlaybackService(
-          audioPlayer: mockPlayer,
-          audioSessionWrapper: mockSessionWrapper,
-        );
-        await service.loadAudio('https://example.com/audio.mp3');
-        await service.seek(const Duration(seconds: 5));
+      service = AudioPlaybackService(
+        audioPlayer: mockPlayer,
+        audioSessionWrapper: mockSessionWrapper,
+      );
+      await service.loadAudio('https://example.com/audio.mp3');
+      await service.seek(const Duration(seconds: 5));
 
-        verify(() => mockPlayer.seek(any())).called(2);
-      },
-    );
+      verify(() => mockPlayer.seek(any())).called(2);
+    });
   });
 
   group('AudioPlaybackService headphone detection', () {
@@ -1190,7 +1203,7 @@ void main() {
       final result = await service.loadAudio('https://example.com/audio.aac');
 
       expect(result, isNull);
-      verifyNever(() => mockPlayer.setUrl(any()));
+      verifyNever(() => mockPlayer.setAudioSource(any()));
     });
 
     test('loadAudioFromFile returns null after dispose', () async {

--- a/mobile/packages/sound_service/test/src/audio_playback_service_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_playback_service_test.dart
@@ -195,6 +195,30 @@ void main() {
       },
     );
 
+    test('setAudioSource creates clipped source from file path', () async {
+      when(
+        () => mockPlayer.setAudioSource(any()),
+      ).thenAnswer((_) async => const Duration(seconds: 5));
+
+      service = AudioPlaybackService(
+        audioPlayer: mockPlayer,
+        audioSessionWrapper: mockSessionWrapper,
+      );
+      final duration = await service.setAudioSource(
+        const AudioSourceConfig.file(
+          '/path/to/local.mp3',
+          start: Duration(seconds: 1),
+          end: Duration(seconds: 4),
+        ),
+      );
+
+      final capturedSource =
+          verify(() => mockPlayer.setAudioSource(captureAny())).captured.single
+              as ClippingAudioSource;
+      expect(capturedSource.child.uri.scheme, 'file');
+      expect(duration, const Duration(seconds: 5));
+    });
+
     test('setAudioSource sets audio source from file path', () async {
       when(
         () => mockPlayer.setAudioSource(any()),
@@ -210,6 +234,51 @@ void main() {
 
       verify(() => mockPlayer.setAudioSource(any())).called(1);
       expect(duration, const Duration(seconds: 12));
+    });
+
+    test('setAudioSource keeps non-http URIs as direct URI sources', () async {
+      when(
+        () => mockPlayer.setAudioSource(any()),
+      ).thenAnswer((_) async => const Duration(seconds: 7));
+
+      service = AudioPlaybackService(
+        audioPlayer: mockPlayer,
+        audioSessionWrapper: mockSessionWrapper,
+      );
+      final duration = await service.setAudioSource(
+        const AudioSourceConfig.network('ftp://example.com/audio.mp3'),
+      );
+
+      final capturedSource =
+          verify(() => mockPlayer.setAudioSource(captureAny())).captured.single
+              as UriAudioSource;
+      expect(capturedSource, isNot(isA<LockCachingAudioSource>()));
+      expect(capturedSource.uri.scheme, 'ftp');
+      expect(duration, const Duration(seconds: 7));
+    });
+
+    test('setAudioSource creates clipped source from network URI', () async {
+      when(
+        () => mockPlayer.setAudioSource(any()),
+      ).thenAnswer((_) async => const Duration(seconds: 6));
+
+      service = AudioPlaybackService(
+        audioPlayer: mockPlayer,
+        audioSessionWrapper: mockSessionWrapper,
+      );
+      final duration = await service.setAudioSource(
+        const AudioSourceConfig.network(
+          'https://example.com/audio.mp3',
+          start: Duration(seconds: 1),
+          end: Duration(seconds: 4),
+        ),
+      );
+
+      final capturedSource =
+          verify(() => mockPlayer.setAudioSource(captureAny())).captured.single
+              as ClippingAudioSource;
+      expect(capturedSource.child.uri.scheme, 'https');
+      expect(duration, const Duration(seconds: 6));
     });
 
     test('play starts playback', () async {

--- a/mobile/test/blocs/video_editor/audio_timing/audio_timing_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/audio_timing/audio_timing_cubit_test.dart
@@ -3,15 +3,58 @@
 // ABOUTME: and start offset calculation using mocktail AudioClipPlayer mocks.
 
 import 'dart:async';
+import 'dart:ui' show Size;
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_editor/audio_timing/audio_timing_cubit.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
 
 class _MockAudioClipPlayer extends Mock implements AudioClipPlayer {}
+
+/// Mock [ProVideoEditor] that returns canned metadata. Allows overriding
+/// the duration returned by [getMetadata] per test.
+class _MockProVideoEditor extends ProVideoEditor {
+  _MockProVideoEditor({
+    this.metadataDuration = const Duration(seconds: 30),
+    this.throwOnGetMetadata = false,
+  });
+
+  final Duration metadataDuration;
+  final bool throwOnGetMetadata;
+
+  int getMetadataCallCount = 0;
+  EditorVideo? lastMetadataSource;
+
+  @override
+  void initializeStream() {
+    // Intentional no-op: testing stub for ProVideoEditor.
+  }
+
+  @override
+  Future<VideoMetadata> getMetadata(
+    EditorVideo value, {
+    bool checkStreamingOptimization = false,
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    getMetadataCallCount++;
+    lastMetadataSource = value;
+    if (throwOnGetMetadata) {
+      throw Exception('mock failure');
+    }
+    return VideoMetadata(
+      duration: metadataDuration,
+      extension: 'mp3',
+      fileSize: 1024,
+      resolution: Size.zero,
+      rotation: 0,
+      bitrate: 128000,
+    );
+  }
+}
 
 /// Creates a test [AudioEvent] with optional overrides.
 AudioEvent _createTestSound({
@@ -55,9 +98,11 @@ void main() {
 
   group(AudioTimingCubit, () {
     late _MockAudioClipPlayer mockClipPlayer;
+    late _MockProVideoEditor mockProVideoEditor;
 
     setUp(() {
       mockClipPlayer = _MockAudioClipPlayer();
+      mockProVideoEditor = _MockProVideoEditor();
       when(
         () => mockClipPlayer.completionStream,
       ).thenAnswer((_) => const Stream.empty());
@@ -69,10 +114,14 @@ void main() {
       when(() => mockClipPlayer.dispose()).thenAnswer((_) async {});
     });
 
-    AudioTimingCubit buildCubit({AudioEvent? sound}) {
+    AudioTimingCubit buildCubit({
+      AudioEvent? sound,
+      ProVideoEditor? proVideoEditor,
+    }) {
       return AudioTimingCubit(
         sound: sound ?? _createTestSound(),
         clipPlayer: mockClipPlayer,
+        proVideoEditor: proVideoEditor ?? mockProVideoEditor,
       );
     }
 
@@ -147,7 +196,11 @@ void main() {
 
       blocTest<AudioTimingCubit, AudioTimingState>(
         'handles null duration gracefully',
-        build: () => buildCubit(sound: _createTestSound(duration: null)),
+        build: () => buildCubit(
+          sound: _createTestSound(duration: null),
+          // Force resolution to fail so audioDuration stays at 0.
+          proVideoEditor: _MockProVideoEditor(throwOnGetMetadata: true),
+        ),
         act: (cubit) => cubit.initialize(),
         expect: () => [
           isA<AudioTimingState>()
@@ -161,6 +214,66 @@ void main() {
             isTrue,
           ),
         ],
+      );
+
+      blocTest<AudioTimingCubit, AudioTimingState>(
+        'resolves missing duration via ProVideoEditor.getMetadata',
+        build: () => buildCubit(
+          sound: _createTestSound(duration: null),
+          proVideoEditor: _MockProVideoEditor(
+            metadataDuration: const Duration(seconds: 25),
+          ),
+        ),
+        act: (cubit) => cubit.initialize(),
+        expect: () => [
+          isA<AudioTimingState>()
+              .having((s) => s.audioDuration, 'audioDuration', 25)
+              .having((s) => s.startOffset, 'startOffset', 0),
+          isA<AudioTimingState>().having(
+            (s) => s.isPlaying,
+            'isPlaying',
+            isTrue,
+          ),
+        ],
+      );
+
+      blocTest<AudioTimingCubit, AudioTimingState>(
+        'falls back to 0 duration when ProVideoEditor.getMetadata throws',
+        build: () => buildCubit(
+          sound: _createTestSound(duration: null),
+          proVideoEditor: _MockProVideoEditor(throwOnGetMetadata: true),
+        ),
+        act: (cubit) => cubit.initialize(),
+        expect: () => [
+          isA<AudioTimingState>()
+              .having((s) => s.audioDuration, 'audioDuration', 0)
+              .having((s) => s.startOffset, 'startOffset', 0),
+          // Still emits isPlaying since play() is called even though
+          // setClippedAudioSource bails early for zero duration
+          isA<AudioTimingState>().having(
+            (s) => s.isPlaying,
+            'isPlaying',
+            isTrue,
+          ),
+        ],
+      );
+
+      test(
+        'skips ProVideoEditor lookup when sound has neither url nor asset',
+        () async {
+          final editor = _MockProVideoEditor();
+          final cubit = buildCubit(
+            sound: _createTestSound(duration: null, url: null),
+            proVideoEditor: editor,
+          );
+
+          await cubit.initialize();
+
+          expect(editor.getMetadataCallCount, equals(0));
+          expect(cubit.state.audioDuration, equals(0));
+
+          await cubit.close();
+        },
       );
 
       blocTest<AudioTimingCubit, AudioTimingState>(

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -7,11 +7,15 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:sound_service/sound_service.dart';
+
+class _MockAudioClipPlayer extends Mock implements AudioClipPlayer {}
 
 /// Mock ProVideoEditor to prevent calls to native platform.
 class _MockProVideoEditor extends ProVideoEditor {
@@ -92,6 +96,10 @@ AudioEvent _createTestAudioEvent({
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  setUpAll(() {
+    registerFallbackValue(const AudioSourceConfig.network(''));
+  });
+
   group('AudioTimingResult', () {
     test('$AudioTimingConfirmed holds updated sound', () {
       final sound = _createTestAudioEvent(title: 'Test Sound');
@@ -142,10 +150,20 @@ void main() {
 
   group(VideoAudioEditorTimingScreen, () {
     late _MockProVideoEditor mockEditor;
+    late _MockAudioClipPlayer mockClipPlayer;
 
     setUp(() {
       mockEditor = _MockProVideoEditor();
       ProVideoEditor.instance = mockEditor;
+      mockClipPlayer = _MockAudioClipPlayer();
+      when(
+        () => mockClipPlayer.completionStream,
+      ).thenAnswer((_) => const Stream.empty());
+      when(() => mockClipPlayer.setClip(any())).thenAnswer((_) async {});
+      when(() => mockClipPlayer.play()).thenAnswer((_) async {});
+      when(() => mockClipPlayer.pause()).thenAnswer((_) async {});
+      when(() => mockClipPlayer.stop()).thenAnswer((_) async {});
+      when(() => mockClipPlayer.dispose()).thenAnswer((_) async {});
     });
 
     Widget buildWidget({AudioEvent? sound, Locale? locale}) {
@@ -157,7 +175,10 @@ void main() {
           locale: locale,
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: VideoAudioEditorTimingScreen(sound: testSound),
+          home: VideoAudioEditorTimingScreen(
+            sound: testSound,
+            clipPlayer: mockClipPlayer,
+          ),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- switch remote audio loading in `AudioPlaybackService` from direct `setUrl()` to `LockCachingAudioSource` for HTTP(S) sources
- keep clipped network sources on the existing URI path, since `just_audio` clipping requires a `UriAudioSource` child in this version
- update `sound_service` tests to cover the caching source path and stub the temp-directory plugin used by the cache

## Root cause
iOS remote sound previews were going through direct progressive playback for `media.divine.video` audio URLs. When the media host ignored byte-range requests, AVFoundation failed with `(-11828) Cannot Open`.

## Validation
- `flutter test test/src/audio_playback_service_test.dart`
- `flutter analyze lib/src/audio_playback_service.dart test/src/audio_playback_service_test.dart`

Fixes #4139
