### PR TITLE
fix(feed): hydrate views/loops on New feed via bulk stats

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -589,10 +589,12 @@ class VideosRepository {
           limit: limit,
           until: until,
         );
+        // Hydrate views/loops — list endpoint omits them for some rows.
+        final hydrated = await _hydrateVideosWithBulkStats(videos);
         if (until == null) {
-          _inMemoryFeedCache?.set('latest', HomeFeedResult(videos: videos));
+          _inMemoryFeedCache?.set('latest', HomeFeedResult(videos: hydrated));
         }
-        return videos;
+        return hydrated;
       } on FunnelcakeException {
         // Fall through to Nostr
       }
@@ -603,10 +605,11 @@ class VideosRepository {
       limit: limit,
       until: until,
     );
+    final hydrated = await _hydrateVideosWithBulkStats(videos);
     if (until == null) {
-      _inMemoryFeedCache?.set('latest', HomeFeedResult(videos: videos));
+      _inMemoryFeedCache?.set('latest', HomeFeedResult(videos: hydrated));
     }
-    return videos;
+    return hydrated;
   }
 
   Future<List<VideoEvent>> _fetchVisibleRecentVideosFromStatsApi({

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -955,6 +955,160 @@ void main() {
           ).called(2);
         });
       });
+
+      group('bulk stats hydration', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+        late VideosRepository repositoryWithApi;
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+        });
+
+        test(
+          'hydrates Funnelcake videos that lack views with bulk stats',
+          () async {
+            when(
+              () => mockFunnelcakeClient.getRecentVideos(
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _createVideoStats(
+                  id: 'event-1',
+                  pubkey: 'author',
+                  dTag: 'dtag-1',
+                  videoUrl: 'https://example.com/video.mp4',
+                ),
+              ],
+            );
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+            ).thenAnswer(
+              (_) async => const BulkVideoStatsResponse(
+                stats: {
+                  'event-1': BulkVideoStatsEntry(
+                    eventId: 'event-1',
+                    reactions: 6,
+                    comments: 1,
+                    reposts: 0,
+                    views: 14,
+                    loops: 7,
+                  ),
+                },
+              ),
+            );
+
+            final result = await repositoryWithApi.getNewVideos();
+
+            expect(result, hasLength(1));
+            expect(result.first.rawTags['views'], equals('14'));
+            expect(result.first.totalLoops, equals(21));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+            ).called(1);
+          },
+        );
+
+        test(
+          'hydrates relay-fallback videos that lack views with bulk stats',
+          () async {
+            when(
+              () => mockFunnelcakeClient.getRecentVideos(
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenThrow(const FunnelcakeException('Network error'));
+
+            final relayEvent = _createVideoEvent(
+              id: 'relay-event',
+              pubkey: 'author',
+              videoUrl: 'https://example.com/relay.mp4',
+              createdAt: 1704067200,
+            );
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => [relayEvent]);
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats(['relay-event']),
+            ).thenAnswer(
+              (_) async => const BulkVideoStatsResponse(
+                stats: {
+                  'relay-event': BulkVideoStatsEntry(
+                    eventId: 'relay-event',
+                    reactions: 3,
+                    comments: 1,
+                    reposts: 0,
+                    views: 11,
+                  ),
+                },
+              ),
+            );
+
+            final result = await repositoryWithApi.getNewVideos();
+
+            expect(result, hasLength(1));
+            expect(result.first.rawTags['views'], equals('11'));
+            expect(result.first.totalLoops, equals(11));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats(['relay-event']),
+            ).called(1);
+          },
+        );
+
+        test('caches the hydrated videos, not the un-hydrated ones', () async {
+          final feedCache = InMemoryFeedCache();
+          final repoWithCache = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            inMemoryFeedCache: feedCache,
+          );
+          when(
+            () => mockFunnelcakeClient.getRecentVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'event-1',
+                pubkey: 'author',
+                dTag: 'dtag-1',
+                videoUrl: 'https://example.com/video.mp4',
+              ),
+            ],
+          );
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+          ).thenAnswer(
+            (_) async => const BulkVideoStatsResponse(
+              stats: {
+                'event-1': BulkVideoStatsEntry(
+                  eventId: 'event-1',
+                  reactions: 0,
+                  comments: 0,
+                  reposts: 0,
+                  views: 14,
+                ),
+              },
+            ),
+          );
+
+          await repoWithCache.getNewVideos();
+          final cached = await repoWithCache.getNewVideos();
+
+          expect(cached.first.rawTags['views'], equals('14'));
+          expect(cached.first.totalLoops, equals(14));
+          verify(
+            () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+          ).called(1);
+        });
+      });
     });
 
     group('getHomeFeedVideos', () {


### PR DESCRIPTION
## Summary
- `getNewVideos` was the only feed-fetch path that skipped `_hydrateVideosWithBulkStats`, so freshly published Nostr videos showed "0 loops" in the **New** feed even when Funnelcake's bulk-stats endpoint already reported view counts.
- The relay fallback path had the same gap.
- Run hydration on both paths and cache the hydrated result so subsequent fetches read the populated counts.

## Why
Reproduced on event `bc96ec17636e1df781d7522814c073dafaa615027cd78520ca719bf4ef3cff68`:
- `GET /api/videos/{id}/views` → `{"views":11,"unique_viewers":6}`
- `POST /api/videos/stats/bulk` → `{"views":14,"loops":7.67}`
- `GET /api/videos?sort=recent` → `loops:7, views:11`
- `GET /api/videos/{id}` → `stats` block has reactions/comments/reposts only, no `views`/`loops`

`VideoEvent.totalLoops = (originalLoops ?? 0) + parseInt(rawTags['views'] ?? '')`. For new videos, `originalLoops` is null (only set for archived Vine imports) and `rawTags['views']` only exists when a Funnelcake list payload included it or hydration filled it in. The New feed's path didn't run any hydration, so `totalLoops` evaluated to `0` despite real engagement on the bulk-stats endpoint.

Other feeds (`getHomeFeedVideos`, `getPopularVideos`, `getVideosByIds`, `fetchVideoWithStats*`) already call `_hydrateVideosWithBulkStats`. This brings `getNewVideos` in line.

## Test plan
- [x] `flutter test test/src/videos_repository_test.dart` (270 tests pass)
- [x] `flutter analyze packages/videos_repository` clean
- [x] `flutter test --coverage` from `packages/videos_repository`; `videos_repository.dart` at 100.00% line coverage
- [x] New tests cover Funnelcake-success path, relay-fallback path, and that the in-memory cache stores the hydrated (not raw) videos
- [ ] Manual: launch app, scroll the **New** feed, confirm a freshly published video shows non-zero loop counts within one bulk-stats round trip