### PR TITLE
fix(notifications): clear unread dot and list highlight when opening inbox

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -78,6 +78,15 @@ class NotificationFeedBloc
   }
 
   /// Handle initial load.
+  ///
+  /// After the page loads, immediately marks all unread notifications as read
+  /// so the "notification not going away" race condition is avoided. The
+  /// [NotificationsView] also dispatches [NotificationFeedMarkAllRead] from
+  /// its `initState`, but that event arrives before the async API call
+  /// completes — meaning the early-exit guard in [_onMarkAllRead] sees an
+  /// empty list and returns without doing anything. Performing the mark-read
+  /// step here, after the data is present, guarantees the unread state is
+  /// cleared regardless of event ordering.
   Future<void> _onStarted(
     NotificationFeedStarted event,
     Emitter<NotificationFeedState> emit,
@@ -87,14 +96,31 @@ class NotificationFeedBloc
     try {
       final page = await _notificationRepository.refresh();
 
+      final hasUnread =
+          page.unreadCount > 0 || page.items.any((n) => !n.isRead);
+
+      final readItems = hasUnread
+          ? page.items.map((n) {
+              if (n.isRead) return n;
+              return switch (n) {
+                VideoNotification() => n.copyWith(isRead: true),
+                ActorNotification() => n.copyWith(isRead: true),
+              };
+            }).toList()
+          : page.items;
+
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
-          notifications: _applyFollowState(page.items),
-          unreadCount: page.unreadCount,
+          notifications: _applyFollowState(readItems),
+          unreadCount: hasUnread ? 0 : page.unreadCount,
           hasMore: page.hasMore,
         ),
       );
+
+      if (hasUnread) {
+        unawaited(_notificationRepository.markAllAsRead());
+      }
     } catch (e, s) {
       addError(e, s);
       emit(state.copyWith(status: NotificationFeedStatus.failure));

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -11,6 +11,8 @@ import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_notifications_provider.dart'
+    show relayNotificationsProvider;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
@@ -51,10 +53,21 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     _scrollController.addListener(_onScroll);
 
     // Mark all notifications as read when the screen is opened.
+    //
+    // Two separate mark-read calls are needed because the inbox uses two
+    // independent systems:
+    //   1. NotificationFeedBloc — drives the list shown in this view.
+    //   2. relayNotificationsProvider — drives the nav-bar dot and the
+    //      "Notifications" badge on the inbox toggle.
+    // The BLoC handles its own read state; the Riverpod provider must be
+    // updated here so the nav dot clears immediately when the user opens
+    // the Notifications tab.
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       context.read<NotificationFeedBloc>().add(
         const NotificationFeedMarkAllRead(),
       );
+      ref.read(relayNotificationsProvider.notifier).markAllAsRead();
     });
   }
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -107,18 +107,21 @@ void main() {
     );
 
     group('NotificationFeedStarted', () {
-      final page = NotificationPage(
-        items: [_videoNotif()],
-        unreadCount: 1,
-        hasMore: true,
-      );
-
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'emits [loading, loaded] on success',
+        'marks all unread notifications as read immediately on load',
         setUp: () {
           when(
             () => mockNotificationRepo.refresh(),
-          ).thenAnswer((_) async => page);
+          ).thenAnswer(
+            (_) async => NotificationPage(
+              items: [_videoNotif(), _actorNotif()],
+              unreadCount: 2,
+              hasMore: true,
+            ),
+          );
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) async {});
         },
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
@@ -126,10 +129,42 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loading),
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
-            notifications: page.items,
-            unreadCount: 1,
+            notifications: [
+              _videoNotif(isRead: true),
+              _actorNotif(isRead: true),
+            ],
           ),
         ],
+        verify: (_) {
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'skips markAllAsRead when all notifications are already read',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.refresh(),
+          ).thenAnswer(
+            (_) async => NotificationPage(
+              items: [_videoNotif(isRead: true)],
+              unreadCount: 0,
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        expect: () => [
+          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [_videoNotif(isRead: true)],
+            hasMore: false,
+          ),
+        ],
+        verify: (_) {
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
+        },
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
@@ -818,6 +853,9 @@ void main() {
             ),
           );
           when(() => mockFollowRepo.isFollowing(pubkey)).thenReturn(true);
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) async {});
         },
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
@@ -831,9 +869,9 @@ void main() {
                 pubkey: pubkey,
                 displayName: 'Carol',
                 isFollowingBack: true,
+                isRead: true,
               ),
             ],
-            unreadCount: 1,
             hasMore: false,
           ),
         ],
@@ -890,6 +928,9 @@ void main() {
             ),
           );
           when(() => mockFollowRepo.isFollowing(pubkey)).thenReturn(true);
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) async {});
         },
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -19,6 +19,8 @@ import 'package:openvine/notifications/widgets/notification_empty_state.dart';
 import 'package:openvine/notifications/widgets/notification_list_item.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_notifications_provider.dart'
+    as relay_notifications;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -33,6 +35,17 @@ class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
+/// Stub [RelayNotifications] notifier that does nothing — prevents the real
+/// provider (which requires auth + network) from running in widget tests.
+class _StubRelayNotifications extends relay_notifications.RelayNotifications {
+  @override
+  Future<relay_notifications.NotificationFeedState> build() async =>
+      const relay_notifications.NotificationFeedState(notifications: []);
+
+  @override
+  Future<void> markAllAsRead() async {}
+}
+
 /// Pumps [NotificationsView] inside the required providers.
 Future<void> _pumpView(
   WidgetTester tester,
@@ -41,6 +54,11 @@ Future<void> _pumpView(
 }) async {
   await tester.pumpWidget(
     ProviderScope(
+      overrides: [
+        relay_notifications.relayNotificationsProvider.overrideWith(
+          _StubRelayNotifications.new,
+        ),
+      ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -85,6 +103,9 @@ Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
+        relay_notifications.relayNotificationsProvider.overrideWith(
+          _StubRelayNotifications.new,
+        ),
         videoEventServiceProvider.overrideWithValue(videoEventService),
         nostrServiceProvider.overrideWithValue(nostrClient),
         videosRepositoryProvider.overrideWithValue(videosRepository),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Two race conditions prevented notifications from being marked as read:

1. NotificationFeedMarkAllRead fired from initState before _onStarted finished loading data, so the early-exit guard saw an empty list and returned without calling markAllAsRead. Fixed by marking all unread items read inline in _onStarted after the page loads.

2. The nav-bar dot and inbox toggle badge are driven by relayNotificationsProvider (Riverpod), but the BLoC-driven inbox never updated that provider. Fixed by calling relayNotificationsProvider.notifier.markAllAsRead() from NotificationsView.initState alongside the existing BLoC event, so the dot clears immediately when the Notifications tab opens.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4048

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore