### PR TITLE
fix(share): always emit https URL, never nostr:nevent

### DIFF
--- a/mobile/lib/services/share_service.dart
+++ b/mobile/lib/services/share_service.dart
@@ -36,14 +36,11 @@ class ShareService {
 
   /// Generate a web app link for a video.
   ///
-  /// Uses the web route only when the video has a real addressable `d` tag.
-  /// Otherwise falls back to a NIP-19 `nevent` link so this method never
-  /// returns a broken `divine.video/video/{eventId}` URL.
+  /// Always emits an `https://divine.video/video/...` URL. The route accepts
+  /// raw event IDs, d-tags, and NIP-19 references, and [VideoEvent.stableId]
+  /// falls back to the event ID when a `d` tag is missing.
   String generateWebLink(VideoEvent video) {
-    if (_hasWebShareableRoute(video)) {
-      return '$_appUrl/video/${video.stableId}';
-    }
-    return generateNostrEventLink(video);
+    return '$_appUrl/video/${video.stableId}';
   }
 
   /// Generate shareable text content.
@@ -51,11 +48,6 @@ class ShareService {
   /// Returns only the web link so users can add their own context.
   String generateShareText(VideoEvent video) {
     return generateWebLink(video);
-  }
-
-  bool _hasWebShareableRoute(VideoEvent video) {
-    final routeId = video.rawTags['d'];
-    return routeId != null && routeId.isNotEmpty;
   }
 
   /// Copy link to clipboard

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -289,19 +288,12 @@ class VideoSharingService {
 
   /// Generate external share URL for the video.
   ///
-  /// Uses the web route only when the video has a real addressable `d` tag.
-  /// Otherwise falls back to a NIP-19 `nevent` link so sharing never emits a
-  /// non-routable `divine.video/video/{eventId}` URL.
+  /// Always emits an `https://divine.video/video/...` URL. The route accepts
+  /// raw event IDs, d-tags, and NIP-19 references, and [VideoEvent.stableId]
+  /// falls back to the event ID when a `d` tag is missing — so this never
+  /// returns a non-routable URL.
   String generateShareUrl(VideoEvent video) {
-    const baseUrl = 'https://divine.video';
-    if (_hasWebShareableRoute(video)) {
-      return '$baseUrl/video/${video.stableId}';
-    }
-
-    final nevent = NIP19Tlv.encodeNevent(
-      Nevent(id: video.id, author: video.pubkey),
-    );
-    return 'nostr:$nevent';
+    return 'https://divine.video/video/${video.stableId}';
   }
 
   /// Generate share text for external sharing (social media, etc.)
@@ -348,15 +340,9 @@ class VideoSharingService {
     };
   }
 
-  bool _hasWebShareableRoute(VideoEvent video) {
-    final routeId = video.rawTags['d'];
-    return routeId != null && routeId.isNotEmpty;
-  }
-
   /// Create the message content for sharing a video.
   ///
-  /// Uses the canonical share URL for the video, preferring a stable web route
-  /// and falling back to a Nostr `nevent` when no web route exists.
+  /// Uses the canonical share URL for the video.
   String _createShareMessage(VideoEvent video, String? personalMessage) {
     final buffer = StringBuffer();
 

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -8,7 +8,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
-import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -668,7 +667,7 @@ void main() {
       expect(url, equals('https://divine.video/video/my-vine-id'));
     });
 
-    test('generateShareUrl falls back to nostr nevent without a d tag', () {
+    test('generateShareUrl falls back to event id when d tag is missing', () {
       final now = DateTime.now();
       const eventId =
           'a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
@@ -683,8 +682,9 @@ void main() {
 
       final url = service.generateShareUrl(video);
 
-      expect(url, startsWith('nostr:nevent1'));
-      expect(NIP19Tlv.isNevent(url.replaceFirst('nostr:', '')), isTrue);
+      // Always emits an https URL — never a nostr: URI. The route
+      // handler accepts raw event IDs as well as d-tags / NIP-19 refs.
+      expect(url, equals('https://divine.video/video/$eventId'));
     });
 
     test('hasSharedWithRecently returns false for unknown user', () {


### PR DESCRIPTION
Closes #4152

## Description

Sharing a video sometimes produced `nostr:nevent1...` instead of an `https://divine.video/...` URL.

Two share builders both gated the web URL on the presence of `rawTags['d']` and fell back to a NIP-19 `nevent` otherwise:

- `mobile/lib/services/video_sharing_service.dart:295-305` — used by the BLoC-driven share sheet
- `mobile/lib/services/share_service.dart:42-47` — older share-options bottom sheet

The gate is dead weight:

- `VideoEvent.stableId` already returns `vineId ?? id`, and `vineId` itself falls back to the event ID when no `d` tag is present (`video_event.dart:589-595`). So `stableId` is never null.
- The `/video/:id` route handler explicitly accepts raw event IDs, d-tags, and NIP-19 references — see the docstring at `video_detail_screen.dart:41-42`.

`https://divine.video/video/${video.stableId}` is always routable.

## What changed

- Drop `_hasWebShareableRoute` and the `nostr:nevent` fallback in both services.
- Always return `https://divine.video/video/${video.stableId}`.
- Drop now-unused `nostr_sdk/nip19_tlv.dart` import from `video_sharing_service.dart` (and from its test).
- Users that explicitly want a Nostr link still get one via `generateNostrEventLink` / "Copy Nostr link" in the share bottom sheet — that code path is unchanged.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Out of scope (separate follow-up)

The same report mentioned a download failure. The user's exported logs
contain **zero entries** from `WatermarkDownloadService` /
`GallerySaveService` for the failed attempt — both flows are silent,
which is itself a problem. The download fix needs:

1. Add entry/exit logs to `downloadOriginal` and `_getVideoFile` so the
   next failure leaves a trace.
2. Then reproduce on iOS/Android and diagnose from the new logs.

Tracked separately so the share fix can ship now.

## Test plan

- [x] `flutter test test/services/video_sharing_service_test.dart` — 24 pass (1 updated assertion: `nostr:nevent1` → `https://divine.video/video/<eventId>` for the no-d-tag case)
- [x] `flutter test test/blocs/share_sheet/share_sheet_bloc_test.dart test/widgets/share_video_menu_comprehensive_test.dart test/widgets/video_feed_item/actions/share_action_button_test.dart` — 75 pass (mock callers unaffected)
- [x] `flutter analyze lib` — clean
- [ ] Manual: tap share on a video that lacks a `d` tag (e.g. older or unmigrated event) → confirm clipboard / share sheet now contains `https://divine.video/video/<id>` instead of `nostr:nevent1...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)