### PR TITLE
chore(download): add diagnostic logs to video-download flow

### DIFF
--- a/mobile/lib/services/gallery_save_service.dart
+++ b/mobile/lib/services/gallery_save_service.dart
@@ -71,6 +71,11 @@ class GallerySaveService {
     String albumName = 'Divine',
     VideoMetadata? metadata,
   }) async {
+    Log.info(
+      'saveVideoToGallery started: aspectRatio=$aspectRatio album=$albumName',
+      name: 'GallerySaveService',
+      category: LogCategory.video,
+    );
     // Declare filePath outside try so catch blocks can access it.
     String? resolvedPath;
 
@@ -114,6 +119,14 @@ class GallerySaveService {
       // On iOS, don't use album parameter - it requires full photo library access
       // With album, iOS shows a second permission dialog for full access
       // Without album, it only needs photosAddOnly permission
+      Log.info(
+        'saveVideoToGallery calling Gal.putVideo: '
+        'path=$resolvedPath size=${file.lengthSync()} '
+        'platform=$defaultTargetPlatform',
+        name: 'GallerySaveService',
+        category: LogCategory.video,
+      );
+
       final galFuture = (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS)
           ? Gal.putVideo(resolvedPath)
           : Gal.putVideo(resolvedPath, album: albumName);

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -99,6 +99,12 @@ class WatermarkDownloadService {
     required String watermarkText,
     required ValueChanged<WatermarkDownloadStage> onProgress,
   }) async {
+    Log.info(
+      'downloadWithWatermark started: videoId=${video.id}',
+      name: _logName,
+      category: LogCategory.video,
+    );
+
     String? tempOutputPath;
 
     try {
@@ -107,8 +113,20 @@ class WatermarkDownloadService {
 
       final videoFile = await _getVideoFile(video);
       if (videoFile == null) {
+        Log.warning(
+          'downloadWithWatermark failed at stage=downloading: '
+          '_getVideoFile returned null for videoId=${video.id}',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return const WatermarkDownloadFailure('Could not download video file');
       }
+      Log.info(
+        'downloadWithWatermark stage=downloading complete: '
+        'path=${videoFile.path}',
+        name: _logName,
+        category: LogCategory.video,
+      );
 
       // Stage 2: Generate watermark and render onto video
       onProgress(WatermarkDownloadStage.watermarking);
@@ -141,6 +159,12 @@ class WatermarkDownloadService {
       );
 
       if (tempOutputPath == null) {
+        Log.warning(
+          'downloadWithWatermark failed at stage=watermarking: '
+          '_renderWithWatermark returned null for videoId=${video.id}',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return const WatermarkDownloadFailure(
           'Failed to render watermarked video',
         );
@@ -154,9 +178,20 @@ class WatermarkDownloadService {
       );
 
       if (saveResult is GallerySavePermissionDenied) {
+        Log.warning(
+          'downloadWithWatermark stopped at stage=saving: permission denied',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return const WatermarkDownloadPermissionDenied();
       }
       if (saveResult is GallerySaveFailure) {
+        Log.warning(
+          'downloadWithWatermark failed at stage=saving: '
+          'reason=${saveResult.reason}',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return WatermarkDownloadFailure(
           'Gallery save failed: ${saveResult.reason}',
         );
@@ -196,14 +231,31 @@ class WatermarkDownloadService {
     required VideoEvent video,
     required ValueChanged<OriginalSaveStage> onProgress,
   }) async {
+    Log.info(
+      'downloadOriginal started: videoId=${video.id}',
+      name: _logName,
+      category: LogCategory.video,
+    );
+
     try {
       // Stage 1: Download / cache the video file
       onProgress(OriginalSaveStage.downloading);
 
       final videoFile = await _getVideoFile(video);
       if (videoFile == null) {
+        Log.warning(
+          'downloadOriginal failed at stage=downloading: '
+          '_getVideoFile returned null for videoId=${video.id}',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return const WatermarkDownloadFailure('Could not download video file');
       }
+      Log.info(
+        'downloadOriginal stage=downloading complete: path=${videoFile.path}',
+        name: _logName,
+        category: LogCategory.video,
+      );
 
       // Stage 2: Save directly to gallery (no watermark)
       onProgress(OriginalSaveStage.saving);
@@ -213,9 +265,19 @@ class WatermarkDownloadService {
       );
 
       if (saveResult is GallerySavePermissionDenied) {
+        Log.warning(
+          'downloadOriginal stopped at stage=saving: permission denied',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return const WatermarkDownloadPermissionDenied();
       }
       if (saveResult is GallerySaveFailure) {
+        Log.warning(
+          'downloadOriginal failed at stage=saving: reason=${saveResult.reason}',
+          name: _logName,
+          category: LogCategory.video,
+        );
         return WatermarkDownloadFailure(
           'Gallery save failed: ${saveResult.reason}',
         );
@@ -240,6 +302,11 @@ class WatermarkDownloadService {
 
   /// Downloads or retrieves the cached video file.
   Future<File?> _getVideoFile(VideoEvent video) async {
+    Log.info(
+      '_getVideoFile started: videoId=${video.id} videoUrl=${video.videoUrl}',
+      name: _logName,
+      category: LogCategory.video,
+    );
     var cacheKey = video.id;
 
     // Check cache first — only use it when the file has a recognised video
@@ -286,8 +353,21 @@ class WatermarkDownloadService {
       );
       return null;
     }
+    Log.info(
+      '_getVideoFile resolved playable URL: $videoUrl',
+      name: _logName,
+      category: LogCategory.video,
+    );
 
     final file = await _mediaCache.cacheFile(videoUrl, key: cacheKey);
+
+    Log.info(
+      '_getVideoFile cacheFile returned: '
+      '${file == null ? "null" : "${file.path} (exists=${file.existsSync()}, "
+                "size=${file.existsSync() ? file.lengthSync() : -1})"}',
+      name: _logName,
+      category: LogCategory.video,
+    );
 
     return file;
   }


### PR DESCRIPTION
## Description

A user reported *"tried to download a video and it failed"* but their exported logs contained **zero entries** from `WatermarkDownloadService` or `GallerySaveService` for the failed attempt. Several silent-failure points in the flow return `WatermarkDownloadFailure` / `GallerySaveFailure` without logging anything — so we can't tell which stage actually broke (URL resolution, cache fetch, ProVideoEditor render, `Gal.putVideo`, permission, etc.).

This is purely an observability fix to unblock diagnosing the actual download bug. Once the next failure is captured we'll know which stage to fix.

## What changed

`Log.info` / `Log.warning` at every entry, exit, and early-return:

- **`downloadWithWatermark`**: entry, post-`_getVideoFile` success, each early-return failure (download / render / save permission / save failure)
- **`downloadOriginal`**: same shape
- **`_getVideoFile`**: entry (with `videoUrl`), resolved playable URL, `cacheFile` result (path / size / exists, or null)
- **`GallerySaveService.saveVideoToGallery`**: entry, just before `Gal.putVideo` with resolved path, file size, and target platform

## Type of Change

- [x] 🧹 Chore (no behavior change — observability only)

## Why now

Without these logs, diagnosing a download failure requires the user to be on a debugger or to add print statements to a debug build. With them, a normal log export captures the exact failure stage.

## Test plan

- [x] `flutter test test/services/watermark_download_service_test.dart test/services/gallery_save_service_test.dart` — 29 pass
- [x] `flutter analyze lib/services/watermark_download_service.dart lib/services/gallery_save_service.dart` — clean
- [ ] Manual: tap "Download" / "Save with watermark" on a video, verify the download log trail in `~/Downloads/openvine_full_logs_*.txt` shows entry → URL → cacheFile result → Gal.putVideo → result, and pinpoints the failure stage on a known-broken video.

## Follow-up

The next download-failure log capture will name a specific stage. The fix PR is gated on that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)