### PR TITLE
fix(test): re-enable Bucket E skipped tests (#3137)

### DIFF
--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -922,83 +922,84 @@ void main() {
         expect(pushedExtra?.id, equals('sound1'));
       });
 
-      testWidgets(
-        'navigating to detail stops current preview',
-        (tester) async {
-          final testSounds = [
-            createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
-          ];
+      testWidgets('navigating to detail stops current preview', (tester) async {
+        final testSounds = [
+          createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
+        ];
 
-          // Use completer to keep play() running so finally block doesn't reset state
-          final playCompleter = Completer<void>();
-          when(
-            () => mockAudioService.loadAudio(any()),
-          ).thenAnswer((_) async => const Duration(seconds: 6));
-          when(
-            () => mockAudioService.play(),
-          ).thenAnswer((_) => playCompleter.future);
-          when(() => mockAudioService.isPlaying).thenReturn(true);
+        // Use completer to keep play() running so finally block doesn't reset state
+        final playCompleter = Completer<void>();
+        when(
+          () => mockAudioService.loadAudio(any()),
+        ).thenAnswer((_) async => const Duration(seconds: 6));
+        when(
+          () => mockAudioService.play(),
+        ).thenAnswer((_) => playCompleter.future);
+        when(() => mockAudioService.isPlaying).thenReturn(true);
 
-          final mockGoRouter = MockGoRouter();
-          when(
-            () => mockGoRouter.push(any(), extra: any(named: 'extra')),
-          ).thenAnswer((_) async => null);
+        final mockGoRouter = MockGoRouter();
+        when(
+          () => mockGoRouter.push(any(), extra: any(named: 'extra')),
+        ).thenAnswer((_) async => null);
 
-          await tester.pumpWidget(
-            ProviderScope(
-              overrides: [
-                trendingSoundsProvider.overrideWith(
-                  () => MockTrendingSoundsNotifier(sounds: testSounds),
-                ),
-                audioPlaybackServiceProvider.overrideWithValue(
-                  mockAudioService,
-                ),
-              ],
-              child: MockGoRouterProvider(
-                goRouter: mockGoRouter,
-                child: MaterialApp(
-                  localizationsDelegates:
-                      AppLocalizations.localizationsDelegates,
-                  supportedLocales: AppLocalizations.supportedLocales,
-                  theme: VineTheme.theme,
-                  home: const SoundsScreen(),
-                ),
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              trendingSoundsProvider.overrideWith(
+                () => MockTrendingSoundsNotifier(sounds: testSounds),
+              ),
+              // Force empty bundled sounds so the all-sounds section contains
+              // exactly one tile (`sound1`); otherwise rootBundle pulls in
+              // bundled sounds and the play / chevron icon order becomes
+              // dependent on whatever the merged VGV runner cached for
+              // `assets/`. Sibling tests above use the same override.
+              soundLibraryServiceProvider.overrideWith(
+                (_) async => SoundLibraryService(),
+              ),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+            child: MockGoRouterProvider(
+              goRouter: mockGoRouter,
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: const SoundsScreen(),
               ),
             ),
-          );
+          ),
+        );
 
-          await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-          // First start a preview - play() stays pending
-          final playButtons = find.byIcon(Icons.play_arrow);
-          await tester.tap(playButtons.first);
-          await tester.pump();
+        // Address the preview / chevron buttons by their per-sound semantic
+        // identifiers so the test no longer depends on icon order in the tree.
+        final previewButton = find.bySemanticsLabel(
+          RegExp('^Preview Cool Beat'),
+        );
+        expect(previewButton, findsOneWidget);
 
-          // Clear previous interactions but keep mock setup
-          clearInteractions(mockAudioService);
-          when(() => mockAudioService.stop()).thenAnswer((_) async {});
+        await tester.tap(previewButton);
+        // Drain microtasks for stop()/loadAudio so _previewingSoundId is set
+        // before we tap the chevron — otherwise _stopPreview short-circuits.
+        await tester.pump();
+        await tester.pump();
 
-          // Now tap chevron to navigate
-          final chevronButtons = find.byIcon(Icons.chevron_right);
-          await tester.tap(chevronButtons.first);
+        clearInteractions(mockAudioService);
+        when(() => mockAudioService.stop()).thenAnswer((_) async {});
 
-          // Complete play() to avoid hanging
-          playCompleter.complete();
-          await tester.pumpAndSettle();
+        final detailButton = find.bySemanticsLabel(
+          'View details for Cool Beat',
+        );
+        expect(detailButton, findsOneWidget);
+        await tester.tap(detailButton);
 
-          // Verify stop was called when navigating away
-          verify(() => mockAudioService.stop()).called(greaterThanOrEqualTo(1));
-        },
-        // TODO(#3137): Order-dependent within its own file — passes only when
-        // earlier-group tests run first. Under VGV's merged suite with
-        // --test-randomize-ordering-seed random, tests from other files
-        // interleave and break the implicit ordering, so stop() is never
-        // observed on the mock. Re-enable after the SoundsScreen chevron
-        // handler assertion is made self-sufficient (likely by moving
-        // shared stubs into this group's setUp or an AudioPlaybackService
-        // fake). Sibling test below covers the navigation happy path.
-        skip: true,
-      );
+        // Complete play() to avoid hanging
+        playCompleter.complete();
+        await tester.pumpAndSettle();
+
+        verify(() => mockAudioService.stop()).called(greaterThanOrEqualTo(1));
+      });
 
       testWidgets('SoundDetailScreen displays sound information', (
         tester,

--- a/mobile/test/services/seed_media_preload_service_test.dart
+++ b/mobile/test/services/seed_media_preload_service_test.dart
@@ -11,7 +11,40 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 
 import '../mocks/mock_path_provider_platform.dart';
 
-@Tags(['skip_very_good_optimization'])
+/// Wires up a mock handler for `flutter/assets` so [rootBundle] reads return
+/// [manifestPayload] for the seed-media manifest path and [videoPayload] for
+/// any `.mp4` asset path. Returning [Uint8List] from a single source-of-truth
+/// here keeps the handler stable across [setUp] / test-body boundaries — see
+/// the `seed_data_preload_service_test.dart` pattern.
+void _mockSeedMediaAssets({
+  required String manifestPayload,
+  Uint8List? videoBytes,
+  bool Function(String assetName)? videoMatcher,
+}) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler('flutter/assets', (ByteData? message) async {
+        if (message == null) return null;
+        final assetName = utf8.decode(message.buffer.asUint8List());
+
+        if (assetName == 'assets/seed_media/manifest.json') {
+          final bytes = Uint8List.fromList(utf8.encode(manifestPayload));
+          return ByteData.sublistView(bytes);
+        }
+
+        if (videoBytes != null &&
+            (videoMatcher?.call(assetName) ?? assetName.endsWith('.mp4'))) {
+          return ByteData.sublistView(videoBytes);
+        }
+
+        return null;
+      });
+}
+
+void _clearAssetMock() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler('flutter/assets', null);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -20,47 +53,40 @@ void main() {
     late MockPathProviderPlatform mockPathProvider;
 
     setUp(() async {
-      // Create real temporary directory for testing
       tempDir = Directory.systemTemp.createTempSync('seed_media_test_');
 
-      // Setup mock path provider
       mockPathProvider = MockPathProviderPlatform();
       mockPathProvider.setTemporaryPath(tempDir.path);
       PathProviderPlatform.instance = mockPathProvider;
 
-      // Clear any cached service instance
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMessageHandler('flutter/assets', null);
+      // rootBundle caches across tests in the merged VGV runner. Drop any
+      // cached payloads so the per-test asset mock is always observed.
+      rootBundle.clear();
+      _clearAssetMock();
     });
 
     tearDown(() async {
-      // Clean up temp directory
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }
 
-      // Clear mock asset handler
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMessageHandler('flutter/assets', null);
+      rootBundle.clear();
+      _clearAssetMock();
     });
 
     test(
       'loadSeedMediaIfNeeded skips load when cache already populated',
       () async {
-        // Setup: Pre-populate cache directory with a marker file
         final cacheDir = Directory(
           path.join(tempDir.path, 'openvine_video_cache'),
         );
         await cacheDir.create(recursive: true);
 
-        // Create a marker file to simulate existing cache
         final markerFile = File(path.join(cacheDir.path, '.seed_media_loaded'));
         await markerFile.writeAsString('loaded');
 
-        // Act: Try to load seed media
         await SeedMediaPreloadService.loadSeedMediaIfNeeded();
 
-        // Assert: Should skip loading (verified by no errors and fast execution)
         expect(
           markerFile.existsSync(),
           isTrue,
@@ -72,7 +98,6 @@ void main() {
     test(
       'loadSeedMediaIfNeeded copies bundled videos to cache when empty',
       () async {
-        // Setup: Mock manifest.json asset
         final manifestJson = jsonEncode({
           'videos': [
             {
@@ -88,41 +113,13 @@ void main() {
           'generatedAt': '2025-11-10T00:00:00.000000',
         });
 
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMessageHandler('flutter/assets', (ByteData? message) async {
-              if (message == null) return null;
+        _mockSeedMediaAssets(
+          manifestPayload: manifestJson,
+          videoBytes: Uint8List.fromList([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        );
 
-              // Message is the asset name as UTF-8 bytes
-              final assetName = utf8.decode(message.buffer.asUint8List());
-
-              if (assetName.contains('manifest.json')) {
-                // Return manifest JSON as bytes
-                final bytes = Uint8List.fromList(utf8.encode(manifestJson));
-                return ByteData.sublistView(bytes);
-              } else if (assetName.contains('.mp4')) {
-                // Return fake video bytes
-                final bytes = Uint8List.fromList([
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                ]);
-                return ByteData.sublistView(bytes);
-              }
-
-              return null;
-            });
-
-        // Act: Load seed media
         await SeedMediaPreloadService.loadSeedMediaIfNeeded();
 
-        // Assert: Check marker file created
         final cacheDir = Directory(
           path.join(tempDir.path, 'openvine_video_cache'),
         );
@@ -133,23 +130,14 @@ void main() {
           reason: 'Marker file should be created after load',
         );
       },
-      // TODO(#3137): Flaky under merged VGV runner — the flutter/assets mock
-      // handler set inside the test body is sometimes observed as null by
-      // rootBundle.loadString before the service can read the manifest,
-      // causing the marker file to never be written. Same pattern as the
-      // already-skipped test below (line 247). Re-enable after the asset
-      // mock is moved into setUpAll or a dedicated AssetBundle override.
-      skip: true,
     );
 
     test('loadSeedMediaIfNeeded handles missing manifest gracefully', () async {
-      // Setup: Mock manifest not found by returning null
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMessageHandler('flutter/assets', (message) async {
-            return null; // Simulate asset not found
+            return null;
           });
 
-      // Act & Assert: Should not throw, just log error
       expect(
         () async => SeedMediaPreloadService.loadSeedMediaIfNeeded(),
         returnsNormally,
@@ -160,17 +148,13 @@ void main() {
     test(
       'loadSeedMediaIfNeeded handles corrupted manifest gracefully',
       () async {
-        // Setup: Mock invalid JSON
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMessageHandler('flutter/assets', (ByteData? message) async {
               if (message == null) return null;
-
-              // Return invalid JSON
               final bytes = Uint8List.fromList(utf8.encode('not valid json'));
               return ByteData.sublistView(bytes);
             });
 
-        // Act & Assert: Should not throw
         expect(
           () async => SeedMediaPreloadService.loadSeedMediaIfNeeded(),
           returnsNormally,
@@ -182,10 +166,9 @@ void main() {
     test(
       'loadSeedMediaIfNeeded uses eventId as filename in cache directory',
       () async {
-        // Setup: Mock manifest with specific eventId
         const testEventId =
             'unique0000test1111cafe2222beef3333dead4444face5555abcd6666ef0012345678';
-        const testFilename = '$testEventId.mp4'; // Filename matches eventId
+        const testFilename = '$testEventId.mp4';
         final manifestJson = jsonEncode({
           'videos': [
             {
@@ -208,30 +191,16 @@ void main() {
           0x45,
         ]);
 
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMessageHandler('flutter/assets', (ByteData? message) async {
-              if (message == null) return null;
+        _mockSeedMediaAssets(
+          manifestPayload: manifestJson,
+          videoBytes: testVideoBytes,
+          videoMatcher: (assetName) =>
+              assetName.contains('unique0000test1111') &&
+              assetName.endsWith('.mp4'),
+        );
 
-              // Message is the asset name as UTF-8 bytes
-              final assetName = utf8.decode(message.buffer.asUint8List());
-
-              if (assetName.contains('manifest.json')) {
-                // Return manifest JSON as bytes
-                final bytes = Uint8List.fromList(utf8.encode(manifestJson));
-                return ByteData.sublistView(bytes);
-              } else if (assetName.contains('unique0000test1111') &&
-                  assetName.contains('.mp4')) {
-                // Return fake video bytes if unique string is in the path
-                return ByteData.sublistView(testVideoBytes);
-              }
-
-              return null;
-            });
-
-        // Act: Load seed media
         await SeedMediaPreloadService.loadSeedMediaIfNeeded();
 
-        // Assert: File should exist in cache directory with eventId as filename
         final cacheDir = Directory(
           path.join(tempDir.path, 'openvine_video_cache'),
         );
@@ -243,7 +212,6 @@ void main() {
           reason: 'Video file should exist with eventId as filename',
         );
 
-        // Verify file content matches
         final fileBytes = await videoFile.readAsBytes();
         expect(
           fileBytes,
@@ -251,8 +219,6 @@ void main() {
           reason: 'File content should match asset bytes',
         );
       },
-      // TODO(any): Fix and re-enable this test
-      skip: true,
     );
   });
 }


### PR DESCRIPTION
## Description

Bucket E of #3137 — re-enables the two tests that were marked `skip: true`
during the VGV migration so the merged-isolate runner exercises them again.

**Related Issue:** Relates to #3137

### Changes

* `mobile/test/services/seed_media_preload_service_test.dart` — the
  `loadSeedMediaIfNeeded copies bundled videos to cache when empty` test
  was racing on the `flutter/assets` mock under the merged VGV runner.
  Pulled the asset mock into a shared `_mockSeedMediaAssets()` helper
  modeled on `seed_data_preload_service_test.dart`, and added
  `rootBundle.clear()` in `setUp` / `tearDown` so cached payloads from
  sibling tests no longer contaminate this one. The
  `@Tags(['skip_very_good_optimization'])` opt-out is dropped — the file
  now passes under `very_good test --optimization`.
* `mobile/test/screens/sounds_screen_test.dart` — the
  `navigating to detail stops current preview` test was order-dependent
  on `Icons.play_arrow.first` / `Icons.chevron_right.first`, which broke
  whenever the merged runner had bundled sounds materialized in
  `soundLibraryServiceProvider`. Overrode that provider with an empty
  `SoundLibraryService()` (matching the sibling tests in this group) and
  switched to per-sound semantic labels so the preview button and the
  chevron unambiguously point at the same `sound1` tile.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `flutter test test/services/seed_media_preload_service_test.dart` passes (default + random ordering, 3× each)
- [x] `flutter test test/screens/sounds_screen_test.dart` passes (default + random ordering, 3× each)
- [x] `very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed random` over both files passes across multiple seeds
- [x] `flutter analyze lib test integration_test` clean
