### PR TITLE
fix: show blurhash thumbnails from Nostr enrichment

### DIFF
--- a/mobile/lib/providers/feed_refresh_helpers.dart
+++ b/mobile/lib/providers/feed_refresh_helpers.dart
@@ -84,7 +84,7 @@ bool videoListsEqual(List<VideoEvent> a, List<VideoEvent> b) {
   if (a.length != b.length) return false;
 
   for (var i = 0; i < a.length; i++) {
-    if (a[i] != b[i]) return false;
+    if (!identical(a[i], b[i])) return false;
   }
   return true;
 }

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -61,7 +61,7 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
           name: callerName,
         );
         if (parsed.rawTags.isNotEmpty) {
-          nostrEventsMap[parsed.id.toLowerCase()] = parsed;
+          nostrEventsMap[parsed.id] = parsed;
         }
       } catch (_) {
         // Skip events that fail to parse

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -54,8 +54,14 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
     for (final event in nostrEvents) {
       try {
         final parsed = VideoEvent.fromNostrEvent(event, permissive: true);
+        Log.info(
+          'enrichVideos: parsed Nostr event ${parsed.id} '
+          'blurhash=${parsed.blurhash} '
+          'rawTags.len=${parsed.rawTags.length}',
+          name: callerName,
+        );
         if (parsed.rawTags.isNotEmpty) {
-          nostrEventsMap[parsed.id] = parsed;
+          nostrEventsMap[parsed.id.toLowerCase()] = parsed;
         }
       } catch (_) {
         // Skip events that fail to parse

--- a/mobile/lib/widgets/blurhash_display.dart
+++ b/mobile/lib/widgets/blurhash_display.dart
@@ -53,22 +53,9 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
         (widget.contentType != null
             ? BlurhashService.getBlurhashForContentType(widget.contentType!)
             : BlurhashService.getDefaultVineBlurhash());
-    Log.info(
-      'BlurhashDisplay._decodeBlurhash: '
-      'widget.blurhash=${widget.blurhash} '
-      'contentType=${widget.contentType} '
-      'effectiveHash=$hash',
-      name: 'BlurhashDisplay',
-      category: LogCategory.ui,
-    );
+
     try {
       final data = BlurhashService.decodeBlurhash(hash);
-      Log.info(
-        'BlurhashDisplay._decodeBlurhash: decoded data='
-        '${data == null ? 'NULL' : 'OK pixels=${data.pixels?.length}'}',
-        name: 'BlurhashDisplay',
-        category: LogCategory.ui,
-      );
 
       if (mounted && data != null) {
         setState(() {

--- a/mobile/lib/widgets/blurhash_display.dart
+++ b/mobile/lib/widgets/blurhash_display.dart
@@ -14,12 +14,14 @@ class BlurhashDisplay extends StatefulWidget {
   const BlurhashDisplay({
     required this.blurhash,
     super.key,
+    this.contentType,
     this.width,
     this.height,
     this.fit = BoxFit.cover,
   });
 
-  final String blurhash;
+  final String? blurhash;
+  final VineContentType? contentType;
   final double? width;
   final double? height;
   final BoxFit fit;
@@ -46,8 +48,27 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
   }
 
   void _decodeBlurhash() {
+    final hash =
+        widget.blurhash ??
+        (widget.contentType != null
+            ? BlurhashService.getBlurhashForContentType(widget.contentType!)
+            : BlurhashService.getDefaultVineBlurhash());
+    Log.info(
+      'BlurhashDisplay._decodeBlurhash: '
+      'widget.blurhash=${widget.blurhash} '
+      'contentType=${widget.contentType} '
+      'effectiveHash=$hash',
+      name: 'BlurhashDisplay',
+      category: LogCategory.ui,
+    );
     try {
-      final data = BlurhashService.decodeBlurhash(widget.blurhash);
+      final data = BlurhashService.decodeBlurhash(hash);
+      Log.info(
+        'BlurhashDisplay._decodeBlurhash: decoded data='
+        '${data == null ? 'NULL' : 'OK pixels=${data.pixels?.length}'}',
+        name: 'BlurhashDisplay',
+        category: LogCategory.ui,
+      );
 
       if (mounted && data != null) {
         setState(() {
@@ -247,7 +268,7 @@ class BlurhashImage extends StatelessWidget {
         children: [
           // Blurhash placeholder
           BlurhashDisplay(
-            blurhash: blurhash!,
+            blurhash: blurhash,
             width: width,
             height: height,
             fit: fit,

--- a/mobile/lib/widgets/blurhash_display.dart
+++ b/mobile/lib/widgets/blurhash_display.dart
@@ -42,7 +42,8 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
   @override
   void didUpdateWidget(BlurhashDisplay oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.blurhash != widget.blurhash) {
+    if (oldWidget.blurhash != widget.blurhash ||
+        oldWidget.contentType != widget.contentType) {
       _decodeBlurhash();
     }
   }

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -628,19 +628,7 @@ class _VideoThumbnail extends StatelessWidget {
   Widget build(BuildContext context) {
     return ColoredBox(
       color: VineTheme.cardBackground,
-      child: video.thumbnailUrl != null
-          ? VideoThumbnailWidget(video: video)
-          : const AspectRatio(
-              aspectRatio: 2 / 3,
-              child: ColoredBox(
-                color: VineTheme.cardBackground,
-                child: Icon(
-                  Icons.videocam,
-                  size: 40,
-                  color: VineTheme.secondaryText,
-                ),
-              ),
-            ),
+      child: VideoThumbnailWidget(video: video),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
+++ b/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
@@ -52,8 +52,9 @@ class _Fallback extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (blurhash != null && blurhash!.isNotEmpty) {
-      return BlurhashDisplay(blurhash: blurhash!);
+    final blurhashValue = blurhash;
+    if (blurhashValue != null && blurhashValue.isNotEmpty) {
+      return BlurhashDisplay(blurhash: blurhashValue);
     }
     return const ProfileTabThumbnailPlaceholder();
   }

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -36,12 +36,10 @@ class VideoThumbnailWidget extends StatefulWidget {
 class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
   String? _thumbnailUrl;
   double? _resolvedAspectRatio;
-  VineContentType? _derivedContentType;
 
   @override
   void initState() {
     super.initState();
-    _derivedContentType = _deriveContentType(widget.video);
     _loadThumbnail();
   }
 
@@ -61,7 +59,6 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
         oldWidget.video.blurhash != widget.video.blurhash ||
         oldWidget.video.dimensions != widget.video.dimensions) {
       _resolvedAspectRatio = null;
-      _derivedContentType = _deriveContentType(widget.video);
       _loadThumbnail();
     }
   }
@@ -110,7 +107,7 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
         // Show blurhash or flat color as background while image loads
         BlurhashDisplay(
           blurhash: widget.video.blurhash,
-          contentType: _derivedContentType,
+          contentType: _deriveContentType(widget.video),
           width: widget.width,
           height: widget.height,
           fit: fit,

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Smart video thumbnail widget that displays thumbnails or blurhash placeholders
 // ABOUTME: Uses existing thumbnail URLs from video events and falls back to blurhash when missing
 
+import 'package:blurhash_service/blurhash_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart'
@@ -35,18 +36,32 @@ class VideoThumbnailWidget extends StatefulWidget {
 class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
   String? _thumbnailUrl;
   double? _resolvedAspectRatio;
+  VineContentType? _derivedContentType;
 
   @override
   void initState() {
     super.initState();
+    _derivedContentType = _deriveContentType(widget.video);
     _loadThumbnail();
   }
+
+  static VineContentType? _deriveContentType(VideoEvent video) =>
+      BlurhashService.deriveContentType(
+        hashtags: video.hashtags,
+        group: video.group,
+        title: video.title,
+        content: video.content,
+      );
 
   @override
   void didUpdateWidget(VideoThumbnailWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.video.id != widget.video.id) {
+    if (oldWidget.video.id != widget.video.id ||
+        oldWidget.video.thumbnailUrl != widget.video.thumbnailUrl ||
+        oldWidget.video.blurhash != widget.video.blurhash ||
+        oldWidget.video.dimensions != widget.video.dimensions) {
       _resolvedAspectRatio = null;
+      _derivedContentType = _deriveContentType(widget.video);
       _loadThumbnail();
     }
   }
@@ -89,26 +104,21 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
   }
 
   Widget _buildContent(BoxFit fit) {
-    if (_thumbnailUrl != null) {
-      // Show the thumbnail with flat color as placeholder while loading
-      return Stack(
-        fit: StackFit.expand,
-        children: [
-          // Show blurhash or flat color as background while image loads
-          if (widget.video.blurhash != null)
-            BlurhashDisplay(
-              blurhash: widget.video.blurhash!,
-              width: widget.width,
-              height: widget.height,
-              fit: fit,
-            )
-          else
-            Container(
-              width: widget.width,
-              height: widget.height,
-              color: VineTheme.surfaceContainer,
-            ),
-          // Actual thumbnail image with error boundary
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // Show blurhash or flat color as background while image loads
+        BlurhashDisplay(
+          blurhash: widget.video.blurhash,
+          contentType: _derivedContentType,
+          width: widget.width,
+          height: widget.height,
+          fit: fit,
+        ),
+
+        // Actual thumbnail image with error boundary, rendered on top of
+        // the blurhash placeholder once it loads.
+        if (_thumbnailUrl != null)
           _SafeNetworkImage(
             url: _thumbnailUrl!,
             width: widget.width,
@@ -117,45 +127,6 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
             videoId: widget.video.id,
             showPlayIcon: widget.showPlayIcon,
             borderRadius: widget.borderRadius,
-          ),
-          // Play icon overlay if requested
-          if (widget.showPlayIcon)
-            Center(
-              child: Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: VineTheme.backgroundColor.withValues(alpha: 0.5),
-                  shape: BoxShape.circle,
-                ),
-                child: const Icon(
-                  Icons.play_arrow,
-                  color: VineTheme.whiteText,
-                  size: 32,
-                ),
-              ),
-            ),
-        ],
-      );
-    }
-
-    // No thumbnail URL - show blurhash or flat placeholder color with
-    // optional play icon
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        if (widget.video.blurhash != null)
-          BlurhashDisplay(
-            blurhash: widget.video.blurhash!,
-            width: widget.width,
-            height: widget.height,
-            fit: fit,
-          )
-        else
-          Container(
-            width: widget.width,
-            height: widget.height,
-            color: VineTheme.surfaceContainer,
           ),
         if (widget.showPlayIcon)
           Center(

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -173,6 +173,49 @@ class BlurhashService {
     return 'L6Pj0^jE.AyE_3t7t7R**0o#DgR4';
   }
 
+  /// Derive a [VineContentType] from free-form metadata strings.
+  ///
+  /// Returns `null` when no keyword matches; callers can then fall back to
+  /// [getDefaultVineBlurhash]. Comparison is case-insensitive.
+  static VineContentType? deriveContentType({
+    Iterable<String> hashtags = const [],
+    String? group,
+    String? title,
+    String? content,
+  }) {
+    final tokens = <String>[
+      ...hashtags.map((h) => h.toLowerCase()),
+      group?.toLowerCase() ?? '',
+      title?.toLowerCase() ?? '',
+      content?.toLowerCase() ?? '',
+    ].join(' ');
+
+    bool hasAny(List<String> keywords) => keywords.any(tokens.contains);
+
+    if (hasAny(['dance', 'choreo'])) return VineContentType.dance;
+    if (hasAny(['nature', 'outdoor', 'wildlife'])) {
+      return VineContentType.nature;
+    }
+    if (hasAny(['food', 'recipe', 'cooking'])) return VineContentType.food;
+    if (hasAny(['music', 'song', 'beat'])) return VineContentType.music;
+    if (hasAny(['tech', 'coding', 'code', 'dev'])) {
+      return VineContentType.tech;
+    }
+    if (hasAny(['art', 'design', 'drawing'])) return VineContentType.art;
+    if (hasAny(['sport', 'fitness', 'workout', 'soccer', 'football'])) {
+      return VineContentType.sports;
+    }
+    if (hasAny(['lifestyle', 'daily', 'vlog'])) {
+      return VineContentType.lifestyle;
+    }
+    if (hasAny(['meme', 'shitpost', 'funny'])) return VineContentType.meme;
+    if (hasAny(['tutorial', 'howto', 'how-to'])) {
+      return VineContentType.tutorial;
+    }
+
+    return null;
+  }
+
   /// Get common vine blurhashes for different content
   /// types.
   static String getBlurhashForContentType(
@@ -220,10 +263,6 @@ class BlurhashService {
   /// Validate blurhash format.
   static bool _isValidBlurhash(String blurhash) {
     if (blurhash.length < 6) return false;
-
-    // Basic validation - should start with 'L'
-    // and contain valid base83 characters
-    if (!blurhash.startsWith('L')) return false;
 
     final validChars = RegExp(r'^[0-9A-Za-z#$%*+,-.:;=?@\[\]^_{|}~]+$');
     return validChars.hasMatch(blurhash);

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -104,6 +104,15 @@ void main() {
         expect(hash!.length, equals(36));
       });
 
+      test('accepts valid square hashes that do not start with L', () async {
+        final bytes = _makeJpeg(width: 100, height: 100);
+        final hash = await BlurhashService.generateBlurhash(bytes);
+
+        expect(hash, isNotNull);
+        expect(hash!.startsWith('L'), isFalse);
+        expect(BlurhashService.decodeBlurhash(hash), isNotNull);
+      });
+
       test('real fixture (720×1280) uses portrait components', () async {
         final thumbnailFile = File('test/fixtures/test_thumbnail.jpg');
         if (!thumbnailFile.existsSync()) {
@@ -185,6 +194,61 @@ void main() {
           );
         },
       );
+    });
+
+    group('deriveContentType', () {
+      test('returns null when no metadata is provided', () {
+        expect(BlurhashService.deriveContentType(), isNull);
+      });
+
+      test('returns null when nothing matches a known keyword', () {
+        expect(
+          BlurhashService.deriveContentType(
+            hashtags: const ['random'],
+            title: 'plain title',
+            content: 'nothing of interest',
+          ),
+          isNull,
+        );
+      });
+
+      test('matches keywords case-insensitively in hashtags', () {
+        expect(
+          BlurhashService.deriveContentType(hashtags: const ['Dance']),
+          equals(VineContentType.dance),
+        );
+      });
+
+      test('matches keywords inside title and content', () {
+        expect(
+          BlurhashService.deriveContentType(title: 'My recipe video'),
+          equals(VineContentType.food),
+        );
+        expect(
+          BlurhashService.deriveContentType(
+            content: 'Watch this football clip',
+          ),
+          equals(VineContentType.sports),
+        );
+      });
+
+      test('matches keywords inside group field', () {
+        expect(
+          BlurhashService.deriveContentType(group: 'tech-talk'),
+          equals(VineContentType.tech),
+        );
+      });
+
+      test('first matching category wins', () {
+        // dance is checked before music, so a clip tagged with both
+        // returns dance.
+        expect(
+          BlurhashService.deriveContentType(
+            hashtags: const ['music', 'dance'],
+          ),
+          equals(VineContentType.dance),
+        );
+      });
     });
 
     group('BlurhashData', () {

--- a/mobile/test/providers/feed_refresh_helpers_test.dart
+++ b/mobile/test/providers/feed_refresh_helpers_test.dart
@@ -204,6 +204,17 @@ void main() {
 
       expect(result, existing);
     });
+
+    test('preserves original instance when no enrichment matches', () {
+      // Regression: mergeEnrichedVideos must return the same VideoEvent
+      // instance (not a copy) when nothing is enriched, so that
+      // videoListsEqual (which uses identical()) correctly detects no change.
+      final a = video('a');
+
+      final result = mergeEnrichedVideos(existing: [a], enriched: []);
+
+      expect(identical(result[0], a), isTrue);
+    });
   });
 
   group('videoListsEqual', () {
@@ -239,6 +250,18 @@ void main() {
 
     test('returns true for two empty lists', () {
       expect(videoListsEqual([], []), isTrue);
+    });
+
+    test('returns false for same id but different instance', () {
+      // Regression: proves identical() is required rather than ==.
+      // After enrichment mergeEnrichedVideos produces a new VideoEvent
+      // instance for every matched video, so a list comparison based on
+      // == would miss those changes and suppress the provider rebuild.
+      final a1 = video('a');
+      final a2 = video('a'); // same id, different object
+
+      expect(identical(a1, a2), isFalse); // guard: really different instances
+      expect(videoListsEqual([a1], [a2]), isFalse);
     });
   });
 

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1,8 +1,10 @@
+import 'package:blurhash_service/blurhash_service.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 
 import '../test_data/video_test_data.dart';
@@ -250,6 +252,130 @@ void main() {
       expect(find.byType(CachedNetworkImage), findsNothing);
       expect(find.byType(Container), findsWidgets);
     });
+
+    testWidgets(
+      'updates blurhash placeholder when enrichment returns same id new instance',
+      (tester) async {
+        const enrichedBlurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+        final unenrichedVideo = createTestVideoEvent(
+          id: 'same-id',
+          hashtags: const ['dance'],
+        );
+        final enrichedVideo = createTestVideoEvent(
+          id: 'same-id',
+          blurhash: enrichedBlurhash,
+          hashtags: const ['dance'],
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: unenrichedVideo,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.byType(BlurhashDisplay), findsOneWidget);
+        expect(
+          tester.widget<BlurhashDisplay>(find.byType(BlurhashDisplay)).blurhash,
+          isNull,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: enrichedVideo,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.widget<BlurhashDisplay>(find.byType(BlurhashDisplay)).blurhash,
+          enrichedBlurhash,
+        );
+      },
+    );
+
+    testWidgets(
+      'updates derived content-type placeholder when metadata changes',
+      (tester) async {
+        final unknownVideo = createTestVideoEvent(
+          id: 'same-id',
+          hashtags: const ['random'],
+          title: 'plain title',
+          content: 'nothing special',
+        );
+        final danceVideo = createTestVideoEvent(
+          id: 'same-id',
+          hashtags: const ['dance'],
+          title: 'plain title',
+          content: 'nothing special',
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: unknownVideo,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.byType(BlurhashDisplay), findsOneWidget);
+        expect(
+          tester
+              .widget<BlurhashDisplay>(find.byType(BlurhashDisplay))
+              .contentType,
+          isNull,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: danceVideo,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(
+          tester
+              .widget<BlurhashDisplay>(find.byType(BlurhashDisplay))
+              .contentType,
+          VineContentType.dance,
+        );
+      },
+    );
 
     testWidgets('does not try to generate thumbnails when URL is missing', (
       tester,


### PR DESCRIPTION
## Description

`videoListsEqual` used `==` to compare `VideoEvent` instances, but `VideoEvent.==` only checks `id`. After background Nostr enrichment merged a blurhash into a video, the enriched list compared as "equal" to the existing state, so no state update was emitted and widgets never rebuilt.

**Root cause:** `a[i] != b[i]` always returned `false` for same-ID videos, so `videoListsEqual` returned `true` and the provider skipped the state update.

**Fix:** Switch `videoListsEqual` to `identical()` so enrichment-created copies are treated as real changes while untouched videos still preserve identity.

**Also fixed:**
- `BlurhashService._isValidBlurhash`: removed the incorrect `L`-prefix requirement because valid blurhashes can start with any base83 character
- `BlurhashService.deriveContentType`: added fallback content-type inference for placeholder selection when no blurhash is available
- `VideoThumbnailWidget` and `BlurhashDisplay`: updated placeholder refresh behavior so blurhash and content-type fallback changes repaint correctly

**Related Issue:** Relates to #3882

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore