### PR TITLE
chore(android): finish removing FFmpegKit residue

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -416,7 +416,7 @@ workflows:
           - POC
     environment:
       flutter: 3.41.9
-      xcode: 16.1  # Pinned to avoid FFmpeg Kit linker issues with newer Xcode
+      xcode: latest
       cocoapods: default
       groups:
         - zendesk_credentials
@@ -545,7 +545,7 @@ workflows:
     instance_type: mac_mini_m2
     environment:
       flutter: 3.41.9
-      xcode: 16.1
+      xcode: latest
       cocoapods: default
       groups:
         - zendesk_credentials

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -106,7 +106,7 @@ android {
             // Handle duplicate OSGI manifests from BouncyCastle
             pickFirsts.add("META-INF/versions/9/OSGI-INF/MANIFEST.MF")
         }
-        // Handle duplicate libc++_shared.so from c2pa-android and ffmpeg-kit
+        // Handle duplicate libc++_shared.so from c2pa-android
         jniLibs {
             pickFirsts.add("lib/arm64-v8a/libc++_shared.so")
             pickFirsts.add("lib/armeabi-v7a/libc++_shared.so")
@@ -120,11 +120,7 @@ flutter {
     source = "../.."
 }
 
-// Exclude FFmpeg native libraries on Android (not needed - using continuous recording)
 configurations.all {
-    exclude(group = "com.arthenica.ffmpegkit", module = "flutter")
-    exclude(group = "com.arthenica.ffmpegkit", module = "ffmpeg-kit-android")
-    exclude(group = "com.arthenica.ffmpegkit", module = "ffmpeg-kit-android-min")
     // Exclude older BouncyCastle jdk15to18 versions to avoid conflicts with c2pa's jdk18on versions
     exclude(group = "org.bouncycastle", module = "bcprov-jdk15to18")
     exclude(group = "org.bouncycastle", module = "bcpkix-jdk15to18")

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -81,8 +81,3 @@
 # Flutter's embedding layer references these, but we're not using split installs
 -dontwarn com.google.android.play.core.splitinstall.**
 -dontwarn com.google.android.play.core.tasks.**
-
-# Ignore FFmpegKit classes (not needed on Android - using continuous recording)
-# iOS/macOS use FFmpeg for video processing, but Android uses camera-based recording
--dontwarn com.arthenica.ffmpegkit.**
--dontwarn com.antonkarpenko.ffmpegkit.**

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -61,23 +61,7 @@ class MainActivity : FlutterActivity() {
     private var nostrSignerPlugin: NostrSignerPlugin? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        try {
-            super.configureFlutterEngine(flutterEngine)
-        } catch (e: Exception) {
-            Log.e(PROOFMODE_TAG, "Exception during FlutterEngine configuration", e)
-            Log.e(PROOFMODE_TAG, "Exception message: ${e.message}")
-            Log.e(PROOFMODE_TAG, "Exception cause: ${e.cause?.message}")
-
-            // Handle FFmpegKit initialization failure on Android (not needed - using continuous recording)
-            // FFmpegKit is only used on iOS/macOS for video processing
-            if (e.message?.contains("FFmpegKit") == true || e.cause?.message?.contains("ffmpegkit") == true) {
-                Log.w(PROOFMODE_TAG, "FFmpegKit plugin failed to initialize (expected on Android)", e)
-                // Continue without FFmpegKit - Android uses camera-based continuous recording
-            } else {
-                // Re-throw other exceptions
-                throw e
-            }
-        }
+        super.configureFlutterEngine(flutterEngine)
 
         // Set up ProofMode platform channel
         setupProofModeChannel(flutterEngine)

--- a/mobile/test/services/audio_extraction_service_test.dart
+++ b/mobile/test/services/audio_extraction_service_test.dart
@@ -138,12 +138,12 @@ void main() {
 
     test('toString includes cause when present', () {
       const exception = AudioExtractionException(
-        'FFmpeg failed',
+        'Audio extraction failed',
         cause: 'Error: No audio stream found',
       );
 
       final str = exception.toString();
-      expect(str, contains('FFmpeg failed'));
+      expect(str, contains('Audio extraction failed'));
       expect(str, contains('caused by:'));
       expect(str, contains('No audio stream found'));
     });


### PR DESCRIPTION
Closes #4167

## Summary

Supersedes #3906 with a fresh branch rebuilt from current `main`.

This keeps the intended FFmpeg residue cleanup but lands it as a clean, reviewable diff with the previously missed Android ProGuard cleanup included.

## Changes

- remove stale FFmpegKit-related Xcode pin/comments from `codemagic.yaml`
- remove stale `com.arthenica.ffmpegkit` excludes from `mobile/android/app/build.gradle.kts`
- remove dead FFmpegKit exception handling from `mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt`
- remove stale FFmpegKit `-dontwarn` rules from `mobile/android/app/proguard-rules.pro`
- rename the arbitrary `"FFmpeg failed"` fixture string in `mobile/test/services/audio_extraction_service_test.dart`

## Verification

From `mobile/`:
- `flutter analyze`
- `flutter test test/services/audio_extraction_service_test.dart`

## Notes

The remaining FFmpeg references outside this diff were intentionally left alone because they are either historical docs/changelog entries, manual test tooling using CLI `ffmpeg`, or unrelated runtime comments rather than stale FFmpegKit dependency residue.