### PR TITLE
chore(feature-flags): hide livestreaming from experimental settings

### DIFF
--- a/mobile/lib/features/feature_flags/README.md
+++ b/mobile/lib/features/feature_flags/README.md
@@ -20,7 +20,6 @@ The feature flag system follows clean architecture principles with clear separat
 - `enhancedVideoPlayer` - Improved video playback engine with better performance
 - `enhancedAnalytics` - Detailed usage tracking and insights
 - `newProfileLayout` - Redesigned user profile screen
-- `livestreamingBeta` - Live video streaming feature (beta)
 - `debugTools` - Developer debugging utilities and diagnostics
 
 ## Quick Start

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -60,7 +60,8 @@ enum FeatureFlag {
     'Show Nostr relay configuration and diagnostics in Settings. '
         'Changing relays can break publishing and discovery — only turn '
         'this on if you know what you are doing.',
-  );
+  )
+  ;
 
   const FeatureFlag(this.displayName, this.description);
 

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -12,10 +12,6 @@ enum FeatureFlag {
     'Detailed usage tracking and insights',
   ),
   newProfileLayout('New Profile Layout', 'Redesigned user profile screen'),
-  livestreamingBeta(
-    'Livestreaming Beta',
-    'Live video streaming feature (beta)',
-  ),
   debugTools('Debug Tools', 'Developer debugging utilities and diagnostics'),
   routerDrivenHome(
     'Router-Driven Home Screen',
@@ -64,8 +60,7 @@ enum FeatureFlag {
     'Show Nostr relay configuration and diagnostics in Settings. '
         'Changing relays can break publishing and discovery — only turn '
         'this on if you know what you are doing.',
-  )
-  ;
+  );
 
   const FeatureFlag(this.displayName, this.description);
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -17,8 +17,6 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_ENHANCED_ANALYTICS');
       case FeatureFlag.newProfileLayout:
         return const bool.fromEnvironment('FF_NEW_PROFILE_LAYOUT');
-      case FeatureFlag.livestreamingBeta:
-        return const bool.fromEnvironment('FF_LIVESTREAMING_BETA');
       case FeatureFlag.debugTools:
         return const bool.fromEnvironment('FF_DEBUG_TOOLS', defaultValue: true);
       case FeatureFlag.routerDrivenHome:
@@ -76,8 +74,6 @@ class BuildConfiguration {
         return 'FF_ENHANCED_ANALYTICS';
       case FeatureFlag.newProfileLayout:
         return 'FF_NEW_PROFILE_LAYOUT';
-      case FeatureFlag.livestreamingBeta:
-        return 'FF_LIVESTREAMING_BETA';
       case FeatureFlag.debugTools:
         return 'FF_DEBUG_TOOLS';
       case FeatureFlag.routerDrivenHome:

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -36,7 +36,6 @@ void main() {
       expect(FeatureFlag.values, contains(FeatureFlag.enhancedVideoPlayer));
       expect(FeatureFlag.values, contains(FeatureFlag.enhancedAnalytics));
       expect(FeatureFlag.values, contains(FeatureFlag.newProfileLayout));
-      expect(FeatureFlag.values, contains(FeatureFlag.livestreamingBeta));
       expect(FeatureFlag.values, contains(FeatureFlag.debugTools));
       expect(FeatureFlag.values, contains(FeatureFlag.integratedApps));
       expect(FeatureFlag.values, contains(FeatureFlag.videoReplies));

--- a/mobile/test/services/build_config_test.dart
+++ b/mobile/test/services/build_config_test.dart
@@ -27,7 +27,6 @@ void main() {
       expect(config.getDefault(FeatureFlag.enhancedVideoPlayer), isFalse);
       expect(config.getDefault(FeatureFlag.enhancedAnalytics), isFalse);
       expect(config.getDefault(FeatureFlag.newProfileLayout), isFalse);
-      expect(config.getDefault(FeatureFlag.livestreamingBeta), isFalse);
     });
 
     test('should have debug tools enabled by default in debug builds', () {


### PR DESCRIPTION
Closes #4170

## Summary

- Removes the **Livestreaming Beta** toggle from the Experimental Features list under Settings. It was a placeholder enum case with no underlying implementation (no UI gates, router guards, or backend wiring referenced the flag), and shouldn't be exposed to users yet.
- Drops the corresponding `getDefault` / `getEnvironmentKey` switch arms and the two tests that pinned the flag's existence and default.
- The Experimental Features screen renders one tile per `FeatureFlag.values` entry (`feature_flag_screen.dart:51-53`), so removing the enum case removes the tile.

## Test plan

- [x] `flutter analyze lib/features/feature_flags test/core/feature_flag_test.dart test/services/build_config_test.dart` — clean
- [x] `flutter test test/core/feature_flag_test.dart test/services/build_config_test.dart` — 18/18 pass
- [ ] Visual: open Settings → Experimental Features and confirm "Livestreaming Beta" no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)