### PR TITLE
fix(deep-link): hit Funnelcake REST before relays for /video/<id>

### DIFF
--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class VideoDetailRouteExtra {
@@ -247,9 +248,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     if (_isLoading) {
       return const Scaffold(
         backgroundColor: VineTheme.backgroundColor,
-        body: Center(
-          child: CircularProgressIndicator(color: VineTheme.vineGreen),
-        ),
+        body: Center(child: BrandedLoadingIndicator()),
       );
     }
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1662,12 +1662,18 @@ class VideosRepository {
   /// `note1...`, `nevent1...`, and `naddr1...` references.
   ///
   /// Lookup order is tuned for `divine.video/video/<id>` deep-links: local
-  /// cache → Funnelcake REST → relay queries (each capped by
-  /// [_routeRelayTimeout]). REST runs before the WebSocket fallback because
-  /// it answers in <1s without waiting on relay connection state, and the
-  /// hash in a divine.video share URL is the canonical d-tag/sha256 served
-  /// by Funnelcake. Relay queries are kept as a fallback for events that
-  /// only exist on user-configured personal relays.
+  /// cache → Funnelcake REST → relay queries. REST runs before the WebSocket
+  /// fallback because it answers in <1s without waiting on relay connection
+  /// state, and the hash in a divine.video share URL is the canonical
+  /// d-tag/sha256 served by Funnelcake. Relay queries are kept as a fallback
+  /// for events that only exist on user-configured personal relays.
+  ///
+  /// Each relay branch caps its own `queryEvents` call at [_routeRelayTimeout]
+  /// (the only thing that can block on cold-start EOSE) and bounds bulk-stats
+  /// hydration with [_statsFetchTimeout] (degrades to the unhydrated video
+  /// rather than restalling the spinner). The orchestrator deliberately does
+  /// not wrap the helpers themselves — a successful relay result followed by
+  /// slow stats enrichment must not be killed as if the relay had hung.
   Future<VideoEvent?> fetchVideoWithStatsForRouteId(String routeId) async {
     final candidate = _VideoRouteCandidate.parse(routeId);
     if (candidate == null) return null;
@@ -1696,21 +1702,21 @@ class VideosRepository {
     if (candidate.eventId != null) {
       final byEventId = await _fetchRouteVideoByEventIdFromRelay(
         candidate.eventId!,
-      ).timeout(_routeRelayTimeout, onTimeout: () => null);
+      );
       if (byEventId != null) return byEventId;
     }
 
     if (candidate.addressableId != null) {
-      final videos = await getVideosByAddressableIds([
+      final byAddressable = await _fetchAddressableVideoFromRelay(
         candidate.addressableId!,
-      ]).timeout(_routeRelayTimeout, onTimeout: () => const <VideoEvent>[]);
-      if (videos.isNotEmpty) return videos.first;
+      );
+      if (byAddressable != null) return byAddressable;
     }
 
     if (candidate.stableId != null) {
       final byStableId = await _fetchVideoByStableIdFromRelay(
         candidate.stableId!,
-      ).timeout(_routeRelayTimeout, onTimeout: () => null);
+      );
       if (byStableId != null) return byStableId;
     }
 
@@ -1819,19 +1825,23 @@ class VideosRepository {
     }
     if (videos.isEmpty) return null;
 
-    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    final hydrated = await _hydrateVideosWithBulkStats(
+      videos,
+    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
     return hydrated.firstOrNull;
   }
 
   Future<VideoEvent?> _fetchRouteVideoByEventIdFromRelay(String eventId) async {
     if (eventId.isEmpty) return null;
 
-    final events = await _nostrClient.queryEvents([
-      Filter(
-        ids: [eventId],
-        kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
-      ),
-    ]);
+    final events = await _nostrClient
+        .queryEvents([
+          Filter(
+            ids: [eventId],
+            kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
+          ),
+        ])
+        .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
     if (events.isEmpty) return null;
 
     final videos = <VideoEvent>[];
@@ -1847,20 +1857,24 @@ class VideosRepository {
     }
     if (videos.isEmpty) return null;
 
-    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    final hydrated = await _hydrateVideosWithBulkStats(
+      videos,
+    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
     return hydrated.firstOrNull;
   }
 
   Future<VideoEvent?> _fetchVideoByStableIdFromRelay(String stableId) async {
-    final events = await _nostrClient.queryEvents([
-      Filter(
-        // Route-specific lookups accept all supported NIP-71 video kinds so
-        // older shared links still resolve instead of failing as not found.
-        kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
-        d: [stableId],
-        limit: 10,
-      ),
-    ]);
+    final events = await _nostrClient
+        .queryEvents([
+          Filter(
+            // Route-specific lookups accept all supported NIP-71 video kinds so
+            // older shared links still resolve instead of failing as not found.
+            kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
+            d: [stableId],
+            limit: 10,
+          ),
+        ])
+        .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
     if (events.isEmpty) return null;
 
     events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -1877,7 +1891,56 @@ class VideosRepository {
     }
     if (videos.isEmpty) return null;
 
-    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    final hydrated = await _hydrateVideosWithBulkStats(
+      videos,
+    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
+    return hydrated.firstOrNull;
+  }
+
+  /// Fetches a video by addressable id (`kind:pubkey:d-tag`) from relay only.
+  ///
+  /// Distinct from [getVideosByAddressableIds] which also runs Funnelcake
+  /// fallback and bulk-stats hydration in the same pipeline. The route
+  /// orchestrator caps relay I/O via [_routeRelayTimeout]; that cap belongs
+  /// around the relay query specifically, not around enrichment that has its
+  /// own timeout. Stats hydration here is bounded by [_statsFetchTimeout]
+  /// so a stalled stats endpoint cannot re-stall deep-link UX.
+  Future<VideoEvent?> _fetchAddressableVideoFromRelay(
+    String addressableId,
+  ) async {
+    final parsed = AId.fromString(addressableId);
+    if (parsed == null || !NIP71VideoKinds.isVideoKind(parsed.kind)) {
+      return null;
+    }
+
+    final events = await _nostrClient
+        .queryEvents([
+          Filter(
+            kinds: [parsed.kind],
+            authors: [parsed.pubkey],
+            d: [parsed.dTag],
+          ),
+        ])
+        .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
+    if (events.isEmpty) return null;
+
+    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final videos = <VideoEvent>[];
+    for (final event in events) {
+      final video = _tryParseAndFilter(
+        event,
+        permissive: true,
+        ignoreBlockFilter: true,
+      );
+      if (video != null) {
+        videos.add(video);
+      }
+    }
+    if (videos.isEmpty) return null;
+
+    final hydrated = await _hydrateVideosWithBulkStats(
+      videos,
+    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
     return hydrated.firstOrNull;
   }
 
@@ -1899,7 +1962,10 @@ class VideosRepository {
     );
     if (video == null) return null;
 
-    final hydrated = await _hydrateVideosWithBulkStats([video]);
+    final videos = [video];
+    final hydrated = await _hydrateVideosWithBulkStats(
+      videos,
+    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
     return hydrated.firstOrNull;
   }
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -40,6 +40,15 @@ const Duration _relaySearchTimeout = Duration(seconds: 15);
 /// healthy Funnelcake responses while still bounding degraded-service latency.
 const Duration _statsFetchTimeout = Duration(seconds: 3);
 
+/// Per-call timeout for relay queries inside the route-lookup orchestrator.
+///
+/// `NostrClient.queryEvents` waits for EOSE from every relay in the pool with
+/// a default 5-second timeout, and any relay still mid-connect during cold
+/// start blocks the whole batch. Capping each route-lookup relay call at 3s
+/// stops a stuck subscription from dominating deep-link UX once Funnelcake
+/// has already been tried.
+const Duration _routeRelayTimeout = Duration(seconds: 3);
+
 /// {@template videos_repository}
 /// Repository for video operations with Nostr.
 ///
@@ -235,10 +244,7 @@ class VideosRepository {
       cursor = nextCursor;
     }
 
-    return (
-      videos: visible.take(limit).toList(),
-      rawBody: rawBody,
-    );
+    return (videos: visible.take(limit).toList(), rawBody: rawBody);
   }
 
   Future<({List<VideoEvent> videos, String? rawBody})>
@@ -1642,15 +1648,11 @@ class VideosRepository {
   /// feed context: notification taps and `divine.video/video/:id` deep-links.
   Future<VideoEvent?> fetchVideoWithStats(String eventId) async {
     if (eventId.isEmpty) return null;
-    final videos = await getVideosByIds(
-      [eventId],
-      hydrateBulkStats: false,
-    );
+    final videos = await getVideosByIds([eventId], hydrateBulkStats: false);
     if (videos.isEmpty) return null;
-    final hydrated = await _hydrateVideosWithBulkStats(videos).timeout(
-      _statsFetchTimeout,
-      onTimeout: () => videos,
-    );
+    final hydrated = await _hydrateVideosWithBulkStats(
+      videos,
+    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
     return hydrated.firstOrNull;
   }
 
@@ -1658,34 +1660,58 @@ class VideosRepository {
   ///
   /// Supports raw event IDs, plain stable IDs / d-tags, and NIP-19
   /// `note1...`, `nevent1...`, and `naddr1...` references.
+  ///
+  /// Lookup order is tuned for `divine.video/video/<id>` deep-links: local
+  /// cache → Funnelcake REST → relay queries (each capped by
+  /// [_routeRelayTimeout]). REST runs before the WebSocket fallback because
+  /// it answers in <1s without waiting on relay connection state, and the
+  /// hash in a divine.video share URL is the canonical d-tag/sha256 served
+  /// by Funnelcake. Relay queries are kept as a fallback for events that
+  /// only exist on user-configured personal relays.
   Future<VideoEvent?> fetchVideoWithStatsForRouteId(String routeId) async {
     final candidate = _VideoRouteCandidate.parse(routeId);
     if (candidate == null) return null;
 
+    final cached = await _fetchRouteVideoFromLocalCache(candidate);
+    if (cached != null) return cached;
+
+    final funnelcakeRouteId = candidate.stableId ?? candidate.eventId;
+    if (funnelcakeRouteId != null) {
+      try {
+        final byFunnelcake = await _fetchVideoFromRouteApi(
+          funnelcakeRouteId,
+          permissive: true,
+        );
+        if (byFunnelcake != null) return byFunnelcake;
+      } on FunnelcakeException catch (e, stackTrace) {
+        developer.log(
+          'Funnelcake route lookup failed; falling back to relay',
+          name: 'VideosRepository',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
     if (candidate.eventId != null) {
-      final byEventId = await _fetchRouteVideoByEventId(candidate.eventId!);
+      final byEventId = await _fetchRouteVideoByEventIdFromRelay(
+        candidate.eventId!,
+      ).timeout(_routeRelayTimeout, onTimeout: () => null);
       if (byEventId != null) return byEventId;
     }
 
     if (candidate.addressableId != null) {
       final videos = await getVideosByAddressableIds([
         candidate.addressableId!,
-      ]);
+      ]).timeout(_routeRelayTimeout, onTimeout: () => const <VideoEvent>[]);
       if (videos.isNotEmpty) return videos.first;
     }
 
     if (candidate.stableId != null) {
-      final byStableId = await _fetchVideoByStableId(candidate.stableId!);
+      final byStableId = await _fetchVideoByStableIdFromRelay(
+        candidate.stableId!,
+      ).timeout(_routeRelayTimeout, onTimeout: () => null);
       if (byStableId != null) return byStableId;
-    }
-
-    final funnelcakeRouteId = candidate.stableId ?? candidate.eventId;
-    if (funnelcakeRouteId != null) {
-      final byFunnelcake = await _fetchVideoFromRouteApi(
-        funnelcakeRouteId,
-        permissive: true,
-      );
-      if (byFunnelcake != null) return byFunnelcake;
     }
 
     return null;
@@ -1751,65 +1777,29 @@ class VideosRepository {
     );
   }
 
-  Future<VideoEvent?> _fetchRouteVideoByEventId(String eventId) async {
-    if (eventId.isEmpty) return null;
+  /// Returns a hydrated video from local storage when either the candidate's
+  /// event id or stable id (d-tag) hits the cache.
+  ///
+  /// Shared links should be able to reopen a video on a cold start before the
+  /// relay layer has finished connecting and before the REST fallback returns.
+  Future<VideoEvent?> _fetchRouteVideoFromLocalCache(
+    _VideoRouteCandidate candidate,
+  ) async {
+    if (_localStorage == null) return null;
 
     final candidates = <Event>[];
 
-    if (_localStorage != null) {
-      // Shared links should be able to reopen a video from local cache on a
-      // cold start before the relay layer has finished connecting.
-      candidates.addAll(await _localStorage.getEventsByIds([eventId]));
-    }
-
-    if (candidates.isEmpty) {
+    if (candidate.eventId != null && candidate.eventId!.isNotEmpty) {
       candidates.addAll(
-        await _nostrClient.queryEvents([
-          Filter(
-            ids: [eventId],
-            kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
-          ),
-        ]),
+        await _localStorage.getEventsByIds([candidate.eventId!]),
       );
     }
 
-    if (candidates.isEmpty) return null;
-
-    final videos = <VideoEvent>[];
-    for (final event in candidates) {
-      final video = _tryParseAndFilter(
-        event,
-        permissive: true,
-        ignoreBlockFilter: true,
-      );
-      if (video != null) {
-        videos.add(video);
-      }
-    }
-    if (videos.isEmpty) return null;
-
-    final hydrated = await _hydrateVideosWithBulkStats(videos);
-    return hydrated.firstOrNull;
-  }
-
-  Future<VideoEvent?> _fetchVideoByStableId(String stableId) async {
-    final candidates = <Event>[];
-
-    if (_localStorage != null) {
-      candidates.addAll(await _localStorage.getEventsByDTag(stableId));
-    }
-
-    if (candidates.isEmpty) {
+    if (candidates.isEmpty &&
+        candidate.stableId != null &&
+        candidate.stableId!.isNotEmpty) {
       candidates.addAll(
-        await _nostrClient.queryEvents([
-          Filter(
-            // Route-specific lookups accept all supported NIP-71 video kinds so
-            // older shared links still resolve instead of failing as not found.
-            kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
-            d: [stableId],
-            limit: 10,
-          ),
-        ]),
+        await _localStorage.getEventsByDTag(candidate.stableId!),
       );
     }
 
@@ -1830,7 +1820,65 @@ class VideosRepository {
     if (videos.isEmpty) return null;
 
     final hydrated = await _hydrateVideosWithBulkStats(videos);
-    return hydrated.isEmpty ? null : hydrated.first;
+    return hydrated.firstOrNull;
+  }
+
+  Future<VideoEvent?> _fetchRouteVideoByEventIdFromRelay(String eventId) async {
+    if (eventId.isEmpty) return null;
+
+    final events = await _nostrClient.queryEvents([
+      Filter(
+        ids: [eventId],
+        kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
+      ),
+    ]);
+    if (events.isEmpty) return null;
+
+    final videos = <VideoEvent>[];
+    for (final event in events) {
+      final video = _tryParseAndFilter(
+        event,
+        permissive: true,
+        ignoreBlockFilter: true,
+      );
+      if (video != null) {
+        videos.add(video);
+      }
+    }
+    if (videos.isEmpty) return null;
+
+    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    return hydrated.firstOrNull;
+  }
+
+  Future<VideoEvent?> _fetchVideoByStableIdFromRelay(String stableId) async {
+    final events = await _nostrClient.queryEvents([
+      Filter(
+        // Route-specific lookups accept all supported NIP-71 video kinds so
+        // older shared links still resolve instead of failing as not found.
+        kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
+        d: [stableId],
+        limit: 10,
+      ),
+    ]);
+    if (events.isEmpty) return null;
+
+    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final videos = <VideoEvent>[];
+    for (final event in events) {
+      final video = _tryParseAndFilter(
+        event,
+        permissive: true,
+        ignoreBlockFilter: true,
+      );
+      if (video != null) {
+        videos.add(video);
+      }
+    }
+    if (videos.isEmpty) return null;
+
+    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    return hydrated.firstOrNull;
   }
 
   Future<VideoEvent?> _fetchVideoFromRouteApi(
@@ -1903,10 +1951,7 @@ class _VideoRouteCandidate {
     // navigation. AId.fromString validates the format and extracts the d-tag.
     final aid = AId.fromString(trimmed);
     if (aid != null && NIP71VideoKinds.isVideoKind(aid.kind)) {
-      return _VideoRouteCandidate(
-        addressableId: trimmed,
-        stableId: aid.dTag,
-      );
+      return _VideoRouteCandidate(addressableId: trimmed, stableId: aid.dTag);
     }
 
     return _VideoRouteCandidate(stableId: trimmed);

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1810,25 +1810,7 @@ class VideosRepository {
     }
 
     if (candidates.isEmpty) return null;
-
-    candidates.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-    final videos = <VideoEvent>[];
-    for (final event in candidates) {
-      final video = _tryParseAndFilter(
-        event,
-        permissive: true,
-        ignoreBlockFilter: true,
-      );
-      if (video != null) {
-        videos.add(video);
-      }
-    }
-    if (videos.isEmpty) return null;
-
-    final hydrated = await _hydrateVideosWithBulkStats(
-      videos,
-    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
-    return hydrated.firstOrNull;
+    return _parseAndHydrateFirstRouteVideo(candidates);
   }
 
   Future<VideoEvent?> _fetchRouteVideoByEventIdFromRelay(String eventId) async {
@@ -1842,25 +1824,7 @@ class VideosRepository {
           ),
         ])
         .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
-    if (events.isEmpty) return null;
-
-    final videos = <VideoEvent>[];
-    for (final event in events) {
-      final video = _tryParseAndFilter(
-        event,
-        permissive: true,
-        ignoreBlockFilter: true,
-      );
-      if (video != null) {
-        videos.add(video);
-      }
-    }
-    if (videos.isEmpty) return null;
-
-    final hydrated = await _hydrateVideosWithBulkStats(
-      videos,
-    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
-    return hydrated.firstOrNull;
+    return _parseAndHydrateFirstRouteVideo(events);
   }
 
   Future<VideoEvent?> _fetchVideoByStableIdFromRelay(String stableId) async {
@@ -1875,26 +1839,7 @@ class VideosRepository {
           ),
         ])
         .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
-    if (events.isEmpty) return null;
-
-    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-    final videos = <VideoEvent>[];
-    for (final event in events) {
-      final video = _tryParseAndFilter(
-        event,
-        permissive: true,
-        ignoreBlockFilter: true,
-      );
-      if (video != null) {
-        videos.add(video);
-      }
-    }
-    if (videos.isEmpty) return null;
-
-    final hydrated = await _hydrateVideosWithBulkStats(
-      videos,
-    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
-    return hydrated.firstOrNull;
+    return _parseAndHydrateFirstRouteVideo(events);
   }
 
   /// Fetches a video by addressable id (`kind:pubkey:d-tag`) from relay only.
@@ -1935,26 +1880,7 @@ class VideosRepository {
           ),
         ])
         .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
-    if (events.isEmpty) return null;
-
-    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-    final videos = <VideoEvent>[];
-    for (final event in events) {
-      final video = _tryParseAndFilter(
-        event,
-        permissive: true,
-        ignoreBlockFilter: true,
-      );
-      if (video != null) {
-        videos.add(video);
-      }
-    }
-    if (videos.isEmpty) return null;
-
-    final hydrated = await _hydrateVideosWithBulkStats(
-      videos,
-    ).timeout(_statsFetchTimeout, onTimeout: () => videos);
-    return hydrated.firstOrNull;
+    return _parseAndHydrateFirstRouteVideo(events);
   }
 
   Future<VideoEvent?> _fetchVideoFromRouteApi(
@@ -1975,7 +1901,33 @@ class VideosRepository {
     );
     if (video == null) return null;
 
-    final videos = [video];
+    return _hydrateFirstRouteVideo([video]);
+  }
+
+  Future<VideoEvent?> _parseAndHydrateFirstRouteVideo(
+    List<Event> events,
+  ) async {
+    if (events.isEmpty) return null;
+
+    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final videos = <VideoEvent>[];
+    for (final event in events) {
+      final video = _tryParseAndFilter(
+        event,
+        permissive: true,
+        ignoreBlockFilter: true,
+      );
+      if (video != null) {
+        videos.add(video);
+      }
+    }
+
+    return _hydrateFirstRouteVideo(videos);
+  }
+
+  Future<VideoEvent?> _hydrateFirstRouteVideo(List<VideoEvent> videos) async {
+    if (videos.isEmpty) return null;
+
     final hydrated = await _hydrateVideosWithBulkStats(
       videos,
     ).timeout(_statsFetchTimeout, onTimeout: () => videos);

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1905,11 +1905,24 @@ class VideosRepository {
   /// around the relay query specifically, not around enrichment that has its
   /// own timeout. Stats hydration here is bounded by [_statsFetchTimeout]
   /// so a stalled stats endpoint cannot re-stall deep-link UX.
+  ///
+  /// Funnelcake fallback for missing addressable ids is intentionally not
+  /// duplicated here. The orchestrator already tries Funnelcake REST as
+  /// step 2 with `funnelcakeRouteId = candidate.stableId ?? candidate.eventId`,
+  /// and `_VideoRouteCandidate.parse` populates `stableId` from
+  /// `decoded.id` / `aid.dTag` for both naddr and raw `kind:pubkey:d-tag`
+  /// inputs — so REST has already been attempted by the time we get here.
+  ///
+  /// Accepts every kind in [NIP71VideoKinds.getAllAcceptableVideoKinds] for
+  /// parity with [_fetchRouteVideoByEventIdFromRelay] /
+  /// [_fetchVideoByStableIdFromRelay]. Older share links pointing at legacy
+  /// kinds (e.g. 21, 22, 34235) reach this branch via naddr1 references and
+  /// must resolve the same way they do via raw event id or bare d-tag.
   Future<VideoEvent?> _fetchAddressableVideoFromRelay(
     String addressableId,
   ) async {
     final parsed = AId.fromString(addressableId);
-    if (parsed == null || !NIP71VideoKinds.isVideoKind(parsed.kind)) {
+    if (parsed == null || !NIP71VideoKinds.isAcceptableVideoKind(parsed.kind)) {
       return null;
     }
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -7875,6 +7875,67 @@ void main() {
       );
 
       test(
+        'addressable relay lookup accepts legacy NIP-71 kinds — '
+        'naddr1 pointing at kind 22 must resolve like a raw 64-hex route',
+        () async {
+          const eventId =
+              'a895f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
+          const author =
+              '4bf0c63fcb93463407af97a5e5ee64fa'
+              '883d107ef9e558472c4eb9aaaefa459d';
+          const dTag = 'legacy-vine-22';
+          // naddr1 referencing legacy kind 22 (NIP-71 short video) — the
+          // pre-relax addressable branch gated on isVideoKind() and would
+          // drop this at the kind check before querying the relay.
+          final naddr = NIP19Tlv.encodeNaddr(
+            Naddr(id: dTag, author: author, kind: 22),
+          );
+          final legacyEvent = Event.fromJson({
+            'id': eventId,
+            'pubkey': author,
+            'created_at': 1739350000,
+            'kind': 22,
+            'tags': [
+              ['d', dTag],
+              ['url', 'https://example.com/legacy.mp4'],
+              ['title', 'Legacy kind-22 addressable'],
+            ],
+            'content': '',
+            'sig': 'sig',
+          });
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+            invocation,
+          ) async {
+            final filters =
+                invocation.positionalArguments.single as List<Filter>;
+            final filter = filters.single;
+            // Only match the addressable filter (kind + author + d-tag),
+            // so the test fails loudly if the gate sends us back to the
+            // event-id or stable-id branches instead.
+            if ((filter.kinds?.contains(22) ?? false) &&
+                (filter.authors?.contains(author) ?? false) &&
+                (filter.d?.contains(dTag) ?? false)) {
+              return [legacyEvent];
+            }
+            return <Event>[];
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(naddr);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.vineId, equals(dTag));
+        },
+      );
+
+      test(
         'resolves plain stable IDs from local storage before relay',
         () async {
           const eventId =

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -7618,6 +7618,114 @@ void main() {
         expect(result, isNull);
       });
 
+      test(
+        'returns Funnelcake video when bulk-stats hydration hangs past '
+        'the stats timeout',
+        () async {
+          const stableId =
+              'e96357668c72c8923340b0ecf4bfacea'
+              '505172c4190e9953e603124c67175f3b';
+          const eventId =
+              'e46ff7d0d71d6c8114b58728afa43f08'
+              'd6286fd9a704683af799fd8f855586c2';
+          final apiHit = Event.fromJson({
+            'id': eventId,
+            'pubkey':
+                '076c979382b90f5d3a2b21f95e1ee86b'
+                '6033f14c92e79b7fad3fe1f1073f4886',
+            'created_at': 1777868006,
+            'kind': 34236,
+            'tags': [
+              ['d', stableId],
+              ['url', 'https://media.divine.video/$stableId'],
+              ['title', 'Stats hang test'],
+            ],
+            'content': 'Stats hang test',
+            'sig': 'sig',
+          });
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(stableId),
+          ).thenAnswer((_) async => apiHit);
+          // Bulk stats endpoint hangs forever — would have re-stalled the
+          // spinner before the stats-timeout was added to the route helpers.
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(any()),
+          ).thenAnswer((_) => Completer<BulkVideoStatsResponse>().future);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo
+              .fetchVideoWithStatsForRouteId(stableId)
+              // Wider than the 3s stats timeout but well below the 15s
+              // route-relay budget — a passing test proves stats hydration
+              // degraded rather than blocking the caller.
+              .timeout(const Duration(seconds: 8));
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          // Stats never hydrated, so derived fields stay at the parsed
+          // event's defaults rather than the (non-existent) API totals.
+          verify(() => mockFunnelcakeClient.getVideoEvent(stableId)).called(1);
+        },
+      );
+
+      test(
+        'addressable relay lookup returns the video even when stats hang — '
+        'the per-helper timeouts must not compound',
+        () async {
+          const eventId =
+              'd695f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
+          const author =
+              '4bf0c63fcb93463407af97a5e5ee64fa'
+              '883d107ef9e558472c4eb9aaaefa459d';
+          const dTag = 'addressable-stats-hang';
+          const rawAddressableId = '34236:$author:$dTag';
+          final event = _createVideoEventWithDTag(
+            id: eventId,
+            pubkey: author,
+            dTag: dTag,
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+          );
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          // The parser sets stableId from the raw addressable id's d-tag, so
+          // the orchestrator still tries REST first. Stub it to miss so the
+          // addressable relay branch is exercised.
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(dTag),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event]);
+          // Stats endpoint hangs forever. The pre-fix orchestrator wrapped
+          // the whole addressable branch in a 3s timeout that would have
+          // killed this successful relay lookup once stats stalled.
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(any()),
+          ).thenAnswer((_) => Completer<BulkVideoStatsResponse>().future);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo
+              .fetchVideoWithStatsForRouteId(rawAddressableId)
+              .timeout(const Duration(seconds: 8));
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.vineId, equals(dTag));
+        },
+      );
+
       test('returns blocked-author videos for direct route lookups', () async {
         const stableId =
             'f96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -349,68 +349,65 @@ void main() {
           );
         });
 
-        test(
-          'continues past a full API page of reply-only videos',
-          () async {
-            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-            when(
-              () => mockFunnelcakeClient.getRecentVideos(
-                limit: any(named: 'limit'),
-                before: any(named: 'before'),
-              ),
-            ).thenAnswer((invocation) async {
-              final before = invocation.namedArguments[#before] as int?;
-              final limit = invocation.namedArguments[#limit] as int? ?? 5;
+        test('continues past a full API page of reply-only videos', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getRecentVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer((invocation) async {
+            final before = invocation.namedArguments[#before] as int?;
+            final limit = invocation.namedArguments[#limit] as int? ?? 5;
 
-              if (before != null) {
-                return [
-                  _createVideoStats(
-                    id: 'feed-video',
-                    pubkey: 'test-pubkey',
-                    dTag: 'feed-dtag',
-                    videoUrl: 'https://example.com/feed.mp4',
-                    createdAt: 1704060000,
-                  ),
-                ];
-              }
-
-              return List.generate(
-                limit,
-                (index) => _createVideoStats(
-                  id: 'video-reply-$index',
+            if (before != null) {
+              return [
+                _createVideoStats(
+                  id: 'feed-video',
                   pubkey: 'test-pubkey',
-                  dTag: 'reply-dtag-$index',
-                  videoUrl: 'https://example.com/reply-$index.mp4',
-                  createdAt: 1704070000 - index,
-                  rawTags: const {
-                    'E': 'root-event-id',
-                    'K': '34236',
-                    'P': 'root-author',
-                    'e': 'root-event-id',
-                    'k': '34236',
-                    'p': 'root-author',
-                  },
+                  dTag: 'feed-dtag',
+                  videoUrl: 'https://example.com/feed.mp4',
+                  createdAt: 1704060000,
                 ),
-              );
-            });
+              ];
+            }
 
-            final repositoryWithApi = VideosRepository(
-              nostrClient: mockNostrClient,
-              funnelcakeApiClient: mockFunnelcakeClient,
-            );
-
-            final result = await repositoryWithApi.getNewVideos();
-
-            expect(result.map((video) => video.id), equals(['feed-video']));
-            verify(
-              () => mockFunnelcakeClient.getRecentVideos(
-                limit: any(named: 'limit'),
-                before: any(named: 'before'),
+            return List.generate(
+              limit,
+              (index) => _createVideoStats(
+                id: 'video-reply-$index',
+                pubkey: 'test-pubkey',
+                dTag: 'reply-dtag-$index',
+                videoUrl: 'https://example.com/reply-$index.mp4',
+                createdAt: 1704070000 - index,
+                rawTags: const {
+                  'E': 'root-event-id',
+                  'K': '34236',
+                  'P': 'root-author',
+                  'e': 'root-event-id',
+                  'k': '34236',
+                  'p': 'root-author',
+                },
               ),
-            ).called(2);
-            verifyNever(() => mockNostrClient.queryEvents(any()));
-          },
-        );
+            );
+          });
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getNewVideos();
+
+          expect(result.map((video) => video.id), equals(['feed-video']));
+          verify(
+            () => mockFunnelcakeClient.getRecentVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).called(2);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        });
 
         test(
           'accumulates visible API videos across mixed reply-heavy pages',
@@ -621,53 +618,49 @@ void main() {
         expect(result.map((video) => video.id), equals(['feed-video']));
       });
 
-      test(
-        'continues past a full relay page of reply-only videos',
-        () async {
-          final feedVideo = _createVideoEvent(
-            id: 'feed-video',
-            pubkey: 'test-pubkey',
-            videoUrl: 'https://example.com/feed.mp4',
-            createdAt: 1704060000,
+      test('continues past a full relay page of reply-only videos', () async {
+        final feedVideo = _createVideoEvent(
+          id: 'feed-video',
+          pubkey: 'test-pubkey',
+          videoUrl: 'https://example.com/feed.mp4',
+          createdAt: 1704060000,
+        );
+
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments.first as List<Filter>;
+          final filter = filters.single;
+          final limit = filter.limit ?? 5;
+
+          if (filter.until != null) {
+            return [feedVideo];
+          }
+
+          return List.generate(
+            limit,
+            (index) => _createVideoEvent(
+              id: 'video-reply-$index',
+              pubkey: 'test-pubkey',
+              videoUrl: 'https://example.com/reply-$index.mp4',
+              createdAt: 1704070000 - index,
+              extraTags: const [
+                ['E', 'root-event-id', '', 'root-author'],
+                ['K', '34236'],
+                ['P', 'root-author'],
+                ['e', 'root-event-id', '', 'root-author'],
+                ['k', '34236'],
+                ['p', 'root-author'],
+              ],
+            ),
           );
+        });
 
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
-            invocation,
-          ) async {
-            final filters =
-                invocation.positionalArguments.first as List<Filter>;
-            final filter = filters.single;
-            final limit = filter.limit ?? 5;
+        final result = await repository.getNewVideos();
 
-            if (filter.until != null) {
-              return [feedVideo];
-            }
-
-            return List.generate(
-              limit,
-              (index) => _createVideoEvent(
-                id: 'video-reply-$index',
-                pubkey: 'test-pubkey',
-                videoUrl: 'https://example.com/reply-$index.mp4',
-                createdAt: 1704070000 - index,
-                extraTags: const [
-                  ['E', 'root-event-id', '', 'root-author'],
-                  ['K', '34236'],
-                  ['P', 'root-author'],
-                  ['e', 'root-event-id', '', 'root-author'],
-                  ['k', '34236'],
-                  ['p', 'root-author'],
-                ],
-              ),
-            );
-          });
-
-          final result = await repository.getNewVideos();
-
-          expect(result.map((video) => video.id), equals(['feed-video']));
-          verify(() => mockNostrClient.queryEvents(any())).called(2);
-        },
-      );
+        expect(result.map((video) => video.id), equals(['feed-video']));
+        verify(() => mockNostrClient.queryEvents(any())).called(2);
+      });
 
       test(
         'accumulates visible relay videos across mixed reply-heavy pages',
@@ -7179,47 +7172,42 @@ void main() {
         },
       );
 
-      test(
-        'returns video without stats when stats hydration times out',
-        () {
-          const eventId = 'timeout-event-id';
-          final nostrEvent = _createVideoEvent(
-            id: eventId,
-            pubkey: 'pubkey-1',
-            videoUrl: 'https://example.com/video.mp4',
-            createdAt: 1739350000,
+      test('returns video without stats when stats hydration times out', () {
+        const eventId = 'timeout-event-id';
+        final nostrEvent = _createVideoEvent(
+          id: eventId,
+          pubkey: 'pubkey-1',
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: 1739350000,
+        );
+
+        return fakeAsync((async) {
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [nostrEvent]);
+
+          // Funnelcake hangs indefinitely — never completes.
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
+          ).thenAnswer((_) => Completer<BulkVideoStatsResponse>().future);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
           );
 
-          return fakeAsync((async) {
-            when(
-              () => mockNostrClient.queryEvents(any()),
-            ).thenAnswer((_) async => [nostrEvent]);
+          VideoEvent? result;
+          unawaited(repo.fetchVideoWithStats(eventId).then((v) => result = v));
 
-            // Funnelcake hangs indefinitely — never completes.
-            when(
-              () => mockFunnelcakeClient.getBulkVideoStats([eventId]),
-            ).thenAnswer((_) => Completer<BulkVideoStatsResponse>().future);
+          // Advance past the 3-second stats-fetch timeout.
+          async.elapse(const Duration(seconds: 4));
 
-            final repo = VideosRepository(
-              nostrClient: mockNostrClient,
-              funnelcakeApiClient: mockFunnelcakeClient,
-            );
-
-            VideoEvent? result;
-            unawaited(
-              repo.fetchVideoWithStats(eventId).then((v) => result = v),
-            );
-
-            // Advance past the 3-second stats-fetch timeout.
-            async.elapse(const Duration(seconds: 4));
-
-            expect(result, isNotNull);
-            expect(result!.id, equals(eventId));
-            // No stats hydrated — originalLoops should remain null.
-            expect(result!.originalLoops, isNull);
-          });
-        },
-      );
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          // No stats hydrated — originalLoops should remain null.
+          expect(result!.originalLoops, isNull);
+        });
+      });
     });
 
     group('fetchVideoWithStatsForRouteId', () {
@@ -7453,15 +7441,60 @@ void main() {
         },
       );
 
-      test('falls back to Funnelcake route lookup when relay misses shared '
-          'stable ID', () async {
+      test(
+        'resolves shared stable IDs via Funnelcake REST without hitting relay',
+        () async {
+          const stableId =
+              'e96357668c72c8923340b0ecf4bfacea'
+              '505172c4190e9953e603124c67175f3b';
+          const eventId =
+              'e46ff7d0d71d6c8114b58728afa43f08'
+              'd6286fd9a704683af799fd8f855586c2';
+          final apiHit = Event.fromJson({
+            'id': eventId,
+            'pubkey':
+                '076c979382b90f5d3a2b21f95e1ee86b'
+                '6033f14c92e79b7fad3fe1f1073f4886',
+            'created_at': 1777868006,
+            'kind': 34236,
+            'tags': [
+              ['d', stableId],
+              ['url', 'https://media.divine.video/$stableId'],
+              ['title', 'Divine team swag'],
+            ],
+            'content': 'Divine team swag!',
+            'sig': 'sig',
+          });
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(stableId),
+          ).thenAnswer((_) async => apiHit);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.stableId, equals(stableId));
+          verify(() => mockFunnelcakeClient.getVideoEvent(stableId)).called(1);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
+
+      test('falls back to relay when Funnelcake REST returns null '
+          '(event only on personal relay)', () async {
         const stableId =
             'e96357668c72c8923340b0ecf4bfacea'
             '505172c4190e9953e603124c67175f3b';
         const eventId =
             'e46ff7d0d71d6c8114b58728afa43f08'
             'd6286fd9a704683af799fd8f855586c2';
-        final relayMissThenApiHit = Event.fromJson({
+        final relayHit = Event.fromJson({
           'id': eventId,
           'pubkey':
               '076c979382b90f5d3a2b21f95e1ee86b'
@@ -7471,19 +7504,26 @@ void main() {
           'tags': [
             ['d', stableId],
             ['url', 'https://media.divine.video/$stableId'],
-            ['title', 'Divine team swag'],
+            ['title', 'Personal relay only'],
           ],
-          'content': 'Divine team swag!',
+          'content': 'Personal relay only',
           'sig': 'sig',
         });
 
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => <Event>[]);
-        when(
           () => mockFunnelcakeClient.getVideoEvent(stableId),
-        ).thenAnswer((_) async => relayMissThenApiHit);
+        ).thenAnswer((_) async => null);
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments.single as List<Filter>;
+          final filter = filters.single;
+          if (filter.d?.contains(stableId) ?? false) {
+            return [relayHit];
+          }
+          return <Event>[];
+        });
 
         final repo = VideosRepository(
           nostrClient: mockNostrClient,
@@ -7494,8 +7534,88 @@ void main() {
 
         expect(result, isNotNull);
         expect(result!.id, equals(eventId));
-        expect(result.stableId, equals(stableId));
         verify(() => mockFunnelcakeClient.getVideoEvent(stableId)).called(1);
+        verify(() => mockNostrClient.queryEvents(any())).called(greaterThan(0));
+      });
+
+      test('falls back to relay when Funnelcake REST throws', () async {
+        const stableId =
+            'e96357668c72c8923340b0ecf4bfacea'
+            '505172c4190e9953e603124c67175f3b';
+        const eventId =
+            'e46ff7d0d71d6c8114b58728afa43f08'
+            'd6286fd9a704683af799fd8f855586c2';
+        final relayHit = Event.fromJson({
+          'id': eventId,
+          'pubkey':
+              '076c979382b90f5d3a2b21f95e1ee86b'
+              '6033f14c92e79b7fad3fe1f1073f4886',
+          'created_at': 1777868006,
+          'kind': 34236,
+          'tags': [
+            ['d', stableId],
+            ['url', 'https://media.divine.video/$stableId'],
+            ['title', 'REST down'],
+          ],
+          'content': 'REST down',
+          'sig': 'sig',
+        });
+
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeClient.getVideoEvent(stableId),
+        ).thenThrow(const FunnelcakeTimeoutException('https://example.test'));
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments.single as List<Filter>;
+          final filter = filters.single;
+          if (filter.d?.contains(stableId) ?? false) {
+            return [relayHit];
+          }
+          return <Event>[];
+        });
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+      });
+
+      test('returns null without blocking when relay queries hang past the '
+          'route timeout', () async {
+        const stableId =
+            'e96357668c72c8923340b0ecf4bfacea'
+            '505172c4190e9953e603124c67175f3b';
+
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeClient.getVideoEvent(stableId),
+        ).thenAnswer((_) async => null);
+        // Relay never completes — simulates a stuck subscription waiting
+        // for EOSE from a still-connecting relay during cold start.
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) => Completer<List<Event>>().future);
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo
+            .fetchVideoWithStatsForRouteId(stableId)
+            // Cap above the in-source 3s timeout but well below the 60s+
+            // user-visible regression — a passing test proves the in-source
+            // timeout fired before the test wrapper.
+            .timeout(const Duration(seconds: 10));
+
+        expect(result, isNull);
       });
 
       test('returns blocked-author videos for direct route lookups', () async {

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -105,7 +106,7 @@ void main() {
     }
 
     group('loading state', () {
-      testWidgets('renders $CircularProgressIndicator while fetching video', (
+      testWidgets('renders $BrandedLoadingIndicator while fetching video', (
         tester,
       ) async {
         // fetchVideoWithStatsForRouteId stays pending
@@ -116,7 +117,8 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
       });
     });
 
@@ -394,7 +396,7 @@ void main() {
           await tester.pumpWidget(buildSubject(videoId: 'cold_start_video'));
           await tester.pump();
 
-          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
           expect(find.text('Video not found'), findsNothing);
 
           isInitialized = true;


### PR DESCRIPTION
Closes #4178

## Summary

- Cold-start `divine.video/video/<sha256>` deep-links were stuck behind a generic spinner for 60s+ before rendering. Reorders `fetchVideoWithStatsForRouteId` to local cache → Funnelcake REST → relay (each capped by a 3s timeout), so the canonical REST source answers first instead of running last after two relay round-trips that wait for EOSE from disconnected relays.
- Swaps the deep-link loading state from a generic Material `CircularProgressIndicator` to `BrandedLoadingIndicator` (matches the rest of the app).

## Why this was slow

`_VideoRouteCandidate.parse` treats a 64-char hex routeId as **both** an event id and a stable id. The previous flow ran:

1. `_nostrClient.queryEvents([Filter(ids:[hash], …)])` — never matches for Blossom-hashed share URLs (kind 34236 event ids are computed differently, the URL hash is the d-tag).
2. `_nostrClient.queryEvents([Filter(d:[hash], …)])` — may match.
3. Funnelcake REST.

`NostrClient.queryEvents` waits for EOSE from every relay in the pool with a 5s default timeout, and any relay still mid-connect during cold start blocks the whole batch. The on-relay-ready retry in `VideoDetailScreen` then re-runs the entire sequence on first relay connection. Worst case: ~5s + ~5s + Funnelcake + relay-ready wait + ~5s + ~5s + Funnelcake = comfortably 60s.

REST is now first because it answers in <1s without waiting on relay state and is the canonical source for divine.video share URLs. Relay is kept as a fallback so events that only live on a user's personal relay still resolve.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `flutter test test/screens/video_detail_screen_test.dart` — 11/11 pass (including updated `BrandedLoadingIndicator` assertions and the cold-start retry test)
- [x] `flutter test packages/videos_repository/` — 322/322 pass, including 4 new `fetchVideoWithStatsForRouteId` tests:
  - resolves shared stable IDs via Funnelcake REST without hitting relay
  - falls back to relay when REST returns null (event only on personal relay)
  - falls back to relay when REST throws (e.g. `FunnelcakeTimeoutException`)
  - returns null without blocking when relay queries hang past the route timeout (verifies the in-source 3s cap fires)
- [ ] Manual: cold-launch app from `https://divine.video/video/c0614bf93911042dc9a3ea571b662ee7e69765e433ecc8468e5a727116577966`, verify branded indicator appears and player renders within ~1–2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)