### PR TITLE
fix(perf): cap profile-tab thumbnail decode size to keep ImageCache from thrashing

### DIFF
--- a/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
+++ b/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
@@ -6,6 +6,16 @@ import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail_placeholder.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
+/// Decoded width cap for profile-tab grid thumbnails.
+///
+/// Three-column tiles render at ≈125dp on a 6.1-inch phone; 400 covers
+/// >3× pixel ratio with headroom and keeps each decoded entry small enough
+/// that a 50+ tile grid stays well under Flutter's default `ImageCache`
+/// budget. Without this cap, `cached_network_image` decodes at native CDN
+/// resolution (~3 MB / image), which thrashes the cache and stalls the
+/// first paint of large profile feeds. See #4190.
+const int _profileTabMemCacheWidth = 400;
+
 /// Cached thumbnail for profile grid tiles.
 ///
 /// Shows a [VineCachedImage] when [thumbnailUrl] is non-empty, falling back
@@ -31,6 +41,7 @@ class ProfileTabThumbnail extends StatelessWidget {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
       return VineCachedImage(
         imageUrl: thumbnailUrl!,
+        memCacheWidth: _profileTabMemCacheWidth,
         fadeInDuration: isPrecached
             ? Duration.zero
             : const Duration(milliseconds: 500),

--- a/mobile/test/widgets/profile/profile_tab_thumbnail_test.dart
+++ b/mobile/test/widgets/profile/profile_tab_thumbnail_test.dart
@@ -99,6 +99,26 @@ void main() {
         expect(image.fadeInDuration, equals(Duration.zero));
         expect(image.fadeOutDuration, equals(Duration.zero));
       });
+
+      // Caps decoded thumbnail size so a 50+ tile profile grid stays under
+      // Flutter's default ImageCache budget. Without it the cache thrashes
+      // on cold-load and stalls the first paint by ~1s (#4190).
+      testWidgets(
+        '$VineCachedImage forwards a memCacheWidth that caps decoded size',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(thumbnailUrl: 'https://example.com/thumb.jpg'),
+          );
+
+          final image = tester.widget<VineCachedImage>(
+            find.byType(VineCachedImage),
+          );
+          expect(image.memCacheWidth, equals(400));
+          // memCacheHeight is intentionally unset so BoxFit.cover scales
+          // proportionally rather than skewing aspect-sensitive crops.
+          expect(image.memCacheHeight, isNull);
+        },
+      );
     });
 
     group('blurhash fallback', () {


### PR DESCRIPTION
## Summary

- Adds a `memCacheWidth: 400` constraint to `ProfileTabThumbnail`'s `VineCachedImage`. The cap mirrors the existing pattern in `video_notification_row.dart` and is sized for 3-column phone tiles at 3.2× pixel ratio.
- Without it, `cached_network_image` decodes thumbnails at native CDN resolution (~3 MB each); a 50+ tile profile grid overflows Flutter's default `ImageCache` budget, thrashes the cache, and stalls first paint by ~1s.
- Single-file production change; benefits every profile tab grid that shares the widget (videos / liked / reposts / saved / collabs / comments).

Surfaced by @hm21 on [PR #4182 review](https://github.com/divinevideo/divine-mobile/pull/4182#pullrequestreview-4257513564).

Closes #4190.

## Why this scope

The two related perf issues — #3603 (de-dup in `build()`) and #3605 (`context.watch` on `BackgroundPublishBloc`) — only affect the **own-profile-with-active-uploads** path. The reviewer's repro is opening *another user's* profile, where `isOwnProfile=false` makes both no-ops. The dominant cost in that path is image decode + `ImageCache` thrash on first paint of the 50-event relay burst, which this PR addresses directly. Both related issues remain open for their assignees.

If QA still observes residual jank after this lands, the next layer to look at is the provider-side cascade in `profile_feed_provider.dart` — `_relayVideosSnapshot()` re-sorts the bucket on every relay tick (`video_event_service.dart:886-887`) and `filterVideoList` does two O(N) passes per emit (`video_event_service.dart:633-697`). That refactor needs its own scoping and is intentionally out of scope here.

## Test plan

- [x] `flutter analyze lib test integration_test` from `mobile/` — clean.
- [x] `flutter test test/widgets/profile/profile_tab_thumbnail_test.dart` — 9 / 9 pass (8 existing + 1 new pinning `memCacheWidth == 400` and `memCacheHeight == null` so `BoxFit.cover` still scales proportionally).
- [x] `flutter test test/widgets/profile/` — 170 / 170 pass.
- [ ] Manual: cold-launch app, open a profile with **50+ videos**. Compare loading-spinner-clear → first-tile-painted timing before/after. Confirm no >16ms frames during the burst (Performance overlay).
- [ ] Manual: open own profile + retained-state path (re-open same profile) + a profile with <10 videos to confirm no regression in the small-grid case.

## Related (not addressed here)

- #3603 — Move profile grid de-duplication out of `build()` (open, assigned).
- #3605 — `context.watch` causing unnecessary widget rebuilds (open).