### PR TITLE
fix(ci): sanitize cloudflare pages deploy metadata

### DIFF
--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -50,6 +50,9 @@ jobs:
               output.write(f"head_ref={metadata['head_ref']}\n")
               output.write(f"head_sha={metadata['head_sha']}\n")
               output.write(f"preview_branch=pr-{metadata['pr_number']}\n")
+              output.write(
+                  f"deploy_commit_message=PR #{metadata['pr_number']} preview deploy for {metadata['head_sha']}\n"
+              )
           PY
 
       - name: Check artifact freshness against current PR head
@@ -174,10 +177,14 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
           command: >-
             pages deploy artifact/web
             --project-name=openvine-app
             --branch=${{ steps.metadata.outputs.preview_branch }}
+            --commit-hash=${{ steps.metadata.outputs.head_sha }}
+            --commit-message="${{ steps.metadata.outputs.deploy_commit_message }}"
+            --commit-dirty=true
 
       - name: Render deployed preview comment
         if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured == 'true' }}

--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -53,7 +53,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
           command: >-
             pages deploy mobile/build/web
             --project-name=openvine-app
             --branch=main
+            --commit-hash=${{ github.sha }}
+            --commit-message="main deploy for ${{ github.sha }}"
+            --commit-dirty=true


### PR DESCRIPTION
Closes #4212

## Summary
- pass explicit ASCII commit metadata to Cloudflare Pages deploys instead of relying on Wrangler git discovery
- pin Wrangler to v4 in both the preview and production Pages deploy workflows
- mark deploys commit-dirty explicitly so the workflows stop warning on generated build artifacts

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile_pr_preview_deploy.yml"); YAML.load_file(".github/workflows/mobile_web_production_deploy.yml"); puts "yaml ok"'

## Context
Fixes the Cloudflare Pages deploy failure from Actions run 25612358859.