### PR TITLE
fix(inbox): show DM unread badge on Messages segment toggle

### DIFF
--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_actions/conversation_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/notifications/view/inbox_notifications_page.dart';
@@ -59,8 +60,11 @@ class _InboxViewState extends ConsumerState<InboxView> {
       }
     });
 
-    // Watch notification unread count for the badge.
+    // Watch unread counts for both segments. Without a Messages-side badge
+    // users had no signal that a still-lit bottom-nav inbox dot was caused
+    // by unread DMs rather than notifications they thought they'd cleared.
     final notificationCount = ref.watch(relayNotificationUnreadCountProvider);
+    final messageCount = context.watch<DmUnreadCountCubit>().state;
     final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
 
     return ColoredBox(
@@ -74,6 +78,7 @@ class _InboxViewState extends ConsumerState<InboxView> {
               selected: _selectedTab,
               onChanged: (tab) => setState(() => _selectedTab = tab),
               notificationCount: notificationCount,
+              messageCount: messageCount,
             ),
             // Content area with rounded top corners
             Expanded(

--- a/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Messages/Notifications segmented toggle for the inbox screen.
 // ABOUTME: Matches the Figma design with primary green active state,
-// ABOUTME: muted inactive state, and a notification badge on the left tab.
+// ABOUTME: muted inactive state, and unread-count badges on each tab.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -18,12 +18,14 @@ class InboxSegmentedToggle extends StatelessWidget {
     required this.selected,
     required this.onChanged,
     this.notificationCount = 0,
+    this.messageCount = 0,
     super.key,
   });
 
   final InboxTab selected;
   final ValueChanged<InboxTab> onChanged;
   final int notificationCount;
+  final int messageCount;
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +51,7 @@ class InboxSegmentedToggle extends StatelessWidget {
               label: 'Messages',
               isSelected: selected == InboxTab.messages,
               onTap: () => onChanged(InboxTab.messages),
+              badgeCount: messageCount,
             ),
           ),
         ],

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
@@ -38,6 +39,9 @@ class _MockMyFollowingBloc extends MockBloc<MyFollowingEvent, MyFollowingState>
 
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
     implements InviteStatusCubit {}
+
+class _MockDmUnreadCountCubit extends MockCubit<int>
+    implements DmUnreadCountCubit {}
 
 /// Minimal mock so the legacy RelayNotifications provider (still used for
 /// unread-count) does not start real timers or HTTP calls.
@@ -106,7 +110,11 @@ void main() {
       );
     });
 
-    Widget buildSubject({ConversationListState? state}) {
+    Widget buildSubject({
+      ConversationListState? state,
+      int dmUnreadCount = 0,
+      int notificationUnreadCount = 0,
+    }) {
       if (state != null) {
         whenListen(
           mockBloc,
@@ -125,10 +133,20 @@ void main() {
       when(() => mockInviteCubit.state).thenReturn(const InviteStatusState());
       when(mockInviteCubit.load).thenAnswer((_) async {});
 
+      final mockDmUnreadCubit = _MockDmUnreadCountCubit();
+      when(() => mockDmUnreadCubit.state).thenReturn(dmUnreadCount);
+      whenListen(
+        mockDmUnreadCubit,
+        const Stream<int>.empty(),
+        initialState: dmUnreadCount,
+      );
+
       return testMaterialApp(
         mockAuthService: mockAuthService,
         additionalOverrides: [
-          relayNotificationUnreadCountProvider.overrideWithValue(0),
+          relayNotificationUnreadCountProvider.overrideWithValue(
+            notificationUnreadCount,
+          ),
           relayNotificationsProvider.overrideWith(_MockRelayNotifications.new),
           notificationRepositoryProvider.overrideWithValue(null),
           goRouterProvider.overrideWithValue(mockGoRouter),
@@ -140,6 +158,7 @@ void main() {
               BlocProvider<ConversationListBloc>.value(value: mockBloc),
               BlocProvider<MyFollowingBloc>.value(value: mockFollowingBloc),
               BlocProvider<InviteStatusCubit>.value(value: mockInviteCubit),
+              BlocProvider<DmUnreadCountCubit>.value(value: mockDmUnreadCubit),
             ],
             child: const InboxView(),
           ),
@@ -154,6 +173,34 @@ void main() {
 
         expect(find.byType(InboxSegmentedToggle), findsOneWidget);
       });
+
+      testWidgets(
+        'forwards DmUnreadCountCubit state to '
+        '$InboxSegmentedToggle.messageCount',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(dmUnreadCount: 5));
+          await tester.pump();
+
+          final toggle = tester.widget<InboxSegmentedToggle>(
+            find.byType(InboxSegmentedToggle),
+          );
+          expect(toggle.messageCount, equals(5));
+        },
+      );
+
+      testWidgets(
+        'forwards relayNotificationUnreadCountProvider to '
+        '$InboxSegmentedToggle.notificationCount',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(notificationUnreadCount: 7));
+          await tester.pump();
+
+          final toggle = tester.widget<InboxSegmentedToggle>(
+            find.byType(InboxSegmentedToggle),
+          );
+          expect(toggle.notificationCount, equals(7));
+        },
+      );
 
       testWidgets('renders $FollowingBar in messages tab', (tester) async {
         await tester.pumpWidget(buildSubject());


### PR DESCRIPTION
## Summary

Closes #4216.

The bottom-nav inbox dot is a sum of unread notifications + unread DMs (`vine_bottom_nav.dart:97-99`), but the inbox UI only surfaced the notifications count via the segmented toggle's `notificationCount` field. Users with unread DMs saw the dot persist after clearing notifications and read it as "the dot didn't reset" — there was nowhere in the UI to learn that DMs were the cause.

Mirror the existing notification-side plumbing on the Messages side: add `messageCount` to `InboxSegmentedToggle` and wire it from `DmUnreadCountCubit.state` in `InboxView`.

## What changes

- `InboxSegmentedToggle` gains a `messageCount` parameter (defaults to `0`, same shape as `notificationCount`). Both sides now surface their count via the existing `_NotificationBadge`.
- `InboxView` watches `DmUnreadCountCubit.state` and forwards it to `messageCount`.

## Out of scope

Already in place — verified during investigation:
- Per-conversation unread dot (`_UnreadDot` in `conversation_tile.dart:172-186`). Once a user opens Messages they can see which conversations are unread; this PR provides the segment-level signal that gets them there.

## Tests

Two new tests in `inbox_view_test.dart`:
- `forwards DmUnreadCountCubit state to InboxSegmentedToggle.messageCount`
- `forwards relayNotificationUnreadCountProvider to InboxSegmentedToggle.notificationCount`

Both pin the wiring so a future regression where `messageCount` falls back to `0` (the cause of the original bug) fails loudly.

All 14 inbox view tests pass; full `flutter analyze lib test integration_test` clean.

## Test plan

- [x] `flutter analyze lib test integration_test` from `mobile/`
- [x] `flutter test test/screens/inbox/inbox_view_test.dart`
- [ ] Manual: send yourself an unread DM from another client, open the divine-mobile inbox, confirm Messages tab now shows a badge with the count, tap into the conversation, confirm count clears and bottom-nav dot clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)