### PR TITLE
fix(ci): pin Xcode to 26.2 to dodge 26.3 SPM workspace-load crash

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -163,7 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 🍎 Setup Xcode
-        # Pinned to 26.3: pro_video_editor 1.15.0's
+        # Pinned to 26.2 (NOT 26.3): pro_video_editor 1.15.0's
         # CompositionBuilder.swift references
         # `AVVideoCompositionLayerInstruction.Configuration`, an iOS 26
         # SDK type. The reference is runtime-gated by
@@ -173,13 +173,21 @@ jobs:
         # with "type 'AVVideoCompositionLayerInstruction' has no
         # member 'Configuration'" before tests can run. The same file
         # also needs the iOS 18 SDK shape (`[String: any Sendable]`)
-        # for AVVideoCompositing — Xcode 26 satisfies both.
-        # macos-15-arm64 ships 26.3 alongside 26.2 / 26.1.1 / 26.0.1
-        # but defaults to 16.4, so the explicit pin is required and
+        # for AVVideoCompositing — any Xcode 26.x satisfies both.
+        #
+        # Xcode 26.3 specifically has an SPM workspace-load race in
+        # `IDESPMWorkspaceDelegate.dependencyPackagesDidUpdate` that
+        # crashes `xcodebuild` with "count of array (53) differs from
+        # count of index set (52)" before tests can run. The crash
+        # reproduces on `main` independent of any PR diff. 26.2 ships
+        # the same iOS 26 SDK without the SPM race, so we pin there.
+        #
+        # macos-15-arm64 ships 26.3 / 26.2 / 26.1.1 / 26.0.1 but
+        # defaults to 16.4, so the explicit pin is required and
         # protects against the runner image's default drifting.
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.2"
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
Closes #4219

## Summary

- Downgrades the iOS Runner Tests lane in `mobile_ci.yaml` from Xcode 26.3 → 26.2.
- Restores the `RunnerTests` lane (and the `mobile-ci` aggregate) that has been red on every PR since #4128 merged, including on `main` itself.

## Why

PR #4128 added the macOS `RunnerTests` lane and pinned it to Xcode 26.3 because `pro_video_editor 1.15.0`'s `CompositionBuilder.swift` references `AVVideoCompositionLayerInstruction.Configuration` — an iOS 26 SDK type. The reference is runtime-gated (`if #available(iOS 26.0, *)`) but Swift type-checks both branches at compile time, so the SDK has to ship the type. Xcode 16.x ships iOS 17/18 SDKs and fails to compile.

Xcode 26.3 specifically has an SPM workspace-load race in `IDESPMWorkspaceDelegate.dependencyPackagesDidUpdate` that crashes `xcodebuild` with `count of array (53) differs from count of index set (52)` before tests can run. The crash reproduces on `origin/main` head independent of any PR diff — see [comment on #4128](https://github.com/divinevideo/divine-mobile/pull/4128#issuecomment-4414556243).

26.2 ships the same iOS 26 SDK without the SPM race. `macos-15-arm64` already has 26.2 installed alongside 26.3, so the pin change is a one-line swap with no infra cost.

A 16.x downgrade isn't an option — `pro_video_editor` requires the iOS 26 SDK at compile time. Reverting #4128 wholesale would also drop the `NostrBridgeAttestationPolicy` regression gating that the lane provides; this surgical pin keeps the gate intact.

## Test plan

- [ ] CI: `iOS Runner Tests` lane completes (no `xcodebuild` crash, RunnerTests pass).
- [ ] CI: `mobile-ci` aggregate is green.
- [ ] If 26.2 also has the race (we'd find out fast on first CI run): fall back to a wholesale revert of #4128 and re-land it once Apple ships 26.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)