### PR TITLE
fix(test): restore PathProviderPlatform.instance in seed-media tearDown

### DIFF
--- a/mobile/test/services/seed_media_preload_service_test.dart
+++ b/mobile/test/services/seed_media_preload_service_test.dart
@@ -51,10 +51,12 @@ void main() {
   group('SeedMediaPreloadService', () {
     late Directory tempDir;
     late MockPathProviderPlatform mockPathProvider;
+    late PathProviderPlatform originalPathProviderInstance;
 
     setUp(() async {
       tempDir = Directory.systemTemp.createTempSync('seed_media_test_');
 
+      originalPathProviderInstance = PathProviderPlatform.instance;
       mockPathProvider = MockPathProviderPlatform();
       mockPathProvider.setTemporaryPath(tempDir.path);
       PathProviderPlatform.instance = mockPathProvider;
@@ -66,6 +68,8 @@ void main() {
     });
 
     tearDown(() async {
+      PathProviderPlatform.instance = originalPathProviderInstance;
+
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }


### PR DESCRIPTION
Closes #4225

## Summary

Fixes the 19 `DraftStorageService` test failures that have been red on every PR (and on `main`) since #4154 merged. Surfaced while investigating why \`mobile-ci\` was blocking — see the parallel revert in #4222 for the orthogonal Xcode 26.x SPM crash.

## Root cause

#4154 ("fix(test): re-enable Bucket E skipped tests #3137", commit \`5a525e7bf\`) removed \`@Tags(['skip_very_good_optimization'])\` from \`mobile/test/services/seed_media_preload_service_test.dart\`, putting it back into the merged VGV optimized-isolate run.

That file's \`setUp\` mutates \`PathProviderPlatform.instance\` to a \`MockPathProviderPlatform\` configured with a temp path — but its \`tearDown\` never restores the original. The leaked mock has no application-documents path set, so when subsequent files in the same isolate (notably the top-level group of \`draft_storage_service_test.dart\`) call \`getApplicationDocumentsDirectory()\`, \`path_provider\` throws \`MissingPlatformDirectoryException(Unable to get application documents directory)\` and 19 tests fail.

\`upload_initialization_helper_test.dart\` and the \`migrateOldDrafts\` sub-group of \`draft_storage_service_test.dart\` already use the save-and-restore pattern; this PR applies the same 4-line fix to the seed-media file.

## Test plan

- [x] **Local repro:** ran \`flutter test test/services/seed_media_preload_service_test.dart test/services/draft_storage_service_test.dart\` together (matching CI ordering: seed-media → draft-storage). Goes from 19 \`MissingPlatformDirectoryException\` failures → all 32 tests passing.
- [ ] CI: \`Tests\` lane on this PR is green.

## Why fix-forward instead of reverting #4154

The win in #4154 (re-enabling the skipped tests inside the merged isolate) is real and worth keeping; only the missing \`tearDown\` line needs to be added. Reverting would re-skip valid coverage and waste #4154's asset-mock refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)