### PR TITLE
fix(ci): unblock mobile-ci (revert #4128 + patch seed-media test leak)

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -148,107 +148,6 @@ jobs:
             exit 1
           fi
           echo "✅ VGV tag count OK: current=$current, baseline=$baseline"
-  runner-tests:
-    name: iOS Runner Tests
-    # Gates the security-sensitive Swift code added in #3979:
-    # NostrBridgeAttestationPolicy (single-instance attach/detach state
-    # machine) and FrameAttestingScriptMessageHandler.eventPayload (pinned
-    # contract that the Dart-bound payload contains exactly
-    # {message, isMainFrame} and no origin host/port/scheme fields).
-    # Without this lane, regressions in those types pass CI and ship.
-    runs-on: macos-15
-    defaults:
-      run:
-        working-directory: mobile/
-    steps:
-      - uses: actions/checkout@v4
-      - name: 🍎 Setup Xcode
-        # Pinned to 26.3: pro_video_editor 1.15.0's
-        # CompositionBuilder.swift references
-        # `AVVideoCompositionLayerInstruction.Configuration`, an iOS 26
-        # SDK type. The reference is runtime-gated by
-        # `if #available(iOS 26.0, *)`, but Swift still type-checks
-        # both branches at compile time, so the type has to exist in
-        # the SDK. Xcode 16.x ships iOS 17/18 SDKs and the build fails
-        # with "type 'AVVideoCompositionLayerInstruction' has no
-        # member 'Configuration'" before tests can run. The same file
-        # also needs the iOS 18 SDK shape (`[String: any Sendable]`)
-        # for AVVideoCompositing — Xcode 26 satisfies both.
-        # macos-15-arm64 ships 26.3 alongside 26.2 / 26.1.1 / 26.0.1
-        # but defaults to 16.4, so the explicit pin is required and
-        # protects against the runner image's default drifting.
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26.3"
-      - name: 🐦 Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.41.9"
-          channel: "stable"
-          cache: true
-      - name: 📦 Enable Swift Package Manager
-        # c2pa_flutter (declared in pubspec.yaml as a git dependency)
-        # ships a CocoaPods stub whose only Swift file is a `#error`
-        # directive demanding SPM — its podspec exists only to satisfy
-        # Flutter's plugin validation. Locally SPM is enabled by
-        # `flutter config --enable-swift-package-manager`, so pub_get
-        # registers the plugin via FlutterGeneratedPluginSwiftPackage
-        # and `pod install` skips it. CI runners start with SPM off,
-        # so without this step pub_get installs c2pa_flutter as a Pod
-        # and `xcodebuild test` compiles the stub → ** TEST FAILED **.
-        # Setting must happen before any flutter command that touches
-        # iOS plugin setup (pub get, precache, build).
-        run: flutter config --enable-swift-package-manager
-      - name: 📥 Precache iOS artifacts
-        run: flutter precache --ios
-      - name: 📦 Install dependencies
-        run: flutter pub get
-      - name: 🔧 Generate iOS Flutter config
-        # `--config-only` writes mobile/ios/Flutter/Generated.xcconfig
-        # which the Podfile reads to resolve FLUTTER_ROOT. Without it,
-        # `pod install` fails. `--config-only` skips Dart compilation;
-        # `--no-codesign` is belt-and-suspenders since this lane never
-        # archives.
-        run: flutter build ios --config-only --no-codesign
-      - name: 🍫 Cache CocoaPods
-        uses: actions/cache@v4
-        with:
-          path: |
-            mobile/ios/Pods
-            ~/Library/Caches/CocoaPods
-          key: pods-${{ runner.os }}-${{ hashFiles('mobile/ios/Podfile.lock') }}
-          restore-keys: pods-${{ runner.os }}-
-      - name: 🥘 Install CocoaPods
-        working-directory: mobile/ios
-        run: pod install
-      - name: 🧪 Run RunnerTests
-        # Code signing is disabled because simulator unit tests don't
-        # need a provisioning profile; with it on, GitHub-hosted runners
-        # without Apple credentials fail with "no profile". `iPhone 16`
-        # is the default preinstalled simulator on macos-15 with
-        # Xcode 16.4 (iPhone 15 was dropped from the default set);
-        # OS=latest is safe because the tests are pure Swift unit tests
-        # with no version-gated APIs.
-        working-directory: mobile/ios
-        run: |
-          set -o pipefail
-          xcodebuild test \
-            -workspace Runner.xcworkspace \
-            -scheme Runner \
-            -only-testing:RunnerTests \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
-            -configuration Debug \
-            -resultBundlePath build/RunnerTests.xcresult \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            COMPILER_INDEX_STORE_ENABLE=NO \
-            | xcpretty
-      - name: 📤 Upload xcresult on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: RunnerTests.xcresult
-          path: mobile/ios/build/RunnerTests.xcresult
   mobile-ci:
     name: Mobile CI
     if: ${{ always() }}
@@ -258,7 +157,6 @@ jobs:
       - analyze
       - tests
       - vgv-tag-gate
-      - runner-tests
     runs-on: ubuntu-latest
     steps:
       - name: Verify upstream jobs
@@ -268,21 +166,18 @@ jobs:
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
           VGV_TAG_GATE_RESULT: ${{ needs.vgv-tag-gate.result }}
-          RUNNER_TESTS_RESULT: ${{ needs.runner-tests.result }}
         run: |
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
           echo "vgv-tag-gate: ${VGV_TAG_GATE_RESULT}"
-          echo "runner-tests: ${RUNNER_TESTS_RESULT}"
 
           if [[ "${GENERATED_FILES_RESULT}" != "success" || \
                 "${FORMAT_RESULT}" != "success" || \
                 "${ANALYZE_RESULT}" != "success" || \
                 "${TESTS_RESULT}" != "success" || \
-                "${VGV_TAG_GATE_RESULT}" != "success" || \
-                "${RUNNER_TESTS_RESULT}" != "success" ]]; then
+                "${VGV_TAG_GATE_RESULT}" != "success" ]]; then
             echo "One or more Mobile CI jobs failed."
             exit 1
           fi

--- a/mobile/test/services/seed_media_preload_service_test.dart
+++ b/mobile/test/services/seed_media_preload_service_test.dart
@@ -51,10 +51,12 @@ void main() {
   group('SeedMediaPreloadService', () {
     late Directory tempDir;
     late MockPathProviderPlatform mockPathProvider;
+    late PathProviderPlatform originalPathProviderInstance;
 
     setUp(() async {
       tempDir = Directory.systemTemp.createTempSync('seed_media_test_');
 
+      originalPathProviderInstance = PathProviderPlatform.instance;
       mockPathProvider = MockPathProviderPlatform();
       mockPathProvider.setTemporaryPath(tempDir.path);
       PathProviderPlatform.instance = mockPathProvider;
@@ -66,6 +68,8 @@ void main() {
     });
 
     tearDown(() async {
+      PathProviderPlatform.instance = originalPathProviderInstance;
+
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }


### PR DESCRIPTION
Closes #4227

## Summary

Combines two orthogonal fixes that have each been deadlocked in their own PR (each blocked by the bug the *other* fixes). Shipping both in one PR so CI can go green in a single run without bypass-merging.

**Closes the deadlock between #4222 and #4224 — both will be closed in favor of this PR.**

## Changes

### 1. Revert #4128 — drop the broken iOS Runner Tests lane

The lane has been red on every PR (and on \`main\` itself) since #4128 merged. Root cause: an SPM workspace-load race in Xcode 26.x's \`IDESPMWorkspaceDelegate.dependencyPackagesDidUpdate\` that crashes \`xcodebuild\` with \`count of array (53) differs from count of index set (52)\` before any test executes.

Reproduced on both Xcode 26.3 (the original pin) and 26.2 (verified on a closed experimental PR — same crash, same stack frames). A 16.x downgrade isn't viable: \`pro_video_editor 1.15.0\`'s \`CompositionBuilder.swift\` references \`AVVideoCompositionLayerInstruction.Configuration\`, an iOS 26 SDK type that Swift type-checks at compile time.

Re-land #4128 once Apple ships an Xcode 26.x without the SPM race (watch for 26.4) or once the \`macos-26-arm64\` runner image is available with a working Xcode. This loses the \`NostrBridgeAttestationPolicy\` regression gate in the meantime.

### 2. Restore \`PathProviderPlatform.instance\` in seed-media test \`tearDown\`

#4154 ("fix(test): re-enable Bucket E skipped tests #3137", commit \`5a525e7bf\`) removed \`@Tags(['skip_very_good_optimization'])\` from \`mobile/test/services/seed_media_preload_service_test.dart\`, putting it back into the merged VGV optimized-isolate run.

That file's \`setUp\` mutates \`PathProviderPlatform.instance\` to a \`MockPathProviderPlatform\` configured only with a temp path — but its \`tearDown\` never restores the original. The leaked mock has no application-documents path set, so subsequent files in the same isolate (notably the top-level group of \`draft_storage_service_test.dart\`) call \`getApplicationDocumentsDirectory()\` against the leaked mock, and \`path_provider\` throws \`MissingPlatformDirectoryException(Unable to get application documents directory)\` — 19 \`DraftStorageService\` tests fail.

The fix mirrors the save-and-restore pattern already used by \`upload_initialization_helper_test.dart\` and the \`migrateOldDrafts\` sub-group of \`draft_storage_service_test.dart\` itself.

## Test plan

- [x] **Local repro:** ran \`flutter test test/services/seed_media_preload_service_test.dart test/services/draft_storage_service_test.dart\` together in CI order. Goes from 19 \`MissingPlatformDirectoryException\` failures → all 32 tests passing.
- [x] **CI on #4224 (just the test fix, before combine):** \`Tests\`, \`Generated Files\`, \`Format\`, \`Analyze\` all green; only \`iOS Runner Tests\` was red, and that lane is removed by part (1) of this PR.
- [ ] CI on this PR: every required check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)