### PR TITLE
chore(release): bump app version to 1.0.13+502

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.12+501
+version: 1.0.13+502
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary

Bumps the Flutter app version from `1.0.12+501` to `1.0.13+502` in `mobile/pubspec.yaml` ahead of the next release.

## Test plan

- [ ] CI passes (analyze / format / tests)
- [ ] iOS / Android build picks up new `CFBundleShortVersionString` / `versionName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)