### PR TITLE
chore(deps): bump pro_video_editor to version 1.16.1

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1856,10 +1856,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "968d6b2ba70705bd645615f2f2b22d54d85ca3d8de43536d8f9fe0f1554ca6d1"
+      sha256: "9485f14a3ffa47fe413aeaa01b7fcd2b3e86d38fc0dafb342dc5ee765776dd09"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.2"
+    version: "1.16.1"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -273,7 +273,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.15.0
+  pro_video_editor: ^1.16.1
   pro_image_editor: ^12.4.4
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
 
## Description

Note the fix is inside of the pro_video_editor so we just bump the version here.

> Resolve a crash occurring when rendering H.264 MP4 files with a container duration that exceeds the video track's actual frame duration. The compositor now clamps the time range to the video track's real duration, preventing requests for frames without available pixel buffers. A fallback to output a black frame has been added to handle cases where no source tracks are available.

**Related Issue:** Closes #3092

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore