### PR TITLE
ci(codemagic): clean stale Xcode/SPM workspace state before iOS builds

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -32,6 +32,20 @@ definitions:
     - &setup_code_signing_xcode
       name: Set up code signing settings on Xcode project
       script: xcode-project use-profiles
+    - &clean_ios_workspace_state
+      name: Clean stale Xcode/SPM workspace state
+      script: |
+        # Xcode 16 + Flutter SPM workspaces occasionally crash the
+        # archive step with `INTERNAL ERROR: Unable to load workspace
+        # 'Runner.xcworkspace'` and `count of array (N) differs from
+        # count of index set (N-1)` from IDESwiftPackageCore. The
+        # cause is an out-of-sync swiftpm workspace-state.json from a
+        # prior step in the same build. Wiping DerivedData and the
+        # workspace's swiftpm/xcuserdata state forces a fresh resolve.
+        rm -rf "$HOME/Library/Developer/Xcode/DerivedData"
+        rm -rf ios/Pods ios/.symlinks
+        rm -rf ios/Runner.xcworkspace/xcuserdata
+        rm -rf ios/Runner.xcworkspace/xcshareddata/swiftpm
     - &install_flutterfire
       name: Install FlutterFire CLI
       script: dart pub global activate flutterfire_cli
@@ -374,6 +388,7 @@ workflows:
       events: []
     scripts:
       - *setup_code_signing_xcode
+      - *clean_ios_workspace_state
       - *install_flutterfire
       - *enable_spm
       - *prepare_ios_spm_packages
@@ -428,6 +443,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *clean_ios_workspace_state
       - *install_flutterfire
       - *enable_spm
       - *flutter_pub_get
@@ -560,6 +576,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *clean_ios_workspace_state
       - *install_flutterfire
       - *enable_spm
       - *flutter_pub_get


### PR DESCRIPTION
Closes #4236

## Summary

The Codemagic iOS archive step intermittently dies with:

> `** INTERNAL ERROR: Unable to load workspace 'Runner.xcworkspace' **`
> `Uncaught Exception: *** -[NSMutableArray insertObjects:atIndexes:]: count of array (53) differs from count of index set (52)`
> `IDESwiftPackageCore … sortedInsert(of:) … registerDependencyFileReferences …`

Root cause is a desynced `Runner.xcworkspace/xcshareddata/swiftpm/workspace-state.json` carried over within a single Codemagic build — the iOS workflow opens the workspace three times (`flutter build ios --config-only`, `pod install`, `flutter build ipa`), and Xcode 16's `IDESwiftPackageCore` occasionally trips on a stale SPM graph from the earlier opens.

## Fix

Add a shared `clean_ios_workspace_state` step that wipes:
- `$HOME/Library/Developer/Xcode/DerivedData`
- `ios/Pods` and `ios/.symlinks`
- `ios/Runner.xcworkspace/xcuserdata`
- `ios/Runner.xcworkspace/xcshareddata/swiftpm`

…before each iOS workflow runs, so the archive step always sees a freshly-resolved SPM graph. Wired into `ios-build`, `ios-simulator-build`, and `e2e-smoke-ios`. `Podfile.lock` is intentionally left in place so pod resolution stays reproducible across CI runs.

## Test plan

- [ ] Run the `iOS Build` workflow on Codemagic from this branch and confirm the archive completes
- [ ] Re-run a few times — the failure was intermittent, so a single green run isn't proof
- [ ] `iOS Simulator Build` workflow still passes
- [ ] `E2E Smoke Tests (iOS)` workflow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)