### PR TITLE
perf(rebuilds): swap context.watch for context.select on three hot widgets

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -141,27 +141,41 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
 
   @override
   Widget build(BuildContext context) {
-    // Restore widget fields via `widget.` — same logic as before.
     final UserProfile? effectiveProfile;
     final bool isLoadingIdentity;
     if (widget.isOwnProfile) {
-      final state = context.watch<MyProfileBloc>().state;
-      effectiveProfile =
-          switch (state) {
-            MyProfileUpdated(:final profile) => profile,
-            MyProfileLoaded(:final profile) => profile,
-            MyProfileLoading(:final profile) => profile,
-            _ => null,
-          } ??
-          widget.profile;
+      // Project to (profile, isInitialOrLoading) so this widget rebuilds only
+      // when the displayed profile or the genuine "still loading" signal
+      // changes. Watching the whole state would also rebuild on isFresh /
+      // extractedUsername / verifiedClaims transitions and on the
+      // MyProfileError variant, none of which the header reads here.
+      final selection = context
+          .select<
+            MyProfileBloc,
+            ({UserProfile? profile, bool isInitialOrLoading})
+          >(
+            (bloc) {
+              final state = bloc.state;
+              return (
+                profile: switch (state) {
+                  MyProfileUpdated(:final profile) => profile,
+                  MyProfileLoaded(:final profile) => profile,
+                  MyProfileLoading(:final profile) => profile,
+                  _ => null,
+                },
+                isInitialOrLoading:
+                    state is MyProfileInitial || state is MyProfileLoading,
+              );
+            },
+          );
+      effectiveProfile = selection.profile ?? widget.profile;
       // Skeleton on the user's own profile is appropriate only while we
       // genuinely have nothing to show. As soon as a cached profile is
       // available, fall through to render the real identity. After
       // MyProfileError(notFound) the generated fallback is the truthful
       // steady state — don't skeleton it.
       isLoadingIdentity =
-          effectiveProfile == null &&
-          (state is MyProfileInitial || state is MyProfileLoading);
+          effectiveProfile == null && selection.isInitialOrLoading;
     } else if (widget.profile != null) {
       effectiveProfile = widget.profile;
       isLoadingIdentity = false;

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -5,6 +5,7 @@ import 'dart:async' show FutureOr;
 import 'dart:io';
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -54,6 +55,41 @@ typedef _ActiveUpload = ({
   String? title,
   String? thumbnailPath,
 });
+
+/// Equatable wrapper over the list of active uploads consumed by
+/// [_ProfileVideosGridState.build]. Exists because `context.select`
+/// compares its selected value with `==`, and a raw `List<_ActiveUpload>`
+/// — even one of structurally-equal records — falls through to identity
+/// equality and would mark the consumer dirty on every progress tick.
+/// Equatable's deep `iterableEquals` over records gives the selector the
+/// progress-insensitive comparison the optimization needs.
+@visibleForTesting
+class ActiveUploadsView extends Equatable {
+  @visibleForTesting
+  const ActiveUploadsView(this.uploads);
+
+  // Public field uses the record type inline so the private [_ActiveUpload]
+  // typedef alias doesn't leak through the public API surface
+  // (avoids `library_private_types_in_public_api`).
+  final List<({String draftId, String? title, String? thumbnailPath})> uploads;
+
+  /// Projects the bloc's [BackgroundPublishState] into the shape the grid
+  /// renders. Used as the selector callback in [_ProfileVideosGridState.build].
+  static ActiveUploadsView fromState(BackgroundPublishState state) {
+    return ActiveUploadsView([
+      for (final upload in state.uploads)
+        if (upload.result == null)
+          (
+            draftId: upload.draft.id,
+            title: upload.draft.title,
+            thumbnailPath: upload.draft.clips.firstOrNull?.thumbnailPath,
+          ),
+    ]);
+  }
+
+  @override
+  List<Object?> get props => [uploads];
+}
 
 /// Grid widget displaying user's videos on their profile
 class ProfileVideosGrid extends ConsumerStatefulWidget {
@@ -195,19 +231,18 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     // thumbnailPath per upload). Progress is intentionally excluded so that
     // per-tick progress emissions don't rebuild the grid — each upload
     // tile subscribes to its own progress in [_VideoGridUploadingTile].
+    //
+    // The selector returns [ActiveUploadsView] (Equatable) rather than a raw
+    // [List]: `context.select` compares its result with `==`, and `List`
+    // equality is identity-based — without the wrapper, a freshly-built list
+    // every tick would defeat the optimization regardless of record equality
+    // inside it.
     final activeUploads = isOwnProfile
-        ? context.select<BackgroundPublishBloc, List<_ActiveUpload>>(
-            (bloc) => [
-              for (final upload in bloc.state.uploads)
-                if (upload.result == null)
-                  (
-                    draftId: upload.draft.id,
-                    title: upload.draft.title,
-                    thumbnailPath:
-                        upload.draft.clips.firstOrNull?.thumbnailPath,
-                  ),
-            ],
-          )
+        ? context
+              .select<BackgroundPublishBloc, ActiveUploadsView>(
+                (bloc) => ActiveUploadsView.fromState(bloc.state),
+              )
+              .uploads
         : const <_ActiveUpload>[];
 
     // De-duplicate relay-delivered videos against active uploads.
@@ -370,11 +405,17 @@ class _VideoGridUploadingTile extends StatelessWidget {
   Widget build(BuildContext context) {
     // Subscribe to this specific upload's progress so the tile rebuilds on
     // every progress tick without the surrounding grid having to.
+    //
+    // Fallback returns 1.0 (not 0): this branch is reached only after the
+    // bloc removes the upload from state on [PublishSuccess]. If the tile
+    // renders one frame before the parent grid prunes it, animating the
+    // spinner forward to full is correct; animating backward to empty
+    // would briefly snap the spinner across a 200ms animation.
     final progress = context.select<BackgroundPublishBloc, double>((bloc) {
       for (final upload in bloc.state.uploads) {
         if (upload.draft.id == draftId) return upload.progress;
       }
-      return 0;
+      return 1.0;
     });
     final path = thumbnailPath;
 

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -46,16 +46,6 @@ class _GridUploadingVideoEntry extends _GridVideoEntry {
   final String? thumbnailPath;
 }
 
-/// Stable projection of an in-progress [BackgroundUpload] used by the grid
-/// build method. Drops [BackgroundUpload.progress] so that progress ticks
-/// don't trigger a grid rebuild — the spinner subscribes to its own
-/// upload's progress in [_VideoGridUploadingTile].
-typedef _ActiveUpload = ({
-  String draftId,
-  String? title,
-  String? thumbnailPath,
-});
-
 /// Debug-only counter incremented at the top of every
 /// [_ProfileVideosGridState.build] call. Used by tests to pin the
 /// rebuild count to 1 across progress-only `BackgroundPublishBloc`
@@ -67,11 +57,10 @@ int debugProfileVideosGridBuildCount = 0;
 
 /// Equatable wrapper over the list of active uploads consumed by
 /// [_ProfileVideosGridState.build]. Exists because `context.select`
-/// compares its selected value with `==`, and a raw `List<_ActiveUpload>`
-/// — even one of structurally-equal records — falls through to identity
-/// equality and would mark the consumer dirty on every progress tick.
-/// Equatable's deep `iterableEquals` over records gives the selector the
-/// progress-insensitive comparison the optimization needs.
+/// compares its selected value with `==`, and a raw list of records falls
+/// through to identity equality even when the records themselves compare
+/// equal structurally. Equatable's deep `iterableEquals` gives the selector
+/// the progress-insensitive comparison the optimization needs.
 @visibleForTesting
 class ActiveUploadsView extends Equatable {
   @visibleForTesting
@@ -256,7 +245,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
                 (bloc) => ActiveUploadsView.fromState(bloc.state),
               )
               .uploads
-        : const <_ActiveUpload>[];
+        : const <({String draftId, String? title, String? thumbnailPath})>[];
 
     // De-duplicate relay-delivered videos against active uploads.
     //

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -36,10 +36,24 @@ class _GridVideoEventEntry extends _GridVideoEntry {
 }
 
 class _GridUploadingVideoEntry extends _GridVideoEntry {
-  _GridUploadingVideoEntry(this.backgroundUpload);
+  _GridUploadingVideoEntry({
+    required this.draftId,
+    required this.thumbnailPath,
+  });
 
-  final BackgroundUpload backgroundUpload;
+  final String draftId;
+  final String? thumbnailPath;
 }
+
+/// Stable projection of an in-progress [BackgroundUpload] used by the grid
+/// build method. Drops [BackgroundUpload.progress] so that progress ticks
+/// don't trigger a grid rebuild — the spinner subscribes to its own
+/// upload's progress in [_VideoGridUploadingTile].
+typedef _ActiveUpload = ({
+  String draftId,
+  String? title,
+  String? thumbnailPath,
+});
 
 /// Grid widget displaying user's videos on their profile
 class ProfileVideosGrid extends ConsumerStatefulWidget {
@@ -175,15 +189,26 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
   @override
   Widget build(BuildContext context) {
     final authService = ref.read(authServiceProvider);
-    final backgroundPublish = context.watch<BackgroundPublishBloc>();
     final isOwnProfile = authService.currentPublicKeyHex == widget.userIdHex;
 
-    // Uploads that are still in progress (no result yet).
+    // Subscribe to the *shape* of the active upload list (id + title +
+    // thumbnailPath per upload). Progress is intentionally excluded so that
+    // per-tick progress emissions don't rebuild the grid — each upload
+    // tile subscribes to its own progress in [_VideoGridUploadingTile].
     final activeUploads = isOwnProfile
-        ? backgroundPublish.state.uploads
-              .where((upload) => upload.result == null)
-              .toList()
-        : <BackgroundUpload>[];
+        ? context.select<BackgroundPublishBloc, List<_ActiveUpload>>(
+            (bloc) => [
+              for (final upload in bloc.state.uploads)
+                if (upload.result == null)
+                  (
+                    draftId: upload.draft.id,
+                    title: upload.draft.title,
+                    thumbnailPath:
+                        upload.draft.clips.firstOrNull?.thumbnailPath,
+                  ),
+            ],
+          )
+        : const <_ActiveUpload>[];
 
     // De-duplicate relay-delivered videos against active uploads.
     //
@@ -213,7 +238,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
             final isDuplicate =
                 !matchedTitles.contains(video.title) &&
                 activeUploads.any(
-                  (upload) => upload.draft.title == video.title,
+                  (upload) => upload.title == video.title,
                 );
 
             // Step 3: Mark the title as matched so only the first duplicate
@@ -243,7 +268,12 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
         : widget.videos;
 
     final allVideos = [
-      ...activeUploads.map(_GridUploadingVideoEntry.new),
+      ...activeUploads.map(
+        (upload) => _GridUploadingVideoEntry(
+          draftId: upload.draftId,
+          thumbnailPath: upload.thumbnailPath,
+        ),
+      ),
       ...filteredVideos.map(_GridVideoEventEntry.new),
     ];
 
@@ -294,7 +324,8 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
               return switch (videoEntry) {
                 final _GridUploadingVideoEntry uploadEntry =>
                   _VideoGridUploadingTile(
-                    backgroundUpload: uploadEntry.backgroundUpload,
+                    draftId: uploadEntry.draftId,
+                    thumbnailPath: uploadEntry.thumbnailPath,
                   ),
                 final _GridVideoEventEntry eventEntry => _VideoGridTile(
                   videoEvent: eventEntry.videoEvent,
@@ -327,32 +358,41 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
 }
 
 class _VideoGridUploadingTile extends StatelessWidget {
-  const _VideoGridUploadingTile({required this.backgroundUpload});
+  const _VideoGridUploadingTile({
+    required this.draftId,
+    required this.thumbnailPath,
+  });
 
-  final BackgroundUpload backgroundUpload;
+  final String draftId;
+  final String? thumbnailPath;
 
   @override
   Widget build(BuildContext context) {
-    final thumbnailPath =
-        backgroundUpload.draft.clips.firstOrNull?.thumbnailPath;
+    // Subscribe to this specific upload's progress so the tile rebuilds on
+    // every progress tick without the surrounding grid having to.
+    final progress = context.select<BackgroundPublishBloc, double>((bloc) {
+      for (final upload in bloc.state.uploads) {
+        if (upload.draft.id == draftId) return upload.progress;
+      }
+      return 0;
+    });
+    final path = thumbnailPath;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(4),
       child: Stack(
         fit: StackFit.expand,
         children: [
-          if (thumbnailPath != null)
+          if (path != null)
             Image.file(
-              File(thumbnailPath),
+              File(path),
               fit: BoxFit.cover,
               errorBuilder: (_, _, _) => const ProfileTabThumbnailPlaceholder(),
             )
           else
             const ProfileTabThumbnailPlaceholder(),
           const ColoredBox(color: Color(0x66000000)),
-          Center(
-            child: PartialCircleSpinner(progress: backgroundUpload.progress),
-          ),
+          Center(child: PartialCircleSpinner(progress: progress)),
         ],
       ),
     );

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -56,6 +56,15 @@ typedef _ActiveUpload = ({
   String? thumbnailPath,
 });
 
+/// Debug-only counter incremented at the top of every
+/// [_ProfileVideosGridState.build] call. Used by tests to pin the
+/// rebuild count to 1 across progress-only `BackgroundPublishBloc`
+/// emissions — a regression to identity-based list equality on the
+/// selector would tick this counter higher. The increment is wrapped
+/// in an `assert` so it is tree-shaken out of release builds.
+@visibleForTesting
+int debugProfileVideosGridBuildCount = 0;
+
 /// Equatable wrapper over the list of active uploads consumed by
 /// [_ProfileVideosGridState.build]. Exists because `context.select`
 /// compares its selected value with `==`, and a raw `List<_ActiveUpload>`
@@ -224,6 +233,10 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
 
   @override
   Widget build(BuildContext context) {
+    assert(() {
+      debugProfileVideosGridBuildCount++;
+      return true;
+    }());
     final authService = ref.read(authServiceProvider);
     final isOwnProfile = authService.currentPublicKeyHex == widget.userIdHex;
 

--- a/mobile/lib/widgets/video_editor/draw_editor/video_editor_draw_item_indicator.dart
+++ b/mobile/lib/widgets/video_editor/draw_editor/video_editor_draw_item_indicator.dart
@@ -15,7 +15,9 @@ class VideoEditorDrawItemIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tool = context.watch<VideoEditorDrawBloc>().state.selectedTool;
+    final tool = context.select<VideoEditorDrawBloc, DrawToolType>(
+      (bloc) => bloc.state.selectedTool,
+    );
 
     final double itemFactor = switch (tool) {
       .pencil => 0,

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -76,6 +78,7 @@ void main() {
       mockAuth = _MockAuthService();
       mockBloc = _MockBackgroundPublishBloc();
       when(() => mockBloc.state).thenReturn(const BackgroundPublishState());
+      debugProfileVideosGridBuildCount = 0;
     });
 
     Widget buildSubject({
@@ -528,37 +531,104 @@ void main() {
         },
       );
 
-      testWidgets('progress-only state emission updates the per-tile spinner', (
-        tester,
-      ) async {
-        when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+      testWidgets(
+        'progress-only state emission does not rebuild the grid '
+        'while the per-tile spinner still receives the update',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
 
-        final draft = _createTestDraft();
-        final initial = BackgroundPublishState(
-          uploads: [
-            BackgroundUpload(draft: draft, result: null, progress: 0.1),
-          ],
-        );
-        final tick = BackgroundPublishState(
-          uploads: [
-            BackgroundUpload(draft: draft, result: null, progress: 0.9),
-          ],
-        );
+          final draft = _createTestDraft();
+          final initial = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draft, result: null, progress: 0.1),
+            ],
+          );
+          final tick = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draft, result: null, progress: 0.9),
+            ],
+          );
 
-        whenListen(mockBloc, Stream.value(tick), initialState: initial);
+          // Use an externally-driven broadcast stream so we can pump the
+          // initial Riverpod async (profileFeedProvider transitions from
+          // AsyncLoading → AsyncData and triggers an orthogonal rebuild
+          // via `ref.watch`) to a steady state before measuring the
+          // bloc-tick's incremental rebuild count.
+          final controller =
+              StreamController<BackgroundPublishState>.broadcast();
+          addTearDown(controller.close);
+          whenListen(mockBloc, controller.stream, initialState: initial);
 
-        await tester.pumpWidget(buildSubject(userIdHex: _ownPubkey));
-        // Flush the queued whenListen emission.
-        await tester.pump();
-        // PartialCircleSpinner.animateTo runs over 200ms — settle the
-        // implicit animation so we read the post-tick value.
-        await tester.pump(const Duration(milliseconds: 250));
+          await tester.pumpWidget(buildSubject(userIdHex: _ownPubkey));
+          // Settle initial async (Riverpod's profileFeedProvider, post-
+          // frame callbacks, etc.) — anything not caused by our tick.
+          await tester.pump();
+          final baselineBuildCount = debugProfileVideosGridBuildCount;
 
-        final spinner = tester.widget<PartialCircleSpinner>(
-          find.byType(PartialCircleSpinner),
-        );
-        expect(spinner.progress, closeTo(0.9, 1e-9));
-      });
+          // Now emit the progress-only update.
+          controller.add(tick);
+          await tester.pump();
+          // PartialCircleSpinner.animateTo runs over 200ms — settle the
+          // implicit animation so we read the post-tick value.
+          await tester.pump(const Duration(milliseconds: 250));
+
+          // (a) Grid did NOT rebuild as a result of the progress-only
+          // emission. A regression to identity-based list equality on
+          // the selector would tick this counter higher.
+          expect(debugProfileVideosGridBuildCount, equals(baselineBuildCount));
+
+          // (b) Per-tile spinner DID receive the updated progress —
+          // the tile's own context.select<...double>(...) projects to
+          // a primitive whose equality compares cleanly.
+          final spinner = tester.widget<PartialCircleSpinner>(
+            find.byType(PartialCircleSpinner),
+          );
+          expect(spinner.progress, closeTo(0.9, 1e-9));
+        },
+      );
+
+      testWidgets(
+        'shape-change state emission does rebuild the grid '
+        '(contrast for the rebuild-count counter)',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+
+          final draftA = _createTestDraft(title: 'A');
+          final draftB = _createTestDraft(title: 'B');
+          final initial = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draftA, result: null, progress: 0.5),
+            ],
+          );
+          final shapeChange = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draftA, result: null, progress: 0.5),
+              BackgroundUpload(draft: draftB, result: null, progress: 0.5),
+            ],
+          );
+
+          final controller =
+              StreamController<BackgroundPublishState>.broadcast();
+          addTearDown(controller.close);
+          whenListen(mockBloc, controller.stream, initialState: initial);
+
+          await tester.pumpWidget(buildSubject(userIdHex: _ownPubkey));
+          await tester.pump();
+          final baselineBuildCount = debugProfileVideosGridBuildCount;
+
+          controller.add(shapeChange);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 250));
+
+          // Shape changed (a new upload appeared) → grid must rebuild
+          // so the new tile is added to the SliverGrid.
+          expect(
+            debugProfileVideosGridBuildCount,
+            greaterThan(baselineBuildCount),
+          );
+          expect(find.byType(PartialCircleSpinner), findsNWidgets(2));
+        },
+      );
     });
 
     group('scroll coordination with NestedScrollView', () {

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -428,6 +428,139 @@ void main() {
       );
     });
 
+    group('rebuild optimization (#3605)', () {
+      // These tests pin the `context.select` contract that keeps the grid
+      // from rebuilding on every `BackgroundPublishBloc` progress tick.
+      //
+      // The optimization hinges on [ActiveUploadsView]'s equality semantics:
+      // two states that differ only in `BackgroundUpload.progress` must
+      // produce equal projections so `context.select` suppresses the
+      // consumer rebuild. A regression to identity-based list equality
+      // would fail the first test below.
+
+      test(
+        'ActiveUploadsView.fromState compares equal across progress-only '
+        'state changes',
+        () {
+          final draft = _createTestDraft();
+          final state1 = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draft, result: null, progress: 0.1),
+            ],
+          );
+          final state2 = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draft, result: null, progress: 0.9),
+            ],
+          );
+
+          expect(
+            ActiveUploadsView.fromState(state1),
+            equals(ActiveUploadsView.fromState(state2)),
+          );
+        },
+      );
+
+      test(
+        'ActiveUploadsView.fromState compares unequal when an upload '
+        'is added',
+        () {
+          final draftA = _createTestDraft(title: 'A');
+          final draftB = _createTestDraft(title: 'B');
+          final state1 = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draftA, result: null, progress: 0.5),
+            ],
+          );
+          final state2 = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draftA, result: null, progress: 0.5),
+              BackgroundUpload(draft: draftB, result: null, progress: 0.5),
+            ],
+          );
+
+          expect(
+            ActiveUploadsView.fromState(state1),
+            isNot(equals(ActiveUploadsView.fromState(state2))),
+          );
+        },
+      );
+
+      test(
+        'ActiveUploadsView.fromState compares unequal when a draft title '
+        'changes',
+        () {
+          final draftA = _createTestDraft(title: 'Old title');
+          final draftB = _createTestDraft(title: 'New title');
+          final state1 = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draftA, result: null, progress: 0.5),
+            ],
+          );
+          final state2 = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draftB, result: null, progress: 0.5),
+            ],
+          );
+
+          expect(
+            ActiveUploadsView.fromState(state1),
+            isNot(equals(ActiveUploadsView.fromState(state2))),
+          );
+        },
+      );
+
+      test(
+        'ActiveUploadsView.fromState excludes uploads with a non-null result',
+        () {
+          final draft = _createTestDraft();
+          final state = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(
+                draft: draft,
+                result: const PublishSuccess(),
+                progress: 1,
+              ),
+            ],
+          );
+
+          expect(ActiveUploadsView.fromState(state).uploads, isEmpty);
+        },
+      );
+
+      testWidgets('progress-only state emission updates the per-tile spinner', (
+        tester,
+      ) async {
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+
+        final draft = _createTestDraft();
+        final initial = BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 0.1),
+          ],
+        );
+        final tick = BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 0.9),
+          ],
+        );
+
+        whenListen(mockBloc, Stream.value(tick), initialState: initial);
+
+        await tester.pumpWidget(buildSubject(userIdHex: _ownPubkey));
+        // Flush the queued whenListen emission.
+        await tester.pump();
+        // PartialCircleSpinner.animateTo runs over 200ms — settle the
+        // implicit animation so we read the post-tick value.
+        await tester.pump(const Duration(milliseconds: 250));
+
+        final spinner = tester.widget<PartialCircleSpinner>(
+          find.byType(PartialCircleSpinner),
+        );
+        expect(spinner.progress, closeTo(0.9, 1e-9));
+      });
+    });
+
     group('scroll coordination with NestedScrollView', () {
       testWidgets(
         'uses PrimaryScrollController from NestedScrollView ancestor',


### PR DESCRIPTION
## Description

`context.watch<X>()` triggers a rebuild whenever any field of `X.state`
changes, even when the widget only reads one or two of them. This PR
replaces three such call sites with `context.select` projections so each
widget rebuilds only when the data it actually consumes changes.

### `profile_videos_grid.dart`

The highest-impact site — `BackgroundPublishState` emits on every upload
progress tick, and the previous `context.watch` made the entire profile
videos grid rebuild every tick (de-duplication loop, layout, etc.) even
though it only cares about the *shape* of the active upload list.

- Project state to `List<({String draftId, String? title, String? thumbnailPath})>`
  via `context.select`. Progress is intentionally excluded so progress
  ticks no longer rebuild the grid.
- ` _VideoGridUploadingTile` now subscribes to its own upload's progress
  via `context.select<BackgroundPublishBloc, double>(...)`, so only the
  affected tile rebuilds when its progress advances.

### `video_editor_draw_item_indicator.dart`

One-line swap — only reads `selectedTool` from a 7-field state. Now
rebuilds only when the selected tool changes (was also rebuilding on
undo/redo, color, and stroke-width changes).

### `profile_header_widget.dart`

Project `MyProfileBloc` state to `(profile, isInitialOrLoading)`. The
header now ignores `isFresh` / `extractedUsername` / `verifiedClaims` /
error-variant transitions that don't affect what it renders.

**Related Issue:** Closes #3605

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `flutter analyze lib test integration_test` clean
- [x] `flutter test` for the three changed files (67 tests pass)
- [ ] Manual: open own profile while a background upload is in flight,
  verify the spinner advances smoothly and the grid no longer flickers
  on every progress tick.
- [ ] Manual: open the video draw editor, switch tools — indicator
  slides as before.
- [ ] Manual: open profile, observe identity skeleton → loaded
  transition; cached → fresh re-emit should not cause a visible blip.