### PR TITLE
feat(dm): auto-sweep self-wrap-failed outgoing_dms via foreground retry service

### DIFF
--- a/mobile/docs/brainstorm/2026-05-10-issue4124-outgoing-dm-auto-sweep-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-10-issue4124-outgoing-dm-auto-sweep-brainstorm.md
@@ -5,243 +5,79 @@ Date: 2026-05-10
 ## Problem Statement
 
 `outgoing_dms` rows where `recipient_wrap_status == sent` and
-`self_wrap_status == failed` only progress today when the user manually
-re-taps the Retry action on the partial-delivery SnackBar
-(`ConversationView._onSendOutcome`). The SnackBar is ephemeral — once
-dismissed (or if the app is killed before the user taps it), the row
-sits durably broken. The self-wrap exists *specifically* for sender
-cross-device sync, so a stuck self-wrap silently breaks the entire
-purpose of NIP-17 self-wrapping. We need an automatic invocation path
-for the `recoverSelfWrap` primitive landed in PR #4106.
+`self_wrap_status == failed` only progressed through the ephemeral
+manual Retry action in the DM failure SnackBar. If the SnackBar was
+dismissed, or the app was killed before the user tapped it, the durable
+queue row stayed broken and sender cross-device sync silently failed.
 
-## Constraints
+## Implemented Design
 
-- Layered architecture: UI → BLoC → Repository → Client. The auto-sweep
-  is a **service**, not a BLoC — same shape as `PendingActionService`.
-- BLoC-first for new state management. No new Riverpod surface beyond
-  what's needed to wire the service into existing providers.
-- `recoverSelfWrap` must remain the only path that publishes a self
-  wrap. The sweep is a **scheduler**, not a publisher.
-- Idempotency cooperation: a manual Retry tap mid-sweep must not
-  republish. `recoverSelfWrap`'s `selfWrapStatus == sent` short-circuit
-  already handles this; the sweep just has to not break the contract.
-- Account-switch / sign-out: the service must rebuild on `userPubkey`
-  identity change and not pick up the previous account's queue rows
-  (mirror `pendingActionServiceProvider`'s null-on-no-userPubkey shape
-  in `app_providers.dart:285`).
-- No Flutter dependency leaks below the service layer.
-  `dm_repository` stays Flutter-free; the foreground stream lives in
-  the service / provider layer.
+The shipped solution adds `OutgoingDmRetryService`, a scheduler-layer
+service that:
 
-## Prior Art
+- listens to app-foreground transitions
+- queries `OutgoingDmsDao.getRetryableForOwner(...)` for the current
+  account
+- dispatches only `recipient: sent / self: failed` rows to
+  `DmRepository.recoverSelfWrap(...)`
+- applies per-row exponential backoff using the same defaults as
+  `PendingActionRetryConfig`
+- logs and counts `recipient: failed` rows without attempting recovery
+- short-circuits overlapping sweeps with an `_isSweeping` guard
+- contains top-level sweep failures so foreground-triggered retries do
+  not surface as unhandled async errors
 
-**Already built (no new code needed):**
-- `DmRepository.recoverSelfWrap(rumorId)` — idempotent, account-scoped,
-  handles JSON-parse failures, has fallback bookkeeping. PR #4106.
-- `OutgoingDmsDao` already exposes everything a retry service needs:
-  - `getRetryableForOwner({ownerPubkey, maxRetries})` — filters to
-    rows where either wrap is `failed` AND retry budget not exhausted.
-  - `getStillPendingForOwner(ownerPubkey)` — rows still `pending` from
-    an interrupted publish (e.g., app kill mid-`sendRumor`).
-  - `incrementRetry(id)` — bumps `retry_count` and `last_attempt_at`
-    atomically inside a transaction.
-  - `markSelfWrapStatus`, `markRecipientWrapStatus` — both stamp
-    `last_attempt_at = DateTime.now()` automatically.
-  - `clearAllForUser(ownerPubkey)` — sign-out / account-switch sweep.
-  PR #3911.
-- `appForegroundProvider` — `StreamProvider<bool>` derived from
-  `WidgetsBindingObserver`, seeds `true` on launch when
-  `lifecycleState == null || resumed`. So the cold-start sweep fires
-  for free without a separate trigger.
-  `mobile/lib/providers/app_lifecycle_provider.dart`.
-- `ConnectionStatusService` (keepAlive) is wired throughout but is
-  **not** a chosen trigger for this service.
+This keeps the layering aligned with the existing
+`PendingActionService` precedent: lifecycle trigger in a service,
+publish logic in the repository.
 
-**Direct precedent for the sweep loop:**
-`PendingActionService` (`mobile/lib/services/pending_action_service.dart`
-+ `app_providers.dart:285`). Listens to connectivity, replays failed
-rows with `PendingActionRetryConfig` defaults (`maxRetries: 5`,
-`initialDelay: 2s`, `maxDelay: 5min`, `backoffMultiplier: 2.0`). Epic
-#3912 / task #3909 explicitly cite this as the pattern to mirror.
+## Provider Wiring
 
-**Schema confirmation:** `outgoing_dms` already has `retry_count`,
-`recipient_wrap_last_error`, `self_wrap_last_error`, `last_attempt_at`
-— no schema migration needed. The DAO doc literally references "the
-retry service" in `getRetryableForOwner`'s doc comment.
+`outgoingDmRetryServiceProvider` is `keepAlive` and returns `null`
+unless:
 
-**Cross-checks:**
-- No conflicting open PR — PR #4234 (open, fixes #4193) edits
-  `ConversationBloc`'s optimistic-state shape, not the retry path.
-- Sister issue #4127 (open) covers surfacing DAO bookkeeping failures;
-  orthogonal — this brainstorm leaves its swallowed-error sites
-  untouched.
+- the user is authenticated
+- `isNostrReadyProvider` is `true`
 
-## Approaches Explored
+That gate ensures `DmRepository.setCredentials(...)` has already run
+before the first sweep can call `recoverSelfWrap(...)`.
 
-### Approach A: Full broad scope, includes new `recoverFullSend` primitive
+The provider bridges the synchronous
+`mobile/lib/providers/app_foreground_provider.dart` notifier into a
+plain `Stream<bool>` so the service stays Riverpod-free and easy to
+unit test. `main.dart` eagerly reads the provider because the service
+has no UI consumer and would otherwise never initialize.
 
-Build `OutgoingDmRetryService` PLUS a new
-`DmRepository.recoverFullSend(rumorId)` for `recipient: failed` rows
-in one PR. Service dispatcher routes by row state to either
-`recoverSelfWrap` or `recoverFullSend`.
+## Recovery Scope
 
-- **Layers:** Service (new), Repository (new method), Provider (new
-  wiring).
-- **Pros:** Completes epic #3912's recovery vision in one PR.
-- **Cons:** ~250–400 LOC. `recoverFullSend` needs careful idempotency
-  thinking — what if the prior attempt's recipient publish landed but
-  local `direct_messages` insert failed last time? Larger
-  test-contract surface.
-- **Risks:** Re-publishing a stale-feeling rumor for an old failed
-  row; bounded by `maxRetries` + receiver-side dedup keys on rumor id.
-- **Complexity:** Medium-High.
+The current implementation intentionally handles only one recovery
+state:
 
-### Approach B: Broad shape, self-wrap-only recovery today (RECOMMENDED)
+- `recipient: sent / self: failed` -> `recoverSelfWrap(...)`
 
-Same service skeleton as A. Strategy table maps row state to recovery
-function — only one entry today (`recipient: sent / self: failed` →
-`recoverSelfWrap`). Other retryable rows are **enumerated, counted,
-and logged** so we get production telemetry on how often
-`recipient: failed` and `pending: pending` rows actually appear before
-committing to a primitive. No `DmRepository` changes; uses existing
-`recoverSelfWrap` only.
+Other queue states are explicitly out of scope for this PR:
 
-- **Layers:** Service (new), Provider (new wiring).
-- **Pros:** Smallest blast radius. Literal scope of #4124. Cleanly
-  extends to A later by adding a second strategy entry + the new
-  primitive. Defers `recoverFullSend` design until we have data.
-- **Cons:** `recipient: failed` rows still sit queued forever in this
-  PR. Splits the broad-scope work across two PRs.
-- **Risks:** Logging-without-acting becomes a quiet liability if
-  counts are non-zero and we don't follow up. Mitigation: open a
-  tracking issue before merge.
-- **Complexity:** Low-Medium. ~150–250 LOC.
+- `recipient: failed` rows are counted in logs only. A future recovery
+  primitive can extend the dispatcher when that behavior is designed.
+- `pending: pending` rows are not part of
+  `getRetryableForOwner(...)`; they remain the concern of a separate
+  interrupted-send recovery path.
 
-### Approach C: Repository-internal sweep
+## Decisions Captured
 
-Move the sweep loop inside `DmRepository`. `setCredentials` accepts an
-optional `Stream<bool> appForegroundStream` and the repo subscribes
-internally. No new service file.
+- Trigger on foreground transitions only. No periodic timer and no
+  connectivity-triggered sweep.
+- Rebuild the service on sign-in, sign-out, and account switch by
+  watching `currentAuthStateProvider`.
+- Keep `recoverSelfWrap(...)` as the only self-wrap publishing path.
+- Treat `StateError` as pass-level "repo not ready" and abort without
+  burning retry budget.
+- Treat `ArgumentError` as row-local terminal state and continue.
+- Bump retry count only on actual publish failure or unexpected throw
+  from the recovery path.
 
-- **Layers:** Repository (new method + new constructor param + sweep
-  loop), Provider (wires the stream).
-- **Pros:** No new service class.
-- **Cons:** Violates separation — `architecture.md` says repos compose
-  data sources, not lifecycle. The `PendingActionService` precedent
-  the epic explicitly names lives in `lib/services/`. Mixes
-  connection-state-aware orchestration into a 1500+ LOC repo, harder
-  to test in isolation.
-- **Risks:** Sets a precedent that any repo can grow a lifecycle
-  observer; erodes layering.
-- **Complexity:** Lower LOC, higher architectural cost.
+## Follow-up Scope
 
-## Recommendation
-
-**Approach B.** Ship `OutgoingDmRetryService` with the broad-shaped
-strategy table but only the self-wrap-only entry wired in today. Open
-a tracking issue before merge for the `recipient: failed` recovery
-primitive (`recoverFullSend`).
-
-### Why B over A
-
-The user's scope answer was "broad" — but the broad architecture
-(service + dispatcher) is what unlocks future extension. The recovery
-primitive `recoverFullSend` is meaningful new code with subtle
-idempotency tradeoffs (recipient already landed, local persistence
-failed, app killed before queue update — three distinct partial
-states), and we currently have **zero production data** on whether
-`recipient: failed` rows are common enough to justify the upfront
-design. Logging the count gets us that data on day one and lets the
-follow-up PR be targeted.
-
-### Why B over C
-
-`PendingActionService` is the in-repo precedent that epic #3912
-explicitly cites. Mirroring it one-for-one means reviewers can compare
-side-by-side; future maintainers find the same shape twice in
-`lib/services/`. The repo-internal variant trades that clarity for
-zero LOC saved (the foreground subscription has to live somewhere
-either way).
-
-### Trigger choice
-
-Single trigger: `appForegroundProvider` transitions to `true`. Per the
-user's choice, no service-init / no connectivity-restore / no periodic
-timer. The `appForegroundProvider`'s seed-on-launch behavior gives us
-the cold-start sweep for free; on connectivity blips, the user's next
-foreground resume catches the work; on long-running foreground
-sessions, the per-row backoff inside the sweep prevents tight loops.
-
-### Backoff + per-row rate limit
-
-Use `PendingActionRetryConfig` defaults verbatim (5 retries, 2s →
-5min, 2× backoff). Per-row predicate: skip if
-`now - lastAttemptAt < backoff(retryCount)`; otherwise dispatch.
-`getRetryableForOwner` already drops rows past `maxRetries` server-
-side. The `incrementRetry` DAO method makes the rate-limit state
-durable across app kill.
-
-## Open Questions for /plan
-
-- [ ] **Cold-start coverage.** `appForegroundProvider`'s initial seed
-      (line 17 of `app_lifecycle_provider.dart`) emits `true` when
-      `lifecycleState == null || resumed`. Confirm this fires the
-      first sweep on cold launch without a separate explicit-init
-      path. If for some reason it does not (e.g., on web), decide
-      whether to add an explicit init-time sweep.
-- [ ] **Readiness gate vs. `dmRepository` provider.** The service must
-      wait for `DmRepository.setCredentials` before calling
-      `recoverSelfWrap` (which throws `StateError` on uninitialized
-      repos). Decide between:
-      (a) gate the provider on `isNostrReadyProvider` like
-          `profileRepositoryProvider` already does;
-      (b) gate the service's sweep loop on a try/catch around
-          `StateError` and treat it as "not yet ready, will retry on
-          next foreground transition."
-      Option (a) is cleaner; option (b) is more resilient to provider
-      ordering surprises.
-- [ ] **Concurrency with manual SnackBar Retry.** The
-      `recoverSelfWrap` `selfWrapStatus == sent` guard handles a
-      concurrent manual tap mid-sweep. But the sweep should also avoid
-      double-scheduling the same row twice in one foreground
-      transition — use the same `_isSyncing` flag pattern from
-      `PendingActionService:60`.
-- [ ] **Telemetry shape for the broad-enumeration count.** Is a
-      `Log.info('sweep observed N recipient-failed rows')` enough, or
-      should this PR also wrap a `Reportable` (per
-      `error_handling.md`) for "N consecutive sweeps observed
-      `recipient: failed` rows for the same rumor"? Coordinate with
-      issue #4127 — the right answer is probably the **counter /
-      debug surface** option from #4127's matrix, not `Reportable`,
-      because `recipient: failed` is an expected network failure
-      class.
-- [ ] **Group DM rows.** `sendGroupMessage` enqueues per-recipient
-      rows with the same `ownerPubkey`. Confirm `getRetryableForOwner`
-      naturally covers them (it should — same filter shape) and write
-      an explicit test for a group-recipient self-wrap-failed row
-      being recovered by the sweep.
-- [ ] **Sign-out coordination.** Verify `clearAllForUser(prevPubkey)`
-      already runs on sign-out (it should, given the DAO doc claims
-      so). If not, decide whether the sweep service is the right
-      place to add it, or whether the existing sign-out wiring should.
-- [ ] **Test contract for "sweep never publishes a recipient wrap."**
-      Pin via `verifyNever(messageService.sendRumor(...))` and
-      `verifyNever(messageService.sendPrivateMessage(...))` after a
-      sweep run, mirroring PR #4106's existing self-wrap-only
-      contract tests.
-
-## Prerequisites
-
-- [ ] Open follow-up issue for `recoverFullSend` (recipient-failed
-      recovery primitive) so the broad-scope work isn't lost.
-      Reference this brainstorm and the enumeration counts the
-      service will start logging.
-- [ ] Confirm with the team that telemetry as `Log.info` counts (not
-      `Reportable`) is acceptable for the recipient-failed
-      enumeration in this PR. Coordinate with #4127.
-
-## Next Step
-
-Run `/plan 4124` with the recommendation above. Before kickoff, file
-the `recoverFullSend` follow-up issue so /plan can reference it
-explicitly in the PR description.
+Future work can extend the dispatcher with a second recovery strategy
+for `recipient: failed` rows once the repository contract is designed
+and production occurrence data warrants it.

--- a/mobile/docs/brainstorm/2026-05-10-issue4124-outgoing-dm-auto-sweep-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-10-issue4124-outgoing-dm-auto-sweep-brainstorm.md
@@ -1,0 +1,247 @@
+# Brainstorm: Auto-sweep `outgoing_dms` self-wrap-failed rows (#4124)
+
+Date: 2026-05-10
+
+## Problem Statement
+
+`outgoing_dms` rows where `recipient_wrap_status == sent` and
+`self_wrap_status == failed` only progress today when the user manually
+re-taps the Retry action on the partial-delivery SnackBar
+(`ConversationView._onSendOutcome`). The SnackBar is ephemeral — once
+dismissed (or if the app is killed before the user taps it), the row
+sits durably broken. The self-wrap exists *specifically* for sender
+cross-device sync, so a stuck self-wrap silently breaks the entire
+purpose of NIP-17 self-wrapping. We need an automatic invocation path
+for the `recoverSelfWrap` primitive landed in PR #4106.
+
+## Constraints
+
+- Layered architecture: UI → BLoC → Repository → Client. The auto-sweep
+  is a **service**, not a BLoC — same shape as `PendingActionService`.
+- BLoC-first for new state management. No new Riverpod surface beyond
+  what's needed to wire the service into existing providers.
+- `recoverSelfWrap` must remain the only path that publishes a self
+  wrap. The sweep is a **scheduler**, not a publisher.
+- Idempotency cooperation: a manual Retry tap mid-sweep must not
+  republish. `recoverSelfWrap`'s `selfWrapStatus == sent` short-circuit
+  already handles this; the sweep just has to not break the contract.
+- Account-switch / sign-out: the service must rebuild on `userPubkey`
+  identity change and not pick up the previous account's queue rows
+  (mirror `pendingActionServiceProvider`'s null-on-no-userPubkey shape
+  in `app_providers.dart:285`).
+- No Flutter dependency leaks below the service layer.
+  `dm_repository` stays Flutter-free; the foreground stream lives in
+  the service / provider layer.
+
+## Prior Art
+
+**Already built (no new code needed):**
+- `DmRepository.recoverSelfWrap(rumorId)` — idempotent, account-scoped,
+  handles JSON-parse failures, has fallback bookkeeping. PR #4106.
+- `OutgoingDmsDao` already exposes everything a retry service needs:
+  - `getRetryableForOwner({ownerPubkey, maxRetries})` — filters to
+    rows where either wrap is `failed` AND retry budget not exhausted.
+  - `getStillPendingForOwner(ownerPubkey)` — rows still `pending` from
+    an interrupted publish (e.g., app kill mid-`sendRumor`).
+  - `incrementRetry(id)` — bumps `retry_count` and `last_attempt_at`
+    atomically inside a transaction.
+  - `markSelfWrapStatus`, `markRecipientWrapStatus` — both stamp
+    `last_attempt_at = DateTime.now()` automatically.
+  - `clearAllForUser(ownerPubkey)` — sign-out / account-switch sweep.
+  PR #3911.
+- `appForegroundProvider` — `StreamProvider<bool>` derived from
+  `WidgetsBindingObserver`, seeds `true` on launch when
+  `lifecycleState == null || resumed`. So the cold-start sweep fires
+  for free without a separate trigger.
+  `mobile/lib/providers/app_lifecycle_provider.dart`.
+- `ConnectionStatusService` (keepAlive) is wired throughout but is
+  **not** a chosen trigger for this service.
+
+**Direct precedent for the sweep loop:**
+`PendingActionService` (`mobile/lib/services/pending_action_service.dart`
++ `app_providers.dart:285`). Listens to connectivity, replays failed
+rows with `PendingActionRetryConfig` defaults (`maxRetries: 5`,
+`initialDelay: 2s`, `maxDelay: 5min`, `backoffMultiplier: 2.0`). Epic
+#3912 / task #3909 explicitly cite this as the pattern to mirror.
+
+**Schema confirmation:** `outgoing_dms` already has `retry_count`,
+`recipient_wrap_last_error`, `self_wrap_last_error`, `last_attempt_at`
+— no schema migration needed. The DAO doc literally references "the
+retry service" in `getRetryableForOwner`'s doc comment.
+
+**Cross-checks:**
+- No conflicting open PR — PR #4234 (open, fixes #4193) edits
+  `ConversationBloc`'s optimistic-state shape, not the retry path.
+- Sister issue #4127 (open) covers surfacing DAO bookkeeping failures;
+  orthogonal — this brainstorm leaves its swallowed-error sites
+  untouched.
+
+## Approaches Explored
+
+### Approach A: Full broad scope, includes new `recoverFullSend` primitive
+
+Build `OutgoingDmRetryService` PLUS a new
+`DmRepository.recoverFullSend(rumorId)` for `recipient: failed` rows
+in one PR. Service dispatcher routes by row state to either
+`recoverSelfWrap` or `recoverFullSend`.
+
+- **Layers:** Service (new), Repository (new method), Provider (new
+  wiring).
+- **Pros:** Completes epic #3912's recovery vision in one PR.
+- **Cons:** ~250–400 LOC. `recoverFullSend` needs careful idempotency
+  thinking — what if the prior attempt's recipient publish landed but
+  local `direct_messages` insert failed last time? Larger
+  test-contract surface.
+- **Risks:** Re-publishing a stale-feeling rumor for an old failed
+  row; bounded by `maxRetries` + receiver-side dedup keys on rumor id.
+- **Complexity:** Medium-High.
+
+### Approach B: Broad shape, self-wrap-only recovery today (RECOMMENDED)
+
+Same service skeleton as A. Strategy table maps row state to recovery
+function — only one entry today (`recipient: sent / self: failed` →
+`recoverSelfWrap`). Other retryable rows are **enumerated, counted,
+and logged** so we get production telemetry on how often
+`recipient: failed` and `pending: pending` rows actually appear before
+committing to a primitive. No `DmRepository` changes; uses existing
+`recoverSelfWrap` only.
+
+- **Layers:** Service (new), Provider (new wiring).
+- **Pros:** Smallest blast radius. Literal scope of #4124. Cleanly
+  extends to A later by adding a second strategy entry + the new
+  primitive. Defers `recoverFullSend` design until we have data.
+- **Cons:** `recipient: failed` rows still sit queued forever in this
+  PR. Splits the broad-scope work across two PRs.
+- **Risks:** Logging-without-acting becomes a quiet liability if
+  counts are non-zero and we don't follow up. Mitigation: open a
+  tracking issue before merge.
+- **Complexity:** Low-Medium. ~150–250 LOC.
+
+### Approach C: Repository-internal sweep
+
+Move the sweep loop inside `DmRepository`. `setCredentials` accepts an
+optional `Stream<bool> appForegroundStream` and the repo subscribes
+internally. No new service file.
+
+- **Layers:** Repository (new method + new constructor param + sweep
+  loop), Provider (wires the stream).
+- **Pros:** No new service class.
+- **Cons:** Violates separation — `architecture.md` says repos compose
+  data sources, not lifecycle. The `PendingActionService` precedent
+  the epic explicitly names lives in `lib/services/`. Mixes
+  connection-state-aware orchestration into a 1500+ LOC repo, harder
+  to test in isolation.
+- **Risks:** Sets a precedent that any repo can grow a lifecycle
+  observer; erodes layering.
+- **Complexity:** Lower LOC, higher architectural cost.
+
+## Recommendation
+
+**Approach B.** Ship `OutgoingDmRetryService` with the broad-shaped
+strategy table but only the self-wrap-only entry wired in today. Open
+a tracking issue before merge for the `recipient: failed` recovery
+primitive (`recoverFullSend`).
+
+### Why B over A
+
+The user's scope answer was "broad" — but the broad architecture
+(service + dispatcher) is what unlocks future extension. The recovery
+primitive `recoverFullSend` is meaningful new code with subtle
+idempotency tradeoffs (recipient already landed, local persistence
+failed, app killed before queue update — three distinct partial
+states), and we currently have **zero production data** on whether
+`recipient: failed` rows are common enough to justify the upfront
+design. Logging the count gets us that data on day one and lets the
+follow-up PR be targeted.
+
+### Why B over C
+
+`PendingActionService` is the in-repo precedent that epic #3912
+explicitly cites. Mirroring it one-for-one means reviewers can compare
+side-by-side; future maintainers find the same shape twice in
+`lib/services/`. The repo-internal variant trades that clarity for
+zero LOC saved (the foreground subscription has to live somewhere
+either way).
+
+### Trigger choice
+
+Single trigger: `appForegroundProvider` transitions to `true`. Per the
+user's choice, no service-init / no connectivity-restore / no periodic
+timer. The `appForegroundProvider`'s seed-on-launch behavior gives us
+the cold-start sweep for free; on connectivity blips, the user's next
+foreground resume catches the work; on long-running foreground
+sessions, the per-row backoff inside the sweep prevents tight loops.
+
+### Backoff + per-row rate limit
+
+Use `PendingActionRetryConfig` defaults verbatim (5 retries, 2s →
+5min, 2× backoff). Per-row predicate: skip if
+`now - lastAttemptAt < backoff(retryCount)`; otherwise dispatch.
+`getRetryableForOwner` already drops rows past `maxRetries` server-
+side. The `incrementRetry` DAO method makes the rate-limit state
+durable across app kill.
+
+## Open Questions for /plan
+
+- [ ] **Cold-start coverage.** `appForegroundProvider`'s initial seed
+      (line 17 of `app_lifecycle_provider.dart`) emits `true` when
+      `lifecycleState == null || resumed`. Confirm this fires the
+      first sweep on cold launch without a separate explicit-init
+      path. If for some reason it does not (e.g., on web), decide
+      whether to add an explicit init-time sweep.
+- [ ] **Readiness gate vs. `dmRepository` provider.** The service must
+      wait for `DmRepository.setCredentials` before calling
+      `recoverSelfWrap` (which throws `StateError` on uninitialized
+      repos). Decide between:
+      (a) gate the provider on `isNostrReadyProvider` like
+          `profileRepositoryProvider` already does;
+      (b) gate the service's sweep loop on a try/catch around
+          `StateError` and treat it as "not yet ready, will retry on
+          next foreground transition."
+      Option (a) is cleaner; option (b) is more resilient to provider
+      ordering surprises.
+- [ ] **Concurrency with manual SnackBar Retry.** The
+      `recoverSelfWrap` `selfWrapStatus == sent` guard handles a
+      concurrent manual tap mid-sweep. But the sweep should also avoid
+      double-scheduling the same row twice in one foreground
+      transition — use the same `_isSyncing` flag pattern from
+      `PendingActionService:60`.
+- [ ] **Telemetry shape for the broad-enumeration count.** Is a
+      `Log.info('sweep observed N recipient-failed rows')` enough, or
+      should this PR also wrap a `Reportable` (per
+      `error_handling.md`) for "N consecutive sweeps observed
+      `recipient: failed` rows for the same rumor"? Coordinate with
+      issue #4127 — the right answer is probably the **counter /
+      debug surface** option from #4127's matrix, not `Reportable`,
+      because `recipient: failed` is an expected network failure
+      class.
+- [ ] **Group DM rows.** `sendGroupMessage` enqueues per-recipient
+      rows with the same `ownerPubkey`. Confirm `getRetryableForOwner`
+      naturally covers them (it should — same filter shape) and write
+      an explicit test for a group-recipient self-wrap-failed row
+      being recovered by the sweep.
+- [ ] **Sign-out coordination.** Verify `clearAllForUser(prevPubkey)`
+      already runs on sign-out (it should, given the DAO doc claims
+      so). If not, decide whether the sweep service is the right
+      place to add it, or whether the existing sign-out wiring should.
+- [ ] **Test contract for "sweep never publishes a recipient wrap."**
+      Pin via `verifyNever(messageService.sendRumor(...))` and
+      `verifyNever(messageService.sendPrivateMessage(...))` after a
+      sweep run, mirroring PR #4106's existing self-wrap-only
+      contract tests.
+
+## Prerequisites
+
+- [ ] Open follow-up issue for `recoverFullSend` (recipient-failed
+      recovery primitive) so the broad-scope work isn't lost.
+      Reference this brainstorm and the enumeration counts the
+      service will start logging.
+- [ ] Confirm with the team that telemetry as `Log.info` counts (not
+      `Reportable`) is acceptable for the recipient-failed
+      enumeration in this PR. Coordinate with #4127.
+
+## Next Step
+
+Run `/plan 4124` with the recommendation above. Before kickoff, file
+the `recoverFullSend` follow-up issue so /plan can reference it
+explicitly in the PR description.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1598,6 +1598,12 @@ class _DivineAppState extends ConsumerState<DivineApp> {
       isFeatureEnabledProvider(FeatureFlag.curatedLists),
     );
 
+    // Eagerly create the outgoing-DM retry service so its foreground
+    // subscription is wired up at app shell setup. The service has no
+    // UI consumer (it operates on the durable outgoing_dms queue), so
+    // without an explicit read it would never be created. See #4124.
+    ref.watch(outgoingDmRetryServiceProvider);
+
     // Wrap with geo-blocking check first, then lifecycle handler
     Widget wrapped = MultiRepositoryProvider(
       providers: [

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -37,6 +37,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -90,6 +91,7 @@ import 'package:openvine/services/notification_preferences_service.dart';
 import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/services/notification_service_enhanced.dart';
 import 'package:openvine/services/nsfw_content_filter.dart';
+import 'package:openvine/services/outgoing_dm_retry_service.dart';
 import 'package:openvine/services/password_reset_listener.dart';
 import 'package:openvine/services/pending_action_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
@@ -311,6 +313,78 @@ PendingActionService? pendingActionService(Ref ref) {
       error: e,
     );
   });
+
+  ref.onDispose(service.dispose);
+  return service;
+}
+
+/// Auto-sweep service for the durable `outgoing_dms` queue.
+///
+/// Listens to app-foreground transitions and re-publishes the missing
+/// self-wrap for any row in `recipient: sent / self: failed` state via
+/// [DmRepository.recoverSelfWrap]. Closes the gap left by the
+/// SnackBar-only manual retry from PR #4106 — see issue #4124.
+///
+/// The service is keepAlive but has no UI consumer, so it is read
+/// eagerly at app shell startup (`main.dart`) so the foreground
+/// subscription is wired up.
+///
+/// Returns null when the user is not authenticated or when
+/// [isNostrReadyProvider] hasn't flipped yet — the underlying
+/// [DmRepository.recoverSelfWrap] requires `setCredentials` to have
+/// run, and gating here is cleaner than catching `StateError` in
+/// every sweep pass.
+@Riverpod(keepAlive: true)
+OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
+  final authService = ref.watch(authServiceProvider);
+
+  // Watch auth state to rebuild on sign-in / sign-out / account switch.
+  ref.watch(currentAuthStateProvider);
+
+  final userPubkey = authService.currentPublicKeyHex;
+  if (userPubkey == null) return null;
+
+  // Gate on Nostr readiness so DmRepository.setCredentials has run by
+  // the time the service's first foreground sweep fires.
+  if (!ref.watch(isNostrReadyProvider)) return null;
+
+  final dmRepository = ref.watch(dmRepositoryProvider);
+  final db = ref.watch(databaseProvider);
+
+  // Bridge the synchronous AppForeground notifier into a Stream<bool>
+  // so the service's contract stays free of Riverpod types and is easy
+  // to drive from unit tests.
+  final foregroundController = StreamController<bool>();
+  ref.onDispose(foregroundController.close);
+
+  final service = OutgoingDmRetryService(
+    dmRepository: dmRepository,
+    outgoingDmsDao: db.outgoingDmsDao,
+    userPubkey: userPubkey,
+    appForegroundStream: foregroundController.stream,
+  );
+
+  // initialize() subscribes to the controller's stream synchronously
+  // (no await before the .listen call), so it is safe to register the
+  // ref.listen below afterwards — fireImmediately will reach the
+  // service's subscriber.
+  service.initialize().catchError((e) {
+    Log.error(
+      'Failed to initialize OutgoingDmRetryService',
+      name: 'AppProviders',
+      error: e,
+    );
+  });
+
+  ref.listen<bool>(
+    appForegroundProvider,
+    (_, next) {
+      if (!foregroundController.isClosed) {
+        foregroundController.add(next);
+      }
+    },
+    fireImmediately: true,
+  );
 
   ref.onDispose(service.dispose);
   return service;

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -166,6 +166,104 @@ final class PendingActionServiceProvider
 String _$pendingActionServiceHash() =>
     r'67a3a30b8cc1072263ce47f4e2bb3c34fa876fa1';
 
+/// Auto-sweep service for the durable `outgoing_dms` queue.
+///
+/// Listens to app-foreground transitions and re-publishes the missing
+/// self-wrap for any row in `recipient: sent / self: failed` state via
+/// [DmRepository.recoverSelfWrap]. Closes the gap left by the
+/// SnackBar-only manual retry from PR #4106 — see issue #4124.
+///
+/// The service is keepAlive but has no UI consumer, so it is read
+/// eagerly at app shell startup (`main.dart`) so the foreground
+/// subscription is wired up.
+///
+/// Returns null when the user is not authenticated or when
+/// [isNostrReadyProvider] hasn't flipped yet — the underlying
+/// [DmRepository.recoverSelfWrap] requires `setCredentials` to have
+/// run, and gating here is cleaner than catching `StateError` in
+/// every sweep pass.
+
+@ProviderFor(outgoingDmRetryService)
+const outgoingDmRetryServiceProvider = OutgoingDmRetryServiceProvider._();
+
+/// Auto-sweep service for the durable `outgoing_dms` queue.
+///
+/// Listens to app-foreground transitions and re-publishes the missing
+/// self-wrap for any row in `recipient: sent / self: failed` state via
+/// [DmRepository.recoverSelfWrap]. Closes the gap left by the
+/// SnackBar-only manual retry from PR #4106 — see issue #4124.
+///
+/// The service is keepAlive but has no UI consumer, so it is read
+/// eagerly at app shell startup (`main.dart`) so the foreground
+/// subscription is wired up.
+///
+/// Returns null when the user is not authenticated or when
+/// [isNostrReadyProvider] hasn't flipped yet — the underlying
+/// [DmRepository.recoverSelfWrap] requires `setCredentials` to have
+/// run, and gating here is cleaner than catching `StateError` in
+/// every sweep pass.
+
+final class OutgoingDmRetryServiceProvider
+    extends
+        $FunctionalProvider<
+          OutgoingDmRetryService?,
+          OutgoingDmRetryService?,
+          OutgoingDmRetryService?
+        >
+    with $Provider<OutgoingDmRetryService?> {
+  /// Auto-sweep service for the durable `outgoing_dms` queue.
+  ///
+  /// Listens to app-foreground transitions and re-publishes the missing
+  /// self-wrap for any row in `recipient: sent / self: failed` state via
+  /// [DmRepository.recoverSelfWrap]. Closes the gap left by the
+  /// SnackBar-only manual retry from PR #4106 — see issue #4124.
+  ///
+  /// The service is keepAlive but has no UI consumer, so it is read
+  /// eagerly at app shell startup (`main.dart`) so the foreground
+  /// subscription is wired up.
+  ///
+  /// Returns null when the user is not authenticated or when
+  /// [isNostrReadyProvider] hasn't flipped yet — the underlying
+  /// [DmRepository.recoverSelfWrap] requires `setCredentials` to have
+  /// run, and gating here is cleaner than catching `StateError` in
+  /// every sweep pass.
+  const OutgoingDmRetryServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'outgoingDmRetryServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$outgoingDmRetryServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<OutgoingDmRetryService?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  OutgoingDmRetryService? create(Ref ref) {
+    return outgoingDmRetryService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(OutgoingDmRetryService? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<OutgoingDmRetryService?>(value),
+    );
+  }
+}
+
+String _$outgoingDmRetryServiceHash() =>
+    r'ddd46e4ed60540af76e8f0df321d8f3b4d4073e7';
+
 /// Relay capability service for detecting NIP-11 Divine extensions
 
 @ProviderFor(relayCapabilityService)

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -166,9 +166,7 @@ class OutgoingDmRetryService {
           // State A: recipient delivered, self-wrap missing. The
           // canonical case #4124 is closing.
           try {
-            final result = await _dmRepository.recoverSelfWrap(
-              rumorId: row.id,
-            );
+            final result = await _dmRepository.recoverSelfWrap(rumorId: row.id);
             if (result.success) {
               // recoverSelfWrap deleted the row on success. The bumped
               // retryCount would be moot anyway, so skip incrementRetry.
@@ -238,6 +236,14 @@ class OutgoingDmRetryService {
         'aborted-not-ready=$abortedNotReady',
         name: 'OutgoingDmRetryService',
         category: LogCategory.system,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'sweep failed: $e',
+        name: 'OutgoingDmRetryService',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
       );
     } finally {
       _isSweeping = false;

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -1,0 +1,246 @@
+// ABOUTME: Service that auto-sweeps the outgoing_dms queue for partial-
+// ABOUTME: delivery rows and dispatches each to DmRepository.recoverSelfWrap.
+// ABOUTME: Triggered by app-foreground transitions, mirrors PendingActionService.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:meta/meta.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Backoff configuration for [OutgoingDmRetryService].
+///
+/// Defaults match `PendingActionRetryConfig` (5 retries, 2s → 5min,
+/// 2× backoff) — same precedent epic #3912 cites.
+class OutgoingDmRetryConfig {
+  const OutgoingDmRetryConfig({
+    this.maxRetries = 5,
+    this.initialDelay = const Duration(seconds: 2),
+    this.maxDelay = const Duration(minutes: 5),
+    this.backoffMultiplier = 2.0,
+  });
+
+  final int maxRetries;
+  final Duration initialDelay;
+  final Duration maxDelay;
+  final double backoffMultiplier;
+
+  /// Minimum required gap between attempts for a row whose previous
+  /// attempt count is [retryCount]. Clamped at [maxDelay].
+  Duration backoffFor(int retryCount) {
+    if (retryCount <= 0) return Duration.zero;
+    var ms = initialDelay.inMilliseconds.toDouble();
+    for (var i = 0; i < retryCount; i++) {
+      ms *= backoffMultiplier;
+      if (ms >= maxDelay.inMilliseconds) return maxDelay;
+    }
+    return Duration(milliseconds: ms.round());
+  }
+}
+
+/// Sweeps the durable `outgoing_dms` queue for rows whose recipient
+/// gift wrap landed but whose self-wrap did not, and re-publishes the
+/// missing self-wrap via [DmRepository.recoverSelfWrap].
+///
+/// **Trigger:** [appForegroundStream] transitions to `true`. The
+/// provider seeds the stream with the current foreground state on
+/// subscription, so the cold-start sweep fires automatically.
+///
+/// **Re-entrancy:** a sweep already in progress short-circuits the
+/// next trigger; the deferred work is picked up on the next foreground
+/// transition.
+///
+/// **Per-row backoff:** rows whose `lastAttemptAt + backoff(retryCount)`
+/// is in the future are skipped this pass. `incrementRetry` is called
+/// only on a real publish failure so transient repo-not-ready states
+/// don't burn the retry budget.
+///
+/// **Scope today:** only `recipient: sent / self: failed` rows are
+/// dispatched. `recipient: failed` rows are enumerated and counted in
+/// logs — issue #4240 will add the `recoverFullSend` primitive and
+/// wire it as the second strategy entry. App-killed `pending: pending`
+/// rows are not in this filter (see [OutgoingDmsDao.getStillPendingForOwner]).
+class OutgoingDmRetryService {
+  OutgoingDmRetryService({
+    required DmRepository dmRepository,
+    required OutgoingDmsDao outgoingDmsDao,
+    required String userPubkey,
+    required Stream<bool> appForegroundStream,
+    OutgoingDmRetryConfig retryConfig = const OutgoingDmRetryConfig(),
+    DateTime Function() now = DateTime.now,
+  }) : _dmRepository = dmRepository,
+       _dao = outgoingDmsDao,
+       _userPubkey = userPubkey,
+       _appForegroundStream = appForegroundStream,
+       _retryConfig = retryConfig,
+       _now = now;
+
+  final DmRepository _dmRepository;
+  final OutgoingDmsDao _dao;
+  final String _userPubkey;
+  final Stream<bool> _appForegroundStream;
+  final OutgoingDmRetryConfig _retryConfig;
+  final DateTime Function() _now;
+
+  StreamSubscription<bool>? _foregroundSubscription;
+  bool _isInitialized = false;
+  bool _isSweeping = false;
+
+  bool get isInitialized => _isInitialized;
+
+  @visibleForTesting
+  bool get isSweeping => _isSweeping;
+
+  /// Subscribe to foreground transitions. Idempotent: calling twice is
+  /// a no-op so the eager-init read in `main.dart` and any test setup
+  /// can coexist safely.
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    _isInitialized = true;
+
+    _foregroundSubscription = _appForegroundStream.listen((foreground) {
+      if (foreground) {
+        unawaited(sweep());
+      }
+    });
+
+    Log.info(
+      'initialized for $_userPubkey',
+      name: 'OutgoingDmRetryService',
+      category: LogCategory.system,
+    );
+  }
+
+  /// Cancel the foreground subscription and mark the service un-init.
+  /// Idempotent.
+  Future<void> dispose() async {
+    await _foregroundSubscription?.cancel();
+    _foregroundSubscription = null;
+    _isInitialized = false;
+  }
+
+  /// One pass over the retryable queue. Public so tests can drive it
+  /// directly without constructing a foreground stream.
+  @visibleForTesting
+  Future<void> sweep() async {
+    if (_isSweeping) {
+      Log.debug(
+        'sweep already in progress, skipping',
+        name: 'OutgoingDmRetryService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    _isSweeping = true;
+
+    try {
+      final retryable = await _dao.getRetryableForOwner(
+        ownerPubkey: _userPubkey,
+        maxRetries: _retryConfig.maxRetries,
+      );
+      if (retryable.isEmpty) return;
+
+      var processedSelfWrap = 0;
+      var failedSelfWrap = 0;
+      var skippedBackoff = 0;
+      var recipientFailedCount = 0;
+      var abortedNotReady = false;
+
+      for (final row in retryable) {
+        if (abortedNotReady) break;
+
+        // Per-row backoff check before any dispatch.
+        final lastAttempt = row.lastAttemptAt;
+        if (lastAttempt != null) {
+          final gap = _now().difference(lastAttempt);
+          final required = _retryConfig.backoffFor(row.retryCount);
+          if (gap < required) {
+            skippedBackoff++;
+            continue;
+          }
+        }
+
+        if (row.recipientWrapStatus == OutgoingWrapStatus.sent &&
+            row.selfWrapStatus == OutgoingWrapStatus.failed) {
+          // State A: recipient delivered, self-wrap missing. The
+          // canonical case #4124 is closing.
+          try {
+            final result = await _dmRepository.recoverSelfWrap(
+              rumorId: row.id,
+            );
+            if (result.success) {
+              // recoverSelfWrap deleted the row on success. The bumped
+              // retryCount would be moot anyway, so skip incrementRetry.
+              processedSelfWrap++;
+            } else {
+              // Publish failed. recoverSelfWrap already wrote
+              // selfWrapStatus=failed + lastError + lastAttemptAt via
+              // markSelfWrapStatus; bump the retry counter so the next
+              // sweep applies backoff and so the row eventually exits
+              // the retryable filter at maxRetries.
+              await _dao.incrementRetry(row.id);
+              failedSelfWrap++;
+            }
+          } on Object catch (e, stackTrace) {
+            // recoverSelfWrap's contract documents StateError (repo or
+            // DAO not initialized) and ArgumentError (row missing /
+            // foreign owner) as part of the public surface. Catching
+            // them — alongside any unexpected throw from the underlying
+            // publish — is the correct behavior here, not a code smell.
+            if (e is StateError) {
+              // No attempt was made because the repo wasn't ready.
+              // Don't bump retry; abort this pass and let the next
+              // foreground transition retry once auth is ready.
+              Log.warning(
+                'repo not ready during sweep; aborting pass: $e',
+                name: 'OutgoingDmRetryService',
+                category: LogCategory.system,
+              );
+              abortedNotReady = true;
+            } else if (e is ArgumentError) {
+              // Row went missing or wrong owner between
+              // getRetryableForOwner and dispatch. Terminal for this
+              // row — don't bump retry.
+              Log.warning(
+                'skipping row ${row.id}: $e',
+                name: 'OutgoingDmRetryService',
+                category: LogCategory.system,
+              );
+            } else {
+              // Unexpected throw before publish completed. Bump retry
+              // so backoff applies and the row eventually exits the
+              // filter.
+              await _dao.incrementRetry(row.id);
+              Log.error(
+                'recoverSelfWrap threw for ${row.id}: $e',
+                name: 'OutgoingDmRetryService',
+                category: LogCategory.system,
+                error: e,
+                stackTrace: stackTrace,
+              );
+            }
+          }
+        } else if (row.recipientWrapStatus == OutgoingWrapStatus.failed) {
+          // State B: recipient publish itself failed. Recovery primitive
+          // lands in #4240; today we only enumerate so we have
+          // production rate-of-occurrence data before designing it.
+          recipientFailedCount++;
+        }
+      }
+
+      Log.info(
+        'sweep complete: '
+        'self-wrap-recovered=$processedSelfWrap '
+        'self-wrap-failed=$failedSelfWrap '
+        'skipped-backoff=$skippedBackoff '
+        'recipient-failed=$recipientFailedCount '
+        'aborted-not-ready=$abortedNotReady',
+        name: 'OutgoingDmRetryService',
+        category: LogCategory.system,
+      );
+    } finally {
+      _isSweeping = false;
+    }
+  }
+}

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -376,6 +376,27 @@ void main() {
 
     group('error handling', () {
       test(
+        'contains a top-level DAO failure and clears the in-progress flag',
+        () async {
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenThrow(Exception('database locked'));
+
+          final service = buildService();
+
+          await expectLater(service.sweep(), completes);
+          expect(service.isSweeping, isFalse);
+          verifyNever(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          );
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test(
         'StateError aborts the pass; remaining rows are not dispatched',
         () async {
           // Two rows; the first throws StateError. The loop must not advance to

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -1,0 +1,634 @@
+// ABOUTME: Unit tests for OutgoingDmRetryService — pinned contracts:
+// ABOUTME: dispatches recipient: sent / self: failed rows to recoverSelfWrap,
+// ABOUTME: never republishes recipient wraps, applies per-row backoff,
+// ABOUTME: enumerates recipient: failed rows without acting on them.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show NIP17SendResult;
+import 'package:openvine/services/outgoing_dm_retry_service.dart';
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+const _ownerPubkey =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+const _otherOwner =
+    '0000000000000000000000000000000000000000000000000000000000000002';
+const _recipientPubkey =
+    '0000000000000000000000000000000000000000000000000000000000000099';
+
+OutgoingDm _row({
+  required String id,
+  required OutgoingWrapStatus recipient,
+  required OutgoingWrapStatus self,
+  int retryCount = 0,
+  DateTime? lastAttemptAt,
+  String ownerPubkey = _ownerPubkey,
+}) {
+  return OutgoingDm(
+    id: id,
+    conversationId: 'conv:$id',
+    recipientPubkey: _recipientPubkey,
+    content: 'hello',
+    createdAt: 1700000000,
+    rumorEventJson: '{}',
+    recipientWrapStatus: recipient,
+    selfWrapStatus: self,
+    queuedAt: DateTime.utc(2026),
+    ownerPubkey: ownerPubkey,
+    retryCount: retryCount,
+    lastAttemptAt: lastAttemptAt,
+  );
+}
+
+NIP17SendResult _successResult(String rumorId) => NIP17SendResult.success(
+  rumorEventId: rumorId,
+  messageEventId: 'wrap:$rumorId',
+  recipientPubkey: _ownerPubkey,
+);
+
+NIP17SendResult _failureResult(String reason) =>
+    NIP17SendResult.failure(reason);
+
+void main() {
+  late _MockDmRepository dmRepository;
+  late _MockOutgoingDmsDao dao;
+  late StreamController<bool> foregroundController;
+
+  setUp(() {
+    dmRepository = _MockDmRepository();
+    dao = _MockOutgoingDmsDao();
+    foregroundController = StreamController<bool>.broadcast();
+
+    // Permissive defaults so individual tests only stub what they care about.
+    when(
+      () => dao.getRetryableForOwner(
+        ownerPubkey: any(named: 'ownerPubkey'),
+        maxRetries: any(named: 'maxRetries'),
+      ),
+    ).thenAnswer((_) async => const <OutgoingDm>[]);
+    when(() => dao.incrementRetry(any())).thenAnswer((_) async => true);
+  });
+
+  tearDown(() async {
+    await foregroundController.close();
+  });
+
+  OutgoingDmRetryService buildService({
+    OutgoingDmRetryConfig retryConfig = const OutgoingDmRetryConfig(),
+    DateTime Function()? now,
+  }) {
+    return OutgoingDmRetryService(
+      dmRepository: dmRepository,
+      outgoingDmsDao: dao,
+      userPubkey: _ownerPubkey,
+      appForegroundStream: foregroundController.stream,
+      retryConfig: retryConfig,
+      now: now ?? () => DateTime.utc(2026, 5, 10, 12),
+    );
+  }
+
+  group(OutgoingDmRetryService, () {
+    group('initialize', () {
+      test('subscribes to the foreground stream', () async {
+        final service = buildService();
+        await service.initialize();
+        expect(service.isInitialized, isTrue);
+        expect(foregroundController.hasListener, isTrue);
+        await service.dispose();
+      });
+
+      test('is idempotent — second call does not double-subscribe', () async {
+        final service = buildService();
+        await service.initialize();
+        await service.initialize();
+        expect(foregroundController.hasListener, isTrue);
+        // The second initialize did not throw and the service stayed init.
+        expect(service.isInitialized, isTrue);
+        await service.dispose();
+      });
+
+      test('dispose cancels the foreground subscription', () async {
+        final service = buildService();
+        await service.initialize();
+        await service.dispose();
+        expect(foregroundController.hasListener, isFalse);
+        expect(service.isInitialized, isFalse);
+      });
+
+      test(
+        'foreground=true triggers a sweep; foreground=false does not',
+        () async {
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => const <OutgoingDm>[]);
+
+          final service = buildService();
+          await service.initialize();
+
+          foregroundController.add(false);
+          await Future<void>.delayed(Duration.zero);
+          verifyNever(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          );
+
+          foregroundController.add(true);
+          await Future<void>.delayed(Duration.zero);
+          verify(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: _ownerPubkey,
+              maxRetries: 5,
+            ),
+          ).called(1);
+
+          await service.dispose();
+        },
+      );
+    });
+
+    group('sweep dispatch', () {
+      test(
+        'dispatches recipient: sent / self: failed rows to recoverSelfWrap',
+        () async {
+          final row = _row(
+            id: 'rumor1',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) async => _successResult('rumor1'));
+
+          final service = buildService();
+          await service.sweep();
+
+          verify(
+            () => dmRepository.recoverSelfWrap(rumorId: 'rumor1'),
+          ).called(1);
+          // recoverSelfWrap deletes the row on success — no incrementRetry.
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test(
+        'does NOT dispatch recipient: failed rows to recoverSelfWrap',
+        () async {
+          final row = _row(
+            id: 'rumor2',
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+
+          final service = buildService();
+          await service.sweep();
+
+          verifyNever(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          );
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test('publish-failure path bumps incrementRetry once', () async {
+        final row = _row(
+          id: 'rumor3',
+          recipient: OutgoingWrapStatus.sent,
+          self: OutgoingWrapStatus.failed,
+          retryCount: 1,
+          // lastAttemptAt is far enough in the past that backoff doesn't gate.
+          lastAttemptAt: DateTime.utc(2025),
+        );
+        when(
+          () => dao.getRetryableForOwner(
+            ownerPubkey: any(named: 'ownerPubkey'),
+            maxRetries: any(named: 'maxRetries'),
+          ),
+        ).thenAnswer((_) async => [row]);
+        when(
+          () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+        ).thenAnswer((_) async => _failureResult('relay timeout'));
+
+        final service = buildService();
+        await service.sweep();
+
+        verify(() => dmRepository.recoverSelfWrap(rumorId: 'rumor3')).called(1);
+        verify(() => dao.incrementRetry('rumor3')).called(1);
+      });
+
+      test('multiple State A rows are processed independently', () async {
+        final rows = [
+          _row(
+            id: 'a',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          ),
+          _row(
+            id: 'b',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          ),
+        ];
+        when(
+          () => dao.getRetryableForOwner(
+            ownerPubkey: any(named: 'ownerPubkey'),
+            maxRetries: any(named: 'maxRetries'),
+          ),
+        ).thenAnswer((_) async => rows);
+        when(
+          () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+        ).thenAnswer((inv) async {
+          final id = inv.namedArguments[#rumorId] as String;
+          return _successResult(id);
+        });
+
+        await buildService().sweep();
+
+        verify(() => dmRepository.recoverSelfWrap(rumorId: 'a')).called(1);
+        verify(() => dmRepository.recoverSelfWrap(rumorId: 'b')).called(1);
+      });
+
+      test('exits early when getRetryableForOwner is empty', () async {
+        when(
+          () => dao.getRetryableForOwner(
+            ownerPubkey: any(named: 'ownerPubkey'),
+            maxRetries: any(named: 'maxRetries'),
+          ),
+        ).thenAnswer((_) async => const <OutgoingDm>[]);
+
+        await buildService().sweep();
+
+        verifyNever(
+          () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+        );
+        verifyNever(() => dao.incrementRetry(any()));
+      });
+    });
+
+    group('per-row backoff', () {
+      test(
+        'skips a row whose lastAttemptAt + backoff is still in the future',
+        () async {
+          final now = DateTime.utc(2026, 5, 10, 12);
+          // retryCount=2 with default config gives backoff 8s. lastAttempt is
+          // 1s ago — well within the gate.
+          final row = _row(
+            id: 'rumor4',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+            retryCount: 2,
+            lastAttemptAt: now.subtract(const Duration(seconds: 1)),
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+
+          await buildService(now: () => now).sweep();
+
+          verifyNever(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          );
+        },
+      );
+
+      test(
+        'dispatches a row whose lastAttemptAt is older than the backoff',
+        () async {
+          final now = DateTime.utc(2026, 5, 10, 12);
+          // retryCount=1 → backoff 4s. lastAttempt is 30s ago — over the gate.
+          final row = _row(
+            id: 'rumor5',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+            retryCount: 1,
+            lastAttemptAt: now.subtract(const Duration(seconds: 30)),
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) async => _successResult('rumor5'));
+
+          await buildService(now: () => now).sweep();
+
+          verify(
+            () => dmRepository.recoverSelfWrap(rumorId: 'rumor5'),
+          ).called(1);
+        },
+      );
+
+      test(
+        'a fresh row (lastAttemptAt == null) is always dispatched',
+        () async {
+          final row = _row(
+            id: 'rumor6',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) async => _successResult('rumor6'));
+
+          await buildService().sweep();
+
+          verify(
+            () => dmRepository.recoverSelfWrap(rumorId: 'rumor6'),
+          ).called(1);
+        },
+      );
+    });
+
+    group('error handling', () {
+      test(
+        'StateError aborts the pass; remaining rows are not dispatched',
+        () async {
+          // Two rows; the first throws StateError. The loop must not advance to
+          // the second — auth-not-ready is a per-pass issue, not per-row.
+          final rows = [
+            _row(
+              id: 'a',
+              recipient: OutgoingWrapStatus.sent,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'b',
+              recipient: OutgoingWrapStatus.sent,
+              self: OutgoingWrapStatus.failed,
+            ),
+          ];
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => rows);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: 'a'),
+          ).thenThrow(StateError('repo not initialized'));
+
+          await buildService().sweep();
+
+          verify(() => dmRepository.recoverSelfWrap(rumorId: 'a')).called(1);
+          verifyNever(() => dmRepository.recoverSelfWrap(rumorId: 'b'));
+          // Did not bump retry — no attempt was actually made.
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test('ArgumentError skips the row but continues with the next', () async {
+        final rows = [
+          _row(
+            id: 'a',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          ),
+          _row(
+            id: 'b',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          ),
+        ];
+        when(
+          () => dao.getRetryableForOwner(
+            ownerPubkey: any(named: 'ownerPubkey'),
+            maxRetries: any(named: 'maxRetries'),
+          ),
+        ).thenAnswer((_) async => rows);
+        when(
+          () => dmRepository.recoverSelfWrap(rumorId: 'a'),
+        ).thenThrow(ArgumentError.value('a', 'rumorId', 'no queued row'));
+        when(
+          () => dmRepository.recoverSelfWrap(rumorId: 'b'),
+        ).thenAnswer((_) async => _successResult('b'));
+
+        await buildService().sweep();
+
+        verify(() => dmRepository.recoverSelfWrap(rumorId: 'a')).called(1);
+        verify(() => dmRepository.recoverSelfWrap(rumorId: 'b')).called(1);
+        // Did not bump retry on the missing-row case — terminal, not
+        // "row failed to publish."
+        verifyNever(() => dao.incrementRetry('a'));
+      });
+
+      test(
+        'unexpected throw bumps retry and continues with the next row',
+        () async {
+          final rows = [
+            _row(
+              id: 'a',
+              recipient: OutgoingWrapStatus.sent,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'b',
+              recipient: OutgoingWrapStatus.sent,
+              self: OutgoingWrapStatus.failed,
+            ),
+          ];
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => rows);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: 'a'),
+          ).thenThrow(Exception('relay disconnected'));
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: 'b'),
+          ).thenAnswer((_) async => _successResult('b'));
+
+          await buildService().sweep();
+
+          verify(() => dao.incrementRetry('a')).called(1);
+          verify(() => dmRepository.recoverSelfWrap(rumorId: 'b')).called(1);
+        },
+      );
+    });
+
+    group('contract: never republishes recipient wraps', () {
+      // Pinning #4106's invariant — the sweep must only ever invoke
+      // recoverSelfWrap, never sendMessage / sendGroupMessage / sendRumor.
+      test(
+        'a full pass over assorted retryable rows only calls recoverSelfWrap',
+        () async {
+          final rows = [
+            _row(
+              id: 'a',
+              recipient: OutgoingWrapStatus.sent,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'b',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'c',
+              recipient: OutgoingWrapStatus.sent,
+              self: OutgoingWrapStatus.failed,
+            ),
+          ];
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => rows);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((inv) async {
+            final id = inv.namedArguments[#rumorId] as String;
+            return _successResult(id);
+          });
+
+          await buildService().sweep();
+
+          verifyNever(
+            () => dmRepository.sendMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+            ),
+          );
+          verifyNever(
+            () => dmRepository.sendGroupMessage(
+              recipientPubkeys: any(named: 'recipientPubkeys'),
+              content: any(named: 'content'),
+            ),
+          );
+          verify(() => dmRepository.recoverSelfWrap(rumorId: 'a')).called(1);
+          verify(() => dmRepository.recoverSelfWrap(rumorId: 'c')).called(1);
+          verifyNever(() => dmRepository.recoverSelfWrap(rumorId: 'b'));
+        },
+      );
+    });
+
+    group('re-entrancy', () {
+      test(
+        'a sweep already in progress short-circuits a second invocation',
+        () async {
+          final completer = Completer<NIP17SendResult>();
+          final row = _row(
+            id: 'rumor7',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) => completer.future);
+
+          final service = buildService();
+          final first = service.sweep();
+          // Yield so the first sweep gets past the in-progress flag set.
+          await Future<void>.delayed(Duration.zero);
+          expect(service.isSweeping, isTrue);
+
+          // Second call returns immediately without entering the loop.
+          await service.sweep();
+          verify(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: _ownerPubkey,
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).called(1);
+
+          completer.complete(_successResult('rumor7'));
+          await first;
+          expect(service.isSweeping, isFalse);
+        },
+      );
+    });
+
+    group('account scope', () {
+      test(
+        'queries getRetryableForOwner with the constructor-provided pubkey',
+        () async {
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => const <OutgoingDm>[]);
+
+          // Build with a service for a SPECIFIC user; verify the query is
+          // scoped to them. The DAO filter is the account-isolation
+          // boundary — pin it here so a future refactor can't drop it.
+          final service = OutgoingDmRetryService(
+            dmRepository: dmRepository,
+            outgoingDmsDao: dao,
+            userPubkey: _otherOwner,
+            appForegroundStream: foregroundController.stream,
+          );
+
+          await service.sweep();
+
+          verify(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: _otherOwner,
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).called(1);
+        },
+      );
+    });
+  });
+
+  group(OutgoingDmRetryConfig, () {
+    const cfg = OutgoingDmRetryConfig();
+
+    test('retry 0 returns Duration.zero (no gate on the first attempt)', () {
+      expect(cfg.backoffFor(0), Duration.zero);
+    });
+
+    test('retry 1 returns initialDelay × multiplier', () {
+      expect(cfg.backoffFor(1), const Duration(seconds: 4));
+    });
+
+    test('retry growth caps at maxDelay', () {
+      // Default config: 2s × 2^N — after enough retries we hit 5min cap.
+      expect(cfg.backoffFor(20), cfg.maxDelay);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Closes #4124. Adds an `OutgoingDmRetryService` that sweeps the durable
`outgoing_dms` queue on every app-foreground transition and re-publishes
the missing self-wrap for any row in `recipient: sent / self: failed`
state via the `recoverSelfWrap` primitive landed in PR #4106.

Today that primitive is only invoked when the user manually taps the
partial-delivery SnackBar's Retry action. The SnackBar is ephemeral, so
dismissed taps and app-killed sessions leave self-wrap-failed rows
durably broken — silently breaking sender cross-device sync, the
*entire purpose* of NIP-17 self-wrapping.

The service mirrors `PendingActionService` one-for-one — same precedent
epic #3912 explicitly cites. It ships with a broad-shaped strategy
table but only the self-wrap-only entry wired today; rows in
`recipient: failed` state are enumerated and counted in logs to inform
the `recoverFullSend` follow-up (#4240).

**Related Issue:** Closes #4124. Follow-up: #4240. Parent epic: #3912.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes

**`OutgoingDmRetryService` (`mobile/lib/services/outgoing_dm_retry_service.dart`)**
- New service. Subscribes to `appForegroundProvider`. On each foreground
  transition to `true`, runs one sweep over `getRetryableForOwner`.
- Per-row backoff via `OutgoingDmRetryConfig` — defaults match
  `PendingActionRetryConfig` verbatim (5 retries, 2s → 5min, 2× backoff).
  Backoff state is durable across app kill (the DAO already writes
  `last_attempt_at` on every `markXxxWrapStatus` / `incrementRetry`).
- Re-entrancy guard: a sweep already in progress short-circuits the
  next trigger.
- Strategy dispatch:
  - **State A** (`recipient: sent / self: failed`) → `recoverSelfWrap`.
    `incrementRetry` is called only on a real publish failure so
    transient repo-not-ready states don't burn the retry budget.
  - **State B** (`recipient: failed`) → log-and-count only. Pinned via
    `verifyNever(recoverSelfWrap(rumorId: 'b'))` in the contract test.
- Error handling: `StateError` (repo not initialized) aborts the pass
  without bumping retry; `ArgumentError` (row missing / foreign owner)
  is terminal-skip; other throws bump retry and continue.

**`outgoingDmRetryServiceProvider` (`mobile/lib/providers/app_providers.dart`)**
- New `@Riverpod(keepAlive: true)` factory. Returns null when
  `userPubkey` is null OR when `isNostrReadyProvider` is false (Pattern A
  from `state_management.md` — gates dependents on readiness instead of
  catching `StateError` inside the service).
- Bridges the synchronous `appForegroundProvider` notifier into a
  `Stream<bool>` via `ref.listen(..., fireImmediately: true)` plus a
  `StreamController`, so the service contract stays free of Riverpod
  types and is easy to drive from unit tests.

**`main.dart`**
- Single `ref.watch(outgoingDmRetryServiceProvider)` at app shell setup.
  The service has no UI consumer (it operates on the durable queue), so
  without an explicit read it would never be created.

**No DAO / repository / UI / BLoC / l10n / schema changes.** The DAO is
already retry-service-ready (`getRetryableForOwner({maxRetries})`,
`incrementRetry`, durable `last_attempt_at`, per-wrap error columns —
all from PR #3911).

## Test plan

Automated:
- [x] `dart format` — no changes.
- [x] `flutter analyze lib test integration_test` — clean.
- [x] `mobile/test/services/outgoing_dm_retry_service_test.dart` — 21
      new tests, all passing. Covers initialize/dispose, dispatch by row
      state, per-row backoff (skip / proceed / fresh), error handling
      (`StateError` aborts pass, `ArgumentError` skips row, generic
      throw bumps retry), re-entrancy guard, account scope, and
      `OutgoingDmRetryConfig.backoffFor` math.
- [x] `mobile/test/services/pending_action_service_test.dart` — 42
      tests, no regression in the precedent service.
- [x] `mobile/test/blocs/dm/` — 146 tests, no regression in DM blocs.
- [x] `mobile/packages/dm_repository` — 219 tests, no regression in
      `recoverSelfWrap`'s contract.
- [x] `mobile/test/providers/dm_repository_provider_test.dart` — 3
      tests, no regression in the DM provider's gift-wrap subscription
      lifecycle.

Pinning contracts added:
- The sweep never invokes `sendMessage` / `sendGroupMessage` / any
  recipient-publishing path (`verifyNever` on each in the
  "never republishes recipient wraps" group).
- `recipient: failed` rows are visible to `getRetryableForOwner` but
  are NOT dispatched to `recoverSelfWrap`.
- `incrementRetry` is called once per real publish failure and never
  on `StateError`/`ArgumentError` (the abort/skip paths).
- A second `sweep()` call while one is already in progress
  short-circuits without re-entering the loop.

Manual verification (please confirm during review):
- [ ] Force a self-wrap publish failure on a 1:1 send (e.g. block the
      second `publishEvent` round in a debug build), then **dismiss**
      the SnackBar without tapping Retry. Background and re-foreground
      the app — the row should be recovered automatically and the
      `outgoing_dms` row should be gone.
- [ ] App-kill the app between the recipient publish and the self-wrap
      publish (debug build). Re-launch. The cold-start foreground
      transition should fire one sweep; if the recipient publish had
      landed, the row should be recovered. (Caveat: a row in
      `recipient: pending / self: pending` state — i.e., we don't yet
      know whether the recipient publish landed — is out of scope for
      this PR's filter; it's covered by #4240's follow-up.)
- [ ] On a long foreground session, observe the per-row backoff in
      logs: `skipped-backoff=N` should grow as the same row gets
      re-evaluated within its backoff window.

## Brainstorm + plan

The design rationale (why a foreground-only trigger; why the broad
service shape with only self-wrap-only recovery wired today; why
mirror `PendingActionService` instead of putting the loop inside
`DmRepository`) is captured in
`mobile/docs/brainstorm/2026-05-10-issue4124-outgoing-dm-auto-sweep-brainstorm.md`,
included in this PR.