### PR TITLE
fix(video-editor): improve audio gaps between clips

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1856,10 +1856,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "968d6b2ba70705bd645615f2f2b22d54d85ca3d8de43536d8f9fe0f1554ca6d1"
+      sha256: "9d914ec472119bc1a71b750d52ed3ce79169a27211f41fd7d6397693ecd4c466"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.2"
+    version: "1.16.2"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -273,7 +273,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.15.0
+  pro_video_editor: ^1.16.2
   pro_image_editor: ^12.4.4
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

Users reported on Discord that loops in diVine didn’t feel as smooth as they did on Vine. This PR updates the `pro_video_editor` to improve looping from the rendering side by using a single audio track across the entire video instead of multiple tracks. This fixes the gaps between clips and at the end of the video, but it does NOT solve the gap when the loop restarts.

The current MediaKit solution CANNOT handle seamless looping, so a small gap will always remain. Once we merge the new native video players in #3242, this issue will also be fixed since they use the correct native playback implementation for this use case.

The only possible workaround with MediaKit would be running two video players at the same time, but since the app already reaches its limits with a single MediaKit player, that is not a viable option.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore