### PR TITLE
feat(video): always-on pause icon + toggles pill when paused

### DIFF
--- a/docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md
+++ b/docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md
@@ -1,0 +1,1001 @@
+# Paused-overlay Toggles Pill Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the existing playback-toggles pill (compilations / mute / CC) above the play icon in every paused-video overlay, and make the pause icon appear reliably whenever the player isn't playing (not gated on a prior-play latch).
+
+**Architecture:** Extract today's private `_PlaybackSettingsPopover` from `feed_settings_menu.dart` into a new public `FeedPlaybackTogglesPill` widget. Both the existing top-bar popover and the new paused-overlay placement render that one widget — single source of truth. Inside `PausedVideoPlayOverlay`, drop the `hasStartedPlayback` latch (keep the buffering gate and first-frame gate) and render the pill above the play icon.
+
+**Tech Stack:** Flutter, `flutter_bloc` (FeedAutoAdvanceCubit, VideoVolumeCubit), Riverpod (subtitleVisibilityProvider), `divine_ui` (DivineIcon, VineTheme).
+
+**Spec:** `docs/superpowers/specs/2026-05-11-paused-overlay-toggles-pill-design.md`
+
+**Worktree:** `.worktrees/paused-overlay-toggles-pill` on branch `feat/paused-overlay-toggles-pill`. Run all Flutter commands from `mobile/`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart` | **Create** | Public widget: scrim-30 capsule with three toggles (auto-advance, mute, captions) + the shared `_PopoverToggle` chip. Reads `FeedAutoAdvanceCubit`, `VideoVolumeCubit`, `subtitleVisibilityProvider` directly — no constructor params. |
+| `mobile/lib/screens/feed/feed_settings_menu.dart` | **Modify** | `_FeedSettingsOverlay` renders `FeedPlaybackTogglesPill` instead of the inlined widget. Delete `_PlaybackSettingsPopover`, `_PlaybackModeToggle`, `_AudioToggle`, `_CaptionsToggle`, `_PopoverToggle`. |
+| `mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart` | **Modify** | (1) Render `FeedPlaybackTogglesPill` above the play icon in `_PausedAffordance`. (2) Drop `_hasStartedPlayback` field + `_subscribeToPlayback` latching logic + `didUpdateWidget` latch reset (`_pausedAt` / unpause-feedback logic stays). (3) Drop `onToggleMuteState` constructor param. (4) Change `shouldShowPlay` to `!isPlaying && !isBuffering`. (5) Drop the `_PausedAffordance.onToggleMuteState` field and the single mute toggle inside it. |
+| `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart` | **Modify** | Replace the "keeps play affordance visible when remounted" test (which asserts the old latch behavior) with new tests that assert (a) pause icon shows immediately when `isPlaying==false && isBuffering==false`, (b) pause icon stays hidden during buffering, (c) the pill renders above the play icon when paused. Migrate test fixture: drop `onToggleMuteState: () {}` and provide `FeedAutoAdvanceCubit` + `VideoVolumeCubit` + `ProviderScope` so the pill renders without throwing. Update the existing unpause-feedback tests' fixture identically. |
+| `mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart` | **Create** | New tests for `FeedPlaybackTogglesPill`: each of the three toggles renders, reflects current state, and dispatches the right side effect on tap. Mirrors what's currently inlined in the popover. |
+
+No other call sites pass `onToggleMuteState` (verified: `grep -n onToggleMuteState mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` returns nothing — they construct `PausedVideoPlayOverlay` without that param today), so removing it does not require edits at `feed_video_overlay.dart` or `pooled_fullscreen_video_feed_screen.dart`.
+
+---
+
+## Chunk 1: Extract `FeedPlaybackTogglesPill`
+
+This chunk creates the new shared widget and switches `FeedSettingsMenu`'s popover to use it. After this chunk the top-bar popover renders identically to today, but its content comes from the new file. The paused overlay is unchanged.
+
+### Task 1.1: Create the new file with the pill and its three toggles
+
+**Files:**
+- Create: `mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart`
+
+- [ ] **Step 1: Create the file with the full implementation**
+
+The content below is the lift-and-shift of `_PlaybackSettingsPopover` + its three private toggles + `_PopoverToggle` from `feed_settings_menu.dart`, exposed as a public widget. Behavior is unchanged.
+
+```dart
+// ABOUTME: Scrim-30 capsule with three playback toggles
+// ABOUTME: (compilations / mute / closed-captions). Rendered both as
+// ABOUTME: the body of the top-bar settings popover and above the play
+// ABOUTME: affordance in the paused-video overlay.
+
+import 'dart:ui';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+
+/// Scrim-30 backdrop-blurred capsule housing the three playback toggles:
+/// auto-advance ("compilations"), audio mute, and closed-captions.
+///
+/// Each toggle reads and writes app-wide state directly
+/// ([FeedAutoAdvanceCubit], [VideoVolumeCubit], `subtitleVisibilityProvider`),
+/// so the pill takes no constructor params and works as a drop-in child of
+/// any feed surface that provides those scopes.
+class FeedPlaybackTogglesPill extends StatelessWidget {
+  const FeedPlaybackTogglesPill({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(24),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 4, sigmaY: 4),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: VineTheme.scrim30,
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: VineTheme.scrim15),
+            boxShadow: const [
+              BoxShadow(color: VineTheme.shadow25, blurRadius: 4),
+            ],
+          ),
+          child: const Padding(
+            padding: EdgeInsets.all(12),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                _PlaybackModeToggle(),
+                _AudioToggle(),
+                _CaptionsToggle(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Auto-advance ("compilations") toggle. Hidden when the OS-level
+/// reduced-motion preference is set — auto-advance is unavailable in
+/// that state. Also hidden when no [FeedAutoAdvanceCubit] is provided
+/// in the surrounding scope, so the pill can be rendered in any
+/// surface without requiring callers to wire up the cubit when they
+/// don't use auto-advance.
+class _PlaybackModeToggle extends StatelessWidget {
+  const _PlaybackModeToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    if (MediaQuery.disableAnimationsOf(context)) {
+      return const SizedBox.shrink();
+    }
+    final cubit = _maybeReadFeedAutoAdvanceCubit(context);
+    if (cubit == null) return const SizedBox.shrink();
+
+    return BlocBuilder<FeedAutoAdvanceCubit, FeedAutoAdvanceState>(
+      bloc: cubit,
+      builder: (context, state) {
+        final enabled = state.enabled;
+        return _PopoverToggle(
+          isOn: enabled,
+          semanticLabel: enabled
+              ? context.l10n.videoActionDisableAutoAdvance
+              : context.l10n.videoActionEnableAutoAdvance,
+          onTap: () {
+            cubit.toggle();
+            if (!cubit.state.isEffectivelyActive) {
+              cubit.clearPendingPaginationAdvance();
+            }
+            announceAutoAdvanceToggle(
+              context,
+              enabled: cubit.state.enabled,
+            );
+          },
+          child: DivineIcon(
+            icon: enabled
+                ? DivineIconName.playbackModeOn
+                : DivineIconName.playbackModeOff,
+            color: VineTheme.onSurface,
+          ),
+        );
+      },
+    );
+  }
+}
+
+FeedAutoAdvanceCubit? _maybeReadFeedAutoAdvanceCubit(BuildContext context) {
+  try {
+    return BlocProvider.of<FeedAutoAdvanceCubit>(context, listen: false);
+  } on ProviderNotFoundException {
+    return null;
+  }
+}
+
+/// Audio mute toggle. Drives [VideoVolumeCubit] directly.
+class _AudioToggle extends StatelessWidget {
+  const _AudioToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    final isMuted = context.select(
+      (VideoVolumeCubit c) => c.state.volume == 0,
+    );
+    return _PopoverToggle(
+      isOn: isMuted,
+      semanticLabel: isMuted
+          ? context.l10n.videoPlayerUnmute
+          : context.l10n.videoPlayerMute,
+      onTap: () {
+        context.read<VideoVolumeCubit>().onPlaybackVolumeChanged(
+          isMuted ? 1 : 0,
+        );
+        SemanticsService.sendAnnouncement(
+          View.of(context),
+          isMuted
+              ? context.l10n.videoPlayerUnmute
+              : context.l10n.videoPlayerMute,
+          Directionality.of(context),
+        );
+      },
+      child: DivineIcon(
+        icon: isMuted
+            ? DivineIconName.speakerSimpleSlash
+            : DivineIconName.speakerSimpleHigh,
+        color: VineTheme.onSurface,
+      ),
+    );
+  }
+}
+
+/// Closed-captions toggle. Active state means subtitles are visible.
+class _CaptionsToggle extends ConsumerWidget {
+  const _CaptionsToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = ref.watch(subtitleVisibilityProvider);
+    return _PopoverToggle(
+      isOn: enabled,
+      semanticLabel: enabled
+          ? context.l10n.videoSettingsCaptionsDisable
+          : context.l10n.videoSettingsCaptionsEnable,
+      onTap: () {
+        ref.read(subtitleVisibilityProvider.notifier).toggle();
+      },
+      child: DivineIcon(
+        icon: enabled
+            ? DivineIconName.closedCaptioningFill
+            : DivineIconName.closedCaptioning,
+        color: VineTheme.onSurface,
+      ),
+    );
+  }
+}
+
+/// 48 px touch target wrapping a 12 px-padded scrim button (40 px
+/// visible at 20 px radius). Background flips between scrim-15 (off)
+/// and scrim-50 (on).
+class _PopoverToggle extends StatelessWidget {
+  const _PopoverToggle({
+    required this.isOn,
+    required this.onTap,
+    required this.child,
+    required this.semanticLabel,
+  });
+
+  final bool isOn;
+  final VoidCallback onTap;
+  final Widget child;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = isOn ? VineTheme.scrim50 : VineTheme.scrim15;
+    return Semantics(
+      button: true,
+      toggled: isOn,
+      label: semanticLabel,
+      container: true,
+      explicitChildNodes: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: SizedBox.square(dimension: 24, child: child),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+> **Note on `_maybeReadFeedAutoAdvanceCubit`:** `BlocProvider.of` throws
+> `ProviderNotFoundException` when the cubit isn't in scope. Catching
+> that and returning `null` is the standard Flutter-Bloc idiom for "use
+> if present, hide otherwise" — see the [package's docs](https://pub.dev/documentation/flutter_bloc/latest/flutter_bloc/BlocProvider/of.html).
+> `context.select` cannot do this because it doesn't have a nullable form.
+> The new `BlocBuilder` wrapper exists only because we can't use
+> `context.select` after the nullable lookup (it requires the cubit to
+> be in scope at the time of the call). Behavior matches the original
+> `context.select` path when the cubit is present.
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `cd mobile && mise exec -- flutter analyze lib/widgets/video_feed_item/feed_playback_toggles_pill.dart`
+Expected: clean — `No issues found!`
+
+If `mise` isn't available, fall back to `flutter analyze …`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
+git commit -m "$(cat <<'EOF'
+feat(feed): extract feed playback toggles pill widget
+
+Lifts the private _PlaybackSettingsPopover and its three toggles out of
+feed_settings_menu.dart into a public widget so the same pill can be
+rendered in both the top-bar popover and the paused-video overlay.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.2: Switch `FeedSettingsMenu` popover to the new shared widget
+
+**Files:**
+- Modify: `mobile/lib/screens/feed/feed_settings_menu.dart`
+
+- [ ] **Step 1: Replace the popover body and delete the now-redundant private widgets**
+
+In `mobile/lib/screens/feed/feed_settings_menu.dart`:
+
+1. Remove these imports (no longer needed in this file after the lift-out):
+   ```dart
+   import 'dart:ui';
+   import 'package:flutter/semantics.dart';
+   import 'package:flutter_bloc/flutter_bloc.dart';
+   import 'package:flutter_riverpod/flutter_riverpod.dart';
+   import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+   import 'package:openvine/providers/subtitle_providers.dart';
+   import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+   ```
+2. Add this import:
+   ```dart
+   import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+   ```
+   Keep the remaining imports (`divine_ui`, `flutter/material`, `openvine/l10n/l10n`).
+3. Inside `_FeedSettingsOverlay.build`, change
+   `child: const Material(... child: _PlaybackSettingsPopover())` to
+   `child: const Material(... child: FeedPlaybackTogglesPill())`.
+4. Delete the now-unused classes from this file:
+   `_PlaybackSettingsPopover`, `_PlaybackModeToggle`, `_AudioToggle`,
+   `_CaptionsToggle`, `_PopoverToggle`. Also update the doc comment on
+   `FeedSettingsMenu` — the line "All three toggles read and write
+   app-wide state…" — to reference the new widget by name. Leave the
+   `OverlayPortal` wrapper, the trigger button, and the open/close
+   logic untouched.
+
+- [ ] **Step 2: Verify analyze and test**
+
+Run from `mobile/`:
+
+```bash
+mise exec -- flutter analyze lib/screens/feed/feed_settings_menu.dart lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
+mise exec -- flutter test test/screens/feed/video_feed_page_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+```
+
+Expected: analyze clean; both `_test.dart` suites pass. (`video_feed_page_test.dart` and `pooled_fullscreen_video_feed_screen_test.dart` cover `FeedSettingsMenu`'s open/close from the top-bar — those tests should still pass because the popover content is byte-for-byte equivalent.)
+
+If `video_feed_page_test.dart` references a deleted private symbol, those references should be `byType(FeedSettingsMenu)` only — we just verified that in the spec. Stop and re-read the test if anything else is failing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/screens/feed/feed_settings_menu.dart
+git commit -m "$(cat <<'EOF'
+refactor(feed): use shared FeedPlaybackTogglesPill in settings popover
+
+No behavior change. The popover renders the same three toggles by
+delegating to the new shared widget instead of inlining the
+implementation here.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.3: Add unit-style widget tests for the extracted pill
+
+**Files:**
+- Create: `mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart`
+
+- [ ] **Step 1: Write the new test file**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/blocs/video_volume/video_volume_state.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+
+class _MockVideoVolumeCubit extends Mock implements VideoVolumeCubit {}
+
+void main() {
+  group(FeedPlaybackTogglesPill, () {
+    late FeedAutoAdvanceCubit autoAdvanceCubit;
+    late VideoVolumeCubit volumeCubit;
+
+    setUp(() {
+      autoAdvanceCubit = FeedAutoAdvanceCubit();
+      volumeCubit = _MockVideoVolumeCubit();
+      when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
+      when(() => volumeCubit.stream)
+          .thenAnswer((_) => const Stream<VideoVolumeState>.empty());
+    });
+
+    tearDown(() async {
+      await autoAdvanceCubit.close();
+    });
+
+    Widget buildSubject({bool reducedMotion = false}) {
+      return ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaQuery(
+            data: MediaQueryData(disableAnimations: reducedMotion),
+            child: MultiBlocProvider(
+              providers: [
+                BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
+                BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+              ],
+              child: const Scaffold(body: FeedPlaybackTogglesPill()),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders all three toggles when cubits are in scope',
+        (tester) async {
+      await tester.pumpWidget(buildSubject());
+      // 3 _PopoverToggle = 3 GestureDetectors inside the pill body.
+      expect(
+        find.byType(GestureDetector),
+        findsNWidgets(3),
+        reason: 'expected 3 toggles in the pill',
+      );
+    });
+
+    testWidgets('hides the compilations toggle under reduced motion',
+        (tester) async {
+      await tester.pumpWidget(buildSubject(reducedMotion: true));
+      expect(find.byType(GestureDetector), findsNWidgets(2));
+    });
+
+    testWidgets('tapping the captions toggle flips subtitle visibility',
+        (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(subtitleVisibilityProvider), isFalse);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
+                BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+              ],
+              child: const Scaffold(body: FeedPlaybackTogglesPill()),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the CC toggle (last GestureDetector in the row).
+      await tester.tap(find.byType(GestureDetector).last);
+      await tester.pump();
+      expect(container.read(subtitleVisibilityProvider), isTrue);
+    });
+
+    testWidgets(
+        'tapping the mute toggle calls VideoVolumeCubit.onPlaybackVolumeChanged',
+        (tester) async {
+      when(() => volumeCubit.state)
+          .thenReturn(const VideoVolumeState(volume: 1));
+      await tester.pumpWidget(buildSubject());
+
+      // Mute toggle is the middle GestureDetector (index 1) when
+      // compilations is visible.
+      await tester.tap(find.byType(GestureDetector).at(1));
+      await tester.pump();
+
+      verify(() => volumeCubit.onPlaybackVolumeChanged(0)).called(1);
+    });
+
+    testWidgets(
+        'tapping the compilations toggle calls FeedAutoAdvanceCubit.toggle',
+        (tester) async {
+      expect(autoAdvanceCubit.state.enabled, isFalse);
+      await tester.pumpWidget(buildSubject());
+
+      await tester.tap(find.byType(GestureDetector).first);
+      await tester.pump();
+
+      expect(autoAdvanceCubit.state.enabled, isTrue);
+    });
+
+    testWidgets('renders without the compilations toggle when '
+        'FeedAutoAdvanceCubit is not provided', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: BlocProvider<VideoVolumeCubit>.value(
+              value: volumeCubit,
+              child: const Scaffold(body: FeedPlaybackTogglesPill()),
+            ),
+          ),
+        ),
+      );
+
+      // 2 toggles (mute + CC), no compilations.
+      expect(find.byType(GestureDetector), findsNWidgets(2));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the new test**
+
+```bash
+cd mobile && mise exec -- flutter test test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart
+```
+
+Expected: 6/6 passing.
+
+If a test fails on the `VideoVolumeState` constructor or `volume` field name, **stop**: open `mobile/lib/blocs/video_volume/video_volume_state.dart` and adjust the test to use whatever the real constructor / property shape is. The plan uses `const VideoVolumeState()` and `VideoVolumeState(volume: 1)` as best guesses given current usage at `feed_settings_menu.dart:215` and `main.dart:1648`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart
+git commit -m "$(cat <<'EOF'
+test: cover FeedPlaybackTogglesPill toggles and missing-cubit guard
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Chunk 2: Always-visible pause + pill in `PausedVideoPlayOverlay`
+
+This chunk does the two user-visible changes: (a) drop the
+`hasStartedPlayback` latch so the pause icon shows whenever the player
+is not playing and not buffering; (b) render the pill above the play
+icon. Driven from the existing tests that need to be updated first
+(TDD: red → green).
+
+### Task 2.1: Update the existing overlay tests to match new behavior
+
+**Files:**
+- Modify: `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`
+
+- [ ] **Step 1: Update the setUp + `buildSubject` helper**
+
+In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
+
+1. Add the imports the test will need for cubits + Riverpod:
+   ```dart
+   import 'package:flutter_bloc/flutter_bloc.dart';
+   import 'package:flutter_riverpod/flutter_riverpod.dart';
+   import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+   import 'package:openvine/blocs/video_volume/video_volume_state.dart';
+   import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+   import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+   ```
+2. Add a private mock:
+   ```dart
+   class _MockVideoVolumeCubit extends Mock implements VideoVolumeCubit {}
+   ```
+3. Inside the existing `group('PausedVideoPlayOverlay', …)`, add:
+   ```dart
+   late FeedAutoAdvanceCubit autoAdvanceCubit;
+   late VideoVolumeCubit volumeCubit;
+   ```
+   In `setUp`, initialize them:
+   ```dart
+   autoAdvanceCubit = FeedAutoAdvanceCubit();
+   volumeCubit = _MockVideoVolumeCubit();
+   when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
+   when(() => volumeCubit.stream)
+       .thenAnswer((_) => const Stream<VideoVolumeState>.empty());
+   ```
+   In `tearDown`, close the cubit:
+   ```dart
+   await autoAdvanceCubit.close();
+   ```
+4. Replace the `buildSubject` body with the version below (wraps the
+   overlay in cubit providers + `ProviderScope`, drops `onToggleMuteState`):
+   ```dart
+   Widget buildSubject({Key? key}) {
+     return ProviderScope(
+       child: MultiBlocProvider(
+         providers: [
+           BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
+           BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+         ],
+         child: MaterialApp(
+           localizationsDelegates: AppLocalizations.localizationsDelegates,
+           supportedLocales: AppLocalizations.supportedLocales,
+           home: Scaffold(
+             body: PausedVideoPlayOverlay(
+               key: key,
+               player: mockPlayer,
+               firstFrameFuture: Future<void>.value(),
+             ),
+           ),
+         ),
+       ),
+     );
+   }
+   ```
+
+- [ ] **Step 2: Replace the "keeps the play affordance visible when remounted" test**
+
+That test (lines 69–108 of the current file) asserts that after a
+remount the overlay is *hidden* until playback transitions through
+playing again. The new behavior is the opposite — the play affordance
+appears as soon as the player reports not-playing and not-buffering,
+regardless of whether the new mount has ever observed a play. Replace
+that whole `testWidgets` with the three tests below:
+
+```dart
+testWidgets(
+  'shows the play affordance immediately when the player is paused, '
+  'even before any play has been observed',
+  (tester) async {
+    await tester.pumpWidget(buildSubject());
+    // First-frame future is already resolved (Future<void>.value()).
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(find.byKey(const ValueKey('paused-play')), findsOneWidget);
+  },
+);
+
+testWidgets(
+  'hides the play affordance while the player is buffering',
+  (tester) async {
+    when(() => mockPlayerState.buffering).thenReturn(true);
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+    bufferingController.add(true);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(find.byKey(const ValueKey('paused-play')), findsNothing);
+  },
+);
+
+testWidgets(
+  'renders the playback toggles pill above the play icon when paused',
+  (tester) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(find.byType(FeedPlaybackTogglesPill), findsOneWidget);
+    expect(find.byKey(const ValueKey('paused-play')), findsOneWidget);
+  },
+);
+```
+
+- [ ] **Step 3: Run the file — expect FAIL**
+
+```bash
+cd mobile && mise exec -- flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart
+```
+
+Expected: the three new tests fail.
+- "shows the play affordance immediately…" fails: today's overlay requires the `_hasStartedPlayback` latch.
+- "renders the playback toggles pill…" fails: today's `_PausedAffordance` doesn't render `FeedPlaybackTogglesPill`.
+- "hides the play affordance while buffering" — may pass today (buffering already gates `shouldShowPlay`); still good to keep as a regression test.
+
+The two unpause-feedback tests should still pass (they're already
+playing-then-pause-then-play, which exercises the unchanged
+`_pausedAt`/`_minPauseForFeedback` machinery).
+
+Do not commit yet — production code changes in the next task make these tests green.
+
+### Task 2.2: Drop the `hasStartedPlayback` latch and render the pill
+
+**Files:**
+- Modify: `mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart`
+
+- [ ] **Step 1: Edit the file**
+
+Apply these changes:
+
+1. **Imports.** Add at the top with the other openvine imports:
+   ```dart
+   import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+   ```
+   Remove the now-unused `package:flutter/semantics.dart` import — the
+   only `SemanticsService.sendAnnouncement` call was inside
+   `_PausedAffordance`'s mute toggle, which is being deleted.
+2. **Constructor.** Remove the `onToggleMuteState` named parameter and
+   field. Update the doc comment block above
+   `PausedVideoPlayOverlay` (currently mentions
+   "in-pause mute toggle") to describe the new pill placement.
+3. **State.** In `_PausedVideoPlayOverlayState`:
+   - Delete the `bool _hasStartedPlayback = false;` field and its doc
+     comment.
+   - In `didUpdateWidget`, delete the
+     `_hasStartedPlayback = false;` line. The rest of the player-swap
+     reset logic stays.
+   - In `_subscribeToPlayback`, delete:
+     - The `final initialPlaying = widget.player.state.playing;` line.
+     - The `_hasStartedPlayback = widget.isVisible && initialPlaying;`
+       line.
+     - The whole `if (isPlaying && !_hasStartedPlayback && widget.isVisible) {…}` latch block inside the `.listen` callback.
+     - The `_hasStartedPlayback &&` clause from the unpause-feedback
+       check (line ~129):
+       ```dart
+       } else if (isPlaying &&
+           !wasPlaying &&
+           _hasStartedPlayback &&
+           widget.isVisible) {
+       ```
+       becomes:
+       ```dart
+       } else if (isPlaying && !wasPlaying && widget.isVisible) {
+       ```
+   - Keep `_previouslyPlaying = initialPlaying;` working by sourcing the
+     initial value inline:
+     ```dart
+     _previouslyPlaying = widget.player.state.playing;
+     ```
+4. **`_PlaybackChrome.build`.** Replace:
+   ```dart
+   final shouldShowPlay = hasStartedPlayback && !isPlaying && !isBuffering;
+   ```
+   with:
+   ```dart
+   final shouldShowPlay = !isPlaying && !isBuffering;
+   ```
+   Drop the `hasStartedPlayback` parameter from `_PlaybackChrome`'s
+   constructor, fields, and the call from `_PausedVideoPlayOverlayState.build` (where it was `hasStartedPlayback: _hasStartedPlayback`).
+5. **`_PausedAffordance`.** Replace its `build`, fields, and constructor
+   so it always renders the pill above the play icon, with no `isMuted`
+   / `onToggleMuteState`:
+   ```dart
+   class _PausedAffordance extends StatelessWidget {
+     const _PausedAffordance({super.key});
+
+     @override
+     Widget build(BuildContext context) {
+       return Center(
+         child: Column(
+           mainAxisSize: MainAxisSize.min,
+           spacing: 16,
+           children: [
+             const FeedPlaybackTogglesPill(),
+             IgnorePointer(
+               child: CenterPlaybackControl(
+                 state: CenterPlaybackControlState.play,
+                 semanticsLabel: context.l10n.videoPlayerPlayVideo,
+               ),
+             ),
+           ],
+         ),
+       );
+     }
+   }
+   ```
+   Update the `_PlaybackChrome.shouldShowPlay` branch:
+   ```dart
+   child = _PausedAffordance(key: const ValueKey('paused-play'));
+   ```
+   The two `_PausedAffordance.isMuted`/`onToggleMuteState` arguments
+   in the existing call disappear. Also drop the `isMuted` and
+   `onToggleMuteState` fields from `_PlaybackChrome` itself — they
+   were only used to forward to `_PausedAffordance`. Drop the
+   surrounding `StreamBuilder<double>` (for `volume`) in
+   `_PausedVideoPlayOverlayState.build`, since `isMuted` is no longer
+   read by `_PlaybackChrome`. The pill computes mute state from
+   `VideoVolumeCubit` itself.
+
+   > **Why dropping the volume StreamBuilder is safe:** The mute
+   > badge in the old `_PausedAffordance` derived `isMuted` from
+   > `widget.player.stream.volume` — i.e. the actual `Player`. The new
+   > pill reads `VideoVolumeCubit`, which is wired to the active
+   > player by the page-level `BlocListener<VideoVolumeCubit>` in
+   > `video_feed_page.dart` and
+   > `pooled_fullscreen_video_feed_screen.dart` (the `onVolumeChanged`
+   > callback on the controller forwards player volume back into the
+   > cubit). Cubit and player stay in sync.
+
+- [ ] **Step 2: Run analyze on the changed file**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib/widgets/video_feed_item/paused_video_play_overlay.dart
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Run the overlay tests — expect PASS**
+
+```bash
+cd mobile && mise exec -- flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart
+```
+
+Expected: 5/5 passing (3 new + 2 existing unpause-feedback).
+
+If the unpause-feedback tests fail with a missing `FeedPlaybackTogglesPill` provider error, double-check Task 2.1 Step 1 wrapped `buildSubject` in `ProviderScope` + the two `BlocProvider.value`s.
+
+- [ ] **Step 4: Commit (both files together)**
+
+```bash
+git add mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart \
+        mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart
+git commit -m "$(cat <<'EOF'
+feat(video): show pause icon reliably and surface toggles when paused
+
+PausedVideoPlayOverlay no longer requires the player to have latched a
+prior play before showing the pause icon — pausing during initial load
+or before first-play now renders the affordance. Buffering still hides
+it to avoid loop-restart blips.
+
+Replaces the optional single mute toggle inside the paused affordance
+with the full FeedPlaybackTogglesPill (compilations / mute / CC), so
+the three controls are discoverable contextually on every video
+surface that uses PausedVideoPlayOverlay.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Chunk 3: Full verification + PR prep
+
+### Task 3.1: Full repo analyze + scoped test suites
+
+**Files:** (verification only — no edits)
+
+- [ ] **Step 1: Run full analyze**
+
+```bash
+cd mobile && mise exec -- flutter analyze lib test integration_test
+```
+
+Expected: `No issues found!` If anything fails, fix at the source — never silence with `// ignore:`.
+
+- [ ] **Step 2: Run all touched test suites**
+
+```bash
+cd mobile && mise exec -- flutter test \
+  test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart \
+  test/widgets/video_feed_item/paused_video_play_overlay_test.dart \
+  test/screens/feed/video_feed_page_test.dart \
+  test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+```
+
+Expected: all passing.
+
+- [ ] **Step 3: Run the full widget+screen test directories that touch this surface, randomised**
+
+```bash
+cd mobile && mise exec -- flutter test \
+  test/widgets/video_feed_item \
+  test/screens/feed \
+  --test-randomize-ordering-seed random
+```
+
+Expected: all green. Order-dependence in this surface is the kind of
+regression random ordering catches.
+
+- [ ] **Step 4: Format**
+
+```bash
+cd mobile && mise exec -- dart format \
+  lib/widgets/video_feed_item/feed_playback_toggles_pill.dart \
+  lib/widgets/video_feed_item/paused_video_play_overlay.dart \
+  lib/screens/feed/feed_settings_menu.dart \
+  test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart \
+  test/widgets/video_feed_item/paused_video_play_overlay_test.dart
+```
+
+If `dart format` reports changes, amend the relevant commit:
+
+```bash
+git add -u
+git commit --amend --no-edit
+```
+
+### Task 3.2: Manual smoke test
+
+These cannot be automated; run them on a real device/simulator before
+opening the PR.
+
+- [ ] **Step 1: Smoke test the home feed**
+
+Run the app on iOS or Android. On the home feed:
+
+1. Tap to pause a playing video → verify the pill (3 buttons) appears above the play icon, and the play icon is visible.
+2. Tap the captions toggle → verify subtitles toggle on/off.
+3. Tap the mute toggle → verify audio mutes/unmutes (use a video known to have audio).
+4. Tap the compilations toggle → verify auto-advance toggles. (Reduced motion off.)
+5. Tap somewhere outside the pill on the paused background → verify the video resumes playing.
+6. While playing, tap the top-bar three-dot menu → verify the same three toggles still appear in the popover, and their state is in sync with what you set from the pill.
+
+- [ ] **Step 2: Smoke test the fullscreen pooled feed**
+
+Push a video into fullscreen (from a profile grid, hashtag feed, or
+search result). Repeat steps 1–5 from Task 3.2 Step 1.
+
+- [ ] **Step 3: Smoke test the "pause before first play" path**
+
+Cold-launch the app, land on the home feed. Before the first video
+visibly starts playing, tap to pause. Verify the pause icon appears
+(this is the bug we fixed — previously it would not).
+
+- [ ] **Step 4: Smoke test the buffering case**
+
+On a flaky network (Network Link Conditioner or airplane-mode toggle
+mid-load), pause a video that's still buffering. Verify the pause icon
+**does not** flash during buffer; it appears once buffering completes
+and the player is paused.
+
+### Task 3.3: Rebase, push, open PR
+
+- [ ] **Step 1: Rebase onto fresh `origin/main`**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+If conflicts arise, resolve them and rerun analyze + tests before
+continuing.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push --force-with-lease -u origin feat/paused-overlay-toggles-pill
+```
+
+- [ ] **Step 3: Open the PR**
+
+Use the `/pr-summary` skill if available; otherwise:
+
+```bash
+gh pr create --base main --title "feat(video): always-on pause icon + toggles pill when paused" --body "$(cat <<'EOF'
+## Summary
+
+- Paused-video overlay now renders the three playback toggles
+  (compilations / mute / CC) above the play icon, applied uniformly
+  across every surface that uses `PausedVideoPlayOverlay`.
+- Pause icon shows whenever the player is paused (not gated on a
+  prior-play latch). Buffering still hides it to avoid loop-restart
+  blips, and the first-frame gate still suppresses the pre-render
+  window.
+- Pill is a single shared `FeedPlaybackTogglesPill` widget — the
+  top-bar three-dot popover now delegates to it too, so the two
+  render sites can't drift.
+
+Spec: `docs/superpowers/specs/2026-05-11-paused-overlay-toggles-pill-design.md`
+Plan: `docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md`
+
+## Test plan
+
+- [x] `flutter analyze lib test integration_test` clean
+- [x] `flutter test test/widgets/video_feed_item test/screens/feed --test-randomize-ordering-seed random` green
+- [x] Manual: home feed paused state, fullscreen pooled feed paused state, pause-before-first-play, pause-during-buffer
+- [ ] Reviewer: please verify on a low-end Android device that the pill backdrop blur isn't dropping frames during the AnimatedSwitcher transition.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Verify CI**
+
+Wait for `build / build` (divine_ui coverage), `Analyze`, `Tests`,
+`Format`, `Generated Files`. All must be green before requesting
+review. If any check fails, treat it as your fault (per
+`agent_workflow.md` rule 5) — investigate the diff, do not retry.
+
+---
+
+## Risk register (carried over from spec for reviewer reference)
+
+1. **Flicker window from dropping the latch.** In the narrow gap
+   between "active video transitioned out of preload-paused" and
+   "isPlaying=true," the play icon could briefly render. The
+   first-frame gate suppresses anything before the first frame; the
+   180 ms `AnimatedSwitcher` smooths the transition. If reports come
+   in, consider a small debounce (~100 ms) before showing the play
+   icon, but do not reintroduce the full latch.
+2. **Visual noise.** Three toggles every time someone pauses is more
+   chrome than the previous single mute. Rollback path: revert the
+   `_PausedAffordance` change only; the extracted pill stays available
+   in the top bar.
+3. **`FeedAutoAdvanceCubit` provider scope.** The compilations toggle
+   now silently hides when the cubit isn't in scope. Current call
+   sites all provide it, so behavior is unchanged today. The graceful
+   degradation means a future call site doesn't crash, but it also
+   means a misconfigured site silently loses the compilations toggle —
+   reviewers should flag a missing `FeedAutoAdvanceCubit` if they
+   spot a new `PausedVideoPlayOverlay` host without it.

--- a/docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md
+++ b/docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md
@@ -20,11 +20,53 @@
 |---|---|---|
 | `mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart` | **Create** | Public widget: scrim-30 capsule with three toggles (auto-advance, mute, captions) + the shared `_PopoverToggle` chip. Reads `FeedAutoAdvanceCubit`, `VideoVolumeCubit`, `subtitleVisibilityProvider` directly — no constructor params. |
 | `mobile/lib/screens/feed/feed_settings_menu.dart` | **Modify** | `_FeedSettingsOverlay` renders `FeedPlaybackTogglesPill` instead of the inlined widget. Delete `_PlaybackSettingsPopover`, `_PlaybackModeToggle`, `_AudioToggle`, `_CaptionsToggle`, `_PopoverToggle`. |
-| `mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart` | **Modify** | (1) Render `FeedPlaybackTogglesPill` above the play icon in `_PausedAffordance`. (2) Drop `_hasStartedPlayback` field + `_subscribeToPlayback` latching logic + `didUpdateWidget` latch reset (`_pausedAt` / unpause-feedback logic stays). (3) Drop `onToggleMuteState` constructor param. (4) Change `shouldShowPlay` to `!isPlaying && !isBuffering`. (5) Drop the `_PausedAffordance.onToggleMuteState` field and the single mute toggle inside it. |
-| `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart` | **Modify** | Replace the "keeps play affordance visible when remounted" test (which asserts the old latch behavior) with new tests that assert (a) pause icon shows immediately when `isPlaying==false && isBuffering==false`, (b) pause icon stays hidden during buffering, (c) the pill renders above the play icon when paused. Migrate test fixture: drop `onToggleMuteState: () {}` and provide `FeedAutoAdvanceCubit` + `VideoVolumeCubit` + `ProviderScope` so the pill renders without throwing. Update the existing unpause-feedback tests' fixture identically. |
+| `mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart` | **Modify** | (1) Render `FeedPlaybackTogglesPill` above the play icon in `_PausedAffordance`. (2) Drop `_hasStartedPlayback` field + `_subscribeToPlayback` latching logic + `didUpdateWidget` latch reset (`_pausedAt` / unpause-feedback logic stays). (3) Drop `onToggleMuteState` constructor param. (4) Change `shouldShowPlay` to `!isPlaying && !isBuffering`. (5) Drop the `_PausedAffordance.onToggleMuteState` field and the single mute toggle inside it. (6) Drop the now-unused `StreamBuilder<double>` (volume stream) wrapper inside `_PausedVideoPlayOverlayState.build`. |
+| `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` | **Modify** | Remove the now-stale 3-line comment at lines 1287–1289 ("Mute toggle intentionally omitted: the popover in the app bar's customActions slot is now the sole entry point, matching the home feed."). After this change, the mute toggle is back inside the pill rendered by the paused overlay; leaving the comment violates the "comments go stale" rule. No code change at the call site (already doesn't pass `onToggleMuteState`). |
+| `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart` | **Modify** | Replace the "keeps play affordance visible when remounted" test (which asserts the old latch behavior) with new tests that assert (a) pause icon shows immediately when `isPlaying==false && isBuffering==false`, (b) pause icon stays hidden during buffering, (c) the pill renders above the play icon when paused. Migrate test fixture: drop `onToggleMuteState: () {}` and provide `FeedAutoAdvanceCubit` + `VideoVolumeCubit` + `ProviderScope` (with `sharedPreferencesProvider` overridden via `createMockSharedPreferences()`) so the pill renders without throwing. Update the existing unpause-feedback tests' fixture identically. |
 | `mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart` | **Create** | New tests for `FeedPlaybackTogglesPill`: each of the three toggles renders, reflects current state, and dispatches the right side effect on tap. Mirrors what's currently inlined in the popover. |
 
-No other call sites pass `onToggleMuteState` (verified: `grep -n onToggleMuteState mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` returns nothing — they construct `PausedVideoPlayOverlay` without that param today), so removing it does not require edits at `feed_video_overlay.dart` or `pooled_fullscreen_video_feed_screen.dart`.
+No other call sites pass `onToggleMuteState` (verified: `grep -n onToggleMuteState mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` returns nothing — they construct `PausedVideoPlayOverlay` without that param today), so removing it does not require code edits at those files (only the stale comment at `pooled_fullscreen_video_feed_screen.dart:1287–1289`).
+
+## Test-fixture invariants (apply to every widget test in this PR)
+
+Both `FeedPlaybackTogglesPill` and `PausedVideoPlayOverlay`-with-pill pump
+`_CaptionsToggle`, which calls `ref.watch(subtitleVisibilityProvider)`. That
+provider's notifier reads `ref.read(sharedPreferencesProvider)`, which
+**throws `UnimplementedError` by default** (`mobile/lib/providers/shared_preferences_provider.dart:4–9`).
+Every `ProviderScope` / `ProviderContainer` in this PR's tests therefore
+needs an override:
+
+```dart
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../helpers/test_provider_overrides.dart';
+// adjust relative path: from test/widgets/video_feed_item/ it's ../../helpers/
+
+late SharedPreferences mockPrefs;
+
+setUp(() {
+  mockPrefs = createMockSharedPreferences();
+  // …other setup…
+});
+
+// Inside buildSubject / each test that creates a ProviderScope or ProviderContainer:
+ProviderScope(
+  overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+  child: …,
+)
+```
+
+`createMockSharedPreferences()` (in `test/helpers/test_provider_overrides.dart`)
+returns a stub where `getBool(any()) → null`, so
+`subtitleVisibilityProvider`'s initial value resolves to `prefs.getBool(...) ?? true = true`
+(see `mobile/lib/providers/subtitle_providers.dart` — the default is `true`,
+**not** `false`; an initial-state assertion of `isFalse` is wrong).
+
+**Do NOT** add `import 'package:openvine/blocs/video_volume/video_volume_state.dart';`
+to any test file. `video_volume_state.dart` is a `part of 'video_volume_cubit.dart';`
+file (first line of the source); importing a part file directly is a Dart
+compile error. `VideoVolumeState` is exported transitively through
+`import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';`.
 
 ---
 
@@ -367,6 +409,13 @@ EOF
 
 - [ ] **Step 1: Write the new test file**
 
+This test uses semantic-label finders (resolved from `AppLocalizations`)
+instead of `find.byType(GestureDetector)`. The pill renders three
+`GestureDetector`s today, but the surrounding test scaffold also creates
+incidental `GestureDetector`s (Material's tap-catchers), so counting by
+type is fragile. Each toggle has a unique `Semantics(label: …)` wrapper,
+which makes `find.bySemanticsLabel` precise and refactor-resistant.
+
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -374,11 +423,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
-import 'package:openvine/blocs/video_volume/video_volume_state.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockVideoVolumeCubit extends Mock implements VideoVolumeCubit {}
 
@@ -386,6 +438,9 @@ void main() {
   group(FeedPlaybackTogglesPill, () {
     late FeedAutoAdvanceCubit autoAdvanceCubit;
     late VideoVolumeCubit volumeCubit;
+    late SharedPreferences mockPrefs;
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
 
     setUp(() {
       autoAdvanceCubit = FeedAutoAdvanceCubit();
@@ -393,26 +448,40 @@ void main() {
       when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
       when(() => volumeCubit.stream)
           .thenAnswer((_) => const Stream<VideoVolumeState>.empty());
+      mockPrefs = createMockSharedPreferences();
     });
 
     tearDown(() async {
       await autoAdvanceCubit.close();
     });
 
-    Widget buildSubject({bool reducedMotion = false}) {
+    Widget buildSubject({
+      bool reducedMotion = false,
+      bool provideAutoAdvance = true,
+    }) {
+      Widget pill = const Scaffold(body: FeedPlaybackTogglesPill());
+
+      pill = provideAutoAdvance
+          ? MultiBlocProvider(
+              providers: [
+                BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
+                BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+              ],
+              child: pill,
+            )
+          : BlocProvider<VideoVolumeCubit>.value(
+              value: volumeCubit,
+              child: pill,
+            );
+
       return ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: MediaQuery(
             data: MediaQueryData(disableAnimations: reducedMotion),
-            child: MultiBlocProvider(
-              providers: [
-                BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
-                BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
-              ],
-              child: const Scaffold(body: FeedPlaybackTogglesPill()),
-            ),
+            child: pill,
           ),
         ),
       );
@@ -421,25 +490,42 @@ void main() {
     testWidgets('renders all three toggles when cubits are in scope',
         (tester) async {
       await tester.pumpWidget(buildSubject());
-      // 3 _PopoverToggle = 3 GestureDetectors inside the pill body.
+      // subtitleVisibilityProvider defaults to true (prefs.getBool ?? true),
+      // so the captions toggle's initial label is the "disable" variant.
       expect(
-        find.byType(GestureDetector),
-        findsNWidgets(3),
-        reason: 'expected 3 toggles in the pill',
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(l10n.videoSettingsCaptionsDisable),
+        findsOneWidget,
       );
     });
 
     testWidgets('hides the compilations toggle under reduced motion',
         (tester) async {
       await tester.pumpWidget(buildSubject(reducedMotion: true));
-      expect(find.byType(GestureDetector), findsNWidgets(2));
+      expect(
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        findsNothing,
+      );
+      expect(
+        find.bySemanticsLabel(l10n.videoActionDisableAutoAdvance),
+        findsNothing,
+      );
+      // Mute + CC still present.
+      expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
     });
 
     testWidgets('tapping the captions toggle flips subtitle visibility',
         (tester) async {
-      final container = ProviderContainer();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+      );
       addTearDown(container.dispose);
-      expect(container.read(subtitleVisibilityProvider), isFalse);
+      // Default getBool(any()) → null, falls through to `?? true`.
+      expect(container.read(subtitleVisibilityProvider), isTrue);
 
       await tester.pumpWidget(
         UncontrolledProviderScope(
@@ -458,10 +544,11 @@ void main() {
         ),
       );
 
-      // Tap the CC toggle (last GestureDetector in the row).
-      await tester.tap(find.byType(GestureDetector).last);
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoSettingsCaptionsDisable),
+      );
       await tester.pump();
-      expect(container.read(subtitleVisibilityProvider), isTrue);
+      expect(container.read(subtitleVisibilityProvider), isFalse);
     });
 
     testWidgets(
@@ -471,9 +558,7 @@ void main() {
           .thenReturn(const VideoVolumeState(volume: 1));
       await tester.pumpWidget(buildSubject());
 
-      // Mute toggle is the middle GestureDetector (index 1) when
-      // compilations is visible.
-      await tester.tap(find.byType(GestureDetector).at(1));
+      await tester.tap(find.bySemanticsLabel(l10n.videoPlayerMute));
       await tester.pump();
 
       verify(() => volumeCubit.onPlaybackVolumeChanged(0)).called(1);
@@ -485,7 +570,9 @@ void main() {
       expect(autoAdvanceCubit.state.enabled, isFalse);
       await tester.pumpWidget(buildSubject());
 
-      await tester.tap(find.byType(GestureDetector).first);
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+      );
       await tester.pump();
 
       expect(autoAdvanceCubit.state.enabled, isTrue);
@@ -493,21 +580,13 @@ void main() {
 
     testWidgets('renders without the compilations toggle when '
         'FeedAutoAdvanceCubit is not provided', (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: BlocProvider<VideoVolumeCubit>.value(
-              value: volumeCubit,
-              child: const Scaffold(body: FeedPlaybackTogglesPill()),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(buildSubject(provideAutoAdvance: false));
 
-      // 2 toggles (mute + CC), no compilations.
-      expect(find.byType(GestureDetector), findsNWidgets(2));
+      expect(
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        findsNothing,
+      );
+      expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
     });
   });
 }
@@ -521,7 +600,9 @@ cd mobile && mise exec -- flutter test test/widgets/video_feed_item/feed_playbac
 
 Expected: 6/6 passing.
 
-If a test fails on the `VideoVolumeState` constructor or `volume` field name, **stop**: open `mobile/lib/blocs/video_volume/video_volume_state.dart` and adjust the test to use whatever the real constructor / property shape is. The plan uses `const VideoVolumeState()` and `VideoVolumeState(volume: 1)` as best guesses given current usage at `feed_settings_menu.dart:215` and `main.dart:1648`.
+If a test fails on the `VideoVolumeState` constructor or `volume` field name, **stop**: open `mobile/lib/blocs/video_volume/video_volume_state.dart` and adjust the test to use whatever the real constructor / property shape is. The plan uses `const VideoVolumeState()` and `VideoVolumeState(volume: 1)` based on the verified source — `class VideoVolumeState extends Equatable` with `this.volume = 1.0` default and `final double volume`. Implicit `int→double` conversion in const contexts is supported, so `volume: 1` and `volume: 1.0` are both valid.
+
+If a test fails with `UnimplementedError` from `sharedPreferencesProvider`, you missed the `overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)]` on one of the `ProviderScope`/`ProviderContainer` constructions. Every Riverpod scope in this file must override it.
 
 - [ ] **Step 3: Commit**
 
@@ -554,14 +635,18 @@ icon. Driven from the existing tests that need to be updated first
 
 In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
 
-1. Add the imports the test will need for cubits + Riverpod:
+1. Add the imports the test will need (do NOT import
+   `video_volume_state.dart` — it's a `part of video_volume_cubit.dart`):
    ```dart
    import 'package:flutter_bloc/flutter_bloc.dart';
    import 'package:flutter_riverpod/flutter_riverpod.dart';
    import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
-   import 'package:openvine/blocs/video_volume/video_volume_state.dart';
+   import 'package:openvine/providers/shared_preferences_provider.dart';
    import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
    import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+   import 'package:shared_preferences/shared_preferences.dart';
+
+   import '../../helpers/test_provider_overrides.dart';
    ```
 2. Add a private mock:
    ```dart
@@ -571,6 +656,7 @@ In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
    ```dart
    late FeedAutoAdvanceCubit autoAdvanceCubit;
    late VideoVolumeCubit volumeCubit;
+   late SharedPreferences mockPrefs;
    ```
    In `setUp`, initialize them:
    ```dart
@@ -579,16 +665,21 @@ In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
    when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
    when(() => volumeCubit.stream)
        .thenAnswer((_) => const Stream<VideoVolumeState>.empty());
+   mockPrefs = createMockSharedPreferences();
    ```
    In `tearDown`, close the cubit:
    ```dart
    await autoAdvanceCubit.close();
    ```
-4. Replace the `buildSubject` body with the version below (wraps the
-   overlay in cubit providers + `ProviderScope`, drops `onToggleMuteState`):
+4. Replace the `buildSubject` body with the version below. It wraps the
+   overlay in `ProviderScope` (with the required `sharedPreferencesProvider`
+   override — without it the pill's captions toggle throws), the two
+   cubit providers, drops `onToggleMuteState`, and keeps everything else
+   the same:
    ```dart
    Widget buildSubject({Key? key}) {
      return ProviderScope(
+       overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
        child: MultiBlocProvider(
          providers: [
            BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
@@ -609,6 +700,10 @@ In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
      );
    }
    ```
+   The unpause-feedback tests pump a second `MaterialApp` mid-test (the
+   "swap to SizedBox.shrink" pattern). Those interim pumps don't need
+   the provider wrapper because they don't pump `PausedVideoPlayOverlay`.
+   Verify by running the suite at Step 3 below.
 
 - [ ] **Step 2: Replace the "keeps the play affordance visible when remounted" test**
 
@@ -656,6 +751,19 @@ testWidgets(
 
     expect(find.byType(FeedPlaybackTogglesPill), findsOneWidget);
     expect(find.byKey(const ValueKey('paused-play')), findsOneWidget);
+
+    // "Above" means: smaller y coordinate. If a future regression
+    // moves the pill below the play icon (e.g. Row instead of Column),
+    // this assertion catches it.
+    final pillCenter =
+        tester.getCenter(find.byType(FeedPlaybackTogglesPill));
+    final playCenter =
+        tester.getCenter(find.byKey(const ValueKey('paused-play')));
+    expect(
+      pillCenter.dy,
+      lessThan(playCenter.dy),
+      reason: 'pill should sit above the play icon',
+    );
   },
 );
 ```
@@ -693,10 +801,23 @@ Apply these changes:
    Remove the now-unused `package:flutter/semantics.dart` import — the
    only `SemanticsService.sendAnnouncement` call was inside
    `_PausedAffordance`'s mute toggle, which is being deleted.
-2. **Constructor.** Remove the `onToggleMuteState` named parameter and
-   field. Update the doc comment block above
-   `PausedVideoPlayOverlay` (currently mentions
-   "in-pause mute toggle") to describe the new pill placement.
+2. **Constructor & doc comments.** Remove the `onToggleMuteState` named
+   parameter and field (and its associated doc comment, currently
+   `paused_video_play_overlay.dart` lines 28–33). Then rewrite the doc
+   comment on the `_PausedAffordance` class (currently lines 316–319,
+   which describes "optional mute toggle (non-web) above the large play
+   icon" and the `onToggleMuteState == null` branch) to describe the
+   new composition:
+   ```dart
+   /// The paused-state stack: the playback-toggles pill
+   /// ([FeedPlaybackTogglesPill]) above the large play icon. The pill
+   /// reads its own state from app-wide cubits/providers, so this widget
+   /// takes no callbacks.
+   ```
+   Leave the top-of-file doc comment on `PausedVideoPlayOverlay` (lines
+   12–14) alone — it still describes the widget's purpose accurately
+   ("Large centered play affordance shown when a pooled video is
+   paused, plus a brief 'unpause' feedback…").
 3. **State.** In `_PausedVideoPlayOverlayState`:
    - Delete the `bool _hasStartedPlayback = false;` field and its doc
      comment.
@@ -762,9 +883,11 @@ Apply these changes:
      }
    }
    ```
-   Update the `_PlaybackChrome.shouldShowPlay` branch:
+   Update the `_PlaybackChrome.shouldShowPlay` branch — note the
+   `const` constructor call (preserves the const-ness the existing
+   code relied on for the `ValueKey('paused-play')` literal):
    ```dart
-   child = _PausedAffordance(key: const ValueKey('paused-play'));
+   child = const _PausedAffordance(key: ValueKey('paused-play'));
    ```
    The two `_PausedAffordance.isMuted`/`onToggleMuteState` arguments
    in the existing call disappear. Also drop the `isMuted` and
@@ -785,10 +908,27 @@ Apply these changes:
    > callback on the controller forwards player volume back into the
    > cubit). Cubit and player stay in sync.
 
-- [ ] **Step 2: Run analyze on the changed file**
+- [ ] **Step 1b: Remove the stale comment at the fullscreen call site**
+
+In `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart`,
+delete the 3-line comment at lines 1287–1289:
+
+```dart
+// Mute toggle intentionally omitted: the popover in
+// the app bar's customActions slot is now the sole
+// entry point, matching the home feed.
+```
+
+The call site itself doesn't change — it already doesn't pass
+`onToggleMuteState`. Only the comment is wrong after the refactor (the
+mute toggle is back inside the pill rendered by the paused overlay).
+
+- [ ] **Step 2: Run analyze on the changed files**
 
 ```bash
-cd mobile && mise exec -- flutter analyze lib/widgets/video_feed_item/paused_video_play_overlay.dart
+cd mobile && mise exec -- flutter analyze \
+  lib/widgets/video_feed_item/paused_video_play_overlay.dart \
+  lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
 ```
 
 Expected: clean.
@@ -803,10 +943,11 @@ Expected: 5/5 passing (3 new + 2 existing unpause-feedback).
 
 If the unpause-feedback tests fail with a missing `FeedPlaybackTogglesPill` provider error, double-check Task 2.1 Step 1 wrapped `buildSubject` in `ProviderScope` + the two `BlocProvider.value`s.
 
-- [ ] **Step 4: Commit (both files together)**
+- [ ] **Step 4: Commit (all three files together)**
 
 ```bash
 git add mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart \
+        mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart \
         mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart
 git commit -m "$(cat <<'EOF'
 feat(video): show pause icon reliably and surface toggles when paused
@@ -816,10 +957,13 @@ prior play before showing the pause icon — pausing during initial load
 or before first-play now renders the affordance. Buffering still hides
 it to avoid loop-restart blips.
 
-Replaces the optional single mute toggle inside the paused affordance
-with the full FeedPlaybackTogglesPill (compilations / mute / CC), so
-the three controls are discoverable contextually on every video
-surface that uses PausedVideoPlayOverlay.
+Adds the three contextual toggles (compilations / mute / CC) above the
+play icon via the shared FeedPlaybackTogglesPill. Today, the paused
+affordance renders no toggles at either call site (home feed and
+fullscreen pooled feed both pass nothing for onToggleMuteState).
+
+Also removes the now-stale "mute toggle intentionally omitted" comment
+at pooled_fullscreen_video_feed_screen.dart.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -917,6 +1061,28 @@ On a flaky network (Network Link Conditioner or airplane-mode toggle
 mid-load), pause a video that's still buffering. Verify the pause icon
 **does not** flash during buffer; it appears once buffering completes
 and the player is paused.
+
+- [ ] **Step 5: Smoke test the preload-flicker regression**
+
+The dropped `_hasStartedPlayback` latch was originally introduced to
+prevent a flicker on preloaded videos: during preload a pooled player
+is *played muted for buffering then paused* — under the new logic the
+brief paused window between `isPlaying=false` and the player resuming
+will render the play icon, then immediately swap to playing through the
+180 ms `AnimatedSwitcher`.
+
+To exercise:
+
+1. On the home feed, swipe quickly between 4–5 consecutive videos
+   without lingering. Each swipe lands on a preloaded item.
+2. Watch the center of the screen at the moment a new video appears.
+   Verify the play icon does **not** flash before playback starts.
+
+If it does flash, the contingency from the spec applies: introduce a
+short debounce (~100 ms) before showing `_PausedAffordance`. Do NOT
+reintroduce the full `_hasStartedPlayback` latch — that defeats the
+whole change. Log it as a follow-up issue if the flash is borderline,
+or block the PR if it's obvious.
 
 ### Task 3.3: Rebase, push, open PR
 

--- a/docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md
+++ b/docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md
@@ -12,6 +12,8 @@
 
 **Worktree:** `.worktrees/paused-overlay-toggles-pill` on branch `feat/paused-overlay-toggles-pill`. Run all Flutter commands from `mobile/`.
 
+**Tooling note.** All `flutter`/`dart` invocations in this plan are prefixed with `mise exec --` to use the repo's pinned Flutter version. If `mise` isn't installed on your machine, drop the prefix and use `flutter`/`dart` directly. The CI gate uses the pinned version regardless.
+
 ---
 
 ## File Structure
@@ -67,6 +69,24 @@ to any test file. `video_volume_state.dart` is a `part of 'video_volume_cubit.da
 file (first line of the source); importing a part file directly is a Dart
 compile error. `VideoVolumeState` is exported transitively through
 `import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';`.
+
+**Cubit-mock pattern (mandatory).** A bare `Mock implements VideoVolumeCubit`
+does **not** provide the internal stream-controller / `BlocBase` machinery
+that `context.select`, `BlocBuilder`, etc. introspect. The canonical pattern
+across this codebase (`mobile/test/screens/feed/video_feed_page_test.dart:33-34`,
+`mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart:46-47`)
+is `MockCubit<VideoVolumeState>` from `package:bloc_test/bloc_test.dart`:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
+```
+
+`MockCubit` ships its own working stream/state machine, so the `stream` stub
+is unnecessary. Keep `when(() => volumeCubit.state).thenReturn(...)` —
+that's the standard idiom.
 
 ---
 
@@ -417,6 +437,7 @@ type is fragile. Each toggle has a unique `Semantics(label: …)` wrapper,
 which makes `find.bySemanticsLabel` precise and refactor-resistant.
 
 ```dart
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -432,7 +453,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
-class _MockVideoVolumeCubit extends Mock implements VideoVolumeCubit {}
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
 
 void main() {
   group(FeedPlaybackTogglesPill, () {
@@ -446,8 +468,6 @@ void main() {
       autoAdvanceCubit = FeedAutoAdvanceCubit();
       volumeCubit = _MockVideoVolumeCubit();
       when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
-      when(() => volumeCubit.stream)
-          .thenAnswer((_) => const Stream<VideoVolumeState>.empty());
       mockPrefs = createMockSharedPreferences();
     });
 
@@ -648,9 +668,14 @@ In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
 
    import '../../helpers/test_provider_overrides.dart';
    ```
-2. Add a private mock:
+2. Add the `bloc_test` import alongside the other new imports above:
    ```dart
-   class _MockVideoVolumeCubit extends Mock implements VideoVolumeCubit {}
+   import 'package:bloc_test/bloc_test.dart';
+   ```
+   And declare the private mock using `MockCubit` (NOT bare `Mock`):
+   ```dart
+   class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+       implements VideoVolumeCubit {}
    ```
 3. Inside the existing `group('PausedVideoPlayOverlay', …)`, add:
    ```dart
@@ -658,13 +683,16 @@ In `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`:
    late VideoVolumeCubit volumeCubit;
    late SharedPreferences mockPrefs;
    ```
-   In `setUp`, initialize them:
+   In `setUp`, initialize them — and **also remove the now-dead player
+   volume stubs** (`when(() => mockPlayerState.volume).thenReturn(100.0);`
+   on the existing line ~37, and `when(() => mockPlayerStream.volume)...`
+   on the existing lines ~44–46). After Task 2.2 drops the
+   `StreamBuilder<double>` over `widget.player.stream.volume`, those
+   stubs are dead and `agent_workflow.md` rule 4 forbids leaving them:
    ```dart
    autoAdvanceCubit = FeedAutoAdvanceCubit();
    volumeCubit = _MockVideoVolumeCubit();
    when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
-   when(() => volumeCubit.stream)
-       .thenAnswer((_) => const Stream<VideoVolumeState>.empty());
    mockPrefs = createMockSharedPreferences();
    ```
    In `tearDown`, close the cubit:
@@ -798,9 +826,14 @@ Apply these changes:
    ```dart
    import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
    ```
-   Remove the now-unused `package:flutter/semantics.dart` import — the
-   only `SemanticsService.sendAnnouncement` call was inside
-   `_PausedAffordance`'s mute toggle, which is being deleted.
+   Remove these imports — both become unused after the
+   `_PausedAffordance` mute-toggle deletion:
+   - `import 'package:flutter/semantics.dart';` (only call was
+     `SemanticsService.sendAnnouncement` inside the deleted mute
+     toggle)
+   - `import 'package:flutter/foundation.dart' show kIsWeb;` (only
+     reference was the deleted `if (!kIsWeb && muteToggle != null)`
+     guard inside `_PausedAffordance.build`)
 2. **Constructor & doc comments.** Remove the `onToggleMuteState` named
    parameter and field (and its associated doc comment, currently
    `paused_video_play_overlay.dart` lines 28–33). Then rewrite the doc
@@ -821,30 +854,41 @@ Apply these changes:
 3. **State.** In `_PausedVideoPlayOverlayState`:
    - Delete the `bool _hasStartedPlayback = false;` field and its doc
      comment.
-   - In `didUpdateWidget`, delete the
-     `_hasStartedPlayback = false;` line. The rest of the player-swap
-     reset logic stays.
-   - In `_subscribeToPlayback`, delete:
-     - The `final initialPlaying = widget.player.state.playing;` line.
-     - The `_hasStartedPlayback = widget.isVisible && initialPlaying;`
-       line.
-     - The whole `if (isPlaying && !_hasStartedPlayback && widget.isVisible) {…}` latch block inside the `.listen` callback.
-     - The `_hasStartedPlayback &&` clause from the unpause-feedback
-       check (line ~129):
-       ```dart
-       } else if (isPlaying &&
-           !wasPlaying &&
-           _hasStartedPlayback &&
-           widget.isVisible) {
-       ```
-       becomes:
-       ```dart
-       } else if (isPlaying && !wasPlaying && widget.isVisible) {
-       ```
-   - Keep `_previouslyPlaying = initialPlaying;` working by sourcing the
-     initial value inline:
+   - In `didUpdateWidget`, delete only the
+     `_hasStartedPlayback = false;` line. Keep
+     `_previouslyPlaying = false;`, `_pausedAt = null;`,
+     `_showUnpauseFeedback = false;`, `_unpauseFeedbackOpacity = 1.0;`,
+     and the surrounding `_subscribeToPlayback()` call.
+   - Rewrite `_subscribeToPlayback` to the body below. This deletes
+     three things relative to current source: the
+     `initialPlaying`/`_hasStartedPlayback` initial latch (current
+     lines 109–111), the inner `if (isPlaying && !_hasStartedPlayback
+     && widget.isVisible) { setState(...); return; }` block — **including
+     its early `return;`** — (current lines 119–124), and the
+     `_hasStartedPlayback &&` clause from the unpause-feedback else-if
+     (current line 130). The result:
      ```dart
-     _previouslyPlaying = widget.player.state.playing;
+     void _subscribeToPlayback() {
+       _previouslyPlaying = widget.player.state.playing;
+       _playingSubscription =
+           widget.player.stream.playing.listen((isPlaying) {
+         if (!mounted) return;
+         final wasPlaying = _previouslyPlaying;
+         _previouslyPlaying = isPlaying;
+
+         if (!isPlaying && wasPlaying) {
+           _pausedAt = clock.now();
+         } else if (isPlaying && !wasPlaying && widget.isVisible) {
+           final pauseDuration = _pausedAt != null
+               ? clock.now().difference(_pausedAt!)
+               : Duration.zero;
+           _pausedAt = null;
+           if (pauseDuration >= _minPauseForFeedback) {
+             _triggerUnpauseFeedback();
+           }
+         }
+       });
+     }
      ```
 4. **`_PlaybackChrome.build`.** Replace:
    ```dart
@@ -998,17 +1042,20 @@ cd mobile && mise exec -- flutter test \
 
 Expected: all passing.
 
-- [ ] **Step 3: Run the full widget+screen test directories that touch this surface, randomised**
+- [ ] **Step 3: Run the affected widget test directory randomised**
 
 ```bash
 cd mobile && mise exec -- flutter test \
   test/widgets/video_feed_item \
-  test/screens/feed \
   --test-randomize-ordering-seed random
 ```
 
-Expected: all green. Order-dependence in this surface is the kind of
-regression random ordering catches.
+Expected: all green. Scoped to `test/widgets/video_feed_item` because
+that's the only directory whose contents this PR touches at the widget
+level — the screen suites are deterministically covered in Step 2.
+Running random ordering against the broader `test/screens/feed` tree
+risks tripping on pre-existing order-sensitive tests that are outside
+this PR's scope.
 
 - [ ] **Step 4: Format**
 
@@ -1062,7 +1109,7 @@ mid-load), pause a video that's still buffering. Verify the pause icon
 **does not** flash during buffer; it appears once buffering completes
 and the player is paused.
 
-- [ ] **Step 5: Smoke test the preload-flicker regression**
+- [ ] **Step 5: Smoke test the preload-flicker regression (recorded)**
 
 The dropped `_hasStartedPlayback` latch was originally introduced to
 prevent a flicker on preloaded videos: during preload a pooled player
@@ -1071,18 +1118,26 @@ brief paused window between `isPlaying=false` and the player resuming
 will render the play icon, then immediately swap to playing through the
 180 ms `AnimatedSwitcher`.
 
-To exercise:
+A naked-eye check cannot reliably distinguish "no flicker" from
+"flicker too fast to see," so this must be a recorded smoke:
 
-1. On the home feed, swipe quickly between 4–5 consecutive videos
-   without lingering. Each swipe lands on a preloaded item.
-2. Watch the center of the screen at the moment a new video appears.
-   Verify the play icon does **not** flash before playback starts.
+1. iOS simulator: **File → Record Screen** (or `xcrun simctl io
+   booted recordVideo flicker.mp4` from a separate terminal). Android
+   emulator: extended controls → **Camera → Record screen**.
+2. With recording active, swipe through 6–8 consecutive videos on the
+   home feed at a natural pace.
+3. Stop recording. Scrub through `flicker.mp4` **frame by frame** (in
+   QuickTime: ← / → arrow keys; in VLC: `E`). Watch the center of the
+   frame as each video first becomes active.
+4. Verify the play icon does **not** appear for any frame before
+   playback starts. Acceptable: the play icon is absent. Not
+   acceptable: a play icon visible for ≥1 frame on any preload swap.
 
-If it does flash, the contingency from the spec applies: introduce a
-short debounce (~100 ms) before showing `_PausedAffordance`. Do NOT
-reintroduce the full `_hasStartedPlayback` latch — that defeats the
-whole change. Log it as a follow-up issue if the flash is borderline,
-or block the PR if it's obvious.
+If a flash is present, the contingency from the spec applies:
+introduce a short debounce (~100 ms) before showing `_PausedAffordance`.
+Do NOT reintroduce the full `_hasStartedPlayback` latch — that defeats
+the whole change. Block the PR if any flash is visible; do not ship
+"borderline."
 
 ### Task 3.3: Rebase, push, open PR
 

--- a/docs/superpowers/specs/2026-05-11-paused-overlay-toggles-pill-design.md
+++ b/docs/superpowers/specs/2026-05-11-paused-overlay-toggles-pill-design.md
@@ -1,0 +1,223 @@
+# Paused-overlay playback-toggles pill + reliable pause button
+
+## Problem
+
+Two related issues on the paused-video state:
+
+1. **The pause button doesn't always show.** Today the gate is
+   `hasStartedPlayback && !isPlaying && !isBuffering` in
+   `PausedVideoPlayOverlay._PlaybackChrome`. If the user pauses before
+   the player has latched as "started," no button renders — they see
+   only the still frame.
+2. **No paused-state discovery** of the three playback toggles
+   (auto-advance / "compilations," mute, closed-captions) that live
+   behind the three-dot menu in the home-feed top bar. The popover
+   isn't visible on fullscreen video, and isn't discoverable while a
+   user is staring at a paused video.
+
+## Goals
+
+- The pause icon renders reliably whenever a video is paused (modulo
+  the still-needed buffering gate that prevents loop-restart blips).
+- The same three toggles already in the top-bar popover are surfaced
+  inside the paused overlay, above the pause icon, so users discover
+  CC, mute, and auto-advance/compilations contextually.
+- Single source of truth for the pill — no copy/paste between the
+  top-bar popover and the paused overlay.
+- Applies to every video surface that uses `PausedVideoPlayOverlay`
+  (home feed, fullscreen pooled feed, anything else built on the same
+  overlay).
+
+## Non-goals
+
+- Removing or changing the top-bar three-dot popover. It stays as the
+  always-reachable entry point while a video is playing.
+- Adding new toggles (e.g. quality, speed). The pill renders exactly
+  the three controls that exist today.
+- Changing the underlying behavior of any toggle. Auto-advance, mute,
+  and captions read/write the same state sources as before
+  (`FeedAutoAdvanceCubit`, `VideoVolumeCubit`,
+  `subtitleVisibilityProvider`).
+
+## Design
+
+### Extract a shared pill widget
+
+`feed_settings_menu.dart` currently houses
+`_PlaybackSettingsPopover` — a private widget that renders a
+scrim-30 backdrop-blurred pill containing three `_PopoverToggle`s
+(`_PlaybackModeToggle`, `_AudioToggle`, `_CaptionsToggle`). The pill
+and its toggles are exactly the UI we want in the paused overlay.
+
+Move the pill + its three toggles + `_PopoverToggle` into a new
+public file:
+
+```
+lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
+```
+
+Public surface:
+
+```dart
+class FeedPlaybackTogglesPill extends StatelessWidget {
+  const FeedPlaybackTogglesPill({super.key});
+  // Renders the scrim-30 capsule with three toggles. Each toggle
+  // reads/writes app-wide state directly — no props needed.
+}
+```
+
+`feed_settings_menu.dart`'s `_FeedSettingsOverlay` then renders
+`const FeedPlaybackTogglesPill()` instead of
+`const _PlaybackSettingsPopover()`. Open/close logic, backdrop tap
+catcher, and `OverlayPortal` wiring stay where they are.
+
+### Guard the auto-advance toggle
+
+`_PlaybackModeToggle` today calls
+`context.select((FeedAutoAdvanceCubit c) => c.state.enabled)`
+unconditionally. That crashes if the widget is mounted in a subtree
+that doesn't provide `FeedAutoAdvanceCubit`. Every current call site
+provides one, but `PausedVideoPlayOverlay` is generic, so a future
+host could miss it.
+
+Inside the extracted toggle, look the cubit up nullably and hide the
+control if absent:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(context);
+  if (!autoAdvanceAvailable) return const SizedBox.shrink();
+
+  final cubit = context
+      .findAncestorStateOfType<BlocProvider<FeedAutoAdvanceCubit>>()
+      // Equivalent: try BlocProvider.of with nullable lookup.
+      ;
+  // ...
+}
+```
+
+(Final shape decided during implementation — the cleanest in-codebase
+idiom is a nullable `BlocProvider.of` lookup, but `context.select` is
+not nullable, so the toggle re-watches via a small `BlocBuilder` or
+hides altogether when the cubit isn't in scope.)
+
+### Render the pill inside the paused overlay
+
+In `PausedVideoPlayOverlay._PausedAffordance`, replace today's
+optional single mute button with the pill, above the play icon:
+
+```dart
+Center(
+  child: Column(
+    mainAxisSize: MainAxisSize.min,
+    spacing: 16,
+    children: const [
+      FeedPlaybackTogglesPill(),
+      IgnorePointer(
+        child: CenterPlaybackControl(
+          state: CenterPlaybackControlState.play,
+          // semanticsLabel from l10n…
+        ),
+      ),
+    ],
+  ),
+)
+```
+
+The `onToggleMuteState` callback param on `PausedVideoPlayOverlay`
+becomes dead. Remove it and the corresponding param-passing at the
+two call sites (`feed_video_overlay.dart`,
+`pooled_fullscreen_video_feed_screen.dart`).
+
+### Fix pause-button visibility
+
+In `_PlaybackChrome.build`:
+
+```dart
+// Before
+final shouldShowPlay = hasStartedPlayback && !isPlaying && !isBuffering;
+
+// After
+final shouldShowPlay = !isPlaying && !isBuffering;
+```
+
+Remove `_hasStartedPlayback`, the latch in
+`_subscribeToPlayback`, and the latch reset in `didUpdateWidget`.
+
+Keep:
+
+- The `firstFrameFuture` gate (`SizedBox.shrink` until the first
+  frame renders) — still prevents flashes on initial mount.
+- The buffering gate — still suppresses loop-restart blips.
+- The `_pausedAt` / `_minPauseForFeedback` / unpause-feedback flash
+  machinery — orthogonal to pause-button visibility, still wanted.
+
+### Tap handling
+
+Toggle taps already use
+`GestureDetector(behavior: HitTestBehavior.opaque, …)`, which absorbs
+the tap before it reaches the surrounding tap-to-play handler. No
+new hit-test work needed.
+
+### Accessibility
+
+Existing toggles already set `Semantics(button:true, toggled:isOn,
+label:…)`. The pill is a `Row` of three of them, so the screen reader
+announces each one in order. The play icon below already has its own
+semantics label.
+
+Test obligations follow existing patterns: each toggle is reachable
+by `find.bySemanticsLabel` / `find.byType` in widget tests, and the
+extracted file's golden behavior (if covered today) moves with it.
+
+## Risks
+
+1. **Flicker window after dropping the latch.** When an active video
+   transitions out of the preload-paused state into playing, there's
+   a narrow window when `isPlaying==false && isBuffering==false`
+   before the player starts. The first-frame gate suppresses anything
+   pre-first-frame; after first-frame the play icon could flash for
+   ~1 frame. Mitigation: the `AnimatedSwitcher`'s 180ms fade smooths
+   it; we'll watch for reports and reintroduce a smaller latch (e.g.
+   debounce by 100ms) if it bites.
+2. **Visual noise.** Three controls every time someone pauses is
+   more chrome than today's single mute. Easy rollback if users
+   complain: revert the `_PausedAffordance` change only, pill stays
+   available in the top bar.
+3. **Strict-coverage on `divine_ui`.** No new public API on
+   `divine_ui` — the pill is in the app's `lib/widgets/`. Existing
+   `DivineIcon`/`DivineIconButton`/`VineTheme.*` usage only.
+
+## Files
+
+| File | Change |
+|---|---|
+| `mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart` | **New.** Public extracted pill housing the three toggles + `_PopoverToggle`. |
+| `mobile/lib/screens/feed/feed_settings_menu.dart` | `_FeedSettingsOverlay` now renders `FeedPlaybackTogglesPill`. Remove `_PlaybackSettingsPopover`, `_PlaybackModeToggle`, `_AudioToggle`, `_CaptionsToggle`, `_PopoverToggle`. |
+| `mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart` | Drop `hasStartedPlayback` latch (state, init, didUpdateWidget, build). Drop `onToggleMuteState` param. Render pill in `_PausedAffordance`. |
+| `mobile/lib/screens/feed/feed_video_overlay.dart` | Stop passing `onToggleMuteState` (if it does today). |
+| `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` | Same. |
+| `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart` | New assertions: pill renders in paused state; pause icon shows without prior-play latch; buffering still hides pause icon. Existing tests that asserted on the mute-toggle prop are migrated to pill presence. |
+| `mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart` | **New.** Mirrors the toggle-content tests that currently live in `feed_settings_menu_test.dart` (auto-advance toggle, mute toggle, captions toggle behavior). |
+| `mobile/test/screens/feed/feed_settings_menu_test.dart` | Trim — toggle-content tests move to the pill test. Keep open/close/anchor tests. |
+
+## Test plan
+
+- `flutter analyze lib test integration_test` clean.
+- `flutter test test/widgets/video_feed_item/ test/screens/feed/feed_settings_menu_test.dart` green.
+- Manual: home feed — tap to pause, verify pill appears above play icon, all three toggles flip state, top-bar popover still works.
+- Manual: fullscreen pooled feed — same.
+- Manual: pause during buffering — pause icon stays hidden until buffer clears (regression check).
+- Manual: pause immediately on app launch before video plays — pause icon now visible (the bug we're fixing).
+
+## Localization
+
+No new strings. All toggle semantic labels come from existing
+`context.l10n.videoActionDisableAutoAdvance` /
+`videoPlayerMute` / `videoSettingsCaptionsDisable` etc.
+
+## Rollout
+
+Single PR. Behind no feature flag — the fix is small enough that flag
+overhead would dwarf the change, and rollback is one revert.

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -2,17 +2,10 @@
 // ABOUTME: Renders the More icon button and the playback-controls popover
 // ABOUTME: that toggles auto-advance, audio mute, and closed captions.
 
-import 'dart:ui';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/providers/subtitle_providers.dart';
-import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
 /// More icon button + playback-controls popover for the home feed top bar.
 ///
@@ -22,7 +15,8 @@ import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 /// the button's bottom-right corner with three scrim-toggled controls:
 /// playback mode (auto-advance), audio mute, and closed captions.
 ///
-/// All three toggles read and write app-wide state (`FeedAutoAdvanceCubit`,
+/// The popover content is the shared [FeedPlaybackTogglesPill] widget, which
+/// reads and writes app-wide state (`FeedAutoAdvanceCubit`,
 /// `VideoVolumeCubit`, and the Riverpod `subtitleVisibilityProvider`) so the
 /// popover does not need any props from the page — it works as a drop-in
 /// child of any feed surface that provides those scopes.
@@ -116,194 +110,10 @@ class _FeedSettingsOverlay extends StatelessWidget {
           offset: const Offset(0, 16),
           child: const Material(
             color: VineTheme.transparent,
-            child: _PlaybackSettingsPopover(),
+            child: FeedPlaybackTogglesPill(),
           ),
         ),
       ],
-    );
-  }
-}
-
-/// The popover content: scrim-30 background, scrim-15 border, 4 px backdrop
-/// blur, 24 px radius, with a single row of three scrim-toggled buttons.
-class _PlaybackSettingsPopover extends ConsumerWidget {
-  const _PlaybackSettingsPopover();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(24),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 4, sigmaY: 4),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: VineTheme.scrim30,
-            borderRadius: BorderRadius.circular(24),
-            border: Border.all(color: VineTheme.scrim15),
-            boxShadow: const [
-              BoxShadow(color: VineTheme.shadow25, blurRadius: 4),
-            ],
-          ),
-          child: const Padding(
-            padding: EdgeInsets.all(12),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 8,
-              children: [
-                _PlaybackModeToggle(),
-                _AudioToggle(),
-                _CaptionsToggle(),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Auto-advance ("playback mode") toggle. Active state means auto-advance is
-/// on (play all). Inactive state means the current video loops indefinitely.
-///
-/// Hidden when the user has enabled reduced-motion at the OS level —
-/// auto-advance is unavailable in that state, matching the previous
-/// `AutoActionButton` rail control.
-class _PlaybackModeToggle extends StatelessWidget {
-  const _PlaybackModeToggle();
-
-  @override
-  Widget build(BuildContext context) {
-    final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(context);
-    if (!autoAdvanceAvailable) return const SizedBox.shrink();
-
-    final enabled = context.select(
-      (FeedAutoAdvanceCubit c) => c.state.enabled,
-    );
-    return _PopoverToggle(
-      isOn: enabled,
-      semanticLabel: enabled
-          ? context.l10n.videoActionDisableAutoAdvance
-          : context.l10n.videoActionEnableAutoAdvance,
-      onTap: () {
-        final cubit = context.read<FeedAutoAdvanceCubit>();
-        cubit.toggle();
-        if (!cubit.state.isEffectivelyActive) {
-          cubit.clearPendingPaginationAdvance();
-        }
-        announceAutoAdvanceToggle(context, enabled: cubit.state.enabled);
-      },
-      child: DivineIcon(
-        icon: enabled
-            ? DivineIconName.playbackModeOn
-            : DivineIconName.playbackModeOff,
-        color: VineTheme.onSurface,
-      ),
-    );
-  }
-}
-
-/// Audio mute toggle. Active state means audio is muted. Drives
-/// [VideoVolumeCubit] directly (the page-level `BlocListener` forwards the
-/// new volume to the active [VideoFeedController]) so the toggle works even
-/// when no controller is mounted yet.
-class _AudioToggle extends StatelessWidget {
-  const _AudioToggle();
-
-  @override
-  Widget build(BuildContext context) {
-    final isMuted = context.select(
-      (VideoVolumeCubit c) => c.state.volume == 0,
-    );
-    return _PopoverToggle(
-      isOn: isMuted,
-      semanticLabel: isMuted
-          ? context.l10n.videoPlayerUnmute
-          : context.l10n.videoPlayerMute,
-      onTap: () {
-        context.read<VideoVolumeCubit>().onPlaybackVolumeChanged(
-          isMuted ? 1 : 0,
-        );
-        SemanticsService.sendAnnouncement(
-          View.of(context),
-          isMuted
-              ? context.l10n.videoPlayerUnmute
-              : context.l10n.videoPlayerMute,
-          Directionality.of(context),
-        );
-      },
-      child: DivineIcon(
-        icon: isMuted
-            ? DivineIconName.speakerSimpleSlash
-            : DivineIconName.speakerSimpleHigh,
-        color: VineTheme.onSurface,
-      ),
-    );
-  }
-}
-
-/// Closed-captions toggle. Active state means subtitles are visible.
-class _CaptionsToggle extends ConsumerWidget {
-  const _CaptionsToggle();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final enabled = ref.watch(subtitleVisibilityProvider);
-    return _PopoverToggle(
-      isOn: enabled,
-      semanticLabel: enabled
-          ? context.l10n.videoSettingsCaptionsDisable
-          : context.l10n.videoSettingsCaptionsEnable,
-      onTap: () {
-        ref.read(subtitleVisibilityProvider.notifier).toggle();
-      },
-      child: DivineIcon(
-        icon: enabled
-            ? DivineIconName.closedCaptioningFill
-            : DivineIconName.closedCaptioning,
-        color: VineTheme.onSurface,
-      ),
-    );
-  }
-}
-
-/// 48 px touch target wrapping a 12 px-padded scrim button (40 px visible at
-/// 20 px radius). Background flips between scrim-15 (off) and scrim-65 (on).
-class _PopoverToggle extends StatelessWidget {
-  const _PopoverToggle({
-    required this.isOn,
-    required this.onTap,
-    required this.child,
-    required this.semanticLabel,
-  });
-
-  final bool isOn;
-  final VoidCallback onTap;
-  final Widget child;
-  final String semanticLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    final bg = isOn ? VineTheme.scrim50 : VineTheme.scrim15;
-    return Semantics(
-      button: true,
-      toggled: isOn,
-      label: semanticLabel,
-      container: true,
-      explicitChildNodes: true,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: bg,
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: SizedBox.square(dimension: 24, child: child),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -623,9 +623,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
       child: MultiBlocListener(
         listeners: [
           // Sync volume when hardware buttons change system volume.
+          // Also forward to the web feed so the in-pause mute toggle in
+          // the paused overlay reaches WebVideoPlayer instances.
           BlocListener<VideoVolumeCubit, VideoVolumeState>(
             listener: (_, state) {
               _controller?.setVolume(state.volume);
+              _webFeedKey.currentState?.setVolume(state.volume);
             },
           ),
           // Initialize controller when videos first become available
@@ -835,6 +838,10 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           widget.webControllerFactory ??
                           defaultWebVideoPlayerControllerFactory,
                       authHeaderProvider: webAuthHeaderProvider,
+                      initialVolume: context
+                          .read<VideoVolumeCubit>()
+                          .state
+                          .volume,
                       onActiveVideoChanged: (video, index) {
                         _pagePosition.value = index.toDouble();
                         _resumeAutoAdvanceAfterSwipe();

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1284,9 +1284,6 @@ class _PooledFullscreenItemContentState
                   children: [
                     if (player != null)
                       PausedVideoPlayOverlay(
-                        // Mute toggle intentionally omitted: the popover in
-                        // the app bar's customActions slot is now the sole
-                        // entry point, matching the home feed.
                         player: player,
                         firstFrameFuture:
                             videoController?.waitUntilFirstFrameRendered,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -494,9 +494,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
         child: MultiBlocListener(
           listeners: [
             // Sync volume when hardware buttons change system volume.
+            // Also forward to the web feed so the in-pause mute toggle in
+            // the paused overlay reaches WebVideoPlayer instances.
             BlocListener<VideoVolumeCubit, VideoVolumeState>(
               listener: (_, state) {
                 controller?.setVolume(state.volume);
+                _webFeedKey.currentState?.setVolume(state.volume);
               },
             ),
             // Reset controller when mode changes so a fresh one is
@@ -613,6 +616,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                             widget.webControllerFactory ??
                             defaultWebVideoPlayerControllerFactory,
                         authHeaderProvider: webAuthHeaderProvider,
+                        initialVolume: context
+                            .read<VideoVolumeCubit>()
+                            .state
+                            .volume,
                         onActiveVideoChanged: (video, index) {
                           _currentWebIndex = index;
                           _pagePosition.value = index.toDouble();

--- a/mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
@@ -75,10 +75,10 @@ class _PlaybackModeToggle extends StatelessWidget {
     final cubit = _maybeReadFeedAutoAdvanceCubit(context);
     if (cubit == null) return const SizedBox.shrink();
 
-    return BlocBuilder<FeedAutoAdvanceCubit, FeedAutoAdvanceState>(
+    return BlocSelector<FeedAutoAdvanceCubit, FeedAutoAdvanceState, bool>(
       bloc: cubit,
-      builder: (context, state) {
-        final enabled = state.enabled;
+      selector: (state) => state.enabled,
+      builder: (context, enabled) {
         return _PopoverToggle(
           isOn: enabled,
           semanticLabel: enabled
@@ -100,14 +100,6 @@ class _PlaybackModeToggle extends StatelessWidget {
         );
       },
     );
-  }
-}
-
-FeedAutoAdvanceCubit? _maybeReadFeedAutoAdvanceCubit(BuildContext context) {
-  try {
-    return BlocProvider.of<FeedAutoAdvanceCubit>(context);
-  } on ProviderNotFoundException {
-    return null;
   }
 }
 
@@ -212,3 +204,6 @@ class _PopoverToggle extends StatelessWidget {
     );
   }
 }
+
+FeedAutoAdvanceCubit? _maybeReadFeedAutoAdvanceCubit(BuildContext context) =>
+    context.read<FeedAutoAdvanceCubit?>();

--- a/mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
@@ -1,0 +1,214 @@
+// ABOUTME: Scrim-30 capsule with three playback toggles
+// ABOUTME: (compilations / mute / closed-captions). Rendered both as
+// ABOUTME: the body of the top-bar settings popover and above the play
+// ABOUTME: affordance in the paused-video overlay.
+
+import 'dart:ui';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+
+/// Scrim-30 backdrop-blurred capsule housing the three playback toggles:
+/// auto-advance ("compilations"), audio mute, and closed-captions.
+///
+/// Each toggle reads and writes app-wide state directly
+/// ([FeedAutoAdvanceCubit], [VideoVolumeCubit], `subtitleVisibilityProvider`),
+/// so the pill takes no constructor params and works as a drop-in child of
+/// any feed surface that provides those scopes.
+class FeedPlaybackTogglesPill extends StatelessWidget {
+  const FeedPlaybackTogglesPill({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(24),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 4, sigmaY: 4),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: VineTheme.scrim30,
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: VineTheme.scrim15),
+            boxShadow: const [
+              BoxShadow(color: VineTheme.shadow25, blurRadius: 4),
+            ],
+          ),
+          child: const Padding(
+            padding: EdgeInsets.all(12),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                _PlaybackModeToggle(),
+                _AudioToggle(),
+                _CaptionsToggle(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Auto-advance ("compilations") toggle. Hidden when the OS-level
+/// reduced-motion preference is set — auto-advance is unavailable in
+/// that state. Also hidden when no [FeedAutoAdvanceCubit] is provided
+/// in the surrounding scope, so the pill can be rendered in any
+/// surface without requiring callers to wire up the cubit when they
+/// don't use auto-advance.
+class _PlaybackModeToggle extends StatelessWidget {
+  const _PlaybackModeToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    if (MediaQuery.disableAnimationsOf(context)) {
+      return const SizedBox.shrink();
+    }
+    final cubit = _maybeReadFeedAutoAdvanceCubit(context);
+    if (cubit == null) return const SizedBox.shrink();
+
+    return BlocBuilder<FeedAutoAdvanceCubit, FeedAutoAdvanceState>(
+      bloc: cubit,
+      builder: (context, state) {
+        final enabled = state.enabled;
+        return _PopoverToggle(
+          isOn: enabled,
+          semanticLabel: enabled
+              ? context.l10n.videoActionDisableAutoAdvance
+              : context.l10n.videoActionEnableAutoAdvance,
+          onTap: () {
+            cubit.toggle();
+            if (!cubit.state.isEffectivelyActive) {
+              cubit.clearPendingPaginationAdvance();
+            }
+            announceAutoAdvanceToggle(context, enabled: cubit.state.enabled);
+          },
+          child: DivineIcon(
+            icon: enabled
+                ? DivineIconName.playbackModeOn
+                : DivineIconName.playbackModeOff,
+            color: VineTheme.onSurface,
+          ),
+        );
+      },
+    );
+  }
+}
+
+FeedAutoAdvanceCubit? _maybeReadFeedAutoAdvanceCubit(BuildContext context) {
+  try {
+    return BlocProvider.of<FeedAutoAdvanceCubit>(context);
+  } on ProviderNotFoundException {
+    return null;
+  }
+}
+
+/// Audio mute toggle. Drives [VideoVolumeCubit] directly.
+class _AudioToggle extends StatelessWidget {
+  const _AudioToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    final isMuted = context.select((VideoVolumeCubit c) => c.state.volume == 0);
+    return _PopoverToggle(
+      isOn: isMuted,
+      semanticLabel: isMuted
+          ? context.l10n.videoPlayerUnmute
+          : context.l10n.videoPlayerMute,
+      onTap: () {
+        context.read<VideoVolumeCubit>().onPlaybackVolumeChanged(
+          isMuted ? 1 : 0,
+        );
+        SemanticsService.sendAnnouncement(
+          View.of(context),
+          isMuted
+              ? context.l10n.videoPlayerUnmute
+              : context.l10n.videoPlayerMute,
+          Directionality.of(context),
+        );
+      },
+      child: DivineIcon(
+        icon: isMuted
+            ? DivineIconName.speakerSimpleSlash
+            : DivineIconName.speakerSimpleHigh,
+        color: VineTheme.onSurface,
+      ),
+    );
+  }
+}
+
+/// Closed-captions toggle. Active state means subtitles are visible.
+class _CaptionsToggle extends ConsumerWidget {
+  const _CaptionsToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = ref.watch(subtitleVisibilityProvider);
+    return _PopoverToggle(
+      isOn: enabled,
+      semanticLabel: enabled
+          ? context.l10n.videoSettingsCaptionsDisable
+          : context.l10n.videoSettingsCaptionsEnable,
+      onTap: () {
+        ref.read(subtitleVisibilityProvider.notifier).toggle();
+      },
+      child: DivineIcon(
+        icon: enabled
+            ? DivineIconName.closedCaptioningFill
+            : DivineIconName.closedCaptioning,
+        color: VineTheme.onSurface,
+      ),
+    );
+  }
+}
+
+/// 48 px touch target wrapping a 12 px-padded scrim button (40 px
+/// visible at 20 px radius). Background flips between scrim-15 (off)
+/// and scrim-50 (on).
+class _PopoverToggle extends StatelessWidget {
+  const _PopoverToggle({
+    required this.isOn,
+    required this.onTap,
+    required this.child,
+    required this.semanticLabel,
+  });
+
+  final bool isOn;
+  final VoidCallback onTap;
+  final Widget child;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = isOn ? VineTheme.scrim50 : VineTheme.scrim15;
+    return Semantics(
+      button: true,
+      toggled: isOn,
+      label: semanticLabel,
+      container: true,
+      explicitChildNodes: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: SizedBox.square(dimension: 24, child: child),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/paused_affordance.dart
+++ b/mobile/lib/widgets/video_feed_item/paused_affordance.dart
@@ -1,0 +1,35 @@
+// ABOUTME: The paused-state composition rendered above a paused video:
+// ABOUTME: the playback toggles pill above the large play icon. Shared
+// ABOUTME: between the native (media_kit) and web (video_player) overlays.
+
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+
+/// The paused-state stack: the playback-toggles pill
+/// ([FeedPlaybackTogglesPill]) above the large play icon. The pill
+/// reads its own state from app-wide cubits/providers, so this widget
+/// takes no callbacks.
+class PausedAffordance extends StatelessWidget {
+  const PausedAffordance({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 16,
+        children: [
+          const FeedPlaybackTogglesPill(),
+          IgnorePointer(
+            child: CenterPlaybackControl(
+              state: CenterPlaybackControlState.play,
+              semanticsLabel: context.l10n.videoPlayerPlayVideo,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart
@@ -3,9 +3,8 @@ import 'dart:async';
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
-import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+import 'package:openvine/widgets/video_feed_item/paused_affordance.dart';
 
 /// Large centered play affordance shown when a pooled video is paused, plus a
 /// brief "unpause" feedback that flashes the pause icon right after playback
@@ -216,7 +215,7 @@ class _PlaybackChrome extends StatelessWidget {
 
     final Widget child;
     if (shouldShowPlay) {
-      child = const _PausedAffordance(key: ValueKey('paused-play'));
+      child = const PausedAffordance(key: ValueKey('paused-play'));
     } else if (shouldShowUnpauseFeedback) {
       // No ValueKey: AnimatedSwitcher already differentiates this
       // IgnorePointer from the Center-rooted play affordance and the
@@ -248,33 +247,6 @@ class _PlaybackChrome extends StatelessWidget {
         );
       },
       child: child,
-    );
-  }
-}
-
-/// The paused-state stack: the playback-toggles pill
-/// ([FeedPlaybackTogglesPill]) above the large play icon. The pill
-/// reads its own state from app-wide cubits/providers, so this widget
-/// takes no callbacks.
-class _PausedAffordance extends StatelessWidget {
-  const _PausedAffordance({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 16,
-        children: [
-          const FeedPlaybackTogglesPill(),
-          IgnorePointer(
-            child: CenterPlaybackControl(
-              state: CenterPlaybackControlState.play,
-              semanticsLabel: context.l10n.videoPlayerPlayVideo,
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 
 import 'package:clock/clock.dart';
-import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
 /// Large centered play affordance shown when a pooled video is paused, plus a
 /// brief "unpause" feedback that flashes the pause icon right after playback
@@ -15,7 +13,6 @@ import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
 class PausedVideoPlayOverlay extends StatefulWidget {
   const PausedVideoPlayOverlay({
     required this.player,
-    this.onToggleMuteState,
     this.firstFrameFuture,
     this.isVisible = true,
     super.key,
@@ -25,24 +22,12 @@ class PausedVideoPlayOverlay extends StatefulWidget {
   final Future<void>? firstFrameFuture;
   final bool isVisible;
 
-  /// Callback invoked when the user taps the in-pause mute toggle.
-  ///
-  /// When `null`, the in-pause mute toggle is hidden — the host surface is
-  /// expected to provide its own mute control elsewhere (e.g. the home feed
-  /// uses the playback-settings popover in the top app bar).
-  final VoidCallback? onToggleMuteState;
-
   @override
   State<PausedVideoPlayOverlay> createState() => _PausedVideoPlayOverlayState();
 }
 
 class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
   StreamSubscription<bool>? _playingSubscription;
-
-  /// Latching flag: set once this widget's player transitions to playing
-  /// for the *current* video. Reset when the player identity changes
-  /// (recycled for a new video) via [didUpdateWidget].
-  bool _hasStartedPlayback = false;
 
   /// Previous value from [Player.stream.playing], used to detect the
   /// paused -> playing transition that triggers the unpause feedback.
@@ -91,7 +76,6 @@ class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
     if (!identical(oldWidget.player, widget.player)) {
       unawaited(_playingSubscription?.cancel());
       _cancelUnpauseFeedbackTimers();
-      _hasStartedPlayback = false;
       _previouslyPlaying = false;
       _pausedAt = null;
       _showUnpauseFeedback = false;
@@ -101,34 +85,15 @@ class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
   }
 
   void _subscribeToPlayback() {
-    // Only latch when the overlay is visible (active video). During preload
-    // the player is played muted for buffering then paused — that play must
-    // not set the latch, otherwise the pause indicator flashes briefly when
-    // the user arrives at the preloaded video (isBuffering=false before
-    // isPlaying=true, amplified by the 180ms AnimatedSwitcher).
-    final initialPlaying = widget.player.state.playing;
-    _previouslyPlaying = initialPlaying;
-    _hasStartedPlayback = widget.isVisible && initialPlaying;
-
+    _previouslyPlaying = widget.player.state.playing;
     _playingSubscription = widget.player.stream.playing.listen((isPlaying) {
       if (!mounted) return;
       final wasPlaying = _previouslyPlaying;
       _previouslyPlaying = isPlaying;
 
-      // Latch first playback of this player for this video.
-      if (isPlaying && !_hasStartedPlayback && widget.isVisible) {
-        setState(() {
-          _hasStartedPlayback = true;
-        });
-        return;
-      }
-
       if (!isPlaying && wasPlaying) {
         _pausedAt = clock.now();
-      } else if (isPlaying &&
-          !wasPlaying &&
-          _hasStartedPlayback &&
-          widget.isVisible) {
+      } else if (isPlaying && !wasPlaying && widget.isVisible) {
         final pauseDuration = _pausedAt != null
             ? clock.now().difference(_pausedAt!)
             : Duration.zero;
@@ -200,33 +165,17 @@ class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
           builder: (context, bufferingSnapshot) {
             final isBuffering = bufferingSnapshot.data ?? false;
 
-            return StreamBuilder<double>(
-              stream: widget.player.stream.volume,
-              initialData: widget.player.state.volume,
-              builder: (context, volumeSnapshot) {
-                // Icon state is driven by the player's volume stream
-                // (not VideoVolumeCubit) deliberately: the player is the
-                // source of truth for what the user is hearing right now.
-                // Using context.select on the cubit would lag by a few
-                // frames while setVolume propagates to the player.
-                final isMuted = volumeSnapshot.data == 0;
-
-                return StreamBuilder<bool>(
-                  stream: widget.player.stream.playing,
-                  initialData: widget.player.state.playing,
-                  builder: (context, playingSnapshot) {
-                    final isPlaying = playingSnapshot.data ?? false;
-                    return _PlaybackChrome(
-                      isPlaying: isPlaying,
-                      isBuffering: isBuffering,
-                      isMuted: isMuted,
-                      hasStartedPlayback: _hasStartedPlayback,
-                      showUnpauseFeedback: _showUnpauseFeedback,
-                      unpauseFeedbackOpacity: _unpauseFeedbackOpacity,
-                      unpauseFadeDuration: _unpauseFadeDuration,
-                      onToggleMuteState: widget.onToggleMuteState,
-                    );
-                  },
+            return StreamBuilder<bool>(
+              stream: widget.player.stream.playing,
+              initialData: widget.player.state.playing,
+              builder: (context, playingSnapshot) {
+                final isPlaying = playingSnapshot.data ?? false;
+                return _PlaybackChrome(
+                  isPlaying: isPlaying,
+                  isBuffering: isBuffering,
+                  showUnpauseFeedback: _showUnpauseFeedback,
+                  unpauseFeedbackOpacity: _unpauseFeedbackOpacity,
+                  unpauseFadeDuration: _unpauseFadeDuration,
                 );
               },
             );
@@ -248,36 +197,26 @@ class _PlaybackChrome extends StatelessWidget {
   const _PlaybackChrome({
     required this.isPlaying,
     required this.isBuffering,
-    required this.isMuted,
-    required this.hasStartedPlayback,
     required this.showUnpauseFeedback,
     required this.unpauseFeedbackOpacity,
     required this.unpauseFadeDuration,
-    required this.onToggleMuteState,
   });
 
   final bool isPlaying;
   final bool isBuffering;
-  final bool isMuted;
-  final bool hasStartedPlayback;
   final bool showUnpauseFeedback;
   final double unpauseFeedbackOpacity;
   final Duration unpauseFadeDuration;
-  final VoidCallback? onToggleMuteState;
 
   @override
   Widget build(BuildContext context) {
-    final shouldShowPlay = hasStartedPlayback && !isPlaying && !isBuffering;
+    final shouldShowPlay = !isPlaying && !isBuffering;
     final shouldShowUnpauseFeedback =
         showUnpauseFeedback && isPlaying && !shouldShowPlay;
 
     final Widget child;
     if (shouldShowPlay) {
-      child = _PausedAffordance(
-        key: const ValueKey('paused-play'),
-        isMuted: isMuted,
-        onToggleMuteState: onToggleMuteState,
-      );
+      child = const _PausedAffordance(key: ValueKey('paused-play'));
     } else if (shouldShowUnpauseFeedback) {
       // No ValueKey: AnimatedSwitcher already differentiates this
       // IgnorePointer from the Center-rooted play affordance and the
@@ -313,49 +252,21 @@ class _PlaybackChrome extends StatelessWidget {
   }
 }
 
-/// The paused-state stack: optional mute toggle (non-web) above the large
-/// play icon. The mute toggle is omitted entirely when [onToggleMuteState]
-/// is `null` — host surfaces that provide their own mute UI elsewhere
-/// (e.g. the home feed's playback-settings popover) should pass `null`.
+/// The paused-state stack: the playback-toggles pill
+/// ([FeedPlaybackTogglesPill]) above the large play icon. The pill
+/// reads its own state from app-wide cubits/providers, so this widget
+/// takes no callbacks.
 class _PausedAffordance extends StatelessWidget {
-  const _PausedAffordance({
-    required this.isMuted,
-    required this.onToggleMuteState,
-    super.key,
-  });
-
-  final bool isMuted;
-  final VoidCallback? onToggleMuteState;
+  const _PausedAffordance({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final muteToggle = onToggleMuteState;
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         spacing: 16,
         children: [
-          if (!kIsWeb && muteToggle != null)
-            DivineIconButton(
-              icon: isMuted
-                  ? DivineIconName.speakerSimpleX
-                  : DivineIconName.speakerHigh,
-              size: DivineIconButtonSize.small,
-              type: DivineIconButtonType.ghost,
-              semanticLabel: isMuted
-                  ? context.l10n.videoPlayerUnmute
-                  : context.l10n.videoPlayerMute,
-              onPressed: () {
-                muteToggle();
-                SemanticsService.sendAnnouncement(
-                  View.of(context),
-                  isMuted
-                      ? context.l10n.videoPlayerUnmute
-                      : context.l10n.videoPlayerMute,
-                  Directionality.of(context),
-                );
-              },
-            ),
+          const FeedPlaybackTogglesPill(),
           IgnorePointer(
             child: CenterPlaybackControl(
               state: CenterPlaybackControlState.play,

--- a/mobile/lib/widgets/video_feed_item/web_paused_video_play_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/web_paused_video_play_overlay.dart
@@ -1,0 +1,82 @@
+// ABOUTME: Paused-state overlay for the web video feed. Watches a
+// ABOUTME: VideoPlayerController and renders the shared PausedAffordance
+// ABOUTME: (pill + play icon) when the player is paused and not buffering.
+
+import 'package:flutter/material.dart';
+import 'package:openvine/widgets/video_feed_item/paused_affordance.dart';
+import 'package:video_player/video_player.dart';
+
+/// Web equivalent of [PausedVideoPlayOverlay] — watches a
+/// [VideoPlayerController] (from `package:video_player`) and renders the
+/// shared [PausedAffordance] when the player is paused and not buffering.
+///
+/// Renders nothing when [controller] is `null` or not initialized.
+class WebPausedVideoPlayOverlay extends StatefulWidget {
+  const WebPausedVideoPlayOverlay({
+    required this.controller,
+    this.isVisible = true,
+    super.key,
+  });
+
+  final VideoPlayerController? controller;
+  final bool isVisible;
+
+  @override
+  State<WebPausedVideoPlayOverlay> createState() =>
+      _WebPausedVideoPlayOverlayState();
+}
+
+class _WebPausedVideoPlayOverlayState extends State<WebPausedVideoPlayOverlay> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller?.addListener(_onControllerTick);
+  }
+
+  @override
+  void didUpdateWidget(covariant WebPausedVideoPlayOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.controller, widget.controller)) {
+      oldWidget.controller?.removeListener(_onControllerTick);
+      widget.controller?.addListener(_onControllerTick);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_onControllerTick);
+    super.dispose();
+  }
+
+  void _onControllerTick() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.isVisible) return const SizedBox.shrink();
+    final controller = widget.controller;
+    if (controller == null || !controller.value.isInitialized) {
+      return const SizedBox.shrink();
+    }
+
+    final value = controller.value;
+    final shouldShowPaused = !value.isPlaying && !value.isBuffering;
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 180),
+      switchInCurve: Curves.easeOutCubic,
+      switchOutCurve: Curves.easeInCubic,
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: ScaleTransition(
+          scale: Tween<double>(begin: 0.92, end: 1).animate(animation),
+          child: child,
+        ),
+      ),
+      child: shouldShowPaused
+          ? const PausedAffordance(key: ValueKey('paused-play'))
+          : const SizedBox.shrink(),
+    );
+  }
+}

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Web-native video feed using Flutter's video_player package
 // ABOUTME: Replaces PooledVideoFeed on web where media_kit is not available
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -203,6 +205,12 @@ class WebVideoFeedState extends State<WebVideoFeed> {
   /// Drops both the controller reference and the GlobalKey so we don't
   /// retain disposed controllers across scroll. If the user scrolls back
   /// to this index, the next [_getPlayerKey] call mints a fresh key.
+  ///
+  /// The notifier mutation is deferred to a microtask: callers reach
+  /// this from `WebVideoPlayerState.dispose()`, which fires during the
+  /// framework's locked unmount tick. Mutating `_controllers.value`
+  /// synchronously would re-enter sibling `ValueListenableBuilder`s and
+  /// trip "setState() called when widget tree was locked".
   void _onPlayerDisposed(int index) {
     _playerKeys.remove(index);
     final current = _controllers.value;
@@ -210,7 +218,10 @@ class WebVideoFeedState extends State<WebVideoFeed> {
     if (controller == null) return;
     _detachCompletionListener(index, controller);
     final next = Map<int, VideoPlayerController>.of(current)..remove(index);
-    _controllers.value = next;
+    scheduleMicrotask(() {
+      if (!mounted) return;
+      _controllers.value = next;
+    });
   }
 
   Future<void> animateToPage(int index) async {
@@ -435,6 +446,13 @@ class _WebVideoFeedItem extends StatelessWidget {
             onRequiresAuth: onRequiresAuth,
           ),
         ),
+        // Single ValueListenableBuilder for both the paused overlay and
+        // the optional itemBuilder. Combining them avoids registering two
+        // listeners on the same notifier, which matters during player
+        // disposal: WebVideoFeedState._onPlayerDisposed mutates the
+        // notifier from inside a tree-locked tear-down, and any rebuild
+        // siblings still subscribed at that moment trip
+        // "setState called when widget tree was locked".
         ValueListenableBuilder<Map<int, VideoPlayerController>>(
           valueListenable: controllersListenable,
           builder: (context, controllers, _) {
@@ -442,32 +460,25 @@ class _WebVideoFeedItem extends StatelessWidget {
             final controller = (tracked != null && tracked.value.isInitialized)
                 ? tracked
                 : null;
-            return WebPausedVideoPlayOverlay(
-              controller: controller,
-              isVisible: isActive,
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                WebPausedVideoPlayOverlay(
+                  controller: controller,
+                  isVisible: isActive,
+                ),
+                if (itemBuilder != null)
+                  itemBuilder!(
+                    context,
+                    video,
+                    index,
+                    isActive: isActive,
+                    controller: controller,
+                  ),
+              ],
             );
           },
         ),
-        if (itemBuilder != null)
-          ValueListenableBuilder<Map<int, VideoPlayerController>>(
-            valueListenable: controllersListenable,
-            builder: (context, controllers, _) {
-              // Only expose the controller once it has initialized so
-              // overlays never receive an uninitialized controller.
-              final tracked = controllers[index];
-              final controller =
-                  (tracked != null && tracked.value.isInitialized)
-                  ? tracked
-                  : null;
-              return itemBuilder!(
-                context,
-                video,
-                index,
-                isActive: isActive,
-                controller: controller,
-              );
-            },
-          ),
       ],
     );
   }

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -64,6 +64,7 @@ class WebVideoFeed extends StatefulWidget {
     this.endThreshold = FeedAutoAdvanceDefaults.endThreshold,
     this.controllerFactory = defaultWebVideoPlayerControllerFactory,
     this.authHeaderProvider,
+    this.initialVolume = 1.0,
     super.key,
   });
 
@@ -120,6 +121,11 @@ class WebVideoFeed extends StatefulWidget {
   /// `kIsWeb && FeatureFlag.hlsAuthWebPlayer`.
   final AuthHeaderProvider? authHeaderProvider;
 
+  /// Volume to apply to each [WebVideoPlayer] when it initialises. Callers
+  /// can update the volume of all live players at runtime via
+  /// [WebVideoFeedState.setVolume].
+  final double initialVolume;
+
   @override
   State<WebVideoFeed> createState() => WebVideoFeedState();
 }
@@ -127,6 +133,20 @@ class WebVideoFeed extends StatefulWidget {
 class WebVideoFeedState extends State<WebVideoFeed> {
   late PageController _pageController;
   int _currentIndex = 0;
+
+  /// Current volume applied to every player on init and on [setVolume].
+  late double _currentVolume = widget.initialVolume;
+
+  /// Applies [volume] to every live [WebVideoPlayer] and remembers it for
+  /// future players that initialise later. Called by the host screens from
+  /// their `BlocListener<VideoVolumeCubit>` so the cubit is the single
+  /// source of truth across native and web feed surfaces.
+  void setVolume(double volume) {
+    _currentVolume = volume;
+    for (final key in _playerKeys.values) {
+      key.currentState?.setVolume(volume);
+    }
+  }
 
   // Track web player keys to control playback.
   final Map<int, GlobalKey<WebVideoPlayerState>> _playerKeys = {};
@@ -362,6 +382,9 @@ class WebVideoFeedState extends State<WebVideoFeed> {
           hlsFallbackUrl: video.getFallbackUrl(),
           onInitialized: (controller) {
             if (!mounted) return;
+            // Apply the current cubit-sourced volume so newly-initialised
+            // players honour mute state set before they mounted.
+            unawaited(controller.setVolume(_currentVolume));
             setState(() {
               _attachCompletionListener(index, controller);
             });

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -9,6 +9,7 @@ import 'package:hls_auth_web_player/hls_auth_web_player.dart'
 import 'package:models/models.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_policy.dart';
+import 'package:openvine/widgets/video_feed_item/web_paused_video_play_overlay.dart';
 import 'package:openvine/widgets/web_video_player.dart';
 import 'package:video_player/video_player.dart';
 
@@ -417,18 +418,35 @@ class _WebVideoFeedItem extends StatelessWidget {
     return Stack(
       fit: StackFit.expand,
       children: [
-        WebVideoPlayer(
-          key: playerKey,
-          url: videoUrl,
-          autoPlay: isActive,
-          headers: headers,
-          controllerFactory: controllerFactory,
-          authHeaderProvider: authHeaderProvider,
-          hlsFallbackUrl: hlsFallbackUrl,
-          onInitialized: onInitialized,
-          onDisposed: onDisposed,
-          onError: onError,
-          onRequiresAuth: onRequiresAuth,
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => playerKey.currentState?.togglePlayPause(),
+          child: WebVideoPlayer(
+            key: playerKey,
+            url: videoUrl,
+            autoPlay: isActive,
+            headers: headers,
+            controllerFactory: controllerFactory,
+            authHeaderProvider: authHeaderProvider,
+            hlsFallbackUrl: hlsFallbackUrl,
+            onInitialized: onInitialized,
+            onDisposed: onDisposed,
+            onError: onError,
+            onRequiresAuth: onRequiresAuth,
+          ),
+        ),
+        ValueListenableBuilder<Map<int, VideoPlayerController>>(
+          valueListenable: controllersListenable,
+          builder: (context, controllers, _) {
+            final tracked = controllers[index];
+            final controller = (tracked != null && tracked.value.isInitialized)
+                ? tracked
+                : null;
+            return WebPausedVideoPlayOverlay(
+              controller: controller,
+              isVisible: isActive,
+            );
+          },
         ),
         if (itemBuilder != null)
           ValueListenableBuilder<Map<int, VideoPlayerController>>(

--- a/mobile/lib/widgets/web_video_player.dart
+++ b/mobile/lib/widgets/web_video_player.dart
@@ -193,6 +193,17 @@ class WebVideoPlayerState extends State<WebVideoPlayer> {
     await _controller?.pause();
   }
 
+  /// Toggles between play and pause based on current controller state.
+  Future<void> togglePlayPause() async {
+    final controller = _controller;
+    if (controller == null || !_isInitialized) return;
+    if (controller.value.isPlaying) {
+      await controller.pause();
+    } else {
+      await controller.play();
+    }
+  }
+
   /// Seeks to the given position.
   Future<void> seekTo(Duration position) async {
     await _controller?.seekTo(position);

--- a/mobile/test/screens/feed/feed_video_overlay_test.dart
+++ b/mobile/test/screens/feed/feed_video_overlay_test.dart
@@ -14,8 +14,10 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -50,6 +52,9 @@ class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
 
 class _MockVideoFeedController extends Mock implements VideoFeedController {}
 
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
+
 class _FakeBuildContext extends Fake implements BuildContext {}
 
 // Full 64-character test IDs (never truncate Nostr IDs)
@@ -70,6 +75,8 @@ AppLocalizations _l10n(WidgetTester tester) =>
 void main() {
   group(FeedVideoOverlay, () {
     late VideoInteractionsBloc mockInteractionsBloc;
+    late VideoVolumeCubit mockVolumeCubit;
+    late FeedAutoAdvanceCubit feedAutoAdvanceCubit;
     late Player mockPlayer;
     late PlayerStream mockStream;
     late PlayerState mockPlayerState;
@@ -91,6 +98,9 @@ void main() {
 
     setUp(() {
       mockInteractionsBloc = _MockVideoInteractionsBloc();
+      mockVolumeCubit = _MockVideoVolumeCubit();
+      when(() => mockVolumeCubit.state).thenReturn(const VideoVolumeState());
+      feedAutoAdvanceCubit = FeedAutoAdvanceCubit();
       mockPlayer = _MockPlayer();
       mockStream = _MockPlayerStream();
       mockPlayerState = _MockPlayerState();
@@ -146,6 +156,7 @@ void main() {
     tearDown(() async {
       await playingController.close();
       await bufferingController.close();
+      await feedAutoAdvanceCubit.close();
       pagePosition.dispose();
     });
 
@@ -189,6 +200,10 @@ void main() {
               ),
               BlocProvider<VideoPlaybackStatusCubit>(
                 create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: mockVolumeCubit),
+              BlocProvider<FeedAutoAdvanceCubit>.value(
+                value: feedAutoAdvanceCubit,
               ),
             ],
             child: feedController == null

--- a/mobile/test/screens/feed/moderated_feed_wiring_test.dart
+++ b/mobile/test/screens/feed/moderated_feed_wiring_test.dart
@@ -14,7 +14,9 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 
@@ -33,6 +35,9 @@ class _MockPlayerState extends Mock implements PlayerState {}
 class _MockCuratedListRepository extends Mock
     implements CuratedListRepository {}
 
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
+
 // Full 64-character Nostr IDs — never truncate.
 const _testVideoId =
     'fe1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd';
@@ -42,6 +47,8 @@ const _testPubkey =
 void main() {
   group('FeedVideoOverlay moderated-content wiring', () {
     late VideoInteractionsBloc mockInteractionsBloc;
+    late VideoVolumeCubit mockVolumeCubit;
+    late FeedAutoAdvanceCubit feedAutoAdvanceCubit;
     late Player mockPlayer;
     late PlayerStream mockStream;
     late PlayerState mockPlayerState;
@@ -60,6 +67,9 @@ void main() {
 
     setUp(() {
       mockInteractionsBloc = _MockVideoInteractionsBloc();
+      mockVolumeCubit = _MockVideoVolumeCubit();
+      when(() => mockVolumeCubit.state).thenReturn(const VideoVolumeState());
+      feedAutoAdvanceCubit = FeedAutoAdvanceCubit();
       mockPlayer = _MockPlayer();
       mockStream = _MockPlayerStream();
       mockPlayerState = _MockPlayerState();
@@ -108,6 +118,7 @@ void main() {
       await bufferingController.close();
       pagePosition.dispose();
       await cubit.close();
+      await feedAutoAdvanceCubit.close();
     });
 
     Widget buildSubject() {
@@ -126,6 +137,10 @@ void main() {
                 value: mockInteractionsBloc,
               ),
               BlocProvider<VideoPlaybackStatusCubit>.value(value: cubit),
+              BlocProvider<VideoVolumeCubit>.value(value: mockVolumeCubit),
+              BlocProvider<FeedAutoAdvanceCubit>.value(
+                value: feedAutoAdvanceCubit,
+              ),
             ],
             child: FeedVideoOverlay(
               video: testVideo,

--- a/mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart
@@ -1,0 +1,179 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
+
+void main() {
+  group(FeedPlaybackTogglesPill, () {
+    late FeedAutoAdvanceCubit autoAdvanceCubit;
+    late VideoVolumeCubit volumeCubit;
+    late SharedPreferences mockPrefs;
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUp(() {
+      autoAdvanceCubit = FeedAutoAdvanceCubit();
+      volumeCubit = _MockVideoVolumeCubit();
+      when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
+      mockPrefs = createMockSharedPreferences();
+    });
+
+    tearDown(() async {
+      await autoAdvanceCubit.close();
+    });
+
+    Widget buildSubject({
+      bool reducedMotion = false,
+      bool provideAutoAdvance = true,
+    }) {
+      Widget pill = const Scaffold(body: FeedPlaybackTogglesPill());
+
+      pill = provideAutoAdvance
+          ? MultiBlocProvider(
+              providers: [
+                BlocProvider<FeedAutoAdvanceCubit>.value(
+                  value: autoAdvanceCubit,
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+              ],
+              child: pill,
+            )
+          : BlocProvider<VideoVolumeCubit>.value(
+              value: volumeCubit,
+              child: pill,
+            );
+
+      return ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaQuery(
+            data: MediaQueryData(disableAnimations: reducedMotion),
+            child: pill,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders all three toggles when cubits are in scope', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      expect(
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(l10n.videoSettingsCaptionsDisable),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides the compilations toggle under reduced motion', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(reducedMotion: true));
+      expect(
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        findsNothing,
+      );
+      expect(
+        find.bySemanticsLabel(l10n.videoActionDisableAutoAdvance),
+        findsNothing,
+      );
+      expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
+    });
+
+    testWidgets('tapping the captions toggle flips subtitle visibility', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+      );
+      addTearDown(container.dispose);
+      // Keep the provider subscribed so auto-dispose timers don't fire
+      // mid-test and trip the timer-pending invariant in testWidgets.
+      container.listen(subtitleVisibilityProvider, (_, _) {});
+      expect(container.read(subtitleVisibilityProvider), isTrue);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<FeedAutoAdvanceCubit>.value(
+                  value: autoAdvanceCubit,
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+              ],
+              child: const Scaffold(body: FeedPlaybackTogglesPill()),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoSettingsCaptionsDisable),
+      );
+      await tester.pump();
+      expect(container.read(subtitleVisibilityProvider), isFalse);
+    });
+
+    testWidgets(
+      'tapping the mute toggle calls VideoVolumeCubit.onPlaybackVolumeChanged',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+
+        await tester.tap(find.bySemanticsLabel(l10n.videoPlayerMute));
+        await tester.pump();
+
+        verify(() => volumeCubit.onPlaybackVolumeChanged(0)).called(1);
+      },
+    );
+
+    testWidgets(
+      'tapping the compilations toggle calls FeedAutoAdvanceCubit.toggle',
+      (tester) async {
+        expect(autoAdvanceCubit.state.enabled, isFalse);
+        await tester.pumpWidget(buildSubject());
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        );
+        await tester.pump();
+
+        expect(autoAdvanceCubit.state.enabled, isTrue);
+      },
+    );
+
+    testWidgets('renders without the compilations toggle when '
+        'FeedAutoAdvanceCubit is not provided', (tester) async {
+      await tester.pumpWidget(buildSubject(provideAutoAdvance: false));
+
+      expect(
+        find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+        findsNothing,
+      );
+      expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart
@@ -1,19 +1,32 @@
 import 'dart:async';
 
+import 'package:bloc_test/bloc_test.dart';
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_play_overlay.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockPlayer extends Mock implements Player {}
 
 class _MockPlayerState extends Mock implements PlayerState {}
 
 class _MockPlayerStream extends Mock implements PlayerStream {}
+
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
 
 void main() {
   group('PausedVideoPlayOverlay', () {
@@ -22,6 +35,9 @@ void main() {
     late PlayerStream mockPlayerStream;
     late StreamController<bool> playingController;
     late StreamController<bool> bufferingController;
+    late FeedAutoAdvanceCubit autoAdvanceCubit;
+    late VideoVolumeCubit volumeCubit;
+    late SharedPreferences mockPrefs;
 
     setUp(() {
       mockPlayer = _MockPlayer();
@@ -34,76 +50,95 @@ void main() {
       when(() => mockPlayer.stream).thenReturn(mockPlayerStream);
       when(() => mockPlayerState.playing).thenReturn(false);
       when(() => mockPlayerState.buffering).thenReturn(false);
-      when(() => mockPlayerState.volume).thenReturn(100.0);
       when(
         () => mockPlayerStream.playing,
       ).thenAnswer((_) => playingController.stream);
       when(
         () => mockPlayerStream.buffering,
       ).thenAnswer((_) => bufferingController.stream);
-      when(
-        () => mockPlayerStream.volume,
-      ).thenAnswer((_) => const Stream<double>.empty());
+
+      autoAdvanceCubit = FeedAutoAdvanceCubit();
+      volumeCubit = _MockVideoVolumeCubit();
+      when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
+      mockPrefs = createMockSharedPreferences();
     });
 
     tearDown(() async {
       await playingController.close();
       await bufferingController.close();
+      await autoAdvanceCubit.close();
     });
 
     Widget buildSubject({Key? key}) {
-      return MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(
-          body: PausedVideoPlayOverlay(
-            key: key,
-            player: mockPlayer,
-            firstFrameFuture: Future<void>.value(),
-            onToggleMuteState: () {},
+      return ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
+            BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: PausedVideoPlayOverlay(
+                key: key,
+                player: mockPlayer,
+                firstFrameFuture: Future<void>.value(),
+              ),
+            ),
           ),
         ),
       );
     }
 
     testWidgets(
-      'keeps the play affordance visible when remounted with the same paused player after playback was observed',
+      'shows the play affordance immediately when the player is paused, '
+      'even before any play has been observed',
       (tester) async {
-        await tester.pumpWidget(buildSubject(key: const ValueKey('first')));
-        await tester.pump();
-
-        playingController.add(true);
-        await tester.pump();
-        playingController.add(false);
+        await tester.pumpWidget(buildSubject());
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 220));
 
         expect(find.byKey(const ValueKey('paused-play')), findsOneWidget);
+      },
+    );
 
-        await tester.pumpWidget(
-          const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: SizedBox.shrink(),
-          ),
-        );
+    testWidgets(
+      'hides the play affordance while the player is buffering',
+      (tester) async {
+        when(() => mockPlayerState.buffering).thenReturn(true);
+        await tester.pumpWidget(buildSubject());
         await tester.pump();
-
-        await tester.pumpWidget(buildSubject(key: const ValueKey('second')));
+        bufferingController.add(true);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 220));
 
-        // After remount _hasStartedPlayback resets, so the overlay is hidden
-        // until the player transitions through playing again.
         expect(find.byKey(const ValueKey('paused-play')), findsNothing);
+      },
+    );
 
-        playingController.add(true);
-        await tester.pump();
-        playingController.add(false);
+    testWidgets(
+      'renders the playback toggles pill above the play icon when paused',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 220));
 
+        expect(find.byType(FeedPlaybackTogglesPill), findsOneWidget);
         expect(find.byKey(const ValueKey('paused-play')), findsOneWidget);
+
+        final pillCenter = tester.getCenter(
+          find.byType(FeedPlaybackTogglesPill),
+        );
+        final playCenter = tester.getCenter(
+          find.byKey(const ValueKey('paused-play')),
+        );
+        expect(
+          pillCenter.dy,
+          lessThan(playCenter.dy),
+          reason: 'pill should sit above the play icon',
+        );
       },
     );
 
@@ -124,10 +159,13 @@ void main() {
           await tester.pumpWidget(buildSubject());
           await tester.pump();
 
-          // Latch: first paused -> playing transition enables future
-          // feedback for this widget + player.
+          // Start from playing so the next paused->playing transition is
+          // observable. Fully settle the AnimatedSwitcher's transition of
+          // the initial paused-play affordance out of the tree before we
+          // re-enter the paused state; without this, AnimatedSwitcher
+          // accumulates outgoing entries across the bounce.
           playingController.add(true);
-          await tester.pump();
+          await tester.pumpAndSettle();
 
           // Pause for longer than the 150 ms feedback threshold.
           playingController.add(false);
@@ -145,7 +183,7 @@ void main() {
 
           // User taps to resume.
           playingController.add(true);
-          // Let AnimatedSwitcher settle after the transition kicks in.
+          // Let AnimatedSwitcher kick the transition off.
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 220));
 
@@ -169,9 +207,12 @@ void main() {
             await tester.pumpWidget(buildSubject());
             await tester.pump();
 
-            // Latch first.
+            // Start from playing so the next paused->playing transition
+            // is observable. Fully settle the AnimatedSwitcher's transition
+            // of the initial paused-play affordance out of the tree before
+            // we re-enter the paused state.
             playingController.add(true);
-            await tester.pump();
+            await tester.pumpAndSettle();
 
             // Simulate a loop-restart blip: paused -> playing within a
             // handful of milliseconds (well below the 150 ms threshold).


### PR DESCRIPTION
## Summary

- Paused-video overlay now renders the three playback toggles (compilations / mute / CC) above the play icon, applied uniformly across every surface that uses `PausedVideoPlayOverlay`.
- Pause icon shows whenever the player is paused (not gated on a prior-play latch). Buffering still hides it to avoid loop-restart blips, and the first-frame gate still suppresses the pre-render window.
- Pill is a single shared `FeedPlaybackTogglesPill` widget — the top-bar three-dot popover now delegates to it too, so the two render sites can't drift.

Spec: `docs/superpowers/specs/2026-05-11-paused-overlay-toggles-pill-design.md`
Plan: `docs/superpowers/plans/2026-05-11-paused-overlay-toggles-pill.md`

## Test plan

- [x] \`flutter analyze lib test integration_test\` clean
- [x] \`flutter test test/widgets/video_feed_item\` green (11 tests, including 6 new pill tests + 3 new overlay behavior tests)
- [x] \`flutter test test/widgets/video_feed_item --test-randomize-ordering-seed random\` 170/170 green
- [x] \`flutter test test/screens/feed/video_feed_page_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart\` green (existing popover-content + auto-advance-via-popover tests still pass after refactor)
- [ ] Manual: home feed paused state — pill renders above play icon, all 3 toggles flip state, top-bar popover still works
- [ ] Manual: fullscreen pooled feed paused state — same
- [ ] Manual: pause-before-first-play — pause icon now visible (the bug we fixed)
- [ ] Manual: pause-during-buffer — pause icon stays hidden until buffer clears
- [ ] Manual: preload-flicker check — frame-by-frame screen recording, swipe through 6–8 videos, verify no play-icon flash on preload swaps

## Architectural notes

The pill widget gracefully degrades when \`FeedAutoAdvanceCubit\` isn't in scope (uses \`context.read<FeedAutoAdvanceCubit?>()\`), so future surfaces using \`PausedVideoPlayOverlay\` won't crash if they don't provide auto-advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)