### PR TITLE
feat(nostr): distinguish PublishNoRelays vs PublishFailed

### DIFF
--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -103,27 +103,18 @@ class AccountDeletionService {
 
       final sentEvent = await _nostrService.publishEvent(event);
 
-      switch (sentEvent) {
-        case PublishSuccess():
-          break;
-        case PublishNoRelays():
-          Log.error(
-            'Failed to publish NIP-62 deletion request: no relays connected',
-            name: 'AccountDeletionService',
-            category: LogCategory.system,
-          );
-          return DeleteAccountResult.failure(
-            'No relays connected — deletion request not sent',
-          );
-        case PublishFailed():
-          Log.error(
-            'Failed to publish NIP-62 deletion request: send error',
-            name: 'AccountDeletionService',
-            category: LogCategory.system,
-          );
-          return DeleteAccountResult.failure(
-            'Failed to publish deletion request to relays',
-          );
+      final failureReason = sentEvent.failureReason;
+      if (failureReason != null) {
+        Log.error(
+          'Failed to publish NIP-62 deletion request: $failureReason',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
+        );
+        return DeleteAccountResult.failure(
+          sentEvent is PublishNoRelays
+              ? 'No relays connected — deletion request not sent'
+              : 'Failed to publish deletion request to relays',
+        );
       }
 
       Log.info(
@@ -198,26 +189,19 @@ class AccountDeletionService {
 
       if (deleteEvent != null) {
         final sentEvent = await _nostrService.publishEvent(deleteEvent);
-        switch (sentEvent) {
-          case PublishSuccess():
-            successCount += kindEvents.length;
-            Log.debug(
-              'Published batch deletion for ${kindEvents.length} kind $kind events',
-              name: 'AccountDeletionService',
-              category: LogCategory.system,
-            );
-          case PublishNoRelays():
-            Log.warning(
-              'Batch deletion for kind $kind skipped: no relays connected',
-              name: 'AccountDeletionService',
-              category: LogCategory.system,
-            );
-          case PublishFailed():
-            Log.warning(
-              'Batch deletion for kind $kind failed: send error',
-              name: 'AccountDeletionService',
-              category: LogCategory.system,
-            );
+        if (sentEvent.isSuccess) {
+          successCount += kindEvents.length;
+          Log.debug(
+            'Published batch deletion for ${kindEvents.length} kind $kind events',
+            name: 'AccountDeletionService',
+            category: LogCategory.system,
+          );
+        } else {
+          Log.warning(
+            'Batch deletion for kind $kind skipped: ${sentEvent.failureReason}',
+            name: 'AccountDeletionService',
+            category: LogCategory.system,
+          );
         }
       }
 

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -111,9 +111,7 @@ class AccountDeletionService {
           category: LogCategory.system,
         );
         return DeleteAccountResult.failure(
-          sentEvent is PublishNoRelays
-              ? 'No relays connected — deletion request not sent'
-              : 'Failed to publish deletion request to relays',
+          'Failed to publish deletion request to relays',
         );
       }
 

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -103,15 +103,27 @@ class AccountDeletionService {
 
       final sentEvent = await _nostrService.publishEvent(event);
 
-      if (sentEvent is! PublishSuccess) {
-        Log.error(
-          'Failed to publish NIP-62 deletion request to any relay',
-          name: 'AccountDeletionService',
-          category: LogCategory.system,
-        );
-        return DeleteAccountResult.failure(
-          'Failed to publish deletion request to relays',
-        );
+      switch (sentEvent) {
+        case PublishSuccess():
+          break;
+        case PublishNoRelays():
+          Log.error(
+            'Failed to publish NIP-62 deletion request: no relays connected',
+            name: 'AccountDeletionService',
+            category: LogCategory.system,
+          );
+          return DeleteAccountResult.failure(
+            'No relays connected — deletion request not sent',
+          );
+        case PublishFailed():
+          Log.error(
+            'Failed to publish NIP-62 deletion request: send error',
+            name: 'AccountDeletionService',
+            category: LogCategory.system,
+          );
+          return DeleteAccountResult.failure(
+            'Failed to publish deletion request to relays',
+          );
       }
 
       Log.info(
@@ -186,13 +198,26 @@ class AccountDeletionService {
 
       if (deleteEvent != null) {
         final sentEvent = await _nostrService.publishEvent(deleteEvent);
-        if (sentEvent is PublishSuccess) {
-          successCount += kindEvents.length;
-          Log.debug(
-            'Published batch deletion for ${kindEvents.length} kind $kind events',
-            name: 'AccountDeletionService',
-            category: LogCategory.system,
-          );
+        switch (sentEvent) {
+          case PublishSuccess():
+            successCount += kindEvents.length;
+            Log.debug(
+              'Published batch deletion for ${kindEvents.length} kind $kind events',
+              name: 'AccountDeletionService',
+              category: LogCategory.system,
+            );
+          case PublishNoRelays():
+            Log.warning(
+              'Batch deletion for kind $kind skipped: no relays connected',
+              name: 'AccountDeletionService',
+              category: LogCategory.system,
+            );
+          case PublishFailed():
+            Log.warning(
+              'Batch deletion for kind $kind failed: send error',
+              name: 'AccountDeletionService',
+              category: LogCategory.system,
+            );
         }
       }
 

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -183,25 +183,19 @@ class ContentReportingService {
         targetRelays: [_moderationRelayUrl],
       );
       // Always continue to local save regardless of publish outcome.
-      switch (sentEvent) {
-        case PublishSuccess():
-          Log.info(
-            'Report published to relays',
-            name: 'ContentReportingService',
-            category: LogCategory.system,
-          );
-        case PublishNoRelays():
-          Log.error(
-            'Failed to publish report: no relays connected',
-            name: 'ContentReportingService',
-            category: LogCategory.system,
-          );
-        case PublishFailed():
-          Log.error(
-            'Failed to publish report: send error',
-            name: 'ContentReportingService',
-            category: LogCategory.system,
-          );
+      final failureReason = sentEvent.failureReason;
+      if (failureReason != null) {
+        Log.error(
+          'Failed to publish NIP-56 report: $failureReason',
+          name: 'ContentReportingService',
+          category: LogCategory.system,
+        );
+      } else {
+        Log.info(
+          'Report published to relays',
+          name: 'ContentReportingService',
+          category: LogCategory.system,
+        );
       }
 
       // Create Zendesk ticket silently for moderation tracking

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -182,6 +182,7 @@ class ContentReportingService {
         reportEvent,
         targetRelays: [_moderationRelayUrl],
       );
+      // Always continue to local save regardless of publish outcome.
       switch (sentEvent) {
         case PublishSuccess():
           Log.info(
@@ -195,14 +196,12 @@ class ContentReportingService {
             name: 'ContentReportingService',
             category: LogCategory.system,
           );
-        // Still save locally even if publish fails
         case PublishFailed():
           Log.error(
             'Failed to publish report: send error',
             name: 'ContentReportingService',
             category: LogCategory.system,
           );
-        // Still save locally even if publish fails
       }
 
       // Create Zendesk ticket silently for moderation tracking

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -182,19 +182,27 @@ class ContentReportingService {
         reportEvent,
         targetRelays: [_moderationRelayUrl],
       );
-      if (sentEvent is! PublishSuccess) {
-        Log.error(
-          'Failed to publish report to relays',
-          name: 'ContentReportingService',
-          category: LogCategory.system,
-        );
+      switch (sentEvent) {
+        case PublishSuccess():
+          Log.info(
+            'Report published to relays',
+            name: 'ContentReportingService',
+            category: LogCategory.system,
+          );
+        case PublishNoRelays():
+          Log.error(
+            'Failed to publish report: no relays connected',
+            name: 'ContentReportingService',
+            category: LogCategory.system,
+          );
         // Still save locally even if publish fails
-      } else {
-        Log.info(
-          'Report published to relays',
-          name: 'ContentReportingService',
-          category: LogCategory.system,
-        );
+        case PublishFailed():
+          Log.error(
+            'Failed to publish report: send error',
+            name: 'ContentReportingService',
+            category: LogCategory.system,
+          );
+        // Still save locally even if publish fails
       }
 
       // Create Zendesk ticket silently for moderation tracking

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -119,25 +119,19 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    switch (published) {
-      case PublishSuccess():
-        Log.info(
-          'Push notification deregistration published',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
-      case PublishNoRelays():
-        Log.error(
-          'Failed to publish deregistration event: no relays connected',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
-      case PublishFailed():
-        Log.error(
-          'Failed to publish deregistration event: send error',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
+    final failureReason = published.failureReason;
+    if (failureReason != null) {
+      Log.error(
+        'Failed to publish deregistration event: $failureReason',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
+    } else {
+      Log.info(
+        'Push notification deregistration published',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
     }
   }
 
@@ -188,25 +182,19 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    switch (published) {
-      case PublishSuccess():
-        Log.info(
-          'Push notification preferences updated',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
-      case PublishNoRelays():
-        Log.error(
-          'Failed to publish preferences event: no relays connected',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
-      case PublishFailed():
-        Log.error(
-          'Failed to publish preferences event: send error',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
+    final failureReason = published.failureReason;
+    if (failureReason != null) {
+      Log.error(
+        'Failed to publish preferences event: $failureReason',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
+    } else {
+      Log.info(
+        'Push notification preferences updated',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
     }
   }
 
@@ -289,25 +277,19 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    switch (published) {
-      case PublishSuccess():
-        Log.info(
-          'Push notification registration published',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
-      case PublishNoRelays():
-        Log.error(
-          'Failed to publish registration event: no relays connected',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
-      case PublishFailed():
-        Log.error(
-          'Failed to publish registration event: send error',
-          name: 'PushNotificationService',
-          category: LogCategory.system,
-        );
+    final failureReason = published.failureReason;
+    if (failureReason != null) {
+      Log.error(
+        'Failed to publish registration event: $failureReason',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
+    } else {
+      Log.info(
+        'Push notification registration published',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -119,18 +119,25 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published is! PublishSuccess) {
-      Log.error(
-        'Failed to publish deregistration event',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-    } else {
-      Log.info(
-        'Push notification deregistration published',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
+    switch (published) {
+      case PublishSuccess():
+        Log.info(
+          'Push notification deregistration published',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
+      case PublishNoRelays():
+        Log.error(
+          'Failed to publish deregistration event: no relays connected',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
+      case PublishFailed():
+        Log.error(
+          'Failed to publish deregistration event: send error',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
     }
   }
 
@@ -181,18 +188,25 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published is! PublishSuccess) {
-      Log.error(
-        'Failed to publish preferences event',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-    } else {
-      Log.info(
-        'Push notification preferences updated',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
+    switch (published) {
+      case PublishSuccess():
+        Log.info(
+          'Push notification preferences updated',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
+      case PublishNoRelays():
+        Log.error(
+          'Failed to publish preferences event: no relays connected',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
+      case PublishFailed():
+        Log.error(
+          'Failed to publish preferences event: send error',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
     }
   }
 
@@ -275,18 +289,25 @@ class PushNotificationService {
     }
 
     final published = await _nostrClient.publishEvent(event);
-    if (published is! PublishSuccess) {
-      Log.error(
-        'Failed to publish registration event',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-    } else {
-      Log.info(
-        'Push notification registration published',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
+    switch (published) {
+      case PublishSuccess():
+        Log.info(
+          'Push notification registration published',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
+      case PublishNoRelays():
+        Log.error(
+          'Failed to publish registration event: no relays connected',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
+      case PublishFailed():
+        Log.error(
+          'Failed to publish registration event: send error',
+          name: 'PushNotificationService',
+          category: LogCategory.system,
+        );
     }
   }
 

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -187,20 +187,27 @@ class VideoSharingService {
 
     final sentEvent = await _nostrService.publishEvent(event);
 
-    if (sentEvent is PublishSuccess) {
-      _shareHistory[recipientPubkey] = DateTime.now();
-      await _updateRecentlySharedWith(recipientPubkey);
+    switch (sentEvent) {
+      case PublishSuccess():
+        _shareHistory[recipientPubkey] = DateTime.now();
+        await _updateRecentlySharedWith(recipientPubkey);
 
-      Log.info(
-        'Video shared via NIP-04: ${event.id}',
-        name: 'VideoSharingService',
-        category: LogCategory.video,
-      );
+        Log.info(
+          'Video shared via NIP-04: ${event.id}',
+          name: 'VideoSharingService',
+          category: LogCategory.video,
+        );
 
-      return ShareResult.createSuccess(event.id);
+        return ShareResult.createSuccess(event.id);
+      case PublishNoRelays():
+        return ShareResult.failure(
+          'Failed to publish share message: no relays connected',
+        );
+      case PublishFailed():
+        return ShareResult.failure(
+          'Failed to publish share message: send error',
+        );
     }
-
-    return ShareResult.failure('Failed to publish share message');
   }
 
   /// Share video to multiple users at once

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -187,27 +187,27 @@ class VideoSharingService {
 
     final sentEvent = await _nostrService.publishEvent(event);
 
-    switch (sentEvent) {
-      case PublishSuccess():
-        _shareHistory[recipientPubkey] = DateTime.now();
-        await _updateRecentlySharedWith(recipientPubkey);
-
-        Log.info(
-          'Video shared via NIP-04: ${event.id}',
-          name: 'VideoSharingService',
-          category: LogCategory.video,
-        );
-
-        return ShareResult.createSuccess(event.id);
-      case PublishNoRelays():
-        return ShareResult.failure(
-          'Failed to publish share message: no relays connected',
-        );
-      case PublishFailed():
-        return ShareResult.failure(
-          'Failed to publish share message: send error',
-        );
+    final failureReason = sentEvent.failureReason;
+    if (failureReason != null) {
+      Log.error(
+        'Failed to publish NIP-04 share message: $failureReason',
+        name: 'VideoSharingService',
+        category: LogCategory.video,
+      );
+      return ShareResult.failure('Failed to publish share message');
     }
+
+    final success = sentEvent as PublishSuccess;
+    _shareHistory[recipientPubkey] = DateTime.now();
+    await _updateRecentlySharedWith(recipientPubkey);
+
+    Log.info(
+      'Video shared via NIP-04: ${event.id}',
+      name: 'VideoSharingService',
+      category: LogCategory.video,
+    );
+
+    return ShareResult.createSuccess(success.event.id);
   }
 
   /// Share video to multiple users at once

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1604,17 +1604,16 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       // Publish the updated event
       final nostrService = ref.read(nostrServiceProvider);
       final publishResult = await nostrService.publishEvent(event);
-      switch (publishResult) {
-        case PublishSuccess():
-          break;
-        case PublishNoRelays():
-          throw Exception(
-            'Failed to publish updated event: no relays connected',
-          );
-        case PublishFailed():
-          throw Exception('Failed to publish updated event: send error');
+      final failureReason = publishResult.failureReason;
+      if (failureReason != null) {
+        Log.error(
+          'Failed to publish video metadata edit: $failureReason',
+          name: 'ShareVideoMenu',
+          category: LogCategory.ui,
+        );
+        throw Exception('Failed to publish updated event');
       }
-      final publishedEvent = publishResult.event;
+      final publishedEvent = (publishResult as PublishSuccess).event;
 
       // Update local cache for immediate UI update
       final personalEventCache = ref.read(personalEventCacheServiceProvider);

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1604,8 +1604,15 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       // Publish the updated event
       final nostrService = ref.read(nostrServiceProvider);
       final publishResult = await nostrService.publishEvent(event);
-      if (publishResult is! PublishSuccess) {
-        throw Exception('Failed to publish updated event');
+      switch (publishResult) {
+        case PublishSuccess():
+          break;
+        case PublishNoRelays():
+          throw Exception(
+            'Failed to publish updated event: no relays connected',
+          );
+        case PublishFailed():
+          throw Exception('Failed to publish updated event: send error');
       }
       final publishedEvent = publishResult.event;
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1599,22 +1599,21 @@ class DmRepository {
     }
 
     final publishResult = await _nostrClient.publishEvent(signed);
-    switch (publishResult) {
-      case PublishSuccess():
-        return NIP17SendResult.success(
-          rumorEventId: publishResult.event.id,
-          messageEventId: publishResult.event.id,
-          recipientPubkey: recipientPubkey,
-        );
-      case PublishNoRelays():
-        return const NIP17SendResult.failure(
-          'NIP-04 publish failed: no relays connected',
-        );
-      case PublishFailed():
-        return const NIP17SendResult.failure(
-          'NIP-04 publish failed: send error',
-        );
+    final failureReason = publishResult.failureReason;
+    if (failureReason != null) {
+      Log.error(
+        'Failed to publish NIP-04 message: $failureReason',
+        category: LogCategory.system,
+      );
+      return const NIP17SendResult.failure('NIP-04 publish failed');
     }
+
+    final sent = publishResult as PublishSuccess;
+    return NIP17SendResult.success(
+      rumorEventId: sent.event.id,
+      messageEventId: sent.event.id,
+      recipientPubkey: recipientPubkey,
+    );
   }
 
   // -------------------------------------------------------------------------

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1599,15 +1599,22 @@ class DmRepository {
     }
 
     final publishResult = await _nostrClient.publishEvent(signed);
-    if (publishResult is! PublishSuccess) {
-      return const NIP17SendResult.failure('NIP-04 publish failed');
+    switch (publishResult) {
+      case PublishSuccess():
+        return NIP17SendResult.success(
+          rumorEventId: publishResult.event.id,
+          messageEventId: publishResult.event.id,
+          recipientPubkey: recipientPubkey,
+        );
+      case PublishNoRelays():
+        return const NIP17SendResult.failure(
+          'NIP-04 publish failed: no relays connected',
+        );
+      case PublishFailed():
+        return const NIP17SendResult.failure(
+          'NIP-04 publish failed: send error',
+        );
     }
-
-    return NIP17SendResult.success(
-      rumorEventId: publishResult.event.id,
-      messageEventId: publishResult.event.id,
-      recipientPubkey: recipientPubkey,
-    );
   }
 
   // -------------------------------------------------------------------------

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7079,6 +7079,212 @@ void main() {
           await Future<void>.delayed(const Duration(milliseconds: 50));
         },
       );
+
+      test(
+        'NIP-17 send succeeds even when NIP-04 fallback gets PublishNoRelays',
+        () async {
+          // The NIP-04 fallback is fire-and-forget; PublishNoRelays must not
+          // bubble up and fail the overall sendMessage result.
+          final mockSigner = _MockNostrSigner();
+          when(mockSigner.getPublicKey).thenAnswer(
+            (_) async => _validPubkeyA,
+          );
+          when(
+            () => mockSigner.encrypt(any(), any()),
+          ).thenAnswer((_) async => 'encrypted-content');
+          when(
+            () => mockSigner.signEvent(any()),
+          ).thenAnswer((inv) async {
+            final e = inv.positionalArguments.first as Event;
+            return e
+              ..id = 'nip04-event-id-no-relays'
+              ..sig = 'sig';
+          });
+
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenAnswer((_) async {});
+
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => const PublishNoRelays());
+
+          final repo = DmRepository(
+            nostrClient: mockNostrClient,
+            messageService: mockMessageService,
+            directMessagesDao: mockDirectMessagesDao,
+            conversationsDao: mockConversationsDao,
+            userPubkey: _validPubkeyA,
+            signer: mockSigner,
+          );
+
+          final result = await repo.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'Hello',
+          );
+
+          // NIP-17 succeeded; NIP-04 fallback silently got PublishNoRelays.
+          expect(result.success, isTrue);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+      );
+
+      test(
+        'NIP-17 send succeeds even when NIP-04 fallback gets PublishFailed',
+        () async {
+          // The NIP-04 fallback is fire-and-forget; PublishFailed must not
+          // bubble up and fail the overall sendMessage result.
+          final mockSigner = _MockNostrSigner();
+          when(mockSigner.getPublicKey).thenAnswer(
+            (_) async => _validPubkeyA,
+          );
+          when(
+            () => mockSigner.encrypt(any(), any()),
+          ).thenAnswer((_) async => 'encrypted-content');
+          when(
+            () => mockSigner.signEvent(any()),
+          ).thenAnswer((inv) async {
+            final e = inv.positionalArguments.first as Event;
+            return e
+              ..id = 'nip04-event-id-send-error'
+              ..sig = 'sig';
+          });
+
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenAnswer((_) async {});
+
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => const PublishFailed());
+
+          final repo = DmRepository(
+            nostrClient: mockNostrClient,
+            messageService: mockMessageService,
+            directMessagesDao: mockDirectMessagesDao,
+            conversationsDao: mockConversationsDao,
+            userPubkey: _validPubkeyA,
+            signer: mockSigner,
+          );
+
+          final result = await repo.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'Hello',
+          );
+
+          // NIP-17 succeeded; NIP-04 fallback silently got PublishFailed.
+          expect(result.success, isTrue);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+      );
     });
 
     group('sendMessage preserves existing conversation metadata', () {

--- a/mobile/packages/nostr_client/lib/src/publish_result.dart
+++ b/mobile/packages/nostr_client/lib/src/publish_result.dart
@@ -46,9 +46,6 @@ extension PublishResultX on PublishResult {
   /// Whether the publish succeeded.
   bool get isSuccess => this is PublishSuccess;
 
-  /// Whether the publish failed for any reason.
-  bool get isFailure => this is! PublishSuccess;
-
   /// A short, reason-specific diagnostic string for logging, or `null` when
   /// the result is [PublishSuccess].
   ///

--- a/mobile/packages/nostr_client/lib/src/publish_result.dart
+++ b/mobile/packages/nostr_client/lib/src/publish_result.dart
@@ -40,3 +40,31 @@ final class PublishFailed extends PublishResult {
   /// Creates a send-failed result.
   const PublishFailed();
 }
+
+/// Shared helpers for [PublishResult] call sites.
+extension PublishResultX on PublishResult {
+  /// Whether the publish succeeded.
+  bool get isSuccess => this is PublishSuccess;
+
+  /// Whether the publish failed for any reason.
+  bool get isFailure => this is! PublishSuccess;
+
+  /// A short, reason-specific diagnostic string for logging, or `null` when
+  /// the result is [PublishSuccess].
+  ///
+  /// Call sites use this to emit a distinguished log message without
+  /// duplicating the branch semantics:
+  ///
+  /// ```dart
+  /// final reason = result.failureReason;
+  /// if (reason != null) {
+  ///   Log.error('Failed to publish X: $reason', name: 'MyService', …);
+  ///   return SomeResult.failure('generic user-facing message');
+  /// }
+  /// ```
+  String? get failureReason => switch (this) {
+    PublishSuccess() => null,
+    PublishNoRelays() => 'no relays connected',
+    PublishFailed() => 'send error',
+  };
+}

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -243,7 +243,7 @@ void main() {
     });
 
     test(
-      'deleteAccount returns failure with no-relays message when PublishNoRelays',
+      'deleteAccount returns generic publish-failure message when PublishNoRelays',
       () async {
         // Arrange
         final expectedEvent = createTestEvent(
@@ -272,7 +272,7 @@ void main() {
 
         // Assert
         expect(result.success, isFalse);
-        expect(result.error, contains('No relays connected'));
+        expect(result.error, contains('Failed to publish'));
       },
     );
 

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -242,6 +242,40 @@ void main() {
       expect(result.error, contains('Failed to publish'));
     });
 
+    test(
+      'deleteAccount returns failure with no-relays message when PublishNoRelays',
+      () async {
+        // Arrange
+        final expectedEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 62,
+          tags: [
+            ['relay', 'ALL_RELAYS'],
+          ],
+          content: 'User requested account deletion via Divine app',
+        );
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => expectedEvent);
+
+        when(
+          () => mockNostrService.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishNoRelays());
+
+        // Act
+        final result = await service.deleteAccount();
+
+        // Assert
+        expect(result.success, isFalse);
+        expect(result.error, contains('No relays connected'));
+      },
+    );
+
     test('deleteAccount should fail when not authenticated', () async {
       // Arrange
       when(() => mockAuthService.isAuthenticated).thenReturn(false);
@@ -548,6 +582,138 @@ void main() {
         expect(result.deletedEventsCount, equals(0));
         verify(() => mockNostrService.publishEvent(any())).called(1);
       });
+
+      test(
+        'batch deletion does not count events when PublishNoRelays',
+        () async {
+          // Arrange
+          final userEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 1,
+            tags: [],
+            content: 'note',
+            id: 'note_1',
+          );
+          final kind5Event = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', 'note_1'],
+              ['k', '1'],
+            ],
+            content: 'deletion',
+          );
+          final nip62Event = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 62,
+            tags: [
+              ['relay', 'ALL_RELAYS'],
+            ],
+            content: 'deletion',
+          );
+
+          when(
+            () => mockNostrService.queryEvents(any()),
+          ).thenAnswer((_) async => [userEvent]);
+
+          var createCallCount = 0;
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async {
+            createCallCount++;
+            if (createCallCount == 1) return kind5Event;
+            return nip62Event;
+          });
+
+          var publishCallCount = 0;
+          when(
+            () => mockNostrService.publishEvent(any()),
+          ).thenAnswer((_) async {
+            publishCallCount++;
+            // First publish is the batch kind-5; second is NIP-62.
+            if (publishCallCount == 1) return const PublishNoRelays();
+            return PublishSuccess(event: nip62Event);
+          });
+
+          // Act
+          final result = await service.deleteAccount();
+
+          // Assert — NIP-62 still succeeds; batch counted 0 because relay
+          // was unreachable for kind-5.
+          expect(result.success, isTrue);
+          expect(result.deletedEventsCount, equals(0));
+        },
+      );
+
+      test(
+        'batch deletion does not count events when PublishFailed',
+        () async {
+          // Arrange
+          final userEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 1,
+            tags: [],
+            content: 'note',
+            id: 'note_2',
+          );
+          final kind5Event = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', 'note_2'],
+              ['k', '1'],
+            ],
+            content: 'deletion',
+          );
+          final nip62Event = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 62,
+            tags: [
+              ['relay', 'ALL_RELAYS'],
+            ],
+            content: 'deletion',
+          );
+
+          when(
+            () => mockNostrService.queryEvents(any()),
+          ).thenAnswer((_) async => [userEvent]);
+
+          var createCallCount = 0;
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async {
+            createCallCount++;
+            if (createCallCount == 1) return kind5Event;
+            return nip62Event;
+          });
+
+          var publishCallCount = 0;
+          when(
+            () => mockNostrService.publishEvent(any()),
+          ).thenAnswer((_) async {
+            publishCallCount++;
+            // First publish is the batch kind-5; second is NIP-62.
+            if (publishCallCount == 1) return const PublishFailed();
+            return PublishSuccess(event: nip62Event);
+          });
+
+          // Act
+          final result = await service.deleteAccount();
+
+          // Assert — NIP-62 still succeeds; batch counted 0 because send
+          // failed.
+          expect(result.success, isTrue);
+          expect(result.deletedEventsCount, equals(0));
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -420,6 +420,47 @@ void main() {
       expect(service.reportHistory, isNotEmpty);
     });
 
+    test(
+      'reportContent() saves report locally when PublishNoRelays',
+      () async {
+        // Arrange
+        final reportEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1984,
+          tags: [],
+          content: 'Spam content',
+        );
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => reportEvent);
+
+        when(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => const PublishNoRelays());
+
+        // Act
+        final result = await service.reportContent(
+          eventId: 'event_no_relays',
+          authorPubkey: 'author_456',
+          reason: ContentFilterReason.spam,
+          details: 'Spam content',
+        );
+
+        // Assert — report is still saved locally regardless of relay state
+        expect(result.success, isTrue);
+        expect(result.error, isNull);
+        expect(service.reportHistory, isNotEmpty);
+      },
+    );
+
     test('reportContent() stores report in history on success', () async {
       // Arrange
       final reportEvent = createTestEvent(

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -268,6 +268,58 @@ void main() {
         verifyNever(() => mockNostrClient.publishEvent(any()));
         service.dispose();
       });
+
+      test(
+        'completes without error when registration publish returns PublishNoRelays',
+        () async {
+          when(
+            () => mockNostrSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
+
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+
+          when(
+            () => mockNostrClient.publishEvent(fakeEvent),
+          ).thenAnswer((_) async => const PublishNoRelays());
+
+          final service = buildService();
+          await expectLater(service.register(testPubkey), completes);
+          service.dispose();
+        },
+      );
+
+      test(
+        'completes without error when registration publish returns PublishFailed',
+        () async {
+          when(
+            () => mockNostrSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
+
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+
+          when(
+            () => mockNostrClient.publishEvent(fakeEvent),
+          ).thenAnswer((_) async => const PublishFailed());
+
+          final service = buildService();
+          await expectLater(service.register(testPubkey), completes);
+          service.dispose();
+        },
+      );
     });
 
     group('deregister', () {
@@ -315,6 +367,50 @@ void main() {
         verifyNever(() => mockNostrClient.publishEvent(any()));
         service.dispose();
       });
+
+      test(
+        'completes without error when deregistration publish returns PublishNoRelays',
+        () async {
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+
+          when(
+            () => mockNostrClient.publishEvent(fakeEvent),
+          ).thenAnswer((_) async => const PublishNoRelays());
+
+          final service = buildService();
+          await expectLater(service.deregister(testPubkey), completes);
+          service.dispose();
+        },
+      );
+
+      test(
+        'completes without error when deregistration publish returns PublishFailed',
+        () async {
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+
+          when(
+            () => mockNostrClient.publishEvent(fakeEvent),
+          ).thenAnswer((_) async => const PublishFailed());
+
+          final service = buildService();
+          await expectLater(service.deregister(testPubkey), completes);
+          service.dispose();
+        },
+      );
     });
 
     group('updatePreferences', () {
@@ -399,6 +495,62 @@ void main() {
               tags: any(named: 'tags'),
             ),
           );
+          service.dispose();
+        },
+      );
+
+      test(
+        'completes without error when preferences publish returns PublishNoRelays',
+        () async {
+          const prefs = NotificationPreferences();
+
+          when(
+            () => mockNostrSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
+
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+
+          when(
+            () => mockNostrClient.publishEvent(fakeEvent),
+          ).thenAnswer((_) async => const PublishNoRelays());
+
+          final service = buildService();
+          await expectLater(service.updatePreferences(prefs), completes);
+          service.dispose();
+        },
+      );
+
+      test(
+        'completes without error when preferences publish returns PublishFailed',
+        () async {
+          const prefs = NotificationPreferences();
+
+          when(
+            () => mockNostrSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
+
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+
+          when(
+            () => mockNostrClient.publishEvent(fakeEvent),
+          ).thenAnswer((_) async => const PublishFailed());
+
+          final service = buildService();
+          await expectLater(service.updatePreferences(prefs), completes);
           service.dispose();
         },
       );

--- a/mobile/test/widgets/share_video_menu_publish_failure_test.dart
+++ b/mobile/test/widgets/share_video_menu_publish_failure_test.dart
@@ -1,0 +1,210 @@
+// ABOUTME: Widget tests for PublishNoRelays and PublishFailed branches in the
+// ABOUTME: ShareVideoMenu edit-video flow. Verifies that the snackbar is shown
+// ABOUTME: for both failure variants and that it does NOT contain raw
+// ABOUTME: branch-detail strings ('no relays connected', 'send error').
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/bookmark_service.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/share_video_menu.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockBookmarkService extends Mock implements BookmarkService {}
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeCuratedListsState extends CuratedListsState {
+  @override
+  Future<List<CuratedList>> build() async => const [];
+}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+VideoEvent _testVideo({required String ownerPubkey}) {
+  return VideoEvent(
+    id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    pubkey: ownerPubkey,
+    createdAt: 1757385263,
+    content: 'Test video content',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+    videoUrl: 'https://cdn.example.com/video.mp4',
+    title: 'Test Video Title',
+    vineId: 'video-d-tag',
+    nostrEventTags: const [
+      ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
+    ],
+  );
+}
+
+void main() {
+  const ownerPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  late MockAuthService mockAuthService;
+  late MockNostrClient mockNostrService;
+  late _MockBookmarkService mockBookmarkService;
+  late _MockPersonalEventCacheService mockPersonalEventCacheService;
+  late _MockVideoEventService mockVideoEventService;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(_FakeVideoEvent());
+  });
+
+  setUp(() {
+    mockAuthService = createMockAuthService();
+    mockNostrService = createMockNostrService();
+    mockBookmarkService = _MockBookmarkService();
+    mockPersonalEventCacheService = _MockPersonalEventCacheService();
+    mockVideoEventService = _MockVideoEventService();
+
+    when(() => mockAuthService.isAuthenticated).thenReturn(true);
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(ownerPubkey);
+
+    when(
+      () => mockAuthService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+        createdAt: any(named: 'createdAt'),
+      ),
+    ).thenAnswer((invocation) async {
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      final content = invocation.namedArguments[#content] as String;
+      return Event(
+        ownerPubkey,
+        NIP71VideoKinds.addressableShortVideo,
+        tags,
+        content,
+      );
+    });
+
+    when(
+      () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+    ).thenReturn(false);
+    when(
+      () => mockBookmarkService.getVideoBookmarkSummary(any()),
+    ).thenReturn('Not bookmarked');
+    when(
+      () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+    ).thenAnswer((_) async => true);
+  });
+
+  Widget buildSubject() {
+    return testProviderScope(
+      mockAuthService: mockAuthService,
+      mockNostrService: mockNostrService,
+      additionalOverrides: [
+        bookmarkServiceProvider.overrideWith((ref) => mockBookmarkService),
+        curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+        isFeatureEnabledProvider(
+          FeatureFlag.curatedLists,
+        ).overrideWithValue(false),
+        isFeatureEnabledProvider(
+          FeatureFlag.debugTools,
+        ).overrideWithValue(false),
+        personalEventCacheServiceProvider.overrideWithValue(
+          mockPersonalEventCacheService,
+        ),
+        videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ShareVideoMenu(video: _testVideo(ownerPubkey: ownerPubkey)),
+        ),
+      ),
+    );
+  }
+
+  /// Pumps the widget and taps through to the Update button in the edit dialog.
+  Future<void> openEditDialogAndTapUpdate(WidgetTester tester) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.text(l10n.shareMenuEditVideo),
+      find.byType(ShareVideoMenu),
+      const Offset(0, -120),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.shareMenuEditVideo));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text(l10n.shareMenuUpdate));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.shareMenuUpdate));
+    await tester.pumpAndSettle();
+  }
+
+  group('ShareVideoMenu edit-video publish failure branches', () {
+    testWidgets(
+      'PublishNoRelays: shows failure snackbar without branch-detail string',
+      (tester) async {
+        when(
+          () => mockNostrService.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishNoRelays());
+
+        await openEditDialogAndTapUpdate(tester);
+
+        // Generic failure snackbar should appear.
+        expect(find.byType(SnackBar), findsOneWidget);
+
+        // The snackbar text must start with 'Failed to update video'.
+        expect(
+          find.textContaining('Failed to update video'),
+          findsOneWidget,
+        );
+
+        // Raw branch detail must NOT leak into user-visible text.
+        expect(find.textContaining('no relays connected'), findsNothing);
+        expect(find.textContaining('send error'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'PublishFailed: shows failure snackbar without branch-detail string',
+      (tester) async {
+        when(
+          () => mockNostrService.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        await openEditDialogAndTapUpdate(tester);
+
+        // Generic failure snackbar should appear.
+        expect(find.byType(SnackBar), findsOneWidget);
+
+        // The snackbar text must start with 'Failed to update video'.
+        expect(
+          find.textContaining('Failed to update video'),
+          findsOneWidget,
+        );
+
+        // Raw branch detail must NOT leak into user-visible text.
+        expect(find.textContaining('no relays connected'), findsNothing);
+        expect(find.textContaining('send error'), findsNothing);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/share_video_menu_publish_failure_test.dart
+++ b/mobile/test/widgets/share_video_menu_publish_failure_test.dart
@@ -171,9 +171,16 @@ void main() {
         // Generic failure snackbar should appear.
         expect(find.byType(SnackBar), findsOneWidget);
 
-        // The snackbar text must start with 'Failed to update video'.
+        // The snackbar text must contain the localized failure prefix.
+        // shareMenuFailedToUpdateVideo takes an error arg; matching on the
+        // prefix ensures the localized key is used rather than a raw string.
+        const publishFailureMessage = 'Failed to publish updated event';
         expect(
-          find.textContaining('Failed to update video'),
+          find.textContaining(
+            l10n.shareMenuFailedToUpdateVideo(
+              'Exception: $publishFailureMessage',
+            ),
+          ),
           findsOneWidget,
         );
 
@@ -195,9 +202,14 @@ void main() {
         // Generic failure snackbar should appear.
         expect(find.byType(SnackBar), findsOneWidget);
 
-        // The snackbar text must start with 'Failed to update video'.
+        // The snackbar text must contain the localized failure prefix.
+        const publishFailureMessage = 'Failed to publish updated event';
         expect(
-          find.textContaining('Failed to update video'),
+          find.textContaining(
+            l10n.shareMenuFailedToUpdateVideo(
+              'Exception: $publishFailureMessage',
+            ),
+          ),
           findsOneWidget,
         );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Audit all call sites from PR #4093 that still collapsed typed publish results back to a binary is/is! PublishSuccess check. Replace each with an exhaustive switch so logging and error messages can distinguish no-relay-connectivity from a genuine send failure.

Affected files:
- account_deletion_service: NIP-62 and batch NIP-09 publishes
- push_notification_service: registration, deregistration, preferences
- content_reporting_service: NIP-56 report publish
- dm_repository: NIP-04 fallback send path
- share_video_menu: metadata edit publish
- video_sharing_service: NIP-04 share send


<!--- Describe your changes in detail -->

**Related Issue:** Closes #4100

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore