### PR TITLE
fix(video-interactions): always fetch relay like count on video open

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -155,12 +155,15 @@ class VideoInteractionsBloc
           ? _repostsRepository.getRepostCount(_addressableId)
           : _repostsRepository.getRepostCountByEventId(_eventId);
 
-      final likeCountFuture = state.likeCount != null
-          ? Future.value(state.likeCount)
-          : _likesRepository.getLikeCount(
-              _eventId,
-              addressableId: _addressableId,
-            );
+      // Always fetch a fresh count from relay. When initialLikeCount was
+      // seeded from Funnelcake REST (e.g. notification tap), the cached REST
+      // value may lag behind real-time relay data and show a stale (lower)
+      // count. The initial state already shows the seeded value immediately;
+      // this round-trip updates it to the accurate relay count once it arrives.
+      final likeCountFuture = _likesRepository.getLikeCount(
+        _eventId,
+        addressableId: _addressableId,
+      );
 
       final results = await Future.wait([
         likeCountFuture,

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -92,9 +92,9 @@ class VideoInteractionsBloc
           if (isLiked == state.isLiked) return state;
 
           // Sync like status only — count is owned by _onLikeToggled.
-          // External sources (cross-device sync via the repo's reaction
-          // subscription) can flip isLiked here, but likeCount is left
-          // alone; cross-device count drift is tracked as a follow-up.
+          // This stream conveys membership of the liked set, not an
+          // authoritative count snapshot, so external flips update
+          // isLiked here without rewriting likeCount.
           return state.copyWith(isLiked: isLiked);
         },
       ),

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -165,6 +165,63 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // Companion to the non-addressable case above: production notification
+        // taps for Kind 34236 videos pass both eventId and addressableId to
+        // getLikeCount(), so the relay query must still fire even when the
+        // count was pre-seeded and an addressableId is present.
+        'always fetches relay like count when seeded with initialLikeCount '
+        'and addressableId',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 75);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 3);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 2);
+        },
+        build: () => createBloc(
+          addressableId: testAddressableId,
+          initialLikeCount: 50,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 50,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 75, // Updated to relay count, not the stale REST seed.
+            repostCount: 2,
+            commentCount: 3,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
         'emits [loading, success] when video is not liked',
         setUp: () {
           when(

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -120,11 +120,21 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'skips relay like count query when seeded with initialLikeCount',
+        // Regression for #4159: the relay must always be queried for a fresh
+        // count even when initialLikeCount was seeded from the Funnelcake REST
+        // API (e.g. notification tap). REST counts are indexed asynchronously
+        // and may lag behind real-time relay data, causing the like count to
+        // appear stale until the user navigates away and back.
+        'always fetches relay like count even when seeded with initialLikeCount',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
           ).thenAnswer((_) async => true);
+          // Relay returns a higher count than the seeded REST value, simulating
+          // the common case where new likes arrived after the REST snapshot.
+          when(
+            () => mockLikesRepository.getLikeCount(testEventId),
+          ).thenAnswer((_) async => 120);
           when(
             () => mockCommentsRepository.getCommentsCount(testEventId),
           ).thenAnswer((_) async => 10);
@@ -142,19 +152,15 @@ void main() {
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isLiked: true,
-            likeCount: 100,
+            likeCount: 120, // Updated to relay count, not the stale REST seed.
             repostCount: 5,
             commentCount: 10,
           ),
         ],
         verify: (_) {
-          verifyNever(() => mockLikesRepository.getLikeCount(any()));
-          verifyNever(
-            () => mockLikesRepository.getLikeCount(
-              any(),
-              addressableId: any(named: 'addressableId'),
-            ),
-          );
+          verify(
+            () => mockLikesRepository.getLikeCount(testEventId),
+          ).called(1);
         },
       );
 
@@ -356,6 +362,13 @@ void main() {
           when(
             () => mockLikesRepository.isLiked(testEventId),
           ).thenAnswer((_) async => false);
+          // getLikeCount is now always queried (relay-fresh path). Return the
+          // same value as the seed so the mid-fetch optimistic-toggle
+          // arithmetic remains identical and the test stays focused on the
+          // toggle-during-fetch race, not count reconciliation.
+          when(
+            () => mockLikesRepository.getLikeCount(testEventId),
+          ).thenAnswer((_) async => 10);
           // Hold the fetch open until the test explicitly releases it so
           // the tap deterministically lands between the loading emit and
           // the success emit. Fixed delays were flaky on CI.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
When a video was opened from a like notification, the like count was seeded from the Funnelcake REST API via initialLikeCount. The VideoInteractionsBloc short-circuited the relay query when state.likeCount was already set, so the displayed count was frozen at the (often stale) REST value — causing the count to appear lower than what the user sees when browsing the home feed, which always queries the relay directly.

Remove the state.likeCount != null guard so getLikeCount() is always called against the relay. The seeded REST value is still shown immediately as an optimistic display; the relay round-trip updates it to the accurate count once it returns.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4159

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore