### PR TITLE
fix(security): redact email PII from auth-flow logs (#4254)

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -9,6 +9,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
 import 'package:openvine/utils/invite_error_utils.dart';
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -272,7 +273,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
 
     if (result.verificationRequired && result.deviceCode != null) {
       Log.info(
-        'Email verification required for $email',
+        'Email verification required for ${redactEmailForLogs(email)}',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
@@ -385,7 +386,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
   /// Send password reset email
   Future<void> sendPasswordResetEmail(String email) async {
     Log.info(
-      'Sending password reset email to $email',
+      'Sending password reset email to ${redactEmailForLogs(email)}',
       name: 'DivineAuthCubit',
       category: LogCategory.auth,
     );

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -10,6 +10,7 @@ import 'package:invite_api_client/invite_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/invite_error_utils.dart';
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'email_verification_state.dart';
@@ -72,7 +73,7 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
     String? inviteCode,
   }) {
     Log.info(
-      'startPolling called for $email '
+      'startPolling called for ${redactEmailForLogs(email)} '
       '(cubit=$hashCode, authSvc=${_authService.hashCode}, '
       'hasExistingTimer=${_pollTimer != null})',
       name: 'EmailVerificationCubit',

--- a/mobile/lib/observability/reportable_error.dart
+++ b/mobile/lib/observability/reportable_error.dart
@@ -83,6 +83,7 @@ String sanitizeForCrashReport(String input) {
       .replaceAll(_nsecPattern, 'nsec1<redacted>')
       .replaceAllMapped(
         _emailPattern,
+        // Reuse the log helper here so both redaction surfaces stay aligned.
         (match) => redactEmailForLogs(match.group(0)!),
       );
 }

--- a/mobile/lib/observability/reportable_error.dart
+++ b/mobile/lib/observability/reportable_error.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Marker interface + wrapper + PII sanitizer used to gate Bloc errors
 // ABOUTME: forwarded to Crashlytics. See .claude/rules/error_handling.md.
 
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
+
 /// Marker interface signalling that an error is worth reporting to Crashlytics.
 ///
 /// Errors that flow through `addError(error, st)` only reach the crash reporter
@@ -72,16 +74,15 @@ final RegExp _emailPattern = RegExp(
 ///   event/profile pointers, not secrets, and removing them removes triage
 ///   value. Call sites that need to redact those should do so explicitly
 ///   before constructing the error message.
-/// - Email: any RFC-5321-ish local@host.tld pattern. Replaced with a
-///   first-char-preserving partial mask so domain-level correlation survives.
+/// - Email: any RFC-5321-ish local@host.tld pattern. Replacement delegates to
+///   [redactEmailForLogs] so log redaction and crash-report redaction stay in
+///   lockstep.
 String sanitizeForCrashReport(String input) {
   return input
       .replaceAll(_npubPattern, 'npub1<redacted>')
       .replaceAll(_nsecPattern, 'nsec1<redacted>')
-      .replaceAllMapped(_emailPattern, (match) {
-        final email = match.group(0)!;
-        final atIndex = email.indexOf('@');
-        // _emailPattern guarantees atIndex > 0 and a domain follows.
-        return '${email.substring(0, 1)}***@${email.substring(atIndex + 1)}';
-      });
+      .replaceAllMapped(
+        _emailPattern,
+        (match) => redactEmailForLogs(match.group(0)!),
+      );
 }

--- a/mobile/lib/observability/reportable_error.dart
+++ b/mobile/lib/observability/reportable_error.dart
@@ -56,17 +56,32 @@ final class Reportable<T extends Object> implements ReportableError {
 
 final RegExp _npubPattern = RegExp('npub1[a-z0-9]+');
 final RegExp _nsecPattern = RegExp('nsec1[a-z0-9]+');
+// Conservative email matcher: local-part of common chars then `@`, host with
+// at least one `.`. Intentionally narrower than RFC 5322 — false negatives on
+// exotic addresses are preferable to false positives on non-email strings.
+final RegExp _emailPattern = RegExp(
+  r'[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}',
+);
 
-/// Strips Nostr `npub1…` and `nsec1…` identifiers from [input] before it is
-/// forwarded to a third-party crash reporter.
+/// Strips Nostr `npub1…` / `nsec1…` identifiers and email addresses from
+/// [input] before it is forwarded to a third-party crash reporter.
 ///
-/// Scope is intentionally narrow: only `npub` (public-key bech32) and `nsec`
-/// (private-key bech32). Other Nostr-format references (`note1`, `nevent1`,
-/// `nprofile1`) encode event/profile pointers, not secrets, and removing them
-/// removes triage value. Call sites that need to redact those should do so
-/// explicitly before constructing the error message.
+/// Scope is intentionally narrow:
+/// - Nostr: only `npub` (public-key bech32) and `nsec` (private-key bech32).
+///   Other Nostr-format references (`note1`, `nevent1`, `nprofile1`) encode
+///   event/profile pointers, not secrets, and removing them removes triage
+///   value. Call sites that need to redact those should do so explicitly
+///   before constructing the error message.
+/// - Email: any RFC-5321-ish local@host.tld pattern. Replaced with a
+///   first-char-preserving partial mask so domain-level correlation survives.
 String sanitizeForCrashReport(String input) {
   return input
       .replaceAll(_npubPattern, 'npub1<redacted>')
-      .replaceAll(_nsecPattern, 'nsec1<redacted>');
+      .replaceAll(_nsecPattern, 'nsec1<redacted>')
+      .replaceAllMapped(_emailPattern, (match) {
+        final email = match.group(0)!;
+        final atIndex = email.indexOf('@');
+        // _emailPattern guarantees atIndex > 0 and a domain follows.
+        return '${email.substring(0, 1)}***@${email.substring(atIndex + 1)}';
+      });
 }

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -24,6 +24,7 @@ import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -150,7 +151,8 @@ class _EmailVerificationScreenState
 
     if (pending != null) {
       Log.info(
-        'Found persisted verification data for ${pending.email}, '
+        'Found persisted verification data for '
+        '${redactEmailForLogs(pending.email)}, '
         'attempting auto-login flow',
         name: 'EmailVerificationScreen',
         category: LogCategory.auth,

--- a/mobile/lib/services/pending_verification_service.dart
+++ b/mobile/lib/services/pending_verification_service.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Enables auto-login when app is cold-started via email verification deep link
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Data class representing pending email verification credentials
@@ -65,7 +66,7 @@ class PendingVerificationService {
         _storage.write(key: _keyInviteCode, value: inviteCode),
       ]);
       Log.info(
-        'Saved pending verification for $email',
+        'Saved pending verification for ${redactEmailForLogs(email)}',
         name: 'PendingVerificationService',
         category: LogCategory.auth,
       );
@@ -121,7 +122,8 @@ class PendingVerificationService {
       // Check expiration
       if (pending.isExpired) {
         Log.info(
-          'Pending verification for $email has expired, clearing',
+          'Pending verification for ${redactEmailForLogs(email)} has expired, '
+          'clearing',
           name: 'PendingVerificationService',
           category: LogCategory.auth,
         );
@@ -130,7 +132,7 @@ class PendingVerificationService {
       }
 
       Log.info(
-        'Loaded pending verification for $email',
+        'Loaded pending verification for ${redactEmailForLogs(email)}',
         name: 'PendingVerificationService',
         category: LogCategory.auth,
       );

--- a/mobile/lib/utils/sensitive_uri_for_logs.dart
+++ b/mobile/lib/utils/sensitive_uri_for_logs.dart
@@ -1,5 +1,7 @@
-// ABOUTME: Redacts secrets from URIs before writing them to diagnostic logs.
-// ABOUTME: Preserves schemes, hosts, paths, and Nostr path segments unchanged except /invite/code.
+// ABOUTME: Redacts secrets and PII from URIs and free-form text before
+// ABOUTME: writing them to diagnostic logs (URIs, email addresses, Nostr keys
+// ABOUTME: are handled here; Nostr key stripping for crash reports lives in
+// ABOUTME: lib/observability/reportable_error.dart).
 
 /// Placeholder for secrets in free-form log text or HTTP headers.
 const redactedSensitiveLogPlaceholder = '[REDACTED]';
@@ -57,4 +59,29 @@ String redactUriStringForLogs(String uriString) {
     out = '/$out';
   }
   return out;
+}
+
+/// Returns an email address safe for diagnostic logs.
+///
+/// - `user@example.com` → `u***@example.com`
+/// - `a@b.co`           → `a***@b.co`   (single-char local-part still gets
+///                                       a fixed-width mask so the original
+///                                       length is not leaked)
+/// - empty input or input missing `@` or with no `.` in the domain →
+///   [redactedSensitiveLogPlaceholder]
+///
+/// The domain is preserved verbatim so ops can correlate failure patterns
+/// across the same provider (e.g. "all gmail.com users are timing out")
+/// without identifying individual accounts. Local-part collapses to a
+/// fixed 4-character mask (`x***`) regardless of length.
+String redactEmailForLogs(String email) {
+  if (email.isEmpty) return redactedSensitiveLogPlaceholder;
+  final atIndex = email.indexOf('@');
+  // No `@`, or `@` at position 0 (empty local-part) → not a usable email.
+  if (atIndex <= 0) return redactedSensitiveLogPlaceholder;
+  final domain = email.substring(atIndex + 1);
+  // Domain must contain at least one `.` to be a routable host.
+  if (!domain.contains('.')) return redactedSensitiveLogPlaceholder;
+  final firstChar = email.substring(0, 1);
+  return '$firstChar***@$domain';
 }

--- a/mobile/test/observability/reportable_error_test.dart
+++ b/mobile/test/observability/reportable_error_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 
 void main() {
   group(Reportable, () {
@@ -152,6 +153,15 @@ void main() {
       expect(
         sanitizeForCrashReport(input),
         contains('@gmail.com'),
+      );
+    });
+
+    test('uses the shared email redactor so masking stays aligned', () {
+      const email = 'first.last+tag@example.com';
+
+      expect(
+        sanitizeForCrashReport('auth failed for $email'),
+        'auth failed for ${redactEmailForLogs(email)}',
       );
     });
   });

--- a/mobile/test/observability/reportable_error_test.dart
+++ b/mobile/test/observability/reportable_error_test.dart
@@ -160,6 +160,7 @@ void main() {
       const email = 'first.last+tag@example.com';
 
       expect(
+        // This locks the crash-report fallback to the same mask shape as logs.
         sanitizeForCrashReport('auth failed for $email'),
         'auth failed for ${redactEmailForLogs(email)}',
       );

--- a/mobile/test/observability/reportable_error_test.dart
+++ b/mobile/test/observability/reportable_error_test.dart
@@ -111,5 +111,48 @@ void main() {
 
       expect(sanitizeForCrashReport(input), equals(input));
     });
+
+    // Issue #4254 — emails are PII and must not flow to Crashlytics.
+    test('replaces an email with the first-char + domain mask', () {
+      const input = 'verification failed for user@example.com after 3 retries';
+
+      expect(
+        sanitizeForCrashReport(input),
+        'verification failed for u***@example.com after 3 retries',
+      );
+    });
+
+    test('replaces multiple emails in the same string', () {
+      const input = 'forwarded alice@a.com to bob@b.io';
+      final out = sanitizeForCrashReport(input);
+
+      expect(out, contains('a***@a.com'));
+      expect(out, contains('b***@b.io'));
+      expect(out, isNot(contains('alice')));
+      expect(out, isNot(contains('bob')));
+    });
+
+    test('strips email PII alongside npub / nsec in one pass', () {
+      const input =
+          'user@example.com leaked nsec1qwertyuiopasdfghjklzxcvbnm0123456789ab '
+          'tied to npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnop';
+      final out = sanitizeForCrashReport(input);
+
+      expect(out, contains('u***@example.com'));
+      expect(out, contains('nsec1<redacted>'));
+      expect(out, contains('npub1<redacted>'));
+      expect(out, isNot(contains('user@example.com')));
+    });
+
+    test('preserves the domain so ops can correlate failure patterns', () {
+      // The whole point of partial (not opaque) redaction: ops can spot
+      // "all gmail.com users are failing" without identifying anyone.
+      const input = 'auth failed for alice@gmail.com';
+
+      expect(
+        sanitizeForCrashReport(input),
+        contains('@gmail.com'),
+      );
+    });
   });
 }

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
@@ -388,6 +389,55 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(() => mockCubit.stopPolling()).called(greaterThan(0));
+      });
+
+      testWidgets('redacts persisted pending email in auto-login logs', (
+        tester,
+      ) async {
+        await LogCaptureService().clearAllLogs();
+        when(() => mockPendingVerification.load()).thenAnswer(
+          (_) async => PendingVerification(
+            deviceCode: 'persisted-device-code',
+            verifier: 'persisted-verifier',
+            email: 'user@example.com',
+            createdAt: DateTime(2026),
+          ),
+        );
+        when(
+          () => mockOAuth.verifyEmail(token: any(named: 'token')),
+        ).thenAnswer((_) async => VerifyEmailResult(success: true));
+        when(
+          () => mockCubit.startPolling(
+            deviceCode: any(named: 'deviceCode'),
+            verifier: any(named: 'verifier'),
+            email: any(named: 'email'),
+            inviteCode: any(named: 'inviteCode'),
+          ),
+        ).thenReturn(null);
+
+        await tester.pumpWidget(createTestWidget(token: 'persisted-token'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+
+        final logMessage = LogCaptureService()
+            .getRecentLogs()
+            .map((entry) => entry.message)
+            .lastWhere(
+              (message) =>
+                  message.startsWith('Found persisted verification data for '),
+            );
+
+        expect(logMessage, contains('u***@example.com'));
+        expect(logMessage, isNot(contains('user@example.com')));
+        verify(() => mockOAuth.verifyEmail(token: 'persisted-token')).called(1);
+        verify(
+          () => mockCubit.startPolling(
+            deviceCode: 'persisted-device-code',
+            verifier: 'persisted-verifier',
+            email: 'user@example.com',
+            inviteCode: null,
+          ),
+        ).called(1);
       });
 
       testWidgets(

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -435,7 +435,6 @@ void main() {
             deviceCode: 'persisted-device-code',
             verifier: 'persisted-verifier',
             email: 'user@example.com',
-            inviteCode: null,
           ),
         ).called(1);
       });

--- a/mobile/test/unit/utils/sensitive_uri_for_logs_test.dart
+++ b/mobile/test/unit/utils/sensitive_uri_for_logs_test.dart
@@ -122,4 +122,69 @@ void main() {
       expect(out, contains('code=$redactedUriComponentForLogs'));
     });
   });
+
+  /// Issue #4254 — redact email PII from auth-flow logs.
+  group('redactEmailForLogs', () {
+    test('partial-redacts a standard email, preserves domain', () {
+      expect(
+        redactEmailForLogs('user@example.com'),
+        equals('u***@example.com'),
+      );
+    });
+
+    test('partial-redacts a single-character local-part', () {
+      // Even one-char local-parts get the fixed `x***` mask — the original
+      // length must not be leaked.
+      expect(redactEmailForLogs('a@b.co'), equals('a***@b.co'));
+    });
+
+    test('preserves subdomains in the domain part', () {
+      expect(
+        redactEmailForLogs('alice@mail.corp.example.com'),
+        equals('a***@mail.corp.example.com'),
+      );
+    });
+
+    test('hides the full local-part even when it is long', () {
+      final out = redactEmailForLogs('first.last+tag@example.com');
+      expect(out, equals('f***@example.com'));
+      expect(out, isNot(contains('first')));
+      expect(out, isNot(contains('last')));
+      expect(out, isNot(contains('tag')));
+    });
+
+    test('returns the opaque placeholder for empty input', () {
+      expect(redactEmailForLogs(''), equals(redactedSensitiveLogPlaceholder));
+    });
+
+    test('returns the opaque placeholder for input without `@`', () {
+      expect(
+        redactEmailForLogs('not-an-email'),
+        equals(redactedSensitiveLogPlaceholder),
+      );
+    });
+
+    test('returns the opaque placeholder for empty local-part', () {
+      expect(
+        redactEmailForLogs('@example.com'),
+        equals(redactedSensitiveLogPlaceholder),
+      );
+    });
+
+    test('returns the opaque placeholder for a domain without a dot', () {
+      // `a@b` (no TLD) is not a routable host — fail closed.
+      expect(
+        redactEmailForLogs('a@b'),
+        equals(redactedSensitiveLogPlaceholder),
+      );
+    });
+
+    test('returns the opaque placeholder for whitespace-only input', () {
+      // No `@` → treated like any other malformed input.
+      expect(
+        redactEmailForLogs('   '),
+        equals(redactedSensitiveLogPlaceholder),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Description

Systematic redaction of email PII from auth-flow logs. Flagged in #3784's review ([point 4](https://github.com/divinevideo/divine-mobile/pull/3784#issuecomment-4419836344)) but kept out of the emergency-security scope of that PR; this PR is the dedicated follow-up.

Audit of `origin/main` found **7 sites** that log email at info/warning level across `PendingVerificationService`, `DivineAuthCubit`, `EmailVerificationCubit`, and `EmailVerificationScreen`. Redacting only the one line Rabble flagged would create inconsistency without security benefit; this PR addresses all 7 sites via a single helper plus a broadened Crashlytics sanitizer.

**Related Issue:** Closes #4254

## What's in this PR

| File | Change |
|------|--------|
| `mobile/lib/utils/sensitive_uri_for_logs.dart` | New `redactEmailForLogs(String)` helper (Option B — partial-redact, preserves domain) |
| `mobile/lib/observability/reportable_error.dart` | Broaden `sanitizeForCrashReport` to strip emails alongside npub/nsec |
| `mobile/lib/services/pending_verification_service.dart` | Wrap 3 log call sites (save / expired / loaded) |
| `mobile/lib/blocs/divine_auth/divine_auth_cubit.dart` | Wrap 2 log call sites (verification-required / password-reset) |
| `mobile/lib/blocs/email_verification/email_verification_cubit.dart` | Wrap 1 log call site (startPolling) |
| `mobile/lib/screens/auth/email_verification_screen.dart` | Wrap 1 log call site (persisted auto-login path) |
| `mobile/test/unit/utils/sensitive_uri_for_logs_test.dart` | +9 cases for the new helper |
| `mobile/test/observability/reportable_error_test.dart` | +4 cases for email stripping in the Crashlytics path |
| `mobile/test/screens/auth/email_verification_screen_test.dart` | Regression test for persisted auto-login log redaction |

## Redaction strategy

Chose **Option B — partial** over **Option A — opaque** (`[REDACTED]`):

```text
user@example.com   → u***@example.com
alice@gmail.com    → a***@gmail.com
first.last+tag@x.y → f***@x.y
```

Rationale: preserves the domain so ops can spot patterns like "all gmail.com users are failing" without identifying individual accounts. Local-part collapses to a fixed-width `x***` mask regardless of length so original length isn't leaked.

Empty / malformed input (no `@`, empty local-part, domain without `.`) falls back to the existing `redactedSensitiveLogPlaceholder` (`[REDACTED]`).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Coordination with #3784

#3784 (still open at time of writing) adds one overlapping auth-log site on top of the 7 handled here:

- `pending_verification_service.dart:118` (post-#3784) — the legacy-nsec migration warning.

Whichever PR merges second will need a tiny rebase to wrap that site too. There is no functional dependency between the two PRs; they only overlap in the same service.

## Test plan

- [x] `flutter analyze lib test integration_test` — no issues
- [x] `flutter test test/unit/utils/sensitive_uri_for_logs_test.dart` — 20/20 (9 new + 11 existing)
- [x] `flutter test test/observability/reportable_error_test.dart` — 17/17 (4 new + 13 existing)
- [x] `flutter test test/blocs/divine_auth/ test/blocs/email_verification/ test/services/email_verification_listener_test.dart` — 96/96 (regression on the originally wrapped auth-log sites)
- [x] `flutter test test/screens/auth/email_verification_screen_test.dart` — 16/16 (regression on the persisted auto-login log path)
- [x] Manual: verified the helper output for the documented shapes in unit tests

## Follow-ups (not in this PR)

- Optional CI guard mirroring `grep_for_nsec_payload.sh` to flag any new `Log\.(info|debug|warning|error).*email` patterns that bypass the helper.
- Other PII (phone numbers, full names) in logs — out of scope for this issue; file separately if discovered.
