### PR TITLE
fix(collabs): make recipient accept/ignore observable in feed/metadata

### DIFF
--- a/mobile/docs/brainstorm/2026-05-11-issue4192-collab-accept-ignore-no-op-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-11-issue4192-collab-accept-ignore-no-op-brainstorm.md
@@ -1,0 +1,383 @@
+# Brainstorm: Collaborator accept/ignore actions have no effect (#4192)
+
+Date: 2026-05-11 (v2 — re-run after end-to-end code verification)
+
+## Problem Statement
+
+When the inviter posts a video with collaborators, mobile writes
+`['p', pubkey, relay, 'collaborator']` tags onto the kind-34236 event eagerly
+on initial publish (`video_event_publisher.dart:835`) and on edit-republish
+(`share_video_menu.dart:1567`). Every render surface — `CollaboratorAvatarRow`
+in the feed item (`video_feed_item.dart:1699-1702`), `MetadataCollaboratorsSection`
+in the expanded sheet (`metadata_user_chips.dart:36-60`) — reads
+`video.collaboratorPubkeys` directly from the parsed event tags
+(`video_event.dart:436-445`). When the recipient taps Accept,
+`CollaboratorResponseService.acceptInvite` publishes a kind-34238 event with
+`['status', 'accepted']` (`collaborator_response_service.dart:54-87`), but
+**no mobile code anywhere subscribes to, parses, or reads kind-34238** —
+verified at confidence 1.00 by grepping every `.dart` file in `mobile/lib`
+and `mobile/packages`: exactly one non-test occurrence of `34238`, the
+constant definition itself. When the recipient taps Ignore, the local
+invite store transitions to `ignored` (`collaborator_invite_actions_cubit.dart:89-98`),
+but the local store has only one read consumer in the entire codebase:
+the same DM card that wrote it. The visible result: Accept and Ignore
+both produce only the literal "Accepted" / "Ignored" status text inside
+the DM card; the video itself, the inviter's view, every third party's
+view, and the recipient's own collabs tab are all unchanged.
+
+## Constraints
+
+- Layered architecture: UI → BLoC → Repository → Client. Source-selection
+  and fallback logic belong in the repository layer
+  (`.claude/rules/architecture.md`).
+- BLoC-first for new state management; Riverpod legacy only.
+- Dark mode; `VineTheme` and `divine_ui`.
+- The Nostr protocol shape is *intentionally settled* on kind-34238 by
+  PR #4045 (merged 2026-05-06 — three days before #4192 was filed).
+  PR #4040 (the same day, 8 hours earlier) tried the video-copy
+  approach and was reverted. The team's verified preference is
+  kind-34238 + spec-aligned semantics.
+- Two-repo lifecycle plan exists:
+  `docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md` — 18
+  tasks, Funnelcake-first. #4192 is item 1 ("accept/ignore action
+  correctness") of parent epic #4201's execution order.
+- Engineering standard from #4192: "Fix the problem without adding
+  new technical debt. If the touched path already has known audit or
+  refactor debt, repay the relevant portion as part of the
+  implementation."
+- Memory: never stack PRs; PR title must be conventional-commit;
+  rebase onto fresh `origin/main` before push.
+
+## Prior Art (verified)
+
+- **Spec**:
+  `docs/superpowers/specs/2026-04-25-collab-invite-acceptance-design.md`
+  defines pending vs confirmed semantics. §"Protocol Shape" intends
+  pending collaborators to be on the latest creator-authored video
+  event with role `Collaborator`; confirmation derives from
+  (creator tag) ∧ (kind-34238 acceptance) ∧ Funnelcake current-state
+  edge.
+- **Lifecycle plan**:
+  `docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md` —
+  Funnelcake Tasks 1–6 ship the `video_collaborators_current_data`
+  read model; Mobile Tasks 15–17 flip the read paths.
+- **Already shipped in mobile** (verified by reading each file):
+  - `collaborator_response_service.dart` — kind-34238 publish.
+  - `collaborator_invite_actions_cubit.dart` — accept (publish +
+    local-store) and ignore (local-store only).
+  - `collaborator_invite_card.dart` — only consumer of the local
+    invite store.
+  - `funnelcake_api_client.dart:739` `getCollabVideos` — confirmed-
+    edges contract on the mobile side; consumed only by
+    `profile_collab_videos_bloc.dart` (2 call sites).
+  - `share_video_menu.dart:1565-1633` — post-publish add re-publishes
+    kind-34236 with collaborator p-tag and sends NIP-17 invite.
+- **Recent git history that matters** (full `git log --oneline`
+  verified):
+  - #3373 → #3559/#3566 → #3683 → #3686 → #3845 → #3888 (model
+    requires the role marker) → #4040 (video-copy approach) →
+    **#4045 (reverted to kind-34238)** → #4093 (publish-result
+    refactor). The protocol path has settled on kind-34238 with
+    explicit intent.
+
+## Reframe given verified context
+
+The earlier brainstorm reasoned about three competing approaches
+without verifying which protocol path the team actually chose three
+days before the bug was filed. With the #4040 → #4045 sequence in
+hand, two things are now clear:
+
+1. The team **explicitly rejected** the "publish a video copy on
+   accept" approach (#4040) and chose kind-34238 with read-side
+   confirmation TBD. Any new approach that re-proposes the video-
+   copy semantics needs to address why #4045 reverted it.
+2. The bug is **not** that the protocol is wrong. The bug is that
+   the read side of the chosen protocol is empty. The fix is to
+   add the missing read side, not to change the wire format.
+
+This narrows the design space considerably.
+
+## Approaches Explored
+
+### Approach A — Wire confirmed-status into every render site (full read-side)
+
+**Description.** New mobile-only read path: subscribe to kind-34238
+events from the relay for every video address currently rendered or
+addressed by an open BLoC, dedup by `(videoAddress, collaboratorPubkey)`,
+verify against the latest creator-authored kind-34236 tags, and
+expose per-video `Map<String, CollaboratorStatus>`. Every render site
+(`CollaboratorAvatarRow`, `MetadataCollaboratorsSection`, the share
+sheet edit dialog) consumes the map and shows only confirmed
+collaborators; the inviter sees a pending decoration for unaccepted
+entries on their own video.
+
+**Layers affected:** Client (new relay subscription); Repository (new
+package `collaborator_repository`); BLoC (new
+`VideoCollaboratorStatusCubit`); UI (three render sites + edit dialog).
+
+**Pros:**
+
+- Covers items 1, 2, and 3 of epic #4201 acceptance criteria
+  ("accept/ignore correctness"; "confirmed collaborator state
+  consistency"; "profile/feed rendering correctness") with one
+  shipped PR.
+- Aligns with #4045's settled protocol.
+- Composable with the lifecycle plan: the new repository can later
+  swap from "relay subscription" to "Funnelcake confirmed-edges
+  endpoint" without touching cubits or UI.
+
+**Cons:**
+
+- Largest scope. Relay traffic scales linearly with visible-video
+  count; needs ref-counted subscription dedup, viewport-aware
+  unsubscribe, and TTL caching to stay sane on hot feeds.
+- Changes third-party viewer behavior (hides pending collaborator
+  avatars from non-author / non-collaborator viewers). That's a
+  visible regression vs today, even if it's product-correct. Needs
+  product sign-off.
+- The "verify against latest kind-34236" cross-check requires
+  mobile to track the creator-authored event for each video, which
+  is what `VideoEventService` already does — but plumbing the join
+  to the kind-34238 stream is non-trivial.
+
+**Risks / Unknowns:**
+
+- Is the visible regression for third-party viewers acceptable, or
+  do we keep current behavior for them and only fix
+  inviter/recipient visibility?
+- Performance impact on cold start when the home feed renders 30+
+  videos that each have a collaborator (each adds a subscription).
+
+**Complexity:** High.
+
+### Approach B — Defer the `'collaborator'` p-tag until acceptance
+
+**Description.** Drop the role tag from initial publish. Mobile
+subscribes to kind-34238 for own-authored videos; on acceptance,
+re-publish the replaceable kind-34236 with the now-confirmed
+collaborator added.
+
+**Eliminated.** The spec §"Protocol Shape" explicitly commits to
+"pending collaborators are represented on the latest creator-
+authored video event with role `Collaborator`." Re-publishing the
+replaceable event on every acceptance is exactly the race that
+#3705 is filed for ("Transient duplicate video on own profile
+during collab accept via Connect"); making it worse before #3705
+is fixed is unacceptable. Also breaks interop with Connect, which
+already follows the current shape.
+
+**Complexity:** High; rejected on correctness.
+
+### Approach C — UI-honesty cosmetic patch
+
+**Description.** Keep behavior; rename Accept/Ignore to
+"Acknowledge"/"Hide"; clarify in copy that the collaboration is
+attached on publish and the recipient's role is to acknowledge.
+
+**Eliminated.** Issue body explicitly cites the engineering
+standard "Fix the problem without adding new technical debt …
+repay the relevant portion as part of the implementation."
+Acknowledging the bug in copy does not satisfy "fix"; the parent
+epic's item 1 ("recipient accept/ignore works reliably") is not
+met.
+
+**Complexity:** Low; rejected on scope-vs-standard mismatch.
+
+### Approach D — Wait for the full two-repo lifecycle
+
+**Description.** Block #4192 on `docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md`
+Tasks 1–6 (Funnelcake) and 15–17 (mobile read flip).
+
+**Eliminated.** Two-repo coordination, slow, scope-creep, and
+duplicates the existing plan rather than executing on #4192. The
+mobile half of the read fix can be shipped first using a relay
+subscription and *later* swap data sources to Funnelcake without
+touching consumers (this is Approach A's composability story).
+
+**Complexity:** High; rejected on scope.
+
+### Approach E — Revive #4040 (kind-34236 video copy on accept)
+
+**Description.** Re-introduce the video-copy protocol that #4040
+shipped briefly. Accept publishes a kind-34236 authored by the
+accepter referencing the source video. Read side becomes trivially
+"is there a video copy from this collaborator?".
+
+**Eliminated.** The team reverted this approach in #4045 eight
+hours later on the same day. Without a documented reason for
+revisiting the decision, a new PR proposing it again would
+re-litigate a decision the area DRI (`@rabble`) just made. If the
+revert reason was specifically "no read side yet" we could revisit,
+but: #4045's PR body says "Stop copying the source video event
+under the collaborator pubkey" — i.e., the conflation between
+"collaborator" and "author of a copy" was the issue, not the read
+side.
+
+**Complexity:** Medium; rejected on social grounds.
+
+### Approach F — Scope to inviter + recipient observability (narrow read side)
+
+**Description.** Same architectural shape as Approach A —
+subscribe to kind-34238, expose per-video confirmed status — but
+narrower scope:
+
+- **Mobile subscribes** to kind-34238 events filtered to videos
+  authored by the current user **only** (one subscription per
+  own-authored video with collab p-tags). This bounds traffic to
+  N = own-videos-with-collabs, which is small.
+- **Inviter side render**: on the inviter's own videos
+  (in their home feed, their profile feed, the metadata sheet,
+  the share edit dialog), show "pending" decoration for tagged-
+  but-not-accepted collaborators; full avatar/chip for confirmed
+  collaborators. After a recipient accepts, the relay echo flips
+  the avatar from pending to confirmed within seconds —
+  observable end-to-end.
+- **Recipient side render**: the local invite store
+  (`accepted`/`ignored`) is consulted for the *current user as
+  collaborator on this video*. When the current user is rendered
+  in `CollaboratorAvatarRow` and their local store says
+  `ignored`, hide their own avatar from their own view of the
+  video; when `accepted` or `pending`, show normally. Ignore now
+  has a visible effect: the recipient stops seeing their own
+  avatar on the video.
+- **Third-party viewers**: unchanged. They continue to see raw
+  collaborator p-tags as today. The wider product-correct fix
+  (hide pending from third parties) defers to the lifecycle
+  plan / #4201's broader acceptance criteria.
+
+**Layers affected:** Client (kind-34238 subscription, scoped);
+new Repository package `collaborator_repository`; BLoC
+(`VideoCollaboratorStatusCubit`); UI (`CollaboratorAvatarRow`,
+`MetadataCollaboratorsSection`, share sheet edit dialog).
+
+**Pros:**
+
+- **Targets exactly the bug as filed.** "Accept and ignore actions
+  have no effect" — after this PR, both actions have visible,
+  testable, end-to-end effects:
+  - Accept → inviter's avatar flips from pending to confirmed.
+  - Ignore → recipient's own avatar disappears from their own view.
+- **Bounded relay traffic.** Subscription scope is "own-authored
+  videos with collab p-tags" — orders of magnitude smaller than
+  Approach A's "every visible video".
+- **No third-party regression.** Anyone outside the inviter/
+  recipient pair sees the same thing they see today. Avoids the
+  product-sign-off blocker.
+- **Composable with the lifecycle plan.** The repository's
+  source can later swap from relay to Funnelcake without touching
+  cubit or UI; the third-party render flip becomes a one-line
+  feature flag in the cubit once Funnelcake is ready.
+- **Repays the touched-path debt.** The hardcoded English in
+  `metadata_user_chips.dart:27,49,77,125` ("Creator",
+  "Collaborators", "Inspired by", "Reposted by") sits on the
+  modified file; running an l10n pass on it satisfies the
+  engineering standard's debt-repayment requirement.
+
+**Cons:**
+
+- Item 2 of epic #4201 acceptance ("confirmed collaborator state
+  consistency across DM/UI/REST/relay") is only partially met —
+  third-party REST/relay consistency stays out of scope until the
+  Funnelcake half lands.
+- Inviter-side relay subscription introduces a new always-on
+  consumer per authored video. Need lifecycle ownership (when does
+  the subscription end? when the video is deleted? when the user
+  signs out?).
+
+**Risks / Unknowns:**
+
+- If the inviter has 100s of own videos with collabs, 100s of
+  active subscriptions. Mitigation: subscribe lazily when the
+  inviter renders the metadata sheet or edit dialog for that
+  video; for the home feed, accept the lazy-load gap (avatars
+  appear once the subscription resolves).
+- The cross-check "kind-34238 from a tagged pubkey + creator-side
+  tag still present on latest kind-34236" is mobile-side
+  reproduction of Funnelcake's planned `video_collaborators_current_data`
+  logic. Has to be re-verified on every replaceable update.
+
+**Complexity:** Medium-High.
+
+## Recommendation
+
+**Approach F**, with the explicit understanding that:
+
+- It directly fixes the issue as filed (#4192 = "accept/ignore
+  has no effect" — both gain visible effects for the people
+  performing the action).
+- It defers the third-party rendering question to the lifecycle
+  plan, where it belongs.
+- It is composable with Approach A: if/when product wants the
+  full third-party fix, the same `collaborator_repository`
+  package gains an option to subscribe to kind-34238 for any
+  rendered video, not only own-authored — and the cubit + UI
+  paths are unchanged.
+
+Rationale ranked by weight:
+
+1. **Right-sized to the issue.** The bug title is about
+   accept/ignore actions having no effect. Approach F makes
+   both actions have observable, testable effects end-to-end.
+2. **No social blocker.** Doesn't re-litigate #4045's protocol
+   decision; doesn't require product sign-off on third-party
+   regression.
+3. **Bounded scope.** One PR, one new package, three render
+   sites, one cubit. Reviewable in one sitting.
+4. **Composable.** The same repository becomes the home for
+   the third-party fix later (Approach A extension) and the
+   Funnelcake swap later (lifecycle plan).
+5. **Repays touched-path debt** (l10n in `metadata_user_chips.dart`)
+   per #4192's engineering standard.
+6. **Aligns with `state_management.md`** — the repository
+   carries the source-selection / cross-source join logic; the
+   cubit only exposes state; UI only reads state.
+
+## Open Questions for /plan
+
+- [ ] Subscription lifecycle: does the inviter's
+      kind-34238 subscription start at login (for all
+      own-authored videos with collabs) or lazily when a
+      relevant surface (metadata sheet / edit dialog / their
+      own feed) renders the video? Tradeoff: eagerness costs
+      relay sockets but makes first-render correct;
+      laziness defers the cost but adds a "loading" state.
+- [ ] Repository instance scope: app-wide singleton or
+      per-screen? App-wide is simpler for dedup but couples
+      to auth lifecycle (sign-out must close subscriptions
+      and clear cache).
+- [ ] Should `ignoreInvite` continue to be local-only per
+      spec §"Accept Flow"? (Brainstorm v1 raised this; the
+      verified protocol decision in #4045 means yes — keep
+      ignore local; no kind-34238 with `status: 'ignored'`.)
+- [ ] Inviter-side "(pending)" copy and styling — product
+      decision: greyed avatar, hourglass icon, "Pending"
+      label, hidden entirely? Today the avatar row has no
+      empty/loading state; will need a small design touch.
+- [ ] Scope of l10n pass on `metadata_user_chips.dart`:
+      add the 4 hardcoded English strings ("Creator",
+      "Collaborators", "Inspired by", "Reposted by") to ARB
+      in the same PR? Aligns with the engineering standard
+      but expands scope to a touched-path fix.
+- [ ] Does `share_video_menu.dart`'s edit dialog flow
+      benefit from the same per-pubkey status? The inviter
+      currently can remove a collaborator (republish without
+      the tag) but can't see at a glance which are pending.
+
+## Prerequisites
+
+- [ ] Confirm `nostr_client` exposes a way to subscribe to
+      `kinds: [34238]` with a `#a` filter — verified via
+      `subscribed_list_video_cache.dart:284-291` precedent
+      that does `Filter(kinds: [kind], authors: [pubkey], d: [dTag])`
+      — `#a` filter support is the open question, since
+      kind-34238 uses an `a` tag, not a `d` tag, for the
+      video address.
+- [ ] Decide subscription lifecycle (open question above).
+
+## Next Step
+
+Run `/plan https://github.com/divinevideo/divine-mobile/issues/4192`
+to produce the concrete implementation plan for Approach F. The
+plan should explicitly note: scope is mobile inviter + recipient
+visibility only; third-party rendering parity defers to the
+lifecycle plan and the broader items 2–4 of epic #4201.

--- a/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
@@ -2,7 +2,9 @@
 // ABOUTME: Accept publishes a response; ignore only updates local UX state.
 
 import 'package:bloc/bloc.dart';
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
 import 'package:openvine/services/collaborator_response_service.dart';
@@ -40,14 +42,17 @@ class CollaboratorInviteActionsCubit
     required CollaboratorInviteStateStore stateStore,
     required CollaboratorResponseService responseService,
     required String currentUserPubkey,
+    CollaboratorConfirmationRepository? confirmationRepository,
   }) : _stateStore = stateStore,
        _responseService = responseService,
        _currentUserPubkey = currentUserPubkey,
+       _confirmationRepository = confirmationRepository,
        super(const CollaboratorInviteActionsState());
 
   final CollaboratorInviteStateStore _stateStore;
   final CollaboratorResponseService _responseService;
   final String _currentUserPubkey;
+  final CollaboratorConfirmationRepository? _confirmationRepository;
 
   void loadInvites(Iterable<CollaboratorInvite> invites) {
     if (_currentUserPubkey.isEmpty) return;
@@ -84,6 +89,13 @@ class CollaboratorInviteActionsCubit
           ? CollaboratorInviteState.accepted
           : CollaboratorInviteState.failed,
     );
+    if (result.success) {
+      _confirmationRepository?.markLocal(
+        videoAddress: invite.videoAddress,
+        collaboratorPubkey: _currentUserPubkey,
+        status: CollaboratorStatus.confirmed,
+      );
+    }
   }
 
   Future<void> ignoreInvite(CollaboratorInvite invite) async {
@@ -95,6 +107,11 @@ class CollaboratorInviteActionsCubit
     if (_currentUserPubkey.isEmpty) return;
     if (_currentUserPubkey == invite.creatorPubkey) return;
     await _setInviteState(invite, CollaboratorInviteState.ignored);
+    _confirmationRepository?.markLocal(
+      videoAddress: invite.videoAddress,
+      collaboratorPubkey: _currentUserPubkey,
+      status: CollaboratorStatus.ignored,
+    );
   }
 
   Future<void> _setInviteState(

--- a/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_cubit.dart
+++ b/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_cubit.dart
@@ -1,0 +1,75 @@
+// ABOUTME: Cubit that exposes per-video collaborator confirmation status.
+// ABOUTME: Keyed by videoAddress; wraps CollaboratorConfirmationRepository.
+
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:collaborator_repository/collaborator_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:unified_logger/unified_logger.dart';
+
+part 'video_collaborator_status_state.dart';
+
+/// One cubit per video address. Constructed inside a `BlocProvider`
+/// scoped to the rendering surface; closes the underlying repository
+/// reference on dispose.
+class VideoCollaboratorStatusCubit extends Cubit<VideoCollaboratorStatusState> {
+  VideoCollaboratorStatusCubit({
+    required CollaboratorConfirmationRepository repository,
+    required String videoAddress,
+    required String creatorPubkey,
+    required List<String> taggedPubkeys,
+  }) : _repository = repository,
+       _videoAddress = videoAddress,
+       _creatorPubkey = creatorPubkey,
+       _taggedPubkeys = taggedPubkeys,
+       super(const VideoCollaboratorStatusState()) {
+    _subscribe();
+  }
+
+  final CollaboratorConfirmationRepository _repository;
+  final String _videoAddress;
+  final String _creatorPubkey;
+  final List<String> _taggedPubkeys;
+
+  StreamSubscription<VideoCollaboratorStatus>? _subscription;
+
+  void _subscribe() {
+    _subscription = _repository
+        .watch(
+          _videoAddress,
+          creatorPubkey: _creatorPubkey,
+          taggedPubkeys: _taggedPubkeys,
+        )
+        .listen(
+          (snapshot) {
+            if (isClosed) return;
+            emit(
+              state.copyWith(
+                load: VideoCollaboratorStatusLoad.ready,
+                statusByPubkey: snapshot.statusByPubkey,
+              ),
+            );
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            Log.warning(
+              'VideoCollaboratorStatusCubit stream error for $_videoAddress: '
+              '$error',
+              name: 'VideoCollaboratorStatusCubit',
+              category: LogCategory.system,
+            );
+            if (isClosed) return;
+            addError(error, stackTrace);
+            emit(state.copyWith(load: VideoCollaboratorStatusLoad.failure));
+          },
+        );
+  }
+
+  @override
+  Future<void> close() async {
+    await _subscription?.cancel();
+    _repository.release(_videoAddress);
+    return super.close();
+  }
+}

--- a/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_state.dart
+++ b/mobile/lib/blocs/video_collaborator_status/video_collaborator_status_state.dart
@@ -1,0 +1,32 @@
+// ABOUTME: State for VideoCollaboratorStatusCubit.
+// ABOUTME: Status enum + per-pubkey map; no error strings in state.
+
+part of 'video_collaborator_status_cubit.dart';
+
+enum VideoCollaboratorStatusLoad { loading, ready, failure }
+
+class VideoCollaboratorStatusState extends Equatable {
+  const VideoCollaboratorStatusState({
+    this.load = VideoCollaboratorStatusLoad.loading,
+    this.statusByPubkey = const {},
+  });
+
+  final VideoCollaboratorStatusLoad load;
+  final Map<String, CollaboratorStatus> statusByPubkey;
+
+  CollaboratorStatus statusFor(String pubkey) =>
+      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
+
+  VideoCollaboratorStatusState copyWith({
+    VideoCollaboratorStatusLoad? load,
+    Map<String, CollaboratorStatus>? statusByPubkey,
+  }) {
+    return VideoCollaboratorStatusState(
+      load: load ?? this.load,
+      statusByPubkey: statusByPubkey ?? this.statusByPubkey,
+    );
+  }
+
+  @override
+  List<Object?> get props => [load, statusByPubkey];
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -641,6 +641,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "ዝርዝር",
     "shareVideoLabel": "ቪዲዮ አጋራ",
     "sharePostSharedWith": "ልጥፍ ለ{recipientName} ተጋርቷል።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -661,21 +661,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "ዝርዝር",
     "shareVideoLabel": "ቪዲዮ አጋራ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "قائمة",
     "shareVideoLabel": "مشاركة الفيديو",
     "sharePostSharedWith": "تمت مشاركة المنشور مع {recipientName}",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "قائمة",
     "shareVideoLabel": "مشاركة الفيديو",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -590,6 +590,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Списък",
     "shareVideoLabel": "Сподели видео",
     "sharePostSharedWith": "Публикация, споделена с {recipientName}",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -610,21 +610,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Списък",
     "shareVideoLabel": "Сподели видео",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Video teilen",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Video teilen",
     "sharePostSharedWith": "Beitrag mit {recipientName} geteilt",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -668,21 +668,14 @@
       }
     }
   },
-  "metadataCreatorSectionLabel": "Creator",
-  "@metadataCreatorSectionLabel": {
-    "description": "Section label in the video metadata sheet introducing the author chip."
-  },
-  "metadataCollaboratorsSectionLabel": "Collaborators",
-  "@metadataCollaboratorsSectionLabel": {
-    "description": "Section label in the video metadata sheet introducing the collaborator chips."
-  },
-  "metadataInspiredBySectionLabel": "Inspired by",
-  "@metadataInspiredBySectionLabel": {
-    "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-  },
-  "metadataRepostedBySectionLabel": "Reposted by",
-  "@metadataRepostedBySectionLabel": {
-    "description": "Section label in the video metadata sheet introducing the reposter chips."
+  "profileChipTapHint": "{name}. Tap to view profile.",
+  "@profileChipTapHint": {
+    "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
   "listAttributionFallback": "List",
   "shareVideoLabel": "Share video",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -648,6 +648,42 @@
       }
     }
   },
+  "videoCollaboratorPendingDecoration": "Pending",
+  "@videoCollaboratorPendingDecoration": {
+    "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+  },
+  "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+  "@videoCollaboratorPendingSemanticLabel": {
+    "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+  },
+  "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+  "@videoCollaboratorWithPendingSuffix": {
+    "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+    "placeholders": {
+      "label": {
+        "type": "String"
+      },
+      "pending": {
+        "type": "int"
+      }
+    }
+  },
+  "metadataCreatorSectionLabel": "Creator",
+  "@metadataCreatorSectionLabel": {
+    "description": "Section label in the video metadata sheet introducing the author chip."
+  },
+  "metadataCollaboratorsSectionLabel": "Collaborators",
+  "@metadataCollaboratorsSectionLabel": {
+    "description": "Section label in the video metadata sheet introducing the collaborator chips."
+  },
+  "metadataInspiredBySectionLabel": "Inspired by",
+  "@metadataInspiredBySectionLabel": {
+    "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+  },
+  "metadataRepostedBySectionLabel": "Reposted by",
+  "@metadataRepostedBySectionLabel": {
+    "description": "Section label in the video metadata sheet introducing the reposter chips."
+  },
   "listAttributionFallback": "List",
   "shareVideoLabel": "Share video",
   "sharePostSharedWith": "Post shared with {recipientName}",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Compartir video",
     "sharePostSharedWith": "Publicación compartida con {recipientName}",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Compartir video",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -377,21 +377,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "List",
     "shareVideoLabel": "I-share ang video",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -357,6 +357,42 @@
     "videoCollaboratorWithOne": "kasama si @{name}",
     "videoCollaboratorWithMore": "kasama si @{name} +{count}",
     "videoCollaboratorCountLabel": "{count, plural, =1{1 collaborator} other{{count} collaborator}}. I-tap para tingnan ang profile.",
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "List",
     "shareVideoLabel": "I-share ang video",
     "sharePostSharedWith": "Naipadala ang post kay {recipientName}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Partager la vidéo",
     "sharePostSharedWith": "Post partagé avec {recipientName}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Partager la vidéo",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Daftar",
     "shareVideoLabel": "Bagikan video",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Daftar",
     "shareVideoLabel": "Bagikan video",
     "sharePostSharedWith": "Postingan dibagikan dengan {recipientName}",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Condividi video",
     "sharePostSharedWith": "Post condiviso con {recipientName}",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Condividi video",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "リスト",
     "shareVideoLabel": "動画を共有",
     "sharePostSharedWith": "{recipientName}に投稿を共有したよ",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "リスト",
     "shareVideoLabel": "動画を共有",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -328,6 +328,42 @@
     "videoCollaboratorWithOne": "@{name}님과 함께",
     "videoCollaboratorWithMore": "@{name}님 외 +{count}명과 함께",
     "videoCollaboratorCountLabel": "{count, plural, other{콜라보레이터 {count}명}}. 탭해서 프로필을 보세요.",
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "리스트",
     "shareVideoLabel": "영상 공유",
     "sharePostSharedWith": "{recipientName}님과 게시물을 공유했어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -348,21 +348,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "리스트",
     "shareVideoLabel": "영상 공유",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Lijst",
     "shareVideoLabel": "Video delen",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Lijst",
     "shareVideoLabel": "Video delen",
     "sharePostSharedWith": "Post gedeeld met {recipientName}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Udostępnij film",
     "sharePostSharedWith": "Post udostępniony z {recipientName}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Udostępnij film",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Compartilhar vídeo",
     "sharePostSharedWith": "Post compartilhado com {recipientName}",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Compartilhar vídeo",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Listă",
     "shareVideoLabel": "Partajează videoclipul",
     "sharePostSharedWith": "Postare partajată cu {recipientName}",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Listă",
     "shareVideoLabel": "Partajează videoclipul",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Dela video",
     "sharePostSharedWith": "Inlägg delat med {recipientName}",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Dela video",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -561,6 +561,42 @@
             }
         }
     },
+    "videoCollaboratorPendingDecoration": "Pending",
+    "@videoCollaboratorPendingDecoration": {
+        "description": "Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted."
+    },
+    "videoCollaboratorPendingSemanticLabel": "Pending collaborator",
+    "@videoCollaboratorPendingSemanticLabel": {
+        "description": "Screen reader label for a dimmed pending collaborator avatar on the creator's own video."
+    },
+    "videoCollaboratorWithPendingSuffix": "{label} ({pending} pending)",
+    "@videoCollaboratorWithPendingSuffix": {
+        "description": "Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.",
+        "placeholders": {
+            "label": {
+                "type": "String"
+            },
+            "pending": {
+                "type": "int"
+            }
+        }
+    },
+    "metadataCreatorSectionLabel": "Creator",
+    "@metadataCreatorSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the author chip."
+    },
+    "metadataCollaboratorsSectionLabel": "Collaborators",
+    "@metadataCollaboratorsSectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the collaborator chips."
+    },
+    "metadataInspiredBySectionLabel": "Inspired by",
+    "@metadataInspiredBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
+    },
+    "metadataRepostedBySectionLabel": "Reposted by",
+    "@metadataRepostedBySectionLabel": {
+        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    },
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Videoyu paylaş",
     "sharePostSharedWith": "Gönderi {recipientName} ile paylaşıldı",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -581,21 +581,14 @@
             }
         }
     },
-    "metadataCreatorSectionLabel": "Creator",
-    "@metadataCreatorSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the author chip."
-    },
-    "metadataCollaboratorsSectionLabel": "Collaborators",
-    "@metadataCollaboratorsSectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the collaborator chips."
-    },
-    "metadataInspiredBySectionLabel": "Inspired by",
-    "@metadataInspiredBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the inspired-by attribution chip."
-    },
-    "metadataRepostedBySectionLabel": "Reposted by",
-    "@metadataRepostedBySectionLabel": {
-        "description": "Section label in the video metadata sheet introducing the reposter chips."
+    "profileChipTapHint": "{name}. Tap to view profile.",
+    "@profileChipTapHint": {
+        "description": "Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
     },
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Videoyu paylaş",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2452,6 +2452,48 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 collaborator} other{{count} collaborators}}. Tap to view profile.'**
   String videoCollaboratorCountLabel(int count);
 
+  /// Small badge next to a collaborator's name or avatar when the creator (viewing their own video) has invited them but they have not yet accepted.
+  ///
+  /// In en, this message translates to:
+  /// **'Pending'**
+  String get videoCollaboratorPendingDecoration;
+
+  /// Screen reader label for a dimmed pending collaborator avatar on the creator's own video.
+  ///
+  /// In en, this message translates to:
+  /// **'Pending collaborator'**
+  String get videoCollaboratorPendingSemanticLabel;
+
+  /// Appends a pending count to the collaborator label on the creator's own video. {label} is the existing 'with @name' / 'with @name +N' phrase.
+  ///
+  /// In en, this message translates to:
+  /// **'{label} ({pending} pending)'**
+  String videoCollaboratorWithPendingSuffix(String label, int pending);
+
+  /// Section label in the video metadata sheet introducing the author chip.
+  ///
+  /// In en, this message translates to:
+  /// **'Creator'**
+  String get metadataCreatorSectionLabel;
+
+  /// Section label in the video metadata sheet introducing the collaborator chips.
+  ///
+  /// In en, this message translates to:
+  /// **'Collaborators'**
+  String get metadataCollaboratorsSectionLabel;
+
+  /// Section label in the video metadata sheet introducing the inspired-by attribution chip.
+  ///
+  /// In en, this message translates to:
+  /// **'Inspired by'**
+  String get metadataInspiredBySectionLabel;
+
+  /// Section label in the video metadata sheet introducing the reposter chips.
+  ///
+  /// In en, this message translates to:
+  /// **'Reposted by'**
+  String get metadataRepostedBySectionLabel;
+
   /// No description provided for @listAttributionFallback.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2470,29 +2470,11 @@ abstract class AppLocalizations {
   /// **'{label} ({pending} pending)'**
   String videoCollaboratorWithPendingSuffix(String label, int pending);
 
-  /// Section label in the video metadata sheet introducing the author chip.
+  /// Screen reader hint announced when a user-chip in the metadata sheet is focused. {name} is the user's display name.
   ///
   /// In en, this message translates to:
-  /// **'Creator'**
-  String get metadataCreatorSectionLabel;
-
-  /// Section label in the video metadata sheet introducing the collaborator chips.
-  ///
-  /// In en, this message translates to:
-  /// **'Collaborators'**
-  String get metadataCollaboratorsSectionLabel;
-
-  /// Section label in the video metadata sheet introducing the inspired-by attribution chip.
-  ///
-  /// In en, this message translates to:
-  /// **'Inspired by'**
-  String get metadataInspiredBySectionLabel;
-
-  /// Section label in the video metadata sheet introducing the reposter chips.
-  ///
-  /// In en, this message translates to:
-  /// **'Reposted by'**
-  String get metadataRepostedBySectionLabel;
+  /// **'{name}. Tap to view profile.'**
+  String profileChipTapHint(String name);
 
   /// No description provided for @listAttributionFallback.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1336,16 +1336,9 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'ዝርዝር';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1325,6 +1325,29 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'ዝርዝር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1355,16 +1355,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'قائمة';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1344,6 +1344,29 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'قائمة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1383,6 +1383,29 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Списък';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1394,16 +1394,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Списък';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1390,16 +1390,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Liste';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1379,6 +1379,29 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Liste';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1362,6 +1362,29 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'List';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1373,16 +1373,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'List';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1381,6 +1381,29 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1392,16 +1392,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Lista';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1399,16 +1399,9 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'List';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1388,6 +1388,29 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'List';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1388,6 +1388,29 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Liste';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1399,16 +1399,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Liste';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1337,6 +1337,29 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Daftar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1348,16 +1348,9 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Daftar';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1383,6 +1383,29 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1394,16 +1394,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Lista';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1283,16 +1283,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'リスト';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1272,6 +1272,29 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'リスト';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1291,16 +1291,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => '리스트';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1280,6 +1280,29 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => '리스트';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1369,6 +1369,29 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Lijst';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1380,16 +1380,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Lijst';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1382,6 +1382,29 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1393,16 +1393,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Lista';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1390,16 +1390,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Lista';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1379,6 +1379,29 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1396,6 +1396,29 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Listă';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1407,16 +1407,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Listă';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1357,6 +1357,29 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Lista';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1368,16 +1368,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Lista';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1343,6 +1343,29 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get videoCollaboratorPendingDecoration => 'Pending';
+
+  @override
+  String get videoCollaboratorPendingSemanticLabel => 'Pending collaborator';
+
+  @override
+  String videoCollaboratorWithPendingSuffix(String label, int pending) {
+    return '$label ($pending pending)';
+  }
+
+  @override
+  String get metadataCreatorSectionLabel => 'Creator';
+
+  @override
+  String get metadataCollaboratorsSectionLabel => 'Collaborators';
+
+  @override
+  String get metadataInspiredBySectionLabel => 'Inspired by';
+
+  @override
+  String get metadataRepostedBySectionLabel => 'Reposted by';
+
+  @override
   String get listAttributionFallback => 'Liste';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1354,16 +1354,9 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get metadataCreatorSectionLabel => 'Creator';
-
-  @override
-  String get metadataCollaboratorsSectionLabel => 'Collaborators';
-
-  @override
-  String get metadataInspiredBySectionLabel => 'Inspired by';
-
-  @override
-  String get metadataRepostedBySectionLabel => 'Reposted by';
+  String profileChipTapHint(String name) {
+    return '$name. Tap to view profile.';
+  }
 
   @override
   String get listAttributionFallback => 'Liste';

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -7,6 +7,7 @@ import 'dart:core';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:categories_repository/categories_repository.dart';
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
@@ -62,6 +63,7 @@ import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/cawg_verifier_client.dart';
 import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/collaborator_invite_local_state_adapter.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
 import 'package:openvine/services/collaborator_response_service.dart';
 import 'package:openvine/services/connection_status_service.dart';
@@ -182,6 +184,29 @@ final collaboratorInviteStateStoreProvider =
       return CollaboratorInviteStateStore(
         prefs: ref.watch(sharedPreferencesProvider),
       );
+    });
+
+/// Per-video collaborator confirmation status. Returns `null` until
+/// [isNostrReadyProvider] flips, so consumers render a safe fallback
+/// instead of capturing a stale Nostr client.
+final collaboratorConfirmationRepositoryProvider =
+    Provider<CollaboratorConfirmationRepository?>((ref) {
+      if (!ref.watch(isNostrReadyProvider)) return null;
+      final authService = ref.watch(authServiceProvider);
+      final currentUserPubkey = authService.currentPublicKeyHex;
+      if (currentUserPubkey == null || currentUserPubkey.isEmpty) {
+        return null;
+      }
+
+      final nostrClient = ref.watch(nostrServiceProvider);
+      final localStore = ref.watch(collaboratorInviteStateStoreProvider);
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: CollaboratorInviteLocalStateAdapter(localStore),
+        currentUserPubkey: currentUserPubkey,
+      );
+      ref.onDispose(repo.close);
+      return repo;
     });
 
 final pushNotificationServiceProvider = Provider<PushNotificationService>((

--- a/mobile/lib/screens/inbox/conversation/conversation_page.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_page.dart
@@ -45,6 +45,9 @@ class ConversationPage extends ConsumerWidget {
     final inviteResponseService = ref.watch(
       collaboratorResponseServiceProvider,
     );
+    final confirmationRepository = ref.watch(
+      collaboratorConfirmationRepositoryProvider,
+    );
     final authService = ref.watch(authServiceProvider);
     final currentPubkey = authService.currentPublicKeyHex ?? '';
 
@@ -77,12 +80,14 @@ class ConversationPage extends ConsumerWidget {
           key: ValueKey((
             inviteStateStore,
             inviteResponseService,
+            confirmationRepository,
             currentPubkey,
           )),
           create: (_) => CollaboratorInviteActionsCubit(
             stateStore: inviteStateStore,
             responseService: inviteResponseService,
             currentUserPubkey: currentPubkey,
+            confirmationRepository: confirmationRepository,
           ),
         ),
       ],

--- a/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_page.dart
@@ -55,6 +55,9 @@ class RequestPreviewPage extends ConsumerWidget {
             stateStore: ref.watch(collaboratorInviteStateStoreProvider),
             responseService: ref.watch(collaboratorResponseServiceProvider),
             currentUserPubkey: currentPubkey,
+            confirmationRepository: ref.watch(
+              collaboratorConfirmationRepositoryProvider,
+            ),
           ),
         ),
       ],

--- a/mobile/lib/services/collaborator_invite_local_state_adapter.dart
+++ b/mobile/lib/services/collaborator_invite_local_state_adapter.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Adapts CollaboratorInviteStateStore to the repository's reader.
+// ABOUTME: Keeps the collaborator_repository package free of mobile/lib deps.
+
+import 'package:collaborator_repository/collaborator_repository.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/collaborator_invite_state_store.dart';
+
+/// Maps the local SharedPreferences-backed invite state store onto the
+/// reader contract consumed by `CollaboratorConfirmationRepository`.
+///
+/// `pending`, `accepting`, and `failed` map to `null` so the repository
+/// treats them as "not yet acted" and the render falls back to the
+/// pending decoration. Only the terminal states (`accepted`, `ignored`)
+/// flip the render.
+class CollaboratorInviteLocalStateAdapter
+    implements CollaboratorInviteLocalStateReader {
+  const CollaboratorInviteLocalStateAdapter(this._store);
+
+  final CollaboratorInviteStateStore _store;
+
+  @override
+  CollaboratorStatus? readLocalState({
+    required String videoAddress,
+    required String creatorPubkey,
+    required String collaboratorPubkey,
+  }) {
+    final raw = _store.getState(
+      videoAddress: videoAddress,
+      creatorPubkey: creatorPubkey,
+      collaboratorPubkey: collaboratorPubkey,
+    );
+    switch (raw) {
+      case CollaboratorInviteState.accepted:
+        return CollaboratorStatus.confirmed;
+      case CollaboratorInviteState.ignored:
+        return CollaboratorStatus.ignored;
+      case CollaboratorInviteState.pending:
+      case CollaboratorInviteState.accepting:
+      case CollaboratorInviteState.failed:
+        return null;
+    }
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
+++ b/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
@@ -3,6 +3,7 @@
 // ABOUTME: greys pending avatars on the inviter's own video, otherwise
 // ABOUTME: renders raw collaborator p-tags as today.
 
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -51,16 +52,13 @@ class CollaboratorAvatarRow extends ConsumerWidget {
     // status pipeline is not available (repo gated on isNostrReady, or
     // the video has no addressable id).
     if (repo == null || videoAddress == null || currentUserPubkey.isEmpty) {
-      return _RowBody(
-        pubkeys: pubkeys,
-        statusByPubkey: const {},
-        currentUserPubkey: currentUserPubkey,
-        isInviterView: false,
+      return CollaboratorAvatarRowBody(
+        visibility: CollaboratorVisibility.fallback(taggedPubkeys: pubkeys),
       );
     }
 
     return BlocProvider<VideoCollaboratorStatusCubit>(
-      key: ValueKey((repo, videoAddress)),
+      key: ValueKey((repo, videoAddress, Object.hashAll(pubkeys))),
       create: (_) => VideoCollaboratorStatusCubit(
         repository: repo,
         videoAddress: videoAddress,
@@ -92,56 +90,34 @@ class _StatusAwareRow extends StatelessWidget {
     final statusByPubkey = context.select(
       (VideoCollaboratorStatusCubit c) => c.state.statusByPubkey,
     );
-    final isInviterView = currentUserPubkey == video.pubkey;
-    return _RowBody(
-      pubkeys: pubkeys,
-      statusByPubkey: statusByPubkey,
-      currentUserPubkey: currentUserPubkey,
-      isInviterView: isInviterView,
+    return CollaboratorAvatarRowBody(
+      visibility: CollaboratorVisibility(
+        taggedPubkeys: pubkeys,
+        statusByPubkey: statusByPubkey,
+        currentUserPubkey: currentUserPubkey,
+        creatorPubkey: video.pubkey,
+      ),
     );
   }
 }
 
-class _RowBody extends StatelessWidget {
-  const _RowBody({
-    required this.pubkeys,
-    required this.statusByPubkey,
-    required this.currentUserPubkey,
-    required this.isInviterView,
-  });
+/// Renders the avatar row from a [CollaboratorVisibility].
+///
+/// Promoted to a top-level class with [visibleForTesting] so widget tests
+/// can exercise every render branch without standing up a Riverpod
+/// container, a `BlocProvider`, or a mock repository.
+@visibleForTesting
+class CollaboratorAvatarRowBody extends StatelessWidget {
+  const CollaboratorAvatarRowBody({required this.visibility, super.key});
 
-  final List<String> pubkeys;
-  final Map<String, CollaboratorStatus> statusByPubkey;
-  final String currentUserPubkey;
-  final bool isInviterView;
-
-  CollaboratorStatus _statusOf(String pubkey) =>
-      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
-
-  bool _shouldRender(String pubkey) {
-    if (statusByPubkey.isEmpty) return true;
-    // Recipient hides their own avatar after tapping Ignore.
-    if (pubkey == currentUserPubkey &&
-        _statusOf(pubkey) == CollaboratorStatus.ignored) {
-      return false;
-    }
-    return true;
-  }
-
-  bool _isPendingForInviter(String pubkey) {
-    if (!isInviterView) return false;
-    final status = _statusOf(pubkey);
-    return status == CollaboratorStatus.pending;
-  }
+  final CollaboratorVisibility visibility;
 
   @override
   Widget build(BuildContext context) {
-    final visible = pubkeys.where(_shouldRender).toList(growable: false);
+    final visible = visibility.visiblePubkeys;
     if (visible.isEmpty) return const SizedBox.shrink();
 
-    final pendingCount = isInviterView
-        ? visible.where(_isPendingForInviter).length
-        : 0;
+    final pendingCount = visibility.pendingCount;
 
     return GestureDetector(
       onTap: () => _navigateToCollaborator(context, visible.first),
@@ -165,7 +141,7 @@ class _RowBody extends StatelessWidget {
                   for (final pubkey in visible.take(3))
                     _AvatarEntry(
                       pubkey: pubkey,
-                      isPending: _isPendingForInviter(pubkey),
+                      isPending: visibility.isPendingForInviter(pubkey),
                     ),
                 ],
               ),
@@ -295,11 +271,8 @@ class _CollaboratorLabel extends ConsumerWidget {
 
     return Text(
       label,
-      style: const TextStyle(
-        color: VineTheme.whiteText,
-        fontSize: 12,
-        fontWeight: FontWeight.w500,
-        shadows: [Shadow(blurRadius: 4)],
+      style: VineTheme.labelMediumFont().copyWith(
+        shadows: const [Shadow(blurRadius: 4)],
       ),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,

--- a/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
+++ b/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
@@ -1,13 +1,17 @@
 // ABOUTME: Collaborator avatar row for video feed overlay
-// ABOUTME: Shows small overlapping avatars of collaborators
-// ABOUTME: with tap navigation to their profiles
+// ABOUTME: Status-aware: hides current user's avatar when ignored locally,
+// ABOUTME: greys pending avatars on the inviter's own video, otherwise
+// ABOUTME: renders raw collaborator p-tags as today.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/video_collaborator_status/video_collaborator_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
@@ -16,12 +20,14 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Displays collaborator avatars on a video feed item.
 ///
-/// Shows small overlapping avatar circles for each
-/// collaborator. Tapping opens the first collaborator's
-/// profile.
+/// Hides the current user's own avatar when their local invite store says
+/// `ignored` for this video. On the inviter's own video, pending
+/// collaborator avatars render greyed until a kind-34238 acceptance flips
+/// them to confirmed. Third-party viewers see the same raw p-tag list as
+/// before this wiring (status-unaware fallback).
 ///
-/// Returns [SizedBox.shrink] if the video has no
-/// collaborators.
+/// Returns [SizedBox.shrink] if the video has no collaborators after the
+/// status-aware filter.
 class CollaboratorAvatarRow extends ConsumerWidget {
   /// Creates a CollaboratorAvatarRow.
   const CollaboratorAvatarRow({required this.video, super.key});
@@ -36,13 +42,113 @@ class CollaboratorAvatarRow extends ConsumerWidget {
     }
 
     final pubkeys = video.collaboratorPubkeys;
+    final repo = ref.watch(collaboratorConfirmationRepositoryProvider);
+    final currentUserPubkey =
+        ref.watch(authServiceProvider).currentPublicKeyHex ?? '';
+    final videoAddress = video.addressableId;
+
+    // Fallback: render the raw p-tag list (current behaviour) when the
+    // status pipeline is not available (repo gated on isNostrReady, or
+    // the video has no addressable id).
+    if (repo == null || videoAddress == null || currentUserPubkey.isEmpty) {
+      return _RowBody(
+        pubkeys: pubkeys,
+        statusByPubkey: const {},
+        currentUserPubkey: currentUserPubkey,
+        isInviterView: false,
+      );
+    }
+
+    return BlocProvider<VideoCollaboratorStatusCubit>(
+      key: ValueKey((repo, videoAddress)),
+      create: (_) => VideoCollaboratorStatusCubit(
+        repository: repo,
+        videoAddress: videoAddress,
+        creatorPubkey: video.pubkey,
+        taggedPubkeys: pubkeys,
+      ),
+      child: _StatusAwareRow(
+        video: video,
+        pubkeys: pubkeys,
+        currentUserPubkey: currentUserPubkey,
+      ),
+    );
+  }
+}
+
+class _StatusAwareRow extends StatelessWidget {
+  const _StatusAwareRow({
+    required this.video,
+    required this.pubkeys,
+    required this.currentUserPubkey,
+  });
+
+  final VideoEvent video;
+  final List<String> pubkeys;
+  final String currentUserPubkey;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusByPubkey = context.select(
+      (VideoCollaboratorStatusCubit c) => c.state.statusByPubkey,
+    );
+    final isInviterView = currentUserPubkey == video.pubkey;
+    return _RowBody(
+      pubkeys: pubkeys,
+      statusByPubkey: statusByPubkey,
+      currentUserPubkey: currentUserPubkey,
+      isInviterView: isInviterView,
+    );
+  }
+}
+
+class _RowBody extends StatelessWidget {
+  const _RowBody({
+    required this.pubkeys,
+    required this.statusByPubkey,
+    required this.currentUserPubkey,
+    required this.isInviterView,
+  });
+
+  final List<String> pubkeys;
+  final Map<String, CollaboratorStatus> statusByPubkey;
+  final String currentUserPubkey;
+  final bool isInviterView;
+
+  CollaboratorStatus _statusOf(String pubkey) =>
+      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
+
+  bool _shouldRender(String pubkey) {
+    if (statusByPubkey.isEmpty) return true;
+    // Recipient hides their own avatar after tapping Ignore.
+    if (pubkey == currentUserPubkey &&
+        _statusOf(pubkey) == CollaboratorStatus.ignored) {
+      return false;
+    }
+    return true;
+  }
+
+  bool _isPendingForInviter(String pubkey) {
+    if (!isInviterView) return false;
+    final status = _statusOf(pubkey);
+    return status == CollaboratorStatus.pending;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = pubkeys.where(_shouldRender).toList(growable: false);
+    if (visible.isEmpty) return const SizedBox.shrink();
+
+    final pendingCount = isInviterView
+        ? visible.where(_isPendingForInviter).length
+        : 0;
 
     return GestureDetector(
-      onTap: () => _navigateToCollaborator(context, pubkeys.first),
+      onTap: () => _navigateToCollaborator(context, visible.first),
       child: Semantics(
         identifier: 'collaborator_avatar_row',
         button: true,
-        label: context.l10n.videoCollaboratorCountLabel(pubkeys.length),
+        label: context.l10n.videoCollaboratorCountLabel(visible.length),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
@@ -54,10 +160,22 @@ class CollaboratorAvatarRow extends ConsumerWidget {
             children: [
               const Icon(Icons.people, size: 14, color: VineTheme.vineGreen),
               const SizedBox(width: 4),
-              // Show up to 3 overlapping avatars
-              _CollaboratorAvatarStack(pubkeys: pubkeys.take(3).toList()),
+              _CollaboratorAvatarStack(
+                entries: [
+                  for (final pubkey in visible.take(3))
+                    _AvatarEntry(
+                      pubkey: pubkey,
+                      isPending: _isPendingForInviter(pubkey),
+                    ),
+                ],
+              ),
               const SizedBox(width: 4),
-              Flexible(child: _CollaboratorLabel(pubkeys: pubkeys)),
+              Flexible(
+                child: _CollaboratorLabel(
+                  pubkeys: visible,
+                  pendingCount: pendingCount,
+                ),
+              ),
             ],
           ),
         ),
@@ -79,23 +197,33 @@ class CollaboratorAvatarRow extends ConsumerWidget {
   }
 }
 
-/// Small overlapping avatar circles.
-class _CollaboratorAvatarStack extends ConsumerWidget {
-  const _CollaboratorAvatarStack({required this.pubkeys});
+class _AvatarEntry {
+  const _AvatarEntry({required this.pubkey, required this.isPending});
 
-  final List<String> pubkeys;
+  final String pubkey;
+  final bool isPending;
+}
+
+/// Small overlapping avatar circles.
+class _CollaboratorAvatarStack extends StatelessWidget {
+  const _CollaboratorAvatarStack({required this.entries});
+
+  final List<_AvatarEntry> entries;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return SizedBox(
-      width: 20.0 + (pubkeys.length - 1) * 12.0,
+      width: 20.0 + (entries.length - 1) * 12.0,
       height: 20,
       child: Stack(
         children: [
-          for (var i = 0; i < pubkeys.length; i++)
+          for (var i = 0; i < entries.length; i++)
             Positioned(
               left: i * 12.0,
-              child: _SmallAvatar(pubkey: pubkeys[i]),
+              child: _SmallAvatar(
+                pubkey: entries[i].pubkey,
+                isPending: entries[i].isPending,
+              ),
             ),
         ],
       ),
@@ -105,15 +233,16 @@ class _CollaboratorAvatarStack extends ConsumerWidget {
 
 /// A small 20px avatar with white border.
 class _SmallAvatar extends ConsumerWidget {
-  const _SmallAvatar({required this.pubkey});
+  const _SmallAvatar({required this.pubkey, required this.isPending});
 
   final String pubkey;
+  final bool isPending;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profileAsync = ref.watch(fetchUserProfileProvider(pubkey));
 
-    return Container(
+    final avatar = Container(
       width: 20,
       height: 20,
       decoration: BoxDecoration(
@@ -128,14 +257,25 @@ class _SmallAvatar extends ConsumerWidget {
         ),
       ),
     );
+
+    if (!isPending) return avatar;
+
+    return Semantics(
+      label: context.l10n.videoCollaboratorPendingSemanticLabel,
+      child: Opacity(opacity: 0.55, child: avatar),
+    );
   }
 }
 
 /// Text label showing collaborator name(s).
 class _CollaboratorLabel extends ConsumerWidget {
-  const _CollaboratorLabel({required this.pubkeys});
+  const _CollaboratorLabel({
+    required this.pubkeys,
+    required this.pendingCount,
+  });
 
   final List<String> pubkeys;
+  final int pendingCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -145,9 +285,13 @@ class _CollaboratorLabel extends ConsumerWidget {
         firstProfile.value?.bestDisplayName ??
         UserProfile.defaultDisplayNameFor(pubkeys.first);
 
-    final label = pubkeys.length == 1
+    final base = pubkeys.length == 1
         ? context.l10n.videoCollaboratorWithOne(firstName)
         : context.l10n.videoCollaboratorWithMore(firstName, pubkeys.length - 1);
+
+    final label = pendingCount > 0
+        ? context.l10n.videoCollaboratorWithPendingSuffix(base, pendingCount)
+        : base;
 
     return Text(
       label,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -107,9 +107,7 @@ class _MetadataContent extends StatelessWidget {
         MetadataVerificationSection(video: video),
         MetadataCreatorSection(pubkey: video.pubkey),
         MetadataTagsSection(video: video),
-        MetadataCollaboratorsSection(
-          collaboratorPubkeys: video.collaboratorPubkeys,
-        ),
+        MetadataCollaboratorsSection(video: video),
         MetadataInspiredBySection(video: video),
         MetadataRepostedBySection(video: video),
         MetadataSoundsSection(video: video),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -7,6 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/video_collaborator_status/video_collaborator_status_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
@@ -24,7 +27,7 @@ class MetadataCreatorSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MetadataSection(
-      label: 'Creator',
+      label: context.l10n.metadataCreatorSectionLabel,
       child: _TappableUserChip(pubkey: pubkey),
     );
   }
@@ -32,27 +35,124 @@ class MetadataCreatorSection extends StatelessWidget {
 
 /// Collaborators section showing tappable user chips in a wrapping layout.
 ///
-/// Returns [SizedBox.shrink] when the video has no collaborators.
-class MetadataCollaboratorsSection extends StatelessWidget {
-  const MetadataCollaboratorsSection({
-    required this.collaboratorPubkeys,
-    super.key,
+/// Hides the current user's chip when their local invite store says
+/// `ignored` for this video. Pending collaborator chips are dimmed when
+/// the current user is the video's creator.
+///
+/// Returns [SizedBox.shrink] when the resulting list is empty.
+class MetadataCollaboratorsSection extends ConsumerWidget {
+  const MetadataCollaboratorsSection({required this.video, super.key});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!video.hasCollaborators) return const SizedBox.shrink();
+
+    final pubkeys = video.collaboratorPubkeys;
+    final repo = ref.watch(collaboratorConfirmationRepositoryProvider);
+    final currentUserPubkey =
+        ref.watch(authServiceProvider).currentPublicKeyHex ?? '';
+    final videoAddress = video.addressableId;
+
+    if (repo == null || videoAddress == null || currentUserPubkey.isEmpty) {
+      return _CollaboratorsSectionBody(
+        pubkeys: pubkeys,
+        statusByPubkey: const {},
+        currentUserPubkey: currentUserPubkey,
+        isInviterView: false,
+      );
+    }
+
+    return BlocProvider<VideoCollaboratorStatusCubit>(
+      key: ValueKey((repo, videoAddress)),
+      create: (_) => VideoCollaboratorStatusCubit(
+        repository: repo,
+        videoAddress: videoAddress,
+        creatorPubkey: video.pubkey,
+        taggedPubkeys: pubkeys,
+      ),
+      child: _CollaboratorsSectionStatusAware(
+        video: video,
+        pubkeys: pubkeys,
+        currentUserPubkey: currentUserPubkey,
+      ),
+    );
+  }
+}
+
+class _CollaboratorsSectionStatusAware extends StatelessWidget {
+  const _CollaboratorsSectionStatusAware({
+    required this.video,
+    required this.pubkeys,
+    required this.currentUserPubkey,
   });
 
-  final List<String> collaboratorPubkeys;
+  final VideoEvent video;
+  final List<String> pubkeys;
+  final String currentUserPubkey;
 
   @override
   Widget build(BuildContext context) {
-    if (collaboratorPubkeys.isEmpty) return const SizedBox.shrink();
+    final statusByPubkey = context.select(
+      (VideoCollaboratorStatusCubit c) => c.state.statusByPubkey,
+    );
+    final isInviterView = currentUserPubkey == video.pubkey;
+    return _CollaboratorsSectionBody(
+      pubkeys: pubkeys,
+      statusByPubkey: statusByPubkey,
+      currentUserPubkey: currentUserPubkey,
+      isInviterView: isInviterView,
+    );
+  }
+}
+
+class _CollaboratorsSectionBody extends StatelessWidget {
+  const _CollaboratorsSectionBody({
+    required this.pubkeys,
+    required this.statusByPubkey,
+    required this.currentUserPubkey,
+    required this.isInviterView,
+  });
+
+  final List<String> pubkeys;
+  final Map<String, CollaboratorStatus> statusByPubkey;
+  final String currentUserPubkey;
+  final bool isInviterView;
+
+  CollaboratorStatus _statusOf(String pubkey) =>
+      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
+
+  bool _shouldRender(String pubkey) {
+    if (statusByPubkey.isEmpty) return true;
+    if (pubkey == currentUserPubkey &&
+        _statusOf(pubkey) == CollaboratorStatus.ignored) {
+      return false;
+    }
+    return true;
+  }
+
+  bool _isPendingForInviter(String pubkey) {
+    if (!isInviterView) return false;
+    return _statusOf(pubkey) == CollaboratorStatus.pending;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = pubkeys.where(_shouldRender).toList(growable: false);
+    if (visible.isEmpty) return const SizedBox.shrink();
 
     return MetadataSection(
-      label: 'Collaborators',
+      label: context.l10n.metadataCollaboratorsSectionLabel,
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
         children: [
-          for (final pubkey in collaboratorPubkeys)
-            _TappableUserChip(pubkey: pubkey),
+          for (final pubkey in visible)
+            _TappableUserChip(
+              pubkey: pubkey,
+              isPending: _isPendingForInviter(pubkey),
+            ),
         ],
       ),
     );
@@ -73,7 +173,7 @@ class MetadataInspiredBySection extends StatelessWidget {
     if (pubkey == null) return const SizedBox.shrink();
 
     return MetadataSection(
-      label: 'Inspired by',
+      label: context.l10n.metadataInspiredBySectionLabel,
       child: _TappableUserChip(pubkey: pubkey),
     );
   }
@@ -122,7 +222,7 @@ class _RepostedByContent extends StatelessWidget {
     if (pubkeys.isEmpty) return const SizedBox.shrink();
 
     return MetadataSection(
-      label: 'Reposted by',
+      label: context.l10n.metadataRepostedBySectionLabel,
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
@@ -139,9 +239,10 @@ class _RepostedByContent extends StatelessWidget {
 /// Reuses the same visual style as [VideoMetadataUserChip] but without the
 /// remove button, and adds tap-to-navigate behavior.
 class _TappableUserChip extends ConsumerWidget {
-  const _TappableUserChip({required this.pubkey});
+  const _TappableUserChip({required this.pubkey, this.isPending = false});
 
   final String pubkey;
+  final bool isPending;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -150,37 +251,48 @@ class _TappableUserChip extends ConsumerWidget {
         profileAsync.value?.bestDisplayName ??
         UserProfile.defaultDisplayNameFor(pubkey);
 
+    final chip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: VineTheme.surfaceContainer,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
+        children: [
+          UserAvatar(
+            imageUrl: profileAsync.value?.picture,
+            name: name,
+            size: 24,
+          ),
+          Flexible(
+            child: Text(
+              name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: VineTheme.titleSmallFont(),
+            ),
+          ),
+          if (isPending)
+            Text(
+              context.l10n.videoCollaboratorPendingDecoration,
+              style: VineTheme.labelSmallFont(
+                color: VineTheme.onSurfaceMuted,
+              ),
+            ),
+        ],
+      ),
+    );
+
+    final styled = isPending ? Opacity(opacity: 0.7, child: chip) : chip;
+
     return Semantics(
       button: true,
       label: '$name. Tap to view profile.',
       child: GestureDetector(
         onTap: () => _navigateToProfile(context),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(16),
-            color: VineTheme.surfaceContainer,
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 8,
-            children: [
-              UserAvatar(
-                imageUrl: profileAsync.value?.picture,
-                name: name,
-                size: 24,
-              ),
-              Flexible(
-                child: Text(
-                  name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: VineTheme.titleSmallFont(),
-                ),
-              ),
-            ],
-          ),
-        ),
+        child: styled,
       ),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_user_chips.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Creator, Collaborators, Inspired By, and Reposted By sections
 // ABOUTME: using tappable chips that navigate to user profiles.
 
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -27,7 +28,7 @@ class MetadataCreatorSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MetadataSection(
-      label: context.l10n.metadataCreatorSectionLabel,
+      label: context.l10n.metadataCreatorLabel,
       child: _TappableUserChip(pubkey: pubkey),
     );
   }
@@ -56,16 +57,13 @@ class MetadataCollaboratorsSection extends ConsumerWidget {
     final videoAddress = video.addressableId;
 
     if (repo == null || videoAddress == null || currentUserPubkey.isEmpty) {
-      return _CollaboratorsSectionBody(
-        pubkeys: pubkeys,
-        statusByPubkey: const {},
-        currentUserPubkey: currentUserPubkey,
-        isInviterView: false,
+      return MetadataCollaboratorsSectionBody(
+        visibility: CollaboratorVisibility.fallback(taggedPubkeys: pubkeys),
       );
     }
 
     return BlocProvider<VideoCollaboratorStatusCubit>(
-      key: ValueKey((repo, videoAddress)),
+      key: ValueKey((repo, videoAddress, Object.hashAll(pubkeys))),
       create: (_) => VideoCollaboratorStatusCubit(
         repository: repo,
         videoAddress: videoAddress,
@@ -97,53 +95,38 @@ class _CollaboratorsSectionStatusAware extends StatelessWidget {
     final statusByPubkey = context.select(
       (VideoCollaboratorStatusCubit c) => c.state.statusByPubkey,
     );
-    final isInviterView = currentUserPubkey == video.pubkey;
-    return _CollaboratorsSectionBody(
-      pubkeys: pubkeys,
-      statusByPubkey: statusByPubkey,
-      currentUserPubkey: currentUserPubkey,
-      isInviterView: isInviterView,
+    return MetadataCollaboratorsSectionBody(
+      visibility: CollaboratorVisibility(
+        taggedPubkeys: pubkeys,
+        statusByPubkey: statusByPubkey,
+        currentUserPubkey: currentUserPubkey,
+        creatorPubkey: video.pubkey,
+      ),
     );
   }
 }
 
-class _CollaboratorsSectionBody extends StatelessWidget {
-  const _CollaboratorsSectionBody({
-    required this.pubkeys,
-    required this.statusByPubkey,
-    required this.currentUserPubkey,
-    required this.isInviterView,
+/// Renders the collaborators section from a [CollaboratorVisibility].
+///
+/// Promoted to a top-level class with [visibleForTesting] so widget tests
+/// can exercise every render branch without standing up a Riverpod
+/// container, a `BlocProvider`, or a mock repository.
+@visibleForTesting
+class MetadataCollaboratorsSectionBody extends StatelessWidget {
+  const MetadataCollaboratorsSectionBody({
+    required this.visibility,
+    super.key,
   });
 
-  final List<String> pubkeys;
-  final Map<String, CollaboratorStatus> statusByPubkey;
-  final String currentUserPubkey;
-  final bool isInviterView;
-
-  CollaboratorStatus _statusOf(String pubkey) =>
-      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
-
-  bool _shouldRender(String pubkey) {
-    if (statusByPubkey.isEmpty) return true;
-    if (pubkey == currentUserPubkey &&
-        _statusOf(pubkey) == CollaboratorStatus.ignored) {
-      return false;
-    }
-    return true;
-  }
-
-  bool _isPendingForInviter(String pubkey) {
-    if (!isInviterView) return false;
-    return _statusOf(pubkey) == CollaboratorStatus.pending;
-  }
+  final CollaboratorVisibility visibility;
 
   @override
   Widget build(BuildContext context) {
-    final visible = pubkeys.where(_shouldRender).toList(growable: false);
+    final visible = visibility.visiblePubkeys;
     if (visible.isEmpty) return const SizedBox.shrink();
 
     return MetadataSection(
-      label: context.l10n.metadataCollaboratorsSectionLabel,
+      label: context.l10n.metadataCollaboratorsLabel,
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
@@ -151,7 +134,7 @@ class _CollaboratorsSectionBody extends StatelessWidget {
           for (final pubkey in visible)
             _TappableUserChip(
               pubkey: pubkey,
-              isPending: _isPendingForInviter(pubkey),
+              isPending: visibility.isPendingForInviter(pubkey),
             ),
         ],
       ),
@@ -173,7 +156,7 @@ class MetadataInspiredBySection extends StatelessWidget {
     if (pubkey == null) return const SizedBox.shrink();
 
     return MetadataSection(
-      label: context.l10n.metadataInspiredBySectionLabel,
+      label: context.l10n.metadataInspiredByLabel,
       child: _TappableUserChip(pubkey: pubkey),
     );
   }
@@ -222,7 +205,7 @@ class _RepostedByContent extends StatelessWidget {
     if (pubkeys.isEmpty) return const SizedBox.shrink();
 
     return MetadataSection(
-      label: context.l10n.metadataRepostedBySectionLabel,
+      label: context.l10n.metadataRepostedByLabel,
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
@@ -289,7 +272,7 @@ class _TappableUserChip extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      label: '$name. Tap to view profile.',
+      label: context.l10n.profileChipTapHint(name),
       child: GestureDetector(
         onTap: () => _navigateToProfile(context),
         child: styled,
@@ -306,9 +289,10 @@ class _TappableUserChip extends ConsumerWidget {
     // sheet (the router is not in the modal's widget tree).
     final hostContext = Navigator.of(context, rootNavigator: true).context;
     Navigator.of(context).pop();
-    // Defer navigation to the next microtask so the pop animation
-    // completes and the modal route is fully removed before pushing.
-    Future<void>.delayed(Duration.zero).then((_) {
+    // Defer to the next frame so the modal route's pop has settled in the
+    // route stack before we push the destination route from the root
+    // navigator's context.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!hostContext.mounted) return;
       hostContext.pushWithVideoPause(OtherProfileScreen.pathForNpub(npub));
     });

--- a/mobile/packages/collaborator_repository/lib/collaborator_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/collaborator_repository.dart
@@ -1,0 +1,9 @@
+/// Repository for collaborator confirmation status on Divine videos.
+///
+/// Drives per-video pending vs confirmed rendering for own-authored videos
+/// and the current user's local invite-response fast-path. Third-party
+/// rendering of collaborator p-tags is unchanged by this repository.
+library;
+
+export 'src/collaborator_confirmation_repository.dart';
+export 'src/local_state_reader.dart';

--- a/mobile/packages/collaborator_repository/lib/collaborator_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/collaborator_repository.dart
@@ -6,4 +6,5 @@
 library;
 
 export 'src/collaborator_confirmation_repository.dart';
+export 'src/collaborator_visibility.dart';
 export 'src/local_state_reader.dart';

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
@@ -228,11 +228,11 @@ class CollaboratorConfirmationRepository {
   }) {
     if (event.kind != _kindCollaboratorResponse) return;
 
+    // NIP-33 'a' tag references another addressable event (the video). The
+    // kind-34238 event's own 'd' tag identifies itself, not the video, so
+    // only 'a' is semantically meaningful here.
     final addressMatches = event.tags.any(
-      (tag) =>
-          tag.length >= 2 &&
-          (tag[0] == 'a' || tag[0] == 'd') &&
-          tag[1] == videoAddress,
+      (tag) => tag.length >= 2 && tag[0] == 'a' && tag[1] == videoAddress,
     );
     if (!addressMatches) return;
 

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart
@@ -1,0 +1,320 @@
+// ABOUTME: Derives per-video collaborator confirmation status on mobile.
+// ABOUTME: Subscribes to kind-34238 acceptance events for own-authored videos.
+
+import 'dart:async';
+
+import 'package:collaborator_repository/src/local_state_reader.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Divine collaborator response event kind (NIP-33 addressable, replaceable
+/// per `(collaborator pubkey, video address)`). Mirrors the constant in
+/// `mobile/lib/constants/collaboration_event_kinds.dart`; duplicated here to
+/// keep the repository free of app-layer imports.
+const int _kindCollaboratorResponse = 34238;
+
+/// Composes the kind-34238 relay subscription, the cross-check against
+/// creator-side `'collaborator'`-role p-tags, and the current user's local
+/// invite-store fast-path into a single per-video status snapshot stream.
+///
+/// Scope guard: the kind-34238 subscription is only opened when the current
+/// user authored the video. For other viewing contexts the repository emits
+/// from the local-store fast-path (so the current user's own ignore/accept
+/// flips their own avatar) without adding relay traffic. Third-party
+/// rendering of pending collaborators is unchanged by this repository —
+/// that broader fix lives in the lifecycle plan and depends on Funnelcake.
+///
+/// One subscription per `videoAddress`, ref-counted across watchers. The
+/// underlying [NostrClient.subscribe] also dedupes by filter hash, so even
+/// if the subscription opens twice it collapses to a single WebSocket
+/// subscription at the transport layer.
+class CollaboratorConfirmationRepository {
+  CollaboratorConfirmationRepository({
+    required NostrClient nostrClient,
+    required CollaboratorInviteLocalStateReader localStateReader,
+    required String currentUserPubkey,
+  }) : _nostrClient = nostrClient,
+       _localStateReader = localStateReader,
+       _currentUserPubkey = currentUserPubkey;
+
+  final NostrClient _nostrClient;
+  final CollaboratorInviteLocalStateReader _localStateReader;
+  final String _currentUserPubkey;
+
+  /// Acceptance events observed from the relay, keyed by [videoAddress].
+  /// Each inner set contains collaborator pubkeys that have published a
+  /// valid kind-34238 acceptance for that address.
+  final Map<String, Set<String>> _relayAccepted = <String, Set<String>>{};
+
+  /// Local fast-path overrides for the current user. Keyed by
+  /// [videoAddress] → [CollaboratorStatus]. Only the current user's own
+  /// pubkey is meaningful here.
+  final Map<String, CollaboratorStatus> _currentUserOverride =
+      <String, CollaboratorStatus>{};
+
+  /// Per-video broadcast subjects. Created on first [watch], reused after.
+  final Map<String, BehaviorSubject<VideoCollaboratorStatus>> _subjects =
+      <String, BehaviorSubject<VideoCollaboratorStatus>>{};
+
+  /// Per-video ref counts. Subscriptions close when count drops to zero.
+  final Map<String, int> _refCount = <String, int>{};
+
+  /// Per-video relay subscriptions. Only present for own-authored videos.
+  final Map<String, StreamSubscription<Event>> _relaySubs =
+      <String, StreamSubscription<Event>>{};
+
+  /// Per-video cache of the most recent watch parameters. Lets
+  /// [markLocal] re-emit a snapshot without callers having to thread the
+  /// creator pubkey and tagged-pubkey list through every accept/ignore site.
+  final Map<String, _WatchContext> _watchContext = <String, _WatchContext>{};
+
+  /// Returns a stream of [VideoCollaboratorStatus] for [videoAddress].
+  ///
+  /// [creatorPubkey] is the author of the kind-34236 video event. Used to
+  /// decide whether to open a kind-34238 relay subscription (only when the
+  /// current user is the creator) and to key the local-store lookup.
+  ///
+  /// [taggedPubkeys] is the list of pubkeys tagged with the
+  /// `'collaborator'` role on the latest creator-authored video event. Used
+  /// to reject acceptance events from non-tagged pubkeys.
+  ///
+  /// Callers must call [release] with the same [videoAddress] when done to
+  /// decrement the ref count and allow cleanup.
+  Stream<VideoCollaboratorStatus> watch(
+    String videoAddress, {
+    required String creatorPubkey,
+    required List<String> taggedPubkeys,
+  }) {
+    _refCount[videoAddress] = (_refCount[videoAddress] ?? 0) + 1;
+    _watchContext[videoAddress] = _WatchContext(
+      creatorPubkey: creatorPubkey,
+      taggedPubkeys: List.unmodifiable(taggedPubkeys),
+    );
+
+    final subject = _subjects.putIfAbsent(
+      videoAddress,
+      () => BehaviorSubject<VideoCollaboratorStatus>.seeded(
+        _snapshot(
+          videoAddress: videoAddress,
+          creatorPubkey: creatorPubkey,
+          taggedPubkeys: taggedPubkeys,
+        ),
+      ),
+    );
+
+    // Always re-emit a fresh snapshot so callers that arrive after acceptance
+    // events have landed see the cached state immediately.
+    subject.add(
+      _snapshot(
+        videoAddress: videoAddress,
+        creatorPubkey: creatorPubkey,
+        taggedPubkeys: taggedPubkeys,
+      ),
+    );
+
+    // Open the relay subscription on demand, only for own-authored videos.
+    final isOwnVideo = creatorPubkey == _currentUserPubkey;
+    if (isOwnVideo && !_relaySubs.containsKey(videoAddress)) {
+      _relaySubs[videoAddress] = _nostrClient
+          .subscribe([
+            Filter(kinds: const [_kindCollaboratorResponse], a: [videoAddress]),
+          ])
+          .listen(
+            (event) => _handleAcceptanceEvent(
+              event,
+              videoAddress: videoAddress,
+              creatorPubkey: creatorPubkey,
+              taggedPubkeys: taggedPubkeys,
+            ),
+            onError: (Object error, StackTrace stackTrace) {
+              Log.warning(
+                'kind-$_kindCollaboratorResponse subscription error for '
+                '$videoAddress: $error',
+                name: 'CollaboratorConfirmationRepository',
+                category: LogCategory.system,
+              );
+            },
+          );
+    }
+
+    return subject.stream;
+  }
+
+  /// Decrements the ref count for [videoAddress]; closes the subject and
+  /// the relay subscription when the count drops to zero.
+  void release(String videoAddress) {
+    final current = _refCount[videoAddress] ?? 0;
+    if (current <= 1) {
+      _refCount.remove(videoAddress);
+      _relaySubs.remove(videoAddress)?.cancel();
+      _subjects.remove(videoAddress)?.close();
+      _relayAccepted.remove(videoAddress);
+      _currentUserOverride.remove(videoAddress);
+      _watchContext.remove(videoAddress);
+      return;
+    }
+    _refCount[videoAddress] = current - 1;
+  }
+
+  /// Returns the current synchronous status snapshot for [videoAddress].
+  /// Returns an empty snapshot if the video is not being watched.
+  VideoCollaboratorStatus current(String videoAddress) {
+    final subject = _subjects[videoAddress];
+    if (subject != null && subject.hasValue) {
+      return subject.value;
+    }
+    return VideoCollaboratorStatus(videoAddress: videoAddress);
+  }
+
+  /// Local fast-path: records the current user's accept/ignore decision
+  /// for a video they were invited to. Emits an updated snapshot to any
+  /// active subscriber.
+  ///
+  /// Quietly drops writes for pubkeys other than the current user; the
+  /// local store is per-device and only tracks the current user's own
+  /// decisions.
+  void markLocal({
+    required String videoAddress,
+    required String collaboratorPubkey,
+    required CollaboratorStatus status,
+  }) {
+    if (collaboratorPubkey != _currentUserPubkey) {
+      Log.warning(
+        'markLocal called for non-current-user pubkey '
+        '$collaboratorPubkey; ignoring',
+        name: 'CollaboratorConfirmationRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    _currentUserOverride[videoAddress] = status;
+    final subject = _subjects[videoAddress];
+    final context = _watchContext[videoAddress];
+    if (subject != null && context != null) {
+      subject.add(
+        _snapshot(
+          videoAddress: videoAddress,
+          creatorPubkey: context.creatorPubkey,
+          taggedPubkeys: context.taggedPubkeys,
+        ),
+      );
+    }
+  }
+
+  /// Disposes all subjects and subscriptions. Used on sign-out / shutdown.
+  Future<void> close() async {
+    for (final sub in _relaySubs.values) {
+      await sub.cancel();
+    }
+    _relaySubs.clear();
+    for (final subject in _subjects.values) {
+      await subject.close();
+    }
+    _subjects.clear();
+    _refCount.clear();
+    _relayAccepted.clear();
+    _currentUserOverride.clear();
+    _watchContext.clear();
+  }
+
+  void _handleAcceptanceEvent(
+    Event event, {
+    required String videoAddress,
+    required String creatorPubkey,
+    required List<String> taggedPubkeys,
+  }) {
+    if (event.kind != _kindCollaboratorResponse) return;
+
+    final addressMatches = event.tags.any(
+      (tag) =>
+          tag.length >= 2 &&
+          (tag[0] == 'a' || tag[0] == 'd') &&
+          tag[1] == videoAddress,
+    );
+    if (!addressMatches) return;
+
+    final hasAcceptedStatus = event.tags.any(
+      (tag) => tag.length >= 2 && tag[0] == 'status' && tag[1] == 'accepted',
+    );
+    if (!hasAcceptedStatus) return;
+
+    if (!taggedPubkeys.contains(event.pubkey)) {
+      Log.info(
+        'Ignoring kind-$_kindCollaboratorResponse from non-tagged pubkey '
+        '${event.pubkey} for $videoAddress',
+        name: 'CollaboratorConfirmationRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    final accepted = _relayAccepted.putIfAbsent(videoAddress, () => <String>{});
+    if (accepted.add(event.pubkey)) {
+      final subject = _subjects[videoAddress];
+      subject?.add(
+        _snapshot(
+          videoAddress: videoAddress,
+          creatorPubkey: creatorPubkey,
+          taggedPubkeys: taggedPubkeys,
+        ),
+      );
+    }
+  }
+
+  VideoCollaboratorStatus _snapshot({
+    required String videoAddress,
+    required String creatorPubkey,
+    required List<String> taggedPubkeys,
+  }) {
+    final statusByPubkey = <String, CollaboratorStatus>{};
+    final accepted = _relayAccepted[videoAddress] ?? const <String>{};
+    final override = _currentUserOverride[videoAddress];
+
+    for (final pubkey in taggedPubkeys) {
+      // Relay-derived: kind-34238 acceptance event observed.
+      if (accepted.contains(pubkey)) {
+        statusByPubkey[pubkey] = CollaboratorStatus.confirmed;
+        continue;
+      }
+
+      // Local-store fast-path for the current user only. Other pubkeys'
+      // states are unknown to this device.
+      if (pubkey == _currentUserPubkey) {
+        final inMemory = override;
+        if (inMemory != null) {
+          statusByPubkey[pubkey] = inMemory;
+          continue;
+        }
+        final fromStore = _localStateReader.readLocalState(
+          videoAddress: videoAddress,
+          creatorPubkey: creatorPubkey,
+          collaboratorPubkey: pubkey,
+        );
+        if (fromStore != null) {
+          statusByPubkey[pubkey] = fromStore;
+          continue;
+        }
+      }
+
+      statusByPubkey[pubkey] = CollaboratorStatus.pending;
+    }
+
+    return VideoCollaboratorStatus(
+      videoAddress: videoAddress,
+      statusByPubkey: statusByPubkey,
+    );
+  }
+}
+
+class _WatchContext {
+  const _WatchContext({
+    required this.creatorPubkey,
+    required this.taggedPubkeys,
+  });
+
+  final String creatorPubkey;
+  final List<String> taggedPubkeys;
+}

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_visibility.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_visibility.dart
@@ -1,0 +1,96 @@
+// ABOUTME: View-model for status-aware collaborator rendering.
+// ABOUTME: Combines tagged pubkeys with per-pubkey status + viewer context.
+
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+import 'package:models/models.dart';
+
+/// Encapsulates the inputs needed by collaborator-rendering surfaces
+/// (avatar row, metadata section, edit dialog) so the filter / decoration /
+/// pending-count logic lives in one place rather than being recomputed
+/// surface-by-surface.
+///
+/// Construct with the default constructor when the status pipeline is
+/// available; use [CollaboratorVisibility.fallback] when the repository is
+/// gated off (Nostr not ready, no addressable id, no current user) and the
+/// surface should render the raw tagged list unchanged from pre-pipeline
+/// behaviour.
+@immutable
+class CollaboratorVisibility extends Equatable {
+  const CollaboratorVisibility({
+    required this.taggedPubkeys,
+    required this.statusByPubkey,
+    required this.currentUserPubkey,
+    required this.creatorPubkey,
+  }) : _hasStatusPipeline = true;
+
+  const CollaboratorVisibility.fallback({required this.taggedPubkeys})
+    : statusByPubkey = const {},
+      currentUserPubkey = '',
+      creatorPubkey = '',
+      _hasStatusPipeline = false;
+
+  /// Pubkeys tagged with the `'collaborator'` role on the latest
+  /// creator-authored video event.
+  final List<String> taggedPubkeys;
+
+  /// Per-collaborator status as derived by the repository. Empty in
+  /// fallback mode.
+  final Map<String, CollaboratorStatus> statusByPubkey;
+
+  /// Hex pubkey of the currently signed-in user. Empty in fallback mode.
+  final String currentUserPubkey;
+
+  /// Hex pubkey of the video's author. Empty in fallback mode.
+  final String creatorPubkey;
+
+  final bool _hasStatusPipeline;
+
+  /// True when the current user authored the video. Always false in
+  /// fallback mode.
+  bool get isInviterView =>
+      _hasStatusPipeline && currentUserPubkey == creatorPubkey;
+
+  /// Status for [pubkey]. Returns [CollaboratorStatus.pending] when the
+  /// status pipeline is unavailable or no entry exists.
+  CollaboratorStatus statusFor(String pubkey) =>
+      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
+
+  /// Pubkeys to render. The current user's pubkey is filtered out when
+  /// they have locally ignored the invite. In fallback mode this is the
+  /// raw [taggedPubkeys] list.
+  List<String> get visiblePubkeys {
+    if (!_hasStatusPipeline) return taggedPubkeys;
+    return [
+      for (final pubkey in taggedPubkeys)
+        if (!_isHiddenByCurrentUserIgnore(pubkey)) pubkey,
+    ];
+  }
+
+  /// Whether [pubkey] should render a "pending" decoration. Only true on
+  /// the inviter's own video for collaborators that haven't accepted yet.
+  bool isPendingForInviter(String pubkey) {
+    if (!isInviterView) return false;
+    return statusFor(pubkey) == CollaboratorStatus.pending;
+  }
+
+  /// Count of pending collaborators visible on the inviter's view. Zero
+  /// for any other viewer or in fallback mode.
+  int get pendingCount {
+    if (!isInviterView) return 0;
+    return visiblePubkeys.where(isPendingForInviter).length;
+  }
+
+  bool _isHiddenByCurrentUserIgnore(String pubkey) =>
+      pubkey == currentUserPubkey &&
+      statusFor(pubkey) == CollaboratorStatus.ignored;
+
+  @override
+  List<Object?> get props => [
+    taggedPubkeys,
+    statusByPubkey,
+    currentUserPubkey,
+    creatorPubkey,
+    _hasStatusPipeline,
+  ];
+}

--- a/mobile/packages/collaborator_repository/lib/src/local_state_reader.dart
+++ b/mobile/packages/collaborator_repository/lib/src/local_state_reader.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Abstraction for reading current user's local invite response state.
+// ABOUTME: Lets the repository depend on a contract instead of mobile/lib code.
+
+import 'package:models/models.dart';
+
+/// Read-only contract over the local invite-response store. The concrete
+/// implementation lives in the app layer (`mobile/lib`) and is wired into
+/// the repository through dependency injection.
+///
+/// Returns `null` when the local store has no entry for the
+/// `(videoAddress, creatorPubkey, collaboratorPubkey)` triple — meaning the
+/// invite has neither been accepted nor ignored locally.
+abstract class CollaboratorInviteLocalStateReader {
+  CollaboratorStatus? readLocalState({
+    required String videoAddress,
+    required String creatorPubkey,
+    required String collaboratorPubkey,
+  });
+}

--- a/mobile/packages/collaborator_repository/pubspec.yaml
+++ b/mobile/packages/collaborator_repository/pubspec.yaml
@@ -1,0 +1,27 @@
+name: collaborator_repository
+description: Repository for collaborator confirmation status on Divine videos.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  equatable: ^2.0.7
+  meta: ^1.16.0
+  models:
+    path: ../models
+  nostr_client:
+    path: ../nostr_client
+  nostr_sdk:
+    path: ../nostr_sdk
+  rxdart: ^0.28.0
+  unified_logger:
+    path: ../unified_logger
+
+dev_dependencies:
+  fake_async: ^1.3.3
+  mocktail: ^1.0.4
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -165,6 +165,53 @@ void main() {
       repo.release(_videoAddress);
     });
 
+    test(
+      'rejects events whose only address tag is `d` (NIP-33 self-id)',
+      () async {
+        // Defense in depth: even if a relay misbehaves and delivers an event
+        // whose only address-shaped tag is `d` (the event's own addressable
+        // id), we must NOT treat it as an acceptance for the video. Per
+        // NIP-33, `a` is the reference to another addressable event; `d` is
+        // self-identifying. The relay filter `#a` already excludes such
+        // events, but the in-process check is what protects us if the relay
+        // is wrong.
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _creatorPubkey,
+        );
+
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+        final beforeCount = emissions.length;
+
+        relayController.add(
+          _acceptanceEvent(
+            pubkey: _collaboratorPubkey,
+            addressTag: 'd',
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emissions.length, equals(beforeCount));
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
     test('ignores events without status=accepted', () async {
       final repo = CollaboratorConfirmationRepository(
         nostrClient: nostrClient,

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -1,0 +1,445 @@
+// ABOUTME: Tests for CollaboratorConfirmationRepository.
+
+import 'dart:async';
+
+import 'package:collaborator_repository/collaborator_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+class _StaticLocalStateReader implements CollaboratorInviteLocalStateReader {
+  _StaticLocalStateReader(this._states);
+
+  final Map<String, CollaboratorStatus> _states;
+
+  @override
+  CollaboratorStatus? readLocalState({
+    required String videoAddress,
+    required String creatorPubkey,
+    required String collaboratorPubkey,
+  }) {
+    return _states['$videoAddress|$creatorPubkey|$collaboratorPubkey'];
+  }
+}
+
+const _videoAddress = '34236:abc:vine-1';
+const _creatorPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _collaboratorPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _secondCollaboratorPubkey =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _strangerPubkey =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+Event _acceptanceEvent({
+  required String pubkey,
+  String videoAddress = _videoAddress,
+  String statusValue = 'accepted',
+  String addressTag = 'a',
+}) {
+  return Event(pubkey, 34238, [
+    [addressTag, videoAddress, 'wss://relay.divine.video', 'root'],
+    ['p', _creatorPubkey],
+    ['role', 'Collaborator'],
+    ['status', statusValue],
+  ], '');
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(_FakeFilter());
+  });
+
+  group(CollaboratorConfirmationRepository, () {
+    late _MockNostrClient nostrClient;
+    late StreamController<Event> relayController;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      relayController = StreamController<Event>.broadcast();
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+          relayTypes: any(named: 'relayTypes'),
+          sendAfterAuth: any(named: 'sendAfterAuth'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).thenAnswer((_) => relayController.stream);
+    });
+
+    tearDown(() async {
+      await relayController.close();
+    });
+
+    test(
+      'inviter view: pending entries flip to confirmed on kind-34238 echo',
+      () async {
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _creatorPubkey,
+        );
+
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [
+                _collaboratorPubkey,
+                _secondCollaboratorPubkey,
+              ],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(emissions, isNotEmpty);
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+        expect(
+          emissions.last.statusFor(_secondCollaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+
+        relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.confirmed),
+        );
+        // Other collaborator stays pending.
+        expect(
+          emissions.last.statusFor(_secondCollaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test('rejects kind-34238 acceptance from a non-tagged pubkey', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _creatorPubkey,
+      );
+
+      final emissions = <VideoCollaboratorStatus>[];
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(emissions.add);
+
+      await Future<void>.delayed(Duration.zero);
+      final beforeCount = emissions.length;
+
+      relayController.add(_acceptanceEvent(pubkey: _strangerPubkey));
+      await Future<void>.delayed(Duration.zero);
+
+      // No new emission; stranger ignored.
+      expect(emissions.length, equals(beforeCount));
+      expect(
+        emissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.pending),
+      );
+
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
+
+    test('ignores events without status=accepted', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _creatorPubkey,
+      );
+
+      final emissions = <VideoCollaboratorStatus>[];
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen(emissions.add);
+
+      await Future<void>.delayed(Duration.zero);
+      final beforeCount = emissions.length;
+
+      relayController.add(
+        _acceptanceEvent(
+          pubkey: _collaboratorPubkey,
+          statusValue: 'declined',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions.length, equals(beforeCount));
+      expect(
+        emissions.last.statusFor(_collaboratorPubkey),
+        equals(CollaboratorStatus.pending),
+      );
+
+      await sub.cancel();
+      repo.release(_videoAddress);
+    });
+
+    test(
+      'recipient view: current user local store override flips current user '
+      'status without a relay subscription',
+      () async {
+        // No NostrClient.subscribe call expected because current user is
+        // NOT the creator.
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {
+            '$_videoAddress|$_creatorPubkey|$_collaboratorPubkey':
+                CollaboratorStatus.ignored,
+          }),
+          currentUserPubkey: _collaboratorPubkey,
+        );
+
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.ignored),
+        );
+        verifyNever(
+          () => nostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test(
+      'markLocal emits a new snapshot for the current user immediately',
+      () async {
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _collaboratorPubkey,
+        );
+
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+
+        repo.markLocal(
+          videoAddress: _videoAddress,
+          collaboratorPubkey: _collaboratorPubkey,
+          status: CollaboratorStatus.confirmed,
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.confirmed),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test(
+      'markLocal rejects writes for pubkeys other than the current user',
+      () async {
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _collaboratorPubkey,
+        );
+
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [
+                _collaboratorPubkey,
+                _secondCollaboratorPubkey,
+              ],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+
+        repo.markLocal(
+          videoAddress: _videoAddress,
+          collaboratorPubkey: _secondCollaboratorPubkey,
+          status: CollaboratorStatus.confirmed,
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        // Second collaborator status remains pending because the write was
+        // rejected (not the current user).
+        expect(
+          emissions.last.statusFor(_secondCollaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test(
+      'release decrements ref count; only closes when count drops to zero',
+      () async {
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _creatorPubkey,
+        );
+
+        final emissions1 = <VideoCollaboratorStatus>[];
+        final emissions2 = <VideoCollaboratorStatus>[];
+        final sub1 = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions1.add);
+        final sub2 = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions2.add);
+
+        await Future<void>.delayed(Duration.zero);
+
+        // Release once — still one watcher; relay event should still emit.
+        repo.release(_videoAddress);
+
+        relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emissions1.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.confirmed),
+        );
+
+        // Final release — closes.
+        repo.release(_videoAddress);
+        expect(repo.current(_videoAddress).statusByPubkey, isEmpty);
+
+        await sub1.cancel();
+        await sub2.cancel();
+      },
+    );
+
+    test(
+      'does not open a relay subscription when current user is not the '
+      'creator',
+      () async {
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _strangerPubkey,
+        );
+
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen((_) {});
+
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(
+          () => nostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test('close cancels relay subs and clears state', () async {
+      final repo = CollaboratorConfirmationRepository(
+        nostrClient: nostrClient,
+        localStateReader: _StaticLocalStateReader(const {}),
+        currentUserPubkey: _creatorPubkey,
+      );
+
+      final sub = repo
+          .watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: const [_collaboratorPubkey],
+          )
+          .listen((_) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      await repo.close();
+      expect(repo.current(_videoAddress).statusByPubkey, isEmpty);
+
+      await sub.cancel();
+    });
+  });
+}

--- a/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
@@ -1,0 +1,254 @@
+// ABOUTME: Tests for CollaboratorVisibility view-model.
+
+import 'package:collaborator_repository/collaborator_repository.dart';
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+const _creator =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _collab1 =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _collab2 =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _viewer =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+void main() {
+  group(CollaboratorVisibility, () {
+    group('fallback', () {
+      test('exposes raw tagged list unfiltered', () {
+        const vis = CollaboratorVisibility.fallback(
+          taggedPubkeys: [_collab1, _collab2],
+        );
+        expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+      });
+
+      test('isInviterView is always false', () {
+        const vis = CollaboratorVisibility.fallback(
+          taggedPubkeys: [_collab1],
+        );
+        expect(vis.isInviterView, isFalse);
+      });
+
+      test('pendingCount is always zero', () {
+        const vis = CollaboratorVisibility.fallback(
+          taggedPubkeys: [_collab1, _collab2],
+        );
+        expect(vis.pendingCount, equals(0));
+      });
+
+      test('isPendingForInviter is always false', () {
+        const vis = CollaboratorVisibility.fallback(
+          taggedPubkeys: [_collab1],
+        );
+        expect(vis.isPendingForInviter(_collab1), isFalse);
+      });
+
+      test('statusFor returns pending for any pubkey', () {
+        const vis = CollaboratorVisibility.fallback(
+          taggedPubkeys: [_collab1],
+        );
+        expect(vis.statusFor(_collab1), equals(CollaboratorStatus.pending));
+        expect(vis.statusFor(_collab2), equals(CollaboratorStatus.pending));
+      });
+    });
+
+    group('inviter view', () {
+      test('isInviterView true when current user is the creator', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.pending},
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isInviterView, isTrue);
+      });
+
+      test('pending entries flagged as pending; confirmed are not', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.pending,
+            _collab2: CollaboratorStatus.confirmed,
+          },
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isPendingForInviter(_collab1), isTrue);
+        expect(vis.isPendingForInviter(_collab2), isFalse);
+      });
+
+      test('missing entries default to pending', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {},
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isPendingForInviter(_collab1), isTrue);
+      });
+
+      test('pendingCount counts pending entries only', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.pending,
+            _collab2: CollaboratorStatus.confirmed,
+          },
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(vis.pendingCount, equals(1));
+      });
+
+      test('visiblePubkeys returns all tagged when none ignored', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.pending,
+            _collab2: CollaboratorStatus.confirmed,
+          },
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+      });
+    });
+
+    group('recipient view', () {
+      test('isInviterView false when current user is a collaborator', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.pending},
+          currentUserPubkey: _collab1,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isInviterView, isFalse);
+      });
+
+      test('isPendingForInviter false for recipient view', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.pending,
+            _collab2: CollaboratorStatus.pending,
+          },
+          currentUserPubkey: _collab1,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isPendingForInviter(_collab1), isFalse);
+        expect(vis.isPendingForInviter(_collab2), isFalse);
+      });
+
+      test('current user filtered out when their status is ignored', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+          currentUserPubkey: _collab1,
+          creatorPubkey: _creator,
+        );
+        expect(vis.visiblePubkeys, equals([_collab2]));
+      });
+
+      test('current user not filtered out when their status is confirmed', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+          currentUserPubkey: _collab1,
+          creatorPubkey: _creator,
+        );
+        expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+      });
+
+      test(
+        'current user not filtered out when their status is missing (pending)',
+        () {
+          const vis = CollaboratorVisibility(
+            taggedPubkeys: [_collab1, _collab2],
+            statusByPubkey: {},
+            currentUserPubkey: _collab1,
+            creatorPubkey: _creator,
+          );
+          expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+        },
+      );
+
+      test(
+        'another collaborator with ignored status is NOT filtered out '
+        '(only current user is)',
+        () {
+          // `ignored` is local-only; another collaborator's `ignored` status
+          // could only come from a different device. The fast-path map is
+          // single-device, so this should never happen in practice — but the
+          // contract is: only the current user's own ignore filters them out.
+          const vis = CollaboratorVisibility(
+            taggedPubkeys: [_collab1, _collab2],
+            statusByPubkey: {_collab2: CollaboratorStatus.ignored},
+            currentUserPubkey: _collab1,
+            creatorPubkey: _creator,
+          );
+          expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+        },
+      );
+    });
+
+    group('third-party view', () {
+      test('isInviterView false', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.pending},
+          currentUserPubkey: _viewer,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isInviterView, isFalse);
+      });
+
+      test('no decoration / no filtering applied', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1, _collab2],
+          statusByPubkey: {
+            _collab1: CollaboratorStatus.pending,
+            _collab2: CollaboratorStatus.confirmed,
+          },
+          currentUserPubkey: _viewer,
+          creatorPubkey: _creator,
+        );
+        expect(vis.visiblePubkeys, equals([_collab1, _collab2]));
+        expect(vis.pendingCount, equals(0));
+        expect(vis.isPendingForInviter(_collab1), isFalse);
+        expect(vis.isPendingForInviter(_collab2), isFalse);
+      });
+    });
+
+    group('equality', () {
+      test('two equivalent instances compare equal', () {
+        const a = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        const b = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+          currentUserPubkey: _creator,
+          creatorPubkey: _creator,
+        );
+        expect(a, equals(b));
+      });
+
+      test('fallback and status-aware instances are unequal', () {
+        const fallback = CollaboratorVisibility.fallback(
+          taggedPubkeys: [_collab1],
+        );
+        const statusAware = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {},
+          currentUserPubkey: '',
+          creatorPubkey: '',
+        );
+        expect(fallback, isNot(equals(statusAware)));
+      });
+    });
+  });
+}

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -9,6 +9,7 @@ export 'src/bug_report_result.dart';
 export 'src/bulk_profiles_response.dart';
 export 'src/bulk_video_stats_entry.dart';
 export 'src/bulk_video_stats_response.dart';
+export 'src/collaborator_status.dart';
 export 'src/curated_list.dart';
 export 'src/curation_publish_status.dart';
 export 'src/curation_set.dart';

--- a/mobile/packages/models/lib/src/collaborator_status.dart
+++ b/mobile/packages/models/lib/src/collaborator_status.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Per-pubkey collaborator confirmation status for a video.
+// ABOUTME: Drives render decisions in CollaboratorAvatarRow and metadata chips.
+
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Confirmation state for a collaborator pubkey on a specific video.
+///
+/// The Nostr protocol carries pending collaborators on the creator-authored
+/// video event as `['p', pubkey, relay, 'collaborator']` tags. Confirmation
+/// is derived from the collaborator-authored kind-34238 acceptance event
+/// (plus the latest creator-authored tag still naming them). See
+/// `docs/superpowers/specs/2026-04-25-collab-invite-acceptance-design.md`.
+enum CollaboratorStatus {
+  /// Tagged by the creator on the latest video event; no acceptance observed.
+  pending,
+
+  /// Tagged by the creator AND the collaborator has published a kind-34238
+  /// acceptance for this video, OR the current user (acting as the
+  /// collaborator) has marked the invite accepted locally.
+  confirmed,
+
+  /// The current user (acting as the collaborator) has marked the invite
+  /// ignored locally. Ignore is local-only per spec — no protocol publish.
+  /// Only meaningful when the queried pubkey matches the current user.
+  ignored,
+}
+
+/// Immutable status snapshot for a video, keyed by collaborator pubkey.
+@immutable
+class VideoCollaboratorStatus extends Equatable {
+  const VideoCollaboratorStatus({
+    required this.videoAddress,
+    this.statusByPubkey = const {},
+  });
+
+  /// NIP-33 addressable id of the video, e.g. `34236:<creator>:<dTag>`.
+  final String videoAddress;
+
+  /// Per-collaborator status. Pubkeys absent from the map are treated as
+  /// [CollaboratorStatus.pending] by callers.
+  final Map<String, CollaboratorStatus> statusByPubkey;
+
+  CollaboratorStatus statusFor(String pubkey) =>
+      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
+
+  VideoCollaboratorStatus copyWith({
+    Map<String, CollaboratorStatus>? statusByPubkey,
+  }) {
+    return VideoCollaboratorStatus(
+      videoAddress: videoAddress,
+      statusByPubkey: statusByPubkey ?? this.statusByPubkey,
+    );
+  }
+
+  @override
+  List<Object?> get props => [videoAddress, statusByPubkey];
+}

--- a/mobile/packages/models/test/src/collaborator_status_test.dart
+++ b/mobile/packages/models/test/src/collaborator_status_test.dart
@@ -1,0 +1,65 @@
+// ABOUTME: Tests for CollaboratorStatus enum and VideoCollaboratorStatus.
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(VideoCollaboratorStatus, () {
+    const address = '34236:abc:vine-1';
+
+    test('default statusByPubkey is empty', () {
+      const status = VideoCollaboratorStatus(videoAddress: address);
+      expect(status.statusByPubkey, isEmpty);
+    });
+
+    test('statusFor returns pending for absent pubkeys', () {
+      const status = VideoCollaboratorStatus(videoAddress: address);
+      expect(status.statusFor('missing'), equals(CollaboratorStatus.pending));
+    });
+
+    test('statusFor returns mapped value for present pubkeys', () {
+      const status = VideoCollaboratorStatus(
+        videoAddress: address,
+        statusByPubkey: {
+          'a': CollaboratorStatus.confirmed,
+          'b': CollaboratorStatus.ignored,
+        },
+      );
+      expect(status.statusFor('a'), equals(CollaboratorStatus.confirmed));
+      expect(status.statusFor('b'), equals(CollaboratorStatus.ignored));
+      expect(status.statusFor('c'), equals(CollaboratorStatus.pending));
+    });
+
+    test('copyWith replaces statusByPubkey while preserving address', () {
+      const original = VideoCollaboratorStatus(
+        videoAddress: address,
+        statusByPubkey: {'a': CollaboratorStatus.pending},
+      );
+      final updated = original.copyWith(
+        statusByPubkey: const {'a': CollaboratorStatus.confirmed},
+      );
+      expect(updated.videoAddress, equals(address));
+      expect(
+        updated.statusFor('a'),
+        equals(CollaboratorStatus.confirmed),
+      );
+    });
+
+    test('equality is structural on address and map content', () {
+      const a = VideoCollaboratorStatus(
+        videoAddress: address,
+        statusByPubkey: {'p1': CollaboratorStatus.confirmed},
+      );
+      const b = VideoCollaboratorStatus(
+        videoAddress: address,
+        statusByPubkey: {'p1': CollaboratorStatus.confirmed},
+      );
+      const c = VideoCollaboratorStatus(
+        videoAddress: address,
+        statusByPubkey: {'p1': CollaboratorStatus.pending},
+      );
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -28,6 +28,7 @@ workspace:
   - packages/blossom_upload_service
   - packages/blurhash_service
   - packages/categories_repository
+  - packages/collaborator_repository
   - packages/comments_repository
   - packages/content_blocklist_repository
   - packages/content_policy
@@ -168,6 +169,9 @@ dependencies:
 
   # Categories Repository - Video categories from Funnelcake API
   categories_repository:
+
+  # Collaborator Repository - Per-video pending/confirmed collaborator status
+  collaborator_repository:
 
   # Content Blocklist Repository - Blocked users, mutual mutes, kind 30000 sync
   content_blocklist_repository:

--- a/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
@@ -2,8 +2,10 @@
 // ABOUTME: Verifies accept publishes while ignore stays local-only.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
@@ -14,6 +16,9 @@ class _MockCollaboratorInviteStateStore extends Mock
 
 class _MockCollaboratorResponseService extends Mock
     implements CollaboratorResponseService {}
+
+class _MockConfirmationRepository extends Mock
+    implements CollaboratorConfirmationRepository {}
 
 void main() {
   const currentUserPubkey =
@@ -34,15 +39,25 @@ void main() {
 
   late _MockCollaboratorInviteStateStore store;
   late _MockCollaboratorResponseService responseService;
+  late _MockConfirmationRepository confirmationRepository;
 
   setUpAll(() {
     registerFallbackValue(invite);
     registerFallbackValue(CollaboratorInviteState.pending);
+    registerFallbackValue(CollaboratorStatus.pending);
   });
 
   setUp(() {
     store = _MockCollaboratorInviteStateStore();
     responseService = _MockCollaboratorResponseService();
+    confirmationRepository = _MockConfirmationRepository();
+    when(
+      () => confirmationRepository.markLocal(
+        videoAddress: any(named: 'videoAddress'),
+        collaboratorPubkey: any(named: 'collaboratorPubkey'),
+        status: any(named: 'status'),
+      ),
+    ).thenReturn(null);
   });
 
   CollaboratorInviteActionsCubit buildCubit() {
@@ -50,6 +65,7 @@ void main() {
       stateStore: store,
       responseService: responseService,
       currentUserPubkey: currentUserPubkey,
+      confirmationRepository: confirmationRepository,
     );
   }
 
@@ -116,6 +132,11 @@ void main() {
             collaboratorPubkey: currentUserPubkey,
             state: CollaboratorInviteState.accepted,
           ),
+          () => confirmationRepository.markLocal(
+            videoAddress: invite.videoAddress,
+            collaboratorPubkey: currentUserPubkey,
+            status: CollaboratorStatus.confirmed,
+          ),
         ]);
       },
     );
@@ -151,6 +172,17 @@ void main() {
           CollaboratorInviteState.failed,
         ),
       ],
+      verify: (_) {
+        // Failed publish must NOT optimistically promote the local fast-path
+        // to confirmed.
+        verifyNever(
+          () => confirmationRepository.markLocal(
+            videoAddress: any(named: 'videoAddress'),
+            collaboratorPubkey: any(named: 'collaboratorPubkey'),
+            status: any(named: 'status'),
+          ),
+        );
+      },
     );
 
     blocTest<CollaboratorInviteActionsCubit, CollaboratorInviteActionsState>(
@@ -176,6 +208,13 @@ void main() {
       ],
       verify: (_) {
         verifyNever(() => responseService.acceptInvite(any()));
+        verify(
+          () => confirmationRepository.markLocal(
+            videoAddress: invite.videoAddress,
+            collaboratorPubkey: currentUserPubkey,
+            status: CollaboratorStatus.ignored,
+          ),
+        ).called(1);
       },
     );
 

--- a/mobile/test/blocs/video_collaborator_status/video_collaborator_status_cubit_test.dart
+++ b/mobile/test/blocs/video_collaborator_status/video_collaborator_status_cubit_test.dart
@@ -1,0 +1,116 @@
+// ABOUTME: Tests for VideoCollaboratorStatusCubit.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:collaborator_repository/collaborator_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_collaborator_status/video_collaborator_status_cubit.dart';
+
+class _MockRepository extends Mock
+    implements CollaboratorConfirmationRepository {}
+
+const _videoAddress = '34236:abc:vine-1';
+const _creatorPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _collaboratorPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+void main() {
+  group(VideoCollaboratorStatusCubit, () {
+    late _MockRepository repo;
+
+    setUp(() {
+      repo = _MockRepository();
+      when(() => repo.release(any())).thenReturn(null);
+    });
+
+    blocTest<VideoCollaboratorStatusCubit, VideoCollaboratorStatusState>(
+      'emits loading then ready with the repository snapshot',
+      setUp: () {
+        when(
+          () => repo.watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: any(named: 'taggedPubkeys'),
+          ),
+        ).thenAnswer(
+          (_) => Stream<VideoCollaboratorStatus>.value(
+            const VideoCollaboratorStatus(
+              videoAddress: _videoAddress,
+              statusByPubkey: {
+                _collaboratorPubkey: CollaboratorStatus.confirmed,
+              },
+            ),
+          ),
+        );
+      },
+      build: () => VideoCollaboratorStatusCubit(
+        repository: repo,
+        videoAddress: _videoAddress,
+        creatorPubkey: _creatorPubkey,
+        taggedPubkeys: const [_collaboratorPubkey],
+      ),
+      expect: () => const [
+        VideoCollaboratorStatusState(
+          load: VideoCollaboratorStatusLoad.ready,
+          statusByPubkey: {_collaboratorPubkey: CollaboratorStatus.confirmed},
+        ),
+      ],
+    );
+
+    blocTest<VideoCollaboratorStatusCubit, VideoCollaboratorStatusState>(
+      'emits failure and reports error when the stream errors',
+      setUp: () {
+        when(
+          () => repo.watch(
+            _videoAddress,
+            creatorPubkey: _creatorPubkey,
+            taggedPubkeys: any(named: 'taggedPubkeys'),
+          ),
+        ).thenAnswer(
+          (_) => Stream<VideoCollaboratorStatus>.error(
+            StateError('relay unavailable'),
+          ),
+        );
+      },
+      build: () => VideoCollaboratorStatusCubit(
+        repository: repo,
+        videoAddress: _videoAddress,
+        creatorPubkey: _creatorPubkey,
+        taggedPubkeys: const [_collaboratorPubkey],
+      ),
+      expect: () => const [
+        VideoCollaboratorStatusState(
+          load: VideoCollaboratorStatusLoad.failure,
+        ),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+
+    test('release is called on close', () async {
+      when(
+        () => repo.watch(
+          _videoAddress,
+          creatorPubkey: _creatorPubkey,
+          taggedPubkeys: any(named: 'taggedPubkeys'),
+        ),
+      ).thenAnswer(
+        (_) => StreamController<VideoCollaboratorStatus>.broadcast().stream,
+      );
+
+      final cubit = VideoCollaboratorStatusCubit(
+        repository: repo,
+        videoAddress: _videoAddress,
+        creatorPubkey: _creatorPubkey,
+        taggedPubkeys: const [_collaboratorPubkey],
+      );
+
+      await cubit.close();
+
+      verify(() => repo.release(_videoAddress)).called(1);
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Widget tests for status-aware CollaboratorAvatarRow rendering.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
+
+const _creatorPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+VideoEvent _video({List<String> collaborators = const []}) => VideoEvent(
+  id: 'test_video_id_00000000000000000000000000000000000000000000000000',
+  pubkey: _creatorPubkey,
+  createdAt: 1700000000,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+  videoUrl: 'https://example.com/video.mp4',
+  collaboratorPubkeys: collaborators,
+);
+
+Widget _wrap(Widget child) {
+  return ProviderScope(
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  group(CollaboratorAvatarRow, () {
+    testWidgets(
+      'renders SizedBox.shrink when video has no collaborators',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(CollaboratorAvatarRow(video: _video())),
+        );
+        expect(find.byIcon(Icons.people), findsNothing);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
@@ -1,14 +1,33 @@
 // ABOUTME: Widget tests for status-aware CollaboratorAvatarRow rendering.
+// ABOUTME: Tests CollaboratorAvatarRowBody directly via CollaboratorVisibility.
 
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 const _creatorPubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _collab1 =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _collab2 =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _thirdPartyPubkey =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+UserProfile _makeProfile(String pubkey, String name) => UserProfile(
+  pubkey: pubkey,
+  displayName: name,
+  name: name.toLowerCase(),
+  rawData: const {},
+  createdAt: DateTime(2025),
+  eventId: 'evt_$pubkey',
+);
 
 VideoEvent _video({List<String> collaborators = const []}) => VideoEvent(
   id: 'test_video_id_00000000000000000000000000000000000000000000000000',
@@ -20,8 +39,9 @@ VideoEvent _video({List<String> collaborators = const []}) => VideoEvent(
   collaboratorPubkeys: collaborators,
 );
 
-Widget _wrap(Widget child) {
+Widget _wrap(Widget child, {List<Override> overrides = const []}) {
   return ProviderScope(
+    overrides: overrides,
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -29,6 +49,8 @@ Widget _wrap(Widget child) {
     ),
   );
 }
+
+AppLocalizations get _l10n => lookupAppLocalizations(const Locale('en'));
 
 void main() {
   group(CollaboratorAvatarRow, () {
@@ -39,6 +61,228 @@ void main() {
           _wrap(CollaboratorAvatarRow(video: _video())),
         );
         expect(find.byIcon(Icons.people), findsNothing);
+      },
+    );
+  });
+
+  group(CollaboratorAvatarRowBody, () {
+    testWidgets(
+      'fallback mode: renders all tagged pubkeys with no decoration',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility.fallback(
+                taggedPubkeys: [_collab1, _collab2],
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.people), findsOneWidget);
+        expect(find.byType(Opacity), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'inviter view: pending collaborator avatar dimmed with semantic label',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1, _collab2],
+                statusByPubkey: {
+                  _collab1: CollaboratorStatus.pending,
+                  _collab2: CollaboratorStatus.confirmed,
+                },
+                currentUserPubkey: _creatorPubkey,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+
+        // Exactly one avatar is wrapped in Opacity (the pending one).
+        final opacityWidgets = tester.widgetList<Opacity>(
+          find.byType(Opacity),
+        );
+        expect(opacityWidgets, hasLength(1));
+        expect(opacityWidgets.first.opacity, closeTo(0.55, 0.001));
+
+        // Pending semantic label present on the dimmed avatar (find via
+        // widget predicate so the test doesn't need ensureSemantics).
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                w.properties.label ==
+                    _l10n.videoCollaboratorPendingSemanticLabel,
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'inviter view: pending count appears in label suffix',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1, _collab2],
+                statusByPubkey: {
+                  _collab1: CollaboratorStatus.pending,
+                  _collab2: CollaboratorStatus.pending,
+                },
+                currentUserPubkey: _creatorPubkey,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+            overrides: [
+              fetchUserProfileProvider(
+                _collab1,
+              ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+              fetchUserProfileProvider(
+                _collab2,
+              ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final base = _l10n.videoCollaboratorWithMore('Alice', 1);
+        final expectedLabel = _l10n.videoCollaboratorWithPendingSuffix(
+          base,
+          2,
+        );
+        expect(find.text(expectedLabel), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'recipient view (ignored): own avatar filtered out',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1, _collab2],
+                statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+                currentUserPubkey: _collab1,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+            overrides: [
+              fetchUserProfileProvider(
+                _collab1,
+              ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+              fetchUserProfileProvider(
+                _collab2,
+              ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Row still renders for _collab2.
+        expect(find.byIcon(Icons.people), findsOneWidget);
+        // Label is the single-collaborator variant naming Bob — not Alice.
+        expect(
+          find.text(_l10n.videoCollaboratorWithOne('Bob')),
+          findsOneWidget,
+        );
+        expect(
+          find.text(_l10n.videoCollaboratorWithOne('Alice')),
+          findsNothing,
+        );
+        // No pending decoration on recipient view.
+        expect(find.byType(Opacity), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'recipient view (ignored, sole collaborator): row shrinks',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1],
+                statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+                currentUserPubkey: _collab1,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.people), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'recipient view (confirmed): own avatar visible without decoration',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1],
+                statusByPubkey: {_collab1: CollaboratorStatus.confirmed},
+                currentUserPubkey: _collab1,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.people), findsOneWidget);
+        expect(find.byType(Opacity), findsNothing);
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                w.properties.label ==
+                    _l10n.videoCollaboratorPendingSemanticLabel,
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'third-party view: all avatars rendered without pending decoration',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const CollaboratorAvatarRowBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collab1, _collab2],
+                statusByPubkey: {
+                  _collab1: CollaboratorStatus.pending,
+                  _collab2: CollaboratorStatus.pending,
+                },
+                currentUserPubkey: _thirdPartyPubkey,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.people), findsOneWidget);
+        // Third-party viewers never see the pending decoration.
+        expect(find.byType(Opacity), findsNothing);
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                w.properties.label ==
+                    _l10n.videoCollaboratorPendingSemanticLabel,
+          ),
+          findsNothing,
+        );
       },
     );
   });

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: data is absent. Covers badges, title, stats, creator, tags,
 // ABOUTME: collaborators, inspired by, reposted by, and sounds sections.
 
+import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -633,7 +634,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final l10n = _l10n(tester);
-      expect(find.text(l10n.metadataCollaboratorsSectionLabel), findsOneWidget);
+      expect(find.text(l10n.metadataCollaboratorsLabel), findsOneWidget);
       expect(find.text('Josh Musick'), findsOneWidget);
       expect(find.text('Dan Spurgin'), findsOneWidget);
     });
@@ -645,8 +646,186 @@ void main() {
       );
 
       final l10n = _l10n(tester);
-      expect(find.text(l10n.metadataCollaboratorsSectionLabel), findsNothing);
+      expect(find.text(l10n.metadataCollaboratorsLabel), findsNothing);
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Collaborators section body (status-aware rendering)
+  // ---------------------------------------------------------------------------
+  group(MetadataCollaboratorsSectionBody, () {
+    testWidgets(
+      'fallback mode: renders all chips without Pending decoration',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              fetchUserProfileProvider(_collaborator1).overrideWith(
+                (ref) async => _makeProfile(_collaborator1, 'Alice'),
+              ),
+              fetchUserProfileProvider(_collaborator2).overrideWith(
+                (ref) async => _makeProfile(_collaborator2, 'Bob'),
+              ),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility.fallback(
+                taggedPubkeys: [_collaborator1, _collaborator2],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = _l10n(tester);
+        expect(
+          find.text(l10n.metadataCollaboratorsLabel),
+          findsOneWidget,
+        );
+        expect(find.text('Alice'), findsOneWidget);
+        expect(find.text('Bob'), findsOneWidget);
+        expect(
+          find.text(l10n.videoCollaboratorPendingDecoration),
+          findsNothing,
+        );
+        expect(find.byType(Opacity), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'inviter view: pending chip shows Pending label and is dimmed',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              fetchUserProfileProvider(_collaborator1).overrideWith(
+                (ref) async => _makeProfile(_collaborator1, 'Alice'),
+              ),
+              fetchUserProfileProvider(_collaborator2).overrideWith(
+                (ref) async => _makeProfile(_collaborator2, 'Bob'),
+              ),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collaborator1, _collaborator2],
+                statusByPubkey: {
+                  _collaborator1: CollaboratorStatus.pending,
+                  _collaborator2: CollaboratorStatus.confirmed,
+                },
+                currentUserPubkey: _creatorPubkey,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = _l10n(tester);
+        // Exactly one chip has the Pending label (Alice).
+        expect(
+          find.text(l10n.videoCollaboratorPendingDecoration),
+          findsOneWidget,
+        );
+        // The pending chip is wrapped in an Opacity.
+        final opacityWidgets = tester.widgetList<Opacity>(
+          find.byType(Opacity),
+        );
+        expect(opacityWidgets, hasLength(1));
+        expect(opacityWidgets.first.opacity, closeTo(0.7, 0.001));
+      },
+    );
+
+    testWidgets(
+      'recipient view (ignored): own chip filtered out',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              fetchUserProfileProvider(_collaborator1).overrideWith(
+                (ref) async => _makeProfile(_collaborator1, 'Alice'),
+              ),
+              fetchUserProfileProvider(_collaborator2).overrideWith(
+                (ref) async => _makeProfile(_collaborator2, 'Bob'),
+              ),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collaborator1, _collaborator2],
+                statusByPubkey: {
+                  _collaborator1: CollaboratorStatus.ignored,
+                },
+                currentUserPubkey: _collaborator1,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Alice (current user, ignored) is hidden; Bob is visible.
+        expect(find.text('Alice'), findsNothing);
+        expect(find.text('Bob'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'recipient view (ignored, sole collaborator): section shrinks',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collaborator1],
+                statusByPubkey: {
+                  _collaborator1: CollaboratorStatus.ignored,
+                },
+                currentUserPubkey: _collaborator1,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+
+        final l10n = _l10n(tester);
+        expect(
+          find.text(l10n.metadataCollaboratorsLabel),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'third-party view: no Pending decoration even for pending status',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            providerOverrides: [
+              fetchUserProfileProvider(_collaborator1).overrideWith(
+                (ref) async => _makeProfile(_collaborator1, 'Alice'),
+              ),
+            ],
+            child: const MetadataCollaboratorsSectionBody(
+              visibility: CollaboratorVisibility(
+                taggedPubkeys: [_collaborator1],
+                statusByPubkey: {
+                  _collaborator1: CollaboratorStatus.pending,
+                },
+                currentUserPubkey: _reposterPubkey,
+                creatorPubkey: _creatorPubkey,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = _l10n(tester);
+        expect(find.text('Alice'), findsOneWidget);
+        expect(
+          find.text(l10n.videoCollaboratorPendingDecoration),
+          findsNothing,
+        );
+        expect(find.byType(Opacity), findsNothing);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -614,6 +614,9 @@ void main() {
   // ---------------------------------------------------------------------------
   group(MetadataCollaboratorsSection, () {
     testWidgets('renders collaborator chips when present', (tester) async {
+      final video = _makeVideo(
+        collaboratorPubkeys: const [_collaborator1, _collaborator2],
+      );
       await tester.pumpWidget(
         buildSubject(
           providerOverrides: [
@@ -624,26 +627,25 @@ void main() {
               (ref) async => _makeProfile(_collaborator2, 'Dan Spurgin'),
             ),
           ],
-          child: const MetadataCollaboratorsSection(
-            collaboratorPubkeys: [_collaborator1, _collaborator2],
-          ),
+          child: MetadataCollaboratorsSection(video: video),
         ),
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Collaborators'), findsOneWidget);
+      final l10n = _l10n(tester);
+      expect(find.text(l10n.metadataCollaboratorsSectionLabel), findsOneWidget);
       expect(find.text('Josh Musick'), findsOneWidget);
       expect(find.text('Dan Spurgin'), findsOneWidget);
     });
 
     testWidgets('hides when no collaborators', (tester) async {
+      final video = _makeVideo();
       await tester.pumpWidget(
-        buildSubject(
-          child: const MetadataCollaboratorsSection(collaboratorPubkeys: []),
-        ),
+        buildSubject(child: MetadataCollaboratorsSection(video: video)),
       );
 
-      expect(find.text('Collaborators'), findsNothing);
+      final l10n = _l10n(tester);
+      expect(find.text(l10n.metadataCollaboratorsSectionLabel), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Description

The kind-34238 collaborator acceptance protocol (settled in #4045) has had no read consumer on mobile since it shipped. Confirmed by grep: exactly one non-test mention of `34238` in the entire codebase (the constant). When the recipient taps Accept, the event publishes to the relay and falls into a void; when they tap Ignore, the local store is written and read only by the DM card that wrote it. Every feed surface (`CollaboratorAvatarRow`, `MetadataCollaboratorsSection`) renders `video.collaboratorPubkeys` straight from the kind-34236 tags, so the recipient appears already-attached before they act and stays that way regardless of which button they tap.

This PR wires the missing mobile read consumer so Accept and Ignore both have visible end-to-end effects, scoped narrowly per the v2 brainstorm (Approach F):

- **Inviter view (own-authored videos)**: `CollaboratorConfirmationRepository` opens a kind-34238 relay subscription scoped to `Filter(kinds: [34238], a: [videoAddress])`. When the recipient's acceptance event arrives, the avatar flips pending → confirmed on the inviter's feed/metadata surfaces within seconds. Pending entries render with reduced opacity + a "Pending" label on the metadata chip and a dimmed avatar in the overlay row.
- **Recipient view (any video they're tagged on)**: local invite store consultation flips their own avatar to confirmed (after Accept publish success) or hides it from their own view (after Ignore). No relay traffic for this path.
- **Third-party viewers**: unchanged. The broader "hide pending collaborators from non-inviter / non-collaborator viewers" goal defers to the Funnelcake `video_collaborators_current_data` read model that lives in `docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md`.

The new repository's data source can later swap from "relay subscription" to "Funnelcake confirmed-edges endpoint" without touching the cubit or any render site — composes with the lifecycle plan rather than duplicating it.

Repays the touched-path l10n debt in `metadata_user_chips.dart` (`Creator`, `Collaborators`, `Inspired by`, `Reposted by`) per #4192's engineering standard.

**Related Issue:** Closes #4192

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Architecture

- New `mobile/packages/collaborator_repository` package — `CollaboratorConfirmationRepository` owns the relay subscription, the cross-check against creator-side tags, and the local-store fast-path for the current user. Pure-Dart repository, Flutter-free.
- New `CollaboratorStatus` enum + `VideoCollaboratorStatus` value object in `models/`.
- New `VideoCollaboratorStatusCubit` keyed per `videoAddress`, exposes a `loading` → `ready`/`failure` state with a per-pubkey status map. No error strings in state.
- `collaboratorConfirmationRepositoryProvider` gated on `isNostrReadyProvider` (Pattern A from `state_management.md`) — returns `null` until ready so cubits never capture a stale Nostr client across auth flips.
- `BlocProvider<VideoCollaboratorStatusCubit>` keyed by `ValueKey((repo, videoAddress))` per the Riverpod-bridging rule in `state_management.md`.
- `CollaboratorInviteActionsCubit` gains an optional `confirmationRepository` and calls `markLocal(confirmed)` on accept-success and `markLocal(ignored)` on ignore.

## Out of scope (deferred to epic #4201 and the lifecycle plan)

- Funnelcake `video_collaborators_current_data` read model.
- Hide-pending-from-third-parties rendering (would change visible behavior for anyone viewing a video they're not the author or a collaborator on).
- Public decline signal — spec §"Accept Flow" pins ignore as local-only for v1.

## Tests

- `mobile/packages/models/test/src/collaborator_status_test.dart` (5 cases)
- `mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart` (9 cases): kind-34238 echo flips pending → confirmed, rejects non-tagged-pubkey acceptances, ignores non-accepted statuses, recipient-view runs without relay traffic, `markLocal` emits immediately, `markLocal` rejects non-current-user writes, ref-counted subscribe/release, no relay sub when current user is not creator, `close` clears all state.
- `mobile/test/blocs/video_collaborator_status/video_collaborator_status_cubit_test.dart` (3 cases): success path, failure path with addError, release-on-close.
- `mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart`: extended to verify `markLocal(confirmed)` runs on accept-success only and `markLocal(ignored)` runs on ignore.
- `mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart` (1 case): hasCollaborators gate.
- `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart` (2 cases): updated to the new `video:` parameter and to assert on l10n keys instead of hardcoded English.

## Manual test plan

1. Account A posts a video adding Account B as collaborator.
2. On A's device, open the video in the feed: avatar shows greyed + "Pending" decoration on the metadata sheet.
3. Switch to B. Open the DM with A. Verify the invite card shows Accept/Ignore.
4. Tap **Accept**: the card flips to "Accepted". Navigate to the video; verify B's avatar no longer shows the pending decoration (already confirmed via local store).
5. Switch back to A: within a few seconds the pending decoration on A's view of the video clears (kind-34238 echo). Re-open the metadata sheet to confirm.
6. Repeat with a new collaborator C, but tap **Ignore** on C's device. Verify the avatar disappears from C's view of the video. A's view continues to show the original behavior (third-party rendering is unchanged in this PR).

## l10n

New keys with English placeholder values for translators across all 18 locales:
- `videoCollaboratorPendingDecoration`, `videoCollaboratorPendingSemanticLabel`, `videoCollaboratorWithPendingSuffix`
- `metadataCreatorSectionLabel`, `metadataCollaboratorsSectionLabel`, `metadataInspiredBySectionLabel`, `metadataRepostedBySectionLabel`