### PR TITLE
fix(invites): clear pending oauth session after consume failure

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -333,6 +333,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
 
       emit(const DivineAuthSuccess());
     } on InviteApiException catch (e) {
+      await _authService.clearPendingDivineOAuthSession();
       Log.error(
         'Invite activation failed: '
         '${InviteErrorUtils.activationFailureLogDetails(e)}',

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -385,6 +385,7 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
 
         return; // Success - exit the retry loop
       } on InviteApiException catch (e) {
+        await _authService.clearPendingDivineOAuthSession();
         Log.error(
           'Invite activation failed: '
           '${InviteErrorUtils.activationFailureLogDetails(e)}',

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -743,13 +743,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> clearPendingDivineOAuthSession() async {
     try {
       await _clearKeycastSessionAndTokens();
-    } catch (e, stack) {
+    } catch (e) {
       Log.warning(
         'Failed to clear pending Divine OAuth session: $e',
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      _reportStorageError(e, stack, 'clearPendingDivineOAuthSession()');
+      // Invite activation failures can legitimately leave no session to clear.
+      // Keep local visibility without sending expected cleanup noise upstream.
     }
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -734,6 +734,25 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     unawaited(crashlytics.recordError(error, stack, reason: reason));
   }
 
+  /// Clears any persisted Divine OAuth session that was created before an
+  /// invite consume completed.
+  ///
+  /// Invite flows can exchange OAuth tokens before invite activation runs.
+  /// If activation then fails, startup must not restore that partial session
+  /// and bypass the invite gate on the next launch.
+  Future<void> clearPendingDivineOAuthSession() async {
+    try {
+      await _clearKeycastSessionAndTokens();
+    } catch (e, stack) {
+      Log.warning(
+        'Failed to clear pending Divine OAuth session: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      _reportStorageError(e, stack, 'clearPendingDivineOAuthSession()');
+    }
+  }
+
   /// Check if there are saved keys on device (without authenticating)
   ///
   /// Useful for showing different UI on welcome screen when user has
@@ -2164,9 +2183,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       final result = await service.connect();
       if (!result.success || result.publicKey == null) {
-        throw Exception(
-          result.errorMessage ?? 'NIP-07 authentication failed.',
-        );
+        throw Exception(result.errorMessage ?? 'NIP-07 authentication failed.');
       }
 
       final pubkey = result.publicKey!;

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -57,6 +57,9 @@ void main() {
       mockAuthService = _MockAuthService();
       mockPendingVerification = _MockPendingVerificationService();
       mockInviteApiClient = _MockInviteApiClient();
+      when(
+        () => mockAuthService.clearPendingDivineOAuthSession(),
+      ).thenAnswer((_) async {});
       when(() => mockOAuth.config).thenReturn(
         const OAuthConfig(
           serverUrl: 'https://login.divine.video',
@@ -331,6 +334,7 @@ void main() {
             verify(
               () => mockAuthService.signInWithDivineOAuth(any()),
             ).called(1);
+            verifyNever(() => mockAuthService.clearPendingDivineOAuthSession());
           },
         );
 
@@ -466,6 +470,11 @@ void main() {
               inviteRecoveryCode: 'AB12-EF34',
             ),
           ],
+          verify: (_) {
+            verify(
+              () => mockAuthService.clearPendingDivineOAuthSession(),
+            ).called(1);
+          },
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -45,6 +45,9 @@ void main() {
       mockOAuth = _MockKeycastOAuth();
       mockAuthService = _MockAuthService();
       mockInviteApiClient = _MockInviteApiClient();
+      when(
+        () => mockAuthService.clearPendingDivineOAuthSession(),
+      ).thenAnswer((_) async {});
       // Reset static state to ensure test isolation
       EmailVerificationCubit.resetCompletedDeviceCode();
     });
@@ -161,6 +164,7 @@ void main() {
             ),
             () => mockAuthService.signInWithDivineOAuth(any()),
           ]);
+          verifyNever(() => mockAuthService.clearPendingDivineOAuthSession());
 
           cubit.close();
           fake.flushMicrotasks();
@@ -208,6 +212,9 @@ void main() {
           expect(cubit.state.errorCode, EmailVerificationError.inviteUnknown);
           expect(cubit.state.showInviteGateRecovery, isTrue);
           expect(cubit.state.inviteRecoveryCode, 'AB12-EF34');
+          verify(
+            () => mockAuthService.clearPendingDivineOAuthSession(),
+          ).called(1);
           verifyNever(() => mockAuthService.signInWithDivineOAuth(any()));
 
           cubit.close();

--- a/mobile/test/services/auth_service_invite_session_cleanup_test.dart
+++ b/mobile/test/services/auth_service_invite_session_cleanup_test.dart
@@ -1,0 +1,205 @@
+// ABOUTME: Tests invite-failure cleanup for persisted Divine OAuth sessions
+// ABOUTME: Verifies failed invite activation cannot leave restart-restorable auth state
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_setup.dart';
+
+class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
+class _FakeFlutterSecureStorage extends Fake implements FlutterSecureStorage {
+  final Map<String, String> data = {};
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => data[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      data.remove(key);
+      return;
+    }
+    data[key] = value;
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    data.remove(key);
+  }
+}
+
+Future<T> _ignoringBackgroundErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (error, stack) {
+      // Ignore async work kicked off after initialize() completes.
+    },
+  );
+  return completer.future;
+}
+
+void main() {
+  setupTestEnvironment();
+
+  group('AuthService invite session cleanup', () {
+    late _MockSecureKeyStorage mockKeyStorage;
+    late _MockUserDataCleanupService mockCleanupService;
+    late _MockKeycastOAuth mockOAuthClient;
+    late _FakeFlutterSecureStorage fakeSecureStorage;
+
+    setUp(() {
+      mockKeyStorage = _MockSecureKeyStorage();
+      mockCleanupService = _MockUserDataCleanupService();
+      mockOAuthClient = _MockKeycastOAuth();
+      fakeSecureStorage = _FakeFlutterSecureStorage();
+
+      when(() => mockKeyStorage.initialize()).thenAnswer((_) async {});
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      when(() => mockKeyStorage.clearCache()).thenReturn(null);
+      when(() => mockKeyStorage.dispose()).thenReturn(null);
+      when(
+        () => mockKeyStorage.getKeyContainer(),
+      ).thenAnswer((_) async => null);
+
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          isIdentityChange: any(named: 'isIdentityChange'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
+
+      when(
+        () => mockOAuthClient.refreshSession(),
+      ).thenAnswer((_) async => null);
+      when(() => mockOAuthClient.close()).thenReturn(null);
+    });
+
+    AuthService createAuthService() {
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: mockKeyStorage,
+        oauthClient: mockOAuthClient,
+        flutterSecureStorage: fakeSecureStorage,
+      );
+    }
+
+    test(
+      'clearPendingDivineOAuthSession removes global OAuth artifacts',
+      () async {
+        fakeSecureStorage.data['keycast_session'] = jsonEncode(
+          KeycastSession(
+            bunkerUrl: 'wss://relay.test',
+            accessToken: 'access-token',
+            refreshToken: 'refresh-token',
+            authorizationHandle: 'auth-handle',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ).toJson(),
+        );
+        fakeSecureStorage.data['keycast_refresh_token'] = 'refresh-token';
+        fakeSecureStorage.data['keycast_auth_handle'] = 'auth-handle';
+
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        await authService.clearPendingDivineOAuthSession();
+
+        expect(fakeSecureStorage.data['keycast_session'], isNull);
+        expect(fakeSecureStorage.data['keycast_refresh_token'], isNull);
+        expect(fakeSecureStorage.data['keycast_auth_handle'], isNull);
+      },
+    );
+
+    test(
+      'restart after invite cleanup does not restore OAuth auth state',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        fakeSecureStorage.data['keycast_session'] = jsonEncode(
+          KeycastSession(
+            bunkerUrl: 'wss://relay.test',
+            accessToken: 'access-token',
+            refreshToken: 'refresh-token',
+            authorizationHandle: 'auth-handle',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ).toJson(),
+        );
+        fakeSecureStorage.data['keycast_refresh_token'] = 'refresh-token';
+        fakeSecureStorage.data['keycast_auth_handle'] = 'auth-handle';
+
+        final initialAuthService = createAuthService();
+        await initialAuthService.clearPendingDivineOAuthSession();
+        await initialAuthService.dispose();
+
+        final restartedAuthService = createAuthService();
+        addTearDown(restartedAuthService.dispose);
+
+        await _ignoringBackgroundErrors(restartedAuthService.initialize);
+
+        expect(restartedAuthService.isAuthenticated, isFalse);
+        expect(
+          restartedAuthService.authState,
+          equals(AuthState.unauthenticated),
+        );
+        verify(() => mockOAuthClient.refreshSession()).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #4260

## Summary

- clear any persisted Divine OAuth session when invite activation fails after OAuth exchange
- route both invite-auth flows through the same cleanup path before showing invite recovery UI
- add regression coverage proving failed invite activation cannot leave restart-restorable OAuth state

## Why

OAuth exchange can complete before invite consume runs. Without explicit cleanup, a failed invite activation can leave a saved Keycast session behind, and app startup may restore that partial auth state on the next launch. This PR closes that gap instead of adding more retry behavior on top of undefined session semantics.

This PR also replaces the earlier draft in this area: #4068 was closed in favor of this narrower follow-up. The old PR mixed stacked history and broader retry behavior; this one isolates the no-tech-debt session-persistence contract first.

## Validation

- flutter test test/blocs/email_verification/email_verification_cubit_test.dart
- flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart
- flutter test test/services/auth_service_invite_session_cleanup_test.dart
- flutter analyze
