### PR TITLE
fix(profile): prevent enrichment callback from overwriting relay state (#3705)

### DIFF
--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -408,6 +408,12 @@ class ProfileFeed extends _$ProfileFeed {
         );
 
         // Enrich with full Nostr event data in the background.
+        // mergeWithCurrent is intentionally true (default) here: relay
+        // events can update replaceable events (e.g. adding a collaborator
+        // p-tag) during the ~5s enrichment window, and replacing state
+        // would overwrite the newer relay version (#3705). The enriched
+        // list carries the pre-update snapshot, but _mergeVideo selects
+        // by createdAt so the relay version's tags win regardless.
         enrichVideosInBackground(
           authorVideos,
           nostrService: ref.read(nostrServiceProvider),
@@ -1104,9 +1110,10 @@ class ProfileFeed extends _$ProfileFeed {
     }
 
     final merged = byKey.values.toList()..sort(_compareVideos);
-    // Drop any session-tombstoned ids the merge carried forward. The
-    // upstream snapshot is already filtered, but `current` may still
-    // contain a video that was just deleted before the source caught up.
+    // Drop any session-tombstoned ids (NIP-09 client-side deletes) the
+    // merge carried forward. Does not cover server-side deletes that
+    // happened after the initial REST page load -- those clear on next
+    // full refresh.
     return _withoutTombstones(merged);
   }
 

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -408,20 +408,24 @@ class ProfileFeed extends _$ProfileFeed {
         );
 
         // Enrich with full Nostr event data in the background.
-        // mergeWithCurrent is intentionally true (default) here: relay
-        // events can update replaceable events (e.g. adding a collaborator
-        // p-tag) during the ~5s enrichment window, and replacing state
-        // would overwrite the newer relay version (#3705). The enriched
-        // list carries the pre-update snapshot, but _mergeVideo selects
-        // by createdAt so the relay version's tags win regardless.
+        // Replace only this REST snapshot's keys: relay events can update
+        // replaceable events (e.g. adding a collaborator p-tag) during the
+        // ~5s enrichment window, so these keys must merge against current
+        // state instead of clobbering it (#3705). But if enrichment causes
+        // a video to be filtered out, that key must disappear rather than
+        // preserving the stale pre-enrichment copy.
+        final enrichmentKeys = {
+          for (final video in authorVideos) _canonicalVideoKey(video),
+        };
         enrichVideosInBackground(
           authorVideos,
           nostrService: ref.read(nostrServiceProvider),
           onEnriched: (enriched) {
             if (!ref.mounted) return;
             final enrichedVideos = _videoEventService.filterVideoList(enriched);
-            _mergeSourceVideos(
+            _mergeEnrichedRestVideos(
               enrichedVideos,
+              sourceKeys: enrichmentKeys,
               hasMoreContent:
                   result.hasMore ??
                   (apiVideos.length >= AppConstants.paginationBatchSize),
@@ -1093,6 +1097,79 @@ class ProfileFeed extends _$ProfileFeed {
     _emitState(nextState);
   }
 
+  void _mergeEnrichedRestVideos(
+    List<VideoEvent> incoming, {
+    required Set<String> sourceKeys,
+    required bool hasMoreContent,
+    required bool isRefreshing,
+    required bool isInitialLoad,
+    int? totalVideoCount,
+    bool isFetchingTotalCount = false,
+  }) {
+    final currentState = state.asData?.value;
+    final mergedVideos = _mergeVideosReplacingCurrentKeys(
+      current: currentState?.videos ?? const <VideoEvent>[],
+      sourceKeys: sourceKeys,
+      incoming: incoming,
+    );
+
+    final nextState =
+        (currentState ??
+                const VideoFeedState(
+                  videos: <VideoEvent>[],
+                  hasMoreContent: false,
+                ))
+            .copyWith(
+              videos: mergedVideos,
+              hasMoreContent: hasMoreContent,
+              isLoadingMore: false,
+              isRefreshing: isRefreshing,
+              isInitialLoad: isInitialLoad,
+              isFetchingTotalCount: isFetchingTotalCount,
+              lastUpdated: DateTime.now(),
+              totalVideoCount: totalVideoCount ?? currentState?.totalVideoCount,
+              error: null,
+            );
+
+    if (currentState != null &&
+        _sameVideoSequence(currentState.videos, nextState.videos) &&
+        currentState.hasMoreContent == nextState.hasMoreContent &&
+        currentState.totalVideoCount == nextState.totalVideoCount &&
+        currentState.isRefreshing == nextState.isRefreshing &&
+        currentState.isInitialLoad == nextState.isInitialLoad &&
+        currentState.isFetchingTotalCount == nextState.isFetchingTotalCount) {
+      return;
+    }
+
+    _emitState(nextState);
+  }
+
+  List<VideoEvent> _mergeVideosReplacingCurrentKeys({
+    required List<VideoEvent> current,
+    required Set<String> sourceKeys,
+    required List<VideoEvent> incoming,
+  }) {
+    if (sourceKeys.isEmpty) return _mergeVideoLists(current, incoming);
+
+    final currentByKey = {
+      for (final video in current)
+        if (sourceKeys.contains(_canonicalVideoKey(video)))
+          _canonicalVideoKey(video): video,
+    };
+    final keepFromCurrent = current
+        .where((video) => !sourceKeys.contains(_canonicalVideoKey(video)))
+        .toList();
+    final mergedSourceVideos = incoming.map((video) {
+      final key = _canonicalVideoKey(video);
+      final currentVideo = currentByKey[key];
+      return currentVideo == null
+          ? video
+          : _mergeEnrichmentIntoCurrent(currentVideo, video);
+    }).toList();
+
+    return _mergeVideoLists(keepFromCurrent, mergedSourceVideos);
+  }
+
   List<VideoEvent> _mergeVideoLists(
     List<VideoEvent> current,
     List<VideoEvent> incoming,
@@ -1123,6 +1200,70 @@ class ProfileFeed extends _$ProfileFeed {
   /// #3384).
   VideoEvent _mergeVideo(VideoEvent existing, VideoEvent incoming) {
     return mergeTwoProfileVideos(existing, incoming);
+  }
+
+  VideoEvent _mergeEnrichmentIntoCurrent(
+    VideoEvent current,
+    VideoEvent enriched,
+  ) {
+    return current.copyWith(
+      publishedAt:
+          (current.publishedAt != null && current.publishedAt!.isNotEmpty)
+          ? current.publishedAt
+          : enriched.publishedAt,
+      rawTags: mergeRawTagsForVideoMerge(current.rawTags, enriched.rawTags),
+      contentWarningLabels: current.contentWarningLabels.isNotEmpty
+          ? current.contentWarningLabels
+          : enriched.contentWarningLabels,
+      title: current.title ?? enriched.title,
+      videoUrl: current.videoUrl ?? enriched.videoUrl,
+      thumbnailUrl: current.thumbnailUrl ?? enriched.thumbnailUrl,
+      duration: current.duration ?? enriched.duration,
+      dimensions: current.dimensions ?? enriched.dimensions,
+      mimeType: current.mimeType ?? enriched.mimeType,
+      sha256: current.sha256 ?? enriched.sha256,
+      fileSize: current.fileSize ?? enriched.fileSize,
+      hashtags: current.hashtags.isNotEmpty
+          ? current.hashtags
+          : enriched.hashtags,
+      vineId: current.vineId ?? enriched.vineId,
+      group: current.group ?? enriched.group,
+      altText: current.altText ?? enriched.altText,
+      blurhash: current.blurhash ?? enriched.blurhash,
+      originalLoops: mergeProfileEngagementCount(
+        current.originalLoops,
+        enriched.originalLoops,
+      ),
+      originalLikes: mergeProfileEngagementCount(
+        current.originalLikes,
+        enriched.originalLikes,
+      ),
+      originalComments: mergeProfileEngagementCount(
+        current.originalComments,
+        enriched.originalComments,
+      ),
+      originalReposts: mergeProfileEngagementCount(
+        current.originalReposts,
+        enriched.originalReposts,
+      ),
+      audioEventId: current.audioEventId ?? enriched.audioEventId,
+      audioEventRelay: current.audioEventRelay ?? enriched.audioEventRelay,
+      collaboratorPubkeys: current.collaboratorPubkeys.isNotEmpty
+          ? current.collaboratorPubkeys
+          : enriched.collaboratorPubkeys,
+      inspiredByVideo: current.inspiredByVideo ?? enriched.inspiredByVideo,
+      textTrackRef: current.textTrackRef ?? enriched.textTrackRef,
+      textTrackContent: current.textTrackContent ?? enriched.textTrackContent,
+      nostrEventTags: current.nostrEventTags.isNotEmpty
+          ? current.nostrEventTags
+          : enriched.nostrEventTags,
+      authorName: current.authorName ?? enriched.authorName,
+      authorAvatar: current.authorAvatar ?? enriched.authorAvatar,
+      nostrLikeCount: mergeProfileEngagementCount(
+        current.nostrLikeCount,
+        enriched.nostrLikeCount,
+      ),
+    );
   }
 
   /// Same logic as [_mergeVideo], exposed for tests (#3384).

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -425,7 +425,6 @@ class ProfileFeed extends _$ProfileFeed {
                 initialLoadPending: _initialLoadPending,
                 videosEmpty: enrichedVideos.isEmpty,
               ),
-              mergeWithCurrent: false,
             );
           },
           callerName: 'ProfileFeedProvider',

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -125,7 +125,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'30e2edca3c5ad94a46cf812e2bb4c0e04c26469a';
+String _$profileFeedHash() => r'f4edbba3f186efbb6c11d643830f26f36640b3fe';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -151,9 +151,11 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
 ///
 /// Returns the original [videos] immediately. Enrichment runs in the
 /// background; when it finishes, [onEnriched] is called with the
-/// enriched list so the caller can update its state. If enrichment
-/// fails, [onEnriched] is never called and the un-enriched videos
-/// remain visible.
+/// enriched list so the caller can update its state.
+///
+/// [onEnriched] is NOT called when enrichment fails, when all videos
+/// already have full tags (nothing to enrich), or when the relay query
+/// returns no events. Callers must not rely on it firing.
 List<VideoEvent> enrichVideosInBackground(
   List<VideoEvent> videos, {
   required NostrClient nostrService,

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -7,6 +7,7 @@ import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -134,12 +135,16 @@ void main() {
     late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
     late _MockVideoEventService mockVideoEventService;
     late _MockNostrClient mockNostrClient;
+    late void Function() onNostrVideosChanged;
+    late List<VideoEvent> relayVideos;
 
     setUp(() {
       _controlledFunnelcakeAvailability = false;
       mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
       mockVideoEventService = _MockVideoEventService();
       mockNostrClient = _MockNostrClient();
+      relayVideos = [];
+      onNostrVideosChanged = () {};
 
       when(
         () => mockFunnelcakeApiClient.getBulkVideoStats(any()),
@@ -153,7 +158,12 @@ void main() {
       when(
         () => mockVideoEventService.addVideoUpdateListener(any()),
       ).thenReturn(() {});
-      when(() => mockVideoEventService.addListener(any())).thenReturn(null);
+      when(() => mockVideoEventService.addListener(any())).thenAnswer((
+        invocation,
+      ) {
+        onNostrVideosChanged =
+            invocation.positionalArguments.single as void Function();
+      });
       when(() => mockVideoEventService.removeListener(any())).thenReturn(null);
       when(
         () => mockVideoEventService.addNewVideoListener(any()),
@@ -161,7 +171,9 @@ void main() {
       when(
         () => mockVideoEventService.subscribeToUserVideos(userId),
       ).thenAnswer((_) async {});
-      when(() => mockVideoEventService.authorVideos(userId)).thenReturn([]);
+      when(
+        () => mockVideoEventService.authorVideos(userId),
+      ).thenAnswer((_) => relayVideos);
       when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
         invocation,
       ) {
@@ -275,6 +287,202 @@ void main() {
 
         expect(state.videos.map((v) => v.id), ['relay-head']);
         expect(state.isInitialLoad, isFalse);
+      },
+    );
+
+    test(
+      'enrichment callback keeps newer relay replaceable event updates',
+      () async {
+        const collaboratorPubkey =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+        final staleEnrichmentEvent = Event(
+          userId,
+          34236,
+          [
+            ['url', 'https://example.com/stale.mp4'],
+            ['title', 'REST snapshot'],
+            ['d', 'video-0'],
+          ],
+          'REST snapshot',
+          createdAt: DateTime(2026, 3, 30, 12).millisecondsSinceEpoch ~/ 1000,
+        );
+        final enrichmentCompleter = Completer<List<Event>>();
+
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [
+              _videoStat(
+                id: staleEnrichmentEvent.id,
+                pubkey: userId,
+                stableId: 'video-0',
+                createdAt: DateTime(2026, 3, 30, 12),
+              ),
+            ],
+          ),
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) => enrichmentCompleter.future);
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        await container.read(profileFeedProvider(userId).future);
+
+        final restHydrated = Completer<void>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 1 &&
+                value.videos.single.id == staleEnrichmentEvent.id &&
+                !restHydrated.isCompleted) {
+              restHydrated.complete();
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await restHydrated.future.timeout(const Duration(milliseconds: 200));
+
+        relayVideos = [
+          _relayVideo(
+            id: 'relay-video-0',
+            pubkey: userId,
+            stableId: 'video-0',
+            createdAt: DateTime(2026, 3, 30, 12, 0, 30),
+          ).copyWith(collaboratorPubkeys: [collaboratorPubkey]),
+        ];
+        onNostrVideosChanged();
+
+        final relayHydrated = Completer<void>();
+        final relaySubscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 1 &&
+                value.videos.single.id == 'relay-video-0' &&
+                value.videos.single.collaboratorPubkeys.contains(
+                  collaboratorPubkey,
+                ) &&
+                !relayHydrated.isCompleted) {
+              relayHydrated.complete();
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(relaySubscription.close);
+        await relayHydrated.future.timeout(const Duration(milliseconds: 200));
+
+        enrichmentCompleter.complete([staleEnrichmentEvent]);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final finalState = container
+            .read(profileFeedProvider(userId))
+            .requireValue;
+        expect(finalState.videos, hasLength(1));
+        expect(finalState.videos.single.id, 'relay-video-0');
+        expect(
+          finalState.videos.single.collaboratorPubkeys,
+          contains(collaboratorPubkey),
+        );
+      },
+    );
+
+    test(
+      'enrichment callback removes videos hidden by enriched labels',
+      () async {
+        final hideEvent = Event(
+          userId,
+          34236,
+          [
+            ['url', 'https://example.com/hidden.mp4'],
+            ['d', 'video-1'],
+            ['content-warning', 'nudity'],
+            ['L', 'content-warning'],
+            ['l', 'nudity', 'content-warning'],
+          ],
+          'Hidden after enrichment',
+          createdAt: DateTime(2026, 3, 30, 12).millisecondsSinceEpoch ~/ 1000,
+        );
+        final enrichmentCompleter = Completer<List<Event>>();
+
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [
+              _videoStat(
+                id: hideEvent.id,
+                pubkey: userId,
+                stableId: 'video-1',
+                createdAt: DateTime(2026, 3, 30, 12),
+              ),
+            ],
+          ),
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) => enrichmentCompleter.future);
+        when(() => mockVideoEventService.filterVideoList(any())).thenAnswer((
+          invocation,
+        ) {
+          final videos =
+              invocation.positionalArguments.single as List<VideoEvent>;
+          return videos
+              .where((video) => !video.contentWarningLabels.contains('nudity'))
+              .toList();
+        });
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        await container.read(profileFeedProvider(userId).future);
+
+        final restHydrated = Completer<void>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 1 &&
+                value.videos.single.id == hideEvent.id &&
+                !restHydrated.isCompleted) {
+              restHydrated.complete();
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await restHydrated.future.timeout(const Duration(milliseconds: 200));
+
+        final removed = Completer<void>();
+        final removalSubscription = container
+            .listen<AsyncValue<VideoFeedState>>(profileFeedProvider(userId), (
+              previous,
+              next,
+            ) {
+              final previousValue = previous?.asData?.value;
+              final nextValue = next.asData?.value;
+              if (previousValue != null &&
+                  previousValue.videos.length == 1 &&
+                  nextValue != null &&
+                  nextValue.videos.isEmpty &&
+                  !removed.isCompleted) {
+                removed.complete();
+              }
+            });
+        addTearDown(removalSubscription.close);
+
+        enrichmentCompleter.complete([hideEvent]);
+        await removed.future.timeout(const Duration(milliseconds: 200));
+
+        final finalState = container
+            .read(profileFeedProvider(userId))
+            .requireValue;
+        expect(finalState.videos, isEmpty);
       },
     );
 


### PR DESCRIPTION
## Summary

- fix the background enrichment race in `ProfileFeed` without introducing a stale-state merge regression
- preserve newer relay-backed replaceable-event updates that arrive during the REST enrichment window
- allow enrichment-filtered videos to disappear instead of keeping the stale pre-enrichment visible copy
- add provider-level regression coverage for both cases and commit the regenerated Riverpod output

## What changed

`profile_feed_provider.dart`:
- replaced the enrichment callback's broad state merge with a targeted reconciliation path for just the original REST snapshot keys
- kept current state as primary for matching keys, then layered enrichment metadata onto it so newer relay updates keep winning
- dropped enriched videos cleanly when enrichment changes make them filter out
- clarified `_withoutTombstones` scope in `_mergeVideoLists` (NIP-09 session deletes only, not server-side)

`profile_feed_provider.g.dart`:
- regenerated after touching the `@Riverpod` source file

`profile_feed_pagination_contract_test.dart`:
- added a regression test proving relay updates are preserved through delayed enrichment
- added a regression test proving enrichment-added hide labels can remove a video from state

`video_nostr_enrichment.dart`:
- clarified `enrichVideosInBackground` doc comment: `onEnriched` is not guaranteed to fire (skipped when nothing to enrich, relay returns empty, or enrichment fails)

## Test plan

- [x] `dart run build_runner build --delete-conflicting-outputs`
- [x] `flutter test test/providers/profile_feed_pagination_contract_test.dart`
- [x] `flutter test test/utils/video_nostr_enrichment_streaming_test.dart`
- [x] `flutter analyze lib/providers/profile_feed_provider.dart lib/utils/video_nostr_enrichment.dart test/providers/profile_feed_pagination_contract_test.dart`
- [ ] manual: set up a collab via Connect, observe author's profile on mobile -- video should not flash duplicate

Closes #3705
