### PR TITLE
fix(search): surface per-source fallback outcomes in people search (#3804)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,7 @@ Generic Flutter and Dart standards live in `.claude/rules/`:
 ## Project Rules
 
 - Most app work happens in `mobile/`. Key entry points are `mobile/lib/main.dart` and `mobile/lib/router/app_router.dart`.
-- Use current code plus focused docs as source of truth: `docs/STATE_MANAGEMENT.md`, `docs/BLOC_UI_MIGRATION_PRD.md`, `docs/NOSTR_EVENT_TYPES.md`, `mobile/docs/NOSTR_VIDEO_EVENTS.md`, `mobile/docs/DESIGN_SYSTEM_COMPONENTS.md`, and `mobile/docs/GOLDEN_TESTING_GUIDE.md`.
+- Use current code plus focused docs as source of truth: `docs/STATE_MANAGEMENT.md`, `docs/BLOC_UI_MIGRATION_PRD.md`, `docs/NOSTR_EVENT_TYPES.md`, `mobile/docs/NOSTR_VIDEO_EVENTS.md`, `mobile/docs/DESIGN_SYSTEM_COMPONENTS.md`, `mobile/docs/GOLDEN_TESTING_GUIDE.md`, and `mobile/docs/PEOPLE_SEARCH.md`.
 - Older docs can drift. If documentation disagrees with code, trust the current implementation, targeted tests, and the newest focused doc.
 
 ## Architecture And State

--- a/mobile/docs/PEOPLE_SEARCH.md
+++ b/mobile/docs/PEOPLE_SEARCH.md
@@ -82,7 +82,7 @@ it fires:
 
 1. The bloc takes the latest snapshot of `state.sourceOutcomes`.
 2. For each source still in `SearchSourcePending` (or absent from the
-   snapshot entirely), it writes
+   snapshot defensively), it writes
    `SearchSourceFailed(reason: timeout, latencyMs: <outer timeout>)`.
 3. Sources that already reported a terminal status keep that status.
 4. The bloc emits `UserSearchStatus.success` with the updated map.

--- a/mobile/docs/PEOPLE_SEARCH.md
+++ b/mobile/docs/PEOPLE_SEARCH.md
@@ -67,8 +67,8 @@ bloc can always distinguish "true empty" from "everything failed".
 |---|---|---|
 | `SearchSourcePending` | Source has not yet reported. Internal/initial state, normally not visible in a terminal envelope. | — |
 | `SearchSourceSkipped` | Source was intentionally not consulted (`offset > 0` for local/NIP-50, or Funnelcake unconfigured). | — |
-| `SearchSourceSuccess` | Source returned successfully. Carries `resultCount` (pre-dedup) and `latencyMs`. | yes |
-| `SearchSourceFailed` | Source threw / timed out. Carries `SearchSourceFailureReason` (`timeout` / `network` / `unavailable` / `other`) and `latencyMs`. | yes |
+| `SearchSourceSuccess` | Source returned successfully. Carries `resultCount` (new distinct profiles this source contributed to the accumulated result set) and `latencyMs`. | yes |
+| `SearchSourceFailed` | Source threw / timed out. Carries `SearchSourceFailureReason` (`timeout` / `network` / `other`) and `latencyMs`. | yes |
 
 The bloc never re-derives or invents source statuses — it forwards
 the repository's view, except when the outer 20 s timeout fires (see

--- a/mobile/docs/PEOPLE_SEARCH.md
+++ b/mobile/docs/PEOPLE_SEARCH.md
@@ -1,0 +1,160 @@
+# People search: data sources, degradation, and UI contract
+
+This document is the canonical reference for how user-profile search
+works in the mobile app. It is the partial implementation answer to
+the parent epic's "explicit data-source strategy" requirement
+(#3801, #3627) and pins the contract that the bloc and UI rely on.
+
+If you change behavior in `ProfileRepository.searchUsersProgressive`,
+`UserSearchBloc`, or `PeopleSection`, update this file at the same
+time.
+
+## Layered flow
+
+```
+Explore / SearchResultsAppBar (UI)
+  └── UserSearchQueryChanged event
+        ↓
+UserSearchBloc                              mobile/lib/blocs/user_search/
+  • debounceRestartable transformer
+  • outer .timeout(userSearchOuterTimeout)  mobile/lib/constants/search_constants.dart
+  • on TimeoutException → promote pending sources to failed(timeout),
+    emit `success` with `sourceOutcomes` populated
+  • on Exception → Reportable wrap + `failure` state
+  • per-yield: forward each newly-terminal source to
+    FeedPerformanceTracker.trackSearchSource
+        ↓
+ProfileRepository.searchUsersProgressive    mobile/packages/profile_repository/
+  Phase 1 (offset==0): searchUsersLocally        SQLite cache, no timeout
+  Phase 2:             funnelcake.searchProfiles REST, no explicit timeout
+  Phase 3 (offset==0): nostrClient.queryUsers    NIP-50 WS, .timeout(5s)
+  Each phase records a SearchSourceStatus in the result envelope.
+  Final yield: _enrichFromCache + _applyFilter (block filter + boost)
+        ↓
+NostrClient.queryUsers                      mobile/packages/nostr_client/
+  • tempRelays = [relay.nostr.band, search.nos.today, nostr.wine]
+```
+
+## Source consultation order
+
+The repository consults sources in a fixed, sequential order:
+
+1. **localCache** — SQLite profile cache. Instant. Consulted only on
+   the first page (`offset == 0`).
+2. **funnelcakeApi** — Funnelcake REST `/api/profiles/search`. Fast.
+   Consulted on every page. Skipped (`SearchSourceSkipped`) when the
+   client is configured without a base URL.
+3. **nip50Relay** — Federated NIP-50 search across three hardcoded
+   relays. Consulted only on the first page (`offset == 0`). Hard
+   timeout of `_nip50SearchTimeout` (5 s).
+
+After each phase that produced new profiles, the repository yields a
+`ProgressiveSearchResult` carrying:
+
+- the accumulated deduplicated profile list
+- the running `Map<SearchSource, SearchSourceStatus>`
+- `isComplete: false` for intermediate yields, `true` for the final
+
+A query with no matches still gets a final yield with
+`profiles: []`, `isComplete: true`, and per-source outcomes — so the
+bloc can always distinguish "true empty" from "everything failed".
+
+## Source statuses
+
+`SearchSourceStatus` is sealed:
+
+| status | meaning | latency? |
+|---|---|---|
+| `SearchSourcePending` | Source has not yet reported. Internal/initial state, normally not visible in a terminal envelope. | — |
+| `SearchSourceSkipped` | Source was intentionally not consulted (`offset > 0` for local/NIP-50, or Funnelcake unconfigured). | — |
+| `SearchSourceSuccess` | Source returned successfully. Carries `resultCount` (pre-dedup) and `latencyMs`. | yes |
+| `SearchSourceFailed` | Source threw / timed out. Carries `SearchSourceFailureReason` (`timeout` / `network` / `unavailable` / `other`) and `latencyMs`. | yes |
+
+The bloc never re-derives or invents source statuses — it forwards
+the repository's view, except when the outer 20 s timeout fires (see
+below).
+
+## Outer-timeout contract
+
+`UserSearchBloc` wraps the entire progressive stream in
+`searchTimeout`, defaulting to `userSearchOuterTimeout` (20 s). When
+it fires:
+
+1. The bloc takes the latest snapshot of `state.sourceOutcomes`.
+2. For each source still in `SearchSourcePending` (or absent from the
+   snapshot entirely), it writes
+   `SearchSourceFailed(reason: timeout, latencyMs: <outer timeout>)`.
+3. Sources that already reported a terminal status keep that status.
+4. The bloc emits `UserSearchStatus.success` with the updated map.
+
+This means after an outer timeout, `state.isDegradedEmpty` is `true`
+iff `state.results` is empty — which is the case the UI cares about.
+
+## `isDegradedEmpty` getter
+
+```dart
+bool get isDegradedEmpty =>
+    results.isEmpty &&
+    sourceOutcomes.values.any((s) => s is SearchSourceFailed);
+```
+
+True iff (1) we have no profiles to show, AND (2) at least one source
+reported failure. This is the single switch the UI uses to decide
+between "true empty" (show empty-state with copy) and "degraded
+empty" (show error-with-retry).
+
+## UI contract (`PeopleSection`)
+
+Branch order in `_PeopleContent.build`:
+
+1. `status == initial || (status == loading && results.isEmpty)` →
+   `_PeopleSkeletonLoader`
+2. `status == failure || isDegradedEmpty` →
+   `SearchSectionErrorState` (retry button)
+3. `results.isEmpty && showAll` → `SearchSectionEmptyState`
+4. `results.isEmpty && !showAll` → hidden section
+5. otherwise → render the list
+
+Outer `PeopleSection.build` also hides the entire section in the All-
+tab preview when the result is truly empty
+(`!showAll && status == success && results.isEmpty && !isDegradedEmpty`).
+Degraded-empty intentionally bypasses the hide so the user can retry
+even from the All tab. This is the #3791 fix.
+
+## Instrumentation
+
+`FeedPerformanceTracker.trackSearchSource(SearchSource, SearchSourceStatus)`
+fires exactly once per source per query, when the source transitions
+from pending into a terminal state. Pending statuses produce no
+event.
+
+Analytics event name: `user_search_source`. Parameters:
+
+- `source`: `localCache` / `funnelcakeApi` / `nip50Relay`
+- `status`: `success` / `failed` / `skipped`
+- `result_count`, `latency_ms` (success only)
+- `reason`, `latency_ms` (failed only)
+
+Existing `feed_first_batch_received`, `feed_load_complete`, and
+`feed_error` events for `feed_type=user_search` are unchanged.
+
+## What is intentionally not in scope
+
+- Changing the 5 s NIP-50 timeout value — latency budget is a product
+  decision (parent epic Q3).
+- Replacing or extending the NIP-50 relay list — parent epic Q4.
+- Auto-navigate-while-typing behavior — see #3802.
+- Focus / keyboard continuity across Explore → Search — see #3803,
+  #3020.
+- Blocklist filtering of search results — see #3805, #948.
+- `searchUsers` (the non-progressive sibling used by
+  `NewMessageSearchBloc`) — different caller, different scope.
+
+## Related issues
+
+- #3804 — this contract's execution ticket
+- #3791 — the user-visible "cant find friends" report this closes
+- #3801 — parent search-stabilization epic
+- #3627 — data-source strategy doc requirement (partial payment)
+- #3593 — suppressed catch blocks (the per-source-failed wrapping
+  pays the relevant Phase 3 portion)

--- a/mobile/docs/brainstorm/2026-05-12-issue3804-people-search-timeout-fallback-ux-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-05-12-issue3804-people-search-timeout-fallback-ux-brainstorm.md
@@ -1,0 +1,228 @@
+# Brainstorm: people-search timeout / fallback UX (#3804)
+
+Date: 2026-05-12
+Parent epic: #3801
+Sibling-blocks: #3791 ("cant find friends")
+Touches: ProfileRepository · UserSearchBloc · PeopleSection · FeedPerformanceTracker
+
+## Problem (from the issue, verified in code)
+
+`ProfileRepository.searchUsersProgressive` runs three phases (local cache → Funnelcake REST → NIP-50 WebSocket) and yields the accumulated list after each. Phase 3 has a 5 s hard timeout; failures are caught with `on Object` and swallowed. `UserSearchBloc` wraps the stream in a 20 s outer `.timeout` and turns `TimeoutException` into `success` with whatever accumulated, without distinguishing it from a true successful empty.
+
+The UI today (`PeopleSection`) only sees `status` + `results.isEmpty`. It cannot tell:
+
+- whether all three sources succeeded with zero matches
+- whether NIP-50 timed out but local + REST returned zero
+- whether REST was unavailable and only NIP-50 contributed
+- whether the outer 20 s timeout fired and cut the stream
+
+All four scenarios render as the same "No results found for X." That is the lived experience of #3791.
+
+## Three approaches considered
+
+### Approach 1 — UI band-aid only
+
+Add a Try-again button under the empty state and rephrase copy.
+
+- pro: ~0 blast radius
+- con: doesn't satisfy the issue's acceptance criteria (data-source strategy, instrumentation, intentional partial states); a true-empty retry yields a true-empty retry
+- **rejected**
+
+### Approach 2 — Enum-only degradation signal
+
+Add `degradedReason: SearchDegradedReason?` to the bloc state. Repository signals degradation via a side-channel callback or terminal event.
+
+- pro: smaller type churn
+- con: side-channel callback inverts the layer flow (repository pushing into UI orchestration); single enum can't represent "2-of-3 sources succeeded"; the resolution still collapses meaningfully different outcomes
+- **rejected**
+
+### Approach 3 — Per-source provenance, end-to-end (recommended)
+
+Repository emits a richer envelope per yield carrying both the accumulated profiles and the per-source outcome map. Bloc state mirrors the map. UI computes degraded-vs-true-empty from the map and shows distinct affordances. Per-source latency/outcome flows into the existing `FeedPerformanceTracker`. Repo gets a short `mobile/docs/PEOPLE_SEARCH.md` codifying the contract.
+
+- pro: meets all four acceptance criteria; #3791's user-visible bug becomes a one-screen fix (degraded-empty → existing `SearchSectionErrorState` with Try again); converts today's silent suppressions into observable signals; partially repays #3593 (suppressed catch blocks) and #3627 (data-source doc)
+- con: changes the signature of `searchUsersProgressive` — but its only caller in `mobile/lib` is `UserSearchBloc`, so the blast radius is small and well-tested
+- **converged on this**
+
+## Design specifics
+
+### New types in `profile_repository`
+
+```dart
+enum SearchSource { localCache, funnelcakeApi, nip50Relay }
+
+sealed class SearchSourceStatus { const SearchSourceStatus(); }
+class SearchSourcePending  extends SearchSourceStatus { const SearchSourcePending(); }
+class SearchSourceSkipped  extends SearchSourceStatus { const SearchSourceSkipped(); }
+class SearchSourceSuccess  extends SearchSourceStatus {
+  const SearchSourceSuccess({required this.resultCount, required this.latencyMs});
+  final int resultCount;
+  final int latencyMs;
+}
+class SearchSourceFailed   extends SearchSourceStatus {
+  const SearchSourceFailed({required this.reason, required this.latencyMs});
+  final SearchSourceFailureReason reason;
+  final int latencyMs;
+}
+enum SearchSourceFailureReason { timeout, network, unavailable, other }
+
+class ProgressiveSearchResult {
+  const ProgressiveSearchResult({
+    required this.profiles,
+    required this.sources,
+    required this.isComplete,
+  });
+  final List<UserProfile> profiles;
+  final Map<SearchSource, SearchSourceStatus> sources;
+  final bool isComplete;
+}
+```
+
+Sealed classes (not enums) because each status carries different shape — `Success` has a count and latency, `Failed` has a reason and latency. That avoids the "enum + side table" smell. These live in the **repository layer** (data shape, not bloc state), so the "no error strings in bloc state" rule from `state_management.md` does not apply to `SearchSourceFailed.reason` — it's an enum tag, not a message.
+
+### `searchUsersProgressive` becomes `Stream<ProgressiveSearchResult>`
+
+Each phase records its outcome in a local map and yields a `ProgressiveSearchResult` carrying the current snapshot. Final yield sets `isComplete: true`. Existing logging stays; failures additionally update the source map.
+
+The non-progressive sibling `searchUsers` (used only by `NewMessageSearchBloc`) is **not** changed in this PR.
+
+### `UserSearchBloc` state
+
+Adds:
+
+```dart
+final Map<SearchSource, SearchSourceStatus> sourceOutcomes;
+
+/// True when we have nothing to show AND at least one source reports failure.
+/// UI shows this as an error state (with retry), not "No results found".
+bool get isDegradedEmpty =>
+    results.isEmpty &&
+    sourceOutcomes.values.any((s) => s is SearchSourceFailed);
+```
+
+The outer 20 s timeout stops silently turning into success-with-empty. On `TimeoutException` the bloc marks every `pending` source as `Failed(reason: timeout)` then emits `success`. Because `isDegradedEmpty` is a getter, the UI consequence is automatic.
+
+Reporting policy (per `error_handling.md` matrix):
+
+- `TimeoutException` → not reportable (network/expected)
+- `on Exception` → wrap with `Reportable(e, context: '_onQueryChanged')` only when the inner is not network/IO. Practically, the only Exception that reaches that catch from the progressive stream today is a `StateError` from the WS client — those *are* worth reporting. Keep the existing `feedTracker.trackFeedError` call.
+
+### UI
+
+`PeopleSection._PeopleContent.build`:
+
+```dart
+// Skeleton when still loading + nothing to show
+if ((status == .initial || status == .loading) && results.isEmpty) {
+  return const _PeopleSkeletonLoader();
+}
+
+// Failure OR degraded-empty → existing error state with Try again
+if (status == .failure || state.isDegradedEmpty) {
+  return SearchSectionErrorState(
+    onRetry: () =>
+        context.read<UserSearchBloc>().add(UserSearchQueryChanged(query)),
+  );
+}
+
+// True empty — kept as-is
+if (results.isEmpty) {
+  if (showAll) return SearchSectionEmptyState(query: query);
+  return const SliverToBoxAdapter(child: SizedBox.shrink());
+}
+```
+
+That single delta is #3791's user-visible fix: when the user types `friend's_name` and every source either timed out or was unavailable, they get "We had trouble reaching some sources — try again" with a retry button, not a misleading "No results found for friend's_name."
+
+The non-empty-but-some-source-failed path keeps the current rendering. We can add a subtle "still loading more" pill in a follow-up if telemetry shows users care; out of scope here.
+
+### Instrumentation
+
+Extend `FeedPerformanceTracker`:
+
+```dart
+void trackSearchSource(SearchSource source, SearchSourceStatus status);
+```
+
+Repository fires it as each phase finishes. Existing `startFeedLoad` / `markFirstVideosReceived` / `markFeedDisplayed` / `trackFeedError` calls keep their current semantics. New event lets us answer in the field: "is NIP-50 the actual problem, or is REST down, or is the query genuinely missing?"
+
+### Constants
+
+`mobile/lib/constants/search_constants.dart` already exists. Add:
+
+```dart
+const nip50QueryTimeout = Duration(seconds: 5);
+const userSearchOuterTimeout = Duration(seconds: 20);
+```
+
+and migrate the hard-coded numbers in `profile_repository.dart` line 1087 and `user_search_bloc.dart` line 26. Touch what we touch (per `code_style.md` "No Hardcoded Values").
+
+### Doc
+
+`mobile/docs/PEOPLE_SEARCH.md` (new, ~80 lines):
+
+1. Layered flow diagram (UI → Bloc → Repository → 3 clients)
+2. Canonical fallback order + skip conditions (offset > 0)
+3. Latency budgets (5 s NIP-50, 20 s outer)
+4. Degradation contract: how `sourceOutcomes` is populated, what `isDegradedEmpty` means, when UI shows error-with-retry vs true-empty
+5. Pointer to FeedPerformanceTracker for instrumentation surface
+
+Linked from #3627 as partial payment.
+
+## Test plan
+
+### Unit / bloc
+
+- `profile_repository_test.dart`: 4 new tests
+  - all sources succeed: `sources` keyed local=success, api=success, relay=success
+  - REST throws: `sources[api] = failed(network)`, others success
+  - NIP-50 times out: `sources[relay] = failed(timeout)`, others success
+  - all-failed: `sources` all failed, `profiles` empty
+  - existing progressive yield tests migrate to `.profiles` accessor
+- `user_search_bloc_test.dart`: 3 new blocTests
+  - outer timeout with empty accumulated: state has `degradedEmpty == true`, status `success`
+  - sources-map round-trips from repository to bloc state unchanged
+  - `isDegradedEmpty` getter correctness across permutations
+  - existing "emits success with partial results when stream times out" test updates assertion on `sourceOutcomes`
+
+### Widget
+
+- `people_section_test.dart`: 2 new tests
+  - state with `{results: [], sources: {nip50Relay: failed}}` renders `SearchSectionErrorState`
+  - state with `{results: [], sources: {all: success}}` renders `SearchSectionEmptyState`
+
+### Manual
+
+- Force-timeout NIP-50 (point relay list at a sink) → degraded-empty banner with retry
+- Funnelcake key empty (`isAvailable=false`) → REST skipped, NIP-50 succeeds, no degraded banner
+- All sources offline → degraded-empty banner with retry
+- Real query that exists → unchanged happy path
+
+## Risk assessment
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Sealed-class type imports break callers in unrelated areas | Low | `searchUsersProgressive` has one caller; sealed types are new, no name collisions |
+| `ProgressiveSearchResult` adds GC pressure on hot search loops | Low | Single object per yield (~3 per query); negligible vs the profile list itself |
+| `FeedPerformanceTracker` enum expansion breaks analytics dashboards | Low | New method, no change to existing events |
+| Outer timeout change surfaces previously-hidden Crashlytics reports | Low | Only `Reportable`-wrapped non-network exceptions report; matrix-aligned |
+| Doc drifts from code | Medium | Cross-link doc from code comments, gate on review |
+
+## Non-goals (explicit)
+
+- Changing the 5 s NIP-50 timeout value (latency budget = product, parent epic Q3)
+- Replacing or adding NIP-50 relays (parent epic Q4)
+- Auto-navigate-while-typing (#3802)
+- Focus / keyboard continuity (#3803, #3020)
+- Blocklist filtering of search (#3805, #948)
+- Replacing `searchUsers` (different caller, different scope)
+- BLoC `addError` sweep (#3592 — separate PR)
+- "Still searching…" inline indicator on non-empty progressive states
+- Caching architecture work (#3624)
+- UI bypass refactor (#3620)
+
+## Open question for the subgroup (non-blocking)
+
+Should the degraded-empty banner copy be specifically "We're having trouble reaching some search sources" (technical truth) or generic "Couldn't load results — try again" (matches existing l10n `searchSomethingWentWrong`)? **Recommendation: reuse `searchSomethingWentWrong` + `searchTryAgain` — they exist, they're already translated to 16+ locales, and they read fine. Don't expand l10n surface without product input.**
+
+If product later wants specific copy, it's a one-line ARB change.

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/search_constants.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:profile_repository/profile_repository.dart';
 
@@ -23,7 +24,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     required ProfileRepository profileRepository,
     FollowRepository? followRepository,
     this.hasVideos = false,
-    this.searchTimeout = const Duration(seconds: 20),
+    this.searchTimeout = userSearchOuterTimeout,
     FeedPerformanceTracker? feedTracker,
   }) : _profileRepository = profileRepository,
        _followRepository = followRepository,
@@ -83,6 +84,10 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
 
     _feedTracker?.startFeedLoad('user_search');
     var trackedFirst = false;
+    // Snapshot of sources whose terminal status has already been
+    // forwarded to feedTracker — prevents duplicate events when a
+    // source's outcome is repeated across yields.
+    final trackedSources = <SearchSource>{};
 
     // Snapshot the follow graph once for this query so every progressive
     // yield uses the same boost set. Boost ordering is applied inside the
@@ -99,22 +104,29 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         boostPubkeys: followedPubkeys,
       );
 
-      await emit.forEach<List<UserProfile>>(
+      await emit.forEach<ProgressiveSearchResult>(
         searchTimeout == null
             ? searchStream
             : searchStream.timeout(searchTimeout!),
-        onData: (results) {
-          if (!trackedFirst && results.isNotEmpty) {
+        onData: (result) {
+          if (!trackedFirst && result.profiles.isNotEmpty) {
             trackedFirst = true;
             _feedTracker?.markFirstVideosReceived(
               'user_search',
-              results.length,
+              result.profiles.length,
             );
+          }
+          for (final entry in result.sources.entries) {
+            if (entry.value is! SearchSourcePending &&
+                trackedSources.add(entry.key)) {
+              _feedTracker?.trackSearchSource(entry.key, entry.value);
+            }
           }
           return state.copyWith(
             status: UserSearchStatus.loading,
-            results: results,
-            resultCount: results.length,
+            results: result.profiles,
+            resultCount: result.profiles.length,
+            sourceOutcomes: result.sources,
           );
         },
       );
@@ -130,22 +142,49 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
 
       _feedTracker?.markFeedDisplayed('user_search', state.results.length);
     } on TimeoutException {
-      // Stream timed out — emit success with whatever results accumulated
-      // so far rather than leaving the UI stuck in loading.
+      // Outer stream timed out. Promote every source still in pending
+      // (or absent from the latest snapshot) to failed(timeout) so the
+      // UI's isDegradedEmpty getter can distinguish this from a true
+      // empty result.
+      final outerTimeoutMs = searchTimeout!.inMilliseconds;
+      final updatedOutcomes =
+          <SearchSource, SearchSourceStatus>{
+            for (final source in SearchSource.values)
+              source: switch (state.sourceOutcomes[source]) {
+                null || SearchSourcePending() => SearchSourceFailed(
+                  reason: SearchSourceFailureReason.timeout,
+                  latencyMs: outerTimeoutMs,
+                ),
+                final SearchSourceStatus s => s,
+              },
+          }..forEach((source, status) {
+            if (status is SearchSourceFailed &&
+                state.sourceOutcomes[source] is! SearchSourceFailed &&
+                trackedSources.add(source)) {
+              _feedTracker?.trackSearchSource(source, status);
+            }
+          });
+
       emit(
         state.copyWith(
           status: UserSearchStatus.success,
           offset: state.results.length,
           hasMore: false,
           isLoadingMore: false,
+          sourceOutcomes: updatedOutcomes,
         ),
       );
-    } on Exception catch (e) {
+    } on Exception catch (e, stackTrace) {
       _feedTracker?.trackFeedError(
         'user_search',
         errorType: 'search_failed',
         errorMessage: e.toString(),
       );
+      // Wrap with Reportable so unexpected non-network/non-timeout
+      // failures surface in Crashlytics. Per error_handling.md, the
+      // expected network/timeout exceptions are matrix-non-reportable
+      // — those land in the TimeoutException branch above.
+      addError(Reportable(e, context: '_onQueryChanged'), stackTrace);
       emit(state.copyWith(status: UserSearchStatus.failure));
     }
   }
@@ -159,7 +198,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     emit(state.copyWith(isLoadingMore: true));
 
     try {
-      final moreResults = await _profileRepository
+      final result = await _profileRepository
           .searchUsersProgressive(
             query: state.query,
             limit: _pageSize,
@@ -169,13 +208,18 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
           )
           .last; // Stream always emits at least once for non-empty queries.
 
-      final allResults = [...state.results, ...moreResults];
+      // Pagination yields contain only the new page; we observe by
+      // counting the profiles in the terminal envelope (filter+boost
+      // applied) against pagination state. The new page is the slice
+      // that the repository computed for offset > 0.
+      final newPage = result.profiles;
+      final allResults = [...state.results, ...newPage];
 
       emit(
         state.copyWith(
           results: allResults,
           offset: allResults.length,
-          hasMore: moreResults.length == _pageSize,
+          hasMore: newPage.length == _pageSize,
           isLoadingMore: false,
         ),
       );

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -18,6 +18,13 @@ part 'user_search_state.dart';
 /// Number of results per page
 const _pageSize = 50;
 
+Map<SearchSource, SearchSourceStatus> _pendingSourceOutcomes() {
+  return {
+    for (final source in SearchSource.values)
+      source: const SearchSourcePending(),
+  };
+}
+
 /// BLoC for searching user profiles.
 class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
   UserSearchBloc({
@@ -79,11 +86,13 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         offset: 0,
         hasMore: false,
         isLoadingMore: false,
+        sourceOutcomes: const {},
       ),
     );
 
     _feedTracker?.startFeedLoad('user_search');
     var trackedFirst = false;
+    var latestSourceOutcomes = _pendingSourceOutcomes();
     // Snapshot of sources whose terminal status has already been
     // forwarded to feedTracker — prevents duplicate events when a
     // source's outcome is repeated across yields.
@@ -122,6 +131,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
               _feedTracker?.trackSearchSource(entry.key, entry.value);
             }
           }
+          latestSourceOutcomes = result.sources;
           return state.copyWith(
             status: UserSearchStatus.loading,
             results: result.profiles,
@@ -150,7 +160,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
       final updatedOutcomes =
           <SearchSource, SearchSourceStatus>{
             for (final source in SearchSource.values)
-              source: switch (state.sourceOutcomes[source]) {
+              source: switch (latestSourceOutcomes[source]) {
                 null || SearchSourcePending() => SearchSourceFailed(
                   reason: SearchSourceFailureReason.timeout,
                   latencyMs: outerTimeoutMs,
@@ -159,7 +169,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
               },
           }..forEach((source, status) {
             if (status is SearchSourceFailed &&
-                state.sourceOutcomes[source] is! SearchSourceFailed &&
+                latestSourceOutcomes[source] is! SearchSourceFailed &&
                 trackedSources.add(source)) {
               _feedTracker?.trackSearchSource(source, status);
             }

--- a/mobile/lib/blocs/user_search/user_search_state.dart
+++ b/mobile/lib/blocs/user_search/user_search_state.dart
@@ -28,6 +28,7 @@ final class UserSearchState extends Equatable {
     this.offset = 0,
     this.hasMore = false,
     this.isLoadingMore = false,
+    this.sourceOutcomes = const {},
   });
 
   /// The current status of the search
@@ -51,6 +52,19 @@ final class UserSearchState extends Equatable {
   /// Whether a "load more" request is in progress
   final bool isLoadingMore;
 
+  /// Per-source outcome map for the current query. Populated as each
+  /// phase of `searchUsersProgressive` reports its terminal status.
+  /// Empty for [UserSearchStatus.initial].
+  final Map<SearchSource, SearchSourceStatus> sourceOutcomes;
+
+  /// `true` when no results are available AND at least one source
+  /// failed. UI surfaces a retry affordance in this state rather than
+  /// the standard "No results found" empty state — distinguishing a
+  /// true miss from a degraded search.
+  bool get isDegradedEmpty =>
+      results.isEmpty &&
+      sourceOutcomes.values.any((s) => s is SearchSourceFailed);
+
   /// Create a copy with updated values
   UserSearchState copyWith({
     UserSearchStatus? status,
@@ -60,6 +74,7 @@ final class UserSearchState extends Equatable {
     int? offset,
     bool? hasMore,
     bool? isLoadingMore,
+    Map<SearchSource, SearchSourceStatus>? sourceOutcomes,
   }) {
     return UserSearchState(
       status: status ?? this.status,
@@ -71,6 +86,7 @@ final class UserSearchState extends Equatable {
       offset: offset ?? this.offset,
       hasMore: hasMore ?? this.hasMore,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      sourceOutcomes: sourceOutcomes ?? this.sourceOutcomes,
     );
   }
 
@@ -83,6 +99,7 @@ final class UserSearchState extends Equatable {
     offset,
     hasMore,
     isLoadingMore,
+    sourceOutcomes,
   ];
 
   static const Object _unset = Object();

--- a/mobile/lib/constants/search_constants.dart
+++ b/mobile/lib/constants/search_constants.dart
@@ -13,6 +13,14 @@ const searchDebounceDuration = Duration(milliseconds: 300);
 /// scans plus remote searches on every keystroke.
 const minSearchQueryLength = 2;
 
+/// Outer timeout the user-search bloc applies to the entire progressive
+/// stream. When it fires, the bloc still emits the accumulated results
+/// but marks every source still in [SearchSourcePending] as
+/// [SearchSourceFailed] with reason
+/// [SearchSourceFailureReason.timeout] — driving the UI to surface a
+/// retry affordance instead of a misleading "No results found".
+const userSearchOuterTimeout = Duration(seconds: 20);
+
 /// Event transformer that debounces then restarts on new events.
 ///
 /// Combines [searchDebounceDuration] debounce with a restartable (switchMap)

--- a/mobile/lib/screens/search_results/widgets/people_section.dart
+++ b/mobile/lib/screens/search_results/widgets/people_section.dart
@@ -33,9 +33,15 @@ class PeopleSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final status = context.select((UserSearchBloc bloc) => bloc.state.status);
     final results = context.select((UserSearchBloc bloc) => bloc.state.results);
+    final isDegradedEmpty = context.select(
+      (UserSearchBloc bloc) => bloc.state.isDegradedEmpty,
+    );
 
-    // In the All tab, hide entire section when results are empty and loaded.
-    if (!showAll && status == .success && results.isEmpty) {
+    // In the All tab, hide entire section when truly empty. A degraded
+    // empty (some source failed) still shows so the user gets a retry
+    // affordance instead of an invisible section that looks like the
+    // friend they searched for "doesn't exist". See #3791.
+    if (!showAll && status == .success && results.isEmpty && !isDegradedEmpty) {
       return const SliverToBoxAdapter(child: SizedBox.shrink());
     }
 
@@ -83,12 +89,19 @@ class _PeopleContent extends StatelessWidget {
     final status = context.select((UserSearchBloc bloc) => bloc.state.status);
     final results = context.select((UserSearchBloc bloc) => bloc.state.results);
     final query = context.select((UserSearchBloc bloc) => bloc.state.query);
+    final isDegradedEmpty = context.select(
+      (UserSearchBloc bloc) => bloc.state.isDegradedEmpty,
+    );
 
     if ((status == .initial || status == .loading) && results.isEmpty) {
       return const _PeopleSkeletonLoader();
     }
 
-    if (status == .failure) {
+    // Degraded-empty: every source we consulted reported failure (or
+    // outer-timeout promoted them all to failure) AND we have nothing
+    // to show. Surface the retry affordance instead of a misleading
+    // "No results found for X" — this is the #3791 fix.
+    if (status == .failure || isDegradedEmpty) {
       return SearchSectionErrorState(
         onRetry: () =>
             context.read<UserSearchBloc>().add(UserSearchQueryChanged(query)),

--- a/mobile/lib/services/feed_performance_tracker.dart
+++ b/mobile/lib/services/feed_performance_tracker.dart
@@ -3,6 +3,14 @@
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:profile_repository/profile_repository.dart'
+    show
+        SearchSource,
+        SearchSourceFailed,
+        SearchSourcePending,
+        SearchSourceSkipped,
+        SearchSourceStatus,
+        SearchSourceSuccess;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Maximum age for a session before it is considered stale and discarded.
@@ -302,6 +310,32 @@ class FeedPerformanceTracker {
   void markVideoSwipeComplete(String videoId) {
     final feedType = 'video_swipe_$videoId';
     markFeedDisplayed(feedType, 1);
+  }
+
+  /// Track terminal outcome of one source in user-profile search.
+  ///
+  /// Called by `UserSearchBloc` once per source per query, when the
+  /// source transitions from pending into a terminal state
+  /// ([SearchSourceSuccess], [SearchSourceFailed], or
+  /// [SearchSourceSkipped]). Pending statuses are intentionally not
+  /// tracked — they would inflate the event count without adding signal.
+  void trackSearchSource(SearchSource source, SearchSourceStatus status) {
+    final parameters = <String, Object>{'source': source.name};
+    switch (status) {
+      case SearchSourcePending():
+        return;
+      case SearchSourceSkipped():
+        parameters['status'] = 'skipped';
+      case SearchSourceSuccess(:final resultCount, :final latencyMs):
+        parameters['status'] = 'success';
+        parameters['result_count'] = resultCount;
+        parameters['latency_ms'] = latencyMs;
+      case SearchSourceFailed(:final reason, :final latencyMs):
+        parameters['status'] = 'failed';
+        parameters['reason'] = reason.name;
+        parameters['latency_ms'] = latencyMs;
+    }
+    _analytics?.logEvent(name: 'user_search_source', parameters: parameters);
   }
 
   /// Track video discovery source

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -7,5 +7,6 @@ export 'src/exceptions.dart';
 export 'src/identity_claim.dart';
 export 'src/identity_claims_repository.dart';
 export 'src/profile_repository.dart';
+export 'src/progressive_search_result.dart';
 export 'src/username_availability_result.dart';
 export 'src/username_claim_result.dart';

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1096,6 +1096,7 @@ class ProfileRepository {
     final prevCount = resultMap.length;
     if (_funnelcakeApiClient?.isAvailable ?? false) {
       final phase2Watch = Stopwatch()..start();
+      final preRestCount = resultMap.length;
       try {
         final restResults = await _funnelcakeApiClient!.searchProfiles(
           query: trimmed,
@@ -1108,7 +1109,7 @@ class ProfileRepository {
           resultMap[result.pubkey] = result.toUserProfile();
         }
         sources[SearchSource.funnelcakeApi] = SearchSourceSuccess(
-          resultCount: restResults.length,
+          resultCount: resultMap.length - preRestCount,
           latencyMs: phase2Watch.elapsedMilliseconds,
         );
       } on Exception catch (e) {

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1036,7 +1036,10 @@ class ProfileRepository {
     if (trimmed.isEmpty) return;
 
     final resultMap = <String, UserProfile>{};
-    final sources = <SearchSource, SearchSourceStatus>{};
+    final sources = <SearchSource, SearchSourceStatus>{
+      for (final source in SearchSource.values)
+        source: const SearchSourcePending(),
+    };
     final useServerSort = sortBy != null;
 
     ProgressiveSearchResult snapshot({

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -32,6 +32,12 @@ const _nameServerHttpTimeout = Duration(seconds: 10);
 // which still carries the typed REST fields after #4175.
 const _publishSeedRelayTimeout = Duration(seconds: 4);
 
+// Caps the NIP-50 user search query. On timeout the bloc still receives
+// the accumulated partial result, with the relay source marked as
+// SearchSourceFailed(reason: timeout) so the UI can surface a retry
+// affordance when nothing else contributed.
+const _nip50SearchTimeout = Duration(seconds: 5);
+
 // TODO(search): Move ProfileSearchFilter to a shared package
 // (e.g., search_utils) when we need to reuse search logic across
 // multiple repositories.
@@ -994,17 +1000,22 @@ class ProfileRepository {
 
   /// Progressively streams user profile search results.
   ///
-  /// Yields accumulated results as each source completes:
-  /// 1. Local cached profiles (instant)
-  /// 2. Funnelcake REST API results merged with local (fast)
-  /// 3. NIP-50 WebSocket results merged with all (first page only)
+  /// Each yield carries a [ProgressiveSearchResult] envelope containing:
+  /// - the accumulated, deduplicated, filter+boost-applied profile list
+  /// - a per-source outcome map ([ProgressiveSearchResult.sources])
+  /// - an [ProgressiveSearchResult.isComplete] flag on the terminal yield
   ///
-  /// Each yield contains the full deduplicated list so far — not just the
-  /// new batch. This matches the progressive pattern used by
-  /// `VideosRepository.searchVideos()`.
+  /// Consults three sources in order:
+  /// 1. Local cached profiles (instant, first page only)
+  /// 2. Funnelcake REST API (fast)
+  /// 3. NIP-50 WebSocket (first page only, with [_nip50SearchTimeout])
   ///
-  /// Parameters match [searchUsers]. When [offset] > 0 the local and NIP-50
-  /// phases are skipped (only the API phase runs).
+  /// On [offset] > 0 the local and NIP-50 phases are recorded as
+  /// [SearchSourceSkipped]. When Funnelcake is unconfigured it is also
+  /// recorded as [SearchSourceSkipped]. Any phase that throws (REST as
+  /// an [Exception], NIP-50 as an [Object] since WebSocket errors
+  /// surface as [Error]) is recorded as [SearchSourceFailed]; the stream
+  /// continues to consult later sources.
   ///
   /// When [boostPubkeys] is non-empty, profiles whose pubkey is in the set
   /// are promoted to the front of each emission while preserving the
@@ -1013,7 +1024,7 @@ class ProfileRepository {
   /// the initial search page. Callers should omit [boostPubkeys] on
   /// load-more requests so already-visible positions stay stable as the
   /// user scrolls.
-  Stream<List<UserProfile>> searchUsersProgressive({
+  Stream<ProgressiveSearchResult> searchUsersProgressive({
     required String query,
     int limit = 200,
     int offset = 0,
@@ -1025,27 +1036,63 @@ class ProfileRepository {
     if (trimmed.isEmpty) return;
 
     final resultMap = <String, UserProfile>{};
+    final sources = <SearchSource, SearchSourceStatus>{};
     final useServerSort = sortBy != null;
+
+    ProgressiveSearchResult snapshot({
+      required bool isComplete,
+      List<UserProfile>? enriched,
+    }) {
+      final profiles =
+          enriched ??
+          _applyFilter(
+            trimmed,
+            resultMap.values.toList(),
+            useServerSort,
+            boostPubkeys,
+          );
+      return ProgressiveSearchResult(
+        profiles: profiles,
+        sources: Map.unmodifiable(sources),
+        isComplete: isComplete,
+      );
+    }
 
     // Phase 1: Local cache (instant, first page only)
     if (offset == 0) {
-      final local = await searchUsersLocally(query: trimmed);
-      for (final profile in local) {
-        resultMap[profile.pubkey] = profile;
-      }
-      if (resultMap.isNotEmpty) {
-        yield _applyFilter(
-          trimmed,
-          resultMap.values.toList(),
-          useServerSort,
-          boostPubkeys,
+      final phase1Watch = Stopwatch()..start();
+      final preCount = resultMap.length;
+      try {
+        final local = await searchUsersLocally(query: trimmed);
+        for (final profile in local) {
+          resultMap[profile.pubkey] = profile;
+        }
+        sources[SearchSource.localCache] = SearchSourceSuccess(
+          resultCount: resultMap.length - preCount,
+          latencyMs: phase1Watch.elapsedMilliseconds,
+        );
+      } on Object catch (e) {
+        sources[SearchSource.localCache] = SearchSourceFailed(
+          reason: SearchSourceFailureReason.other,
+          latencyMs: phase1Watch.elapsedMilliseconds,
+        );
+        Log.warning(
+          'Local cache search failed: $e',
+          name: 'ProfileRepository.searchUsersProgressive',
+          category: LogCategory.api,
         );
       }
+      if (resultMap.isNotEmpty) {
+        yield snapshot(isComplete: false);
+      }
+    } else {
+      sources[SearchSource.localCache] = const SearchSourceSkipped();
     }
 
     // Phase 2: Funnelcake REST API (fast)
     final prevCount = resultMap.length;
     if (_funnelcakeApiClient?.isAvailable ?? false) {
+      final phase2Watch = Stopwatch()..start();
       try {
         final restResults = await _funnelcakeApiClient!.searchProfiles(
           query: trimmed,
@@ -1057,42 +1104,65 @@ class ProfileRepository {
         for (final result in restResults) {
           resultMap[result.pubkey] = result.toUserProfile();
         }
+        sources[SearchSource.funnelcakeApi] = SearchSourceSuccess(
+          resultCount: restResults.length,
+          latencyMs: phase2Watch.elapsedMilliseconds,
+        );
       } on Exception catch (e) {
+        sources[SearchSource.funnelcakeApi] = SearchSourceFailed(
+          reason: SearchSourceFailureReason.network,
+          latencyMs: phase2Watch.elapsedMilliseconds,
+        );
         Log.warning(
           'REST search failed: $e',
           name: 'ProfileRepository.searchUsersProgressive',
           category: LogCategory.api,
         );
       }
+    } else {
+      sources[SearchSource.funnelcakeApi] = const SearchSourceSkipped();
     }
 
     // Yield after Phase 2 if new results were added.
     // Skips enrichment for faster progressive display; the final Phase 3
     // yield enriches all results from cache.
     if (resultMap.length > prevCount) {
-      yield _applyFilter(
-        trimmed,
-        resultMap.values.toList(),
-        useServerSort,
-        boostPubkeys,
-      );
+      yield snapshot(isComplete: false);
     }
 
     // Phase 3: NIP-50 WebSocket (first page only)
     if (offset == 0) {
       final preWsCount = resultMap.length;
+      final phase3Watch = Stopwatch()..start();
       try {
         final events = await _nostrClient
             .queryUsers(trimmed, limit: limit)
-            .timeout(const Duration(seconds: 5));
+            .timeout(_nip50SearchTimeout);
         for (final event in events) {
           final profile = UserProfile.fromNostrEvent(event);
           resultMap.putIfAbsent(profile.pubkey, () => profile);
         }
+        sources[SearchSource.nip50Relay] = SearchSourceSuccess(
+          resultCount: resultMap.length - preWsCount,
+          latencyMs: phase3Watch.elapsedMilliseconds,
+        );
+      } on TimeoutException {
+        sources[SearchSource.nip50Relay] = SearchSourceFailed(
+          reason: SearchSourceFailureReason.timeout,
+          latencyMs: phase3Watch.elapsedMilliseconds,
+        );
+        Log.warning(
+          'NIP-50 search timed out after ${_nip50SearchTimeout.inSeconds}s',
+          name: 'ProfileRepository.searchUsersProgressive',
+          category: LogCategory.relay,
+        );
       } on Object catch (e) {
-        // Intentionally catches Object: WebSocket failures surface as
-        // StateError (an Error, not Exception), unlike the REST phase above.
-        // TimeoutException is also caught here when NIP-50 relays are slow.
+        // WebSocket failures surface as StateError (an Error, not
+        // Exception), so we catch Object.
+        sources[SearchSource.nip50Relay] = SearchSourceFailed(
+          reason: SearchSourceFailureReason.other,
+          latencyMs: phase3Watch.elapsedMilliseconds,
+        );
         Log.warning(
           'NIP-50 search failed: $e',
           name: 'ProfileRepository.searchUsersProgressive',
@@ -1100,18 +1170,30 @@ class ProfileRepository {
         );
       }
 
-      // Only enrich + yield again if WS added new profiles
       if (resultMap.length > preWsCount) {
         final enriched = await _enrichFromCache(resultMap.values.toList());
-        yield _applyFilter(trimmed, enriched, useServerSort, boostPubkeys);
+        yield snapshot(
+          isComplete: true,
+          enriched: _applyFilter(
+            trimmed,
+            enriched,
+            useServerSort,
+            boostPubkeys,
+          ),
+        );
         return;
       }
+    } else {
+      sources[SearchSource.nip50Relay] = const SearchSourceSkipped();
     }
 
     // Final yield: enriched + filtered (when WS didn't add anything or
     // was skipped due to offset > 0)
     final enriched = await _enrichFromCache(resultMap.values.toList());
-    yield _applyFilter(trimmed, enriched, useServerSort, boostPubkeys);
+    yield snapshot(
+      isComplete: true,
+      enriched: _applyFilter(trimmed, enriched, useServerSort, boostPubkeys),
+    );
   }
 
   /// Applies the configured search filter or falls back to name matching,

--- a/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
+++ b/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
@@ -1,0 +1,131 @@
+// ABOUTME: Per-source provenance types for progressive user search.
+// ABOUTME: Lets the bloc/UI distinguish true-empty from any-source-failed.
+//
+// The repository's `searchUsersProgressive` consults three sources in
+// order: local SQLite cache, the Funnelcake REST API, and NIP-50 relay
+// search. Each phase records its outcome in a `Map<SearchSource,
+// SearchSourceStatus>` that travels with every progressive yield. The
+// bloc reads this map to derive `isDegradedEmpty` — the state that drives
+// the UI to show a retry affordance instead of a misleading
+// "No results found" when every source failed.
+//
+// See: mobile/docs/PEOPLE_SEARCH.md
+
+import 'package:models/models.dart';
+
+/// Data source consulted by `searchUsersProgressive`.
+enum SearchSource {
+  /// Local SQLite profile cache. Consulted only on the first page
+  /// (offset == 0).
+  localCache,
+
+  /// Funnelcake REST API. Consulted on every page; skipped when the
+  /// client is configured without a base URL.
+  funnelcakeApi,
+
+  /// NIP-50 relay search. Consulted only on the first page
+  /// (offset == 0); subject to a fixed query timeout.
+  nip50Relay,
+}
+
+/// Reason a source failed to produce results.
+enum SearchSourceFailureReason {
+  /// The source did not respond within its budget (e.g. NIP-50 5 s
+  /// query timeout or the bloc's outer stream timeout).
+  timeout,
+
+  /// The source threw a network-shaped exception
+  /// (HTTP error, connection refused, etc.).
+  network,
+
+  /// The source is configured but not currently usable
+  /// (e.g. Funnelcake client has no base URL).
+  unavailable,
+
+  /// Any other failure — typically a `StateError` from the WebSocket
+  /// layer or an unexpected runtime error.
+  other,
+}
+
+/// Outcome of consulting a single search source.
+sealed class SearchSourceStatus {
+  const SearchSourceStatus();
+}
+
+/// Source has not yet reported a result.
+///
+/// Emitted as the initial value while the bloc waits for a phase to
+/// complete. When the outer stream timeout fires, every entry still in
+/// `pending` is promoted to [SearchSourceFailed] with reason
+/// [SearchSourceFailureReason.timeout].
+class SearchSourcePending extends SearchSourceStatus {
+  /// Creates a pending status.
+  const SearchSourcePending();
+}
+
+/// Source was intentionally not consulted for this query.
+///
+/// Local cache and NIP-50 are skipped on paginated requests
+/// (offset > 0); Funnelcake is skipped when the client is unavailable.
+class SearchSourceSkipped extends SearchSourceStatus {
+  /// Creates a skipped status.
+  const SearchSourceSkipped();
+}
+
+/// Source returned a result successfully.
+class SearchSourceSuccess extends SearchSourceStatus {
+  /// Creates a success status with [resultCount] and [latencyMs].
+  const SearchSourceSuccess({
+    required this.resultCount,
+    required this.latencyMs,
+  });
+
+  /// Number of distinct profiles this source contributed before
+  /// deduplication.
+  final int resultCount;
+
+  /// Wall-clock latency for the source's call, in milliseconds.
+  final int latencyMs;
+}
+
+/// Source failed to produce results.
+class SearchSourceFailed extends SearchSourceStatus {
+  /// Creates a failed status with [reason] and [latencyMs].
+  const SearchSourceFailed({
+    required this.reason,
+    required this.latencyMs,
+  });
+
+  /// Coarse failure category. Free-form error messages live in logs,
+  /// not in this type — keeping the type cheap and PII-free.
+  final SearchSourceFailureReason reason;
+
+  /// Wall-clock latency between starting the call and observing the
+  /// failure, in milliseconds.
+  final int latencyMs;
+}
+
+/// One progressive yield from `searchUsersProgressive`.
+///
+/// Carries both the accumulated deduplicated profile list and the
+/// running per-source outcome map. The final yield sets [isComplete]
+/// to `true`.
+class ProgressiveSearchResult {
+  /// Creates a progressive search result snapshot.
+  const ProgressiveSearchResult({
+    required this.profiles,
+    required this.sources,
+    required this.isComplete,
+  });
+
+  /// Accumulated, deduplicated, filter+boost-applied profile list.
+  final List<UserProfile> profiles;
+
+  /// Outcome of each source consulted so far. Sources not yet reached
+  /// may be absent from the map; the bloc treats absence as
+  /// [SearchSourcePending] equivalent.
+  final Map<SearchSource, SearchSourceStatus> sources;
+
+  /// `true` when no further yields will arrive for this query.
+  final bool isComplete;
+}

--- a/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
+++ b/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
@@ -54,9 +54,9 @@ sealed class SearchSourceStatus {
 
 /// Source has not yet reported a result.
 ///
-/// Emitted as the initial value while the bloc waits for a phase to
-/// complete. When the outer stream timeout fires, every entry still in
-/// `pending` is promoted to [SearchSourceFailed] with reason
+/// Emitted in progressive envelopes for sources the repository has not
+/// consulted yet. When the outer stream timeout fires, every entry still
+/// in `pending` is promoted to [SearchSourceFailed] with reason
 /// [SearchSourceFailureReason.timeout].
 class SearchSourcePending extends SearchSourceStatus {
   /// Creates a pending status.
@@ -91,10 +91,7 @@ class SearchSourceSuccess extends SearchSourceStatus {
 /// Source failed to produce results.
 class SearchSourceFailed extends SearchSourceStatus {
   /// Creates a failed status with [reason] and [latencyMs].
-  const SearchSourceFailed({
-    required this.reason,
-    required this.latencyMs,
-  });
+  const SearchSourceFailed({required this.reason, required this.latencyMs});
 
   /// Coarse failure category. Free-form error messages live in logs,
   /// not in this type — keeping the type cheap and PII-free.
@@ -121,9 +118,9 @@ class ProgressiveSearchResult {
   /// Accumulated, deduplicated, filter+boost-applied profile list.
   final List<UserProfile> profiles;
 
-  /// Outcome of each source consulted so far. Sources not yet reached
-  /// may be absent from the map; the bloc treats absence as
-  /// [SearchSourcePending] equivalent.
+  /// Outcome of each search source at this snapshot. Progressive
+  /// intermediate yields may still contain [SearchSourcePending] for
+  /// phases the repository has not reached yet.
   final Map<SearchSource, SearchSourceStatus> sources;
 
   /// `true` when no further yields will arrive for this query.

--- a/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
+++ b/mobile/packages/profile_repository/lib/src/progressive_search_result.dart
@@ -38,10 +38,6 @@ enum SearchSourceFailureReason {
   /// (HTTP error, connection refused, etc.).
   network,
 
-  /// The source is configured but not currently usable
-  /// (e.g. Funnelcake client has no base URL).
-  unavailable,
-
   /// Any other failure — typically a `StateError` from the WebSocket
   /// layer or an unexpected runtime error.
   other,
@@ -80,8 +76,8 @@ class SearchSourceSuccess extends SearchSourceStatus {
     required this.latencyMs,
   });
 
-  /// Number of distinct profiles this source contributed before
-  /// deduplication.
+  /// Number of new distinct profiles this source contributed to the
+  /// accumulated result set.
   final int resultCount;
 
   /// Wall-clock latency for the source's call, in milliseconds.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -752,100 +752,90 @@ void main() {
           verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
         });
 
-        test(
-          'does not overwrite a newer locally-cached bio with stale '
-          'Funnelcake data (regression: bio appears not to save)',
-          () async {
-            // Simulate: user just saved their bio. The local cache holds
-            // the freshly-published profile (createdAt = 1704153600, newer).
-            // Funnelcake returns a stale cached profile
-            // (createdAt = 1704067200, older). The bio must NOT be
-            // overwritten, the relay path must still run (so a newer Kind 0
-            // on relays can win), and the return value must be the locally
-            // cached profile when relays find nothing newer.
-            const newerTimestamp = 1704153600; // newer — just saved
-            const olderTimestamp = 1704067200; // older — stale Funnelcake cache
+        test('does not overwrite a newer locally-cached bio with stale '
+            'Funnelcake data (regression: bio appears not to save)', () async {
+          // Simulate: user just saved their bio. The local cache holds
+          // the freshly-published profile (createdAt = 1704153600, newer).
+          // Funnelcake returns a stale cached profile
+          // (createdAt = 1704067200, older). The bio must NOT be
+          // overwritten, the relay path must still run (so a newer Kind 0
+          // on relays can win), and the return value must be the locally
+          // cached profile when relays find nothing newer.
+          const newerTimestamp = 1704153600; // newer — just saved
+          const olderTimestamp = 1704067200; // older — stale Funnelcake cache
 
-            final freshlySavedProfile = UserProfile(
-              pubkey: testPubkey,
-              displayName: 'Test User',
-              about: 'My new bio',
-              rawData: const {
+          final freshlySavedProfile = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Test User',
+            about: 'My new bio',
+            rawData: const {'display_name': 'Test User', 'about': 'My new bio'},
+            createdAt: DateTime.fromMillisecondsSinceEpoch(
+              newerTimestamp * 1000,
+              isUtc: true,
+            ),
+            eventId: testEventId,
+          );
+
+          // Use a fresh DAO mock so we can control getProfile return values
+          // without stub-ordering issues from the outer setUp.
+          final freshDao = MockUserProfilesDao();
+          when(
+            () => freshDao.getProfile(any()),
+          ).thenAnswer((_) async => freshlySavedProfile);
+          when(() => freshDao.upsertProfile(any())).thenAnswer((_) async {});
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: freshDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockProfileStatsDao,
+          );
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileFound(
+              profile: UserProfileData.fromJson(testPubkey, const {
                 'display_name': 'Test User',
-                'about': 'My new bio',
-              },
-              createdAt: DateTime.fromMillisecondsSinceEpoch(
-                newerTimestamp * 1000,
-                isUtc: true,
-              ),
-              eventId: testEventId,
-            );
+                'about': '', // stale — bio not yet indexed by Funnelcake
+                'created_at': olderTimestamp,
+              }),
+            ),
+          );
 
-            // Use a fresh DAO mock so we can control getProfile return values
-            // without stub-ordering issues from the outer setUp.
-            final freshDao = MockUserProfilesDao();
-            when(
-              () => freshDao.getProfile(any()),
-            ).thenAnswer((_) async => freshlySavedProfile);
-            when(
-              () => freshDao.upsertProfile(any()),
-            ).thenAnswer((_) async {});
+          // Relays find nothing newer — the local cache is the fallback.
+          when(
+            () => mockNostrClient.fetchProfile(testPubkey),
+          ).thenAnswer((_) async => null);
 
-            final repo = ProfileRepository(
-              nostrClient: mockNostrClient,
-              userProfilesDao: freshDao,
-              httpClient: mockHttpClient,
-              funnelcakeApiClient: mockFunnelcakeClient,
-              profileStatsDao: mockProfileStatsDao,
-            );
+          final result = await repo.fetchFreshProfile(pubkey: testPubkey);
 
-            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-            when(
-              () => mockFunnelcakeClient.getUserProfile(testPubkey),
-            ).thenAnswer(
-              (_) async => UserProfileFound(
-                profile: UserProfileData.fromJson(testPubkey, const {
-                  'display_name': 'Test User',
-                  'about': '', // stale — bio not yet indexed by Funnelcake
-                  'created_at': olderTimestamp,
-                }),
-              ),
-            );
-
-            // Relays find nothing newer — the local cache is the fallback.
-            when(
-              () => mockNostrClient.fetchProfile(testPubkey),
-            ).thenAnswer((_) async => null);
-
-            final result = await repo.fetchFreshProfile(pubkey: testPubkey);
-
-            // The stale Funnelcake profile must NOT overwrite the newer cache.
-            verifyNever(
-              () => freshDao.upsertProfile(
-                any(
-                  that: isA<UserProfile>().having(
-                    (p) => p.about,
-                    'about',
-                    equals(''),
-                  ),
+          // The stale Funnelcake profile must NOT overwrite the newer cache.
+          verifyNever(
+            () => freshDao.upsertProfile(
+              any(
+                that: isA<UserProfile>().having(
+                  (p) => p.about,
+                  'about',
+                  equals(''),
                 ),
               ),
-            );
+            ),
+          );
 
-            // The relay path must have been invoked so a newer Kind 0 can
-            // still win — a future refactor cannot safely turn the Funnelcake
-            // break into an early return while keeping this assertion green.
-            verify(
-              () => mockNostrClient.fetchProfile(testPubkey),
-            ).called(1);
+          // The relay path must have been invoked so a newer Kind 0 can
+          // still win — a future refactor cannot safely turn the Funnelcake
+          // break into an early return while keeping this assertion green.
+          verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
 
-            // The return value must be the freshly-saved local profile,
-            // not null (the break path falls back to the cache when relays
-            // find nothing).
-            expect(result, isNotNull);
-            expect(result!.about, equals('My new bio'));
-          },
-        );
+          // The return value must be the freshly-saved local profile,
+          // not null (the break path falls back to the cache when relays
+          // find nothing).
+          expect(result, isNotNull);
+          expect(result!.about, equals('My new bio'));
+        });
       });
 
       group('indexer relay fallback', () {
@@ -1393,10 +1383,7 @@ void main() {
 
         verify(
           () => mockNostrClient.sendProfile(
-            profileContent: {
-              'display_name': 'Test User',
-              'banner': '0x33ccbf',
-            },
+            profileContent: {'display_name': 'Test User', 'banner': '0x33ccbf'},
           ),
         ).called(1);
       });
@@ -1555,86 +1542,77 @@ void main() {
 
           verify(
             () => mockNostrClient.sendProfile(
+              profileContent: {'display_name': 'New Name', 'about': 'Bio'},
+            ),
+          ).called(1);
+        });
+
+        test('preserves nip05 from currentProfile.rawData when sourced from '
+            'Funnelcake REST (post-#4175 fromUserProfileFound mirrors typed '
+            'fields into rawData)', () async {
+          // After #4175, fromUserProfileFound populates rawData from
+          // typed REST fields. Construct a profile in that shape and
+          // assert nip05 survives a profile edit unchanged.
+          final funnelcakeProfile = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Old Name',
+            nip05: '_@ike.divine.video',
+            rawData: const {
+              'display_name': 'Old Name',
+              'nip05': '_@ike.divine.video',
+            },
+            createdAt: DateTime.now(),
+            eventId: 'rest-$testPubkey',
+          );
+
+          when(() => mockProfileEvent.content).thenReturn(
+            jsonEncode({
+              'display_name': 'New Name',
+              'nip05': '_@ike.divine.video',
+            }),
+          );
+
+          await profileRepository.saveProfileEvent(
+            displayName: 'New Name',
+            currentProfile: funnelcakeProfile,
+          );
+
+          verify(
+            () => mockNostrClient.sendProfile(
               profileContent: {
                 'display_name': 'New Name',
-                'about': 'Bio',
+                'nip05': '_@ike.divine.video',
               },
             ),
           ).called(1);
         });
 
-        test(
-          'preserves nip05 from currentProfile.rawData when sourced from '
-          'Funnelcake REST (post-#4175 fromUserProfileFound mirrors typed '
-          'fields into rawData)',
-          () async {
-            // After #4175, fromUserProfileFound populates rawData from
-            // typed REST fields. Construct a profile in that shape and
-            // assert nip05 survives a profile edit unchanged.
-            final funnelcakeProfile = UserProfile(
-              pubkey: testPubkey,
-              displayName: 'Old Name',
-              nip05: '_@ike.divine.video',
-              rawData: const {
-                'display_name': 'Old Name',
-                'nip05': '_@ike.divine.video',
-              },
-              createdAt: DateTime.now(),
-              eventId: 'rest-$testPubkey',
-            );
+        test('clearNip05 removes nip05 even when sourced from a '
+            'post-#4175 Funnelcake profile', () async {
+          final funnelcakeProfile = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Old Name',
+            nip05: '_@ike.divine.video',
+            rawData: const {
+              'display_name': 'Old Name',
+              'nip05': '_@ike.divine.video',
+            },
+            createdAt: DateTime.now(),
+            eventId: 'rest-$testPubkey',
+          );
 
-            when(() => mockProfileEvent.content).thenReturn(
-              jsonEncode({
-                'display_name': 'New Name',
-                'nip05': '_@ike.divine.video',
-              }),
-            );
+          await profileRepository.saveProfileEvent(
+            displayName: 'New Name',
+            clearNip05: true,
+            currentProfile: funnelcakeProfile,
+          );
 
-            await profileRepository.saveProfileEvent(
-              displayName: 'New Name',
-              currentProfile: funnelcakeProfile,
-            );
-
-            verify(
-              () => mockNostrClient.sendProfile(
-                profileContent: {
-                  'display_name': 'New Name',
-                  'nip05': '_@ike.divine.video',
-                },
-              ),
-            ).called(1);
-          },
-        );
-
-        test(
-          'clearNip05 removes nip05 even when sourced from a '
-          'post-#4175 Funnelcake profile',
-          () async {
-            final funnelcakeProfile = UserProfile(
-              pubkey: testPubkey,
-              displayName: 'Old Name',
-              nip05: '_@ike.divine.video',
-              rawData: const {
-                'display_name': 'Old Name',
-                'nip05': '_@ike.divine.video',
-              },
-              createdAt: DateTime.now(),
-              eventId: 'rest-$testPubkey',
-            );
-
-            await profileRepository.saveProfileEvent(
-              displayName: 'New Name',
-              clearNip05: true,
-              currentProfile: funnelcakeProfile,
-            );
-
-            verify(
-              () => mockNostrClient.sendProfile(
-                profileContent: {'display_name': 'New Name'},
-              ),
-            ).called(1);
-          },
-        );
+          verify(
+            () => mockNostrClient.sendProfile(
+              profileContent: {'display_name': 'New Name'},
+            ),
+          ).called(1);
+        });
 
         test(
           'clearNip05 is a no-op when a new nip05 is also provided',
@@ -2291,10 +2269,7 @@ void main() {
             ),
           ).called(1);
           verifyNever(
-            () => mockNostrClient.queryUsers(
-              any(),
-              limit: any(named: 'limit'),
-            ),
+            () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
           );
         },
       );
@@ -2340,10 +2315,7 @@ void main() {
             ),
           ).called(1);
           verifyNever(
-            () => mockNostrClient.queryUsers(
-              any(),
-              limit: any(named: 'limit'),
-            ),
+            () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
           );
         },
       );
@@ -2757,6 +2729,18 @@ void main() {
         // First emission: local results only
         expect(emissions.first.profiles, hasLength(1));
         expect(emissions.first.profiles.first.pubkey, equals(testPubkey));
+        expect(
+          emissions.first.sources[SearchSource.localCache],
+          isA<SearchSourceSuccess>(),
+        );
+        expect(
+          emissions.first.sources[SearchSource.funnelcakeApi],
+          isA<SearchSourcePending>(),
+        );
+        expect(
+          emissions.first.sources[SearchSource.nip50Relay],
+          isA<SearchSourcePending>(),
+        );
         expect(emissions.first.isComplete, isFalse);
 
         // Last emission: merged and enriched
@@ -3230,124 +3214,103 @@ void main() {
           },
         );
 
-        test(
-          'is a no-op when the boost set is empty',
-          () async {
-            when(
-              () => mockFunnelcakeClient.searchProfiles(
+        test('is a no-op when the boost set is empty', () async {
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'test',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [restResult(pubA, 'Zoe'), restResult(pubB, 'Maya')],
+          );
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo
+              .searchUsersProgressive(
                 query: 'test',
-                limit: any(named: 'limit'),
-                offset: any(named: 'offset'),
-                sortBy: any(named: 'sortBy'),
-                hasVideos: any(named: 'hasVideos'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                restResult(pubA, 'Zoe'),
-                restResult(pubB, 'Maya'),
-              ],
-            );
+                sortBy: 'followers',
+                boostPubkeys: const <String>{},
+              )
+              .last;
 
-            final repo = ProfileRepository(
-              nostrClient: mockNostrClient,
-              userProfilesDao: mockUserProfilesDao,
-              httpClient: mockHttpClient,
-              funnelcakeApiClient: mockFunnelcakeClient,
-            );
+          expect(
+            result.profiles.map((p) => p.displayName).toList(),
+            equals(['Zoe', 'Maya']),
+          );
+        });
 
-            final result = await repo
-                .searchUsersProgressive(
-                  query: 'test',
-                  sortBy: 'followers',
-                  boostPubkeys: const <String>{},
-                )
-                .last;
+        test('is a no-op when boostPubkeys is null', () async {
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'test',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [restResult(pubA, 'Zoe'), restResult(pubB, 'Maya')],
+          );
 
-            expect(
-              result.profiles.map((p) => p.displayName).toList(),
-              equals(['Zoe', 'Maya']),
-            );
-          },
-        );
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
 
-        test(
-          'is a no-op when boostPubkeys is null',
-          () async {
-            when(
-              () => mockFunnelcakeClient.searchProfiles(
+          final result = await repo
+              .searchUsersProgressive(query: 'test', sortBy: 'followers')
+              .last;
+
+          expect(
+            result.profiles.map((p) => p.displayName).toList(),
+            equals(['Zoe', 'Maya']),
+          );
+        });
+
+        test('is a no-op when no result is in the boost set', () async {
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'test',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [restResult(pubA, 'Zoe'), restResult(pubB, 'Maya')],
+          );
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo
+              .searchUsersProgressive(
                 query: 'test',
-                limit: any(named: 'limit'),
-                offset: any(named: 'offset'),
-                sortBy: any(named: 'sortBy'),
-                hasVideos: any(named: 'hasVideos'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                restResult(pubA, 'Zoe'),
-                restResult(pubB, 'Maya'),
-              ],
-            );
+                sortBy: 'followers',
+                boostPubkeys: {'f' * 64},
+              )
+              .last;
 
-            final repo = ProfileRepository(
-              nostrClient: mockNostrClient,
-              userProfilesDao: mockUserProfilesDao,
-              httpClient: mockHttpClient,
-              funnelcakeApiClient: mockFunnelcakeClient,
-            );
-
-            final result = await repo
-                .searchUsersProgressive(
-                  query: 'test',
-                  sortBy: 'followers',
-                )
-                .last;
-
-            expect(
-              result.profiles.map((p) => p.displayName).toList(),
-              equals(['Zoe', 'Maya']),
-            );
-          },
-        );
-
-        test(
-          'is a no-op when no result is in the boost set',
-          () async {
-            when(
-              () => mockFunnelcakeClient.searchProfiles(
-                query: 'test',
-                limit: any(named: 'limit'),
-                offset: any(named: 'offset'),
-                sortBy: any(named: 'sortBy'),
-                hasVideos: any(named: 'hasVideos'),
-              ),
-            ).thenAnswer(
-              (_) async => [
-                restResult(pubA, 'Zoe'),
-                restResult(pubB, 'Maya'),
-              ],
-            );
-
-            final repo = ProfileRepository(
-              nostrClient: mockNostrClient,
-              userProfilesDao: mockUserProfilesDao,
-              httpClient: mockHttpClient,
-              funnelcakeApiClient: mockFunnelcakeClient,
-            );
-
-            final result = await repo
-                .searchUsersProgressive(
-                  query: 'test',
-                  sortBy: 'followers',
-                  boostPubkeys: {'f' * 64},
-                )
-                .last;
-
-            expect(
-              result.profiles.map((p) => p.displayName).toList(),
-              equals(['Zoe', 'Maya']),
-            );
-          },
-        );
+          expect(
+            result.profiles.map((p) => p.displayName).toList(),
+            equals(['Zoe', 'Maya']),
+          );
+        });
       });
 
       group('source provenance', () {
@@ -3424,20 +3387,12 @@ void main() {
         });
 
         test(
-          'records SearchSourceFailed(network) when REST throws',
+          'records SearchSourceFailed(other) when local cache throws',
           () async {
             when(
               () => mockUserProfilesDao.getAllProfiles(),
-            ).thenAnswer((_) async => []);
-            when(
-              () => mockFunnelcakeClient.searchProfiles(
-                query: 'test',
-                limit: any(named: 'limit'),
-                offset: any(named: 'offset'),
-                sortBy: any(named: 'sortBy'),
-                hasVideos: any(named: 'hasVideos'),
-              ),
-            ).thenThrow(Exception('connection refused'));
+            ).thenThrow(StateError('db down'));
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
             when(
               () => mockNostrClient.queryUsers('test', limit: 200),
             ).thenAnswer((_) async => []);
@@ -3453,14 +3408,48 @@ void main() {
                 .searchUsersProgressive(query: 'test')
                 .last;
 
-            final apiStatus = result.sources[SearchSource.funnelcakeApi];
-            expect(apiStatus, isA<SearchSourceFailed>());
+            final localStatus = result.sources[SearchSource.localCache];
+            expect(localStatus, isA<SearchSourceFailed>());
             expect(
-              (apiStatus! as SearchSourceFailed).reason,
-              SearchSourceFailureReason.network,
+              (localStatus! as SearchSourceFailed).reason,
+              SearchSourceFailureReason.other,
             );
           },
         );
+
+        test('records SearchSourceFailed(network) when REST throws', () async {
+          when(
+            () => mockUserProfilesDao.getAllProfiles(),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'test',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenThrow(Exception('connection refused'));
+          when(
+            () => mockNostrClient.queryUsers('test', limit: 200),
+          ).thenAnswer((_) async => []);
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.searchUsersProgressive(query: 'test').last;
+
+          final apiStatus = result.sources[SearchSource.funnelcakeApi];
+          expect(apiStatus, isA<SearchSourceFailed>());
+          expect(
+            (apiStatus! as SearchSourceFailed).reason,
+            SearchSourceFailureReason.network,
+          );
+        });
 
         test(
           'records SearchSourceFailed(timeout) when NIP-50 times out',
@@ -3837,43 +3826,40 @@ void main() {
         },
       );
 
-      test(
-        'returns server error message when claim returns 400 '
-        'with JSON error body',
-        () async {
-          when(
-            () => mockNostrClient.createNip98AuthHeader(
-              url: any(named: 'url'),
-              method: any(named: 'method'),
-              payload: any(named: 'payload'),
-            ),
-          ).thenAnswer((_) => Future.value('authHeader'));
-          when(
-            () => mockHttpClient.post(
-              any(),
-              headers: any(named: 'headers'),
-              body: any(named: 'body'),
-            ),
-          ).thenAnswer(
-            (_) => Future.value(
-              Response('{"error": "Name server rejected claim"}', 400),
-            ),
-          );
+      test('returns server error message when claim returns 400 '
+          'with JSON error body', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) => Future.value(
+            Response('{"error": "Name server rejected claim"}', 400),
+          ),
+        );
 
-          final result = await profileRepository.claimUsername(
-            username: 'validuser',
-          );
+        final result = await profileRepository.claimUsername(
+          username: 'validuser',
+        );
 
-          expect(
-            result,
-            isA<UsernameClaimError>().having(
-              (e) => e.message,
-              'message',
-              'Name server rejected claim',
-            ),
-          );
-        },
-      );
+        expect(
+          result,
+          isA<UsernameClaimError>().having(
+            (e) => e.message,
+            'message',
+            'Name server rejected claim',
+          ),
+        );
+      });
 
       test('returns error with default message when server returns '
           'non-200 with unparseable body', () async {
@@ -4081,28 +4067,25 @@ void main() {
         expect(result, isA<UsernameInvalidFormat>());
       });
 
-      test(
-        'returns UsernameInvalidFormat for too-short names',
-        () async {
-          final result = await profileRepository.checkUsernameAvailability(
-            username: 'ab',
-          );
+      test('returns UsernameInvalidFormat for too-short names', () async {
+        final result = await profileRepository.checkUsernameAvailability(
+          username: 'ab',
+        );
 
-          expect(
-            result,
-            isA<UsernameInvalidFormat>().having(
-              (e) => e.reason,
-              'reason',
-              'Usernames must be 3–63 characters',
-            ),
-          );
-          verifyNever(
-            () => mockHttpClient.get(
-              Uri.parse('https://names.divine.video/api/username/check/ab'),
-            ),
-          );
-        },
-      );
+        expect(
+          result,
+          isA<UsernameInvalidFormat>().having(
+            (e) => e.reason,
+            'reason',
+            'Usernames must be 3–63 characters',
+          ),
+        );
+        verifyNever(
+          () => mockHttpClient.get(
+            Uri.parse('https://names.divine.video/api/username/check/ab'),
+          ),
+        );
+      });
 
       test(
         'returns UsernameInvalidFormat for names with underscores',
@@ -4375,49 +4358,46 @@ void main() {
         expect(result, equals(const UsernameTaken()));
       });
 
-      test(
-        'returns UsernameCheckError when the GET exceeds the timeout',
-        () {
-          fakeAsync((async) {
-            when(
-              () => mockHttpClient.get(
-                Uri.parse(
-                  'https://names.divine.video/api/username/check/testuser',
-                ),
+      test('returns UsernameCheckError when the GET exceeds the timeout', () {
+        fakeAsync((async) {
+          when(
+            () => mockHttpClient.get(
+              Uri.parse(
+                'https://names.divine.video/api/username/check/testuser',
               ),
-            ).thenAnswer((_) async {
-              // Simulates an unresponsive name server: never resolves within
-              // the repository's _nameServerHttpTimeout (10s).
-              await Future<void>.delayed(const Duration(minutes: 5));
-              return Response('unused', 200);
-            });
-
-            UsernameAvailabilityResult? result;
-            unawaited(
-              profileRepository
-                  .checkUsernameAvailability(username: 'testuser')
-                  .then((r) => result = r),
-            );
-
-            async
-              ..elapse(const Duration(seconds: 9))
-              ..flushMicrotasks();
-            expect(result, isNull);
-
-            async
-              ..elapse(const Duration(seconds: 2))
-              ..flushMicrotasks();
-            expect(
-              result,
-              isA<UsernameCheckError>().having(
-                (e) => e.message,
-                'message',
-                contains('TimeoutException'),
-              ),
-            );
+            ),
+          ).thenAnswer((_) async {
+            // Simulates an unresponsive name server: never resolves within
+            // the repository's _nameServerHttpTimeout (10s).
+            await Future<void>.delayed(const Duration(minutes: 5));
+            return Response('unused', 200);
           });
-        },
-      );
+
+          UsernameAvailabilityResult? result;
+          unawaited(
+            profileRepository
+                .checkUsernameAvailability(username: 'testuser')
+                .then((r) => result = r),
+          );
+
+          async
+            ..elapse(const Duration(seconds: 9))
+            ..flushMicrotasks();
+          expect(result, isNull);
+
+          async
+            ..elapse(const Duration(seconds: 2))
+            ..flushMicrotasks();
+          expect(
+            result,
+            isA<UsernameCheckError>().having(
+              (e) => e.message,
+              'message',
+              contains('TimeoutException'),
+            ),
+          );
+        });
+      });
     });
 
     group('UsernameAvailabilityResult', () {
@@ -4885,10 +4865,9 @@ void main() {
           (_) async => BulkProfilesResponse(
             profiles: {
               testPubkey2: UserProfileFound(
-                profile: UserProfileData.fromJson(
-                  testPubkey2,
-                  const {'display_name': 'API User'},
-                ),
+                profile: UserProfileData.fromJson(testPubkey2, const {
+                  'display_name': 'API User',
+                }),
               ),
             },
           ),
@@ -5161,10 +5140,9 @@ void main() {
             (_) async => BulkProfilesResponse(
               profiles: {
                 testPubkey: UserProfileFound(
-                  profile: UserProfileData.fromJson(
-                    testPubkey,
-                    const {'display_name': 'Real User'},
-                  ),
+                  profile: UserProfileData.fromJson(testPubkey, const {
+                    'display_name': 'Real User',
+                  }),
                 ),
                 testPubkey2: const UserProfileNotPublished(pubkey: testPubkey2),
               },
@@ -5281,9 +5259,7 @@ void main() {
 
           when(
             () => mockUserProfilesDao.getAllProfiles(),
-          ).thenAnswer(
-            (_) async => [blockedProfile, allowedProfile],
-          );
+          ).thenAnswer((_) async => [blockedProfile, allowedProfile]);
 
           when(
             () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
@@ -5314,105 +5290,96 @@ void main() {
         },
       );
 
-      test(
-        'returns all profiles when blockFilter is null',
-        () async {
-          final profile1 = UserProfile(
-            pubkey: blockedPubkey,
-            displayName: 'User One',
-            rawData: const {'display_name': 'User One'},
-            createdAt: DateTime(2026),
-            eventId: 'evt_one',
-          );
-          final profile2 = UserProfile(
-            pubkey: testPubkey,
-            displayName: 'User Two',
-            rawData: const {'display_name': 'User Two'},
-            createdAt: DateTime(2026),
-            eventId: testEventId,
-          );
+      test('returns all profiles when blockFilter is null', () async {
+        final profile1 = UserProfile(
+          pubkey: blockedPubkey,
+          displayName: 'User One',
+          rawData: const {'display_name': 'User One'},
+          createdAt: DateTime(2026),
+          eventId: 'evt_one',
+        );
+        final profile2 = UserProfile(
+          pubkey: testPubkey,
+          displayName: 'User Two',
+          rawData: const {'display_name': 'User Two'},
+          createdAt: DateTime(2026),
+          eventId: testEventId,
+        );
 
-          when(
-            () => mockUserProfilesDao.getAllProfiles(),
-          ).thenAnswer((_) async => [profile1, profile2]);
+        when(
+          () => mockUserProfilesDao.getAllProfiles(),
+        ).thenAnswer((_) async => [profile1, profile2]);
 
-          when(
-            () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
-          ).thenAnswer((_) async => []);
+        when(
+          () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
+        ).thenAnswer((_) async => []);
 
-          // Default profileRepository has no blockFilter.
-          final emissions = await profileRepository
-              .searchUsersProgressive(query: 'user')
-              .toList();
+        // Default profileRepository has no blockFilter.
+        final emissions = await profileRepository
+            .searchUsersProgressive(query: 'user')
+            .toList();
 
-          expect(emissions.last.profiles, hasLength(2));
-        },
-      );
+        expect(emissions.last.profiles, hasLength(2));
+      });
 
-      test(
-        'filters blocked users from searchUsersLocally results',
-        () async {
-          const blockedPubkey =
-              'dddddddddddddddddddddddddddddddd'
-              'dddddddddddddddddddddddddddddddd';
-          final blockedProfile = UserProfile(
-            pubkey: blockedPubkey,
-            displayName: 'Blocked User',
-            rawData: const {'display_name': 'Blocked User'},
-            createdAt: DateTime(2026),
-            eventId: 'evt_blocked_local',
-          );
-          final allowedProfile = UserProfile(
-            pubkey: testPubkey,
-            displayName: 'Allowed User',
-            rawData: const {'display_name': 'Allowed User'},
-            createdAt: DateTime(2026),
-            eventId: testEventId,
-          );
+      test('filters blocked users from searchUsersLocally results', () async {
+        const blockedPubkey =
+            'dddddddddddddddddddddddddddddddd'
+            'dddddddddddddddddddddddddddddddd';
+        final blockedProfile = UserProfile(
+          pubkey: blockedPubkey,
+          displayName: 'Blocked User',
+          rawData: const {'display_name': 'Blocked User'},
+          createdAt: DateTime(2026),
+          eventId: 'evt_blocked_local',
+        );
+        final allowedProfile = UserProfile(
+          pubkey: testPubkey,
+          displayName: 'Allowed User',
+          rawData: const {'display_name': 'Allowed User'},
+          createdAt: DateTime(2026),
+          eventId: testEventId,
+        );
 
-          when(
-            () => mockUserProfilesDao.getAllProfiles(),
-          ).thenAnswer((_) async => [blockedProfile, allowedProfile]);
+        when(
+          () => mockUserProfilesDao.getAllProfiles(),
+        ).thenAnswer((_) async => [blockedProfile, allowedProfile]);
 
-          final repoWithBlockFilter = ProfileRepository(
-            nostrClient: mockNostrClient,
-            userProfilesDao: mockUserProfilesDao,
-            httpClient: mockHttpClient,
-            blockFilter: (pubkey) => pubkey == blockedPubkey,
-          );
+        final repoWithBlockFilter = ProfileRepository(
+          nostrClient: mockNostrClient,
+          userProfilesDao: mockUserProfilesDao,
+          httpClient: mockHttpClient,
+          blockFilter: (pubkey) => pubkey == blockedPubkey,
+        );
 
-          final result = await repoWithBlockFilter.searchUsersLocally(
-            query: 'user',
-          );
+        final result = await repoWithBlockFilter.searchUsersLocally(
+          query: 'user',
+        );
 
-          expect(result.map((p) => p.pubkey), isNot(contains(blockedPubkey)));
-          expect(result, hasLength(1));
-          expect(result.first.pubkey, equals(testPubkey));
-        },
-      );
+        expect(result.map((p) => p.pubkey), isNot(contains(blockedPubkey)));
+        expect(result, hasLength(1));
+        expect(result.first.pubkey, equals(testPubkey));
+      });
 
-      test(
-        'fetchFreshProfile returns null for a blocked pubkey',
-        () async {
-          const blockedPubkey =
-              'dddddddddddddddddddddddddddddddd'
-              'dddddddddddddddddddddddddddddddd';
+      test('fetchFreshProfile returns null for a blocked pubkey', () async {
+        const blockedPubkey =
+            'dddddddddddddddddddddddddddddddd'
+            'dddddddddddddddddddddddddddddddd';
 
-          final repoWithBlockFilter = ProfileRepository(
-            nostrClient: mockNostrClient,
-            userProfilesDao: mockUserProfilesDao,
-            httpClient: mockHttpClient,
-            blockFilter: (pubkey) => pubkey == blockedPubkey,
-          );
+        final repoWithBlockFilter = ProfileRepository(
+          nostrClient: mockNostrClient,
+          userProfilesDao: mockUserProfilesDao,
+          httpClient: mockHttpClient,
+          blockFilter: (pubkey) => pubkey == blockedPubkey,
+        );
 
-          final result = await repoWithBlockFilter.fetchFreshProfile(
-            pubkey: blockedPubkey,
-          );
+        final result = await repoWithBlockFilter.fetchFreshProfile(
+          pubkey: blockedPubkey,
+        );
 
-          expect(result, isNull);
-          verifyNever(() => mockNostrClient.fetchProfile(any()));
-        },
-      );
+        expect(result, isNull);
+        verifyNever(() => mockNostrClient.fetchProfile(any()));
+      });
 
       test(
         'fetchBatchProfiles excludes blocked pubkeys from map result',
@@ -5425,14 +5392,12 @@ void main() {
           when(() => blockedEvent.kind).thenReturn(0);
           when(() => blockedEvent.pubkey).thenReturn(blockedPubkey);
           when(() => blockedEvent.createdAt).thenReturn(1704067200);
-          when(
-            () => blockedEvent.id,
-          ).thenReturn(
+          when(() => blockedEvent.id).thenReturn(
             'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
           );
-          when(() => blockedEvent.content).thenReturn(
-            '{"display_name":"Blocked Batch User"}',
-          );
+          when(
+            () => blockedEvent.content,
+          ).thenReturn('{"display_name":"Blocked Batch User"}');
 
           when(
             () => mockUserProfilesDao.getProfilesByPubkeys(any()),

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -2755,11 +2755,13 @@ void main() {
         expect(emissions.length, greaterThanOrEqualTo(2));
 
         // First emission: local results only
-        expect(emissions.first, hasLength(1));
-        expect(emissions.first.first.pubkey, equals(testPubkey));
+        expect(emissions.first.profiles, hasLength(1));
+        expect(emissions.first.profiles.first.pubkey, equals(testPubkey));
+        expect(emissions.first.isComplete, isFalse);
 
         // Last emission: merged and enriched
-        expect(emissions.last.length, greaterThanOrEqualTo(1));
+        expect(emissions.last.profiles.length, greaterThanOrEqualTo(1));
+        expect(emissions.last.isComplete, isTrue);
       });
 
       test('skips local phase when offset > 0', () async {
@@ -2775,6 +2777,14 @@ void main() {
 
         // Assert - only one emission (no local phase)
         expect(emissions, hasLength(1));
+        expect(
+          emissions.single.sources[SearchSource.localCache],
+          isA<SearchSourceSkipped>(),
+        );
+        expect(
+          emissions.single.sources[SearchSource.nip50Relay],
+          isA<SearchSourceSkipped>(),
+        );
 
         // NIP-50 should NOT be called for offset > 0
         verifyNever(
@@ -2799,8 +2809,8 @@ void main() {
 
         // Assert - no local emission (empty), just the final one
         expect(emissions, hasLength(1));
-        expect(emissions.first, hasLength(1));
-        expect(emissions.first.first.pubkey, equals(testPubkey));
+        expect(emissions.first.profiles, hasLength(1));
+        expect(emissions.first.profiles.first.pubkey, equals(testPubkey));
       });
 
       group('with FunnelcakeApiClient', () {
@@ -2864,11 +2874,14 @@ void main() {
           expect(emissions.length, greaterThanOrEqualTo(2));
 
           // First emission: local only
-          expect(emissions.first, hasLength(1));
-          expect(emissions.first.first.displayName, equals('Test Cached'));
+          expect(emissions.first.profiles, hasLength(1));
+          expect(
+            emissions.first.profiles.first.displayName,
+            equals('Test Cached'),
+          );
 
           // Last emission: merged results
-          expect(emissions.last.length, greaterThanOrEqualTo(1));
+          expect(emissions.last.profiles.length, greaterThanOrEqualTo(1));
         });
 
         test('continues when REST fails and yields WS results', () async {
@@ -2902,8 +2915,12 @@ void main() {
               .searchUsersProgressive(query: 'test')
               .last;
 
-          expect(result, hasLength(1));
-          expect(result.first.pubkey, equals(testPubkey));
+          expect(result.profiles, hasLength(1));
+          expect(result.profiles.first.pubkey, equals(testPubkey));
+          expect(
+            result.sources[SearchSource.funnelcakeApi],
+            isA<SearchSourceFailed>(),
+          );
         });
 
         test('continues when WS fails and yields REST results', () async {
@@ -2945,8 +2962,12 @@ void main() {
               .searchUsersProgressive(query: 'test')
               .last;
 
-          expect(result, hasLength(1));
-          expect(result.first.displayName, equals('Test REST'));
+          expect(result.profiles, hasLength(1));
+          expect(result.profiles.first.displayName, equals('Test REST'));
+          expect(
+            result.sources[SearchSource.nip50Relay],
+            isA<SearchSourceFailed>(),
+          );
         });
 
         test('yields enriched results when WS adds new profiles', () async {
@@ -2998,7 +3019,7 @@ void main() {
               .last;
 
           // Both REST and WS results merged
-          expect(result, hasLength(2));
+          expect(result.profiles, hasLength(2));
         });
 
         test('uses custom profileSearchFilter when no server sort', () async {
@@ -3092,8 +3113,8 @@ void main() {
 
             // Assert - final yield preserves server order, filter not called
             // on non-empty results
-            expect(result, hasLength(1));
-            expect(result.first.displayName, equals('Alice REST'));
+            expect(result.profiles, hasLength(1));
+            expect(result.profiles.first.displayName, equals('Alice REST'));
             expect(finalYieldFilterCalled, isFalse);
           },
         );
@@ -3161,7 +3182,7 @@ void main() {
                 .last;
 
             expect(
-              result.map((p) => p.displayName).toList(),
+              result.profiles.map((p) => p.displayName).toList(),
               equals(['Liz', 'Zoe', 'Maya']),
             );
           },
@@ -3203,7 +3224,7 @@ void main() {
                 .last;
 
             expect(
-              result.map((p) => p.displayName).toList(),
+              result.profiles.map((p) => p.displayName).toList(),
               equals(['A', 'C', 'B', 'D']),
             );
           },
@@ -3243,7 +3264,7 @@ void main() {
                 .last;
 
             expect(
-              result.map((p) => p.displayName).toList(),
+              result.profiles.map((p) => p.displayName).toList(),
               equals(['Zoe', 'Maya']),
             );
           },
@@ -3282,7 +3303,7 @@ void main() {
                 .last;
 
             expect(
-              result.map((p) => p.displayName).toList(),
+              result.profiles.map((p) => p.displayName).toList(),
               equals(['Zoe', 'Maya']),
             );
           },
@@ -3322,8 +3343,233 @@ void main() {
                 .last;
 
             expect(
-              result.map((p) => p.displayName).toList(),
+              result.profiles.map((p) => p.displayName).toList(),
               equals(['Zoe', 'Maya']),
+            );
+          },
+        );
+      });
+
+      group('source provenance', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        });
+
+        test('records success on every source when all succeed', () async {
+          final cachedProfile = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Cached',
+            rawData: const {'display_name': 'Cached'},
+            createdAt: DateTime(2026),
+            eventId: testEventId,
+          );
+          when(
+            () => mockUserProfilesDao.getAllProfiles(),
+          ).thenAnswer((_) async => [cachedProfile]);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: 'test',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ProfileSearchResult(
+                pubkey: 'a' * 64,
+                displayName: 'REST User',
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              ),
+            ],
+          );
+
+          final wsEvent = MockEvent();
+          when(() => wsEvent.kind).thenReturn(0);
+          when(() => wsEvent.pubkey).thenReturn('b' * 64);
+          when(() => wsEvent.createdAt).thenReturn(1704067200);
+          when(() => wsEvent.id).thenReturn('c' * 64);
+          when(
+            () => wsEvent.content,
+          ).thenReturn(jsonEncode({'display_name': 'WS User'}));
+          when(
+            () => mockNostrClient.queryUsers('test', limit: 200),
+          ).thenAnswer((_) async => [wsEvent]);
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.searchUsersProgressive(query: 'test').last;
+
+          expect(
+            result.sources[SearchSource.localCache],
+            isA<SearchSourceSuccess>(),
+          );
+          expect(
+            result.sources[SearchSource.funnelcakeApi],
+            isA<SearchSourceSuccess>(),
+          );
+          expect(
+            result.sources[SearchSource.nip50Relay],
+            isA<SearchSourceSuccess>(),
+          );
+          expect(result.isComplete, isTrue);
+        });
+
+        test(
+          'records SearchSourceFailed(network) when REST throws',
+          () async {
+            when(
+              () => mockUserProfilesDao.getAllProfiles(),
+            ).thenAnswer((_) async => []);
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'test',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenThrow(Exception('connection refused'));
+            when(
+              () => mockNostrClient.queryUsers('test', limit: 200),
+            ).thenAnswer((_) async => []);
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(query: 'test')
+                .last;
+
+            final apiStatus = result.sources[SearchSource.funnelcakeApi];
+            expect(apiStatus, isA<SearchSourceFailed>());
+            expect(
+              (apiStatus! as SearchSourceFailed).reason,
+              SearchSourceFailureReason.network,
+            );
+          },
+        );
+
+        test(
+          'records SearchSourceFailed(timeout) when NIP-50 times out',
+          () async {
+            when(
+              () => mockUserProfilesDao.getAllProfiles(),
+            ).thenAnswer((_) async => []);
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
+            when(
+              () => mockNostrClient.queryUsers('test', limit: 200),
+            ).thenAnswer((_) async {
+              // Sleep past the 5 s NIP-50 timeout so .timeout() fires.
+              await Future<void>.delayed(const Duration(seconds: 6));
+              return <Event>[];
+            });
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(query: 'test')
+                .last;
+
+            final relayStatus = result.sources[SearchSource.nip50Relay];
+            expect(relayStatus, isA<SearchSourceFailed>());
+            expect(
+              (relayStatus! as SearchSourceFailed).reason,
+              SearchSourceFailureReason.timeout,
+            );
+          },
+          timeout: const Timeout(Duration(seconds: 10)),
+        );
+
+        test(
+          'records failures across all sources when everything fails',
+          () async {
+            when(
+              () => mockUserProfilesDao.getAllProfiles(),
+            ).thenAnswer((_) async => []);
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'test',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenThrow(Exception('REST down'));
+            when(
+              () => mockNostrClient.queryUsers('test', limit: 200),
+            ).thenThrow(StateError('WS down'));
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(query: 'test')
+                .last;
+
+            expect(result.profiles, isEmpty);
+            expect(
+              result.sources[SearchSource.localCache],
+              isA<SearchSourceSuccess>(), // empty local is still "success"
+            );
+            expect(
+              result.sources[SearchSource.funnelcakeApi],
+              isA<SearchSourceFailed>(),
+            );
+            expect(
+              result.sources[SearchSource.nip50Relay],
+              isA<SearchSourceFailed>(),
+            );
+            expect(result.isComplete, isTrue);
+          },
+        );
+
+        test(
+          'records SearchSourceSkipped for funnelcake when unavailable',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
+            when(
+              () => mockUserProfilesDao.getAllProfiles(),
+            ).thenAnswer((_) async => []);
+            when(
+              () => mockNostrClient.queryUsers('test', limit: 200),
+            ).thenAnswer((_) async => []);
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(query: 'test')
+                .last;
+
+            expect(
+              result.sources[SearchSource.funnelcakeApi],
+              isA<SearchSourceSkipped>(),
             );
           },
         );
@@ -5055,16 +5301,16 @@ void main() {
               .toList();
 
           // Every emission should exclude the blocked profile.
-          for (final profiles in emissions) {
+          for (final result in emissions) {
             expect(
-              profiles.map((p) => p.pubkey),
+              result.profiles.map((p) => p.pubkey),
               isNot(contains(blockedPubkey)),
             );
           }
 
           // The allowed profile should be present in the last emission.
-          expect(emissions.last, hasLength(1));
-          expect(emissions.last.first.pubkey, equals(testPubkey));
+          expect(emissions.last.profiles, hasLength(1));
+          expect(emissions.last.profiles.first.pubkey, equals(testPubkey));
         },
       );
 
@@ -5099,7 +5345,7 @@ void main() {
               .searchUsersProgressive(query: 'user')
               .toList();
 
-          expect(emissions.last, hasLength(2));
+          expect(emissions.last.profiles, hasLength(2));
         },
       );
 

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -1500,6 +1500,54 @@ void main() {
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
+        'resets prior source outcomes before timing out a new query',
+        setUp: () {
+          final controller = StreamController<ProgressiveSearchResult>();
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'fresh-query',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+        },
+        build: () =>
+            createBloc(searchTimeout: const Duration(milliseconds: 10)),
+        seed: () => const UserSearchState(
+          status: UserSearchStatus.success,
+          query: 'stale-query',
+          sourceOutcomes: {
+            SearchSource.localCache: SearchSourceSuccess(
+              resultCount: 0,
+              latencyMs: 1,
+            ),
+            SearchSource.funnelcakeApi: SearchSourceSkipped(),
+            SearchSource.nip50Relay: SearchSourceSuccess(
+              resultCount: 0,
+              latencyMs: 5,
+            ),
+          },
+        ),
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('fresh-query')),
+        wait: const Duration(milliseconds: 500),
+        verify: (bloc) {
+          expect(bloc.state.status, UserSearchStatus.success);
+          expect(bloc.state.query, 'fresh-query');
+          for (final source in SearchSource.values) {
+            expect(
+              bloc.state.sourceOutcomes[source],
+              isA<SearchSourceFailed>().having(
+                (f) => f.reason,
+                'reason',
+                SearchSourceFailureReason.timeout,
+              ),
+            );
+          }
+        },
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
         'isDegradedEmpty becomes true when outer timeout fires on empty '
         'accumulated results',
         setUp: () {
@@ -1540,72 +1588,63 @@ void main() {
         expect(state.isDegradedEmpty, isFalse);
       });
 
-      test(
-        'isDegradedEmpty getter: false with non-empty results even when '
-        'a source failed',
-        () {
-          final profile = UserProfile(
-            pubkey: 'a' * 64,
-            displayName: 'Alice',
-            createdAt: DateTime.now(),
-            eventId: 'e1',
-            rawData: const {'display_name': 'Alice'},
-          );
-          final state = UserSearchState(
-            status: UserSearchStatus.success,
-            results: [profile],
-            sourceOutcomes: const {
-              SearchSource.nip50Relay: SearchSourceFailed(
-                reason: SearchSourceFailureReason.timeout,
-                latencyMs: 5000,
-              ),
-            },
-          );
-          expect(state.isDegradedEmpty, isFalse);
-        },
-      );
+      test('isDegradedEmpty getter: false with non-empty results even when '
+          'a source failed', () {
+        final profile = UserProfile(
+          pubkey: 'a' * 64,
+          displayName: 'Alice',
+          createdAt: DateTime.now(),
+          eventId: 'e1',
+          rawData: const {'display_name': 'Alice'},
+        );
+        final state = UserSearchState(
+          status: UserSearchStatus.success,
+          results: [profile],
+          sourceOutcomes: const {
+            SearchSource.nip50Relay: SearchSourceFailed(
+              reason: SearchSourceFailureReason.timeout,
+              latencyMs: 5000,
+            ),
+          },
+        );
+        expect(state.isDegradedEmpty, isFalse);
+      });
 
-      test(
-        'isDegradedEmpty getter: true with empty results and a failed '
-        'source',
-        () {
-          const state = UserSearchState(
-            status: UserSearchStatus.success,
-            sourceOutcomes: {
-              SearchSource.nip50Relay: SearchSourceFailed(
-                reason: SearchSourceFailureReason.timeout,
-                latencyMs: 5000,
-              ),
-            },
-          );
-          expect(state.isDegradedEmpty, isTrue);
-        },
-      );
+      test('isDegradedEmpty getter: true with empty results and a failed '
+          'source', () {
+        const state = UserSearchState(
+          status: UserSearchStatus.success,
+          sourceOutcomes: {
+            SearchSource.nip50Relay: SearchSourceFailed(
+              reason: SearchSourceFailureReason.timeout,
+              latencyMs: 5000,
+            ),
+          },
+        );
+        expect(state.isDegradedEmpty, isTrue);
+      });
 
-      test(
-        'isDegradedEmpty getter: false with empty results but all sources '
-        'succeeded (true empty)',
-        () {
-          const state = UserSearchState(
-            status: UserSearchStatus.success,
-            sourceOutcomes: {
-              SearchSource.localCache: SearchSourceSuccess(
-                resultCount: 0,
-                latencyMs: 1,
-              ),
-              SearchSource.funnelcakeApi: SearchSourceSuccess(
-                resultCount: 0,
-                latencyMs: 50,
-              ),
-              SearchSource.nip50Relay: SearchSourceSuccess(
-                resultCount: 0,
-                latencyMs: 500,
-              ),
-            },
-          );
-          expect(state.isDegradedEmpty, isFalse);
-        },
-      );
+      test('isDegradedEmpty getter: false with empty results but all sources '
+          'succeeded (true empty)', () {
+        const state = UserSearchState(
+          status: UserSearchStatus.success,
+          sourceOutcomes: {
+            SearchSource.localCache: SearchSourceSuccess(
+              resultCount: 0,
+              latencyMs: 1,
+            ),
+            SearchSource.funnelcakeApi: SearchSourceSuccess(
+              resultCount: 0,
+              latencyMs: 50,
+            ),
+            SearchSource.nip50Relay: SearchSourceSuccess(
+              resultCount: 0,
+              latencyMs: 500,
+            ),
+          },
+        );
+        expect(state.isDegradedEmpty, isFalse);
+      });
     });
   });
 }

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -20,6 +20,13 @@ class _MockFeedPerformanceTracker extends Mock
     implements FeedPerformanceTracker {}
 
 void main() {
+  setUpAll(() {
+    // Required so `any(that: isA<SearchSourceSuccess>())` can be used as a
+    // matcher for the `SearchSourceStatus` parameter of `trackSearchSource`.
+    registerFallbackValue(const SearchSourcePending());
+    registerFallbackValue(SearchSource.localCache);
+  });
+
   group('UserSearchBloc', () {
     late _MockProfileRepository mockProfileRepository;
 
@@ -58,6 +65,24 @@ void main() {
       );
     }
 
+    /// Wraps [profiles] in a `ProgressiveSearchResult` envelope so the
+    /// mocked `searchUsersProgressive` returns the new stream shape.
+    /// Optional [sources] threads source provenance for tests that
+    /// assert on `state.sourceOutcomes`.
+    Stream<ProgressiveSearchResult> progressive(
+      List<UserProfile> profiles, {
+      Map<SearchSource, SearchSourceStatus>? sources,
+      bool isComplete = true,
+    }) {
+      return Stream.value(
+        ProgressiveSearchResult(
+          profiles: profiles,
+          sources: sources ?? const {},
+          isComplete: isComplete,
+        ),
+      );
+    }
+
     test('initial state is correct', () {
       final bloc = createBloc();
       expect(bloc.state.status, UserSearchStatus.initial);
@@ -85,7 +110,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([createTestProfile('a' * 64, 'Alice')]),
+            (_) => progressive([createTestProfile('a' * 64, 'Alice')]),
           );
         },
         build: createBloc,
@@ -131,7 +156,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value(createTestProfiles(50)));
+          ).thenAnswer((_) => progressive(createTestProfiles(50)));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
@@ -162,7 +187,9 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream<List<UserProfile>>.error(Exception('Network error')),
+            (_) => Stream<ProgressiveSearchResult>.error(
+              Exception('Network error'),
+            ),
           );
         },
         build: createBloc,
@@ -236,7 +263,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([createTestProfile('b' * 64, 'Flutter Dev 2')]),
+            (_) => progressive([createTestProfile('b' * 64, 'Flutter Dev 2')]),
           );
         },
         build: createBloc,
@@ -298,7 +325,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer((_) => progressive([]));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const UserSearchQueryChanged('  bob  ')),
@@ -335,7 +362,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer((_) => progressive([]));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const UserSearchQueryChanged('xyz')),
@@ -362,7 +389,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer((_) => progressive([]));
         },
         build: createBloc,
         act: (bloc) {
@@ -443,12 +470,20 @@ void main() {
           ).thenAnswer(
             (_) => Stream.fromIterable([
               // First yield: local cached result
-              [createTestProfile('a' * 64, 'Alice Local')],
+              ProgressiveSearchResult(
+                profiles: [createTestProfile('a' * 64, 'Alice Local')],
+                sources: const {},
+                isComplete: false,
+              ),
               // Second yield: merged with remote
-              [
-                createTestProfile('a' * 64, 'Alice Local'),
-                createTestProfile('b' * 64, 'Alice Remote'),
-              ],
+              ProgressiveSearchResult(
+                profiles: [
+                  createTestProfile('a' * 64, 'Alice Local'),
+                  createTestProfile('b' * 64, 'Alice Remote'),
+                ],
+                sources: const {},
+                isComplete: true,
+              ),
             ]),
           );
         },
@@ -475,7 +510,7 @@ void main() {
       blocTest<UserSearchBloc, UserSearchState>(
         'emits success with partial results when stream times out',
         setUp: () {
-          final controller = StreamController<List<UserProfile>>();
+          final controller = StreamController<ProgressiveSearchResult>();
           when(
             () => mockProfileRepository.searchUsersProgressive(
               query: 'slow',
@@ -485,7 +520,13 @@ void main() {
             ),
           ).thenAnswer((_) {
             // Emit one batch then stall (never close the stream).
-            controller.add([createTestProfile('a' * 64, 'Slow User')]);
+            controller.add(
+              ProgressiveSearchResult(
+                profiles: [createTestProfile('a' * 64, 'Slow User')],
+                sources: const {},
+                isComplete: false,
+              ),
+            );
             return controller.stream;
           });
         },
@@ -501,11 +542,40 @@ void main() {
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.loading)
               .having((s) => s.results.length, 'results.length', 1),
-          // Timeout fires → success with accumulated results
+          // Timeout fires → success with accumulated results AND every
+          // pending source marked failed(timeout) so the UI can
+          // distinguish degraded-empty from a true success.
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.success)
               .having((s) => s.results.length, 'results.length', 1)
-              .having((s) => s.hasMore, 'hasMore', false),
+              .having((s) => s.hasMore, 'hasMore', false)
+              .having(
+                (s) => s.sourceOutcomes[SearchSource.localCache],
+                'local source outcome',
+                isA<SearchSourceFailed>().having(
+                  (f) => f.reason,
+                  'reason',
+                  SearchSourceFailureReason.timeout,
+                ),
+              )
+              .having(
+                (s) => s.sourceOutcomes[SearchSource.funnelcakeApi],
+                'api source outcome',
+                isA<SearchSourceFailed>().having(
+                  (f) => f.reason,
+                  'reason',
+                  SearchSourceFailureReason.timeout,
+                ),
+              )
+              .having(
+                (s) => s.sourceOutcomes[SearchSource.nip50Relay],
+                'relay source outcome',
+                isA<SearchSourceFailed>().having(
+                  (f) => f.reason,
+                  'reason',
+                  SearchSourceFailureReason.timeout,
+                ),
+              ),
         ],
       );
     });
@@ -521,7 +591,7 @@ void main() {
               offset: 50,
               sortBy: 'followers',
             ),
-          ).thenAnswer((_) => Stream.value(createTestProfiles(10)));
+          ).thenAnswer((_) => progressive(createTestProfiles(10)));
         },
         build: createBloc,
         seed: () => UserSearchState(
@@ -556,7 +626,20 @@ void main() {
               offset: 50,
               sortBy: 'followers',
             ),
-          ).thenAnswer((_) => Stream.fromIterable([partial, full]));
+          ).thenAnswer(
+            (_) => Stream.fromIterable([
+              ProgressiveSearchResult(
+                profiles: partial,
+                sources: const {},
+                isComplete: false,
+              ),
+              ProgressiveSearchResult(
+                profiles: full,
+                sources: const {},
+                isComplete: true,
+              ),
+            ]),
+          );
         },
         build: createBloc,
         seed: () => UserSearchState(
@@ -591,7 +674,7 @@ void main() {
               offset: 50,
               sortBy: 'followers',
             ),
-          ).thenAnswer((_) => Stream.value(createTestProfiles(50)));
+          ).thenAnswer((_) => progressive(createTestProfiles(50)));
         },
         build: createBloc,
         seed: () => UserSearchState(
@@ -662,7 +745,9 @@ void main() {
               sortBy: 'followers',
             ),
           ).thenAnswer(
-            (_) => Stream<List<UserProfile>>.error(Exception('Network error')),
+            (_) => Stream<ProgressiveSearchResult>.error(
+              Exception('Network error'),
+            ),
           );
         },
         build: createBloc,
@@ -729,7 +814,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
               boostPubkeys: any(named: 'boostPubkeys'),
             ),
-          ).thenAnswer((_) => Stream.value([profile('01', 'Liz Sweigart')]));
+          ).thenAnswer((_) => progressive([profile('01', 'Liz Sweigart')]));
         },
         build: () {
           final follows = _MockFollowRepository();
@@ -764,7 +849,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
               boostPubkeys: any(named: 'boostPubkeys'),
             ),
-          ).thenAnswer((_) => Stream.value([profile('00', 'Zoe')]));
+          ).thenAnswer((_) => progressive([profile('00', 'Zoe')]));
         },
         build: () {
           final follows = _MockFollowRepository();
@@ -802,7 +887,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
               boostPubkeys: any(named: 'boostPubkeys'),
             ),
-          ).thenAnswer((_) => Stream.value([liz, zoe, maya]));
+          ).thenAnswer((_) => progressive([liz, zoe, maya]));
         },
         build: () {
           final follows = _MockFollowRepository();
@@ -841,7 +926,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([profile('99', 'Liz From Page 2')]));
+          ).thenAnswer((_) => progressive([profile('99', 'Liz From Page 2')]));
         },
         build: () {
           final follows = _MockFollowRepository();
@@ -883,7 +968,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer((_) => progressive([]));
         },
         build: () => UserSearchBloc(
           profileRepository: mockProfileRepository,
@@ -914,7 +999,7 @@ void main() {
               sortBy: 'followers',
               hasVideos: true,
             ),
-          ).thenAnswer((_) => Stream.value(createTestProfiles(10)));
+          ).thenAnswer((_) => progressive(createTestProfiles(10)));
         },
         build: () => UserSearchBloc(
           profileRepository: mockProfileRepository,
@@ -951,7 +1036,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer((_) => progressive([]));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
@@ -984,7 +1069,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([createTestProfile('a' * 64, 'Alice')]),
+            (_) => progressive([createTestProfile('a' * 64, 'Alice')]),
           );
           when(
             () => mockProfileRepository.searchUsersProgressive(
@@ -994,7 +1079,9 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream<List<UserProfile>>.error(Exception('Network error')),
+            (_) => Stream<ProgressiveSearchResult>.error(
+              Exception('Network error'),
+            ),
           );
         },
         build: createBloc,
@@ -1053,7 +1140,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([createTestProfile('a' * 64, 'Alice')]),
+            (_) => progressive([createTestProfile('a' * 64, 'Alice')]),
           );
           when(
             () => mockProfileRepository.searchUsersProgressive(
@@ -1063,7 +1150,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([
+            (_) => progressive([
               createTestProfile('b' * 64, 'Bob'),
               createTestProfile('c' * 64, 'Bobby'),
             ]),
@@ -1128,7 +1215,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([createTestProfile('a' * 64, 'Alice')]),
+            (_) => progressive([createTestProfile('a' * 64, 'Alice')]),
           );
         },
         build: () => UserSearchBloc(profileRepository: mockProfileRepository),
@@ -1210,6 +1297,7 @@ void main() {
           1,
           true,
           false,
+          <SearchSource, SearchSourceStatus>{},
         ]);
       });
     });
@@ -1241,7 +1329,7 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream.value([createTestProfile('a' * 64, 'Alice')]),
+            (_) => progressive([createTestProfile('a' * 64, 'Alice')]),
           );
         },
         build: createBlocWithTracker,
@@ -1269,7 +1357,9 @@ void main() {
               hasVideos: any(named: 'hasVideos'),
             ),
           ).thenAnswer(
-            (_) => Stream<List<UserProfile>>.error(Exception('Network error')),
+            (_) => Stream<ProgressiveSearchResult>.error(
+              Exception('Network error'),
+            ),
           );
         },
         build: createBlocWithTracker,
@@ -1296,6 +1386,224 @@ void main() {
         wait: debounceDuration,
         verify: (_) {
           verifyNever(() => mockTracker.startFeedLoad(any()));
+        },
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'forwards each terminal source outcome to trackSearchSource',
+        setUp: () {
+          when(
+            () => mockRepo.searchUsersProgressive(
+              query: 'alice',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(
+              ProgressiveSearchResult(
+                profiles: [createTestProfile('a' * 64, 'Alice')],
+                sources: const {
+                  SearchSource.localCache: SearchSourceSuccess(
+                    resultCount: 1,
+                    latencyMs: 1,
+                  ),
+                  SearchSource.funnelcakeApi: SearchSourceFailed(
+                    reason: SearchSourceFailureReason.network,
+                    latencyMs: 200,
+                  ),
+                  SearchSource.nip50Relay: SearchSourceSkipped(),
+                },
+                isComplete: true,
+              ),
+            ),
+          );
+        },
+        build: createBlocWithTracker,
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
+        wait: debounceDuration,
+        verify: (_) {
+          verify(
+            () => mockTracker.trackSearchSource(
+              SearchSource.localCache,
+              any(that: isA<SearchSourceSuccess>()),
+            ),
+          ).called(1);
+          verify(
+            () => mockTracker.trackSearchSource(
+              SearchSource.funnelcakeApi,
+              any(that: isA<SearchSourceFailed>()),
+            ),
+          ).called(1);
+          verify(
+            () => mockTracker.trackSearchSource(
+              SearchSource.nip50Relay,
+              any(that: isA<SearchSourceSkipped>()),
+            ),
+          ).called(1);
+        },
+      );
+    });
+
+    group('source provenance', () {
+      const debounceDuration = Duration(milliseconds: 400);
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'round-trips sourceOutcomes from repository envelope into state',
+        setUp: () {
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'alice',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(
+              ProgressiveSearchResult(
+                profiles: [createTestProfile('a' * 64, 'Alice')],
+                sources: const {
+                  SearchSource.localCache: SearchSourceSuccess(
+                    resultCount: 1,
+                    latencyMs: 1,
+                  ),
+                  SearchSource.funnelcakeApi: SearchSourceSuccess(
+                    resultCount: 0,
+                    latencyMs: 50,
+                  ),
+                  SearchSource.nip50Relay: SearchSourceFailed(
+                    reason: SearchSourceFailureReason.timeout,
+                    latencyMs: 5000,
+                  ),
+                },
+                isComplete: true,
+              ),
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
+        wait: debounceDuration,
+        verify: (bloc) {
+          final relay = bloc.state.sourceOutcomes[SearchSource.nip50Relay];
+          expect(relay, isA<SearchSourceFailed>());
+          expect(
+            (relay! as SearchSourceFailed).reason,
+            SearchSourceFailureReason.timeout,
+          );
+          expect(
+            bloc.state.sourceOutcomes[SearchSource.localCache],
+            isA<SearchSourceSuccess>(),
+          );
+          expect(bloc.state.isDegradedEmpty, isFalse); // results non-empty
+        },
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'isDegradedEmpty becomes true when outer timeout fires on empty '
+        'accumulated results',
+        setUp: () {
+          // Never-completing stream that emits no envelope at all.
+          final controller = StreamController<ProgressiveSearchResult>();
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'unreachable',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+        },
+        build: () =>
+            createBloc(searchTimeout: const Duration(milliseconds: 10)),
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('unreachable')),
+        wait: const Duration(milliseconds: 500),
+        verify: (bloc) {
+          expect(bloc.state.status, UserSearchStatus.success);
+          expect(bloc.state.results, isEmpty);
+          expect(bloc.state.isDegradedEmpty, isTrue);
+          for (final source in SearchSource.values) {
+            expect(
+              bloc.state.sourceOutcomes[source],
+              isA<SearchSourceFailed>().having(
+                (f) => f.reason,
+                'reason',
+                SearchSourceFailureReason.timeout,
+              ),
+            );
+          }
+        },
+      );
+
+      test('isDegradedEmpty getter: false on initial state', () {
+        const state = UserSearchState();
+        expect(state.isDegradedEmpty, isFalse);
+      });
+
+      test(
+        'isDegradedEmpty getter: false with non-empty results even when '
+        'a source failed',
+        () {
+          final profile = UserProfile(
+            pubkey: 'a' * 64,
+            displayName: 'Alice',
+            createdAt: DateTime.now(),
+            eventId: 'e1',
+            rawData: const {'display_name': 'Alice'},
+          );
+          final state = UserSearchState(
+            status: UserSearchStatus.success,
+            results: [profile],
+            sourceOutcomes: const {
+              SearchSource.nip50Relay: SearchSourceFailed(
+                reason: SearchSourceFailureReason.timeout,
+                latencyMs: 5000,
+              ),
+            },
+          );
+          expect(state.isDegradedEmpty, isFalse);
+        },
+      );
+
+      test(
+        'isDegradedEmpty getter: true with empty results and a failed '
+        'source',
+        () {
+          const state = UserSearchState(
+            status: UserSearchStatus.success,
+            sourceOutcomes: {
+              SearchSource.nip50Relay: SearchSourceFailed(
+                reason: SearchSourceFailureReason.timeout,
+                latencyMs: 5000,
+              ),
+            },
+          );
+          expect(state.isDegradedEmpty, isTrue);
+        },
+      );
+
+      test(
+        'isDegradedEmpty getter: false with empty results but all sources '
+        'succeeded (true empty)',
+        () {
+          const state = UserSearchState(
+            status: UserSearchStatus.success,
+            sourceOutcomes: {
+              SearchSource.localCache: SearchSourceSuccess(
+                resultCount: 0,
+                latencyMs: 1,
+              ),
+              SearchSource.funnelcakeApi: SearchSourceSuccess(
+                resultCount: 0,
+                latencyMs: 50,
+              ),
+              SearchSource.nip50Relay: SearchSourceSuccess(
+                resultCount: 0,
+                latencyMs: 500,
+              ),
+            },
+          );
+          expect(state.isDegradedEmpty, isFalse);
         },
       );
     });

--- a/mobile/test/screens/search_results/widgets/people_section_test.dart
+++ b/mobile/test/screens/search_results/widgets/people_section_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/screens/search_results/widgets/people_section.dart';
 import 'package:openvine/screens/search_results/widgets/search_section_empty_state.dart';
 import 'package:openvine/screens/search_results/widgets/search_section_error_state.dart';
 import 'package:openvine/screens/search_results/widgets/section_header.dart';
+import 'package:profile_repository/profile_repository.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -202,6 +203,89 @@ void main() {
 
         expect(find.byType(SearchSectionErrorState), findsOneWidget);
       });
+    });
+
+    group('degraded-empty (#3791)', () {
+      const failedRelay = UserSearchState(
+        status: UserSearchStatus.success,
+        query: 'friend-name',
+        sourceOutcomes: {
+          SearchSource.nip50Relay: SearchSourceFailed(
+            reason: SearchSourceFailureReason.timeout,
+            latencyMs: 5000,
+          ),
+        },
+      );
+
+      const allSucceeded = UserSearchState(
+        status: UserSearchStatus.success,
+        query: 'friend-name',
+        sourceOutcomes: {
+          SearchSource.localCache: SearchSourceSuccess(
+            resultCount: 0,
+            latencyMs: 1,
+          ),
+          SearchSource.funnelcakeApi: SearchSourceSuccess(
+            resultCount: 0,
+            latencyMs: 50,
+          ),
+          SearchSource.nip50Relay: SearchSourceSuccess(
+            resultCount: 0,
+            latencyMs: 500,
+          ),
+        },
+      );
+
+      testWidgets(
+        'renders $SearchSectionErrorState when results empty AND a source '
+        'failed (degraded-empty)',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(failedRelay);
+
+          await tester.pumpWidget(buildSubject(showAll: true));
+
+          expect(find.byType(SearchSectionErrorState), findsOneWidget);
+          expect(find.byType(SearchSectionEmptyState), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'renders $SearchSectionEmptyState when results empty AND all '
+        'sources succeeded (true empty)',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(allSucceeded);
+
+          await tester.pumpWidget(buildSubject(showAll: true));
+
+          expect(find.byType(SearchSectionEmptyState), findsOneWidget);
+          expect(find.byType(SearchSectionErrorState), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'shows section header and error in All tab preview when '
+        'degraded-empty (so user sees retry instead of hidden section)',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(failedRelay);
+
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SectionHeader), findsOneWidget);
+          expect(find.byType(SearchSectionErrorState), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'hides section entirely in All tab preview when truly empty',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(allSucceeded);
+
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SectionHeader), findsNothing);
+          expect(find.byType(SearchSectionErrorState), findsNothing);
+        },
+      );
     });
 
     testWidgets('retry dispatches $UserSearchQueryChanged with current query', (

--- a/mobile/test/services/feed_performance_tracker_test.dart
+++ b/mobile/test/services/feed_performance_tracker_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
+import 'package:profile_repository/profile_repository.dart';
 
 class _MockFeedPerformanceTracker extends Mock
     implements FeedPerformanceTracker {}
@@ -48,6 +49,40 @@ void main() {
 
         verify(() => tracker.startVideoSwipeTracking(videoId)).called(1);
         verify(() => tracker.markVideoSwipeComplete(videoId)).called(1);
+      });
+    });
+
+    group('trackSearchSource', () {
+      late FeedPerformanceTracker tracker;
+
+      setUp(() {
+        // Real instance with analytics bypassed so the call path is
+        // exercised end-to-end without requiring Firebase init.
+        tracker = FeedPerformanceTracker.testInstance();
+      });
+
+      test('does not throw for any terminal source status', () {
+        // Each branch of the switch is exercised; pending is a no-op.
+        tracker
+          ..trackSearchSource(
+            SearchSource.localCache,
+            const SearchSourcePending(),
+          )
+          ..trackSearchSource(
+            SearchSource.localCache,
+            const SearchSourceSkipped(),
+          )
+          ..trackSearchSource(
+            SearchSource.funnelcakeApi,
+            const SearchSourceSuccess(resultCount: 3, latencyMs: 42),
+          )
+          ..trackSearchSource(
+            SearchSource.nip50Relay,
+            const SearchSourceFailed(
+              reason: SearchSourceFailureReason.timeout,
+              latencyMs: 5000,
+            ),
+          );
       });
     });
   });

--- a/mobile/test/widgets/find_people_sheet_test.dart
+++ b/mobile/test/widgets/find_people_sheet_test.dart
@@ -108,7 +108,7 @@ void main() {
         tester,
       ) async {
         // Use a StreamController to control when results arrive
-        final controller = StreamController<List<UserProfile>>();
+        final controller = StreamController<ProgressiveSearchResult>();
         when(
           () => mockProfileRepo.searchUsersProgressive(
             query: any(named: 'query'),
@@ -128,7 +128,13 @@ void main() {
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
         // Close the stream to avoid pending timer errors
-        controller.add([]);
+        controller.add(
+          const ProgressiveSearchResult(
+            profiles: [],
+            sources: {},
+            isComplete: true,
+          ),
+        );
         await controller.close();
         await tester.pumpAndSettle();
       });
@@ -145,16 +151,22 @@ void main() {
             hasVideos: any(named: 'hasVideos'),
           ),
         ).thenAnswer(
-          (_) => Stream.value([
-            UserProfile(
-              pubkey: pubkey,
-              displayName: 'Bob',
-              picture: 'https://example.com/bob.jpg',
-              createdAt: DateTime.now(),
-              eventId: 'event-$pubkey',
-              rawData: const {'display_name': 'Bob'},
+          (_) => Stream.value(
+            ProgressiveSearchResult(
+              profiles: [
+                UserProfile(
+                  pubkey: pubkey,
+                  displayName: 'Bob',
+                  picture: 'https://example.com/bob.jpg',
+                  createdAt: DateTime.now(),
+                  eventId: 'event-$pubkey',
+                  rawData: const {'display_name': 'Bob'},
+                ),
+              ],
+              sources: const {},
+              isComplete: true,
             ),
-          ]),
+          ),
         );
 
         await openSheet(tester);
@@ -176,7 +188,15 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer(
+            (_) => Stream.value(
+              const ProgressiveSearchResult(
+                profiles: [],
+                sources: {},
+                isComplete: true,
+              ),
+            ),
+          );
 
           await openSheet(tester);
 
@@ -197,7 +217,8 @@ void main() {
             hasVideos: any(named: 'hasVideos'),
           ),
         ).thenAnswer(
-          (_) => Stream<List<UserProfile>>.error(Exception('Network error')),
+          (_) =>
+              Stream<ProgressiveSearchResult>.error(Exception('Network error')),
         );
 
         await openSheet(tester);
@@ -219,7 +240,15 @@ void main() {
             sortBy: any(named: 'sortBy'),
             hasVideos: any(named: 'hasVideos'),
           ),
-        ).thenAnswer((_) => Stream.value([]));
+        ).thenAnswer(
+          (_) => Stream.value(
+            const ProgressiveSearchResult(
+              profiles: [],
+              sources: {},
+              isComplete: true,
+            ),
+          ),
+        );
 
         await openSheet(tester);
 
@@ -304,7 +333,15 @@ void main() {
               limit: any(named: 'limit'),
               sortBy: any(named: 'sortBy'),
             ),
-          ).thenAnswer((_) => Stream.value([]));
+          ).thenAnswer(
+            (_) => Stream.value(
+              const ProgressiveSearchResult(
+                profiles: [],
+                sources: {},
+                isComplete: true,
+              ),
+            ),
+          );
 
           await openSheet(tester);
 

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -39,7 +39,15 @@ _MockProfileRepository _createMockProfileRepository({
       hasVideos: any(named: 'hasVideos'),
       boostPubkeys: any(named: 'boostPubkeys'),
     ),
-  ).thenAnswer((_) => Stream.value(searchResults));
+  ).thenAnswer(
+    (_) => Stream.value(
+      ProgressiveSearchResult(
+        profiles: searchResults,
+        sources: const {},
+        isComplete: true,
+      ),
+    ),
+  );
 
   // Mock getCachedProfile
   for (final profile in cachedProfiles) {
@@ -420,7 +428,7 @@ void main() {
         // NIP-50 WebSocket phase) while the REST phase has already
         // delivered results.
         final streamController =
-            StreamController<List<UserProfile>>.broadcast();
+            StreamController<ProgressiveSearchResult>.broadcast();
         addTearDown(streamController.close);
 
         final alice = UserProfile(
@@ -469,7 +477,13 @@ void main() {
         // Emit the first batch — stream stays open, so the BLoC
         // stays in `loading` with results available. The fix is that
         // the picker now renders these results instead of a spinner.
-        streamController.add([alice]);
+        streamController.add(
+          ProgressiveSearchResult(
+            profiles: [alice],
+            sources: const {},
+            isComplete: false,
+          ),
+        );
         await tester.pump();
 
         // The tile renders while the stream is still open (loading). Before
@@ -519,7 +533,13 @@ void main() {
                 invocation.namedArguments[#boostPubkeys] as Set<String>? ??
                 const <String>{};
             final results = [zoe, liz];
-            if (boost.isEmpty) return Stream.value(results);
+            ProgressiveSearchResult wrap(List<UserProfile> profiles) =>
+                ProgressiveSearchResult(
+                  profiles: profiles,
+                  sources: const {},
+                  isComplete: true,
+                );
+            if (boost.isEmpty) return Stream.value(wrap(results));
             final boosted = <UserProfile>[];
             final rest = <UserProfile>[];
             for (final p in results) {
@@ -529,7 +549,7 @@ void main() {
                 rest.add(p);
               }
             }
-            return Stream.value([...boosted, ...rest]);
+            return Stream.value(wrap([...boosted, ...rest]));
           });
           when(
             () =>
@@ -630,7 +650,8 @@ void main() {
           createdAt: DateTime.now(),
           eventId: 'event_bob',
         );
-        final bobController = StreamController<List<UserProfile>>.broadcast();
+        final bobController =
+            StreamController<ProgressiveSearchResult>.broadcast();
         addTearDown(bobController.close);
 
         final mockProfileRepo = _createMockProfileRepository();
@@ -643,7 +664,15 @@ void main() {
             hasVideos: any(named: 'hasVideos'),
             boostPubkeys: any(named: 'boostPubkeys'),
           ),
-        ).thenAnswer((_) => Stream.value([alice]));
+        ).thenAnswer(
+          (_) => Stream.value(
+            ProgressiveSearchResult(
+              profiles: [alice],
+              sources: const {},
+              isComplete: true,
+            ),
+          ),
+        );
         when(
           () => mockProfileRepo.searchUsersProgressive(
             query: 'bob',
@@ -689,7 +718,13 @@ void main() {
         expect(find.text('Alice'), findsOneWidget);
 
         // When 'bob' results arrive, the list updates in place.
-        bobController.add([bob]);
+        bobController.add(
+          ProgressiveSearchResult(
+            profiles: [bob],
+            sources: const {},
+            isComplete: true,
+          ),
+        );
         // Pump twice: once to let the stream event propagate through the
         // bloc's emit.forEach, once more for the rebuilt BlocBuilder.
         await tester.pump();


### PR DESCRIPTION
## Description

People search degraded silently. When NIP-50 relays timed out or the
Funnelcake REST API was unavailable, `UserSearchBloc` collapsed the
result into either `success` (with whatever accumulated) or `failure`,
and `PeopleSection` rendered "No results found for X" — visually
identical to a true miss. The lived consequence is #3791: users typed
a friend's username, saw an empty results screen, and concluded the
friend wasn't on Divine.

This PR threads per-source provenance from the repository all the way
to the UI:

- `ProfileRepository.searchUsersProgressive` now emits
  `Stream<ProgressiveSearchResult>` carrying both the profile list and
  a `Map<SearchSource, SearchSourceStatus>` recording each phase's
  outcome (success / failed / skipped, with latency and a typed
  failure reason).
- `UserSearchBloc` mirrors the map in state, promotes pending sources
  to `failed(timeout)` when the outer 20 s stream timeout fires, and
  exposes an `isDegradedEmpty` getter (`results.isEmpty AND any source
  failed`).
- `PeopleSection` routes degraded-empty to the existing
  `SearchSectionErrorState` (with Try-again button), instead of the
  misleading "No results found".
- Per-source latency / failure flows into a new
  `FeedPerformanceTracker.trackSearchSource` event so we can answer
  in the field whether NIP-50, Funnelcake, or the query itself is the
  culprit.
- New canonical contract doc at `mobile/docs/PEOPLE_SEARCH.md`
  (partial payment of #3627, the data-source-strategy doc gap from
  the parent epic).

The 5 s NIP-50 timeout is also lifted to a file-local constant for
symmetry with the other timeouts in `profile_repository.dart`, and
the bloc's outer 20 s timeout is lifted to
`search_constants.userSearchOuterTimeout`.

**Related Issue:** Closes #3791. Closes #3804. Refs #3801 (parent
epic), #3627 (data-source doc — partial), #3593 (suppressed catch
blocks — partial, Phase 3 of progressive search).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation

## How Has This Been Tested?

From `mobile/`:
- `flutter analyze lib test integration_test` — clean.
- `flutter test test/blocs/user_search/` — 44 tests, all green
  (8 new: source-provenance group + tracker round-trip + outer-
  timeout-marks-pending + four `isDegradedEmpty` getter cases;
  existing tests migrated to envelope shape).
- `flutter test test/screens/search_results/widgets/people_section_test.dart`
  — 15 tests, all green (4 new degraded-empty cases).
- `flutter test test/services/feed_performance_tracker_test.dart` — 4
  tests, all green (1 new: `trackSearchSource` smoke test).
- `flutter test test/widgets/find_people_sheet_test.dart
  test/widgets/user_picker_sheet_test.dart` — 30 tests, all green
  (mechanical stub migration only — these features aren't part of
  #3804's UX work).
- `(cd packages/profile_repository && flutter test)` — 212 tests, all
  green (5 new in `source provenance` sub-group, existing progressive
  tests migrated to the `.profiles` accessor on the envelope).

Manual verification will be added once a TestFlight build is cut.

## Out of scope (per parent-epic decomposition)

- Auto-navigate-while-typing (#3802)
- Focus / keyboard continuity (#3803, #3020)
- Blocklist filtering of search (#3805, #948)
- Changing the 5 s NIP-50 timeout value (parent epic Q3)
- Replacing or extending the NIP-50 relay list (parent epic Q4)
- Replacing the non-progressive sibling `searchUsers` (used by
  `NewMessageSearchBloc` — different scope)
- Whole-bloc `addError` sweep (#3592)