### PR TITLE
fix(ci): remove unassignable TestFlight groups

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -406,13 +406,11 @@ workflows:
         auth: integration
         submit_to_testflight: true
         submit_to_app_store: false
-        # Auto-distribute internal builds to the existing internal TestFlight groups.
+        # Auto-distribute internal builds to assignable TestFlight groups.
         beta_groups:
           - "AOS"
           - "GW"
           - "rabblelabs"
-          - "RL Devs"
-          - "VGV"
 
   ios-simulator-build:
     name: iOS Simulator Build


### PR DESCRIPTION
Closes #4270

## Summary
- Remove `RL Devs` and `VGV` from Codemagic TestFlight beta group assignment.
- Keep distribution limited to assignable groups that accepted the uploaded build: `AOS`, `GW`, and `rabblelabs`.

## Test plan
- [x] `ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml'); puts 'codemagic.yaml parsed OK'"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)