### PR TITLE
fix(profile): pre-seed cached profile in subscription

### DIFF
--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -103,9 +103,9 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     Emitter<MyProfileState> emit,
   ) async {
     // Pre-seed with cached profile so the real display name is shown
-    // immediately rather than the generated fallback ("Feminist Sloth 82")
-    // while the Drift watch stream fires its first event. Mirrors the same
-    // pattern used in _onLoadRequested.
+    // immediately rather than a generated fallback while the Drift watch
+    // stream fires its first event. Mirrors the same pattern used in
+    // _onLoadRequested.
     final cachedProfile = await _profileRepository.getCachedProfile(
       pubkey: pubkey,
     );

--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -102,7 +102,20 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     MyProfileSubscriptionRequested event,
     Emitter<MyProfileState> emit,
   ) async {
-    emit(const MyProfileLoading());
+    // Pre-seed with cached profile so the real display name is shown
+    // immediately rather than the generated fallback ("Feminist Sloth 82")
+    // while the Drift watch stream fires its first event. Mirrors the same
+    // pattern used in _onLoadRequested.
+    final cachedProfile = await _profileRepository.getCachedProfile(
+      pubkey: pubkey,
+    );
+    emit(
+      MyProfileLoading(
+        profile: cachedProfile,
+        extractedUsername: cachedProfile?.divineUsername,
+        externalNip05: cachedProfile?.externalNip05,
+      ),
+    );
 
     await emit.forEach<UserProfile?>(
       _profileRepository.watchProfile(pubkey: pubkey),

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -673,17 +673,35 @@ void main() {
 
     group('$MyProfileSubscriptionRequested', () {
       blocTest<MyProfileBloc, MyProfileState>(
-        'emits [loading, updated] when stream emits a profile',
+        'emits [loading with cached profile, updated] when stream emits a profile',
         setUp: () {
-          final profile = createTestProfile();
+          final cachedProfile = createTestProfile(
+            displayName: 'Cached Name',
+            eventId:
+                'cached12345678901234567890123456789012345678901234567890123456',
+          );
+          final streamProfile = createTestProfile(
+            displayName: 'Stream Name',
+            eventId:
+                'stream12345678901234567890123456789012345678901234567890123456',
+          );
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => cachedProfile);
           when(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
-          ).thenAnswer((_) => Stream.value(profile));
+          ).thenAnswer((_) => Stream.value(streamProfile));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
         expect: () => [
-          isA<MyProfileLoading>(),
+          // Initial emit carries the cached profile so the real name is
+          // shown immediately — no generated-name flash (#4181).
+          isA<MyProfileLoading>().having(
+            (s) => s.profile?.displayName,
+            'profile.displayName',
+            'Cached Name',
+          ),
           isA<MyProfileUpdated>().having(
             (s) => s.profile.pubkey,
             'profile.pubkey',
@@ -692,35 +710,8 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).called(1);
-          verifyNever(
-            () => mockProfileRepository.fetchFreshProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          );
-          verifyNever(
-            () => mockProfileRepository.getCachedProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          );
-        },
-      );
-
-      blocTest<MyProfileBloc, MyProfileState>(
-        'emits only [loading] when stream emits null',
-        setUp: () {
-          when(
-            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
-          ).thenAnswer((_) => Stream.value(null));
-        },
-        build: createBloc,
-        act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
-        expect: () => [
-          // Initial loading + stream null → same state, BLoC deduplicates
-          isA<MyProfileLoading>(),
-        ],
-        verify: (_) {
           verify(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).called(1);
@@ -729,8 +720,35 @@ void main() {
               pubkey: any(named: 'pubkey'),
             ),
           );
+        },
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'emits [loading with null profile] when no cache and stream emits null',
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => Stream.value(null));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
+        expect: () => [
+          // No cache → loading with null profile; stream null → same
+          // state deduplication means only one emit.
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
+        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).called(1);
+          verify(
+            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+          ).called(1);
           verifyNever(
-            () => mockProfileRepository.getCachedProfile(
+            () => mockProfileRepository.fetchFreshProfile(
               pubkey: any(named: 'pubkey'),
             ),
           );
@@ -738,27 +756,39 @@ void main() {
       );
 
       blocTest<MyProfileBloc, MyProfileState>(
-        'emits [loading, updated, updated] '
+        'emits [loading with cached, updated, updated] '
         'when stream emits multiple profiles',
         setUp: () {
-          final cached = createTestProfile(
-            displayName: 'Old Name',
+          final cachedProfile = createTestProfile(
+            displayName: 'Cached Name',
             eventId:
                 'cached12345678901234567890123456789012345678901234567890123456',
           );
-          final fresh = createTestProfile(
+          final oldName = createTestProfile(
+            displayName: 'Old Name',
+            eventId:
+                'oldnam12345678901234567890123456789012345678901234567890123456',
+          );
+          final newName = createTestProfile(
             displayName: 'New Name',
             eventId:
                 'fresh123456789012345678901234567890123456789012345678901234567',
           );
           when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => cachedProfile);
+          when(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
-          ).thenAnswer((_) => Stream.fromIterable([cached, fresh]));
+          ).thenAnswer((_) => Stream.fromIterable([oldName, newName]));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
         expect: () => [
-          isA<MyProfileLoading>(),
+          isA<MyProfileLoading>().having(
+            (s) => s.profile?.displayName,
+            'profile.displayName',
+            'Cached Name',
+          ),
           isA<MyProfileUpdated>().having(
             (s) => s.profile.displayName,
             'displayName',
@@ -772,15 +802,13 @@ void main() {
         ],
         verify: (_) {
           verify(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).called(1);
+          verify(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).called(1);
           verifyNever(
             () => mockProfileRepository.fetchFreshProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          );
-          verifyNever(
-            () => mockProfileRepository.getCachedProfile(
               pubkey: any(named: 'pubkey'),
             ),
           );
@@ -792,13 +820,16 @@ void main() {
         setUp: () {
           final profile = createTestProfile(nip05: '_@alice.divine.video');
           when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).thenAnswer((_) => Stream.value(profile));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
         expect: () => [
-          isA<MyProfileLoading>(),
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
           isA<MyProfileUpdated>().having(
             (s) => s.extractedUsername,
             'extractedUsername',
@@ -806,6 +837,9 @@ void main() {
           ),
         ],
         verify: (_) {
+          verify(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).called(1);
           verify(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).called(1);
@@ -817,13 +851,16 @@ void main() {
         setUp: () {
           final profile = createTestProfile(nip05: 'alice@example.com');
           when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).thenAnswer((_) => Stream.value(profile));
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
         expect: () => [
-          isA<MyProfileLoading>(),
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
           isA<MyProfileUpdated>()
               .having(
                 (s) => s.externalNip05,
@@ -833,6 +870,9 @@ void main() {
               .having((s) => s.extractedUsername, 'extractedUsername', isNull),
         ],
         verify: (_) {
+          verify(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).called(1);
           verify(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).called(1);
@@ -854,6 +894,9 @@ void main() {
           );
           var callCount = 0;
           when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).thenAnswer((_) {
             callCount++;
@@ -868,13 +911,13 @@ void main() {
           bloc.add(const MyProfileSubscriptionRequested());
         },
         expect: () => [
-          isA<MyProfileLoading>(),
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
           isA<MyProfileUpdated>().having(
             (s) => s.profile.displayName,
             'displayName',
             'First',
           ),
-          isA<MyProfileLoading>(),
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
           isA<MyProfileUpdated>().having(
             (s) => s.profile.displayName,
             'displayName',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
MyProfileSubscriptionRequested was emitting MyProfileLoading(profile: null) before the Drift watch stream fired its first event. This caused the profile header to briefly fall back to UserName.fromPubKey, which renders the generated name (e.g. 'Feminist Sloth 82') while AsyncLoading, before switching to the real name once the stream arrived.

Fix mirrors the existing pattern in _onLoadRequested: call getCachedProfile first and carry it in the initial MyProfileLoading emit so the real display name is shown from frame one.


<!--- Describe your changes in detail -->

**Related Issue:** Closes #4181

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore