### PR TITLE
fix(ios-camera): restart audio capture session around AVAudioSession reconfigure

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -328,10 +328,18 @@ class CameraController: NSObject {
             // attachAudioToSessionIfNeeded() must run on sessionQueue (it
             // mutates capture-session state); the lock-backed
             // `audioInterrupted` accessor handles cross-queue safety.
+            // Only clear `audioInterrupted` after a successful recovery —
+            // otherwise `captureOutput` would resume appending audio from a
+            // still-broken session and re-introduce the silent-AAC-track
+            // failure this patch eliminates. If recovery fails, keep the
+            // flag set so the next recording continues without audio.
             sessionQueue.async { [weak self] in
                 guard let self = self else { return }
-                _ = self.attachAudioToSessionIfNeeded()
-                self.audioInterrupted = false
+                if self.attachAudioToSessionIfNeeded() {
+                    self.audioInterrupted = false
+                } else {
+                    print("[DivineCameraController] Audio recovery failed; keeping audioInterrupted=true")
+                }
             }
         @unknown default:
             break

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -27,6 +27,11 @@ class CameraController: NSObject {
     private var videoWriterInput: AVAssetWriterInput?
     private var audioWriterInput: AVAssetWriterInput?
     private var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
+
+    /// Set by the AVAudioSession interruption observer. While true the
+    /// audio capture path is known to be silent and we skip appending
+    /// audio buffers to the asset writer.
+    private var audioInterrupted: Bool = false
     
     private var textureRegistry: FlutterTextureRegistry
     private var textureId: Int64 = -1
@@ -114,6 +119,11 @@ class CameraController: NSObject {
         self.textureRegistry = textureRegistry
         super.init()
         checkCameraAvailability()
+        registerAudioSessionInterruptionObserver()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     /// Checks which cameras are available on the device.
@@ -216,7 +226,8 @@ class CameraController: NSObject {
     /// - Use the built-in microphone for recording (NOT the Bluetooth mic)
     /// This prevents iOS from switching to HFP (phone call) mode which causes the
     /// "call started/ended" sounds on Bluetooth headsets.
-    private func configureAudioSessionForRecording() {
+    @discardableResult
+    private func configureAudioSessionForRecording() -> Bool {
         let audioSession = AVAudioSession.sharedInstance()
         do {
             // Use playAndRecord category since we need both:
@@ -232,15 +243,70 @@ class CameraController: NSObject {
             // - Triggers "call started/ended" sounds on headsets
             // - Switches to low-quality phone audio
             // - Routes microphone input through Bluetooth (not needed for video)
+            //
+            // Deactivate the current session first so any in-flight AVPlayer
+            // (.playback category) fully releases its audio pipeline before we
+            // switch categories. Without this, setCategory on an active session
+            // can fail or the mic gets no samples because the session
+            // transitions while still active.
+            try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
             try audioSession.setCategory(
                 .playAndRecord,
-                mode: .default,
+                mode: .videoRecording,
                 options: [.defaultToSpeaker, .allowBluetoothA2DP]
             )
             try audioSession.setActive(true)
             print("[DivineCameraController] Audio session configured: A2DP for playback, built-in mic for recording")
+            return true
         } catch {
             print("[DivineCameraController] Failed to configure audio session: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Observe AVAudioSession interruptions (Spotify, phone calls, Siri,
+    /// alarms). On `.began` we mark audio as interrupted so any in-flight
+    /// recording stops trying to append audio buffers. On `.ended` with
+    /// `.shouldResume` we attempt to reactivate the session and restart the
+    /// audio capture session so the next recording (or the remainder of the
+    /// current one) gets sound back.
+    private func registerAudioSessionInterruptionObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioSessionInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+    }
+
+    @objc private func handleAudioSessionInterruption(_ notification: Notification) {
+        guard
+            let info = notification.userInfo,
+            let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+        else { return }
+
+        switch type {
+        case .began:
+            audioInterrupted = true
+            print("[DivineCameraController] AVAudioSession interruption began")
+        case .ended:
+            let shouldResume: Bool = {
+                guard let raw = info[AVAudioSessionInterruptionOptionKey] as? UInt else {
+                    return false
+                }
+                return AVAudioSession.InterruptionOptions(rawValue: raw).contains(.shouldResume)
+            }()
+            print("[DivineCameraController] AVAudioSession interruption ended (shouldResume=\(shouldResume))")
+            // Always try to recover — even when shouldResume is false the
+            // user can still press record again and we want a working session.
+            sessionQueue.async { [weak self] in
+                guard let self = self else { return }
+                _ = self.attachAudioToSessionIfNeeded()
+                self.audioInterrupted = false
+            }
+        @unknown default:
+            break
         }
     }
     
@@ -698,16 +764,63 @@ class CameraController: NSObject {
     /// or no audio device exists. Returning false is non-fatal — recording
     /// continues without audio (matches the previous behaviour).
     private func attachAudioToSessionIfNeeded() -> Bool {
-        // Already set up and running? Nothing to do.
+        // Already set up with input/output wired to a capture session?
+        //
+        // Two recovery cases on this path:
+        //   1. Category drift — the feed's AVPlayer can reset the shared
+        //      session to .playback between recordings. We must do a full
+        //      reconfigure (deactivate + setCategory + activate).
+        //   2. Audio interruption (e.g. Spotify briefly took over) — the
+        //      category stays .playAndRecord but iOS deactivates our
+        //      session and stops the audio AVCaptureSession. We must
+        //      reactivate (setActive(true) only) before restarting capture.
+        //
+        // IMPORTANT: do NOT call configureAudioSessionForRecording() when
+        // the category is already correct. Its setActive(false) step
+        // silently breaks the audio route while the audio AVCaptureSession
+        // is running — buffers keep flowing but contain digital silence,
+        // producing a recording with a valid AAC track that has no sound.
         if let existing = self.audioCaptureSession,
            self.audioInput != nil,
            self.audioOutput != nil {
-            if !existing.isRunning {
-                existing.startRunning()
+            let session = AVAudioSession.sharedInstance()
+            let needsReconfigure = session.category != .playAndRecord
+            if needsReconfigure {
+                // CRITICAL: stop the audio AVCaptureSession before the
+                // setActive(false)/setActive(true) cycle inside
+                // configureAudioSessionForRecording(). If we don't, the
+                // capture session keeps the now-stale audio route attached
+                // and continues delivering buffers that contain only
+                // digital silence — producing a recording with a valid
+                // AAC track that has no sound.
+                let wasRunning = existing.isRunning
+                if wasRunning {
+                    existing.stopRunning()
+                }
+                let configured = configureAudioSessionForRecording()
+                if wasRunning {
+                    existing.startRunning()
+                }
+                if !configured {
+                    return false
+                }
+            } else {
+                // Recover from interruption: setActive(true) is a no-op when
+                // the session is already active, but reactivates it after
+                // an interruption (Spotify, phone call, Siri, etc.).
+                do {
+                    try session.setActive(true)
+                } catch {
+                    print("[DivineCameraController] setActive(true) on existing session failed: \(error.localizedDescription)")
+                    return false
+                }
+                if !existing.isRunning {
+                    existing.startRunning()
+                }
             }
             return true
         }
-        
+
         // Make sure the AVAudioSession category is set.
         // DivineCameraPlugin.preWarmFrameworks() runs at plugin registration
         // and should already have done this; calling it again is cheap when warm.
@@ -1371,11 +1484,15 @@ class CameraController: NSObject {
         // blocks for ~1.4s on older A9/A10 iPads — accepted as edge case.
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
-            _ = self.attachAudioToSessionIfNeeded()
-            
+            let audioReady = self.attachAudioToSessionIfNeeded() && !self.audioInterrupted
+            if !audioReady {
+                print("[DivineCameraController] Audio not ready — recording WITHOUT audio track")
+            }
+
             self.videoOutputQueue.async { [weak self] in
                 guard let self = self else { return }
                 self.startRecordingAfterAudioReady(
+                    audioReady: audioReady,
                     useCache: useCache,
                     outputDirectory: outputDirectory,
                     completion: completion
@@ -1386,7 +1503,14 @@ class CameraController: NSObject {
     
     /// Continues startRecording on the videoOutputQueue after audio has been
     /// attached to the session. Split out for readability.
+    ///
+    /// `audioReady` is the result of `attachAudioToSessionIfNeeded()`. When
+    /// false (mic permission denied, AVAudioSession activation failed, or an
+    /// active interruption is in progress) we skip adding the audio writer
+    /// input entirely so the resulting MP4 has no audio track at all rather
+    /// than a valid AAC track containing only digital silence.
     private func startRecordingAfterAudioReady(
+        audioReady: Bool,
         useCache: Bool,
         outputDirectory: String?,
         completion: @escaping (String?) -> Void
@@ -1451,26 +1575,35 @@ class CameraController: NSObject {
                 sourcePixelBufferAttributes: sourcePixelBufferAttributes
             )
 
-            // Audio input settings
-            let audioSettings: [String: Any] = [
-                AVFormatIDKey: kAudioFormatMPEG4AAC,
-                AVSampleRateKey: 44100.0,
-                AVNumberOfChannelsKey: 1,
-                AVEncoderBitRateKey: 64000,
-            ]
-            let audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
-            audioInput.expectsMediaDataInRealTime = true
-
             if writer.canAdd(videoInput) {
                 writer.add(videoInput)
             }
-            if writer.canAdd(audioInput) {
-                writer.add(audioInput)
+
+            // Only add an audio writer input when we know the audio capture
+            // path is alive. Otherwise the writer would emit a valid AAC
+            // track containing only digital silence — the exact bug we're
+            // trying to prevent.
+            var addedAudioInput: AVAssetWriterInput?
+            if audioReady {
+                let audioSettings: [String: Any] = [
+                    AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVSampleRateKey: 44100.0,
+                    AVNumberOfChannelsKey: 1,
+                    AVEncoderBitRateKey: 64000,
+                ]
+                let audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+                audioInput.expectsMediaDataInRealTime = true
+                if writer.canAdd(audioInput) {
+                    writer.add(audioInput)
+                    addedAudioInput = audioInput
+                } else {
+                    print("[DivineCameraController] writer.canAdd(audioInput)=false — recording without audio")
+                }
             }
 
             self.assetWriter = writer
             self.videoWriterInput = videoInput
-            self.audioWriterInput = audioInput
+            self.audioWriterInput = addedAudioInput
             self.pixelBufferAdaptor = adaptor
 
             // Start writing
@@ -1548,7 +1681,7 @@ class CameraController: NSObject {
         
         videoOutputQueue.async { [weak self] in
             guard let self = self else { return }
-            
+
             self.videoWriterInput?.markAsFinished()
             self.audioWriterInput?.markAsFinished()
             

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -250,6 +250,9 @@ class CameraController: NSObject {
             // can fail or the mic gets no samples because the session
             // transitions while still active.
             try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+            // .videoRecording mode enables system-level noise suppression and
+            // echo cancellation tuned for direct capture (vs .default which is
+            // tuned for VoIP). This gives better mic quality without extra work.
             try audioSession.setCategory(
                 .playAndRecord,
                 mode: .videoRecording,
@@ -288,8 +291,12 @@ class CameraController: NSObject {
 
         switch type {
         case .began:
-            audioInterrupted = true
-            print("[DivineCameraController] AVAudioSession interruption began")
+            // Dispatch to sessionQueue so reads and writes to audioInterrupted
+            // always happen on the same serial queue, avoiding data races.
+            sessionQueue.async { [weak self] in
+                self?.audioInterrupted = true
+                print("[DivineCameraController] AVAudioSession interruption began")
+            }
         case .ended:
             let shouldResume: Bool = {
                 guard let raw = info[AVAudioSessionInterruptionOptionKey] as? UInt else {
@@ -1484,6 +1491,12 @@ class CameraController: NSObject {
         // blocks for ~1.4s on older A9/A10 iPads — accepted as edge case.
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
+            // Note: there is a brief window between this check and the first
+            // audioInput.append() call on videoOutputQueue. An interruption
+            // arriving in that window produces a silent track rather than no
+            // audio track. The captureOutput guard (!audioInterrupted) limits
+            // the damage; full protection would require a writer-level lock
+            // that is not worth the added complexity here.
             let audioReady = self.attachAudioToSessionIfNeeded() && !self.audioInterrupted
             if !audioReady {
                 print("[DivineCameraController] Audio not ready — recording WITHOUT audio track")
@@ -1939,7 +1952,10 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
         }
         // Handle audio output
         else if output == audioOutput {
-            if isRecording, let writer = assetWriter, let audioInput = audioWriterInput {
+            // Skip appending while interrupted — iOS keeps delivering
+            // (silent) buffers after the session is deactivated, which
+            // would produce a valid AAC track with no sound.
+            if isRecording, !audioInterrupted, let writer = assetWriter, let audioInput = audioWriterInput {
                 // Only append audio after session has started
                 if isWriterSessionStarted && writer.status == .writing && audioInput.isReadyForMoreMediaData {
                     audioInput.append(sampleBuffer)

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -31,7 +31,26 @@ class CameraController: NSObject {
     /// Set by the AVAudioSession interruption observer. While true the
     /// audio capture path is known to be silent and we skip appending
     /// audio buffers to the asset writer.
-    private var audioInterrupted: Bool = false
+    ///
+    /// Synchronized via `audioInterruptedLock` because writes happen on
+    /// `sessionQueue` (interruption handler) but reads happen on
+    /// `videoOutputQueue` (`captureOutput`) — without a lock those
+    /// cross-queue accesses are an unsynchronized data race on a plain
+    /// `Bool`.
+    private let audioInterruptedLock = NSLock()
+    private var _audioInterrupted: Bool = false
+    private var audioInterrupted: Bool {
+        get {
+            audioInterruptedLock.lock()
+            defer { audioInterruptedLock.unlock() }
+            return _audioInterrupted
+        }
+        set {
+            audioInterruptedLock.lock()
+            _audioInterrupted = newValue
+            audioInterruptedLock.unlock()
+        }
+    }
     
     private var textureRegistry: FlutterTextureRegistry
     private var textureId: Int64 = -1
@@ -291,12 +310,11 @@ class CameraController: NSObject {
 
         switch type {
         case .began:
-            // Dispatch to sessionQueue so reads and writes to audioInterrupted
-            // always happen on the same serial queue, avoiding data races.
-            sessionQueue.async { [weak self] in
-                self?.audioInterrupted = true
-                print("[DivineCameraController] AVAudioSession interruption began")
-            }
+            // Access goes through the lock-backed `audioInterrupted`
+            // accessor so cross-queue reads from `videoOutputQueue`
+            // (captureOutput) see a consistent value.
+            self.audioInterrupted = true
+            print("[DivineCameraController] AVAudioSession interruption began")
         case .ended:
             let shouldResume: Bool = {
                 guard let raw = info[AVAudioSessionInterruptionOptionKey] as? UInt else {
@@ -307,6 +325,9 @@ class CameraController: NSObject {
             print("[DivineCameraController] AVAudioSession interruption ended (shouldResume=\(shouldResume))")
             // Always try to recover — even when shouldResume is false the
             // user can still press record again and we want a working session.
+            // attachAudioToSessionIfNeeded() must run on sessionQueue (it
+            // mutates capture-session state); the lock-backed
+            // `audioInterrupted` accessor handles cross-queue safety.
             sessionQueue.async { [weak self] in
                 guard let self = self else { return }
                 _ = self.attachAudioToSessionIfNeeded()
@@ -805,11 +826,18 @@ class CameraController: NSObject {
                     existing.stopRunning()
                 }
                 let configured = configureAudioSessionForRecording()
-                if wasRunning {
-                    existing.startRunning()
-                }
                 if !configured {
                     return false
+                }
+                // After a successful reconfigure, restart the dedicated
+                // audio capture session whenever it is not running — not
+                // just when it happened to be running before stopRunning().
+                // An interruption / category drift can leave the session
+                // already stopped on entry, in which case `wasRunning`
+                // is false but we still need to bring it back up so the
+                // next recording actually captures audio.
+                if !existing.isRunning {
+                    existing.startRunning()
                 }
             } else {
                 // Recover from interruption: setActive(true) is a no-op when
@@ -831,8 +859,17 @@ class CameraController: NSObject {
         // Make sure the AVAudioSession category is set.
         // DivineCameraPlugin.preWarmFrameworks() runs at plugin registration
         // and should already have done this; calling it again is cheap when warm.
-        configureAudioSessionForRecording()
-        
+        //
+        // Propagate failure: if setCategory / setActive fails on the cold
+        // path, the dedicated audio capture session would still be built
+        // and started below, but with no working AVAudioSession the
+        // captured buffers would be silent. Returning false here keeps
+        // the new `audioReady` contract honest — the recording proceeds
+        // without an audio track instead of producing a silent AAC track.
+        if !configureAudioSessionForRecording() {
+            return false
+        }
+
         let session = self.audioCaptureSession ?? AVCaptureSession()
         session.automaticallyConfiguresApplicationAudioSession = false
         session.beginConfiguration()

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -53,9 +53,15 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             // 1. AudioToolbox + AVAudioSession + mediaserverd XPC roundtrip.
             let audioSession = AVAudioSession.sharedInstance()
             do {
+                // Use the same mode as the real recording path
+                // (CameraController.configureAudioSessionForRecording).
+                // Pre-warming with a different mode means the warmed audio
+                // route doesn't match what we actually use at record time,
+                // so the first recording still pays the mode-switch cost
+                // and the warmed behaviour drifts from the real one.
                 try audioSession.setCategory(
                     .playAndRecord,
-                    mode: .default,
+                    mode: .videoRecording,
                     options: [.defaultToSpeaker, .allowBluetoothA2DP]
                 )
                 // Do NOT call setActive(true) — that would steal audio focus


### PR DESCRIPTION
## Description


Fixes muted audio in recordings on iOS when the user interacts with another audio app (Spotify, a phone call, Siri, an alarm) before or during a recording.

## Why

iOS sends an `AVAudioSession.interruptionNotification` when another app takes the shared audio session. Before this change the plugin had no observer for that notification, so:

1. The session stayed in an interrupted (deactivated) state — no mic input — but `captureOutput(_:didOutput:from:)` kept running and appended silent AAC buffers to the asset writer, producing a video with a flat-line audio track.
2. After the interruption ended, the audio capture session was never restarted, so subsequent recordings were also muted until the app was relaunched.

## Manual test plan

1. Start a recording.
2. Trigger an interruption (receive a phone call, start Spotify, or
   ask Siri a question) and then dismiss it.
3. Stop the recording — verify audio is present for the portion before
   the interruption.
4. Start a new recording immediately after the interruption — verify
   audio is present throughout.
5. Repeat with Bluetooth headset connected.

**Related Issue:** Closes #3881 Closes #4171

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore