### PR TITLE
fix(notifications): complete tap-target routing for all notification kinds

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -175,17 +175,22 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       case ActorNotification(:final actor, :final type, :final targetEventId):
         switch (type) {
           case NotificationKind.follow:
-          case NotificationKind.mention:
             _navigateToProfile(context, actor.pubkey);
+          case NotificationKind.mention:
           case NotificationKind.likeComment:
           case NotificationKind.reply:
-            // targetEventId is the kind 1111 comment; the resolver
-            // walks its E tag to the root video.
+            // mention → targetEventId is the kind-1 mention event; the
+            // resolver walks its E-tags to the root video.
+            // likeComment/reply → targetEventId is the referenced comment
+            // event; same resolver path.
+            // Falls back to the actor's profile when resolution fails.
             if (targetEventId != null && targetEventId.isNotEmpty) {
               await _navigateToVideo(
                 context,
                 targetEventId,
                 notificationKind: type,
+                profileFallbackPubkey:
+                    type == NotificationKind.mention ? actor.pubkey : null,
               );
             } else {
               _navigateToProfile(context, actor.pubkey);
@@ -207,6 +212,10 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     String videoEventId, {
     String? videoAddressableId,
     NotificationKind? notificationKind,
+    /// When set and the resolver cannot find a root video, navigate to this
+    /// actor's profile instead of showing a "video not found" snackbar.
+    /// Used for mentions, which may reference a plain post with no video.
+    String? profileFallbackPubkey,
   }) async {
     Log.info(
       'Navigating to video from notification: '
@@ -224,7 +233,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     final isComment =
         notificationKind == NotificationKind.comment ||
         notificationKind == NotificationKind.reply ||
-        notificationKind == NotificationKind.likeComment;
+        notificationKind == NotificationKind.likeComment ||
+        notificationKind == NotificationKind.mention;
 
     // Resolve the navigation target.
     String routeId;
@@ -241,12 +251,16 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       if (!context.mounted) return;
 
       if (resolved == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.notificationsVideoNotFound),
-            duration: const Duration(seconds: 2),
-          ),
-        );
+        if (profileFallbackPubkey != null) {
+          _navigateToProfile(context, profileFallbackPubkey);
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(context.l10n.notificationsVideoNotFound),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
         return;
       }
       routeId = resolved;

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -245,6 +245,13 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
         notificationKind == NotificationKind.mention;
 
     // Resolve the navigation target.
+    //
+    // The stable-ID path (videoAddressableId set) and the raw-event-id
+    // fallback are synchronous — no await before navigation.
+    // The resolver path (comment/mention without addressable ID) requires
+    // one relay round-trip; we await only that before opening the screen,
+    // then hand the video fetch off as a stream so the screen opens
+    // immediately showing its own loading indicator.
     String routeId;
     if (videoAddressableId != null && videoAddressableId.isNotEmpty) {
       // Stable path: addressable ID works even after a metadata update.
@@ -277,46 +284,67 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       routeId = videoEventId;
     }
 
-    VideoEvent? video;
-    try {
-      video = await videosRepository.fetchVideoWithStatsForRouteId(routeId);
-      if (!context.mounted) return;
-    } catch (e) {
-      Log.error(
-        'Failed to fetch video: $e',
-        name: 'NotificationsView',
-        category: LogCategory.ui,
-      );
-    }
+    // Capture context-dependent objects before the async gap so they remain
+    // valid in the post-navigation callbacks below.
+    final l10n = context.l10n;
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final router = GoRouter.of(context);
+
+    // Build the video fetch as a Future so we can:
+    //   (a) navigate immediately — the screen shows BrandedLoadingIndicator
+    //   (b) pop + snackbar if the video turns out to be unavailable
+    final videoFuture = videosRepository
+        .fetchVideoWithStatsForRouteId(routeId)
+        .then((video) {
+          if (video == null) {
+            if (router.canPop()) router.pop();
+            scaffoldMessenger.showSnackBar(
+              SnackBar(
+                content: Text(l10n.notificationsVideoNotFound),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+            // Return empty list — stream completes without emitting videos.
+            return <VideoEvent>[];
+          }
+          if (videoEventService.shouldHideVideo(video)) {
+            if (router.canPop()) router.pop();
+            scaffoldMessenger.showSnackBar(
+              SnackBar(
+                content: Text(l10n.notificationsVideoUnavailable),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+            return <VideoEvent>[];
+          }
+          return [video];
+        })
+        .onError<Object>((e, stackTrace) {
+          Log.error(
+            'Failed to fetch video for notification',
+            name: 'NotificationsView',
+            category: LogCategory.ui,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          if (router.canPop()) router.pop();
+          scaffoldMessenger.showSnackBar(
+            SnackBar(
+              content: Text(l10n.notificationsVideoNotFound),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+          return <VideoEvent>[];
+        });
 
     if (!context.mounted) return;
-
-    if (video == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.notificationsVideoNotFound),
-          duration: const Duration(seconds: 2),
-        ),
-      );
-      return;
-    }
-
-    if (videoEventService.shouldHideVideo(video)) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.notificationsVideoUnavailable),
-          duration: const Duration(seconds: 2),
-        ),
-      );
-      return;
-    }
 
     context.push(
       PooledFullscreenVideoFeedScreen.path,
       extra: PooledFullscreenVideoFeedArgs(
-        videosStream: Stream.value([video]),
+        videosStream: Stream.fromFuture(videoFuture),
         initialIndex: 0,
-        contextTitle: context.l10n.notificationsFromNotification,
+        contextTitle: l10n.notificationsFromNotification,
         autoOpenComments: isComment,
       ),
     );

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -197,8 +197,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
                 targetEventId,
                 videoAddressableId: videoAddressableId,
                 notificationKind: type,
-                profileFallbackPubkey:
-                    type == NotificationKind.mention ? actor.pubkey : null,
+                profileFallbackPubkey: type == NotificationKind.mention
+                    ? actor.pubkey
+                    : null,
               );
             } else {
               _navigateToProfile(context, actor.pubkey);
@@ -220,6 +221,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     String videoEventId, {
     String? videoAddressableId,
     NotificationKind? notificationKind,
+
     /// When set and the resolver cannot find a root video, navigate to this
     /// actor's profile instead of showing a "video not found" snackbar.
     /// Used for mentions, which may reference a plain post with no video.

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -184,23 +184,21 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           case NotificationKind.mention:
           case NotificationKind.likeComment:
           case NotificationKind.reply:
-            // mention → targetEventId is the kind-1 mention event; the
-            // resolver walks its E-tags to the root video.
-            // likeComment/reply → targetEventId is the referenced comment
-            // event; same resolver path.
-            // videoAddressableId is the stable NIP-33 ID built from the
-            // server-provided d_tag — when set it bypasses the resolver.
-            // Falls back to the actor's profile when resolution fails.
+            // targetEventId is the event the resolver will walk to find the
+            // root video. Falls back to the actor's profile only for mentions,
+            // where the mention may have no video context at all.
             if (targetEventId != null && targetEventId.isNotEmpty) {
-              await _navigateToVideo(
+              final navigated = await _navigateToVideo(
                 context,
                 targetEventId,
                 videoAddressableId: videoAddressableId,
                 notificationKind: type,
-                profileFallbackPubkey: type == NotificationKind.mention
-                    ? actor.pubkey
-                    : null,
               );
+              if (!navigated &&
+                  type == NotificationKind.mention &&
+                  context.mounted) {
+                _navigateToProfile(context, actor.pubkey);
+              }
             } else {
               _navigateToProfile(context, actor.pubkey);
             }
@@ -216,16 +214,20 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     }
   }
 
-  Future<void> _navigateToVideo(
+  /// Resolves the video route and pushes [PooledFullscreenVideoFeedScreen].
+  ///
+  /// Returns `true` if a navigation was pushed, `false` if resolution failed
+  /// (resolver returned null) and no navigation occurred. The caller decides
+  /// what to do on `false` — e.g. the mention branch falls back to profile.
+  ///
+  /// The video fetch runs concurrently after the push so the screen opens
+  /// immediately; if the fetch fails or the video is unavailable a snackbar
+  /// is shown on the notifications scaffold without touching the router.
+  Future<bool> _navigateToVideo(
     BuildContext context,
     String videoEventId, {
     String? videoAddressableId,
     NotificationKind? notificationKind,
-
-    /// When set and the resolver cannot find a root video, navigate to this
-    /// actor's profile instead of showing a "video not found" snackbar.
-    /// Used for mentions, which may reference a plain post with no video.
-    String? profileFallbackPubkey,
   }) async {
     Log.info(
       'Navigating to video from notification: '
@@ -237,10 +239,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     final videoEventService = ref.read(videoEventServiceProvider);
     final videosRepository = ref.read(videosRepositoryProvider);
 
-    // Use the stable NIP-33 addressable ID whenever the notification payload
-    // includes one. It survives metadata updates because it's keyed on
-    // (kind:pubkey:d-tag) rather than the mutable event hash.
-    final isComment =
+    final shouldAutoOpenComments =
         notificationKind == NotificationKind.comment ||
         notificationKind == NotificationKind.reply ||
         notificationKind == NotificationKind.likeComment ||
@@ -258,27 +257,18 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     if (videoAddressableId != null && videoAddressableId.isNotEmpty) {
       // Stable path: addressable ID works even after a metadata update.
       routeId = videoAddressableId;
-    } else if (isComment) {
-      // Comment path: walk E/e tags to find the root video event ID.
+    } else if (shouldAutoOpenComments) {
+      // Comment/mention path: walk E/e tags to find the root video event ID.
       final resolved = await NotificationTargetResolver(
         videoEventService: videoEventService,
         nostrService: ref.read(nostrServiceProvider),
       ).resolveVideoEventIdFromNotificationTarget(videoEventId);
 
-      if (!context.mounted) return;
+      if (!context.mounted) return false;
 
       if (resolved == null) {
-        if (profileFallbackPubkey != null) {
-          _navigateToProfile(context, profileFallbackPubkey);
-        } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(context.l10n.notificationsVideoNotFound),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-        }
-        return;
+        // Resolution failed — caller decides the fallback (e.g. profile).
+        return false;
       }
       routeId = resolved;
     } else {
@@ -286,31 +276,27 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       routeId = videoEventId;
     }
 
-    // Capture context-dependent objects before the async gap so they remain
-    // valid in the post-navigation callbacks below.
+    // Capture l10n and scaffold messenger before the async gap; they remain
+    // valid even after the push transitions away from this view.
     final l10n = context.l10n;
     final scaffoldMessenger = ScaffoldMessenger.of(context);
-    final router = GoRouter.of(context);
 
-    // Build the video fetch as a Future so we can:
-    //   (a) navigate immediately — the screen shows BrandedLoadingIndicator
-    //   (b) pop + snackbar if the video turns out to be unavailable
+    // Fetch the video concurrently. The stream is consumed by the opened
+    // screen's BLoC — we never pop here to avoid touching the wrong route
+    // if the user navigated away before the fetch resolved.
     final videoFuture = videosRepository
         .fetchVideoWithStatsForRouteId(routeId)
         .then((video) {
           if (video == null) {
-            if (router.canPop()) router.pop();
             scaffoldMessenger.showSnackBar(
               SnackBar(
                 content: Text(l10n.notificationsVideoNotFound),
                 duration: const Duration(seconds: 2),
               ),
             );
-            // Return empty list — stream completes without emitting videos.
             return <VideoEvent>[];
           }
           if (videoEventService.shouldHideVideo(video)) {
-            if (router.canPop()) router.pop();
             scaffoldMessenger.showSnackBar(
               SnackBar(
                 content: Text(l10n.notificationsVideoUnavailable),
@@ -329,7 +315,6 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             error: e,
             stackTrace: stackTrace,
           );
-          if (router.canPop()) router.pop();
           scaffoldMessenger.showSnackBar(
             SnackBar(
               content: Text(l10n.notificationsVideoNotFound),
@@ -339,7 +324,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           return <VideoEvent>[];
         });
 
-    if (!context.mounted) return;
+    if (!context.mounted) return false;
 
     context.push(
       PooledFullscreenVideoFeedScreen.path,
@@ -347,9 +332,10 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
         videosStream: Stream.fromFuture(videoFuture),
         initialIndex: 0,
         contextTitle: l10n.notificationsFromNotification,
-        autoOpenComments: isComment,
+        autoOpenComments: shouldAutoOpenComments,
       ),
     );
+    return true;
   }
 
   void _navigateToProfile(BuildContext context, String userPubkey) {

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -172,7 +172,12 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           videoAddressableId: videoAddressableId,
           notificationKind: type,
         );
-      case ActorNotification(:final actor, :final type, :final targetEventId):
+      case ActorNotification(
+        :final actor,
+        :final type,
+        :final targetEventId,
+        :final videoAddressableId,
+      ):
         switch (type) {
           case NotificationKind.follow:
             _navigateToProfile(context, actor.pubkey);
@@ -183,11 +188,14 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             // resolver walks its E-tags to the root video.
             // likeComment/reply → targetEventId is the referenced comment
             // event; same resolver path.
+            // videoAddressableId is the stable NIP-33 ID built from the
+            // server-provided d_tag — when set it bypasses the resolver.
             // Falls back to the actor's profile when resolution fails.
             if (targetEventId != null && targetEventId.isNotEmpty) {
               await _navigateToVideo(
                 context,
                 targetEventId,
+                videoAddressableId: videoAddressableId,
                 notificationKind: type,
                 profileFallbackPubkey:
                     type == NotificationKind.mention ? actor.pubkey : null,

--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -19,6 +19,7 @@ class ActorNotification extends NotificationItem {
     super.sourceEventIds,
     this.commentText,
     this.isFollowingBack = false,
+    this.videoAddressableId,
   }) : assert(
          type == NotificationKind.follow ||
              type == NotificationKind.mention ||
@@ -38,6 +39,16 @@ class ActorNotification extends NotificationItem {
   /// Whether the current user already follows this actor back.
   final bool isFollowingBack;
 
+  /// Stable NIP-33 addressable ID (`34236:pubkey:d-tag`) of the video
+  /// context for [NotificationKind.likeComment] and
+  /// [NotificationKind.reply] notifications, when the server provided
+  /// the `d_tag` in the notification payload.
+  ///
+  /// When set, the tap handler navigates directly to the video using
+  /// this ID without a relay round-trip through the resolver.
+  /// Falls back to the resolver when null.
+  final String? videoAddressableId;
+
   /// Returns a copy with the given fields replaced.
   ActorNotification copyWith({
     String? id,
@@ -49,6 +60,7 @@ class ActorNotification extends NotificationItem {
     bool? isFollowingBack,
     String? targetEventId,
     List<String>? sourceEventIds,
+    String? videoAddressableId,
   }) {
     return ActorNotification(
       id: id ?? this.id,
@@ -60,6 +72,7 @@ class ActorNotification extends NotificationItem {
       isFollowingBack: isFollowingBack ?? this.isFollowingBack,
       targetEventId: targetEventId ?? this.targetEventId,
       sourceEventIds: sourceEventIds ?? this.sourceEventIds,
+      videoAddressableId: videoAddressableId ?? this.videoAddressableId,
     );
   }
 
@@ -74,5 +87,6 @@ class ActorNotification extends NotificationItem {
     isFollowingBack,
     targetEventId,
     sourceEventIds,
+    videoAddressableId,
   ];
 }

--- a/mobile/packages/models/test/src/actor_notification_test.dart
+++ b/mobile/packages/models/test/src/actor_notification_test.dart
@@ -53,6 +53,48 @@ void main() {
           targetEventId: 'd' * 64,
         );
       });
+
+      test('videoAddressableId defaults to null', () {
+        final notification = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+        );
+
+        expect(notification.videoAddressableId, isNull);
+      });
+
+      test('exposes videoAddressableId when set on likeComment', () {
+        final addressableId = '34236:${'a' * 64}:vine-abc';
+        final notification = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+          videoAddressableId: addressableId,
+        );
+
+        expect(notification.videoAddressableId, equals(addressableId));
+      });
+
+      test('unequal when videoAddressableId differs', () {
+        final a = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+        );
+        final b = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+          videoAddressableId: '34236:${'a' * 64}:vine-abc',
+        );
+
+        expect(a, isNot(equals(b)));
+      });
     });
 
     group('equality', () {
@@ -133,6 +175,38 @@ void main() {
         final updated = original.copyWith(isRead: true);
 
         expect(updated.targetEventId, equals('c' * 64));
+      });
+
+      test('preserves videoAddressableId when not overridden', () {
+        final addressableId = '34236:${'b' * 64}:vine-xyz';
+        final original = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+          videoAddressableId: addressableId,
+        );
+
+        final updated = original.copyWith(isRead: true);
+
+        expect(updated.videoAddressableId, equals(addressableId));
+      });
+
+      test('updates videoAddressableId when overridden', () {
+        final initial = '34236:${'b' * 64}:vine-old';
+        final updated = '34236:${'b' * 64}:vine-new';
+        final original = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.likeComment,
+          actor: actor,
+          timestamp: timestamp,
+          videoAddressableId: initial,
+        );
+
+        final copy = original.copyWith(videoAddressableId: updated);
+
+        expect(copy.videoAddressableId, equals(updated));
+        expect(original.videoAddressableId, equals(initial));
       });
     });
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -726,6 +726,18 @@ class NotificationRepository {
           n.sourceEventId.isNotEmpty ? n.sourceEventId : null,
         _ => null,
       };
+      // Build the stable NIP-33 addressable ID from the server-provided
+      // d_tag for likeComment and reply — same pattern as _groupVideoAnchored
+      // for likes. When set, the tap handler navigates directly to the video
+      // without a relay round-trip through NotificationTargetResolver.
+      final videoAddressableId =
+          (mapped == NotificationKind.likeComment ||
+              mapped == NotificationKind.reply) &&
+          n.referencedDTag != null &&
+          n.referencedDTag!.isNotEmpty
+          ? '${NIP71VideoKinds.addressableShortVideo}'
+              ':$_userPubkey:${n.referencedDTag}'
+          : null;
       result.add(
         ActorNotification(
           id: n.dedupeKey,
@@ -738,6 +750,7 @@ class NotificationRepository {
           sourceEventIds: n.sourceEventId.isNotEmpty
               ? [n.sourceEventId]
               : const [],
+          videoAddressableId: videoAddressableId,
         ),
       );
     }
@@ -817,6 +830,15 @@ class NotificationRepository {
         raw.sourceEventId.isNotEmpty ? raw.sourceEventId : null,
       _ => null,
     };
+    // Stable NIP-33 addressable ID for likeComment/reply — bypasses resolver.
+    final videoAddressableId =
+        (mapped == NotificationKind.likeComment ||
+            mapped == NotificationKind.reply) &&
+        raw.referencedDTag != null &&
+        raw.referencedDTag!.isNotEmpty
+        ? '${NIP71VideoKinds.addressableShortVideo}'
+            ':$_userPubkey:${raw.referencedDTag}'
+        : null;
     return ActorNotification(
       id: raw.dedupeKey,
       type: mapped,
@@ -828,6 +850,7 @@ class NotificationRepository {
       sourceEventIds: raw.sourceEventId.isNotEmpty
           ? [raw.sourceEventId]
           : const [],
+      videoAddressableId: videoAddressableId,
     );
   }
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -715,29 +715,6 @@ class NotificationRepository {
               kind == NotificationKind.reply)
           ? kind
           : NotificationKind.system;
-      // likeComment and reply reference a comment event via referencedEventId;
-      // the resolver walks its E-tags to reach the root video.
-      // mention is anchored to the source event (sourceEventId) — the kind-1
-      // event that mentioned the user. The resolver handles it identically.
-      final targetEventId = switch (mapped) {
-        NotificationKind.likeComment ||
-        NotificationKind.reply => n.referencedEventId,
-        NotificationKind.mention =>
-          n.sourceEventId.isNotEmpty ? n.sourceEventId : null,
-        _ => null,
-      };
-      // Build the stable NIP-33 addressable ID from the server-provided
-      // d_tag for likeComment and reply — same pattern as _groupVideoAnchored
-      // for likes. When set, the tap handler navigates directly to the video
-      // without a relay round-trip through NotificationTargetResolver.
-      final videoAddressableId =
-          (mapped == NotificationKind.likeComment ||
-                  mapped == NotificationKind.reply) &&
-              n.referencedDTag != null &&
-              n.referencedDTag!.isNotEmpty
-          ? '${NIP71VideoKinds.addressableShortVideo}'
-                ':$_userPubkey:${n.referencedDTag}'
-          : null;
       result.add(
         ActorNotification(
           id: n.dedupeKey,
@@ -746,11 +723,11 @@ class NotificationRepository {
           timestamp: n.createdAt,
           isRead: n.read,
           commentText: _truncateComment(n.content, kind),
-          targetEventId: targetEventId,
+          targetEventId: _actorTargetEventId(mapped, n),
           sourceEventIds: n.sourceEventId.isNotEmpty
               ? [n.sourceEventId]
               : const [],
-          videoAddressableId: videoAddressableId,
+          videoAddressableId: _actorVideoAddressableId(mapped, n),
         ),
       );
     }
@@ -820,25 +797,6 @@ class NotificationRepository {
             kind == NotificationKind.reply)
         ? kind
         : NotificationKind.system;
-    // likeComment and reply reference a comment event via referencedEventId;
-    // mention uses sourceEventId (the kind-1 mention event itself).
-    // The resolver handles all three identically — walks E-tags to root video.
-    final targetEventId = switch (mapped) {
-      NotificationKind.likeComment ||
-      NotificationKind.reply => raw.referencedEventId,
-      NotificationKind.mention =>
-        raw.sourceEventId.isNotEmpty ? raw.sourceEventId : null,
-      _ => null,
-    };
-    // Stable NIP-33 addressable ID for likeComment/reply — bypasses resolver.
-    final videoAddressableId =
-        (mapped == NotificationKind.likeComment ||
-                mapped == NotificationKind.reply) &&
-            raw.referencedDTag != null &&
-            raw.referencedDTag!.isNotEmpty
-        ? '${NIP71VideoKinds.addressableShortVideo}'
-              ':$_userPubkey:${raw.referencedDTag}'
-        : null;
     return ActorNotification(
       id: raw.dedupeKey,
       type: mapped,
@@ -846,16 +804,58 @@ class NotificationRepository {
       timestamp: raw.createdAt,
       isRead: raw.read,
       commentText: _truncateComment(raw.content, kind),
-      targetEventId: targetEventId,
+      targetEventId: _actorTargetEventId(mapped, raw),
       sourceEventIds: raw.sourceEventId.isNotEmpty
           ? [raw.sourceEventId]
           : const [],
-      videoAddressableId: videoAddressableId,
+      videoAddressableId: _actorVideoAddressableId(mapped, raw),
     );
   }
 
   /// Returns null if [s] is null or empty, otherwise [s].
   static String? _nonEmpty(String? s) => (s == null || s.isEmpty) ? null : s;
+
+  /// Returns the `targetEventId` for an actor-anchored notification.
+  ///
+  /// - `likeComment`/`reply` → the referenced comment event ID (resolver
+  ///   walks its E-tags to reach the root video).
+  /// - `mention` → the source event ID (the kind-1 event that mentioned
+  ///   the user; same resolver path).
+  /// - Everything else → null.
+  ///
+  /// Used by both the page-load path ([_mapActorAnchored]) and the
+  /// realtime path ([enrichOne]) to stay in lockstep.
+  static String? _actorTargetEventId(
+    NotificationKind mapped,
+    RelayNotification n,
+  ) => switch (mapped) {
+    NotificationKind.likeComment ||
+    NotificationKind.reply => n.referencedEventId,
+    NotificationKind.mention =>
+      n.sourceEventId.isNotEmpty ? n.sourceEventId : null,
+    _ => null,
+  };
+
+  /// Returns the stable NIP-33 addressable ID for an actor-anchored
+  /// notification, when the server provided the video's `d_tag`.
+  ///
+  /// Only populated for `likeComment` and `reply` — the tap handler uses
+  /// it to navigate directly to the video without a relay round-trip.
+  ///
+  /// Used by both the page-load path ([_mapActorAnchored]) and the
+  /// realtime path ([enrichOne]) to stay in lockstep.
+  String? _actorVideoAddressableId(
+    NotificationKind mapped,
+    RelayNotification n,
+  ) {
+    if (mapped != NotificationKind.likeComment &&
+        mapped != NotificationKind.reply) {
+      return null;
+    }
+    final dTag = n.referencedDTag;
+    if (dTag == null || dTag.isEmpty) return null;
+    return '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag';
+  }
 
   /// Consolidates follow notifications — keeps the earliest per pubkey.
   List<RelayNotification> _consolidateFollows(List<RelayNotification> raw) {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -732,11 +732,11 @@ class NotificationRepository {
       // without a relay round-trip through NotificationTargetResolver.
       final videoAddressableId =
           (mapped == NotificationKind.likeComment ||
-              mapped == NotificationKind.reply) &&
-          n.referencedDTag != null &&
-          n.referencedDTag!.isNotEmpty
+                  mapped == NotificationKind.reply) &&
+              n.referencedDTag != null &&
+              n.referencedDTag!.isNotEmpty
           ? '${NIP71VideoKinds.addressableShortVideo}'
-              ':$_userPubkey:${n.referencedDTag}'
+                ':$_userPubkey:${n.referencedDTag}'
           : null;
       result.add(
         ActorNotification(
@@ -833,11 +833,11 @@ class NotificationRepository {
     // Stable NIP-33 addressable ID for likeComment/reply — bypasses resolver.
     final videoAddressableId =
         (mapped == NotificationKind.likeComment ||
-            mapped == NotificationKind.reply) &&
-        raw.referencedDTag != null &&
-        raw.referencedDTag!.isNotEmpty
+                mapped == NotificationKind.reply) &&
+            raw.referencedDTag != null &&
+            raw.referencedDTag!.isNotEmpty
         ? '${NIP71VideoKinds.addressableShortVideo}'
-            ':$_userPubkey:${raw.referencedDTag}'
+              ':$_userPubkey:${raw.referencedDTag}'
         : null;
     return ActorNotification(
       id: raw.dedupeKey,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -715,9 +715,17 @@ class NotificationRepository {
               kind == NotificationKind.reply)
           ? kind
           : NotificationKind.system;
-      final isCommentTargeted =
-          mapped == NotificationKind.likeComment ||
-          mapped == NotificationKind.reply;
+      // likeComment and reply reference a comment event via referencedEventId;
+      // the resolver walks its E-tags to reach the root video.
+      // mention is anchored to the source event (sourceEventId) — the kind-1
+      // event that mentioned the user. The resolver handles it identically.
+      final targetEventId = switch (mapped) {
+        NotificationKind.likeComment ||
+        NotificationKind.reply => n.referencedEventId,
+        NotificationKind.mention =>
+          n.sourceEventId.isNotEmpty ? n.sourceEventId : null,
+        _ => null,
+      };
       result.add(
         ActorNotification(
           id: n.dedupeKey,
@@ -726,7 +734,7 @@ class NotificationRepository {
           timestamp: n.createdAt,
           isRead: n.read,
           commentText: _truncateComment(n.content, kind),
-          targetEventId: isCommentTargeted ? n.referencedEventId : null,
+          targetEventId: targetEventId,
           sourceEventIds: n.sourceEventId.isNotEmpty
               ? [n.sourceEventId]
               : const [],
@@ -799,9 +807,16 @@ class NotificationRepository {
             kind == NotificationKind.reply)
         ? kind
         : NotificationKind.system;
-    final isCommentTargeted =
-        mapped == NotificationKind.likeComment ||
-        mapped == NotificationKind.reply;
+    // likeComment and reply reference a comment event via referencedEventId;
+    // mention uses sourceEventId (the kind-1 mention event itself).
+    // The resolver handles all three identically — walks E-tags to root video.
+    final targetEventId = switch (mapped) {
+      NotificationKind.likeComment ||
+      NotificationKind.reply => raw.referencedEventId,
+      NotificationKind.mention =>
+        raw.sourceEventId.isNotEmpty ? raw.sourceEventId : null,
+      _ => null,
+    };
     return ActorNotification(
       id: raw.dedupeKey,
       type: mapped,
@@ -809,7 +824,7 @@ class NotificationRepository {
       timestamp: raw.createdAt,
       isRead: raw.read,
       commentText: _truncateComment(raw.content, kind),
-      targetEventId: isCommentTargeted ? raw.referencedEventId : null,
+      targetEventId: targetEventId,
       sourceEventIds: raw.sourceEventId.isNotEmpty
           ? [raw.sourceEventId]
           : const [],

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -856,6 +856,29 @@ void main() {
         expect(item.type, equals(NotificationKind.mention));
       });
 
+      test(
+        'mention carries sourceEventId as targetEventId for resolver',
+        () async {
+          // A mention's referencedEventId is null (no video anchor); the
+          // client resolver uses sourceEventId — the kind-1 event that
+          // mentioned the user — to walk E-tags and find the root video.
+          stubNotifications([
+            makeNotification(
+              notificationType: 'mention',
+              sourceKind: 1,
+              sourceEventId: 'mention_evt_id',
+              referencedEventId: null,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.mention));
+          expect(item.targetEventId, equals('mention_evt_id'));
+        },
+      );
+
       test('follow maps to follow ($ActorNotification)', () async {
         stubNotifications([
           makeNotification(

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -788,6 +788,49 @@ void main() {
         expect(item.targetEventId, equals('comment_event_xyz'));
       });
 
+      test(
+        'likeComment carries videoAddressableId when referencedDTag is set',
+        () async {
+          // When the server provides the d_tag for the video the comment was
+          // on, the repository builds the stable NIP-33 addressable ID so the
+          // tap handler can skip the resolver entirely.
+          stubNotifications([
+            makeNotification(
+              isReferencedVideo: false,
+              referencedEventId: 'comment_event_xyz',
+              referencedDTag: 'vine-abc',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(
+            item.videoAddressableId,
+            equals('34236:$userPubkey:vine-abc'),
+          );
+        },
+      );
+
+      test(
+        'likeComment videoAddressableId is null when referencedDTag is absent',
+        () async {
+          stubNotifications([
+            makeNotification(
+              isReferencedVideo: false,
+              referencedEventId: 'comment_event_xyz',
+              // referencedDTag intentionally omitted
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.videoAddressableId, isNull);
+        },
+      );
+
       test('reply on a video maps to comment ($VideoNotification)', () async {
         stubNotifications([
           makeNotification(notificationType: 'reply', sourceKind: 1),
@@ -1430,6 +1473,46 @@ void main() {
         expect(actor.type, equals(NotificationKind.likeComment));
         expect(actor.targetEventId, equals('comment_evt_id'));
       });
+
+      test(
+        'enrichOne: likeComment carries videoAddressableId when '
+        'referencedDTag is set',
+        () async {
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+          final result = await repository.enrichOne(
+            raw(
+              referencedEventId: 'comment_evt_id',
+              isReferencedVideo: false,
+              referencedDTag: 'vine-xyz',
+            ),
+          );
+
+          expect(result, isA<ActorNotification>());
+          final actor = result! as ActorNotification;
+          expect(actor.type, equals(NotificationKind.likeComment));
+          expect(
+            actor.videoAddressableId,
+            equals('34236:$userPubkey:vine-xyz'),
+          );
+        },
+      );
+
+      test(
+        'enrichOne: likeComment videoAddressableId is null when '
+        'referencedDTag is absent',
+        () async {
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+          final result = await repository.enrichOne(
+            raw(referencedEventId: 'comment_evt_id', isReferencedVideo: false),
+          );
+
+          expect(result, isA<ActorNotification>());
+          final actor = result! as ActorNotification;
+          expect(actor.videoAddressableId, isNull);
+        },
+      );
     });
 
     group('reactive snapshot', () {

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -22,6 +22,7 @@ import 'package:openvine/notifications/widgets/notification_list_item.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -58,6 +59,13 @@ Future<void> _pumpView(
   );
 }
 
+/// Return type for [_pumpRoutedView] — collects navigations to both the
+/// video feed and profile screens so tests can assert on either.
+typedef _RoutedViewResult = ({
+  List<PooledFullscreenVideoFeedArgs> videoArgs,
+  List<String> profileNpubs,
+});
+
 Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
   WidgetTester tester,
   NotificationFeedBloc bloc, {
@@ -65,7 +73,26 @@ Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
   required NostrClient nostrClient,
   required VideosRepository videosRepository,
 }) async {
-  final capturedArgs = <PooledFullscreenVideoFeedArgs>[];
+  final result = await _pumpRoutedViewFull(
+    tester,
+    bloc,
+    videoEventService: videoEventService,
+    nostrClient: nostrClient,
+    videosRepository: videosRepository,
+  );
+  return result.videoArgs;
+}
+
+/// Like [_pumpRoutedView] but also captures profile navigations.
+Future<_RoutedViewResult> _pumpRoutedViewFull(
+  WidgetTester tester,
+  NotificationFeedBloc bloc, {
+  required VideoEventService videoEventService,
+  required NostrClient nostrClient,
+  required VideosRepository videosRepository,
+}) async {
+  final capturedVideoArgs = <PooledFullscreenVideoFeedArgs>[];
+  final capturedProfileNpubs = <String>[];
   final router = GoRouter(
     initialLocation: '/',
     routes: [
@@ -76,7 +103,14 @@ Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
       GoRoute(
         path: PooledFullscreenVideoFeedScreen.path,
         builder: (context, state) {
-          capturedArgs.add(state.extra! as PooledFullscreenVideoFeedArgs);
+          capturedVideoArgs.add(state.extra! as PooledFullscreenVideoFeedArgs);
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+      GoRoute(
+        path: OtherProfileScreen.pathWithNpub,
+        builder: (context, state) {
+          capturedProfileNpubs.add(state.pathParameters['npub']!);
           return const Scaffold(body: SizedBox.shrink());
         },
       ),
@@ -104,7 +138,7 @@ Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
     ),
   );
 
-  return capturedArgs;
+  return (videoArgs: capturedVideoArgs, profileNpubs: capturedProfileNpubs);
 }
 
 VideoEvent _video(String id) => VideoEvent(
@@ -505,6 +539,440 @@ void main() {
           expect(args.autoOpenComments, isTrue);
           final videos = await args.videosStream.first;
           expect(videos.single.id, resolvedVideo.id);
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Tap-target routing — regression coverage for all notification kinds
+    // -----------------------------------------------------------------------
+
+    group('tap routing — like', () {
+      testWidgets(
+        'like tap opens the target video with autoOpenComments:false '
+        'using the stable addressable id',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const addressableId =
+              '34236:'
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+              ':vine-like';
+          final likedVideo = _video('liked_video_event');
+
+          when(
+            () =>
+                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).thenAnswer((_) async => likedVideo);
+          when(
+            () => videoService.shouldHideVideo(likedVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                VideoNotification(
+                  id: 'like-1',
+                  type: NotificationKind.like,
+                  videoEventId: 'liked_video_event',
+                  videoAddressableId: addressableId,
+                  actors: const [
+                    ActorInfo(pubkey: 'liker_pubkey', displayName: 'Alice'),
+                  ],
+                  totalCount: 1,
+                  timestamp: DateTime(2026),
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verify(
+            () =>
+                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).called(1);
+          expect(result.videoArgs, hasLength(1));
+          expect(result.videoArgs.single.autoOpenComments, isFalse);
+          final videos = await result.videoArgs.single.videosStream.first;
+          expect(videos.single.id, likedVideo.id);
+        },
+      );
+
+      testWidgets(
+        'like tap falls back to raw eventId when no addressable id is set',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const rawEventId = 'raw_like_event_id';
+          final likedVideo = _video(rawEventId);
+
+          when(
+            () => videosRepository.fetchVideoWithStatsForRouteId(rawEventId),
+          ).thenAnswer((_) async => likedVideo);
+          when(
+            () => videoService.shouldHideVideo(likedVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                VideoNotification(
+                  id: 'like-2',
+                  type: NotificationKind.like,
+                  videoEventId: rawEventId,
+                  actors: const [
+                    ActorInfo(pubkey: 'liker_pubkey', displayName: 'Bob'),
+                  ],
+                  totalCount: 1,
+                  timestamp: DateTime(2026),
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verify(
+            () => videosRepository.fetchVideoWithStatsForRouteId(rawEventId),
+          ).called(1);
+          expect(result.videoArgs, hasLength(1));
+          expect(result.videoArgs.single.autoOpenComments, isFalse);
+        },
+      );
+    });
+
+    group('tap routing — repost', () {
+      testWidgets(
+        'repost tap opens the target video with autoOpenComments:false '
+        'and actor identity is present in the notification',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const addressableId =
+              '34236:'
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+              ':vine-repost';
+          final repostedVideo = _video('reposted_video_event');
+
+          when(
+            () =>
+                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).thenAnswer((_) async => repostedVideo);
+          when(
+            () => videoService.shouldHideVideo(repostedVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                VideoNotification(
+                  id: 'repost-1',
+                  type: NotificationKind.repost,
+                  videoEventId: 'reposted_video_event',
+                  videoAddressableId: addressableId,
+                  actors: const [
+                    // Actor identity must be visible in the row.
+                    ActorInfo(
+                      pubkey: 'reposter_pubkey',
+                      displayName: 'Charlie',
+                    ),
+                  ],
+                  totalCount: 1,
+                  timestamp: DateTime(2026),
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          // Actor name is rendered in the row before tapping.
+          expect(find.textContaining('Charlie'), findsOneWidget);
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verify(
+            () =>
+                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).called(1);
+          expect(result.videoArgs, hasLength(1));
+          expect(result.videoArgs.single.autoOpenComments, isFalse);
+          final videos = await result.videoArgs.single.videosStream.first;
+          expect(videos.single.id, repostedVideo.id);
+        },
+      );
+    });
+
+    group('tap routing — follow', () {
+      testWidgets(
+        'follow tap navigates to the actor profile',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          // A real 64-char hex pubkey so encodePubKey produces a valid npub.
+          final followerPubkey = 'a' * 64;
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'follow-1',
+                  type: NotificationKind.follow,
+                  actor: ActorInfo(
+                    pubkey: followerPubkey,
+                    displayName: 'Dave',
+                  ),
+                  timestamp: DateTime(2026),
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          expect(result.videoArgs, isEmpty);
+          expect(result.profileNpubs, hasLength(1));
+          // npub must be the bech32 encoding of followerPubkey.
+          expect(result.profileNpubs.single, startsWith('npub'));
+        },
+      );
+    });
+
+    group('tap routing — mention', () {
+      testWidgets(
+        'mention tap resolves the mention event to the root video '
+        'and opens with autoOpenComments:true',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const mentionEventId = 'mention_kind1_event';
+          const rootVideoEventId = 'mention_root_video';
+          final mentionedInVideo = _video(rootVideoEventId);
+
+          // The mention event is a kind-1 with an uppercase E tag pointing
+          // to the root video — the same resolver path used for replies.
+          when(
+            () => videoService.getVideoById(mentionEventId),
+          ).thenReturn(null);
+          when(
+            () => nostrClient.fetchEventById(mentionEventId),
+          ).thenAnswer((_) async {
+            final event = Event(
+              'c' * 64,
+              1,
+              const [
+                ['E', rootVideoEventId],
+              ],
+              'hey @user great video',
+              createdAt: 1700000000,
+            );
+            event.id = mentionEventId;
+            return event;
+          });
+          when(
+            () => videosRepository.fetchVideoWithStatsForRouteId(
+              rootVideoEventId,
+            ),
+          ).thenAnswer((_) async => mentionedInVideo);
+          when(
+            () => videoService.shouldHideVideo(mentionedInVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'mention-1',
+                  type: NotificationKind.mention,
+                  actor: ActorInfo(
+                    pubkey: 'mentioner_pubkey',
+                    displayName: 'Eve',
+                  ),
+                  timestamp: DateTime(2026),
+                  targetEventId: mentionEventId,
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verify(
+            () => nostrClient.fetchEventById(mentionEventId),
+          ).called(1);
+          verify(
+            () => videosRepository.fetchVideoWithStatsForRouteId(
+              rootVideoEventId,
+            ),
+          ).called(1);
+          expect(result.videoArgs, hasLength(1));
+          expect(result.videoArgs.single.autoOpenComments, isTrue);
+          final videos = await result.videoArgs.single.videosStream.first;
+          expect(videos.single.id, mentionedInVideo.id);
+        },
+      );
+
+      testWidgets(
+        'mention tap falls back to actor profile when resolver cannot '
+        'find the root video',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const mentionEventId = 'unresolvable_mention_event';
+          final mentionerPubkey =
+              'f' * 64;
+
+          // Resolver returns null — event has no E-tags and is not a video.
+          when(
+            () => videoService.getVideoById(mentionEventId),
+          ).thenReturn(null);
+          when(
+            () => nostrClient.fetchEventById(mentionEventId),
+          ).thenAnswer((_) async {
+            final event = Event(
+              'd' * 64,
+              1,
+              const [],
+              'plain mention with no video context',
+              createdAt: 1700000000,
+            );
+            event.id = mentionEventId;
+            return event;
+          });
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'mention-2',
+                  type: NotificationKind.mention,
+                  actor: ActorInfo(
+                    pubkey: mentionerPubkey,
+                    displayName: 'Frank',
+                  ),
+                  timestamp: DateTime(2026),
+                  targetEventId: mentionEventId,
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          expect(result.videoArgs, isEmpty);
+          expect(result.profileNpubs, hasLength(1));
+          expect(result.profileNpubs.single, startsWith('npub'));
+        },
+      );
+
+      testWidgets(
+        'mention tap with null targetEventId falls back to actor profile',
+        (tester) async {
+          // Defensive case: if the repository could not populate targetEventId
+          // (e.g. empty sourceEventId), the view falls back gracefully.
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          final mentionerPubkey = 'e' * 64;
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'mention-3',
+                  type: NotificationKind.mention,
+                  actor: ActorInfo(
+                    pubkey: mentionerPubkey,
+                    displayName: 'Grace',
+                  ),
+                  timestamp: DateTime(2026),
+                  // targetEventId intentionally null — no source event id
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          verifyNever(() => nostrClient.fetchEventById(any()));
+          expect(result.videoArgs, isEmpty);
+          expect(result.profileNpubs, hasLength(1));
+          expect(result.profileNpubs.single, startsWith('npub'));
         },
       );
     });

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -541,6 +541,68 @@ void main() {
           expect(videos.single.id, resolvedVideo.id);
         },
       );
+
+      testWidgets(
+        'likeComment tap uses videoAddressableId directly when available '
+        '— no relay round-trip through resolver',
+        (tester) async {
+          // When the repository populates videoAddressableId from the
+          // server-provided d_tag, the stable NIP-33 path must be taken
+          // and fetchEventById must never be called.
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const addressableId =
+              '34236:'
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+              ':vine-liked-comment';
+          final video = _video('liked_comment_video');
+
+          when(
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).thenAnswer((_) async => video);
+          when(() => videoService.shouldHideVideo(video)).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'lc-addr',
+                  type: NotificationKind.likeComment,
+                  actor: ActorInfo(pubkey: 'liker_pubkey', displayName: 'Liz'),
+                  timestamp: DateTime(2026),
+                  targetEventId: 'some_comment_event_id',
+                  // videoAddressableId set — bypasses resolver.
+                  videoAddressableId: addressableId,
+                ),
+              ],
+            ),
+          );
+
+          final capturedArgs = await _pumpRoutedView(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          // Resolver must NOT be called — stable path is taken directly.
+          verifyNever(() => nostrClient.fetchEventById(any()));
+          verify(
+            () =>
+                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+          ).called(1);
+          expect(capturedArgs, hasLength(1));
+          expect(capturedArgs.single.autoOpenComments, isTrue);
+          final videos = await capturedArgs.single.videosStream.first;
+          expect(videos.single.id, video.id);
+        },
+      );
     });
 
     // -----------------------------------------------------------------------

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -594,8 +594,7 @@ void main() {
           // Resolver must NOT be called — stable path is taken directly.
           verifyNever(() => nostrClient.fetchEventById(any()));
           verify(
-            () =>
-                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
           ).called(1);
           expect(capturedArgs, hasLength(1));
           expect(capturedArgs.single.autoOpenComments, isTrue);
@@ -624,8 +623,7 @@ void main() {
           final likedVideo = _video('liked_video_event');
 
           when(
-            () =>
-                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
           ).thenAnswer((_) async => likedVideo);
           when(
             () => videoService.shouldHideVideo(likedVideo),
@@ -662,8 +660,7 @@ void main() {
           await tester.pumpAndSettle();
 
           verify(
-            () =>
-                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
           ).called(1);
           expect(result.videoArgs, hasLength(1));
           expect(result.videoArgs.single.autoOpenComments, isFalse);
@@ -741,8 +738,7 @@ void main() {
           final repostedVideo = _video('reposted_video_event');
 
           when(
-            () =>
-                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
           ).thenAnswer((_) async => repostedVideo);
           when(
             () => videoService.shouldHideVideo(repostedVideo),
@@ -786,8 +782,7 @@ void main() {
           await tester.pumpAndSettle();
 
           verify(
-            () =>
-                videosRepository.fetchVideoWithStatsForRouteId(addressableId),
+            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
           ).called(1);
           expect(result.videoArgs, hasLength(1));
           expect(result.videoArgs.single.autoOpenComments, isFalse);
@@ -936,8 +931,7 @@ void main() {
           final nostrClient = _MockNostrClient();
           final videosRepository = _MockVideosRepository();
           const mentionEventId = 'unresolvable_mention_event';
-          final mentionerPubkey =
-              'f' * 64;
+          final mentionerPubkey = 'f' * 64;
 
           // Resolver returns null — event has no E-tags and is not a video.
           when(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Notification taps now consistently land users on the correct target content for all notification kinds (likes, comments, replies, reposts, likeComment, mentions, follows). The main issues were: (1) `likeComment` taps showing "video not found" because the resolver was looking for a comment event on the relay instead of using the stable NIP-33 addressable ID the server already provides; (2) `mention` taps routing to the actor profile instead of the video context; and (3) all notification taps blocking on a network fetch before navigation, causing a visible delay. Fixed by carrying `videoAddressableId` on `ActorNotification` (populated from `referencedDTag`), routing `mention` through the resolver alongside `reply`/`likeComment`, and navigating immediately via `Stream.fromFuture` so the screen opens at once with its own loading indicator

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4205

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore