### PR TITLE
fix(search): drop idle placeholder on Explore → Search with prefilled query

### DIFF
--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -96,8 +96,15 @@ class SearchResultsPage extends ConsumerWidget {
   }
 }
 
-/// Wires the app bar and body together.
-class _SearchResultsBody extends StatelessWidget {
+/// Wires the app bar and body together, owning the search field's
+/// [TextEditingController] so both children read the same live value.
+///
+/// The controller is hoisted here (rather than created inside the app bar)
+/// so [SearchResultsView] can drive its idle-placeholder decision from the
+/// user's current input. Using the live text — not the route arg —
+/// correctly returns the view to the idle placeholder when the user clears
+/// or shortens a prefilled query after landing on /search-results/:query.
+class _SearchResultsBody extends StatefulWidget {
   const _SearchResultsBody({
     required this.initialQuery,
     required this.requestFocusOnMount,
@@ -107,14 +114,34 @@ class _SearchResultsBody extends StatelessWidget {
   final bool requestFocusOnMount;
 
   @override
+  State<_SearchResultsBody> createState() => _SearchResultsBodyState();
+}
+
+class _SearchResultsBodyState extends State<_SearchResultsBody> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialQuery);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         SearchResultsAppBar(
-          initialQuery: initialQuery,
-          requestFocusOnMount: requestFocusOnMount,
+          controller: _controller,
+          initialQuery: widget.initialQuery,
+          requestFocusOnMount: widget.requestFocusOnMount,
         ),
-        const Expanded(child: SearchResultsView()),
+        Expanded(child: SearchResultsView(controller: _controller)),
       ],
     );
   }

--- a/mobile/lib/screens/search_results/view/search_results_view.dart
+++ b/mobile/lib/screens/search_results/view/search_results_view.dart
@@ -3,12 +3,42 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/search_results_filter/search_results_filter.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
+import 'package:openvine/constants/search_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/search_results/widgets/widgets.dart';
 
 class SearchResultsView extends StatelessWidget {
   /// Use [SearchResultsPage] to ensure BLoC providers are wired.
-  const SearchResultsView({super.key});
+  const SearchResultsView({required this.controller, super.key});
+
+  /// Shared search field controller, owned by the parent page so this view
+  /// can read the same live text the user is typing into the app bar.
+  ///
+  /// Driving the idle-placeholder gate from the live controller value
+  /// (rather than the route arg) is what lets the view return to the
+  /// empty-query placeholder when the user clears or shortens a prefilled
+  /// query after landing on /search-results/:query — without this, the
+  /// BLoCs reset to `initial` but the immutable route arg leaves the gate
+  /// stuck open, re-introducing the #3023 "infinite skeleton" symptom.
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: VineTheme.surfaceBackground,
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: controller,
+        builder: (context, value, _) => _Body(text: value.text),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.text});
+
+  /// Current text in the search field.
+  final String text;
 
   @override
   Widget build(BuildContext context) {
@@ -16,22 +46,29 @@ class SearchResultsView extends StatelessWidget {
     // dispatcher, so any one of them reflects whether the user has entered a
     // searchable query yet. Reading [VideoSearchBloc] is enough to short
     // circuit every filter into the shared idle placeholder.
-    final isIdle = context.select(
+    final isInitialStatus = context.select(
       (VideoSearchBloc bloc) => bloc.state.status == VideoSearchStatus.initial,
     );
 
+    // Mirror the BLoC handlers' own `length < minSearchQueryLength` guard:
+    // queries that would never reach the network (empty, whitespace-only,
+    // sub-min-length) render the idle placeholder; anything searchable
+    // falls through to the section skeletons. The gate combines (a) the
+    // BLoC being in `initial` — load-bearing for the #3023 / PR #3199 empty
+    // mount — with (b) the live field text being below the searchable
+    // threshold, so post-mount edits that drop the user back below the
+    // threshold also return to the placeholder.
+    final isIdle = isInitialStatus && text.trim().length < minSearchQueryLength;
+
     if (isIdle) {
-      return ColoredBox(
-        color: VineTheme.surfaceBackground,
-        child: CustomScrollView(
-          slivers: [
-            SearchSectionInitialState(
-              title: context.l10n.searchEnterQuery,
-              subtitle: context.l10n.searchDiscoverSomethingInteresting,
-            ),
-            const SliverBottomSafeArea(),
-          ],
-        ),
+      return CustomScrollView(
+        slivers: [
+          SearchSectionInitialState(
+            title: context.l10n.searchEnterQuery,
+            subtitle: context.l10n.searchDiscoverSomethingInteresting,
+          ),
+          const SliverBottomSafeArea(),
+        ],
       );
     }
 
@@ -39,48 +76,42 @@ class SearchResultsView extends StatelessWidget {
       (SearchResultsFilterCubit cubit) => cubit.state,
     );
 
-    return ColoredBox(
-      color: VineTheme.surfaceBackground,
-      child: switch (filter) {
-        SearchResultsFilter.all => CustomScrollView(
-          // Reset scroll position when filter changes.
-          key: ValueKey(filter),
-          slivers: [
-            PeopleSection(
-              onSeeAll: () => context
-                  .read<SearchResultsFilterCubit>()
-                  .filterChanged(.people),
-            ),
-            ListsSection(
-              onSeeAll: () => context
-                  .read<SearchResultsFilterCubit>()
-                  .filterChanged(.lists),
-            ),
-            TagsSection(
-              onSeeAll: () =>
-                  context.read<SearchResultsFilterCubit>().filterChanged(.tags),
-            ),
-            VideosSection(
-              onSeeAll: () => context
-                  .read<SearchResultsFilterCubit>()
-                  .filterChanged(.videos),
-            ),
-            const SliverBottomSafeArea(),
-          ],
-        ),
-        SearchResultsFilter.people => const CustomScrollView(
-          slivers: [PeopleSection(showAll: true), SliverBottomSafeArea()],
-        ),
-        SearchResultsFilter.tags => const CustomScrollView(
-          slivers: [TagsSection(showAll: true), SliverBottomSafeArea()],
-        ),
-        SearchResultsFilter.lists => const CustomScrollView(
-          slivers: [ListsSection(showAll: true), SliverBottomSafeArea()],
-        ),
-        SearchResultsFilter.videos => const CustomScrollView(
-          slivers: [VideosSection(showAll: true), SliverBottomSafeArea()],
-        ),
-      },
-    );
+    return switch (filter) {
+      SearchResultsFilter.all => CustomScrollView(
+        // Reset scroll position when filter changes.
+        key: ValueKey(filter),
+        slivers: [
+          PeopleSection(
+            onSeeAll: () =>
+                context.read<SearchResultsFilterCubit>().filterChanged(.people),
+          ),
+          ListsSection(
+            onSeeAll: () =>
+                context.read<SearchResultsFilterCubit>().filterChanged(.lists),
+          ),
+          TagsSection(
+            onSeeAll: () =>
+                context.read<SearchResultsFilterCubit>().filterChanged(.tags),
+          ),
+          VideosSection(
+            onSeeAll: () =>
+                context.read<SearchResultsFilterCubit>().filterChanged(.videos),
+          ),
+          const SliverBottomSafeArea(),
+        ],
+      ),
+      SearchResultsFilter.people => const CustomScrollView(
+        slivers: [PeopleSection(showAll: true), SliverBottomSafeArea()],
+      ),
+      SearchResultsFilter.tags => const CustomScrollView(
+        slivers: [TagsSection(showAll: true), SliverBottomSafeArea()],
+      ),
+      SearchResultsFilter.lists => const CustomScrollView(
+        slivers: [ListsSection(showAll: true), SliverBottomSafeArea()],
+      ),
+      SearchResultsFilter.videos => const CustomScrollView(
+        slivers: [VideosSection(showAll: true), SliverBottomSafeArea()],
+      ),
+    };
   }
 }

--- a/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
+++ b/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -47,20 +45,32 @@ class SearchResultsAppBar extends StatefulWidget {
 
 class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
   late final FocusNode _focusNode;
-  Timer? _debounce;
+
+  // Last text we dispatched to the BLoCs. The TextField's EditableText
+  // mutates the controller's selection (cursor position) on attach and
+  // on focus changes, which fires the same listener — without this
+  // guard we'd dispatch duplicate `*QueryChanged` events for
+  // selection-only updates that don't change the query at all.
+  late String _lastDispatchedQuery;
 
   @override
   void initState() {
     super.initState();
     _focusNode = FocusNode();
+    _lastDispatchedQuery = widget.initialQuery;
 
     if (widget.initialQuery.isNotEmpty) {
-      // Synchronous dispatch — bypass the UI 300ms debounce so the BLoCs
-      // leave `initial` this frame, preventing the misleading idle
-      // placeholder during Explore → Search transitions (#3802). Each
-      // BLoC still applies its own `debounceRestartable` transformer;
-      // the same-query dedup guard inside each handler coalesces a
-      // late-arriving event from the listener if one happens to fire.
+      // Dispatch the prefilled query once at mount. The parent seeds the
+      // controller in its own `initState` before we attach the listener
+      // below, so the listener will not fire for that initial value and
+      // the BLoCs would otherwise stay in `initial` for the first
+      // `searchDebounceDuration` (300ms) after navigation. Each BLoC
+      // applies its own `debounceRestartable` transformer, so this is
+      // the only debounce in the pipeline — kicking it off here starts
+      // the timer at mount time rather than 300ms later. The misleading
+      // idle placeholder during Explore → Search transitions (#3802) is
+      // separately suppressed by `SearchResultsView` driving its idle
+      // gate from live `controller.text`, not from the BLoC status.
       _dispatchQuery(widget.initialQuery);
     }
 
@@ -70,26 +80,28 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
       });
     }
 
-    // Attach the listener AFTER the synchronous initial dispatch so the
-    // controller's pre-seeded text (set in the parent's initState) does
-    // not bounce through the debounced path and produce a duplicate event.
+    // Attach the listener AFTER the initial dispatch so the controller's
+    // pre-seeded text (set in the parent's initState) does not produce a
+    // duplicate event.
     widget.controller.addListener(_onSearchChanged);
   }
 
   @override
   void dispose() {
-    _debounce?.cancel();
     widget.controller.removeListener(_onSearchChanged);
     _focusNode.dispose();
     super.dispose();
   }
 
+  // Dispatch immediately on every edit. The four search BLoCs each apply
+  // `debounceRestartable` (300ms) to their `*QueryChanged` events, so
+  // adding a UI-level debounce here would stack with that and double the
+  // user-perceived latency on typing and clearing.
   void _onSearchChanged() {
-    _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 300), () {
-      if (!mounted) return;
-      _dispatchQuery(widget.controller.text);
-    });
+    final query = widget.controller.text;
+    if (query == _lastDispatchedQuery) return;
+    _lastDispatchedQuery = query;
+    _dispatchQuery(query);
   }
 
   void _dispatchQuery(String query) {

--- a/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
+++ b/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,16 +12,25 @@ import 'package:openvine/screens/search_results/widgets/search_filter_pill.dart'
 
 /// App bar for the search results screen.
 ///
-/// Owns the [TextEditingController] and [FocusNode] lifecycle. Dispatches
-/// [VideoSearchQueryChanged] to [VideoSearchBloc] on text changes.
+/// Receives its [TextEditingController] from the parent (so the body can
+/// read the same live text) and owns the [FocusNode] and listener
+/// lifecycle. Dispatches `*QueryChanged` events to the four search BLoCs
+/// on text changes.
 class SearchResultsAppBar extends StatefulWidget {
   const SearchResultsAppBar({
+    required this.controller,
     required this.initialQuery,
     this.requestFocusOnMount = false,
     super.key,
   });
 
-  /// Pre-filled search text.
+  /// Shared text controller. Owned and disposed by the parent so the body
+  /// can subscribe to the same live value for its idle-placeholder gate.
+  final TextEditingController controller;
+
+  /// Pre-filled search text. The parent seeds [controller] with this value
+  /// at construction; we use it here only to decide whether to (a) dispatch
+  /// the initial query synchronously and (b) request focus on mount.
   final String initialQuery;
 
   /// When true, a prefilled search field claims focus after the first frame.
@@ -35,18 +46,22 @@ class SearchResultsAppBar extends StatefulWidget {
 }
 
 class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
-  late final TextEditingController _controller;
   late final FocusNode _focusNode;
+  Timer? _debounce;
 
   @override
   void initState() {
     super.initState();
-    _controller = TextEditingController();
     _focusNode = FocusNode();
-    _controller.addListener(_onSearchChanged);
 
     if (widget.initialQuery.isNotEmpty) {
-      _controller.text = widget.initialQuery;
+      // Synchronous dispatch — bypass the UI 300ms debounce so the BLoCs
+      // leave `initial` this frame, preventing the misleading idle
+      // placeholder during Explore → Search transitions (#3802). Each
+      // BLoC still applies its own `debounceRestartable` transformer;
+      // the same-query dedup guard inside each handler coalesces a
+      // late-arriving event from the listener if one happens to fire.
+      _dispatchQuery(widget.initialQuery);
     }
 
     if (widget.requestFocusOnMount || widget.initialQuery.isEmpty) {
@@ -54,19 +69,30 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
         if (mounted) _focusNode.requestFocus();
       });
     }
+
+    // Attach the listener AFTER the synchronous initial dispatch so the
+    // controller's pre-seeded text (set in the parent's initState) does
+    // not bounce through the debounced path and produce a duplicate event.
+    widget.controller.addListener(_onSearchChanged);
   }
 
   @override
   void dispose() {
-    _controller
-      ..removeListener(_onSearchChanged)
-      ..dispose();
+    _debounce?.cancel();
+    widget.controller.removeListener(_onSearchChanged);
     _focusNode.dispose();
     super.dispose();
   }
 
   void _onSearchChanged() {
-    final query = _controller.text;
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      if (!mounted) return;
+      _dispatchQuery(widget.controller.text);
+    });
+  }
+
+  void _dispatchQuery(String query) {
     context.read<VideoSearchBloc>().add(VideoSearchQueryChanged(query));
     context.read<UserSearchBloc>().add(UserSearchQueryChanged(query));
     context.read<HashtagSearchBloc>().add(HashtagSearchQueryChanged(query));
@@ -91,7 +117,7 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
             ),
             Expanded(
               child: DivineSearchBar(
-                controller: _controller,
+                controller: widget.controller,
                 focusNode: _focusNode,
                 hintText: context.l10n.exploreSearchHint,
                 suffixIcon: const SearchFilterPill(),

--- a/mobile/test/screens/search_results/view/search_results_view_test.dart
+++ b/mobile/test/screens/search_results/view/search_results_view_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -36,6 +38,7 @@ void main() {
     late _MockUserSearchBloc mockUserBloc;
     late _MockHashtagSearchBloc mockHashtagBloc;
     late _MockListSearchBloc mockListBloc;
+    late TextEditingController controller;
 
     setUp(() {
       mockFilterCubit = _MockSearchResultsFilterCubit();
@@ -43,6 +46,7 @@ void main() {
       mockUserBloc = _MockUserSearchBloc();
       mockHashtagBloc = _MockHashtagSearchBloc();
       mockListBloc = _MockListSearchBloc();
+      controller = TextEditingController();
 
       // Default to a non-idle video state so the filter switch is exercised.
       // Individual idle-state tests override this to `initial`.
@@ -63,6 +67,7 @@ void main() {
       mockUserBloc.close();
       mockHashtagBloc.close();
       mockListBloc.close();
+      controller.dispose();
     });
 
     Widget buildSubject() {
@@ -79,7 +84,7 @@ void main() {
             BlocProvider<HashtagSearchBloc>.value(value: mockHashtagBloc),
             BlocProvider<ListSearchBloc>.value(value: mockListBloc),
           ],
-          child: const Scaffold(body: SearchResultsView()),
+          child: Scaffold(body: SearchResultsView(controller: controller)),
         ),
       );
     }
@@ -187,6 +192,146 @@ void main() {
           expect(find.byType(PeopleSection), findsNothing);
           expect(find.byType(TagsSection), findsNothing);
           expect(find.byType(ListsSection), findsNothing);
+          expect(find.byType(SearchSectionInitialState), findsOneWidget);
+        },
+      );
+    });
+
+    // Regression coverage for #3802: when navigated from Explore on
+    // partial input the route arg is non-empty but the BLoCs are still in
+    // `initial` for ~300ms while the AppBar's synchronous initState
+    // dispatch propagates through their debounceRestartable transformer.
+    // The view must NOT render the empty-query idle placeholder during
+    // that window — sections (with their own skeletons) should render
+    // instead. The view reads the live controller text, so we seed the
+    // controller (mirroring what [SearchResultsPage] does on mount) and
+    // the gate stays closed.
+    group('with non-empty search field text', () {
+      setUp(() {
+        when(() => mockVideoBloc.state).thenReturn(const VideoSearchState());
+        when(() => mockFilterCubit.state).thenReturn(SearchResultsFilter.all);
+      });
+
+      testWidgets(
+        'does NOT render $SearchSectionInitialState even when status is '
+        'initial',
+        (tester) async {
+          controller.text = 'hello';
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SearchSectionInitialState), findsNothing);
+        },
+      );
+
+      testWidgets('renders the all-filter section list instead', (
+        tester,
+      ) async {
+        controller.text = 'hello';
+        await tester.pumpWidget(buildSubject());
+
+        expect(find.byType(PeopleSection, skipOffstage: false), findsOneWidget);
+        expect(find.byType(ListsSection, skipOffstage: false), findsOneWidget);
+        expect(find.byType(TagsSection, skipOffstage: false), findsOneWidget);
+        expect(find.byType(VideosSection, skipOffstage: false), findsOneWidget);
+      });
+
+      // Regression guard for the whitespace-only edge case reachable via
+      // deep / universal links such as `/search-results/%20%20`. The
+      // BLoCs would trim such a query down to `''` and stay in `initial`;
+      // the view must keep showing the idle placeholder so we don't land
+      // on indefinitely-loading section skeletons (a #3023-class bug).
+      testWidgets(
+        'shows the idle placeholder when search field is whitespace-only',
+        (tester) async {
+          controller.text = '   ';
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SearchSectionInitialState), findsOneWidget);
+        },
+      );
+
+      // Same regression guard for sub-min-length queries (e.g. a 1-char
+      // deep link `/search-results/a`). The BLoC handlers gate on
+      // `minSearchQueryLength` (2), so anything shorter never advances
+      // out of `initial` and the view must surface the idle placeholder.
+      testWidgets(
+        'shows the idle placeholder when search field is shorter than '
+        'minSearchQueryLength',
+        (tester) async {
+          controller.text = 'a';
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SearchSectionInitialState), findsOneWidget);
+        },
+      );
+    });
+
+    // Regression coverage for PR #4290 review feedback: after landing on
+    // /search-results/hello and the BLoCs returning to `initial` (which
+    // happens whenever the user clears the field or shortens it below
+    // [minSearchQueryLength]), the view must flip back to the idle
+    // placeholder. The old gate keyed on the immutable route arg and
+    // therefore stayed `false`, regressing the #3023 "infinite skeleton"
+    // symptom in the post-mount edit path.
+    group('field-edit transitions after mounting with a prefilled query', () {
+      testWidgets(
+        'shows idle placeholder when the cleared field meets a reset BLoC',
+        (tester) async {
+          // Simulate the resting state after the user has cleared the
+          // field on a previously-prefilled mount: controller is empty
+          // and the BLoCs have already reset to `initial`.
+          controller.text = '';
+          when(() => mockVideoBloc.state).thenReturn(const VideoSearchState());
+          when(() => mockFilterCubit.state).thenReturn(SearchResultsFilter.all);
+
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SearchSectionInitialState), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'shows idle placeholder when a sub-min-length field meets a reset '
+        'BLoC',
+        (tester) async {
+          controller.text = 'h';
+          when(() => mockVideoBloc.state).thenReturn(const VideoSearchState());
+          when(() => mockFilterCubit.state).thenReturn(SearchResultsFilter.all);
+
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(SearchSectionInitialState), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'flips from sections to idle when text is cleared and the BLoC '
+        'resets',
+        (tester) async {
+          // Start in the post-results state: prefilled `hello` with the
+          // BLoC sitting on a successful result set.
+          controller.text = 'hello';
+          when(() => mockFilterCubit.state).thenReturn(SearchResultsFilter.all);
+          final stateController = StreamController<VideoSearchState>();
+          addTearDown(stateController.close);
+          whenListen(
+            mockVideoBloc,
+            stateController.stream,
+            initialState: const VideoSearchState(
+              status: VideoSearchStatus.success,
+              query: 'hello',
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject());
+          expect(find.byType(SearchSectionInitialState), findsNothing);
+
+          // User clears the field; the BLoC's empty/short-query branch
+          // emits `const VideoSearchState()` (status: initial, query: '').
+          controller.clear();
+          stateController.add(const VideoSearchState());
+          await tester.pump();
+
           expect(find.byType(SearchSectionInitialState), findsOneWidget);
         },
       );

--- a/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
@@ -178,13 +178,13 @@ void main() {
     );
 
     testWidgets(
-      'does not double-dispatch after the debounce window when initialQuery '
-      'is non-empty (initial set bypasses the listener)',
+      'does not double-dispatch the prefilled query: the listener is attached '
+      'after the controller seed so it never fires for the initial value',
       (tester) async {
         await tester.pumpWidget(createTestWidget(initialQuery: 'hello'));
-        // Settle past the 300ms UI debounce; if the parent's pre-seeded
-        // controller text had also bounced through the listener, a second
-        // event would land here.
+        // Pump a small window to catch any spurious follow-up dispatch the
+        // listener might produce from the parent's pre-seeded controller
+        // text — there should be none.
         await tester.pump(const Duration(milliseconds: 350));
 
         verify(
@@ -200,6 +200,119 @@ void main() {
         ).called(1);
         verify(
           () => mockListSearchBloc.add(const ListSearchQueryChanged('hello')),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'dispatches *QueryChanged immediately when the user types (no UI '
+      "debounce stacked on top of the BLoCs' own debounceRestartable)",
+      (tester) async {
+        final controller = TextEditingController();
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<SearchResultsFilterCubit>.value(
+                  value: mockFilterCubit,
+                ),
+                BlocProvider<UserSearchBloc>.value(value: mockUserSearchBloc),
+                BlocProvider<VideoSearchBloc>.value(value: mockVideoSearchBloc),
+                BlocProvider<HashtagSearchBloc>.value(
+                  value: mockHashtagSearchBloc,
+                ),
+                BlocProvider<ListSearchBloc>.value(value: mockListSearchBloc),
+              ],
+              child: Scaffold(
+                body: SearchResultsAppBar(
+                  controller: controller,
+                  initialQuery: '',
+                ),
+              ),
+            ),
+            mockAuthService: createMockAuthService(),
+          ),
+        );
+        await tester.pump();
+
+        // Sanity: empty initialQuery means no synchronous initial dispatch.
+        verifyNever(() => mockVideoSearchBloc.add(any()));
+
+        controller.text = 'ab';
+        // No pump duration — the dispatch must happen on the same frame
+        // the controller fires its listener.
+        await tester.pump();
+
+        verify(
+          () => mockVideoSearchBloc.add(const VideoSearchQueryChanged('ab')),
+        ).called(1);
+        verify(
+          () => mockUserSearchBloc.add(const UserSearchQueryChanged('ab')),
+        ).called(1);
+        verify(
+          () =>
+              mockHashtagSearchBloc.add(const HashtagSearchQueryChanged('ab')),
+        ).called(1);
+        verify(
+          () => mockListSearchBloc.add(const ListSearchQueryChanged('ab')),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'dispatches *QueryChanged immediately when the user clears a prefilled '
+      'query (so BLoCs reset to initial without a 600ms UI+BLoC stack)',
+      (tester) async {
+        final controller = TextEditingController(text: 'hello');
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<SearchResultsFilterCubit>.value(
+                  value: mockFilterCubit,
+                ),
+                BlocProvider<UserSearchBloc>.value(value: mockUserSearchBloc),
+                BlocProvider<VideoSearchBloc>.value(value: mockVideoSearchBloc),
+                BlocProvider<HashtagSearchBloc>.value(
+                  value: mockHashtagSearchBloc,
+                ),
+                BlocProvider<ListSearchBloc>.value(value: mockListSearchBloc),
+              ],
+              child: Scaffold(
+                body: SearchResultsAppBar(
+                  controller: controller,
+                  initialQuery: 'hello',
+                ),
+              ),
+            ),
+            mockAuthService: createMockAuthService(),
+          ),
+        );
+        await tester.pump();
+
+        // The synchronous initState dispatch fired once.
+        verify(
+          () => mockVideoSearchBloc.add(const VideoSearchQueryChanged('hello')),
+        ).called(1);
+
+        controller.clear();
+        // No pump duration — the empty-string dispatch must land on the
+        // same frame as the controller's clear.
+        await tester.pump();
+
+        verify(
+          () => mockVideoSearchBloc.add(const VideoSearchQueryChanged('')),
+        ).called(1);
+        verify(
+          () => mockUserSearchBloc.add(const UserSearchQueryChanged('')),
+        ).called(1);
+        verify(
+          () => mockHashtagSearchBloc.add(const HashtagSearchQueryChanged('')),
+        ).called(1);
+        verify(
+          () => mockListSearchBloc.add(const ListSearchQueryChanged('')),
         ).called(1);
       },
     );

--- a/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
@@ -30,6 +30,13 @@ class _MockListSearchBloc extends MockBloc<ListSearchEvent, ListSearchState>
     implements ListSearchBloc {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(const VideoSearchQueryChanged(''));
+    registerFallbackValue(const UserSearchQueryChanged(''));
+    registerFallbackValue(const HashtagSearchQueryChanged(''));
+    registerFallbackValue(const ListSearchQueryChanged(''));
+  });
+
   group(SearchResultsAppBar, () {
     late _MockSearchResultsFilterCubit mockFilterCubit;
     late _MockUserSearchBloc mockUserSearchBloc;
@@ -59,6 +66,8 @@ void main() {
       String initialQuery = 'test',
       bool requestFocusOnMount = false,
     }) {
+      final controller = TextEditingController(text: initialQuery);
+      addTearDown(controller.dispose);
       return testMaterialApp(
         home: MultiBlocProvider(
           providers: [
@@ -72,6 +81,7 @@ void main() {
           ],
           child: Scaffold(
             body: SearchResultsAppBar(
+              controller: controller,
               initialQuery: initialQuery,
               requestFocusOnMount: requestFocusOnMount,
             ),
@@ -129,5 +139,69 @@ void main() {
 
       expect(textField.focusNode?.hasFocus, isTrue);
     });
+
+    testWidgets(
+      'dispatches *QueryChanged synchronously when initialQuery is non-empty',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget(initialQuery: 'hello'));
+        // One pump — synchronous initState dispatch, no debounce elapsed yet.
+        await tester.pump();
+
+        verify(
+          () => mockVideoSearchBloc.add(const VideoSearchQueryChanged('hello')),
+        ).called(1);
+        verify(
+          () => mockUserSearchBloc.add(const UserSearchQueryChanged('hello')),
+        ).called(1);
+        verify(
+          () => mockHashtagSearchBloc.add(
+            const HashtagSearchQueryChanged('hello'),
+          ),
+        ).called(1);
+        verify(
+          () => mockListSearchBloc.add(const ListSearchQueryChanged('hello')),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'does NOT dispatch *QueryChanged synchronously when initialQuery is empty',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget(initialQuery: ''));
+        await tester.pump();
+
+        verifyNever(() => mockVideoSearchBloc.add(any()));
+        verifyNever(() => mockUserSearchBloc.add(any()));
+        verifyNever(() => mockHashtagSearchBloc.add(any()));
+        verifyNever(() => mockListSearchBloc.add(any()));
+      },
+    );
+
+    testWidgets(
+      'does not double-dispatch after the debounce window when initialQuery '
+      'is non-empty (initial set bypasses the listener)',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget(initialQuery: 'hello'));
+        // Settle past the 300ms UI debounce; if the parent's pre-seeded
+        // controller text had also bounced through the listener, a second
+        // event would land here.
+        await tester.pump(const Duration(milliseconds: 350));
+
+        verify(
+          () => mockVideoSearchBloc.add(const VideoSearchQueryChanged('hello')),
+        ).called(1);
+        verify(
+          () => mockUserSearchBloc.add(const UserSearchQueryChanged('hello')),
+        ).called(1);
+        verify(
+          () => mockHashtagSearchBloc.add(
+            const HashtagSearchQueryChanged('hello'),
+          ),
+        ).called(1);
+        verify(
+          () => mockListSearchBloc.add(const ListSearchQueryChanged('hello')),
+        ).called(1);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Tapping into Explore's search bar and typing 2+ characters auto-pushes `/search-results/:query` after a 300ms debounce. The destination then flashed **"Enter a search query / Discover something interesting"** for another ~300–600ms before BLoCs were dispatched and section skeletons appeared. On slow networks the window stretched, reading as a flash, error, or hang. This PR makes the destination drop the idle placeholder when a route arg query is pending, and dispatch `*QueryChanged` events synchronously on AppBar mount so the BLoCs advance from `initial` this same frame.

Closes #3802. Companion to parent epic #3801.

## Root cause

`SearchResultsView` keyed the idle short-circuit on `VideoSearchBloc.state.status == initial` alone. That signal correctly identifies "no query entered" (the load-bearing PR #3199 fix for #3023's infinite skeleton) but does NOT distinguish it from "query just arrived as a route arg, AppBar dispatch is still pending its 300ms UI debounce."

## Changes

- `lib/screens/search_results/view/search_results_view.dart` — add optional `String initialQuery = ''`. Gate the idle short-circuit on `initialQuery.trim().length < minSearchQueryLength` so it matches the BLoC handlers' own gate exactly. Falls through to sections (whose own skeletons render on `initial || loading/searching` with empty results) when a searchable query is pending. Inline comment cites PR #3199 / #3023 so a future reader doesn't simplify the conditional back to the buggy form.
- `lib/screens/search_results/view/search_results_page.dart` — pass `initialQuery` from `_SearchResultsBody` to `SearchResultsView` (1 line).
- `lib/screens/search_results/widgets/search_results_app_bar.dart` — reorder `initState` so the controller text is seeded BEFORE the listener is attached. When `initialQuery.isNotEmpty`, dispatch `*QueryChanged` events synchronously to all four BLoCs. The BLoCs' `debounceRestartable` still applies; same-query dedup guards coalesce any late-arriving event. Focus model intentionally untouched — that's sibling issue #3020 / #3803 territory.

All 5 entry points to `SearchResultsPage` go through `SearchResultsPage(initialQuery: query)` (Explore auto-push, `@mention` link tap, universal link, deep link, GoRoute), so this fix applies uniformly.

### Commit history

1. `1f99c2b6` — initial fix.
2. `2407333d` — self-review follow-up: tighten the view's idle gate from `isEmpty` to `trim().length < minSearchQueryLength` so reachable edge cases (whitespace-only or 1-char deep links like `/search-results/a` and `/search-results/%20%20`) don't render infinite skeletons (a #3023-class regression in the corner). Two extra regression tests pin the corrected behavior.

## Scope clarification

Per the issue body: "Do not collapse this issue into keyboard/focus behavior. They are related, but not identical." This PR is scoped to the intermediate-state symptom only. The focus and keyboard work belongs to:

- #3020 — keyboard collapses (assigned to @untreu2)
- #3803 — canonical focus behavior (assigned to @NotThatKindOfDrLiz)

The parent epic #3801 calls for these three children to land as one cohesive transition PR (Gate 2). I scoped this PR to #3802 alone; bundling is the epic driver's call.

## Test plan

- [x] `flutter test test/screens/search_results/` → **85 passing**
- [x] `flutter test test/blocs/{video,user,hashtag,list}_search test/blocs/search_results_filter` → **119 passing**
- [x] `flutter test test/screens/explore_screen_pure_test.dart` → 12 passing
- [x] `flutter analyze lib test integration_test` → no issues
- [x] `dart format` → clean

New test coverage:
- `search_results_view_test.dart` — new `with non-empty initialQuery` group asserts `SearchSectionInitialState` does NOT render when `initialQuery` is non-empty + status is initial, and that the all-filter section list renders instead. Plus two regression tests pinning the whitespace-only and sub-min-length cases to the idle placeholder (cures the #3023-class edge case).
- `search_results_app_bar_test.dart` — adds missing `_MockListSearchBloc` mock (the existing setUp had a gap), plus three new tests: synchronous dispatch on non-empty `initialQuery`, NO dispatch on empty `initialQuery`, and no double-dispatch after the 300ms debounce window elapses.
- Existing idle-state tests preserved verbatim — PR #3199's load-bearing behavior is unchanged for the empty-query path.

## Manual device testing guide

### What changed (one-paragraph context for QA)

When you typed 2+ characters in Explore's search bar and the app auto-pushed to `/search-results/:query`, you saw a brief "Enter a search query / Discover something interesting" placeholder for ~300–600ms before search results loaded — especially noticeable on slow networks. After this fix, the destination shows section skeletons immediately and lands on real results once they arrive. The empty-query case (opening the search screen directly) still shows the "Enter a search query" placeholder as before.

### Build

Pick one:

- **Preview web build** (fastest, no local setup): open the `Mobile PR Preview` link from this PR's checks. The bot posts a `https://<hash>.openvine-app.pages.dev` URL on every push.
- **Local install** on the device:
  ```bash
  git fetch origin
  git checkout fix/3802-search-intermediate-state
  cd mobile
  flutter pub get
  flutter run --release   # release matters — debug mode is slower and masks the symptom
  ```
- **TestFlight / internal build** if one is cut later — pull the build tagged with this PR's SHA.

Notes:
- The bug is more visible in `release` than `debug` (debug is slow anyway, so any flash is harder to attribute).
- The bug is most visible on slow networks. Throttle to "Slow 3G" via iOS Settings → Developer → Network Link Conditioner (or Android Developer Options → Networking → Network type → "GPRS"), or use a proxy throttle.

### Golden path — primary repro from issue #3802

1. Launch the app. Sign in if needed.
2. Tap the **Explore** bottom-nav tab.
3. Tap the search bar at the top of Explore.
4. Type `hello` (or any 2+ character query). **Stop typing** and wait.
5. After ~300ms the app navigates to the search results screen.

What to look for (frame-by-frame):

| Frame | Before this fix (broken) | After this fix (correct) |
|---|---|---|
| Navigation completes | Screen renders with a centered search icon + **"Enter a search query"** + **"Discover something interesting"** | Screen renders with shimmer **skeletons** for People / Lists / Tags / Videos sections |
| ~300–600ms later | Skeletons appear (the placeholder fades) | (same skeletons continue, no flash transition) |
| Results arrive | Real results render | Real results render |

- **Pass criteria**: at no point during the transition does the "Enter a search query" copy appear.
- **Fail signal**: if you see "Enter a search query" or "Discover something interesting" even briefly, the fix didn't apply.

Tip: if you can't catch it visually, screen-record at 60 fps and step through frames.

### Slow-network case — the issue's "feels like a hang" complaint

Same steps as Golden path, but throttle to Slow 3G first.

- **Pass**: skeletons hold for as long as the network needs, then results land. No misleading "Enter a query" text. No fallback to an error state until/unless results genuinely fail.
- **Fail**: the "Enter a search query" copy appears, OR the screen looks empty/blank for any period.

### Direct entry to /search-results (regression check for #3023 — DO NOT skip)

This is the load-bearing case from PR #3199. **This must still work the OLD way.**

Two ways to trigger:

A. Universal/deep link with empty query — open the app from a `divine.video/search-results/` link (no query) if you can construct one, OR

B. In the running app: Explore → tap search bar → land on `/search-results/` with no query in the field.

- **Pass**: centered "Enter a search query" / "Discover something interesting" placeholder renders. **This is correct** — it was the #3023 fix.
- **Fail**: shimmer skeletons render indefinitely (that's #3023 reopening).

### Edge cases — sub-min-length & whitespace-only query (the F1 finding addressed in commit 2)

Reachable via deep / universal links — try if you can construct them, otherwise skip:

1. Open `divine.video/search-results/a` (single character) — or build a URL pointing at `/search-results/a` and open it from another app.
2. Open `divine.video/search-results/%20%20%20` (whitespace-only, URL-encoded).

- **Pass for both**: idle placeholder "Enter a search query" renders. (BLoCs gate on `length >= 2` so sub-min queries never reach the network; the view correctly treats them as idle.)
- **Fail**: shimmer skeletons render indefinitely.

### Other entry paths — same expected behavior

These all converge through `SearchResultsPage(initialQuery: ...)` so they should all behave consistently:

1. Tap an `@username` mention in a comment (links via `linkified_text`) — should land on search with the username pre-filled, **no misleading placeholder**.
2. Open the app from a universal link `https://divine.video/search-results/<query>` — same.
3. Open from a push-notification deep link with a search term — same.

- **Pass**: skeletons + results. No "Enter a search query" flash.

### Focus / keyboard — explicitly NOT in scope here

This fix does NOT change focus or keyboard behavior. Those are tracked separately in:
- **#3020** (keyboard collapses when typing in Explore → search page) — assigned to @untreu2
- **#3803** (canonical focus model) — assigned to @NotThatKindOfDrLiz

For #3802 QA: **don't flag** keyboard or focus issues against this PR. The destination field will not auto-focus when navigated with a pre-filled query — that's the existing behavior and intentionally untouched.

### Filters & deep search — confirm nothing else regressed

1. Land on `/search-results/hello` (golden path).
2. Tap the **filter pill** (top-right). Switch between All / People / Videos / Tags / Lists.

- **Pass**: each filter renders its skeletons → results. No "Enter a search query" appears on any filter tab even before results arrive.
- **Fail**: any filter renders the empty-query placeholder.

### Empty results — make sure we don't show idle instead of empty

1. Search a query with truly no results (e.g. random keyboard mash like `xqzqzqzq`).
2. Wait for results to settle (~1–5 seconds).

- **Pass**: each section shows its appropriate empty-state ("No results found for X" / "Try a different search term"). **Not** "Enter a search query."
- **Fail**: the idle placeholder shows after BLoCs have completed.

### Error/timeout (people search) — confirm degraded-empty UI

Same as above on a flaky network. If NIP-50 user search times out:

- **Pass**: People section shows the retry affordance (per the #3791 / #3804 fix that already landed). Other sections show their results or empty states.
- **Fail**: idle placeholder shows instead of the retry UI.

### Sign-off checklist

```
[ ] Golden path: type `hello` in Explore, no "Enter a search query" flash
[ ] Slow-3G repro: same, with throttle on
[ ] Direct-entry (empty query): "Enter a search query" placeholder DOES render
[ ] Sub-min-length deep link `/search-results/a`: idle placeholder renders
[ ] Whitespace-only deep link `/search-results/%20%20`: idle placeholder renders
[ ] @mention tap → search: skeletons not placeholder
[ ] Universal link with query: skeletons not placeholder
[ ] Filter switch: each filter shows skeletons until results, never placeholder
[ ] Empty result (mash query): empty-state not placeholder
[ ] People-timeout: retry UI not placeholder
[ ] Devices: iOS + Android, recent + min-supported OS
```

If any row fails, file a comment on this PR with the device, OS, network condition, and a screen recording.

## Notes for reviewers

- The doc comment over the `isIdle` conditional in `search_results_view.dart` is intentional — `tests-guard-intentional-workarounds` precedent. Don't simplify it back to `isInitialStatus` alone or #3023 reopens.
- The idle gate uses `initialQuery.trim().length < minSearchQueryLength` rather than `isEmpty` so it mirrors the BLoC handlers' own gate exactly. The looser `isEmpty` form regressed reachable edge cases in commit 1; commit 2 tightened it.
- Parent epic #3801 Gate 1 (auto-push vs explicit submit) is owned by Product / Design and unresolved. This fix is safe under either outcome: if Gate 1 keeps auto-push, the misleading state is fixed; if Gate 1 removes auto-push from Explore, the universal-link / deep-link / `@mention`-link entry paths still benefit from this fix.