### PR TITLE
fix(auth): update existing account sign-in copy

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1332,7 +1332,7 @@
     "analyticsDiagnosticsUseFixture": "የቋሚ መረጃን ተጠቀም",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "አዲስ Divine መለያ ይፍጠሩ",
-    "authSignInDifferentAccount": "በተለየ መለያ ይግቡ",
+    "authSignInDifferentAccount": "በነባር መለያ ይግቡ",
     "authSignBackIn": "ተመልሰው ይግቡ",
     "authTermsPrefix": "ከላይ ያለውን አማራጭ በመምረጥ፣ ቢያንስ 16 ዓመት እንደሆናችሁ አረጋግጠዋል እና በዚህ ተስማምተዋል።",
     "authTermsOfService": "የአገልግሎት ውል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1139,7 +1139,7 @@
     "analyticsDiagnosticsUseFixture": "استخدام بيانات وهمية",
     "analyticsNa": "غير متوفر",
     "authCreateNewAccount": "إنشاء حساب Divine جديد",
-    "authSignInDifferentAccount": "تسجيل الدخول بحساب آخر",
+    "authSignInDifferentAccount": "تسجيل الدخول بحساب موجود",
     "authSignBackIn": "عد إلى تسجيل الدخول",
     "authTermsPrefix": "باختيار خيار أعلاه، أنت تؤكّد أنّ عمرك 16 عامًا على الأقل وتوافق على ",
     "authTermsOfService": "شروط الخدمة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1216,7 +1216,7 @@
     "analyticsDiagnosticsUseFixture": "Използвай примерни данни",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "Създай нов Divine акаунт",
-    "authSignInDifferentAccount": "Влез с друг акаунт",
+    "authSignInDifferentAccount": "Влез със съществуващ акаунт",
     "authSignBackIn": "Влез отново",
     "authTermsPrefix": "Като избереш опция по-горе, потвърждаваш, че си на 16 или повече и се съгласяваш с",
     "authTermsOfService": "Условия за ползване",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Fixture-Daten verwenden",
     "analyticsNa": "N/V",
     "authCreateNewAccount": "Neues Divine-Konto erstellen",
-    "authSignInDifferentAccount": "Mit anderem Konto anmelden",
+    "authSignInDifferentAccount": "Mit bestehendem Konto anmelden",
     "authSignBackIn": "Wieder anmelden",
     "authTermsPrefix": "Indem du oben eine Option wählst, bestätigst du, dass du mindestens 16 Jahre alt bist und den ",
     "authTermsOfService": "Nutzungsbedingungen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1415,7 +1415,7 @@
   "analyticsDiagnosticsUseFixture": "Use fixture data",
   "analyticsNa": "N/A",
   "authCreateNewAccount": "Create a new Divine account",
-  "authSignInDifferentAccount": "Sign in with a different account",
+  "authSignInDifferentAccount": "Sign in with an existing account",
   "authSignBackIn": "Sign back in",
   "authTermsPrefix": "By selecting an option above, you confirm you are at least 16 years old and agree to the ",
   "authTermsOfService": "Terms of Service",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1146,7 +1146,7 @@
     "analyticsDiagnosticsUseFixture": "Usar datos de prueba",
     "analyticsNa": "N/D",
     "authCreateNewAccount": "Crear una cuenta nueva en Divine",
-    "authSignInDifferentAccount": "Iniciar sesión con otra cuenta",
+    "authSignInDifferentAccount": "Iniciar sesión con una cuenta existente",
     "authSignBackIn": "Volver a iniciar sesión",
     "authTermsPrefix": "Al seleccionar una opción, confirmás que tenés al menos 16 años y aceptás los ",
     "authTermsOfService": "Términos del Servicio",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -684,7 +684,7 @@
     "analyticsDiagnosticsUseFixture": "Gumamit ng fixture data",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "Gumawa ng bagong Divine account",
-    "authSignInDifferentAccount": "Mag-sign in gamit ang ibang account",
+    "authSignInDifferentAccount": "Mag-sign in gamit ang umiiral na account",
     "authSignBackIn": "Mag-sign in muli",
     "authTermsPrefix": "Sa pagpili ng opsyon sa itaas, kinukumpirma mo na ikaw ay 16 na taong gulang o mas matanda at sumasang-ayon sa ",
     "authTermsOfService": "Terms of Service",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Utiliser des données fixtures",
     "analyticsNa": "N/D",
     "authCreateNewAccount": "Créer un nouveau compte Divine",
-    "authSignInDifferentAccount": "Se connecter avec un autre compte",
+    "authSignInDifferentAccount": "Se connecter avec un compte existant",
     "authSignBackIn": "Se reconnecter",
     "authTermsPrefix": "En choisissant une option ci-dessus, tu confirmes avoir au moins 16 ans et accepter les ",
     "authTermsOfService": "Conditions d'utilisation",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1139,7 +1139,7 @@
     "analyticsDiagnosticsUseFixture": "Pakai data fixture",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "Buat akun Divine baru",
-    "authSignInDifferentAccount": "Masuk dengan akun yang berbeda",
+    "authSignInDifferentAccount": "Masuk dengan akun yang sudah ada",
     "authSignBackIn": "Masuk kembali",
     "authTermsPrefix": "Dengan memilih opsi di atas, kamu mengonfirmasi bahwa kamu berusia minimal 16 tahun dan setuju dengan ",
     "authTermsOfService": "Ketentuan Layanan",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Usa dati fixture",
     "analyticsNa": "N/D",
     "authCreateNewAccount": "Crea un nuovo account Divine",
-    "authSignInDifferentAccount": "Accedi con un account diverso",
+    "authSignInDifferentAccount": "Accedi con un account esistente",
     "authSignBackIn": "Rientra",
     "authTermsPrefix": "Selezionando un'opzione sopra, confermi di avere almeno 16 anni e accetti i ",
     "authTermsOfService": "Termini di servizio",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1139,7 +1139,7 @@
     "analyticsDiagnosticsUseFixture": "フィクスチャデータを使う",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "新しい Divine アカウントを作ろう",
-    "authSignInDifferentAccount": "別のアカウントでサインイン",
+    "authSignInDifferentAccount": "既存のアカウントでサインイン",
     "authSignBackIn": "もう一回サインイン",
     "authTermsPrefix": "上のオプションを選ぶと、16歳以上であることを確認し、次に同意したことになるよ: ",
     "authTermsOfService": "利用規約",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -621,7 +621,7 @@
     "analyticsDiagnosticsUseFixture": "고정 데이터 사용",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "새 Divine 계정 만들기",
-    "authSignInDifferentAccount": "다른 계정으로 로그인",
+    "authSignInDifferentAccount": "기존 계정으로 로그인",
     "authSignBackIn": "다시 로그인",
     "authTermsPrefix": "위에서 옵션을 선택하면 만 16세 이상임을 확인하고 다음 내용에 동의하는 것이에요: ",
     "authTermsOfService": "이용약관",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Fixture-data gebruiken",
     "analyticsNa": "N.v.t.",
     "authCreateNewAccount": "Nieuw Divine-account aanmaken",
-    "authSignInDifferentAccount": "Inloggen met een ander account",
+    "authSignInDifferentAccount": "Inloggen met een bestaand account",
     "authSignBackIn": "Opnieuw inloggen",
     "authTermsPrefix": "Door hierboven een optie te kiezen bevestig je dat je minstens 16 jaar bent en ga je akkoord met de ",
     "authTermsOfService": "Servicevoorwaarden",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Użyj danych testowych",
     "analyticsNa": "N/D",
     "authCreateNewAccount": "Utwórz nowe konto Divine",
-    "authSignInDifferentAccount": "Zaloguj się na inne konto",
+    "authSignInDifferentAccount": "Zaloguj się na istniejące konto",
     "authSignBackIn": "Zaloguj się z powrotem",
     "authTermsPrefix": "Wybierając opcję powyżej, potwierdzasz, że masz przynajmniej 16 lat i zgadzasz się z ",
     "authTermsOfService": "Regulaminem",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Usar dados de fixture",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "Criar uma nova conta Divine",
-    "authSignInDifferentAccount": "Entrar com outra conta",
+    "authSignInDifferentAccount": "Entrar com uma conta existente",
     "authSignBackIn": "Entrar de novo",
     "authTermsPrefix": "Ao selecionar uma opção acima, você confirma que tem pelo menos 16 anos e concorda com os ",
     "authTermsOfService": "Termos de Serviço",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Folosește date de test",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "Creează un cont Divine nou",
-    "authSignInDifferentAccount": "Autentifică-te cu un alt cont",
+    "authSignInDifferentAccount": "Autentifică-te cu un cont existent",
     "authSignBackIn": "Reautentifică-te",
     "authTermsPrefix": "Selecționând o opțiune de mai sus, confirmi că ai cel puțin 16 ani și ești de acord cu ",
     "authTermsOfService": "Termenii serviciului",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1142,7 +1142,7 @@
     "analyticsDiagnosticsUseFixture": "Använd fixturedata",
     "analyticsNa": "N/A",
     "authCreateNewAccount": "Skapa ett nytt Divine-konto",
-    "authSignInDifferentAccount": "Logga in med ett annat konto",
+    "authSignInDifferentAccount": "Logga in med ett befintligt konto",
     "authSignBackIn": "Logga in igen",
     "authTermsPrefix": "Genom att välja ett alternativ ovan bekräftar du att du är minst 16 år gammal och godkänner ",
     "authTermsOfService": "Användarvillkor",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1139,7 +1139,7 @@
     "analyticsDiagnosticsUseFixture": "Sabit test verisini kullan",
     "analyticsNa": "Yok",
     "authCreateNewAccount": "Yeni bir Divine hesabı oluştur",
-    "authSignInDifferentAccount": "Farklı bir hesapla giriş yap",
+    "authSignInDifferentAccount": "Mevcut bir hesapla giriş yap",
     "authSignBackIn": "Tekrar giriş yap",
     "authTermsPrefix": "Yukarıdaki bir seçeneği seçerek en az 16 yaşında olduğunu onayladığını ve ",
     "authTermsOfService": "Hizmet Şartları",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4517,7 +4517,7 @@ abstract class AppLocalizations {
   /// No description provided for @authSignInDifferentAccount.
   ///
   /// In en, this message translates to:
-  /// **'Sign in with a different account'**
+  /// **'Sign in with an existing account'**
   String get authSignInDifferentAccount;
 
   /// No description provided for @authSignBackIn.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2508,7 +2508,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authCreateNewAccount => 'አዲስ Divine መለያ ይፍጠሩ';
 
   @override
-  String get authSignInDifferentAccount => 'በተለየ መለያ ይግቡ';
+  String get authSignInDifferentAccount => 'በነባር መለያ ይግቡ';
 
   @override
   String get authSignBackIn => 'ተመልሰው ይግቡ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2526,7 +2526,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authCreateNewAccount => 'إنشاء حساب Divine جديد';
 
   @override
-  String get authSignInDifferentAccount => 'تسجيل الدخول بحساب آخر';
+  String get authSignInDifferentAccount => 'تسجيل الدخول بحساب موجود';
 
   @override
   String get authSignBackIn => 'عد إلى تسجيل الدخول';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2599,7 +2599,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authCreateNewAccount => 'Създай нов Divine акаунт';
 
   @override
-  String get authSignInDifferentAccount => 'Влез с друг акаунт';
+  String get authSignInDifferentAccount => 'Влез със съществуващ акаунт';
 
   @override
   String get authSignBackIn => 'Влез отново';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2586,7 +2586,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authCreateNewAccount => 'Neues Divine-Konto erstellen';
 
   @override
-  String get authSignInDifferentAccount => 'Mit anderem Konto anmelden';
+  String get authSignInDifferentAccount => 'Mit bestehendem Konto anmelden';
 
   @override
   String get authSignBackIn => 'Wieder anmelden';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2557,7 +2557,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authCreateNewAccount => 'Create a new Divine account';
 
   @override
-  String get authSignInDifferentAccount => 'Sign in with a different account';
+  String get authSignInDifferentAccount => 'Sign in with an existing account';
 
   @override
   String get authSignBackIn => 'Sign back in';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2587,7 +2587,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authCreateNewAccount => 'Crear una cuenta nueva en Divine';
 
   @override
-  String get authSignInDifferentAccount => 'Iniciar sesión con otra cuenta';
+  String get authSignInDifferentAccount =>
+      'Iniciar sesión con una cuenta existente';
 
   @override
   String get authSignBackIn => 'Volver a iniciar sesión';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2599,7 +2599,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authSignInDifferentAccount =>
-      'Mag-sign in gamit ang ibang account';
+      'Mag-sign in gamit ang umiiral na account';
 
   @override
   String get authSignBackIn => 'Mag-sign in muli';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2594,7 +2594,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authCreateNewAccount => 'Créer un nouveau compte Divine';
 
   @override
-  String get authSignInDifferentAccount => 'Se connecter avec un autre compte';
+  String get authSignInDifferentAccount =>
+      'Se connecter avec un compte existant';
 
   @override
   String get authSignBackIn => 'Se reconnecter';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2530,7 +2530,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get authCreateNewAccount => 'Buat akun Divine baru';
 
   @override
-  String get authSignInDifferentAccount => 'Masuk dengan akun yang berbeda';
+  String get authSignInDifferentAccount => 'Masuk dengan akun yang sudah ada';
 
   @override
   String get authSignBackIn => 'Masuk kembali';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2585,7 +2585,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authCreateNewAccount => 'Crea un nuovo account Divine';
 
   @override
-  String get authSignInDifferentAccount => 'Accedi con un account diverso';
+  String get authSignInDifferentAccount => 'Accedi con un account esistente';
 
   @override
   String get authSignBackIn => 'Rientra';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2427,7 +2427,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authCreateNewAccount => '新しい Divine アカウントを作ろう';
 
   @override
-  String get authSignInDifferentAccount => '別のアカウントでサインイン';
+  String get authSignInDifferentAccount => '既存のアカウントでサインイン';
 
   @override
   String get authSignBackIn => 'もう一回サインイン';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2437,7 +2437,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authCreateNewAccount => '새 Divine 계정 만들기';
 
   @override
-  String get authSignInDifferentAccount => '다른 계정으로 로그인';
+  String get authSignInDifferentAccount => '기존 계정으로 로그인';
 
   @override
   String get authSignBackIn => '다시 로그인';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2565,7 +2565,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authCreateNewAccount => 'Nieuw Divine-account aanmaken';
 
   @override
-  String get authSignInDifferentAccount => 'Inloggen met een ander account';
+  String get authSignInDifferentAccount => 'Inloggen met een bestaand account';
 
   @override
   String get authSignBackIn => 'Opnieuw inloggen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2629,7 +2629,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authCreateNewAccount => 'Utwórz nowe konto Divine';
 
   @override
-  String get authSignInDifferentAccount => 'Zaloguj się na inne konto';
+  String get authSignInDifferentAccount => 'Zaloguj się na istniejące konto';
 
   @override
   String get authSignBackIn => 'Zaloguj się z powrotem';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2577,7 +2577,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authCreateNewAccount => 'Criar uma nova conta Divine';
 
   @override
-  String get authSignInDifferentAccount => 'Entrar com outra conta';
+  String get authSignInDifferentAccount => 'Entrar com uma conta existente';
 
   @override
   String get authSignBackIn => 'Entrar de novo';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2644,7 +2644,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authCreateNewAccount => 'Creează un cont Divine nou';
 
   @override
-  String get authSignInDifferentAccount => 'Autentifică-te cu un alt cont';
+  String get authSignInDifferentAccount => 'Autentifică-te cu un cont existent';
 
   @override
   String get authSignBackIn => 'Reautentifică-te';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2552,7 +2552,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authCreateNewAccount => 'Skapa ett nytt Divine-konto';
 
   @override
-  String get authSignInDifferentAccount => 'Logga in med ett annat konto';
+  String get authSignInDifferentAccount => 'Logga in med ett befintligt konto';
 
   @override
   String get authSignBackIn => 'Logga in igen';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2538,7 +2538,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authCreateNewAccount => 'Yeni bir Divine hesabı oluştur';
 
   @override
-  String get authSignInDifferentAccount => 'Farklı bir hesapla giriş yap';
+  String get authSignInDifferentAccount => 'Mevcut bir hesapla giriş yap';
 
   @override
   String get authSignBackIn => 'Tekrar giriş yap';

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -142,7 +142,7 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        expect(find.text('Sign in with a different account'), findsOneWidget);
+        expect(find.text('Sign in with an existing account'), findsOneWidget);
       });
 
       testWidgets('displays terms notice with legal links', (tester) async {
@@ -180,7 +180,7 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Sign in with a different account'));
+        await tester.tap(find.text('Sign in with an existing account'));
         await tester.pumpAndSettle();
 
         verify(() => mockAuthService.acceptTerms()).called(1);
@@ -215,7 +215,7 @@ void main() {
         await tester.pump();
 
         expect(find.text('Create a new Divine account'), findsNothing);
-        expect(find.text('Sign in with a different account'), findsNothing);
+        expect(find.text('Sign in with an existing account'), findsNothing);
       });
 
       testWidgets('hides action buttons when auth state is authenticating', (
@@ -227,7 +227,7 @@ void main() {
         await tester.pump();
 
         expect(find.text('Create a new Divine account'), findsNothing);
-        expect(find.text('Sign in with a different account'), findsNothing);
+        expect(find.text('Sign in with an existing account'), findsNothing);
       });
 
       testWidgets('does not call acceptTerms when auth state is checking', (
@@ -368,7 +368,7 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Sign in with a different account'));
+        await tester.tap(find.text('Sign in with an existing account'));
         await tester.pumpAndSettle();
 
         verify(() => mockAuthService.acceptTerms()).called(1);


### PR DESCRIPTION
## Summary
- Update the welcome-screen secondary sign-in action from “different account” to “existing account”.
- Apply the copy change across all localized ARB files and regenerated l10n outputs.
- Update welcome-screen test expectations for the new copy.

## Test plan
- [x] `flutter gen-l10n`
- [x] `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- dart format lib test integration_test`
- [x] Dart analyzer on changed generated l10n files and `test/screens/welcome_screen_test.dart`
- [x] `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- flutter analyze lib test integration_test`
- [x] `flutter test test/l10n/arb_consistency_test.dart`
- [x] `flutter test test/screens/welcome_screen_test.dart`
- [x] l10n hardcoded-string scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)