### PR TITLE
fix(feed): hide Android loading overlay when first-frame callback stalls

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -4,7 +4,12 @@ import 'dart:io';
 
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/foundation.dart'
-    show ValueListenable, kIsWeb, visibleForTesting;
+    show
+        TargetPlatform,
+        ValueListenable,
+        defaultTargetPlatform,
+        kIsWeb,
+        visibleForTesting;
 import 'package:flutter/widgets.dart';
 import 'package:infinite_video_feed/src/models/builders.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
@@ -63,6 +68,7 @@ class InfiniteVideoFeed extends StatefulWidget {
       (!kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS));
 
   static bool? _isSupportedOverrideForTesting;
+  static TargetPlatform? _targetPlatformOverrideForTesting;
 
   // coverage:ignore-start
   // Test hook used by app-layer widget tests outside this package.
@@ -74,6 +80,18 @@ class InfiniteVideoFeed extends StatefulWidget {
   @visibleForTesting
   static set debugIsSupportedOverride(bool? value) {
     _isSupportedOverrideForTesting = value;
+  }
+
+  /// Overrides the platform used by Android-specific feed behavior in tests.
+  ///
+  /// Set to `null` to clear the override.
+  @visibleForTesting
+  static TargetPlatform? get debugTargetPlatformOverride =>
+      _targetPlatformOverrideForTesting;
+
+  @visibleForTesting
+  static set debugTargetPlatformOverride(TargetPlatform? value) {
+    _targetPlatformOverrideForTesting = value;
   }
   // coverage:ignore-end
 
@@ -223,6 +241,10 @@ class InfiniteVideoFeed extends StatefulWidget {
 /// [currentIndex] for owning widgets that need to drive the feed
 /// imperatively.
 class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
+  TargetPlatform get _targetPlatform =>
+      InfiniteVideoFeed._targetPlatformOverrideForTesting ??
+      defaultTargetPlatform;
+
   static const _logName = 'InfiniteVideoFeed';
   static const _loopEndThreshold = Duration(seconds: 1);
   static const _loopStartThreshold = Duration(seconds: 1);
@@ -670,9 +692,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       // unmount or a rapid re-init for the same index. Both are observable in
       // production, but not reproducible in package widget tests without
       // microsecond-precise control over native platform-channel timing.
-      _log(
-        'Abort stale init at index $index (${video.id}) during $step',
-      );
+      _log('Abort stale init at index $index (${video.id}) during $step');
       if (identical(_controllers[index], controller)) {
         _controllers.remove(index);
       }
@@ -1102,6 +1122,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
         final hasVideoSize =
             controller != null && controller.state.videoHeight != 0;
+        final shouldShowLoading =
+            !hasError && _shouldShowLoadingLayer(controller: controller);
 
         return Stack(
           fit: StackFit.expand,
@@ -1109,8 +1131,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             // Loading layer — shown while the video surface is not yet
             // available. Removed once the first frame is rendered so the
             // widget (and any timers it owns) are properly disposed.
-            if (!hasError &&
-                (!hasVideoSize || !controller.state.isFirstFrameRendered))
+            //
+            // Android feed fallback: when the native backend reaches
+            // ready/playing with known dimensions but never delivers the
+            // first-frame callback, the thumbnail can otherwise remain
+            // permanently layered above the live video.
+            if (shouldShowLoading)
               ?widget.loadingBuilder?.call(
                 context,
                 index,
@@ -1142,5 +1168,21 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         );
       },
     );
+  }
+
+  bool _shouldShowLoadingLayer({
+    required DivineVideoPlayerController? controller,
+  }) {
+    if (controller == null) return true;
+
+    final state = controller.state;
+    final hasVideoSize = state.videoHeight != 0;
+    if (!hasVideoSize) return true;
+    if (state.isFirstFrameRendered) return false;
+
+    final allowAndroidFallback =
+        _targetPlatform == TargetPlatform.android &&
+        (state.isPlaying || state.status.isReady);
+    return !allowAndroidFallback;
   }
 }

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -4,12 +4,7 @@ import 'dart:io';
 
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/foundation.dart'
-    show
-        TargetPlatform,
-        ValueListenable,
-        defaultTargetPlatform,
-        kIsWeb,
-        visibleForTesting;
+    show ValueListenable, kIsWeb, visibleForTesting;
 import 'package:flutter/widgets.dart';
 import 'package:infinite_video_feed/src/models/builders.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
@@ -68,7 +63,6 @@ class InfiniteVideoFeed extends StatefulWidget {
       (!kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS));
 
   static bool? _isSupportedOverrideForTesting;
-  static TargetPlatform? _targetPlatformOverrideForTesting;
 
   // coverage:ignore-start
   // Test hook used by app-layer widget tests outside this package.
@@ -80,18 +74,6 @@ class InfiniteVideoFeed extends StatefulWidget {
   @visibleForTesting
   static set debugIsSupportedOverride(bool? value) {
     _isSupportedOverrideForTesting = value;
-  }
-
-  /// Overrides the platform used by Android-specific feed behavior in tests.
-  ///
-  /// Set to `null` to clear the override.
-  @visibleForTesting
-  static TargetPlatform? get debugTargetPlatformOverride =>
-      _targetPlatformOverrideForTesting;
-
-  @visibleForTesting
-  static set debugTargetPlatformOverride(TargetPlatform? value) {
-    _targetPlatformOverrideForTesting = value;
   }
   // coverage:ignore-end
 
@@ -241,10 +223,6 @@ class InfiniteVideoFeed extends StatefulWidget {
 /// [currentIndex] for owning widgets that need to drive the feed
 /// imperatively.
 class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
-  TargetPlatform get _targetPlatform =>
-      InfiniteVideoFeed._targetPlatformOverrideForTesting ??
-      defaultTargetPlatform;
-
   static const _logName = 'InfiniteVideoFeed';
   static const _loopEndThreshold = Duration(seconds: 1);
   static const _loopStartThreshold = Duration(seconds: 1);
@@ -1122,21 +1100,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
         final hasVideoSize =
             controller != null && controller.state.videoHeight != 0;
-        final shouldShowLoading =
-            !hasError && _shouldShowLoadingLayer(controller: controller);
-
         return Stack(
           fit: StackFit.expand,
           children: [
             // Loading layer — shown while the video surface is not yet
             // available. Removed once the first frame is rendered so the
             // widget (and any timers it owns) are properly disposed.
-            //
-            // Android feed fallback: when the native backend reaches
-            // ready/playing with known dimensions but never delivers the
-            // first-frame callback, the thumbnail can otherwise remain
-            // permanently layered above the live video.
-            if (shouldShowLoading)
+            if (!hasError &&
+                (!hasVideoSize || !controller.state.isFirstFrameRendered))
               ?widget.loadingBuilder?.call(
                 context,
                 index,
@@ -1168,21 +1139,5 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         );
       },
     );
-  }
-
-  bool _shouldShowLoadingLayer({
-    required DivineVideoPlayerController? controller,
-  }) {
-    if (controller == null) return true;
-
-    final state = controller.state;
-    final hasVideoSize = state.videoHeight != 0;
-    if (!hasVideoSize) return true;
-    if (state.isFirstFrameRendered) return false;
-
-    final allowAndroidFallback =
-        _targetPlatform == TargetPlatform.android &&
-        (state.isPlaying || state.status.isReady);
-    return !allowAndroidFallback;
   }
 }

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,7 +32,6 @@ void main() {
   late _MockMediaCacheManager cache;
 
   setUp(() {
-    InfiniteVideoFeed.debugTargetPlatformOverride = null;
     cache = _MockMediaCacheManager();
     // Stub all cache checks to return null — nothing is cached in tests.
     when(() => cache.getCachedFileSync(any())).thenReturn(null);
@@ -47,10 +45,6 @@ void main() {
     when(
       () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
     ).thenReturn(mockCancellable);
-  });
-
-  tearDown(() {
-    InfiniteVideoFeed.debugTargetPlatformOverride = null;
   });
 
   group(InfiniteVideoFeed, () {
@@ -273,7 +267,6 @@ void main() {
       testWidgets('shows loading while first frame is not rendered', (
         tester,
       ) async {
-        InfiniteVideoFeed.debugTargetPlatformOverride = TargetPlatform.iOS;
         DivineVideoPlayerController.resetIdCounterForTesting();
         const globalChannel = MethodChannel('divine_video_player');
         const playerChannel = MethodChannel('divine_video_player/player_0');
@@ -350,174 +343,6 @@ void main() {
           null,
         );
       });
-
-      testWidgets(
-        'uses the default platform when no test override is set',
-        (tester) async {
-          DivineVideoPlayerController.resetIdCounterForTesting();
-          const globalChannel = MethodChannel('divine_video_player');
-          const playerChannel = MethodChannel('divine_video_player/player_0');
-          const eventChannelName = 'divine_video_player/player_0/events';
-          const methodCodec = StandardMethodCodec();
-
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            globalChannel,
-            (call) async {
-              if (call.method == 'create') return <Object?, Object?>{};
-              return null;
-            },
-          );
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            playerChannel,
-            (_) async => null,
-          );
-          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
-            eventChannelName,
-            (message) async {
-              final call = methodCodec.decodeMethodCall(message);
-              if (call.method == 'listen') {
-                scheduleMicrotask(() async {
-                  await tester.binding.defaultBinaryMessenger
-                      .handlePlatformMessage(
-                        eventChannelName,
-                        methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
-                          'status': 'ready',
-                          'videoWidth': 1280,
-                          'videoHeight': 720,
-                          'isFirstFrameRendered': false,
-                        }),
-                        (_) {},
-                      );
-                });
-              }
-              return methodCodec.encodeSuccessEnvelope(null);
-            },
-          );
-
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                videos: [_makeVideo('default_platform_without_override')],
-                cache: cache,
-                prefetchCount: 0,
-                preloadGracePeriod: Duration.zero,
-                loadingBuilder: (_, _, {required isSquare}) =>
-                    const Text('loading'),
-                videoBuilder: (_, _, _) => const Text('video'),
-              ),
-            ),
-          );
-
-          await tester.pump();
-          await tester.pump();
-
-          expect(find.text('video'), findsOneWidget);
-          if (defaultTargetPlatform == TargetPlatform.android) {
-            expect(find.text('loading'), findsNothing);
-          } else {
-            expect(find.text('loading'), findsOneWidget);
-          }
-
-          await tester.pumpWidget(const SizedBox.shrink());
-          await tester.pumpAndSettle();
-
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            globalChannel,
-            null,
-          );
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            playerChannel,
-            null,
-          );
-          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
-            eventChannelName,
-            null,
-          );
-        },
-      );
-
-      testWidgets(
-        'hides loading on Android when ready without first-frame callback',
-        (tester) async {
-          InfiniteVideoFeed.debugTargetPlatformOverride =
-              TargetPlatform.android;
-          DivineVideoPlayerController.resetIdCounterForTesting();
-          const globalChannel = MethodChannel('divine_video_player');
-          const playerChannel = MethodChannel('divine_video_player/player_0');
-          const eventChannelName = 'divine_video_player/player_0/events';
-          const methodCodec = StandardMethodCodec();
-
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            globalChannel,
-            (call) async {
-              if (call.method == 'create') return <Object?, Object?>{};
-              return null;
-            },
-          );
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            playerChannel,
-            (_) async => null,
-          );
-          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
-            eventChannelName,
-            (message) async {
-              final call = methodCodec.decodeMethodCall(message);
-              if (call.method == 'listen') {
-                scheduleMicrotask(() async {
-                  await tester.binding.defaultBinaryMessenger
-                      .handlePlatformMessage(
-                        eventChannelName,
-                        methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
-                          'status': 'ready',
-                          'videoWidth': 1280,
-                          'videoHeight': 720,
-                          'isFirstFrameRendered': false,
-                        }),
-                        (_) {},
-                      );
-                });
-              }
-              return methodCodec.encodeSuccessEnvelope(null);
-            },
-          );
-
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                videos: [_makeVideo('android_ready_without_first_frame')],
-                cache: cache,
-                prefetchCount: 0,
-                preloadGracePeriod: Duration.zero,
-                loadingBuilder: (_, _, {required isSquare}) =>
-                    const Text('loading'),
-                videoBuilder: (_, _, _) => const Text('video'),
-              ),
-            ),
-          );
-
-          await tester.pump();
-          await tester.pump();
-
-          expect(find.text('loading'), findsNothing);
-          expect(find.text('video'), findsOneWidget);
-
-          await tester.pumpWidget(const SizedBox.shrink());
-          await tester.pumpAndSettle();
-
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            globalChannel,
-            null,
-          );
-          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            playerChannel,
-            null,
-          );
-          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
-            eventChannelName,
-            null,
-          );
-        },
-      );
 
       testWidgets('renders default VideoItemWidget when video size is ready', (
         tester,

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -25,23 +25,19 @@ VideoEvent _makeVideo(String id, {String? videoUrl}) => VideoEvent(
 
 Widget _wrapFeed(InfiniteVideoFeed feed) => Directionality(
   textDirection: TextDirection.ltr,
-  child: MediaQuery(
-    data: const MediaQueryData(),
-    child: feed,
-  ),
+  child: MediaQuery(data: const MediaQueryData(), child: feed),
 );
 
 void main() {
   late _MockMediaCacheManager cache;
 
   setUp(() {
+    InfiniteVideoFeed.debugTargetPlatformOverride = null;
     cache = _MockMediaCacheManager();
     // Stub all cache checks to return null — nothing is cached in tests.
     when(() => cache.getCachedFileSync(any())).thenReturn(null);
     // Stub eviction (used when cache file is corrupt on failover).
-    when(
-      () => cache.removeCachedFile(any()),
-    ).thenAnswer((_) async {});
+    when(() => cache.removeCachedFile(any())).thenAnswer((_) async {});
     // Stub cacheFileCancellable so DiskPrefetcher does not throw.
     final mockCancellable = _MockCancellable();
     when(() => mockCancellable.file).thenAnswer((_) async => null);
@@ -52,6 +48,10 @@ void main() {
     ).thenReturn(mockCancellable);
   });
 
+  tearDown(() {
+    InfiniteVideoFeed.debugTargetPlatformOverride = null;
+  });
+
   group(InfiniteVideoFeed, () {
     test('isSupported can be evaluated', () {
       expect(InfiniteVideoFeed.isSupported, isA<bool>());
@@ -60,9 +60,7 @@ void main() {
     group('empty video list', () {
       testWidgets('renders without error', (tester) async {
         await tester.pumpWidget(
-          _wrapFeed(
-            InfiniteVideoFeed(videos: const [], cache: cache),
-          ),
+          _wrapFeed(InfiniteVideoFeed(videos: const [], cache: cache)),
         );
 
         // PageView with 0 items renders an empty scrollable.
@@ -74,18 +72,11 @@ void main() {
 
         await tester.pumpWidget(
           _wrapFeed(
-            InfiniteVideoFeed(
-              key: key,
-              videos: const [],
-              cache: cache,
-            ),
+            InfiniteVideoFeed(key: key, videos: const [], cache: cache),
           ),
         );
 
-        expect(
-          () => key.currentState!.animateToPage(0),
-          returnsNormally,
-        );
+        expect(() => key.currentState!.animateToPage(0), returnsNormally);
       });
 
       testWidgets('pauseActive and resumeActive are no-ops for empty list', (
@@ -105,26 +96,25 @@ void main() {
     });
 
     group('with videos', () {
-      testWidgets(
-        'pagePositionListenable exposes initial page position',
-        (tester) async {
-          final key = GlobalKey<InfiniteVideoFeedState>();
+      testWidgets('pagePositionListenable exposes initial page position', (
+        tester,
+      ) async {
+        final key = GlobalKey<InfiniteVideoFeedState>();
 
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                key: key,
-                videos: List.generate(2, (i) => _makeVideo('p$i')),
-                cache: cache,
-                prefetchCount: 0,
-                preloadGracePeriod: Duration.zero,
-              ),
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              key: key,
+              videos: List.generate(2, (i) => _makeVideo('p$i')),
+              cache: cache,
+              prefetchCount: 0,
+              preloadGracePeriod: Duration.zero,
             ),
-          );
+          ),
+        );
 
-          expect(key.currentState!.pagePositionListenable.value, equals(0));
-        },
-      );
+        expect(key.currentState!.pagePositionListenable.value, equals(0));
+      });
 
       testWidgets('pagePositionListenable updates after page animation', (
         tester,
@@ -148,10 +138,7 @@ void main() {
         await tester.drag(find.byType(PageView), const Offset(0, -80));
         await tester.pump();
         expect(key.currentState!.currentIndex, equals(0));
-        expect(
-          key.currentState!.pagePositionListenable.value,
-          greaterThan(0),
-        );
+        expect(key.currentState!.pagePositionListenable.value, greaterThan(0));
       });
 
       testWidgets('renders PageView with correct item count', (tester) async {
@@ -285,6 +272,7 @@ void main() {
       testWidgets('shows loading while first frame is not rendered', (
         tester,
       ) async {
+        InfiniteVideoFeed.debugTargetPlatformOverride = TargetPlatform.iOS;
         DivineVideoPlayerController.resetIdCounterForTesting();
         const globalChannel = MethodChannel('divine_video_player');
         const playerChannel = MethodChannel('divine_video_player/player_0');
@@ -361,6 +349,89 @@ void main() {
           null,
         );
       });
+
+      testWidgets(
+        'hides loading on Android when ready without first-frame callback',
+        (tester) async {
+          InfiniteVideoFeed.debugTargetPlatformOverride =
+              TargetPlatform.android;
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          const globalChannel = MethodChannel('divine_video_player');
+          const playerChannel = MethodChannel('divine_video_player/player_0');
+          const eventChannelName = 'divine_video_player/player_0/events';
+          const methodCodec = StandardMethodCodec();
+
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            globalChannel,
+            (call) async {
+              if (call.method == 'create') return <Object?, Object?>{};
+              return null;
+            },
+          );
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            playerChannel,
+            (_) async => null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+            eventChannelName,
+            (message) async {
+              final call = methodCodec.decodeMethodCall(message);
+              if (call.method == 'listen') {
+                scheduleMicrotask(() async {
+                  await tester.binding.defaultBinaryMessenger
+                      .handlePlatformMessage(
+                        eventChannelName,
+                        methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
+                          'status': 'ready',
+                          'videoWidth': 1280,
+                          'videoHeight': 720,
+                          'isFirstFrameRendered': false,
+                        }),
+                        (_) {},
+                      );
+                });
+              }
+              return methodCodec.encodeSuccessEnvelope(null);
+            },
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('android_ready_without_first_frame')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                loadingBuilder: (_, _, {required isSquare}) =>
+                    const Text('loading'),
+                videoBuilder: (_, _, _) => const Text('video'),
+              ),
+            ),
+          );
+
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('loading'), findsNothing);
+          expect(find.text('video'), findsOneWidget);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pumpAndSettle();
+
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            globalChannel,
+            null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            playerChannel,
+            null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+            eventChannelName,
+            null,
+          );
+        },
+      );
 
       testWidgets('renders default VideoItemWidget when video size is ready', (
         tester,
@@ -443,9 +514,7 @@ void main() {
         final videos = List.generate(3, (i) => _makeVideo('v$i'));
 
         await tester.pumpWidget(
-          _wrapFeed(
-            InfiniteVideoFeed(key: key, videos: videos, cache: cache),
-          ),
+          _wrapFeed(InfiniteVideoFeed(key: key, videos: videos, cache: cache)),
         );
 
         expect(key.currentState!.currentIndex, equals(0));
@@ -564,101 +633,97 @@ void main() {
         expect(find.byType(InfiniteVideoFeed), findsOneWidget);
       });
 
-      testWidgets(
-        'same id but changed playback URL is treated as non-append '
-        '(controller is rebuilt)',
-        (tester) async {
-          final key = GlobalKey<InfiniteVideoFeedState>();
-          final videos1 = [
-            _makeVideo('a', videoUrl: 'https://example.com/a-v1.m3u8'),
-            _makeVideo('b'),
-          ];
+      testWidgets('same id but changed playback URL is treated as non-append '
+          '(controller is rebuilt)', (tester) async {
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos1 = [
+          _makeVideo('a', videoUrl: 'https://example.com/a-v1.m3u8'),
+          _makeVideo('b'),
+        ];
 
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                key: key,
-                videos: videos1,
-                cache: cache,
-                preloadGracePeriod: Duration.zero,
-                prefetchCount: 0,
-              ),
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              key: key,
+              videos: videos1,
+              cache: cache,
+              preloadGracePeriod: Duration.zero,
+              prefetchCount: 0,
             ),
-          );
-          await tester.pump(const Duration(milliseconds: 50));
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 50));
 
-          // Same ids, but the playback URL for index 0 changed.
-          final videos2 = [
-            _makeVideo('a', videoUrl: 'https://example.com/a-v2.m3u8'),
-            _makeVideo('b'),
-          ];
+        // Same ids, but the playback URL for index 0 changed.
+        final videos2 = [
+          _makeVideo('a', videoUrl: 'https://example.com/a-v2.m3u8'),
+          _makeVideo('b'),
+        ];
 
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                key: key,
-                videos: videos2,
-                cache: cache,
-                preloadGracePeriod: Duration.zero,
-                prefetchCount: 0,
-              ),
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              key: key,
+              videos: videos2,
+              cache: cache,
+              preloadGracePeriod: Duration.zero,
+              prefetchCount: 0,
             ),
-          );
-          // pump twice (not pumpAndSettle): the post-frame callback that
-          // jumps the PageController needs one frame; pumpAndSettle would
-          // hang waiting for the mocked controller.initialize() future.
-          await tester.pump();
-          await tester.pump();
+          ),
+        );
+        // pump twice (not pumpAndSettle): the post-frame callback that
+        // jumps the PageController needs one frame; pumpAndSettle would
+        // hang waiting for the mocked controller.initialize() future.
+        await tester.pump();
+        await tester.pump();
 
-          // The widget survives the URL swap. The teardown branch runs
-          // because the resolved source for index 0 differs even though
-          // the id matches; without the URL comparison the cached
-          // controller for 'a' would still be wired to the old URL.
-          expect(find.byType(InfiniteVideoFeed), findsOneWidget);
-          expect(key.currentState!.currentIndex, equals(0));
-        },
-      );
+        // The widget survives the URL swap. The teardown branch runs
+        // because the resolved source for index 0 differs even though
+        // the id matches; without the URL comparison the cached
+        // controller for 'a' would still be wired to the old URL.
+        expect(find.byType(InfiniteVideoFeed), findsOneWidget);
+        expect(key.currentState!.currentIndex, equals(0));
+      });
 
-      testWidgets(
-        'urlResolver change for same id is treated as non-append',
-        (tester) async {
-          final key = GlobalKey<InfiniteVideoFeedState>();
-          final videos = [_makeVideo('a'), _makeVideo('b')];
+      testWidgets('urlResolver change for same id is treated as non-append', (
+        tester,
+      ) async {
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('a'), _makeVideo('b')];
 
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                key: key,
-                videos: videos,
-                cache: cache,
-                urlResolver: (v) => 'https://cdn.example.com/v1/${v.id}.mp4',
-                preloadGracePeriod: Duration.zero,
-                prefetchCount: 0,
-              ),
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              key: key,
+              videos: videos,
+              cache: cache,
+              urlResolver: (v) => 'https://cdn.example.com/v1/${v.id}.mp4',
+              preloadGracePeriod: Duration.zero,
+              prefetchCount: 0,
             ),
-          );
-          await tester.pump(const Duration(milliseconds: 50));
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 50));
 
-          // Replace the videos list (new identity) AND swap the resolver
-          // so the same ids resolve to a different playback source.
-          await tester.pumpWidget(
-            _wrapFeed(
-              InfiniteVideoFeed(
-                key: key,
-                videos: List<VideoEvent>.from(videos),
-                cache: cache,
-                urlResolver: (v) => 'https://cdn.example.com/v2/${v.id}.mp4',
-                preloadGracePeriod: Duration.zero,
-                prefetchCount: 0,
-              ),
+        // Replace the videos list (new identity) AND swap the resolver
+        // so the same ids resolve to a different playback source.
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              key: key,
+              videos: List<VideoEvent>.from(videos),
+              cache: cache,
+              urlResolver: (v) => 'https://cdn.example.com/v2/${v.id}.mp4',
+              preloadGracePeriod: Duration.zero,
+              prefetchCount: 0,
             ),
-          );
-          await tester.pump();
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
 
-          expect(find.byType(InfiniteVideoFeed), findsOneWidget);
-        },
-      );
+        expect(find.byType(InfiniteVideoFeed), findsOneWidget);
+      });
 
       testWidgets(
         'non-append replacement jumps PageController to widget.initialIndex',
@@ -826,10 +891,7 @@ void main() {
 
         // animateToPage on a non-empty list should not throw even though
         // DivineVideoPlayerController cannot be initialized in tests.
-        expect(
-          () => key.currentState!.animateToPage(0),
-          returnsNormally,
-        );
+        expect(() => key.currentState!.animateToPage(0), returnsNormally);
 
         // Drain the animation.
         await tester.pumpAndSettle();

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -349,6 +350,91 @@ void main() {
           null,
         );
       });
+
+      testWidgets(
+        'uses the default platform when no test override is set',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          const globalChannel = MethodChannel('divine_video_player');
+          const playerChannel = MethodChannel('divine_video_player/player_0');
+          const eventChannelName = 'divine_video_player/player_0/events';
+          const methodCodec = StandardMethodCodec();
+
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            globalChannel,
+            (call) async {
+              if (call.method == 'create') return <Object?, Object?>{};
+              return null;
+            },
+          );
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            playerChannel,
+            (_) async => null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+            eventChannelName,
+            (message) async {
+              final call = methodCodec.decodeMethodCall(message);
+              if (call.method == 'listen') {
+                scheduleMicrotask(() async {
+                  await tester.binding.defaultBinaryMessenger
+                      .handlePlatformMessage(
+                        eventChannelName,
+                        methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
+                          'status': 'ready',
+                          'videoWidth': 1280,
+                          'videoHeight': 720,
+                          'isFirstFrameRendered': false,
+                        }),
+                        (_) {},
+                      );
+                });
+              }
+              return methodCodec.encodeSuccessEnvelope(null);
+            },
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('default_platform_without_override')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                loadingBuilder: (_, _, {required isSquare}) =>
+                    const Text('loading'),
+                videoBuilder: (_, _, _) => const Text('video'),
+              ),
+            ),
+          );
+
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('video'), findsOneWidget);
+          if (defaultTargetPlatform == TargetPlatform.android) {
+            expect(find.text('loading'), findsNothing);
+          } else {
+            expect(find.text('loading'), findsOneWidget);
+          }
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pumpAndSettle();
+
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            globalChannel,
+            null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            playerChannel,
+            null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+            eventChannelName,
+            null,
+          );
+        },
+      );
 
       testWidgets(
         'hides loading on Android when ready without first-frame callback',

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
@@ -140,21 +140,20 @@ class PooledVideoPlayer extends StatelessWidget {
                       onRetry: () => feedController.retryLoad(index),
                     )
               else ...[
-                /// Thumbnail / spinner shown until the first frame.
-                loadingBuilder?.call(context) ??
-                    _DefaultLoadingState(thumbnailUrl: thumbnailUrl),
-
-                /// Video texture, hidden when off-screen to avoid
-                /// media_kit texture bleeding during page transitions.
                 if (videoController != null && player != null)
-                  Opacity(
-                    opacity: isActive ? 1 : 0,
-                    child: _RevealVideoAfterFirstFrame(
-                      videoController: videoController,
-                      readyForFallback: loadState == LoadState.ready,
-                      child: videoBuilder(context, videoController, player),
-                    ),
-                  ),
+                  _FirstFrameVisibilityGate(
+                    isActive: isActive,
+                    videoController: videoController,
+                    readyForFallback: loadState == LoadState.ready,
+                    loading:
+                        loadingBuilder?.call(context) ??
+                        _DefaultLoadingState(thumbnailUrl: thumbnailUrl),
+                    child: videoBuilder(context, videoController, player),
+                  )
+                else
+                  /// Thumbnail / spinner shown until the player exists.
+                  loadingBuilder?.call(context) ??
+                      _DefaultLoadingState(thumbnailUrl: thumbnailUrl),
               ],
 
               /// Consumer-provided overlay (controls, progress bar, etc.).
@@ -167,24 +166,27 @@ class PooledVideoPlayer extends StatelessWidget {
   }
 }
 
-class _RevealVideoAfterFirstFrame extends StatefulWidget {
-  const _RevealVideoAfterFirstFrame({
+class _FirstFrameVisibilityGate extends StatefulWidget {
+  const _FirstFrameVisibilityGate({
+    required this.isActive,
     required this.videoController,
     required this.readyForFallback,
+    required this.loading,
     required this.child,
   });
 
+  final bool isActive;
   final VideoController videoController;
   final bool readyForFallback;
+  final Widget loading;
   final Widget child;
 
   @override
-  State<_RevealVideoAfterFirstFrame> createState() =>
-      _RevealVideoAfterFirstFrameState();
+  State<_FirstFrameVisibilityGate> createState() =>
+      _FirstFrameVisibilityGateState();
 }
 
-class _RevealVideoAfterFirstFrameState
-    extends State<_RevealVideoAfterFirstFrame> {
+class _FirstFrameVisibilityGateState extends State<_FirstFrameVisibilityGate> {
   bool _hasRenderedFirstFrame = false;
   bool _revealedByTimeout = false;
 
@@ -227,7 +229,7 @@ class _RevealVideoAfterFirstFrameState
   }
 
   @override
-  void didUpdateWidget(covariant _RevealVideoAfterFirstFrame oldWidget) {
+  void didUpdateWidget(covariant _FirstFrameVisibilityGate oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.videoController, widget.videoController)) {
       _stopListeningToTextureId(oldWidget.videoController);
@@ -384,12 +386,24 @@ class _RevealVideoAfterFirstFrameState
         widget.readyForFallback &&
         (_hasDecodedFrames || _revealedByTimeout) &&
         (_hasRenderedFirstFrame || _revealedByTimeout);
+    final shouldShowLoading = !widget.isActive || !shouldReveal;
 
-    return AnimatedOpacity(
-      duration: const Duration(milliseconds: 120),
-      curve: Curves.easeOut,
-      opacity: shouldReveal ? 1 : 0,
-      child: widget.child,
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        if (shouldShowLoading) widget.loading,
+        Opacity(
+          // Keep the texture alive off-screen for preloading, but hide it to
+          // avoid media_kit texture bleeding during page transitions.
+          opacity: widget.isActive ? 1 : 0,
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 120),
+            curve: Curves.easeOut,
+            opacity: shouldReveal ? 1 : 0,
+            child: widget.child,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -437,11 +451,7 @@ class _DefaultErrorState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(
-              Icons.error_outline,
-              color: Color(0xB3FFFFFF),
-              size: 48,
-            ),
+            const Icon(Icons.error_outline, color: Color(0xB3FFFFFF), size: 48),
             const SizedBox(height: 16),
             const Text(
               'Failed to load video',

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
@@ -40,9 +40,7 @@ _MockPlayer _createMockPlayer(StreamController<Duration> positionCtrl) {
   when(() => mockPlayer.stream).thenReturn(mockStream);
   // Stub position stream so _subscribeToPosition can emit decoded-frame
   // events that drive the _hasDecodedFrames flag in PooledVideoPlayer.
-  when(() => mockStream.position).thenAnswer(
-    (_) => positionCtrl.stream,
-  );
+  when(() => mockStream.position).thenAnswer((_) => positionCtrl.stream);
 
   return mockPlayer;
 }
@@ -421,6 +419,57 @@ void main() {
         },
       );
 
+      testWidgets('removes loadingBuilder after first frame on active page', (
+        tester,
+      ) async {
+        final firstFrameCompleter = Completer<void>();
+        when(
+          () => mockVideoController.waitUntilFirstFrameRendered,
+        ).thenAnswer((_) => firstFrameCompleter.future);
+
+        await tester.pumpWidget(
+          buildWidget(
+            loadingBuilder: (context) =>
+                const SizedBox(key: Key('custom_loading')),
+          ),
+        );
+
+        expect(find.byKey(const Key('custom_loading')), findsOneWidget);
+
+        firstFrameCompleter.complete();
+        await tester.pump();
+        positionController.add(const Duration(milliseconds: 100));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
+
+        expect(find.byKey(const Key('custom_loading')), findsNothing);
+      });
+
+      testWidgets('keeps loadingBuilder for off-screen ready page', (
+        tester,
+      ) async {
+        final firstFrameCompleter = Completer<void>();
+        when(
+          () => mockVideoController.waitUntilFirstFrameRendered,
+        ).thenAnswer((_) => firstFrameCompleter.future);
+
+        await tester.pumpWidget(
+          buildWidget(
+            isActive: false,
+            loadingBuilder: (context) =>
+                const SizedBox(key: Key('custom_loading')),
+          ),
+        );
+
+        firstFrameCompleter.complete();
+        await tester.pump();
+        positionController.add(const Duration(milliseconds: 100));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
+
+        expect(find.byKey(const Key('custom_loading')), findsOneWidget);
+      });
+
       testWidgets('keeps video transparent until first frame renders', (
         tester,
       ) async {
@@ -673,36 +722,30 @@ void main() {
         verifyNever(() => mockController.togglePlayPause());
       });
 
-      testWidgets(
-        'gesture detector added when onDoubleTap provided',
-        (tester) async {
-          await tester.pumpWidget(buildWidget(onDoubleTap: (_) {}));
-
-          expect(find.byType(GestureDetector), findsOneWidget);
-        },
-      );
-
-      testWidgets(
-        'no gesture detector when only onDoubleTap with no '
-        'videoController',
-        (tester) async {
-          // Default state has no videoController (loading)
-          indexNotifiers[0] = ValueNotifier(const VideoIndexState());
-          await tester.pumpWidget(buildWidget(onDoubleTap: (_) {}));
-
-          // GestureDetector always exists; onDoubleTapDown is null when
-          // there is no videoController (isReady = false).
-          expect(find.byType(GestureDetector), findsOneWidget);
-          final gesture = tester.widget<GestureDetector>(
-            find.byType(GestureDetector),
-          );
-          expect(gesture.onDoubleTapDown, isNull);
-        },
-      );
-
-      testWidgets('double tap calls onDoubleTap when provided', (
+      testWidgets('gesture detector added when onDoubleTap provided', (
         tester,
       ) async {
+        await tester.pumpWidget(buildWidget(onDoubleTap: (_) {}));
+
+        expect(find.byType(GestureDetector), findsOneWidget);
+      });
+
+      testWidgets('no gesture detector when only onDoubleTap with no '
+          'videoController', (tester) async {
+        // Default state has no videoController (loading)
+        indexNotifiers[0] = ValueNotifier(const VideoIndexState());
+        await tester.pumpWidget(buildWidget(onDoubleTap: (_) {}));
+
+        // GestureDetector always exists; onDoubleTapDown is null when
+        // there is no videoController (isReady = false).
+        expect(find.byType(GestureDetector), findsOneWidget);
+        final gesture = tester.widget<GestureDetector>(
+          find.byType(GestureDetector),
+        );
+        expect(gesture.onDoubleTapDown, isNull);
+      });
+
+      testWidgets('double tap calls onDoubleTap when provided', (tester) async {
         TapDownDetails? receivedDetails;
 
         await tester.pumpWidget(
@@ -718,32 +761,31 @@ void main() {
         expect(receivedDetails, isNotNull);
       });
 
-      testWidgets(
-        'onDoubleTap and onTap coexist on same gesture detector',
-        (tester) async {
-          var tapped = false;
-          TapDownDetails? receivedDetails;
+      testWidgets('onDoubleTap and onTap coexist on same gesture detector', (
+        tester,
+      ) async {
+        var tapped = false;
+        TapDownDetails? receivedDetails;
 
-          await tester.pumpWidget(
-            buildWidget(
-              onTap: () => tapped = true,
-              onDoubleTap: (details) => receivedDetails = details,
-            ),
-          );
+        await tester.pumpWidget(
+          buildWidget(
+            onTap: () => tapped = true,
+            onDoubleTap: (details) => receivedDetails = details,
+          ),
+        );
 
-          expect(find.byType(GestureDetector), findsOneWidget);
+        expect(find.byType(GestureDetector), findsOneWidget);
 
-          // Double tap should fire onDoubleTap, not onTap
-          final gesture = find.byType(GestureDetector);
-          await tester.tap(gesture);
-          await tester.pump(const Duration(milliseconds: 50));
-          await tester.tap(gesture);
-          await tester.pump(const Duration(milliseconds: 350));
+        // Double tap should fire onDoubleTap, not onTap
+        final gesture = find.byType(GestureDetector);
+        await tester.tap(gesture);
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(gesture);
+        await tester.pump(const Duration(milliseconds: 350));
 
-          expect(receivedDetails, isNotNull);
-          expect(tapped, isFalse);
-        },
-      );
+        expect(receivedDetails, isNotNull);
+        expect(tapped, isFalse);
+      });
     });
 
     group('ValueListenableBuilder', () {
@@ -1046,18 +1088,14 @@ void main() {
           const Rect.fromLTWH(0, 0, 1920, 1080),
         );
         final secondCompleter = Completer<void>();
-        when(
-          () => newMockVideoController.id,
-        ).thenReturn(newTextureIdNotifier);
+        when(() => newMockVideoController.id).thenReturn(newTextureIdNotifier);
         when(
           () => newMockVideoController.rect,
         ).thenReturn(newTextureRectNotifier);
         when(
           () => newMockVideoController.waitUntilFirstFrameRendered,
         ).thenAnswer((_) => secondCompleter.future);
-        when(
-          () => newMockVideoController.player,
-        ).thenReturn(mockPlayer);
+        when(() => newMockVideoController.player).thenReturn(mockPlayer);
 
         // Swap to new controller — should reset reveal state
         indexNotifiers[0]!.value = VideoIndexState(
@@ -1216,42 +1254,41 @@ void main() {
         },
       );
 
-      testWidgets(
-        'reveals video when waitUntilFirstFrameRendered fails',
-        (tester) async {
-          when(
-            () => mockVideoController.waitUntilFirstFrameRendered,
-          ).thenAnswer((_) => Future<void>.error(Exception('surface lost')));
+      testWidgets('reveals video when waitUntilFirstFrameRendered fails', (
+        tester,
+      ) async {
+        when(
+          () => mockVideoController.waitUntilFirstFrameRendered,
+        ).thenAnswer((_) => Future<void>.error(Exception('surface lost')));
 
-          indexNotifiers[0] = ValueNotifier(
-            VideoIndexState(
-              loadState: LoadState.ready,
-              videoController: mockVideoController,
-              player: mockPlayer,
-            ),
-          );
+        indexNotifiers[0] = ValueNotifier(
+          VideoIndexState(
+            loadState: LoadState.ready,
+            videoController: mockVideoController,
+            player: mockPlayer,
+          ),
+        );
 
-          await tester.pumpWidget(buildWidget());
-          await tester.pump();
-          // catchError in _subscribeToFirstFrame sets
-          // _hasRenderedFirstFrame=true and cancels the timer, so we need a
-          // position event to satisfy _hasDecodedFrames for shouldReveal to
-          //be true.
-          positionController.add(const Duration(milliseconds: 100));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 120));
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+        // catchError in _subscribeToFirstFrame sets
+        // _hasRenderedFirstFrame=true and cancels the timer, so we need a
+        // position event to satisfy _hasDecodedFrames for shouldReveal to
+        //be true.
+        positionController.add(const Duration(milliseconds: 100));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
 
-          final opacityFinder = find.ancestor(
-            of: find.byKey(const Key('video_widget')),
-            matching: find.byType(AnimatedOpacity),
-          );
+        final opacityFinder = find.ancestor(
+          of: find.byKey(const Key('video_widget')),
+          matching: find.byType(AnimatedOpacity),
+        );
 
-          expect(
-            tester.widget<AnimatedOpacity>(opacityFinder).opacity,
-            equals(1),
-          );
-        },
-      );
+        expect(
+          tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+          equals(1),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- add an Android-only feed fallback that drops the loading thumbnail once the player is ready or playing with known dimensions, even if the first-frame callback never arrives
- keep the change scoped to InfiniteVideoFeed so editor, preview, and other non-feed player flows are unchanged
- add a regression test for the Android fallback path while preserving the existing non-Android first-frame loading behavior

Closes #4301

## Verification
- flutter test test/src/widgets/infinite_video_feed_test.dart
- flutter analyze