### PR TITLE
fix(feed): reset interaction counts on video reuse

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -46,6 +46,7 @@ import 'package:openvine/widgets/video_feed_item/paused_video_play_overlay.dart'
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_author_info_section.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
 import 'package:openvine/widgets/video_feed_item/video_player_subtitle_layer.dart';
 import 'package:openvine/widgets/web_video_auth_header_provider.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
@@ -986,12 +987,9 @@ class _PooledFullscreenItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // ref.watch + record key: see video_feed_page.dart for rationale.
-    // Without this, a fullscreen entry that mounts during the auth-flip
-    // window (warm-up materialized providers pre-auth, then provider
-    // graph rebuilds) snapshots a stale LikesRepository whose underlying
-    // Nostr instance has an empty cached pubkey — every sendLike then
-    // throws StateError. See #3503.
+    // ref.watch + record key: repository identity swaps and feed-cell reuse
+    // must both recreate the per-video bloc so counts never leak between
+    // videos. See #3503.
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
@@ -1002,7 +1000,13 @@ class _PooledFullscreenItem extends ConsumerWidget {
     final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
+      key: videoInteractionsBlocKey(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        video: video,
+        includeVideoReplies: showVideoReplies,
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -1054,13 +1058,19 @@ class _WebFullscreenItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // See _PooledFullscreenItem.build for the rationale on watch + key. #3503.
+    // See _PooledFullscreenItem.build for the watch + key rationale. #3503.
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
+    final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
+      key: videoInteractionsBlocKey(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        video: video,
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -1068,7 +1078,7 @@ class _WebFullscreenItem extends ConsumerWidget {
               likesRepository: likesRepository,
               commentsRepository: commentsRepository,
               repostsRepository: repostsRepository,
-              addressableId: video.addressableId,
+              addressableId: addressableId,
               initialLikeCount: video.nostrLikeCount != null
                   ? video.totalLikes
                   : null,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -39,6 +39,7 @@ import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
 import 'package:openvine/widgets/web_video_auth_header_provider.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:openvine/widgets/web_video_player.dart';
@@ -954,12 +955,9 @@ class _PooledVideoFeedItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // ref.watch + record key: when any of these provider instances is
-    // rebuilt (auth flip / sign-out / account switch) the BlocProvider's
-    // key changes, the stale bloc is closed, and the new one's create:
-    // captures the fresh repository chain. Records compare structurally
-    // (per-field ==), and these classes don't override == — so equality
-    // falls through to identity, which is what we want. See #3503.
+    // ref.watch + record key: repository identity swaps and feed-cell reuse
+    // must both recreate the per-video bloc so counts never leak between
+    // videos. See #3503.
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
@@ -971,7 +969,13 @@ class _PooledVideoFeedItem extends ConsumerWidget {
     final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
+      key: videoInteractionsBlocKey(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        video: video,
+        includeVideoReplies: showVideoReplies,
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -1023,13 +1027,19 @@ class _WebVideoFeedItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // See _PooledVideoFeedItem.build for the rationale on watch + key. #3503.
+    // See _PooledVideoFeedItem.build for the watch + key rationale. #3503.
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
+    final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
+      key: videoInteractionsBlocKey(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        video: video,
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -1037,7 +1047,7 @@ class _WebVideoFeedItem extends ConsumerWidget {
               likesRepository: likesRepository,
               commentsRepository: commentsRepository,
               repostsRepository: repostsRepository,
-              addressableId: video.addressableId,
+              addressableId: addressableId,
               initialLikeCount: video.nostrLikeCount != null
                   ? video.totalLikes
                   : null,

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -32,6 +32,7 @@ import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
 
 class FeedVideos extends ConsumerStatefulWidget {
@@ -434,10 +435,11 @@ class __OverlayState extends ConsumerState<_Overlay> {
     final video = widget.video;
     final pagePositionListenable = _pagePositionListenable;
 
-    // See _PooledFullscreenItem.build for the rationale on watch + key. #3503.
+    // See _PooledFullscreenItem.build for the watch + key rationale. #3503.
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
+    final addressableId = video.addressableId;
 
     final authService = ref.watch(authServiceProvider);
     final currentUserPubkey = authService.currentPublicKeyHex;
@@ -514,11 +516,12 @@ class __OverlayState extends ConsumerState<_Overlay> {
           isAutoAdvanceActive: effectiveAutoActive,
           onSkipBrokenVideo: _skipToNextVideo,
           child: BlocProvider<VideoInteractionsBloc>(
-            key: ValueKey((
-              likesRepository,
-              commentsRepository,
-              repostsRepository,
-            )),
+            key: videoInteractionsBlocKey(
+              likesRepository: likesRepository,
+              commentsRepository: commentsRepository,
+              repostsRepository: repostsRepository,
+              video: video,
+            ),
             create: (_) =>
                 VideoInteractionsBloc(
                     eventId: video.id,
@@ -526,7 +529,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
                     likesRepository: likesRepository,
                     commentsRepository: commentsRepository,
                     repostsRepository: repostsRepository,
-                    addressableId: video.addressableId,
+                    addressableId: addressableId,
                     initialLikeCount: video.nostrLikeCount != null
                         ? video.totalLikes
                         : null,

--- a/mobile/lib/widgets/video_feed_item/video_interactions_bloc_key.dart
+++ b/mobile/lib/widgets/video_feed_item/video_interactions_bloc_key.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+import 'package:models/models.dart';
+
+/// Key for the per-video interaction bloc host.
+ValueKey<Object> videoInteractionsBlocKey({
+  required Object likesRepository,
+  required Object commentsRepository,
+  required Object repostsRepository,
+  required VideoEvent video,
+  bool includeVideoReplies = false,
+}) {
+  return ValueKey((
+    likesRepository,
+    commentsRepository,
+    repostsRepository,
+    video.stableId,
+    video.addressableId,
+    includeVideoReplies,
+  ));
+}

--- a/mobile/test/widgets/video_feed_item/video_interactions_bloc_key_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_interactions_bloc_key_test.dart
@@ -1,0 +1,162 @@
+import 'package:comments_repository/comments_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/actions/like_action_button.dart';
+import 'package:openvine/widgets/video_feed_item/actions/repost_action_button.dart';
+import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
+import 'package:reposts_repository/reposts_repository.dart';
+
+class _MockLikesRepository extends Mock implements LikesRepository {}
+
+class _MockCommentsRepository extends Mock implements CommentsRepository {}
+
+class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+void main() {
+  group(videoInteractionsBlocKey, () {
+    late _MockLikesRepository likesRepository;
+    late _MockCommentsRepository commentsRepository;
+    late _MockRepostsRepository repostsRepository;
+
+    setUp(() {
+      likesRepository = _MockLikesRepository();
+      commentsRepository = _MockCommentsRepository();
+      repostsRepository = _MockRepostsRepository();
+    });
+
+    test('changes when the hosted video changes', () {
+      final firstKey = videoInteractionsBlocKey(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        video: _video(id: 'video-a'),
+      );
+      final secondKey = videoInteractionsBlocKey(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        video: _video(id: 'video-b'),
+      );
+
+      expect(firstKey, isNot(equals(secondKey)));
+    });
+
+    testWidgets('does not keep fetched counts after feed cell reuse', (
+      tester,
+    ) async {
+      when(() => likesRepository.isLiked(any())).thenAnswer((_) async => false);
+      when(
+        () => likesRepository.getLikeCount(
+          any(),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((invocation) async {
+        final eventId = invocation.positionalArguments.single as String;
+        return eventId == 'video-a' ? 100 : 0;
+      });
+      when(
+        () => commentsRepository.getCommentsCount(
+          any(),
+          rootAddressableId: any(named: 'rootAddressableId'),
+          includeVideoReplies: any(named: 'includeVideoReplies'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => repostsRepository.getRepostCountByEventId(any()),
+      ).thenAnswer((invocation) async {
+        final eventId = invocation.positionalArguments.single as String;
+        return eventId == 'video-a' ? 40 : 0;
+      });
+
+      await tester.pumpWidget(
+        _InteractionHost(
+          likesRepository: likesRepository,
+          commentsRepository: commentsRepository,
+          repostsRepository: repostsRepository,
+          video: _video(id: 'video-a'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('100'), findsOneWidget);
+      expect(find.text('40'), findsOneWidget);
+
+      await tester.pumpWidget(
+        _InteractionHost(
+          likesRepository: likesRepository,
+          commentsRepository: commentsRepository,
+          repostsRepository: repostsRepository,
+          video: _video(id: 'video-b'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text('100'), findsNothing);
+      expect(find.text('40'), findsNothing);
+      expect(find.text(l10n.videoActionLikeLabel), findsOneWidget);
+      expect(find.text(l10n.videoActionRepostLabel), findsOneWidget);
+    });
+  });
+}
+
+class _InteractionHost extends StatelessWidget {
+  const _InteractionHost({
+    required this.likesRepository,
+    required this.commentsRepository,
+    required this.repostsRepository,
+    required this.video,
+  });
+
+  final LikesRepository likesRepository;
+  final CommentsRepository commentsRepository;
+  final RepostsRepository repostsRepository;
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: BlocProvider<VideoInteractionsBloc>(
+          key: videoInteractionsBlocKey(
+            likesRepository: likesRepository,
+            commentsRepository: commentsRepository,
+            repostsRepository: repostsRepository,
+            video: video,
+          ),
+          create: (_) => VideoInteractionsBloc(
+            eventId: video.id,
+            authorPubkey: video.pubkey,
+            likesRepository: likesRepository,
+            commentsRepository: commentsRepository,
+            repostsRepository: repostsRepository,
+          )..add(const VideoInteractionsFetchRequested()),
+          child: Column(
+            children: [
+              LikeActionButton(video: video),
+              RepostActionButton(video: video),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+VideoEvent _video({required String id}) {
+  return VideoEvent(
+    id: id,
+    pubkey: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    createdAt: 1757385263,
+    content: 'Test video',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+  );
+}


### PR DESCRIPTION
Closes #4306

## Summary
- Include video identity in `VideoInteractionsBloc` host keys across feed surfaces so recycled cells recreate per-video state.
- Add a regression widget test that rebuilds the same host from a `100`/`40` video to a zero-count video and verifies stale counts disappear.

## Test plan
- [x] `dart format mobile/lib/screens/feed/video_feed_page.dart mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart mobile/lib/widgets/video_feed_item/feed_videos.dart mobile/lib/widgets/video_feed_item/video_interactions_bloc_key.dart mobile/test/widgets/video_feed_item/video_interactions_bloc_key_test.dart`
- [x] `flutter test test/widgets/video_feed_item/video_interactions_bloc_key_test.dart`
- [x] `flutter analyze lib/screens/feed/video_feed_page.dart lib/screens/feed/pooled_fullscreen_video_feed_screen.dart lib/widgets/video_feed_item/feed_videos.dart lib/widgets/video_feed_item/video_interactions_bloc_key.dart test/widgets/video_feed_item/video_interactions_bloc_key_test.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)