### PR TITLE
fix(feed): route For You through recommendations

### DIFF
--- a/mobile/lib/blocs/video_feed/home_feed_cache.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_cache.dart
@@ -17,10 +17,10 @@ const homeFeedCacheTimeKey = 'home_feed_cache_time';
 /// Maximum age of cached home feed before it's considered stale.
 const homeFeedCacheMaxAge = Duration(hours: 1);
 
-/// Reads and writes cached home feed data from SharedPreferences.
+/// Reads and writes cached Home tab feed data from SharedPreferences.
 ///
-/// The cache stores the raw JSON response from the Funnelcake API
-/// so it can be parsed into [HomeFeedResult] on next cold start
+/// The cache stores the latest raw JSON response for a cacheable Home tab
+/// mode so it can be parsed into [HomeFeedResult] on next cold start
 /// without any network request.
 ///
 /// Cache entries older than [homeFeedCacheMaxAge] are ignored.

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -94,6 +94,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// [_onAutoRefreshRequested] to skip refreshes when data is fresh.
   DateTime? _lastRefreshedAt;
 
+  bool _usesHomeFeedCache(FeedMode mode) =>
+      mode == FeedMode.forYou || mode == FeedMode.following;
+
   /// Handle feed started event.
   ///
   /// Fires [_loadVideos] immediately without waiting for the follow list to
@@ -430,7 +433,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
     // Serve cached home feed on first load for instant startup.
     if (_serveCachedHomeFeed &&
         !_cacheServed &&
-        mode == FeedMode.following &&
+        _usesHomeFeedCache(mode) &&
         _sharedPreferences != null) {
       _cacheServed = true;
       final cached = _homeFeedCache.read(_sharedPreferences);
@@ -487,7 +490,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
       await _fetchCreatorProfiles(validVideos, emit);
 
       // Cache the raw response for next cold start (fire-and-forget).
-      if (mode == FeedMode.following &&
+      if (_usesHomeFeedCache(mode) &&
           _sharedPreferences != null &&
           result.rawResponseBody != null) {
         unawaited(

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1916,7 +1916,11 @@ class FunnelcakeApiClient {
 
         final source = raw['source'] as String? ?? 'unknown';
 
-        return RecommendationsResponse(videos: videos, source: source);
+        return RecommendationsResponse(
+          videos: videos,
+          source: source,
+          rawBody: response.body,
+        );
       } else if (response.statusCode == 404) {
         throw FunnelcakeNotFoundException(
           resource: 'Recommendations',

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -692,10 +692,10 @@ class FunnelcakeApiClient {
       throw const FunnelcakeException('Pubkey cannot be empty');
     }
 
-    final queryParams = _videoQueryParameters({
+    final queryParams = <String, String>{
       'limit': limit.toString(),
       'sort': sort,
-    });
+    };
     if (before != null) {
       queryParams['before'] = before.toString();
     }

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -867,11 +867,13 @@ void main() {
         expect(uri.path, equals('/api/users/$testPubkey/feed'));
         expect(uri.queryParameters['limit'], equals('50'));
         expect(uri.queryParameters['sort'], equals('recent'));
-        expect(uri.queryParameters['nsfw'], equals('show'));
+        expect(uri.queryParameters.containsKey('nsfw'), isFalse);
         expect(
-          uri.queryParameters['moderation_profile'],
-          equals(FunnelcakeApiClient.defaultModerationProfile),
+          uri.queryParameters.containsKey('moderation_profile'),
+          isFalse,
         );
+        expect(uri.queryParameters.containsKey('content_safety'), isFalse);
+        expect(uri.queryParameters.containsKey('exclude_label'), isFalse);
         expect(uri.queryParameters.containsKey('before'), isFalse);
       });
 

--- a/mobile/packages/models/lib/src/recommendations_response.dart
+++ b/mobile/packages/models/lib/src/recommendations_response.dart
@@ -8,7 +8,11 @@ import 'package:models/src/video_stats.dart';
 @immutable
 class RecommendationsResponse {
   /// Creates a new [RecommendationsResponse].
-  const RecommendationsResponse({required this.videos, required this.source});
+  const RecommendationsResponse({
+    required this.videos,
+    required this.source,
+    this.rawBody,
+  });
 
   /// The recommended videos.
   final List<VideoStats> videos;
@@ -18,6 +22,9 @@ class RecommendationsResponse {
   /// Possible values: `"personalized"`, `"popular"`, `"recent"`,
   /// or `"error"`.
   final String source;
+
+  /// The raw JSON response body from the API, if available.
+  final String? rawBody;
 
   /// Whether recommendations are personalized (vs fallback).
   bool get isPersonalized => source == 'personalized';

--- a/mobile/packages/models/test/src/recommendations_response_test.dart
+++ b/mobile/packages/models/test/src/recommendations_response_test.dart
@@ -9,6 +9,17 @@ void main() {
 
         expect(response.videos, isEmpty);
         expect(response.source, equals('popular'));
+        expect(response.rawBody, isNull);
+      });
+
+      test('creates instance with raw body', () {
+        const response = RecommendationsResponse(
+          videos: [],
+          source: 'personalized',
+          rawBody: '{"videos":[]}',
+        );
+
+        expect(response.rawBody, equals('{"videos":[]}'));
       });
     });
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1949,7 +1949,10 @@ class VideosRepository {
       );
     }
 
-    return HomeFeedResult(videos: videos);
+    return HomeFeedResult(
+      videos: videos,
+      rawResponseBody: response.rawBody,
+    );
   }
 
   /// Fetches personalized video recommendations.

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -8749,6 +8749,7 @@ void main() {
           (_) async => RecommendationsResponse(
             videos: [recommended],
             source: 'personalized',
+            rawBody: '{"videos":[{"id":"recommended-video"}]}',
           ),
         );
 
@@ -8766,6 +8767,10 @@ void main() {
         expect(result.videos.single.id, equals('recommended-video'));
         expect(result.videoListSources, isEmpty);
         expect(result.listOnlyVideoIds, isEmpty);
+        expect(
+          result.rawResponseBody,
+          equals('{"videos":[{"id":"recommended-video"}]}'),
+        );
         verify(
           () => mockFunnelcakeClient.getRecommendations(
             pubkey: 'user-pubkey',
@@ -8833,8 +8838,10 @@ void main() {
               category: any(named: 'category'),
             ),
           ).thenAnswer(
-            (_) async =>
-                const RecommendationsResponse(videos: [], source: 'popular'),
+            (_) async => const RecommendationsResponse(
+              videos: [],
+              source: 'popular',
+            ),
           );
           when(
             () => mockFunnelcakeClient.getWatchingVideos(

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -11,10 +11,33 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockAudioExtractionService extends Mock
     implements AudioExtractionService {}
+
+class _MockPathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => '/documents';
+}
+
+class _MockSplitProVideoEditor extends ProVideoEditor {
+  @override
+  Stream<dynamic> initializeStream() => const Stream.empty();
+
+  @override
+  Future<String> renderVideoToFile(
+    String outputPath,
+    VideoRenderData renderData, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    return outputPath;
+  }
+}
 
 DivineVideoClip _createClip({
   String id = 'clip-1',
@@ -94,8 +117,14 @@ void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
     late List<DivineVideoClip> threeClips;
+    late PathProviderPlatform originalPathProviderInstance;
+    late ProVideoEditor originalProVideoEditor;
 
     setUp(() {
+      originalPathProviderInstance = PathProviderPlatform.instance;
+      originalProVideoEditor = ProVideoEditor.instance;
+      PathProviderPlatform.instance = _MockPathProviderPlatform();
+      ProVideoEditor.instance = _MockSplitProVideoEditor();
       twoClips = [
         _createClip(id: 'a', duration: const Duration(seconds: 2)),
         _createClip(id: 'b'),
@@ -105,6 +134,11 @@ void main() {
         _createClip(id: 'b', duration: const Duration(seconds: 1)),
         _createClip(id: 'c'),
       ];
+    });
+
+    tearDown(() {
+      PathProviderPlatform.instance = originalPathProviderInstance;
+      ProVideoEditor.instance = originalProVideoEditor;
     });
 
     ClipEditorBloc buildBloc({

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1991,6 +1991,39 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedState>(
+        'writes forYou raw response body to Home tab cache after fresh fetch',
+        setUp: () {
+          final videos = createTestVideos(3);
+          when(() => mockCache.read(sharedPreferences)).thenReturn(null);
+          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+          when(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: videos,
+              rawResponseBody: '{"videos":[{"id":"for-you"}]}',
+            ),
+          );
+        },
+        build: createBlocWithCache,
+        act: (bloc) => bloc.add(const VideoFeedStarted()),
+        verify: (_) {
+          verify(
+            () => mockCache.write(
+              sharedPreferences,
+              '{"videos":[{"id":"for-you"}]}',
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
         'does not write cache when rawResponseBody is null',
         setUp: () {
           final videos = createTestVideos(3);
@@ -2042,7 +2075,7 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedState>(
-        'does not serve following cache for forYou mode',
+        'serves cached Home tab data before fresh forYou recommendations',
         setUp: () {
           final cachedVideos = createTestVideos(2, idPrefix: 'cached');
           final recommendedVideos = createTestVideos(
@@ -2053,6 +2086,7 @@ void main() {
           when(
             () => mockCache.read(sharedPreferences),
           ).thenReturn(HomeFeedResult(videos: cachedVideos));
+          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
           when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
           when(
             () => mockVideosRepository.getRecommendedVideos(
@@ -2071,6 +2105,10 @@ void main() {
           const VideoFeedState(),
           isA<VideoFeedState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'cached count', 2)
+              .having((s) => s.videos.first.id, 'first cached id', 'cached-0'),
+          isA<VideoFeedState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'recommended count', 3)
               .having(
                 (s) => s.videos.first.id,
@@ -2079,7 +2117,7 @@ void main() {
               ),
         ],
         verify: (_) {
-          verifyNever(() => mockCache.read(any()));
+          verify(() => mockCache.read(sharedPreferences)).called(1);
         },
       );
 

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -383,7 +383,10 @@ void main() {
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
           const VideoFeedState(),
-          const VideoFeedState(status: VideoFeedStatus.success, hasMore: false),
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+            hasMore: false,
+          ),
         ],
       );
 
@@ -2058,7 +2061,9 @@ void main() {
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: recommendedVideos));
+          ).thenAnswer(
+            (_) async => HomeFeedResult(videos: recommendedVideos),
+          );
         },
         build: createBlocWithCache,
         act: (bloc) => bloc.add(const VideoFeedStarted()),


### PR DESCRIPTION
Closes #4310

## Summary
- Route the home For You feed through Funnelcake recommendations and keep popular videos as the fallback/pagination path.
- Preserve recommendation raw responses and consume them through the Home tab cache for cold-start For You/Following loads.
- Stop `/api/users/{pubkey}/feed` requests from sending unsupported moderation/safety query params.
- Isolate clip-editor split tests from global `path_provider` / `pro_video_editor` plugin state so the release test bundle stays stable.

## Test plan
- [x] Dart MCP `run_tests` for `test/blocs/video_feed/video_feed_bloc_test.dart`, `test/blocs/video_feed/home_feed_cache_test.dart`, `packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart`, `packages/models/test/src/recommendations_response_test.dart`, `packages/videos_repository/test/src/videos_repository_test.dart`, and `test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart` — `+727: All tests passed!`
- [x] Dart MCP `analyze_files` on changed files — `No errors`
- [x] Pre-push hook: merge-conflict check, analyzer, and changed-file tests passed before force-with-lease update

🤖 Generated with [Claude Code](https://claude.com/claude-code)