### PR TITLE
fix(notifications): navigate to video+comments on reply notification tap

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io'
     if (dart.library.html) 'package:openvine/utils/platform_io_web.dart'
     as io;
@@ -76,6 +77,7 @@ import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
+import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/seed_data_preload_service.dart';
@@ -135,7 +137,11 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     title,
     body,
     details,
-    payload: data['referencedEventId'] as String?,
+    payload: jsonEncode({
+      'referencedEventId': data['referencedEventId'],
+      // FCM payload uses 'type', not 'notificationType'
+      'notificationType': data['type'],
+    }),
   );
 }
 
@@ -181,6 +187,63 @@ Future<void> _runTimedStartupTask({
   } finally {
     StartupPerformanceService.instance.completePhase(phaseName);
   }
+}
+
+/// Resolves [referencedEventId] from a push notification payload to a video
+/// event ID, then pushes a [DeepLink] into [deepLinkService].
+///
+/// For `notificationType == "reply"` (and other comment-type notifications),
+/// [referencedEventId] is the ID of a Kind 1111 comment event, not a video.
+/// [NotificationTargetResolver] fetches that event from the relay, walks its
+/// NIP-22 `E` / NIP-10 `e` tags, and returns the root video event ID.
+///
+/// For video-type events the resolver returns the same ID unchanged.
+Future<void> _resolveAndPushNotificationDeepLink({
+  required String referencedEventId,
+  required String? notificationType,
+  required ProviderContainer container,
+}) async {
+  final deepLinkService = container.read(deepLinkServiceProvider);
+  final autoOpenComments = notificationType == 'reply';
+
+  String? videoEventId;
+  try {
+    videoEventId = await NotificationTargetResolver(
+      videoEventService: container.read(videoEventServiceProvider),
+      nostrService: container.read(nostrServiceProvider),
+    ).resolveVideoEventIdFromNotificationTarget(referencedEventId);
+  } catch (e) {
+    Log.error(
+      'Failed to resolve notification target: $e',
+      name: 'main',
+      category: LogCategory.system,
+    );
+  }
+
+  if (videoEventId == null) {
+    Log.warning(
+      'Could not resolve notification target to a video, '
+      'referencedEventId=$referencedEventId type=$notificationType',
+      name: 'main',
+      category: LogCategory.system,
+    );
+    return;
+  }
+
+  Log.info(
+    'Resolved notification target: $referencedEventId → $videoEventId '
+    '(type=$notificationType, autoOpenComments=$autoOpenComments)',
+    name: 'main',
+    category: LogCategory.system,
+  );
+
+  deepLinkService.pushLink(
+    DeepLink(
+      type: DeepLinkType.video,
+      videoRef: videoEventId,
+      autoOpenComments: autoOpenComments,
+    ),
+  );
 }
 
 StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
@@ -378,10 +441,20 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
         final referencedEventId =
             initialMessage.data['referencedEventId'] as String?;
         if (referencedEventId != null) {
+          // FCM payload uses 'type', not 'notificationType'
+          final notificationType = initialMessage.data['type'] as String?;
           Log.info(
-            'App launched from push notification, target: $referencedEventId',
+            'App launched from push notification, target: $referencedEventId '
+            '(type: $notificationType)',
             name: 'main',
             category: LogCategory.system,
+          );
+          unawaited(
+            _resolveAndPushNotificationDeepLink(
+              referencedEventId: referencedEventId,
+              notificationType: notificationType,
+              container: container,
+            ),
           );
         }
       }
@@ -390,11 +463,20 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
       FirebaseMessaging.onMessageOpenedApp.listen((message) {
         final referencedEventId = message.data['referencedEventId'] as String?;
         if (referencedEventId != null) {
+          // FCM payload uses 'type', not 'notificationType'
+          final notificationType = message.data['type'] as String?;
           Log.info(
             'Push notification tapped (background), '
-            'target: $referencedEventId',
+            'target: $referencedEventId (type: $notificationType)',
             name: 'main',
             category: LogCategory.system,
+          );
+          unawaited(
+            _resolveAndPushNotificationDeepLink(
+              referencedEventId: referencedEventId,
+              notificationType: notificationType,
+              container: container,
+            ),
           );
         }
       });
@@ -1050,7 +1132,61 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     );
 
     // Initialize the deep link service for video content
-    ref.read(deepLinkServiceProvider).initialize();
+    final deepLinkService = ref.read(deepLinkServiceProvider);
+    deepLinkService.initialize();
+
+    // Route local notification taps (background-built via flutter_local_notifications)
+    // through the same deep-link stream so the build() listener handles navigation.
+    ref.read(notificationServiceProvider).onNotificationTap =
+        (
+          referencedEventId,
+          notificationType,
+        ) {
+          Log.info(
+            '🔔 Local notification tap: eventId=$referencedEventId '
+            'type=$notificationType',
+            name: 'DeepLinkHandler',
+            category: LogCategory.ui,
+          );
+          unawaited(
+            NotificationTargetResolver(
+                  videoEventService: ref.read(videoEventServiceProvider),
+                  nostrService: ref.read(nostrServiceProvider),
+                )
+                .resolveVideoEventIdFromNotificationTarget(referencedEventId)
+                .then((videoEventId) {
+                  if (videoEventId == null) {
+                    Log.warning(
+                      'Could not resolve local notification target to a video, '
+                      'referencedEventId=$referencedEventId type=$notificationType',
+                      name: 'DeepLinkHandler',
+                      category: LogCategory.ui,
+                    );
+                    return;
+                  }
+                  Log.info(
+                    'Resolved local notification target: '
+                    '$referencedEventId → $videoEventId',
+                    name: 'DeepLinkHandler',
+                    category: LogCategory.ui,
+                  );
+                  deepLinkService.pushLink(
+                    DeepLink(
+                      type: DeepLinkType.video,
+                      videoRef: videoEventId,
+                      autoOpenComments: notificationType == 'reply',
+                    ),
+                  );
+                })
+                .catchError((Object e) {
+                  Log.error(
+                    'Failed to resolve local notification target: $e',
+                    name: 'DeepLinkHandler',
+                    category: LogCategory.ui,
+                  );
+                }),
+          );
+        };
 
     // Initialize the deep link service for password reset
     ref.read(passwordResetListenerProvider).initialize();
@@ -1177,7 +1313,8 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   deepLink.videoRef!,
                 );
                 Log.info(
-                  '📱 Navigating to video: $targetPath',
+                  '📱 Navigating to video: $targetPath'
+                  '${deepLink.autoOpenComments ? " (open comments)" : ""}',
                   name: 'DeepLinkHandler',
                   category: LogCategory.ui,
                 );
@@ -1185,17 +1322,20 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   // Skip if already showing this video (getInitialLink
                   // and uriLinkStream can both fire for the same URL).
                   if (currentLocation == targetPath) break;
+                  final routeExtra = deepLink.autoOpenComments
+                      ? const VideoDetailRouteExtra(autoOpenComments: true)
+                      : null;
                   final isReplacingExistingVideoRoute = currentLocation
                       .startsWith('${VideoDetailScreen.basePath}/');
                   if (isReplacingExistingVideoRoute) {
                     // When another shared video is opened while a shared
                     // video route is already visible, replace the current
                     // detail route instead of stacking it.
-                    router.go(targetPath);
+                    router.go(targetPath, extra: routeExtra);
                   } else {
                     // Keep the home route underneath the first shared video
                     // so back navigation returns to the main screen.
-                    router.push(targetPath);
+                    router.push(targetPath, extra: routeExtra);
                   }
                   Log.info(
                     '✅ Navigation completed to: $targetPath',

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -77,6 +77,8 @@ import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
+import 'package:openvine/services/notification_service.dart'
+    show NotificationKind;
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -139,7 +141,8 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     details,
     payload: jsonEncode({
       'referencedEventId': data['referencedEventId'],
-      // FCM payload uses 'type', not 'notificationType'
+      // Normalise at the boundary: FCM wire key is 'type'; the internal
+      // payload (read by NotificationService) uses 'notificationType'.
       'notificationType': data['type'],
     }),
   );
@@ -189,6 +192,25 @@ Future<void> _runTimedStartupTask({
   }
 }
 
+/// Normalises the raw FCM [RemoteMessage.data] map into the two fields the
+/// app cares about, translating the wire key `'type'` to `notificationType`
+/// so the rest of the app never has to know which key the FCM server uses.
+///
+/// Returns `null` when the payload carries no `referencedEventId`.
+({String referencedEventId, String? notificationType})? _parseFcmPayload(
+  Map<String, dynamic> data,
+) {
+  final referencedEventId = data['referencedEventId'] as String?;
+  if (referencedEventId == null || referencedEventId.isEmpty) return null;
+  // FCM wire payload uses the key 'type'; local-notification JSON uses
+  // 'notificationType'. Normalise here so callers see one shape.
+  final notificationType = data['type'] as String?;
+  return (
+    referencedEventId: referencedEventId,
+    notificationType: notificationType,
+  );
+}
+
 /// Resolves [referencedEventId] from a push notification payload to a video
 /// event ID, then pushes a [DeepLink] into [deepLinkService].
 ///
@@ -204,7 +226,7 @@ Future<void> _resolveAndPushNotificationDeepLink({
   required ProviderContainer container,
 }) async {
   final deepLinkService = container.read(deepLinkServiceProvider);
-  final autoOpenComments = notificationType == 'reply';
+  final autoOpenComments = notificationType == NotificationKind.reply;
 
   String? videoEventId;
   try {
@@ -438,21 +460,19 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
       final initialMessage = await FirebaseMessaging.instance
           .getInitialMessage();
       if (initialMessage != null) {
-        final referencedEventId =
-            initialMessage.data['referencedEventId'] as String?;
-        if (referencedEventId != null) {
-          // FCM payload uses 'type', not 'notificationType'
-          final notificationType = initialMessage.data['type'] as String?;
+        final parsed = _parseFcmPayload(initialMessage.data);
+        if (parsed != null) {
           Log.info(
-            'App launched from push notification, target: $referencedEventId '
-            '(type: $notificationType)',
+            'App launched from push notification, '
+            'target: ${parsed.referencedEventId} '
+            '(type: ${parsed.notificationType})',
             name: 'main',
             category: LogCategory.system,
           );
           unawaited(
             _resolveAndPushNotificationDeepLink(
-              referencedEventId: referencedEventId,
-              notificationType: notificationType,
+              referencedEventId: parsed.referencedEventId,
+              notificationType: parsed.notificationType,
               container: container,
             ),
           );
@@ -461,20 +481,19 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
 
       // Handle taps on notifications while app is in background
       FirebaseMessaging.onMessageOpenedApp.listen((message) {
-        final referencedEventId = message.data['referencedEventId'] as String?;
-        if (referencedEventId != null) {
-          // FCM payload uses 'type', not 'notificationType'
-          final notificationType = message.data['type'] as String?;
+        final parsed = _parseFcmPayload(message.data);
+        if (parsed != null) {
           Log.info(
             'Push notification tapped (background), '
-            'target: $referencedEventId (type: $notificationType)',
+            'target: ${parsed.referencedEventId} '
+            '(type: ${parsed.notificationType})',
             name: 'main',
             category: LogCategory.system,
           );
           unawaited(
             _resolveAndPushNotificationDeepLink(
-              referencedEventId: referencedEventId,
-              notificationType: notificationType,
+              referencedEventId: parsed.referencedEventId,
+              notificationType: parsed.notificationType,
               container: container,
             ),
           );
@@ -1137,56 +1156,24 @@ class _DivineAppState extends ConsumerState<DivineApp> {
 
     // Route local notification taps (background-built via flutter_local_notifications)
     // through the same deep-link stream so the build() listener handles navigation.
-    ref.read(notificationServiceProvider).onNotificationTap =
-        (
-          referencedEventId,
-          notificationType,
-        ) {
-          Log.info(
-            '🔔 Local notification tap: eventId=$referencedEventId '
-            'type=$notificationType',
-            name: 'DeepLinkHandler',
-            category: LogCategory.ui,
-          );
-          unawaited(
-            NotificationTargetResolver(
-                  videoEventService: ref.read(videoEventServiceProvider),
-                  nostrService: ref.read(nostrServiceProvider),
-                )
-                .resolveVideoEventIdFromNotificationTarget(referencedEventId)
-                .then((videoEventId) {
-                  if (videoEventId == null) {
-                    Log.warning(
-                      'Could not resolve local notification target to a video, '
-                      'referencedEventId=$referencedEventId type=$notificationType',
-                      name: 'DeepLinkHandler',
-                      category: LogCategory.ui,
-                    );
-                    return;
-                  }
-                  Log.info(
-                    'Resolved local notification target: '
-                    '$referencedEventId → $videoEventId',
-                    name: 'DeepLinkHandler',
-                    category: LogCategory.ui,
-                  );
-                  deepLinkService.pushLink(
-                    DeepLink(
-                      type: DeepLinkType.video,
-                      videoRef: videoEventId,
-                      autoOpenComments: notificationType == 'reply',
-                    ),
-                  );
-                })
-                .catchError((Object e) {
-                  Log.error(
-                    'Failed to resolve local notification target: $e',
-                    name: 'DeepLinkHandler',
-                    category: LogCategory.ui,
-                  );
-                }),
-          );
-        };
+    final container = ProviderScope.containerOf(context);
+    ref
+        .read(notificationServiceProvider)
+        .onNotificationTap = (referencedEventId, notificationType) {
+      Log.info(
+        '🔔 Local notification tap: eventId=$referencedEventId '
+        'type=$notificationType',
+        name: 'DeepLinkHandler',
+        category: LogCategory.ui,
+      );
+      unawaited(
+        _resolveAndPushNotificationDeepLink(
+          referencedEventId: referencedEventId,
+          notificationType: notificationType,
+          container: container,
+        ),
+      );
+    };
 
     // Initialize the deep link service for password reset
     ref.read(passwordResetListenerProvider).initialize();

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -192,6 +192,55 @@ Future<void> _runTimedStartupTask({
   }
 }
 
+/// Describes the router action to take when navigating to a video deep link.
+@visibleForTesting
+enum VideoDeepLinkNavAction {
+  /// Navigate to the route, keeping the current route in the back stack.
+  push,
+
+  /// Replace the current route in-place (already on a video route).
+  go,
+
+  /// Re-trigger the current route with [autoOpenComments] set to `true`.
+  ///
+  /// Used when the user is already on the target video but a reply
+  /// notification tap needs the comments sheet to open.
+  goSameRouteWithComments,
+
+  /// The router is already on the target route with nothing new to do.
+  skip,
+}
+
+/// Determines which router action to take for a video deep-link navigation
+/// given the current router location and the incoming [DeepLink].
+///
+/// Extracted for testability — the caller executes the action; this function
+/// only decides what action that should be.
+@visibleForTesting
+VideoDeepLinkNavAction resolveVideoDeepLinkNavAction({
+  required String currentLocation,
+  required String targetPath,
+  required bool autoOpenComments,
+}) {
+  if (currentLocation == targetPath) {
+    // Already on the exact target route.
+    if (autoOpenComments) {
+      // Reply notification tap while the video is already visible — retrigger
+      // the route with autoOpenComments so the comments sheet opens.
+      return VideoDeepLinkNavAction.goSameRouteWithComments;
+    }
+    // Duplicate navigation with nothing new to do (e.g. getInitialLink +
+    // uriLinkStream both fire for the same URL). Safe to skip.
+    return VideoDeepLinkNavAction.skip;
+  }
+  if (currentLocation.startsWith('${VideoDetailScreen.basePath}/')) {
+    // A different video is already showing — replace it in-place.
+    return VideoDeepLinkNavAction.go;
+  }
+  // Coming from a non-video route — push so back returns home.
+  return VideoDeepLinkNavAction.push;
+}
+
 /// Normalises the raw FCM [RemoteMessage.data] map into the two fields the
 /// app cares about, translating the wire key `'type'` to `notificationType`
 /// so the rest of the app never has to know which key the FCM server uses.
@@ -1306,23 +1355,30 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
-                  // Skip if already showing this video (getInitialLink
-                  // and uriLinkStream can both fire for the same URL).
-                  if (currentLocation == targetPath) break;
                   final routeExtra = deepLink.autoOpenComments
                       ? const VideoDetailRouteExtra(autoOpenComments: true)
                       : null;
-                  final isReplacingExistingVideoRoute = currentLocation
-                      .startsWith('${VideoDetailScreen.basePath}/');
-                  if (isReplacingExistingVideoRoute) {
-                    // When another shared video is opened while a shared
-                    // video route is already visible, replace the current
-                    // detail route instead of stacking it.
-                    router.go(targetPath, extra: routeExtra);
-                  } else {
-                    // Keep the home route underneath the first shared video
-                    // so back navigation returns to the main screen.
-                    router.push(targetPath, extra: routeExtra);
+                  final action = resolveVideoDeepLinkNavAction(
+                    currentLocation: currentLocation,
+                    targetPath: targetPath,
+                    autoOpenComments: deepLink.autoOpenComments,
+                  );
+                  switch (action) {
+                    case VideoDeepLinkNavAction.skip:
+                      break;
+                    case VideoDeepLinkNavAction.goSameRouteWithComments:
+                      // Already on the video — retrigger so the comments
+                      // sheet opens in response to a reply notification tap.
+                      router.go(targetPath, extra: routeExtra);
+                    case VideoDeepLinkNavAction.go:
+                      // When another shared video is opened while a shared
+                      // video route is already visible, replace the current
+                      // detail route instead of stacking it.
+                      router.go(targetPath, extra: routeExtra);
+                    case VideoDeepLinkNavAction.push:
+                      // Keep the home route underneath the first shared video
+                      // so back navigation returns to the main screen.
+                      router.push(targetPath, extra: routeExtra);
                   }
                   Log.info(
                     '✅ Navigation completed to: $targetPath',

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -28,6 +28,7 @@ class DeepLink {
     this.searchTerm,
     this.inviteCode,
     this.index,
+    this.autoOpenComments = false,
   });
 
   final DeepLinkType type;
@@ -43,12 +44,17 @@ class DeepLink {
   final String? inviteCode;
   final int? index; // Optional video index for feed view
 
+  /// When true the video detail screen should open the comments section
+  /// automatically (e.g. navigating from a reply notification).
+  final bool autoOpenComments;
+
   @override
   String toString() {
     final indexStr = index != null ? ', index: $index' : '';
     switch (type) {
       case DeepLinkType.video:
-        return 'DeepLink(type: video, videoRef: $videoRef)';
+        final commentsStr = autoOpenComments ? ', autoOpenComments: true' : '';
+        return 'DeepLink(type: video, videoRef: $videoRef$commentsStr)';
       case DeepLinkType.profile:
         return 'DeepLink(type: profile, npub: $npub$indexStr)';
       case DeepLinkType.hashtag:
@@ -251,5 +257,15 @@ class DeepLinkService {
   void dispose() {
     _subscription?.cancel();
     _controller.close();
+  }
+
+  /// Programmatically push a [DeepLink] into the stream.
+  ///
+  /// Use this when a navigation intent is received outside of the OS
+  /// universal-link / custom-scheme channel (e.g. from an FCM payload or a
+  /// local notification tap) so that the same [deepLinksProvider] listener in
+  /// the widget tree can handle it uniformly.
+  void pushLink(DeepLink link) {
+    _controller.add(link);
   }
 }

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -16,6 +16,16 @@ enum NotificationType {
   processingStarted,
 }
 
+/// Push-notification kind values as they appear in the FCM payload `type` field
+/// and in the local-notification JSON payload `notificationType` field.
+///
+/// Use these constants instead of bare string literals so that the routing
+/// policy (e.g. "open comments for replies") is defined in one place.
+abstract final class NotificationKind {
+  /// The originating notification was a reply to one of the user's videos.
+  static const String reply = 'reply';
+}
+
 /// Notification data structure
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class AppNotification {

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Service for showing user notifications about upload status and publishing
 // ABOUTME: Handles local notifications and in-app messages for video processing updates
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -109,6 +111,15 @@ class NotificationService {
   final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
   bool _pluginInitialized = false;
+
+  /// Optional callback invoked when the user taps a local notification.
+  ///
+  /// The callback receives two arguments: the [referencedEventId] (Nostr event
+  /// ID of the content the notification is about) and [notificationType] (e.g.
+  /// `"reply"`, `"reaction"`, `"repost"`, `"zap"`, `"follow"`).  Either value
+  /// may be null if the payload doesn't carry that field.
+  void Function(String referencedEventId, String? notificationType)?
+  onNotificationTap;
 
   /// List of recent notifications
   List<AppNotification> get notifications => List.unmodifiable(_notifications);
@@ -415,26 +426,40 @@ class NotificationService {
   }
 
   /// Handle notification tap
-  ///
-  /// TODO: Implement navigation based on notification action:
-  /// - 'open_feed': Navigate to home feed screen
-  /// - 'open_uploads': Navigate to uploads screen
-  /// - 'retry_upload': Navigate to failed upload and show retry UI
-  /// - 'show_progress': Navigate to upload progress screen
   void _onNotificationTapped(NotificationResponse response) {
+    _handleNotificationTapPayload(response.payload);
+  }
+
+  /// Parses [payload] and invokes [onNotificationTap] when a valid
+  /// [referencedEventId] can be extracted.
+  ///
+  /// Exposed for testing; production callers should use
+  /// [_onNotificationTapped] or configure [onNotificationTap] instead.
+  @visibleForTesting
+  void handleNotificationTapPayload(String? payload) =>
+      _handleNotificationTapPayload(payload);
+
+  void _handleNotificationTapPayload(String? payload) {
     Log.debug(
-      'Notification tapped: ${response.payload}',
+      'Notification tapped: $payload',
       name: 'NotificationService',
       category: LogCategory.system,
     );
-    // TODO: Handle notification actions (navigate to relevant screen)
-    // Example implementation:
-    // final data = jsonDecode(response.payload ?? '{}');
-    // final action = data['action'];
-    // switch (action) {
-    //   case 'open_feed': navigatorKey.currentState?.pushNamed('/feed');
-    //   case 'retry_upload': navigatorKey.currentState?.pushNamed('/uploads');
-    // }
+
+    if (payload == null || payload.isEmpty) return;
+
+    try {
+      final data = jsonDecode(payload) as Map<String, dynamic>;
+      final referencedEventId = data['referencedEventId'] as String?;
+      final notificationType = data['notificationType'] as String?;
+      if (referencedEventId != null && referencedEventId.isNotEmpty) {
+        onNotificationTap?.call(referencedEventId, notificationType);
+      }
+    } catch (_) {
+      // Legacy payloads were bare event IDs (plain strings, not JSON).
+      // Treat the whole payload as a referencedEventId with unknown type.
+      onNotificationTap?.call(payload, null);
+    }
   }
 
   /// Send a local notification with title and body

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -468,6 +468,10 @@ class NotificationService {
     } catch (_) {
       // Legacy payloads were bare event IDs (plain strings, not JSON).
       // Treat the whole payload as a referencedEventId with unknown type.
+      // TODO(#4329): Remove this fallback once all clients have been emitting
+      // JSON payloads (referencedEventId + notificationType) for at least one
+      // full app-store release cycle and telemetry confirms this path is
+      // never reached. See issue for the full removal plan.
       onNotificationTap?.call(payload, null);
     }
   }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -826,8 +826,14 @@ class NotificationRepository {
     NotificationKind mapped,
     RelayNotification n,
   ) => switch (mapped) {
-    NotificationKind.likeComment ||
-    NotificationKind.reply => n.referencedEventId,
+    NotificationKind.likeComment || NotificationKind.reply =>
+      // Prefer the referenced (parent) event ID. Fall back to the source
+      // event ID (the reply event itself) when the server omits
+      // referenced_event_id — both carry NIP-22 E-tags the resolver can
+      // walk to find the root video.
+      n.referencedEventId?.isNotEmpty == true
+          ? n.referencedEventId
+          : (n.sourceEventId.isNotEmpty ? n.sourceEventId : null),
     NotificationKind.mention =>
       n.sourceEventId.isNotEmpty ? n.sourceEventId : null,
     _ => null,

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -862,6 +862,50 @@ void main() {
         expect(item.targetEventId, equals('parent_comment_id'));
       });
 
+      test(
+        'reply falls back to sourceEventId when referencedEventId is null',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'reply',
+              sourceKind: 1,
+              isReferencedVideo: false,
+              sourceEventId: 'reply_event_id',
+              referencedEventId: null,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.reply));
+          // targetEventId must be non-null so _onItemTap can call the resolver
+          // instead of falling back to the actor's profile screen.
+          expect(item.targetEventId, equals('reply_event_id'));
+        },
+      );
+
+      test(
+        'reply falls back to sourceEventId when referencedEventId is empty',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'reply',
+              sourceKind: 1,
+              isReferencedVideo: false,
+              sourceEventId: 'reply_event_id',
+              referencedEventId: '',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.reply));
+          expect(item.targetEventId, equals('reply_event_id'));
+        },
+      );
+
       test('comment maps to comment', () async {
         stubNotifications([
           makeNotification(notificationType: 'comment', sourceKind: 1),

--- a/mobile/test/main_video_deep_link_nav_action_test.dart
+++ b/mobile/test/main_video_deep_link_nav_action_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Regression tests for resolveVideoDeepLinkNavAction routing decision
+// ABOUTME: Verifies the same-route + autoOpenComments case that previously
+// ABOUTME: caused reply notification taps to no-op when already on the video.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/screens/video_detail_screen.dart';
+
+void main() {
+  const videoId =
+      'abc123def456abc123def456abc123def456abc123def456abc123def456abc123';
+  final targetPath = VideoDetailScreen.pathForId(videoId);
+
+  group('resolveVideoDeepLinkNavAction', () {
+    group('same route (currentLocation == targetPath)', () {
+      test(
+        'returns skip when already on the video and autoOpenComments is false '
+        '— duplicate link event, nothing new to do',
+        () {
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: targetPath,
+            targetPath: targetPath,
+            autoOpenComments: false,
+          );
+          expect(action, equals(app.VideoDeepLinkNavAction.skip));
+        },
+      );
+
+      // Regression: a reply notification tap while already on /video/<id>
+      // used to break early (skip) before the action `autoOpenComments: true`
+      // could be forwarded to the route.  The comments sheet never opened.
+      test(
+        'returns goSameRouteWithComments when already on the video and '
+        'autoOpenComments is true — reply notification tap must open sheet',
+        () {
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: targetPath,
+            targetPath: targetPath,
+            autoOpenComments: true,
+          );
+          expect(
+            action,
+            equals(app.VideoDeepLinkNavAction.goSameRouteWithComments),
+          );
+        },
+      );
+    });
+
+    group('different video already showing (replacing video route)', () {
+      test(
+        'returns go when a different video is currently visible',
+        () {
+          const otherId =
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+          final otherPath = VideoDetailScreen.pathForId(otherId);
+
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: otherPath,
+            targetPath: targetPath,
+            autoOpenComments: false,
+          );
+          expect(action, equals(app.VideoDeepLinkNavAction.go));
+        },
+      );
+
+      test(
+        'returns go with autoOpenComments when a different video is showing',
+        () {
+          const otherId =
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+          final otherPath = VideoDetailScreen.pathForId(otherId);
+
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: otherPath,
+            targetPath: targetPath,
+            autoOpenComments: true,
+          );
+          expect(action, equals(app.VideoDeepLinkNavAction.go));
+        },
+      );
+    });
+
+    group('coming from a non-video route', () {
+      test(
+        'returns push from the home feed so back returns to the main screen',
+        () {
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: '/home/0',
+            targetPath: targetPath,
+            autoOpenComments: false,
+          );
+          expect(action, equals(app.VideoDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push even when autoOpenComments is true',
+        () {
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: '/home/0',
+            targetPath: targetPath,
+            autoOpenComments: true,
+          );
+          expect(action, equals(app.VideoDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from welcome / unauthenticated route',
+        () {
+          final action = app.resolveVideoDeepLinkNavAction(
+            currentLocation: '/welcome',
+            targetPath: targetPath,
+            autoOpenComments: false,
+          );
+          expect(action, equals(app.VideoDeepLinkNavAction.push));
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/providers/deep_link_provider_test.dart
+++ b/mobile/test/providers/deep_link_provider_test.dart
@@ -121,4 +121,58 @@ void main() {
       expect(receivedB, hasLength(1));
     },
   );
+
+  group('DeepLink.autoOpenComments', () {
+    test('defaults to false', () {
+      const link = DeepLink(type: DeepLinkType.video, videoRef: 'abc');
+      expect(link.autoOpenComments, isFalse);
+    });
+
+    test('can be set to true', () {
+      const link = DeepLink(
+        type: DeepLinkType.video,
+        videoRef: 'abc',
+        autoOpenComments: true,
+      );
+      expect(link.autoOpenComments, isTrue);
+    });
+
+    test('toString includes autoOpenComments when true', () {
+      const link = DeepLink(
+        type: DeepLinkType.video,
+        videoRef: 'abc',
+        autoOpenComments: true,
+      );
+      expect(link.toString(), contains('autoOpenComments: true'));
+    });
+
+    test('toString omits autoOpenComments when false', () {
+      const link = DeepLink(type: DeepLinkType.video, videoRef: 'abc');
+      expect(link.toString(), isNot(contains('autoOpenComments')));
+    });
+  });
+
+  group('DeepLinkService.pushLink', () {
+    test('emits the link on linkStream', () async {
+      final service = DeepLinkService();
+      addTearDown(service.dispose);
+
+      final received = <DeepLink>[];
+      final sub = service.linkStream.listen(received.add);
+      addTearDown(sub.cancel);
+
+      const link = DeepLink(
+        type: DeepLinkType.video,
+        videoRef: 'test-event-id',
+        autoOpenComments: true,
+      );
+      service.pushLink(link);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first.videoRef, equals('test-event-id'));
+      expect(received.first.autoOpenComments, isTrue);
+    });
+  });
 }

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for NotificationService permission handling and local notification display
 // ABOUTME: Verifies platform-specific permission requests and notification sending functionality
 
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/notification_service.dart';
 
@@ -225,6 +227,104 @@ void main() {
       expect(
         service.notifications.first.type,
         equals(NotificationType.uploadFailed),
+      );
+    });
+  });
+
+  group('NotificationService.onNotificationTap', () {
+    late NotificationService service;
+
+    setUp(() {
+      service = NotificationService();
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    // The FCM data map from divine-push-service uses 'type' (not 'notificationType').
+    // _firebaseMessagingBackgroundHandler re-encodes it into our internal JSON
+    // payload as 'notificationType' so the local notification tap handler can
+    // read it back with the consistent internal key name.
+    // See: docs/superpowers/specs/2026-04-07-push-notifications-design.md
+    test('invokes callback with eventId and type from JSON payload', () {
+      String? capturedId;
+      String? capturedType;
+      service.onNotificationTap = (id, type) {
+        capturedId = id;
+        capturedType = type;
+      };
+
+      service.handleNotificationTapPayload(
+        jsonEncode({
+          'referencedEventId': 'abc123',
+          'notificationType': 'reply',
+        }),
+      );
+
+      expect(capturedId, equals('abc123'));
+      expect(capturedType, equals('reply'));
+    });
+
+    test('invokes callback with null type when notificationType missing', () {
+      String? capturedId;
+      String? capturedType;
+      service.onNotificationTap = (id, type) {
+        capturedId = id;
+        capturedType = type;
+      };
+
+      service.handleNotificationTapPayload(
+        jsonEncode({'referencedEventId': 'def456'}),
+      );
+
+      expect(capturedId, equals('def456'));
+      expect(capturedType, isNull);
+    });
+
+    test('handles legacy bare event-ID payload (non-JSON)', () {
+      String? capturedId;
+      String? capturedType;
+      service.onNotificationTap = (id, type) {
+        capturedId = id;
+        capturedType = type;
+      };
+
+      service.handleNotificationTapPayload('legacyEventId999');
+
+      expect(capturedId, equals('legacyEventId999'));
+      expect(capturedType, isNull);
+    });
+
+    test('does not invoke callback when payload is null', () {
+      var called = false;
+      service.onNotificationTap = (id, type) => called = true;
+
+      service.handleNotificationTapPayload(null);
+
+      expect(called, isFalse);
+    });
+
+    test('does not invoke callback when referencedEventId is absent', () {
+      var called = false;
+      service.onNotificationTap = (id, type) => called = true;
+
+      service.handleNotificationTapPayload(
+        jsonEncode({'notificationType': 'reaction'}),
+      );
+
+      expect(called, isFalse);
+    });
+
+    test('no-ops gracefully when onNotificationTap is not set', () {
+      expect(
+        () => service.handleNotificationTapPayload(
+          jsonEncode({
+            'referencedEventId': 'abc',
+            'notificationType': 'reply',
+          }),
+        ),
+        returnsNormally,
       );
     });
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Three layered bugs prevented 'replied to your comment' notifications from navigating to the video's comment section:

1. FCM handlers logged referencedEventId but never navigated. Wire all three tap paths (cold-start, background, local notification) through DeepLinkService.pushLink() so the existing deep-link listener in the widget tree handles routing uniformly.

2. FCM data map uses 'type' key (not 'notificationType'). Reading the wrong key always produced null, making autoOpenComments always false and breaking type-based routing logic.

3. _actorTargetEventId returned n.referencedEventId for reply notifications, but the server omits referenced_event_id for comment-anchored replies. A null targetEventId caused _onItemTap to fall back to _navigateToProfile unconditionally. Fix: fall back to sourceEventId (the reply event itself) which always carries NIP-22 E-tags the NotificationTargetResolver can walk to find the root video.

Also adds DeepLink.autoOpenComments, DeepLinkService.pushLink(), NotificationService.onNotificationTap callback, and _resolveAndPushNotificationDeepLink helper that runs NotificationTargetResolver before pushing the deep link (since referencedEventId is a comment event ID, not a video event ID).

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4092

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore