### PR TITLE
feat(feed): add popular source toggle

### DIFF
--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Uses VideosRepository which tries Funnelcake, NIP-50, then
 // ABOUTME: client-side engagement sorting as fallbacks.
 
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -15,6 +17,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'popular_videos_feed_provider.g.dart';
+
+/// Selected source for the Popular tab's v2 feed.
+final popularVideosVariantProvider = StateProvider<PopularVideosVariant>(
+  (ref) => PopularVideosVariant.native,
+);
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
@@ -41,11 +48,14 @@ class PopularVideosFeed extends _$PopularVideosFeed {
     // Watch blocklist version — rebuilds when block/unblock actions occur.
     ref.watch(blocklistVersionProvider);
 
+    // Watch the user-selected native/classic split.
+    final variant = ref.watch(popularVideosVariantProvider);
+
     // Watch appReady gate
     final isAppReady = ref.watch(appReadyProvider);
 
     Log.info(
-      'PopularVideosFeed: Building (appReady: $isAppReady)',
+      'PopularVideosFeed: Building (appReady: $isAppReady, variant: ${variant.name})',
       name: 'PopularVideosFeedProvider',
       category: LogCategory.video,
     );
@@ -61,14 +71,15 @@ class PopularVideosFeed extends _$PopularVideosFeed {
       return const VideoFeedState(videos: [], hasMoreContent: true);
     }
 
-    return _loadFirstPage();
+    return _loadFirstPage(variant);
   }
 
-  Future<VideoFeedState> _loadFirstPage() async {
+  Future<VideoFeedState> _loadFirstPage(PopularVideosVariant variant) async {
     try {
       final videosRepository = ref.read(videosRepositoryProvider);
       final videos = await videosRepository.getPopularVideos(
         limit: AppConstants.paginationBatchSize,
+        variant: variant,
       );
 
       if (!ref.mounted) {
@@ -126,9 +137,11 @@ class PopularVideosFeed extends _$PopularVideosFeed {
 
     try {
       final videosRepository = ref.read(videosRepositoryProvider);
+      final variant = ref.read(popularVideosVariantProvider);
       final newVideos = await videosRepository.getPopularVideos(
         limit: 50,
         until: _nextCursor,
+        variant: variant,
       );
 
       if (!ref.mounted) return;
@@ -203,12 +216,13 @@ class PopularVideosFeed extends _$PopularVideosFeed {
     );
 
     _nextCursor = null;
+    final variant = ref.read(popularVideosVariantProvider);
 
     await staleWhileRevalidate(
       getCurrentState: () => state,
       isMounted: () => ref.mounted,
       setState: (s) => state = s,
-      fetchFresh: _loadFirstPage,
+      fetchFresh: () => _loadFirstPage(variant),
     );
   }
 

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -63,7 +63,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'722f41829a5d6ba75f3f04a3882686011e1c67d6';
+String _$popularVideosFeedHash() => r'ed9368aeb283968fcb2adb1cfcd01ca135d32884';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
@@ -321,9 +322,96 @@ class _PopularVideosTrendingContentState
             key: headerKey,
             hashtags: hashtags,
             isLoading: !TopHashtagsService.instance.isLoaded,
+            leading: const _PopularFeedVariantToggle(),
           ),
         ),
       ],
+    );
+  }
+}
+
+class _PopularFeedVariantToggle extends ConsumerWidget {
+  const _PopularFeedVariantToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selected = ref.watch(popularVideosVariantProvider);
+
+    return Semantics(
+      label: 'Popular feed source',
+      child: Container(
+        key: const Key('popular-feed-variant-toggle'),
+        height: 32,
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          color: VineTheme.surfaceContainer,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: VineTheme.outlineMuted),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _PopularFeedVariantButton(
+              label: 'New',
+              variant: PopularVideosVariant.native,
+              selected: selected == PopularVideosVariant.native,
+            ),
+            _PopularFeedVariantButton(
+              label: 'Classic',
+              variant: PopularVideosVariant.classic,
+              selected: selected == PopularVideosVariant.classic,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PopularFeedVariantButton extends ConsumerWidget {
+  const _PopularFeedVariantButton({
+    required this.label,
+    required this.variant,
+    required this.selected,
+  });
+
+  final String label;
+  final PopularVideosVariant variant;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Semantics(
+      button: true,
+      selected: selected,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          if (selected) return;
+          ref.read(popularVideosVariantProvider.notifier).state = variant;
+        },
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          height: 28,
+          constraints: const BoxConstraints(minWidth: 54),
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          decoration: BoxDecoration(
+            color: selected ? VineTheme.vineGreen : VineTheme.transparent,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: VineTheme.labelMediumFont(
+              color: selected
+                  ? VineTheme.primaryDarkGreen
+                  : VineTheme.onSurfaceMuted55,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/trending_hashtags_section.dart
+++ b/mobile/lib/widgets/trending_hashtags_section.dart
@@ -16,6 +16,7 @@ class TrendingHashtagsSection extends StatelessWidget {
     required this.hashtags,
     super.key,
     this.isLoading = false,
+    this.leading,
     this.onHashtagTap,
   });
 
@@ -24,6 +25,9 @@ class TrendingHashtagsSection extends StatelessWidget {
 
   /// Whether hashtags are still loading
   final bool isLoading;
+
+  /// Optional fixed control rendered to the left of the scrolling hashtags.
+  final Widget? leading;
 
   /// Optional callback when a hashtag is tapped.
   /// If not provided, defaults to navigating via goHashtag.
@@ -35,9 +39,24 @@ class TrendingHashtagsSection extends StatelessWidget {
       color: VineTheme.backgroundColor,
       child: SizedBox(
         height: 52,
-        child: hashtags.isEmpty
-            ? const _HashtagLoadingPlaceholder()
-            : _HashtagChipList(hashtags: hashtags, onHashtagTap: onHashtagTap),
+        child: Row(
+          children: [
+            if (leading != null)
+              Padding(
+                padding: const EdgeInsetsDirectional.only(start: 12, end: 6),
+                child: Center(child: leading),
+              ),
+            Expanded(
+              child: hashtags.isEmpty
+                  ? const _HashtagLoadingPlaceholder()
+                  : _HashtagChipList(
+                      hashtags: hashtags,
+                      leadingInset: leading == null ? 16 : 0,
+                      onHashtagTap: onHashtagTap,
+                    ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -61,9 +80,14 @@ class _HashtagLoadingPlaceholder extends StatelessWidget {
 
 /// Horizontal scrollable list of tappable hashtag chips.
 class _HashtagChipList extends StatelessWidget {
-  const _HashtagChipList({required this.hashtags, this.onHashtagTap});
+  const _HashtagChipList({
+    required this.hashtags,
+    required this.leadingInset,
+    this.onHashtagTap,
+  });
 
   final List<String> hashtags;
+  final double leadingInset;
   final void Function(String hashtag)? onHashtagTap;
 
   @override
@@ -75,8 +99,8 @@ class _HashtagChipList extends StatelessWidget {
       data: MediaQuery.of(context).copyWith(textScaler: textScaler),
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.only(
-          left: 16,
+        padding: EdgeInsets.only(
+          left: leadingInset,
           right: 16,
           top: 12,
           bottom: 12,

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -12,6 +12,15 @@ import 'package:meta/meta.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
+/// Source split for the v2 popular feed.
+enum PopularVideosVariant {
+  /// New/native Divine videos, excluding imported Vine archive items.
+  native,
+
+  /// Imported classic Vine archive items only.
+  classic,
+}
+
 /// HTTP client for the Funnelcake REST API.
 ///
 /// Funnelcake provides a ClickHouse-backed analytics API that offers
@@ -459,6 +468,66 @@ class FunnelcakeApiClient {
       rethrow;
     } catch (e) {
       throw FunnelcakeException('Failed to fetch watching videos: $e');
+    }
+  }
+
+  /// Fetches the v2 popular feed filtered to native Divine or classic Vine
+  /// imports.
+  ///
+  /// Native mode maps to `sort=popular&period=now&exclude_platform=vine`;
+  /// classic mode maps to `sort=popular&period=week&platform=vine`.
+  Future<List<VideoStats>> getV2PopularVideos({
+    required PopularVideosVariant variant,
+    int limit = 50,
+    int? before,
+  }) async {
+    if (!isAvailable) {
+      throw const FunnelcakeNotConfiguredException();
+    }
+
+    final queryParams = _videoQueryParameters({
+      'sort': 'popular',
+      'period': variant == PopularVideosVariant.classic ? 'week' : 'now',
+      'limit': limit.toString(),
+    });
+    if (variant == PopularVideosVariant.classic) {
+      queryParams['platform'] = 'vine';
+    } else {
+      queryParams['exclude_platform'] = 'vine';
+    }
+    if (before != null) {
+      queryParams['before'] = before.toString();
+    }
+
+    final uri = Uri.parse(
+      '$_baseUrl/api/v2/videos',
+    ).replace(queryParameters: queryParams);
+
+    try {
+      final response = await _get(uri);
+
+      if (response.statusCode == 200) {
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
+
+        return items
+            .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
+            .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
+            .toList();
+      }
+
+      throw FunnelcakeApiException(
+        message: 'Failed to fetch v2 popular videos',
+        statusCode: response.statusCode,
+        url: uri.toString(),
+      );
+    } on TimeoutException {
+      throw FunnelcakeTimeoutException(uri.toString());
+    } on FunnelcakeException {
+      rethrow;
+    } catch (e) {
+      throw FunnelcakeException('Failed to fetch v2 popular videos: $e');
     }
   }
 

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -2634,6 +2634,57 @@ void main() {
       );
     });
 
+    group('getV2PopularVideos', () {
+      test(
+        'classic mode requests weekly popular imported Vine videos',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response('[]', 200));
+
+          await client.getV2PopularVideos(
+            variant: PopularVideosVariant.classic,
+          );
+
+          final uri =
+              verify(
+                    () => mockHttpClient.get(
+                      captureAny(),
+                      headers: any(named: 'headers'),
+                    ),
+                  ).captured.single
+                  as Uri;
+          expect(uri.path, equals('/api/v2/videos'));
+          expect(uri.queryParameters['sort'], equals('popular'));
+          expect(uri.queryParameters['period'], equals('week'));
+          expect(uri.queryParameters['platform'], equals('vine'));
+          expect(uri.queryParameters.containsKey('exclude_platform'), isFalse);
+        },
+      );
+
+      test('native mode requests now-popular non-Vine videos', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('[]', 200));
+
+        await client.getV2PopularVideos(variant: PopularVideosVariant.native);
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.path, equals('/api/v2/videos'));
+        expect(uri.queryParameters['sort'], equals('popular'));
+        expect(uri.queryParameters['period'], equals('now'));
+        expect(uri.queryParameters['exclude_platform'], equals('vine'));
+        expect(uri.queryParameters.containsKey('platform'), isFalse);
+      });
+    });
+
     group('getClassicVines', () {
       const validResponseBody =
           '''

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -702,15 +702,42 @@ class VideosRepository {
     int? until,
     int? offset,
     LeaderboardPeriod? period,
+    PopularVideosVariant? variant,
     int fetchMultiplier = 4,
     bool skipCache = false,
   }) async {
-    final cacheKey = period == null ? 'popular' : 'popular:${period.wireValue}';
+    final cacheKey = variant != null
+        ? 'popular:v2:${variant.name}'
+        : period == null
+        ? 'popular'
+        : 'popular:${period.wireValue}';
 
     // Return in-memory cached result when available (initial page only).
     if (!skipCache && until == null && offset == null) {
       final cached = _inMemoryFeedCache?.get(cacheKey);
       if (cached != null) return cached.videos;
+    }
+
+    // v2 platform-filtered popular feed path. Funnelcake-only: no relay
+    // fallback because relays do not expose server-controlled platform fields.
+    if (variant != null) {
+      if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
+        return const [];
+      }
+      try {
+        final stats = await _funnelcakeApiClient.getV2PopularVideos(
+          variant: variant,
+          limit: limit,
+          before: until,
+        );
+        final videos = _transformVideoStats(stats, sortByCreatedAt: false);
+        if (until == null && offset == null) {
+          _inMemoryFeedCache?.set(cacheKey, HomeFeedResult(videos: videos));
+        }
+        return videos;
+      } on FunnelcakeException {
+        return const [];
+      }
     }
 
     // Period-windowed leaderboard path. Funnelcake-only — no NIP-50 fallback,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3907,6 +3907,28 @@ void main() {
             ),
           ).called(1);
         });
+
+        test('returns empty list when v2 API throws', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: any(named: 'variant'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenThrow(const FunnelcakeException('Network error'));
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getPopularVideos(
+            variant: PopularVideosVariant.native,
+          );
+
+          expect(result, isEmpty);
+        });
       });
     });
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -84,6 +84,7 @@ void main() {
     setUpAll(() {
       registerFallbackValue(<Filter>[]);
       registerFallbackValue(LeaderboardPeriod.week);
+      registerFallbackValue(PopularVideosVariant.classic);
     });
 
     test('can be instantiated', () {
@@ -3825,6 +3826,87 @@ void main() {
             );
           },
         );
+      });
+
+      group('with v2 popular variant', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+        });
+
+        test('calls v2 API for classic popular videos', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: any(named: 'variant'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'classic-popular',
+                pubkey: 'classic-pubkey',
+                dTag: 'classic-dtag',
+                videoUrl: 'https://example.com/classic.mp4',
+              ),
+            ],
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getPopularVideos(
+            variant: PopularVideosVariant.classic,
+          );
+
+          expect(result.single.id, equals('classic-popular'));
+          verify(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: PopularVideosVariant.classic,
+              limit: 25,
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockFunnelcakeClient.getWatchingVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          );
+        });
+
+        test('calls v2 API for native popular videos', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: any(named: 'variant'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer((_) async => <VideoStats>[]);
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await repositoryWithApi.getPopularVideos(
+            variant: PopularVideosVariant.native,
+            limit: 10,
+            until: 1704067200,
+          );
+
+          verify(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: PopularVideosVariant.native,
+              limit: 10,
+              before: 1704067200,
+            ),
+          ).called(1);
+        });
       });
     });
 

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -281,6 +281,7 @@ void main() {
           () => mockVideosRepository.getPopularVideos(
             limit: any(named: 'limit'),
             until: any(named: 'until'),
+            variant: PopularVideosVariant.native,
             fetchMultiplier: any(named: 'fetchMultiplier'),
             skipCache: any(named: 'skipCache'),
           ),

--- a/mobile/test/widgets/trending_hashtags_section_test.dart
+++ b/mobile/test/widgets/trending_hashtags_section_test.dart
@@ -17,6 +17,7 @@ void main() {
     Widget buildTestWidget({
       List<String> hashtags = const [],
       bool isLoading = false,
+      Widget? leading,
       void Function(String)? onHashtagTap,
     }) {
       return MaterialApp(
@@ -26,6 +27,7 @@ void main() {
           body: TrendingHashtagsSection(
             hashtags: hashtags,
             isLoading: isLoading,
+            leading: leading,
             onHashtagTap:
                 onHashtagTap ??
                 (hashtag) {
@@ -84,6 +86,29 @@ void main() {
       // Verify it's horizontal
       final listView = tester.widget<ListView>(listViewFinder);
       expect(listView.scrollDirection, Axis.horizontal);
+    });
+
+    testWidgets('renders leading control before trending hashtags', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          leading: const SizedBox(
+            key: Key('popular-source-toggle'),
+            width: 120,
+            child: Text('New'),
+          ),
+          hashtags: ['art'],
+        ),
+      );
+
+      final toggleTopLeft = tester.getTopLeft(
+        find.byKey(const Key('popular-source-toggle')),
+      );
+      final titleTopLeft = tester.getTopLeft(find.text('Trending'));
+
+      expect(toggleTopLeft.dx, lessThan(titleTopLeft.dx));
+      expect(find.text('#art'), findsOneWidget);
     });
 
     testWidgets('tapping hashtag calls onHashtagTap callback', (tester) async {


### PR DESCRIPTION
## Summary\n- add a New/Classic toggle to the Popular tab hashtag rail\n- route Popular feed requests through the new v2 API split for native Divine videos vs classic Vine imports\n- add client, repository, and hashtag-section widget coverage\n\n## Verification\n- flutter analyze\n- flutter test test/src/funnelcake_api_client_test.dart --name getV2PopularVideos (from mobile/packages/funnelcake_api_client)\n- flutter test test/src/videos_repository_test.dart --name "with v2 popular variant" (from mobile/packages/videos_repository)\n- flutter test test/widgets/trending_hashtags_section_test.dart (from mobile)\n- pre-push hook: analyzer, generated file check, changed-file tests