### PR TITLE
test(clip-editor): inject splitter into ClipEditorBloc to unblock CI

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -7,10 +7,29 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
 import 'package:unified_logger/unified_logger.dart';
 
 part 'clip_editor_event.dart';
 part 'clip_editor_state.dart';
+
+/// Function signature matching [VideoEditorSplitService.splitClip], used as
+/// an injectable seam so tests can swap in a pure-Dart fake that does not
+/// touch `path_provider` or `pro_video_editor` plugins.
+typedef SplitClipFn =
+    Future<void> Function({
+      required DivineVideoClip sourceClip,
+      required Duration splitPosition,
+      required void Function(
+        DivineVideoClip startClip,
+        DivineVideoClip endClip,
+      )?
+      onClipsCreated,
+      required void Function(DivineVideoClip clip, String thumbnailPath)?
+      onThumbnailExtracted,
+      required void Function(DivineVideoClip clip, EditorVideo video)?
+      onClipRendered,
+    });
 
 /// BLoC for managing video clip editor state.
 ///
@@ -28,8 +47,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   ClipEditorBloc({
     required this.onFinalClipInvalidated,
     AudioExtractionService? audioExtractionService,
+    SplitClipFn? splitClip,
   }) : _audioExtractionService =
            audioExtractionService ?? AudioExtractionService(),
+       _splitClip = splitClip ?? VideoEditorSplitService.splitClip,
        super(const ClipEditorState()) {
     // Clip data
     on<ClipEditorInitialized>(_onInitialized);
@@ -64,6 +85,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
   final void Function() onFinalClipInvalidated;
   final AudioExtractionService _audioExtractionService;
+  final SplitClipFn _splitClip;
 
   // === CLIP DATA ===
 
@@ -265,7 +287,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       // file) was processed before ClipEditorOriginalClipReplaced
       // had inserted the new clip ids — the index lookup failed and
       // the clips kept pointing at the original source video.
-      await VideoEditorSplitService.splitClip(
+      await _splitClip(
         sourceClip: selectedClip,
         splitPosition: splitPosition,
         onClipsCreated: (startClip, endClip) {

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -57,6 +57,39 @@ DivineVideoClip _createClipNoFile({String id = 'clip-no-file'}) {
   );
 }
 
+/// Pure-Dart fake of [VideoEditorSplitService.splitClip] for tests.
+///
+/// Mirrors the real service's clip-id and duration math so the bloc behaves
+/// identically without touching `path_provider` or `pro_video_editor`
+/// plugins. Without this seam, the real service awaits
+/// `getApplicationDocumentsDirectory()` before invoking `onClipsCreated`,
+/// which hangs on Linux CI when sibling tests in the VGV-merged bundle
+/// leave the global plugin mocks in a broken state.
+Future<void> _fakeSplitClip({
+  required DivineVideoClip sourceClip,
+  required Duration splitPosition,
+  required void Function(DivineVideoClip startClip, DivineVideoClip endClip)?
+  onClipsCreated,
+  required void Function(DivineVideoClip clip, String thumbnailPath)?
+  onThumbnailExtracted,
+  required void Function(DivineVideoClip clip, EditorVideo video)?
+  onClipRendered,
+}) async {
+  final absoluteSplitPos = sourceClip.trimStart + splitPosition;
+  final timestampMs = DateTime.now().microsecondsSinceEpoch;
+  final startClip = sourceClip.copyWith(
+    id: '${timestampMs}_start',
+    duration: absoluteSplitPos,
+    trimEnd: Duration.zero,
+  );
+  final endClip = sourceClip.copyWith(
+    id: '${timestampMs}_end',
+    duration: sourceClip.duration - absoluteSplitPos,
+    trimStart: Duration.zero,
+  );
+  onClipsCreated?.call(startClip, endClip);
+}
+
 void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
@@ -76,10 +109,12 @@ void main() {
 
     ClipEditorBloc buildBloc({
       AudioExtractionService? audioExtractionService,
+      SplitClipFn? splitClip,
     }) {
       return ClipEditorBloc(
         onFinalClipInvalidated: () {},
         audioExtractionService: audioExtractionService,
+        splitClip: splitClip,
       );
     }
 
@@ -411,7 +446,7 @@ void main() {
     group('ClipEditorSplitRequested', () {
       blocTest<ClipEditorBloc, ClipEditorState>(
         'stops editing and replaces clip when split position is valid',
-        build: buildBloc,
+        build: () => buildBloc(splitClip: _fakeSplitClip),
         seed: () {
           final clip = _createClip(
             id: 'split-me',
@@ -447,7 +482,7 @@ void main() {
       test('uses state splitPosition for resulting clip durations', () async {
         final clip = _createClip(id: 'x', duration: const Duration(seconds: 2));
 
-        final bloc = buildBloc();
+        final bloc = buildBloc(splitClip: _fakeSplitClip);
 
         bloc.emit(
           ClipEditorState(
@@ -507,8 +542,8 @@ void main() {
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(
-        'stops editing and performs split with default service',
-        build: buildBloc,
+        'stops editing and performs split with injected splitter',
+        build: () => buildBloc(splitClip: _fakeSplitClip),
         seed: () {
           final clip = _createClip(duration: const Duration(seconds: 2));
           return ClipEditorState(
@@ -566,7 +601,7 @@ void main() {
             id: 'source-clip',
             duration: const Duration(seconds: 2),
           );
-          final bloc = buildBloc()
+          final bloc = buildBloc(splitClip: _fakeSplitClip)
             ..emit(
               ClipEditorState(
                 clips: [clip],
@@ -606,7 +641,7 @@ void main() {
             duration: const Duration(seconds: 4),
           ).copyWith(trimStart: const Duration(milliseconds: 500));
 
-          final bloc = buildBloc()
+          final bloc = buildBloc(splitClip: _fakeSplitClip)
             ..emit(
               ClipEditorState(
                 clips: [clip],
@@ -640,7 +675,7 @@ void main() {
               trimEnd: const Duration(seconds: 2),
             );
 
-        final bloc = buildBloc()
+        final bloc = buildBloc(splitClip: _fakeSplitClip)
           ..emit(
             ClipEditorState(
               clips: [clip],


### PR DESCRIPTION
Closes #4317

## Summary

Six `ClipEditorBloc > ClipEditorSplitRequested` tests have been failing on Linux CI for multiple consecutive main runs (e.g. [25777519187](https://github.com/divinevideo/divine-mobile/actions/runs/25777519187), [25784037741](https://github.com/divinevideo/divine-mobile/actions/runs/25784037741) on #4311) — either asserting "shorter than expected" or hitting the 10-min timeout.

**Root cause.** `ClipEditorBloc._onSplitRequested` hardcoded `VideoEditorSplitService.splitClip`, a static method that awaits real `path_provider` (`getApplicationDocumentsDirectory`) and `pro_video_editor` (`renderVideoToFile`) plugins. Under `very_good test --optimization` (one shared isolate), sibling tests mutate the global plugin mocks without restoring them:

- `test/screens/video_metadata_cover_screen_test.dart` — `tearDown` nulls the `plugins.flutter.io/path_provider` channel mock installed by `test/test_setup.dart`.
- `test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart`, `test/blocs/sound_waveform/sound_waveform_bloc_test.dart`, `test/screens/video_editor/video_audio_editor_timing_screen_test.dart` — reassign `ProVideoEditor.instance` with no `tearDown` to restore the previous instance.

When the random seed runs any of those before `clip_editor_bloc_test.dart`, `splitClip`'s `await getDocumentsPath()` blocks before `onClipsCreated` can fire → the bloc emits only state 1 (`isEditing: false`) and the test sees a shorter-than-expected emit list or times out.

**Fix.** Add a `SplitClipFn` typedef + optional `splitClip` constructor parameter to `ClipEditorBloc`, defaulting to `VideoEditorSplitService.splitClip` so production behaviour is unchanged. The six affected tests now pass a pure-Dart `_fakeSplitClip` that mirrors the real service's clip-id and duration math and synchronously invokes `onClipsCreated`. No more dependency on global plugin mock state.

Sibling `test/services/video_editor/video_editor_split_service_test.dart` keeps exercising the real `VideoEditorSplitService.splitClip` (already gated with `@Tags(['skip_very_good_optimization'])` and its own `MockProVideoEditor` + `MockPathProviderPlatform`).

## Test plan
- [x] `flutter test test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart` — 57 pass locally
- [x] Merged-bundle regression: `very_good test --optimization --concurrency=1 --test-randomize-ordering-seed 2914136997` with the four polluter files + `clip_editor_bloc_test.dart` — 115 pass (CI's failing seed)
- [x] `flutter test test/services/video_editor/video_editor_split_service_test.dart` — sibling service test still green
- [x] `flutter analyze lib/blocs/video_editor lib/services/video_editor test/blocs/video_editor test/services/video_editor` — no issues
- [ ] CI green on this PR

## Follow-up
- The four polluter files should add proper `tearDown` to restore global state; out of scope here to keep the blast radius small.