### PR TITLE
fix: stop isNostrReady from re-arming .then on a resolved completer

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1214,6 +1214,19 @@ bool isNostrReady(Ref ref) {
   final ready = nostrClient.hasKeys;
 
   if (!ready) {
+    // If the ready future has already settled but `hasKeys` is still
+    // false, `refreshPublicKey()` returned an empty string during
+    // initialize() (signer not yet configured at cold boot). Attaching
+    // another `.then(...)` here would fire on the next microtask and
+    // re-invalidate this provider in a tight loop — every rebuild adds
+    // a fresh subscription to the already-resolved completer. Just
+    // return false and wait for an external rebuild trigger (auth
+    // state change or a new NostrClient instance from
+    // nostrServiceProvider).
+    if (nostrClient.isReadyResolved) {
+      return false;
+    }
+
     // One-shot listener: wait for initialize() to complete on the current
     // client, then invalidate so this provider re-reads hasKeys.
     final readyFuture = nostrClient.ready;

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2665,7 +2665,7 @@ final class IsNostrReadyProvider extends $FunctionalProvider<bool, bool, bool>
   }
 }
 
-String _$isNostrReadyHash() => r'8e478bdb678b1c1b0c35ce9a9099dd3c50aa728f';
+String _$isNostrReadyHash() => r'45f0b46f7dccacfaa8562434a26e41b1b923e6bb';
 
 /// Provider that sets Zendesk user identity when auth state changes
 /// Watch this provider at app startup to keep Zendesk identity in sync with auth

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -200,6 +200,17 @@ class NostrClient {
   /// "signer is ready" without busy-polling `hasKeys` — see #3352.
   Future<void> get ready => _readyCompleter.future;
 
+  /// Synchronous companion to [ready]: whether [initialize] has settled
+  /// (successfully or with an error).
+  ///
+  /// Consumers that attach `.then(...)` to [ready] on every rebuild must
+  /// check this first — once the completer is settled, every fresh
+  /// `.then(...)` fires on the next microtask, so re-arming without a
+  /// gate produces a tight invalidate loop on the "ready resolved but
+  /// `hasKeys` still false" path (signer started empty during cold
+  /// boot, then `refreshPublicKey()` returned `''`).
+  bool get isReadyResolved => _readyCompleter.isCompleted;
+
   /// Public key of the client
   String get publicKey => _nostr.publicKey;
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -2583,6 +2583,38 @@ void main() {
           await readyExpectation;
         },
       );
+
+      test('isReadyResolved is false before initialize() runs', () {
+        expect(client.isReadyResolved, isFalse);
+      });
+
+      test('isReadyResolved is true after initialize() succeeds', () async {
+        when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
+        when(() => mockRelayManager.initialize()).thenAnswer((_) async {});
+
+        await client.initialize();
+
+        expect(client.isReadyResolved, isTrue);
+      });
+
+      test(
+        'isReadyResolved is true after initialize() fails — gives '
+        'isNostrReadyProvider a synchronous "future already settled" '
+        'check so it stops re-arming .then on a completed completer',
+        () async {
+          final boom = StateError('refresh failed');
+          when(() => mockNostr.refreshPublicKey()).thenThrow(boom);
+
+          final readyExpectation = expectLater(
+            client.ready,
+            throwsA(same(boom)),
+          );
+          await expectLater(client.initialize(), throwsA(same(boom)));
+          await readyExpectation;
+
+          expect(client.isReadyResolved, isTrue);
+        },
+      );
     });
 
     group('relay convenience properties', () {

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -151,6 +151,11 @@ MockNostrClient createMockNostrService() {
   // Tests that need the ready transition should override this in their own
   // setUp via Completer<void>.future — see is_nostr_ready_provider_test.dart.
   when(() => mockNostr.ready).thenAnswer((_) => Completer<void>().future);
+  // Match the stubbed `ready` (a Completer that never completes): the
+  // synchronous gate isReadyResolved reads isCompleted on the same
+  // completer, so it must be false by default. Tests that exercise the
+  // "settled but hasKeys still false" path override this to true.
+  when(() => mockNostr.isReadyResolved).thenReturn(false);
   return mockNostr;
 }
 

--- a/mobile/test/unit/providers/is_nostr_ready_provider_test.dart
+++ b/mobile/test/unit/providers/is_nostr_ready_provider_test.dart
@@ -33,6 +33,9 @@ void main() {
       when(
         () => mockNostrClient.ready,
       ).thenAnswer((_) => readyCompleter.future);
+      // Default: the ready future is still pending. The "settled but
+      // hasKeys still false" regression case overrides this stub.
+      when(() => mockNostrClient.isReadyResolved).thenReturn(false);
     });
 
     ProviderContainer createContainer() {
@@ -156,6 +159,44 @@ void main() {
 
       // No expectations — the test passes if no exception leaks.
     });
+
+    test(
+      'returns false without re-arming .then when ready is already '
+      'settled but hasKeys is still false (regression: #4276 log storm — '
+      'cold boot where refreshPublicKey() returned an empty key)',
+      () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(() => mockNostrClient.hasKeys).thenReturn(false);
+        // ready future already settled, but the client never picked up a
+        // key (signer not configured yet). The bug: every rebuild
+        // attached a fresh `.then(...)` to this already-resolved future,
+        // which fired on the next microtask and `invalidateSelf`'d,
+        // producing hundreds of invalidations in a few milliseconds.
+        when(() => mockNostrClient.isReadyResolved).thenReturn(true);
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        // First read returns false — gate fires before any .then is
+        // attached.
+        expect(container.read(isNostrReadyProvider), isFalse);
+
+        // Yield to the microtask queue twice. With the bug, this is
+        // where the re-armed `.then` would fire and the loop would
+        // spin. With the fix, nothing happens.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        // Still false on a subsequent read. The contract is "stay
+        // false until an external rebuild trigger arrives" — auth
+        // state change or a fresh NostrClient instance.
+        expect(container.read(isNostrReadyProvider), isFalse);
+
+        // And critically: the provider never reached for the `ready`
+        // future, because the synchronous gate caught it first.
+        verifyNever(() => mockNostrClient.ready);
+      },
+    );
 
     test('profileRepositoryProvider is null when isNostrReady is false', () {
       final container = ProviderContainer(


### PR DESCRIPTION
## Description

#4276 (commit `c0fbeb734`) swapped the 50 ms polling timer in `isNostrReadyProvider` for an event-driven `nostrClient.ready.then(...)` listener that calls `ref.invalidateSelf()` once the future resolves.

The new shape spins a tight microtask loop on the cold-boot path where `Nostr.refreshPublicKey()` returns an empty string (signer not yet configured): the `_readyCompleter` resolves successfully but `hasKeys` stays `false`, so every rebuild attaches **another** `.then(...)` to the already-resolved future, which fires on the next microtask and re-invalidates the provider. Hundreds of `[SYSTEM] isNostrReady: NostrClient.ready completed, invalidating` log lines burst in a few ms at startup before an external rebuild (usually `nostrServiceProvider` producing a fresh client whose signer is now configured) breaks the loop via the `identical(...)` guard.

### Fix

- Add `NostrClient.isReadyResolved` as a synchronous companion to `ready` (mirrors `_readyCompleter.isCompleted`).
- In `isNostrReady`, short-circuit before attaching a new `.then(...)` when the completer is already settled but `hasKeys` is still `false`. The provider returns `false` and waits for an external rebuild trigger (auth state change or a new `NostrClient` instance) instead of re-arming.

The normal happy path (`!isReadyResolved` → attach listener once → fires when initialize() completes → invalidate → rebuild reads `hasKeys=true`) is unchanged.

**Related Issue:** Closes #4321 (regression from #4276, parent #3352)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `flutter analyze lib test integration_test` — no issues
- [x] `flutter test mobile/test/unit/providers/is_nostr_ready_provider_test.dart` — 8 pass, including new regression test for the bail-out path
- [x] `flutter test mobile/packages/nostr_client/test/src/nostr_client_test.dart` — 131 pass, including 3 new tests for `isReadyResolved`
- [ ] Manual cold-boot smoke on macOS — verify the `NostrClient.ready completed, invalidating` log no longer floods the debug console at startup
