### PR TITLE
feat(mobile): client-side image byte guard before Blossom (#4272)

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -14,6 +14,7 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
+import 'package:openvine/services/image_upload_validation.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -112,6 +113,10 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     Emitter<ProfileEditorState> emit,
   ) async {
     emit(state.copyWith(pendingAvatarStatus: PendingAvatarStatus.uploading));
+
+    if (_emitIfAvatarClientImageInvalid(event, emit)) {
+      return;
+    }
 
     BlossomUploadResult result;
     try {
@@ -279,6 +284,10 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
   ) async {
     emit(state.copyWith(pendingBannerStatus: PendingBannerStatus.uploading));
 
+    if (_emitIfBannerClientImageInvalid(event, emit)) {
+      return;
+    }
+
     BlossomUploadResult result;
     try {
       if (event.bytes != null) {
@@ -353,6 +362,114 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       BlossomUploadFailureReason.server => BannerUploadError.server,
       BlossomUploadFailureReason.unknown => BannerUploadError.generic,
     };
+  }
+
+  /// Client-side byte/extension guard before [BlossomUploadService] for avatar.
+  ///
+  /// Returns `true` when [emit] already handled a failure (caller must return).
+  bool _emitIfAvatarClientImageInvalid(
+    ProfilePictureUploadRequested event,
+    Emitter<ProfileEditorState> emit,
+  ) {
+    final ImageUploadValidationResult validation = event.bytes != null
+        ? validateImageBytes(
+            event.bytes!,
+            ImageUploadKind.avatar,
+            filename: event.filename,
+          )
+        : validateImageFile(event.file!, ImageUploadKind.avatar);
+
+    if (validation.isOk) {
+      return false;
+    }
+
+    final (String message, AvatarUploadError error) = switch (validation) {
+      ImageUploadValidationTooLarge(
+        :final limitBytes,
+        :final actualBytes,
+      ) =>
+        (
+          'Avatar exceeds client byte limit ($actualBytes bytes > $limitBytes)',
+          AvatarUploadError.fileTooLarge,
+        ),
+      ImageUploadValidationUnsupportedFormat(:final extension) => (
+        'Avatar has unsupported file extension: .$extension',
+        AvatarUploadError.generic,
+      ),
+      ImageUploadValidationUnreadable(:final cause) => (
+        'Avatar file unreadable before upload${cause != null ? ': $cause' : ''}',
+        AvatarUploadError.generic,
+      ),
+      ImageUploadValidationOk() => throw StateError('unreachable'),
+    };
+
+    Log.error(
+      message,
+      name: 'ProfileEditorBloc',
+      category: LogCategory.ui,
+    );
+    addError(Exception(message), StackTrace.current);
+    emit(
+      state.copyWith(
+        pendingAvatarStatus: PendingAvatarStatus.failed,
+        avatarUploadError: error,
+      ),
+    );
+    return true;
+  }
+
+  /// Client-side byte/extension guard before [BlossomUploadService] for banner.
+  ///
+  /// Returns `true` when [emit] already handled a failure (caller must return).
+  bool _emitIfBannerClientImageInvalid(
+    ProfileBannerUploadRequested event,
+    Emitter<ProfileEditorState> emit,
+  ) {
+    final ImageUploadValidationResult validation = event.bytes != null
+        ? validateImageBytes(
+            event.bytes!,
+            ImageUploadKind.banner,
+            filename: event.filename,
+          )
+        : validateImageFile(event.file!, ImageUploadKind.banner);
+
+    if (validation.isOk) {
+      return false;
+    }
+
+    final (String message, BannerUploadError error) = switch (validation) {
+      ImageUploadValidationTooLarge(
+        :final limitBytes,
+        :final actualBytes,
+      ) =>
+        (
+          'Banner exceeds client byte limit ($actualBytes bytes > $limitBytes)',
+          BannerUploadError.fileTooLarge,
+        ),
+      ImageUploadValidationUnsupportedFormat(:final extension) => (
+        'Banner has unsupported file extension: .$extension',
+        BannerUploadError.generic,
+      ),
+      ImageUploadValidationUnreadable(:final cause) => (
+        'Banner file unreadable before upload${cause != null ? ': $cause' : ''}',
+        BannerUploadError.generic,
+      ),
+      ImageUploadValidationOk() => throw StateError('unreachable'),
+    };
+
+    Log.error(
+      message,
+      name: 'ProfileEditorBloc',
+      category: LogCategory.ui,
+    );
+    addError(Exception(message), StackTrace.current);
+    emit(
+      state.copyWith(
+        pendingBannerStatus: PendingBannerStatus.failed,
+        bannerUploadError: error,
+      ),
+    );
+    return true;
   }
 
   void _onProfileBannerColorSelected(

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -24,6 +24,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
 import 'package:openvine/screens/apps/web_iframe_sandbox_screen.dart';
 import 'package:openvine/screens/key_management_screen.dart';
+import 'package:openvine/services/image_upload_validation.dart';
 import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/profile/nostr_info_sheet_content.dart';
@@ -1357,9 +1358,9 @@ class _ProfileSetupScreenViewState
     try {
       return await _picker.pickImage(
         source: source,
-        maxWidth: 1024,
-        maxHeight: 1024,
-        imageQuality: 85,
+        maxWidth: ImageUploadPolicy.profileAvatarPickerMaxWidth,
+        maxHeight: ImageUploadPolicy.profileAvatarPickerMaxHeight,
+        imageQuality: ImageUploadPolicy.profileAvatarPickerImageQuality,
         requestFullMetadata: false,
       );
     } catch (e) {
@@ -1395,7 +1396,16 @@ class _ProfileSetupScreenViewState
 
       final typeGroup = XTypeGroup(
         label: context.l10n.profileSetupImagesTypeGroup,
-        extensions: const <String>['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'],
+        extensions: const <String>[
+          'jpg',
+          'jpeg',
+          'png',
+          'gif',
+          'webp',
+          'bmp',
+          'heic',
+          'heif',
+        ],
       );
 
       final file = await openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
@@ -1773,8 +1783,9 @@ class _BannerActionRow extends StatelessWidget {
     try {
       picked = await picker.pickImage(
         source: ImageSource.gallery,
-        maxWidth: 1500,
-        imageQuality: 85,
+        maxWidth: ImageUploadPolicy.profileBannerPickerMaxWidth,
+        maxHeight: ImageUploadPolicy.profileBannerPickerMaxHeight,
+        imageQuality: ImageUploadPolicy.profileBannerPickerImageQuality,
         requestFullMetadata: false,
       );
     } catch (e) {

--- a/mobile/lib/services/image_upload_validation.dart
+++ b/mobile/lib/services/image_upload_validation.dart
@@ -1,0 +1,157 @@
+// ABOUTME: Client-side image upload policy (#4272) — byte cap and filename checks
+// ABOUTME: before Blossom metadata strip / hashing; not a security boundary.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+
+/// Profile / banner Blossom uploads: matches EN l10n "max 10MB" for file-too-large copy.
+const int kProfileImageUploadMaxBytes = 10 * 1024 * 1024;
+
+/// Which upload path is being validated (drives [ImageUploadPolicy.maxBytes]).
+enum ImageUploadKind {
+  /// Staged profile avatar on the profile editor flow.
+  avatar,
+
+  /// Staged profile banner on the profile editor flow.
+  banner,
+
+  /// Generated video thumbnail uploaded via the upload manager pipeline.
+  videoThumbnail,
+
+  /// Bug report attachment images (Zendesk / email); same byte ceiling as profile
+  /// until product defines a separate attachment policy.
+  bugReportAttachment,
+}
+
+/// Named limits per [ImageUploadKind] (single source of truth for validators).
+abstract final class ImageUploadPolicy {
+  /// Maximum uncompressed / on-disk size in bytes before calling Blossom.
+  static int maxBytes(ImageUploadKind kind) => switch (kind) {
+    ImageUploadKind.avatar => kProfileImageUploadMaxBytes,
+    ImageUploadKind.banner => kProfileImageUploadMaxBytes,
+    ImageUploadKind.videoThumbnail => kProfileImageUploadMaxBytes,
+    ImageUploadKind.bugReportAttachment => kProfileImageUploadMaxBytes,
+  };
+}
+
+/// Outcome of [validateImageBytes] / [validateImageFile].
+sealed class ImageUploadValidationResult {
+  const ImageUploadValidationResult();
+
+  /// True when validation passed and upload policy allows proceeding.
+  bool get isOk => this is ImageUploadValidationOk;
+}
+
+/// Validation passed.
+final class ImageUploadValidationOk extends ImageUploadValidationResult {
+  const ImageUploadValidationOk();
+}
+
+/// Byte length exceeds [ImageUploadPolicy.maxBytes] for this [ImageUploadKind].
+final class ImageUploadValidationTooLarge extends ImageUploadValidationResult {
+  const ImageUploadValidationTooLarge({
+    required this.limitBytes,
+    required this.actualBytes,
+  });
+
+  final int limitBytes;
+  final int actualBytes;
+}
+
+/// Filename extension is present and not in the allowed image set (see
+/// [_kAllowedImageExtensions]).
+final class ImageUploadValidationUnsupportedFormat
+    extends ImageUploadValidationResult {
+  const ImageUploadValidationUnsupportedFormat({required this.extension});
+
+  /// Lowercase extension without leading dot, e.g. `txt`, `mp4`.
+  final String extension;
+}
+
+/// File missing, unreadable length, or other I/O failure when checking size.
+final class ImageUploadValidationUnreadable
+    extends ImageUploadValidationResult {
+  const ImageUploadValidationUnreadable({this.cause});
+
+  final Object? cause;
+}
+
+const Set<String> _kAllowedImageExtensions = {
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'bmp',
+  'heic',
+  'heif',
+};
+
+String? _normalizedExtension(String? filename, {String? fallbackPath}) {
+  final source = (filename != null && filename.isNotEmpty)
+      ? filename
+      : fallbackPath;
+  if (source == null || source.isEmpty) return null;
+  final ext = p.extension(source).replaceFirst('.', '').toLowerCase();
+  return ext.isEmpty ? null : ext;
+}
+
+ImageUploadValidationResult _validateLengthAndExtension(
+  int length,
+  ImageUploadKind kind, {
+  String? filename,
+  String? fallbackPath,
+}) {
+  final limit = ImageUploadPolicy.maxBytes(kind);
+  if (length > limit) {
+    return ImageUploadValidationTooLarge(
+      limitBytes: limit,
+      actualBytes: length,
+    );
+  }
+
+  final ext = _normalizedExtension(filename, fallbackPath: fallbackPath);
+  if (ext != null && !_kAllowedImageExtensions.contains(ext)) {
+    return ImageUploadValidationUnsupportedFormat(extension: ext);
+  }
+
+  return const ImageUploadValidationOk();
+}
+
+/// Validates [bytes] length against [ImageUploadPolicy.maxBytes].
+///
+/// When [filename] is non-empty, a non-empty extension must be in the allowed
+/// image set; missing extension does not fail (web / odd paths stay permissive).
+ImageUploadValidationResult validateImageBytes(
+  Uint8List bytes,
+  ImageUploadKind kind, {
+  String? filename,
+}) {
+  return _validateLengthAndExtension(
+    bytes.length,
+    kind,
+    filename: filename,
+  );
+}
+
+/// Reads length from [file] via metadata only (no full file read into memory).
+ImageUploadValidationResult validateImageFile(File file, ImageUploadKind kind) {
+  if (!file.existsSync()) {
+    return const ImageUploadValidationUnreadable();
+  }
+
+  int length;
+  try {
+    length = file.lengthSync();
+  } on Object catch (e) {
+    return ImageUploadValidationUnreadable(cause: e);
+  }
+
+  return _validateLengthAndExtension(
+    length,
+    kind,
+    fallbackPath: file.path,
+  );
+}

--- a/mobile/lib/services/image_upload_validation.dart
+++ b/mobile/lib/services/image_upload_validation.dart
@@ -34,6 +34,23 @@ abstract final class ImageUploadPolicy {
     ImageUploadKind.videoThumbnail => kProfileImageUploadMaxBytes,
     ImageUploadKind.bugReportAttachment => kProfileImageUploadMaxBytes,
   };
+
+  // --- `image_picker` downscaling hints (keep in sync with call sites) ---
+
+  /// Square cap for profile avatar picks (gallery / camera / web).
+  static const double profileAvatarPickerMaxWidth = 1024;
+  static const double profileAvatarPickerMaxHeight = 1024;
+  static const int profileAvatarPickerImageQuality = 85;
+
+  /// Wide cap for profile banner picks (matches PR #4232 / issue #4272 notes).
+  static const double profileBannerPickerMaxWidth = 1500;
+  static const double profileBannerPickerMaxHeight = 500;
+  static const int profileBannerPickerImageQuality = 85;
+
+  /// Cap for bug-report multi-image picks (mobile).
+  static const double bugReportAttachmentPickerMaxWidth = 1920;
+  static const double bugReportAttachmentPickerMaxHeight = 1920;
+  static const int bugReportAttachmentPickerImageQuality = 80;
 }
 
 /// Outcome of [validateImageBytes] / [validateImageFile].

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/services/image_upload_validation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 // ABOUTME: Mobile-only image attachment picker for bug reports.
@@ -47,8 +48,10 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
     List<XFile> picked;
     try {
       picked = await ImageAttachmentPicker.imagePicker.pickMultiImage(
-        maxWidth: 1920,
-        imageQuality: 80,
+        maxWidth: ImageUploadPolicy.bugReportAttachmentPickerMaxWidth,
+        maxHeight: ImageUploadPolicy.bugReportAttachmentPickerMaxHeight,
+        imageQuality: ImageUploadPolicy.bugReportAttachmentPickerImageQuality,
+        requestFullMetadata: false,
       );
     } catch (error, stackTrace) {
       Log.error(

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -13,13 +13,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/services/image_upload_validation.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
-
-class _FakeFile extends Fake implements File {}
 
 void main() {
   group('ProfileEditorBloc', () {
@@ -61,7 +60,7 @@ void main() {
               'fallback12345678901234567890123456789012345678901234567890123456',
         ),
       );
-      registerFallbackValue(_FakeFile());
+      registerFallbackValue(File('mocktail_file_fallback.jpg'));
       registerFallbackValue(Uint8List(0));
     });
 
@@ -1891,6 +1890,7 @@ void main() {
       const testStagedUrl = 'https://media.divine.video/staged-hash';
       const testPersistedUrl = 'https://media.divine.video/persisted-hash';
       final testBytes = Uint8List.fromList([0xFF, 0xD8, 0xFF]);
+      late Directory avatarFilePickTempDir;
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
         'ProfilePictureUploadRequested with bytes stages on success',
@@ -1956,6 +1956,9 @@ void main() {
       blocTest<ProfileEditorBloc, ProfileEditorState>(
         'ProfilePictureUploadRequested with file stages on success',
         setUp: () {
+          avatarFilePickTempDir = Directory.systemTemp.createTempSync(
+            'profile_editor_avatar_file_',
+          );
           when(
             () => mockBlossomUploadService.uploadImage(
               imageFile: any(named: 'imageFile'),
@@ -1970,10 +1973,17 @@ void main() {
             ),
           );
         },
+        tearDown: () {
+          if (avatarFilePickTempDir.existsSync()) {
+            avatarFilePickTempDir.deleteSync(recursive: true);
+          }
+        },
         build: createBloc,
-        act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, file: _FakeFile()),
-        ),
+        act: (bloc) {
+          final f = File('${avatarFilePickTempDir.path}/picked.jpg')
+            ..writeAsBytesSync(testBytes);
+          bloc.add(ProfilePictureUploadRequested(pubkey: testPubkey, file: f));
+        },
         expect: () => [
           isA<ProfileEditorState>().having(
             (s) => s.pendingAvatarStatus,
@@ -1999,6 +2009,135 @@ void main() {
               nostrPubkey: testPubkey,
             ),
           ).called(1);
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'client byte guard rejects oversize avatar bytes before Blossom',
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: Uint8List(kProfileImageUploadMaxBytes + 1),
+            filename: 'big.jpg',
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.pendingAvatarStatus,
+            'pendingAvatarStatus',
+            PendingAvatarStatus.uploading,
+          ),
+          isA<ProfileEditorState>()
+              .having(
+                (s) => s.pendingAvatarStatus,
+                'pendingAvatarStatus',
+                PendingAvatarStatus.failed,
+              )
+              .having(
+                (s) => s.avatarUploadError,
+                'avatarUploadError',
+                AvatarUploadError.fileTooLarge,
+              ),
+        ],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
+          verifyNever(
+            () => mockBlossomUploadService.uploadImageBytes(
+              bytes: any(named: 'bytes'),
+              filename: any(named: 'filename'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              mimeType: any(named: 'mimeType'),
+            ),
+          );
+          verifyNever(
+            () => mockBlossomUploadService.uploadImage(
+              imageFile: any(named: 'imageFile'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'client extension guard rejects avatar bytes with bad filename before Blossom',
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.exe',
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.pendingAvatarStatus,
+            'pendingAvatarStatus',
+            PendingAvatarStatus.uploading,
+          ),
+          isA<ProfileEditorState>()
+              .having(
+                (s) => s.pendingAvatarStatus,
+                'pendingAvatarStatus',
+                PendingAvatarStatus.failed,
+              )
+              .having(
+                (s) => s.avatarUploadError,
+                'avatarUploadError',
+                AvatarUploadError.generic,
+              ),
+        ],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
+          verifyNever(
+            () => mockBlossomUploadService.uploadImageBytes(
+              bytes: any(named: 'bytes'),
+              filename: any(named: 'filename'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              mimeType: any(named: 'mimeType'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'client byte guard rejects oversize banner bytes before Blossom',
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ProfileBannerUploadRequested(
+            pubkey: testPubkey,
+            bytes: Uint8List(kProfileImageUploadMaxBytes + 1),
+            filename: 'big.jpg',
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.pendingBannerStatus,
+            'pendingBannerStatus',
+            PendingBannerStatus.uploading,
+          ),
+          isA<ProfileEditorState>()
+              .having(
+                (s) => s.pendingBannerStatus,
+                'pendingBannerStatus',
+                PendingBannerStatus.failed,
+              )
+              .having(
+                (s) => s.bannerUploadError,
+                'bannerUploadError',
+                BannerUploadError.fileTooLarge,
+              ),
+        ],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
+          verifyNever(
+            () => mockBlossomUploadService.uploadImageBytes(
+              bytes: any(named: 'bytes'),
+              filename: any(named: 'filename'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              mimeType: any(named: 'mimeType'),
+            ),
+          );
         },
       );
 

--- a/mobile/test/unit/services/image_upload_validation_test.dart
+++ b/mobile/test/unit/services/image_upload_validation_test.dart
@@ -112,4 +112,20 @@ void main() {
       }
     });
   });
+
+  group('ImageUploadPolicy picker hints', () {
+    test('banner max width exceeds max height (wide hero)', () {
+      expect(
+        ImageUploadPolicy.profileBannerPickerMaxWidth,
+        greaterThan(ImageUploadPolicy.profileBannerPickerMaxHeight),
+      );
+    });
+
+    test('bug report picker uses square cap', () {
+      expect(
+        ImageUploadPolicy.bugReportAttachmentPickerMaxWidth,
+        ImageUploadPolicy.bugReportAttachmentPickerMaxHeight,
+      );
+    });
+  });
 }

--- a/mobile/test/unit/services/image_upload_validation_test.dart
+++ b/mobile/test/unit/services/image_upload_validation_test.dart
@@ -1,0 +1,115 @@
+// ABOUTME: Unit tests for image_upload_validation (#4272 plan §2).
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/image_upload_validation.dart';
+
+void main() {
+  group('validateImageBytes', () {
+    test('ok at exactly max bytes (avatar)', () {
+      final bytes = Uint8List(kProfileImageUploadMaxBytes);
+      final r = validateImageBytes(bytes, ImageUploadKind.avatar);
+      expect(r, isA<ImageUploadValidationOk>());
+      expect(r.isOk, isTrue);
+    });
+
+    test('tooLarge one byte over limit (banner)', () {
+      final bytes = Uint8List(kProfileImageUploadMaxBytes + 1);
+      final r = validateImageBytes(bytes, ImageUploadKind.banner);
+      expect(r, isA<ImageUploadValidationTooLarge>());
+      final t = r as ImageUploadValidationTooLarge;
+      expect(t.limitBytes, kProfileImageUploadMaxBytes);
+      expect(t.actualBytes, kProfileImageUploadMaxBytes + 1);
+    });
+
+    test('empty bytes ok', () {
+      final r = validateImageBytes(Uint8List(0), ImageUploadKind.avatar);
+      expect(r.isOk, isTrue);
+    });
+
+    test('unsupportedFormat when filename has disallowed extension', () {
+      final bytes = Uint8List(10);
+      final r = validateImageBytes(
+        bytes,
+        ImageUploadKind.avatar,
+        filename: 'x.exe',
+      );
+      expect(r, isA<ImageUploadValidationUnsupportedFormat>());
+      expect((r as ImageUploadValidationUnsupportedFormat).extension, 'exe');
+    });
+
+    test('ok when filename has allowed extension', () {
+      final bytes = Uint8List(10);
+      final r = validateImageBytes(
+        bytes,
+        ImageUploadKind.avatar,
+        filename: 'Photo.JPEG',
+      );
+      expect(r.isOk, isTrue);
+    });
+
+    test('ok when filename has no extension (permissive)', () {
+      final bytes = Uint8List(10);
+      final r = validateImageBytes(
+        bytes,
+        ImageUploadKind.avatar,
+        filename: 'blob',
+      );
+      expect(r.isOk, isTrue);
+    });
+
+    test('HEIC allowed (iOS gallery)', () {
+      final bytes = Uint8List(1);
+      final r = validateImageBytes(
+        bytes,
+        ImageUploadKind.avatar,
+        filename: 'img.heic',
+      );
+      expect(r.isOk, isTrue);
+    });
+  });
+
+  group('validateImageFile', () {
+    test('unreadable when file missing', () {
+      final f = File('/nonexistent/path/4272_missing_image.jpg');
+      final r = validateImageFile(f, ImageUploadKind.banner);
+      expect(r, isA<ImageUploadValidationUnreadable>());
+    });
+
+    test('unsupportedFormat for disallowed extension on disk', () {
+      final dir = Directory.systemTemp.createTempSync('img_val_test_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+
+      final f = File('${dir.path}/notes.txt');
+      f.writeAsBytesSync(Uint8List(8));
+
+      final r = validateImageFile(f, ImageUploadKind.avatar);
+      expect(r, isA<ImageUploadValidationUnsupportedFormat>());
+      expect((r as ImageUploadValidationUnsupportedFormat).extension, 'txt');
+    });
+
+    test('ok for small png path', () {
+      final dir = Directory.systemTemp.createTempSync('img_val_test_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+
+      final f = File('${dir.path}/x.png');
+      f.writeAsBytesSync(Uint8List(4));
+
+      final r = validateImageFile(f, ImageUploadKind.videoThumbnail);
+      expect(r.isOk, isTrue);
+    });
+  });
+
+  group('ImageUploadPolicy.maxBytes', () {
+    test('all kinds use profile ceiling for now', () {
+      for (final k in ImageUploadKind.values) {
+        expect(
+          ImageUploadPolicy.maxBytes(k),
+          kProfileImageUploadMaxBytes,
+        );
+      }
+    });
+  });
+}

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -72,7 +72,9 @@ void main() {
         when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
+            maxHeight: any(named: 'maxHeight'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => pickedFiles);
 
@@ -100,7 +102,9 @@ void main() {
         when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
+            maxHeight: any(named: 'maxHeight'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenThrow(Exception('picker failed'));
 
@@ -127,7 +131,9 @@ void main() {
         when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
+            maxHeight: any(named: 'maxHeight'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => fourFiles);
 
@@ -156,7 +162,9 @@ void main() {
         when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
+            maxHeight: any(named: 'maxHeight'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => threeFiles);
 
@@ -178,7 +186,9 @@ void main() {
         when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
+            maxHeight: any(named: 'maxHeight'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => twoFiles);
 
@@ -244,7 +254,9 @@ void main() {
         when(
           () => mockPicker.pickMultiImage(
             maxWidth: any(named: 'maxWidth'),
+            maxHeight: any(named: 'maxHeight'),
             imageQuality: any(named: 'imageQuality'),
+            requestFullMetadata: any(named: 'requestFullMetadata'),
           ),
         ).thenAnswer((_) async => pickedFiles);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Large gallery images could reach `BlossomUploadService` (strip metadata, hash, network) before any explicit client byte check. This PR adds a **shared validation layer** and wires it into the profile upload path, while keeping **picker limits** aligned with the same policy constants.

**Related Issue:** Closes #4272

### Changes (summary)

- **`mobile/lib/services/image_upload_validation.dart`** — `ImageUploadKind`, `ImageUploadPolicy` (byte cap **10 MiB** for profile-aligned kinds, aligned with existing EN copy for “max 10MB”), `validateImageBytes` / synchronous `validateImageFile`, extension allowlist (incl. HEIC/HEIF); picker hint constants for avatar, banner, and bug-report attachments.
- **`mobile/lib/blocs/profile_editor/profile_editor_bloc.dart`** — after `emit(uploading)` for avatar/banner, validate before any `BlossomUploadService.uploadImage*` call; `tooLarge` → existing `fileTooLarge` errors; other validation failures → `generic`; `addError` matches the existing failure path.
- **`mobile/lib/screens/profile_setup_screen.dart`** — uses policy constants for `image_picker` / desktop file selector; banner flow passes **both** `maxWidth` and `maxHeight`; desktop `XTypeGroup` includes **heic** / **heif**.
- **`mobile/lib/widgets/image_attachment_picker.dart`** — policy constants, **`maxHeight`**, **`requestFullMetadata: false`** for `pickMultiImage`.
- **Tests** — `mobile/test/unit/services/image_upload_validation_test.dart`, `mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart` (including client guard cases under `profile picture staging`), `mobile/test/widgets/image_attachment_picker_test.dart`; regression coverage via `mobile/test/screens/profile_setup_screen_test.dart` where applicable.

### Server 413 is still the backstop

The client guard improves **UX** and saves **local work + bandwidth** for obviously oversized files. **Relay/server rejection (e.g. 413)** remains the authoritative limit if policy diverges or an edge case bypasses the client check.

### Out of scope (by design)

- **`pro_image_editor`** for avatar/banner crop UX — tracked as a separate improvement; the byte guard remains valuable regardless.
- **`UploadManager`** video thumbnail upload path — unchanged in this PR (optional follow-up if generated thumbnails can exceed policy).

### Scope / audit (#4272)

**`uploadImage` / `uploadImageBytes` in `mobile/lib` (callers only):**

1. `mobile/lib/blocs/profile_editor/profile_editor_bloc.dart` — avatar and banner uploads (`ProfilePictureUploadRequested`, `ProfileBannerUploadRequested`).
2. `mobile/lib/services/upload_manager.dart` — generated video thumbnail file after `VideoThumbnailService.extractThumbnail` (not user gallery pick).

**Image pickers in `mobile/lib`:**

1. `mobile/lib/screens/profile_setup_screen.dart` — `ImagePicker.pickImage` (avatar + banner flows), plus desktop gallery `file_selector.openFile` for avatar.
2. `mobile/lib/widgets/image_attachment_picker.dart` — `pickMultiImage` for bug-report attachments (Zendesk/email path; not per-image Blossom upload).

**Not found in `mobile/lib`:** any other `pickImage` / `pickMultiImage` / `ImagePicker` usage; no `file_picker` usage. `mobile/lib/widgets/bug_report_dialog.dart` imports `XFile` only.

**Package layer:** only `mobile/packages/blossom_upload_service` defines `uploadImage` / `uploadImageBytes`; no other package under `mobile/packages/*/lib` calls these methods.

### Verification (from `mobile/`)

- `flutter analyze`
- `flutter test test/blocs/profile_editor/profile_editor_bloc_test.dart --name "profile picture staging"`  
  (Run **alone** with `--name`: combining other test files in the same command skips tests in files whose names do not match the filter.)
- `flutter test test/unit/services/image_upload_validation_test.dart test/widgets/image_attachment_picker_test.dart`
- `flutter test test/screens/profile_setup_screen_test.dart`

**l10n:** No new ARB keys or user-visible strings were added for this work; full `/check-l10n` was not required. Run it if follow-up copy changes land.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore