### PR TITLE
refactor(collabs): centralize collaborator p-tag construction

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -838,10 +838,7 @@ class VideoEventPublisher {
         tags.add(['expiration', expirationTimestamp.toString()]);
       }
 
-      // Add Divine collaborator-marked p-tags for this NIP-71 video event.
-      for (final pubkey in collaboratorPubkeys) {
-        tags.add(buildCollaboratorPTag(pubkey));
-      }
+      tags.addAll(buildCollaboratorPTags(collaboratorPubkeys));
 
       // Add Inspired By a-tag (specific video reference)
       if (inspiredByAddressableId != null) {

--- a/mobile/lib/utils/collaborator_tags.dart
+++ b/mobile/lib/utils/collaborator_tags.dart
@@ -11,3 +11,12 @@ List<String> buildCollaboratorPTag(String pubkey) => [
   collaboratorInviteRelayHint,
   'collaborator',
 ];
+
+/// Builds Divine collaborator-marked `p` tags for each [pubkey].
+///
+/// Equivalent to `pubkeys.map(buildCollaboratorPTag).toList()`. Accepts any
+/// [Iterable] so callers can pass a `List`, a `Set`, or another iterable
+/// without converting.
+List<List<String>> buildCollaboratorPTags(Iterable<String> pubkeys) => [
+  for (final pubkey in pubkeys) buildCollaboratorPTag(pubkey),
+];

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1562,10 +1562,7 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
         tags.add(['alt', widget.video.altText!]);
       }
 
-      // Add collaborator p-tags
-      for (final pubkey in _collaboratorPubkeys) {
-        tags.add(buildCollaboratorPTag(pubkey));
-      }
+      tags.addAll(buildCollaboratorPTags(_collaboratorPubkeys));
 
       // Add inspired-by a-tag (video reference)
       if (_inspiredByVideo != null) {

--- a/mobile/test/utils/collaborator_tags_test.dart
+++ b/mobile/test/utils/collaborator_tags_test.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Tests for the Divine collaborator p-tag helpers.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
+
+void main() {
+  final pubkeyA = 'a' * 64;
+  final pubkeyB = 'b' * 64;
+  final pubkeyC = 'c' * 64;
+
+  group('buildCollaboratorPTag', () {
+    test(
+      'builds a 4-element Divine-convention p-tag with lowercase marker',
+      () {
+        expect(
+          buildCollaboratorPTag(pubkeyA),
+          equals(['p', pubkeyA, collaboratorInviteRelayHint, 'collaborator']),
+        );
+      },
+    );
+  });
+
+  group('buildCollaboratorPTags', () {
+    test('returns an empty list for empty input', () {
+      expect(buildCollaboratorPTags(const <String>[]), isEmpty);
+    });
+
+    test('plural output equals iteration of singular over the same input', () {
+      final pubkeys = [pubkeyA, pubkeyB, pubkeyC];
+      expect(
+        buildCollaboratorPTags(pubkeys),
+        equals(pubkeys.map(buildCollaboratorPTag).toList()),
+      );
+    });
+
+    test('accepts a Set as well as a List', () {
+      final pubkeys = <String>{pubkeyA, pubkeyB};
+      final result = buildCollaboratorPTags(pubkeys);
+      expect(result, hasLength(2));
+      expect(
+        result,
+        everyElement(
+          predicate<List<String>>(
+            (tag) =>
+                tag.length == 4 &&
+                tag[0] == 'p' &&
+                tag[2] == collaboratorInviteRelayHint &&
+                tag[3] == 'collaborator',
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #3704. Closes the residual scope of #4201.

- Add `buildCollaboratorPTags(Iterable<String>)` plural helper alongside the singular `buildCollaboratorPTag` in `mobile/lib/utils/collaborator_tags.dart`.
- Replace the inline for-loops at the two emitter sites — `video_event_publisher.dart` (initial publish) and `share_video_menu.dart` (post-publish edit) — with one `tags.addAll(buildCollaboratorPTags(...))` call each.
- Remove the call-site comments that restated the helper's intent; the Divine 4th-element convention is documented on the helper itself.

No protocol or behaviour change: same kind-34236 event with the same 4-element `['p', pubkey, relay, 'collaborator']` tag shape.

## Why

#3704 asks to centralize p-tag construction and stop building tag arrays in widget state. The singular helper was already centralized (#3686 / #3847 lineage); this PR closes the loop with a plural form so the widget edit path no longer iterates over `_collaboratorPubkeys` inline. Surface area is intentionally minimal — the widget remains the orchestrator for the kind-34236 edit event's full tag list, but tag *construction* for the collaborator portion now lives entirely in `collaborator_tags.dart`.

## Out of scope

- Lifting the entire kind-34236 edit-publish path out of `share_video_menu` would require parallel lifts of title / imeta / hashtags / content-warning / engagement-count construction and is significantly larger than #3704. Track separately if needed.
- Funnelcake-dependent confirmed-read switch (Tasks 15–17 of `docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md`); gates on backend.

## Tests

New: `mobile/test/utils/collaborator_tags_test.dart` covers
- singular helper builds the expected 4-element shape with lowercase marker
- plural helper output equals `pubkeys.map(buildCollaboratorPTag).toList()`
- plural helper accepts a `Set` as well as a `List`
- plural helper returns empty for empty input

Verified green:
- `mobile/test/services/video_event_publisher_collaborator_tags_test.dart` — asserts publisher output contains the expected tag shape (invariant under this refactor).
- `mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart` — asserts edit-path republishes the lowercase-marker tag (invariant under this refactor).

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` on touched files — clean.
- [x] `flutter analyze lib test integration_test` — no issues.
- [x] `flutter test test/utils/collaborator_tags_test.dart` — 4 passed.
- [x] `flutter test test/services/video_event_publisher_collaborator_tags_test.dart test/widgets/share_video_menu_edit_collaborator_tags_test.dart` — 3 passed.
- [ ] Manual smoke: post a video with 2 collaborators on account A; edit the video to add/remove a collaborator; inspect the kind-34236 event tags on the relay to confirm the 4-element Divine p-tag shape persists across both paths.

## Epic closeout

Following this PR, the closeout actions on #4201 (acceptance-criteria mapping comment, #3664 backend reassignment) will be posted as a follow-up so the AC table can cite this PR's merge SHA.