### PR TITLE
docs: note headless-CI hint in path_resolver web-shard comment

### DIFF
--- a/mobile/test/utils/path_resolver_test.dart
+++ b/mobile/test/utils/path_resolver_test.dart
@@ -3,7 +3,8 @@
 // `getDocumentsPath` on web is covered by the web-only test below; run it with
 // `flutter test test/utils/path_resolver_test.dart --platform chrome` (manual /
 // local — not executed in CI). `flutter build web` only checks compilation, not
-// this runtime branch.
+// this runtime branch. On headless setups, set `CHROME_EXECUTABLE` to your
+// Chrome/Chromium binary and wrap the command with `xvfb-run -a`.
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Closes #4333

## Summary

Follow-up to #4327. That PR trimmed the web-shard testing bullet from `CONTRIBUTING.md`. Most of the trimmed content is still documented elsewhere (build-script flags live in `docs/BUILD_SCRIPTS_README.md`, and the `--platform chrome` invocation is already in this test file's leading comment + `skip:` message). The only piece without another home was the headless-CI hint about `CHROME_EXECUTABLE` and `xvfb-run -a`.

This appends that hint to the existing comment block in `mobile/test/utils/path_resolver_test.dart` so it stays co-located with the test it applies to, instead of re-bloating `CONTRIBUTING.md`.

## Description

Comment-only change. No code, no test, no behavior delta.

**Related Issue:** N/A — surfaced during review of #4327.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- `flutter analyze mobile/test/utils/path_resolver_test.dart` → `No issues found!`
- No runtime impact; comment-only.