### PR TITLE
refactor(notifications): stream notification tap events

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -78,7 +78,7 @@ import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_service.dart'
-    show NotificationKind;
+    show NotificationPayloadKind, NotificationTapEvent;
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -275,7 +275,7 @@ Future<void> _resolveAndPushNotificationDeepLink({
   required ProviderContainer container,
 }) async {
   final deepLinkService = container.read(deepLinkServiceProvider);
-  final autoOpenComments = notificationType == NotificationKind.reply;
+  final autoOpenComments = notificationType == NotificationPayloadKind.reply;
 
   String? videoEventId;
   try {
@@ -1170,6 +1170,7 @@ class DivineApp extends ConsumerStatefulWidget {
 class _DivineAppState extends ConsumerState<DivineApp> {
   bool _backgroundInitDone = false;
   StreamSubscription<void>? _shakeSubscription;
+  StreamSubscription<NotificationTapEvent>? _notificationTapSubscription;
 
   @override
   void initState() {
@@ -1188,6 +1189,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
 
   @override
   void dispose() {
+    _notificationTapSubscription?.cancel();
     _shakeSubscription?.cancel();
     super.dispose();
   }
@@ -1206,23 +1208,25 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     // Route local notification taps (background-built via flutter_local_notifications)
     // through the same deep-link stream so the build() listener handles navigation.
     final container = ProviderScope.containerOf(context);
-    ref
+    _notificationTapSubscription?.cancel();
+    _notificationTapSubscription = ref
         .read(notificationServiceProvider)
-        .onNotificationTap = (referencedEventId, notificationType) {
-      Log.info(
-        '🔔 Local notification tap: eventId=$referencedEventId '
-        'type=$notificationType',
-        name: 'DeepLinkHandler',
-        category: LogCategory.ui,
-      );
-      unawaited(
-        _resolveAndPushNotificationDeepLink(
-          referencedEventId: referencedEventId,
-          notificationType: notificationType,
-          container: container,
-        ),
-      );
-    };
+        .notificationTapStream
+        .listen((tapEvent) {
+          Log.info(
+            '🔔 Local notification tap: eventId=${tapEvent.referencedEventId} '
+            'type=${tapEvent.notificationType}',
+            name: 'DeepLinkHandler',
+            category: LogCategory.ui,
+          );
+          unawaited(
+            _resolveAndPushNotificationDeepLink(
+              referencedEventId: tapEvent.referencedEventId,
+              notificationType: tapEvent.notificationType,
+              container: container,
+            ),
+          );
+        });
 
     // Initialize the deep link service for password reset
     ref.read(passwordResetListenerProvider).initialize();

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -168,7 +168,11 @@ final firebaseOnMessageProvider = Provider<Stream<RemoteMessage>>(
 );
 
 final notificationServiceProvider = Provider<NotificationService>(
-  (ref) => NotificationService(),
+  (ref) {
+    final service = NotificationService();
+    ref.onDispose(service.dispose);
+    return service;
+  },
 );
 
 final collaboratorResponseServiceProvider =

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -27,6 +27,16 @@ class NotificationTapEvent {
 
   final String referencedEventId;
   final String? notificationType;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotificationTapEvent &&
+          referencedEventId == other.referencedEventId &&
+          notificationType == other.notificationType;
+
+  @override
+  int get hashCode => Object.hash(referencedEventId, notificationType);
 }
 
 /// Push-notification kind values as they appear in the FCM payload `type` field
@@ -134,8 +144,7 @@ class NotificationService {
   final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
   bool _pluginInitialized = false;
-  final StreamController<NotificationTapEvent> _notificationTapController =
-      StreamController<NotificationTapEvent>.broadcast();
+  StreamController<NotificationTapEvent>? _notificationTapController;
 
   /// List of recent notifications
   List<AppNotification> get notifications => List.unmodifiable(_notifications);
@@ -145,7 +154,9 @@ class NotificationService {
 
   /// Stream of local-notification taps emitted after payload parsing.
   Stream<NotificationTapEvent> get notificationTapStream =>
-      _notificationTapController.stream;
+      (_notificationTapController ??=
+              StreamController<NotificationTapEvent>.broadcast())
+          .stream;
 
   /// Initialize notification service
   ///
@@ -497,8 +508,9 @@ class NotificationService {
   }
 
   void _emitNotificationTap(NotificationTapEvent event) {
-    if (_disposed || _notificationTapController.isClosed) return;
-    _notificationTapController.add(event);
+    final controller = _notificationTapController;
+    if (_disposed || controller == null || controller.isClosed) return;
+    controller.add(event);
   }
 
   /// Send a local notification with title and body
@@ -742,7 +754,7 @@ class NotificationService {
     if (_disposed) return;
 
     _disposed = true;
-    _notificationTapController.close();
+    _notificationTapController?.close();
     _notifications.clear();
   }
 

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Service for showing user notifications about upload status and publishing
 // ABOUTME: Handles local notifications and in-app messages for video processing updates
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -16,12 +17,24 @@ enum NotificationType {
   processingStarted,
 }
 
+/// Normalized notification-tap payload emitted by [NotificationService].
+@immutable
+class NotificationTapEvent {
+  const NotificationTapEvent({
+    required this.referencedEventId,
+    required this.notificationType,
+  });
+
+  final String referencedEventId;
+  final String? notificationType;
+}
+
 /// Push-notification kind values as they appear in the FCM payload `type` field
 /// and in the local-notification JSON payload `notificationType` field.
 ///
 /// Use these constants instead of bare string literals so that the routing
 /// policy (e.g. "open comments for replies") is defined in one place.
-abstract final class NotificationKind {
+abstract final class NotificationPayloadKind {
   /// The originating notification was a reply to one of the user's videos.
   static const String reply = 'reply';
 }
@@ -121,21 +134,18 @@ class NotificationService {
   final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
   bool _pluginInitialized = false;
-
-  /// Optional callback invoked when the user taps a local notification.
-  ///
-  /// The callback receives two arguments: the [referencedEventId] (Nostr event
-  /// ID of the content the notification is about) and [notificationType] (e.g.
-  /// `"reply"`, `"reaction"`, `"repost"`, `"zap"`, `"follow"`).  Either value
-  /// may be null if the payload doesn't carry that field.
-  void Function(String referencedEventId, String? notificationType)?
-  onNotificationTap;
+  final StreamController<NotificationTapEvent> _notificationTapController =
+      StreamController<NotificationTapEvent>.broadcast();
 
   /// List of recent notifications
   List<AppNotification> get notifications => List.unmodifiable(_notifications);
 
   /// Check if notification permissions are granted
   bool get hasPermissions => _permissionsGranted;
+
+  /// Stream of local-notification taps emitted after payload parsing.
+  Stream<NotificationTapEvent> get notificationTapStream =>
+      _notificationTapController.stream;
 
   /// Initialize notification service
   ///
@@ -440,11 +450,11 @@ class NotificationService {
     _handleNotificationTapPayload(response.payload);
   }
 
-  /// Parses [payload] and invokes [onNotificationTap] when a valid
+  /// Parses [payload] and emits a [NotificationTapEvent] when a valid
   /// [referencedEventId] can be extracted.
   ///
   /// Exposed for testing; production callers should use
-  /// [_onNotificationTapped] or configure [onNotificationTap] instead.
+  /// [_onNotificationTapped] or listen to [notificationTapStream].
   @visibleForTesting
   void handleNotificationTapPayload(String? payload) =>
       _handleNotificationTapPayload(payload);
@@ -463,7 +473,12 @@ class NotificationService {
       final referencedEventId = data['referencedEventId'] as String?;
       final notificationType = data['notificationType'] as String?;
       if (referencedEventId != null && referencedEventId.isNotEmpty) {
-        onNotificationTap?.call(referencedEventId, notificationType);
+        _emitNotificationTap(
+          NotificationTapEvent(
+            referencedEventId: referencedEventId,
+            notificationType: notificationType,
+          ),
+        );
       }
     } catch (_) {
       // Legacy payloads were bare event IDs (plain strings, not JSON).
@@ -472,8 +487,18 @@ class NotificationService {
       // JSON payloads (referencedEventId + notificationType) for at least one
       // full app-store release cycle and telemetry confirms this path is
       // never reached. See issue for the full removal plan.
-      onNotificationTap?.call(payload, null);
+      _emitNotificationTap(
+        NotificationTapEvent(
+          referencedEventId: payload,
+          notificationType: null,
+        ),
+      );
     }
+  }
+
+  void _emitNotificationTap(NotificationTapEvent event) {
+    if (_disposed || _notificationTapController.isClosed) return;
+    _notificationTapController.add(event);
   }
 
   /// Send a local notification with title and body
@@ -717,6 +742,7 @@ class NotificationService {
     if (_disposed) return;
 
     _disposed = true;
+    _notificationTapController.close();
     _notifications.clear();
   }
 

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -231,7 +231,7 @@ void main() {
     });
   });
 
-  group('NotificationService.onNotificationTap', () {
+  group('NotificationService.notificationTapStream', () {
     late NotificationService service;
 
     setUp(() {
@@ -247,13 +247,10 @@ void main() {
     // payload as 'notificationType' so the local notification tap handler can
     // read it back with the consistent internal key name.
     // See: docs/superpowers/specs/2026-04-07-push-notifications-design.md
-    test('invokes callback with eventId and type from JSON payload', () {
-      String? capturedId;
-      String? capturedType;
-      service.onNotificationTap = (id, type) {
-        capturedId = id;
-        capturedType = type;
-      };
+    test('emits eventId and type from JSON payload', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
 
       service.handleNotificationTapPayload(
         jsonEncode({
@@ -262,61 +259,70 @@ void main() {
         }),
       );
 
-      expect(capturedId, equals('abc123'));
-      expect(capturedType, equals('reply'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(events.single.referencedEventId, equals('abc123'));
+      expect(events.single.notificationType, equals('reply'));
     });
 
-    test('invokes callback with null type when notificationType missing', () {
-      String? capturedId;
-      String? capturedType;
-      service.onNotificationTap = (id, type) {
-        capturedId = id;
-        capturedType = type;
-      };
+    test('emits null type when notificationType missing', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
 
       service.handleNotificationTapPayload(
         jsonEncode({'referencedEventId': 'def456'}),
       );
 
-      expect(capturedId, equals('def456'));
-      expect(capturedType, isNull);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(events.single.referencedEventId, equals('def456'));
+      expect(events.single.notificationType, isNull);
     });
 
-    test('handles legacy bare event-ID payload (non-JSON)', () {
-      String? capturedId;
-      String? capturedType;
-      service.onNotificationTap = (id, type) {
-        capturedId = id;
-        capturedType = type;
-      };
+    test('handles legacy bare event-ID payload (non-JSON)', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
 
       service.handleNotificationTapPayload('legacyEventId999');
 
-      expect(capturedId, equals('legacyEventId999'));
-      expect(capturedType, isNull);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(events.single.referencedEventId, equals('legacyEventId999'));
+      expect(events.single.notificationType, isNull);
     });
 
-    test('does not invoke callback when payload is null', () {
-      var called = false;
-      service.onNotificationTap = (id, type) => called = true;
+    test('does not emit when payload is null', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
 
       service.handleNotificationTapPayload(null);
 
-      expect(called, isFalse);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, isEmpty);
     });
 
-    test('does not invoke callback when referencedEventId is absent', () {
-      var called = false;
-      service.onNotificationTap = (id, type) => called = true;
+    test('does not emit when referencedEventId is absent', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
 
       service.handleNotificationTapPayload(
         jsonEncode({'notificationType': 'reaction'}),
       );
 
-      expect(called, isFalse);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, isEmpty);
     });
 
-    test('no-ops gracefully when onNotificationTap is not set', () {
+    test('no-ops gracefully when the stream has no listeners', () {
       expect(
         () => service.handleNotificationTapPayload(
           jsonEncode({

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -334,4 +334,25 @@ void main() {
       );
     });
   });
+
+  group('NotificationTapEvent', () {
+    test('uses value equality for event comparisons', () {
+      const first = NotificationTapEvent(
+        referencedEventId: 'abc123',
+        notificationType: 'reply',
+      );
+      const second = NotificationTapEvent(
+        referencedEventId: 'abc123',
+        notificationType: 'reply',
+      );
+      const third = NotificationTapEvent(
+        referencedEventId: 'xyz789',
+        notificationType: 'reply',
+      );
+
+      expect(first, equals(second));
+      expect(first.hashCode, equals(second.hashCode));
+      expect(first, isNot(equals(third)));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- replace the mutable local-notification tap callback with a typed broadcast stream
- rename the payload kind constants to avoid colliding with the domain NotificationKind enum
- keep the existing payload parsing and legacy bare-string fallback behavior intact while wiring main.dart through the new stream subscription

## Testing
- flutter test test/services/notification_service_test.dart
- flutter test test/providers/deep_link_provider_test.dart
- flutter test test/main_video_deep_link_nav_action_test.dart
- flutter analyze

Closes #4343
