### PR TITLE
fix(video-editor): timeline resets after clip adjustment or duplication

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -342,6 +342,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     if (!_isTrimmingLayer &&
         !_isTrimmingClip &&
         !_isDraggingLayer &&
+        !_isSeeking &&
         _pendingSeekPosition == null &&
         playerState.position != _lastReportedPosition) {
       _lastReportedPosition = playerState.position;

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -16,6 +16,7 @@ import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_edi
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_playhead.dart';
 
@@ -137,7 +138,6 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
           listener: (context, state) => _syncScrollToPosition(
             state.currentPosition,
             totalDuration,
-            totalWidth,
           ),
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
@@ -705,24 +705,36 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   /// Derives the time at the playhead from scroll offset.
   void _updatePlayheadTime() {
     if (!_scrollController.hasClients) return;
-    final seconds = _scrollController.offset / _pixelsPerSecond;
-    final ms = (seconds * 1000).round().clamp(0, _totalDuration.inMilliseconds);
-    _playheadPosition.value = Duration(milliseconds: ms);
+    _playheadPosition.value = timelineScrollOffsetToPosition(
+      context.read<ClipEditorBloc>().state.clips,
+      _scrollController.offset,
+      _pixelsPerSecond,
+      _totalDuration,
+    );
   }
+
+  /// Converts a composite playback [position] to the corresponding scroll
+  /// offset in the timeline content, accounting for the 1-px gap that
+  /// [VideoEditorTimelineClipStrip] inserts between adjacent clips.
+  ///
+  /// Without this correction, the scroll target is up to
+  /// `(clipIndex × clipGap)` pixels short of the trim-handle marker's
+  /// actual visual position — noticeable at high zoom levels.
+  double _positionToScrollOffset(Duration position) =>
+      timelinePositionToScrollOffset(
+        context.read<ClipEditorBloc>().state.clips,
+        position,
+        _pixelsPerSecond,
+      );
 
   void _syncScrollToPosition(
     Duration position,
     Duration totalDuration,
-    double totalWidth,
   ) {
     if (!_scrollController.hasClients) return;
     if (totalDuration == Duration.zero) return;
 
-    // Derive target directly from position × pixelsPerSecond so the
-    // scroll is always consistent with the ruler/clip layout, even if
-    // the player-reported duration differs from the sum of clip
-    // durations (which determines maxScrollExtent).
-    final target = position.inMilliseconds / 1000.0 * _pixelsPerSecond;
+    final target = _positionToScrollOffset(position);
     final maxExtent = _scrollController.position.maxScrollExtent;
     _scrollController.animateTo(
       target.clamp(0, maxExtent),
@@ -737,9 +749,12 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     if (!force && now - _lastSeekMs < _seekThrottleMs) return;
     _lastSeekMs = now;
 
-    final seconds = _scrollController.offset / _pixelsPerSecond;
-    final ms = (seconds * 1000).round().clamp(0, _totalDuration.inMilliseconds);
-    final position = Duration(milliseconds: ms);
+    final position = timelineScrollOffsetToPosition(
+      context.read<ClipEditorBloc>().state.clips,
+      _scrollController.offset,
+      _pixelsPerSecond,
+      _totalDuration,
+    );
     context.read<VideoEditorMainBloc>().add(VideoEditorSeekRequested(position));
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -689,11 +689,29 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     );
     if (newPps == _pixelsPerSecond) return;
 
-    final ratio = newPps / _pixelsPerSecond;
+    // Anchor the zoom on the current playback position so inter-clip gaps
+    // (which stay 1 px regardless of pixelsPerSecond) don't drift the
+    // viewport off the playhead. Multiplying the raw scroll offset by the
+    // zoom ratio would over-shoot by `clipsPassed × clipGap × (ratio - 1)`
+    // px once the playhead is past clip 0.
+    final clips = context.read<ClipEditorBloc>().state.clips;
+    final anchorPosition = _scrollController.hasClients
+        ? timelineScrollOffsetToPosition(
+            clips,
+            _scrollController.offset,
+            _pixelsPerSecond,
+            _totalDuration,
+          )
+        : Duration.zero;
+
     setState(() => _pixelsPerSecond = newPps);
 
     if (_scrollController.hasClients) {
-      final newOffset = _scrollController.offset * ratio;
+      final newOffset = timelinePositionToScrollOffset(
+        clips,
+        anchorPosition,
+        newPps,
+      );
       _scrollController.jumpTo(
         newOffset.clamp(0, _scrollController.position.maxScrollExtent),
       );
@@ -705,12 +723,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   /// Derives the time at the playhead from scroll offset.
   void _updatePlayheadTime() {
     if (!_scrollController.hasClients) return;
-    _playheadPosition.value = timelineScrollOffsetToPosition(
-      context.read<ClipEditorBloc>().state.clips,
-      _scrollController.offset,
-      _pixelsPerSecond,
-      _totalDuration,
-    );
+    _playheadPosition.value = _scrollOffsetToPosition(_scrollController.offset);
   }
 
   /// Converts a composite playback [position] to the corresponding scroll
@@ -725,6 +738,16 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         context.read<ClipEditorBloc>().state.clips,
         position,
         _pixelsPerSecond,
+      );
+
+  /// Inverse of [_positionToScrollOffset]: maps a [scrollOffset] back to a
+  /// composite playback position, clamped to the current total duration.
+  Duration _scrollOffsetToPosition(double scrollOffset) =>
+      timelineScrollOffsetToPosition(
+        context.read<ClipEditorBloc>().state.clips,
+        scrollOffset,
+        _pixelsPerSecond,
+        _totalDuration,
       );
 
   void _syncScrollToPosition(
@@ -749,12 +772,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     if (!force && now - _lastSeekMs < _seekThrottleMs) return;
     _lastSeekMs = now;
 
-    final position = timelineScrollOffsetToPosition(
-      context.read<ClipEditorBloc>().state.clips,
-      _scrollController.offset,
-      _pixelsPerSecond,
-      _totalDuration,
-    );
+    final position = _scrollOffsetToPosition(_scrollController.offset);
     context.read<VideoEditorMainBloc>().add(VideoEditorSeekRequested(position));
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -19,10 +19,13 @@ double timelinePositionToScrollOffset(
 ) {
   var acc = Duration.zero;
   var gapPixels = 0.0;
-  for (final clip in clips) {
+  for (var i = 0; i < clips.length; i++) {
+    final clip = clips[i];
     if (acc + clip.trimmedDuration > position) break;
     acc += clip.trimmedDuration;
-    gapPixels += TimelineConstants.clipGap;
+    if (i < clips.length - 1) {
+      gapPixels += TimelineConstants.clipGap;
+    }
   }
   return position.inMicroseconds / 1_000_000.0 * pixelsPerSecond + gapPixels;
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -42,15 +42,22 @@ Duration timelineScrollOffsetToPosition(
 ) {
   var acc = Duration.zero;
   var gapPixels = 0.0;
-  for (final clip in clips) {
+  for (var i = 0; i < clips.length; i++) {
+    final clip = clips[i];
     final clipEndPx =
         (acc + clip.trimmedDuration).inMicroseconds /
             1_000_000.0 *
             pixelsPerSecond +
         gapPixels;
     if (scrollOffset <= clipEndPx) break;
+    final gapEndPx = clipEndPx + TimelineConstants.clipGap;
+    if (i < clips.length - 1 && scrollOffset < gapEndPx) {
+      return acc + clip.trimmedDuration;
+    }
     acc += clip.trimmedDuration;
-    gapPixels += TimelineConstants.clipGap;
+    if (i < clips.length - 1) {
+      gapPixels += TimelineConstants.clipGap;
+    }
   }
   final seconds = (scrollOffset - gapPixels) / pixelsPerSecond;
   final ms = (seconds * 1000).round().clamp(0, totalDuration.inMilliseconds);

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -1,0 +1,55 @@
+// ABOUTME: Pure geometry helpers for the video editor timeline.
+// ABOUTME: Converts between playback positions and scroll offsets,
+// ABOUTME: accounting for the 1-px gap between adjacent clip strips.
+
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+
+/// Converts a composite playback [position] to the corresponding scroll
+/// offset in the timeline content, accounting for the
+/// [TimelineConstants.clipGap]-wide gap between adjacent clip strips.
+///
+/// Without this correction the scroll target is up to
+/// `(clipsPassedCount × clipGap)` pixels short of the trim-handle
+/// marker's actual visual position.
+double timelinePositionToScrollOffset(
+  List<DivineVideoClip> clips,
+  Duration position,
+  double pixelsPerSecond,
+) {
+  var acc = Duration.zero;
+  var gapPixels = 0.0;
+  for (final clip in clips) {
+    if (acc + clip.trimmedDuration > position) break;
+    acc += clip.trimmedDuration;
+    gapPixels += TimelineConstants.clipGap;
+  }
+  return position.inMicroseconds / 1_000_000.0 * pixelsPerSecond + gapPixels;
+}
+
+/// Converts a timeline [scrollOffset] to the corresponding playback
+/// position — the exact inverse of [timelinePositionToScrollOffset].
+///
+/// The result is clamped to `[Duration.zero, totalDuration]`.
+Duration timelineScrollOffsetToPosition(
+  List<DivineVideoClip> clips,
+  double scrollOffset,
+  double pixelsPerSecond,
+  Duration totalDuration,
+) {
+  var acc = Duration.zero;
+  var gapPixels = 0.0;
+  for (final clip in clips) {
+    final clipEndPx =
+        (acc + clip.trimmedDuration).inMicroseconds /
+            1_000_000.0 *
+            pixelsPerSecond +
+        gapPixels;
+    if (scrollOffset <= clipEndPx) break;
+    acc += clip.trimmedDuration;
+    gapPixels += TimelineConstants.clipGap;
+  }
+  final seconds = (scrollOffset - gapPixels) / pixelsPerSecond;
+  final ms = (seconds * 1000).round().clamp(0, totalDuration.inMilliseconds);
+  return Duration(milliseconds: ms);
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -85,6 +85,13 @@ void main() {
       );
     });
 
+    test('does not add a trailing gap at total duration', () {
+      expect(
+        timelinePositionToScrollOffset(clips, totalDuration, pps),
+        equals(366.0), // 7 * 52 + 2
+      );
+    });
+
     test('empty clip list — no gaps added', () {
       expect(
         timelinePositionToScrollOffset([], const Duration(seconds: 3), pps),
@@ -161,6 +168,13 @@ void main() {
       );
     });
 
+    test('maps the exact end offset back to total duration', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 366.0, pps, totalDuration),
+        equals(totalDuration),
+      );
+    });
+
     test('empty clip list — no gap subtraction', () {
       expect(
         timelineScrollOffsetToPosition(
@@ -184,6 +198,7 @@ void main() {
         const Duration(milliseconds: 2500),
         const Duration(seconds: 5),
         const Duration(seconds: 6),
+        totalDuration,
       ]) {
         test('position $pos survives round-trip', () {
           final offset = timelinePositionToScrollOffset(clips, pos, pps);

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -198,4 +198,63 @@ void main() {
       }
     },
   );
+
+  // Regression for the pinch-zoom drift fix in `_updatePinchZoom`.
+  //
+  // Old bug: zoom preserved scroll by `_scrollController.offset * ratio`,
+  // which over-shoots by `clipsPassed × clipGap × (ratio - 1)` px once the
+  // playhead is past clip 0 (gaps stay 1 px, they don't scale with pps).
+  //
+  // New behavior re-anchors through the gap-aware helpers: derive the
+  // current playback position at the old pps, then map it back to a scroll
+  // offset at the new pps. The composite position must remain stable.
+  group('pinch-zoom anchoring keeps playhead position stable', () {
+    const newPps = 104.0; // 2× zoom-in
+
+    for (final pos in [
+      const Duration(milliseconds: 2500), // inside clip 1
+      const Duration(seconds: 5), // boundary clip 1/2
+      const Duration(seconds: 6), // inside clip 2
+    ]) {
+      test('position $pos stays centered across pps change', () {
+        // Simulate the playhead sitting at `pos` at the old pps.
+        final oldOffset = timelinePositionToScrollOffset(clips, pos, pps);
+
+        // What the new gap-aware pinch logic would jump to:
+        final anchorPosition = timelineScrollOffsetToPosition(
+          clips,
+          oldOffset,
+          pps,
+          totalDuration,
+        );
+        final newOffset = timelinePositionToScrollOffset(
+          clips,
+          anchorPosition,
+          newPps,
+        );
+
+        // The recovered position at the new pps must match the original.
+        final recovered = timelineScrollOffsetToPosition(
+          clips,
+          newOffset,
+          newPps,
+          totalDuration,
+        );
+        expect(recovered, equals(pos));
+
+        // Sanity: the naive `oldOffset * ratio` path drifts (proving the
+        // gap-aware re-anchor is doing real work past clip 0).
+        const ratio = newPps / pps;
+        final naiveOffset = oldOffset * ratio;
+        expect(
+          naiveOffset,
+          isNot(equals(newOffset)),
+          reason:
+              'Past clip 0 the naive scroll-rescale must differ from the '
+              'gap-aware anchoring; otherwise the regression would be '
+              'silently lost.',
+        );
+      });
+    }
+  });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -1,0 +1,201 @@
+// ABOUTME: Unit tests for the pure timeline geometry helpers.
+// ABOUTME: Verifies scroll-offset ↔ playback-position conversion symmetry
+// ABOUTME: across single-clip, multi-clip, and empty-clip compositions.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+DivineVideoClip _clip(String id, int seconds) => DivineVideoClip(
+  id: id,
+  video: EditorVideo.file('/tmp/$id.mp4'),
+  duration: Duration(seconds: seconds),
+  recordedAt: DateTime(2025),
+  targetAspectRatio: .vertical,
+  originalAspectRatio: 9 / 16,
+);
+
+void main() {
+  // Three-clip composition used throughout most tests:
+  //   clip 0 → 2 s, clip 1 → 3 s, clip 2 → 2 s  (total 7 s)
+  // At pixelsPerSecond=52 and clipGap=1 the layout is:
+  //   [0…104 px] gap [105…260 px] gap [261…365 px]
+  //
+  // Position → offset reference table
+  //   pos  0 s  → 0 * 52 + 0 gaps =   0 px
+  //   pos  1 s  → 1 * 52 + 0 gaps =  52 px  (within clip 0)
+  //   pos  2 s  → 2 * 52 + 1 gap  = 105 px  (start of gap after clip 0)
+  //   pos  2.5s → 2.5*52 + 1 gap  = 131 px  (within clip 1)
+  //   pos  5 s  → 5 * 52 + 2 gaps = 262 px  (start of gap after clip 1)
+  //   pos  6 s  → 6 * 52 + 2 gaps = 314 px  (within clip 2)
+
+  final clips = [
+    _clip('c0', 2),
+    _clip('c1', 3),
+    _clip('c2', 2),
+  ];
+  const pps = 52.0;
+  const totalDuration = Duration(seconds: 7);
+
+  group(timelinePositionToScrollOffset, () {
+    test('returns 0 for zero position', () {
+      expect(
+        timelinePositionToScrollOffset(clips, Duration.zero, pps),
+        equals(0.0),
+      );
+    });
+
+    test('no gap offset within first clip', () {
+      expect(
+        timelinePositionToScrollOffset(clips, const Duration(seconds: 1), pps),
+        equals(52.0),
+      );
+    });
+
+    test('adds one gap at the boundary between clip 0 and clip 1', () {
+      expect(
+        timelinePositionToScrollOffset(clips, const Duration(seconds: 2), pps),
+        equals(105.0), // 2 * 52 + 1
+      );
+    });
+
+    test('one gap within clip 1', () {
+      expect(
+        timelinePositionToScrollOffset(
+          clips,
+          const Duration(milliseconds: 2500),
+          pps,
+        ),
+        equals(131.0), // 2.5 * 52 + 1
+      );
+    });
+
+    test('adds two gaps at the boundary between clip 1 and clip 2', () {
+      expect(
+        timelinePositionToScrollOffset(clips, const Duration(seconds: 5), pps),
+        equals(262.0), // 5 * 52 + 2
+      );
+    });
+
+    test('two gaps within clip 2', () {
+      expect(
+        timelinePositionToScrollOffset(clips, const Duration(seconds: 6), pps),
+        equals(314.0), // 6 * 52 + 2
+      );
+    });
+
+    test('empty clip list — no gaps added', () {
+      expect(
+        timelinePositionToScrollOffset([], const Duration(seconds: 3), pps),
+        equals(156.0), // 3 * 52
+      );
+    });
+
+    test('single clip — no gaps', () {
+      expect(
+        timelinePositionToScrollOffset(
+          [_clip('only', 10)],
+          const Duration(seconds: 4),
+          pps,
+        ),
+        equals(208.0), // 4 * 52
+      );
+    });
+  });
+
+  group(timelineScrollOffsetToPosition, () {
+    test('returns zero for zero offset', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 0.0, pps, totalDuration),
+        equals(Duration.zero),
+      );
+    });
+
+    test('no gap correction within first clip', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 52.0, pps, totalDuration),
+        equals(const Duration(seconds: 1)),
+      );
+    });
+
+    test('subtracts one gap at clip 0/1 boundary', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 105.0, pps, totalDuration),
+        equals(const Duration(seconds: 2)),
+      );
+    });
+
+    test('subtracts one gap within clip 1', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 131.0, pps, totalDuration),
+        equals(const Duration(milliseconds: 2500)),
+      );
+    });
+
+    test('subtracts two gaps at clip 1/2 boundary', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 262.0, pps, totalDuration),
+        equals(const Duration(seconds: 5)),
+      );
+    });
+
+    test('subtracts two gaps within clip 2', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 314.0, pps, totalDuration),
+        equals(const Duration(seconds: 6)),
+      );
+    });
+
+    test('clamps negative offsets to Duration.zero', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, -10.0, pps, totalDuration),
+        equals(Duration.zero),
+      );
+    });
+
+    test('clamps offsets beyond end to totalDuration', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 99999.0, pps, totalDuration),
+        equals(totalDuration),
+      );
+    });
+
+    test('empty clip list — no gap subtraction', () {
+      expect(
+        timelineScrollOffsetToPosition(
+          [],
+          156.0,
+          pps,
+          const Duration(seconds: 10),
+        ),
+        equals(const Duration(seconds: 3)),
+      );
+    });
+  });
+
+  group(
+    'round-trip: scrollOffsetToPosition ∘ positionToScrollOffset == id',
+    () {
+      for (final pos in [
+        Duration.zero,
+        const Duration(seconds: 1),
+        const Duration(seconds: 2),
+        const Duration(milliseconds: 2500),
+        const Duration(seconds: 5),
+        const Duration(seconds: 6),
+      ]) {
+        test('position $pos survives round-trip', () {
+          final offset = timelinePositionToScrollOffset(clips, pos, pps);
+          final recovered = timelineScrollOffsetToPosition(
+            clips,
+            offset,
+            pps,
+            totalDuration,
+          );
+          expect(recovered, equals(pos));
+        });
+      }
+    },
+  );
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -133,6 +133,13 @@ void main() {
       );
     });
 
+    test('maps offsets inside the clip 0/1 gap to the shared boundary', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 104.5, pps, totalDuration),
+        equals(const Duration(seconds: 2)),
+      );
+    });
+
     test('subtracts one gap within clip 1', () {
       expect(
         timelineScrollOffsetToPosition(clips, 131.0, pps, totalDuration),
@@ -143,6 +150,13 @@ void main() {
     test('subtracts two gaps at clip 1/2 boundary', () {
       expect(
         timelineScrollOffsetToPosition(clips, 262.0, pps, totalDuration),
+        equals(const Duration(seconds: 5)),
+      );
+    });
+
+    test('maps offsets inside the clip 1/2 gap to the shared boundary', () {
+      expect(
+        timelineScrollOffsetToPosition(clips, 261.5, pps, totalDuration),
         equals(const Duration(seconds: 5)),
       );
     });


### PR DESCRIPTION

## Description

Resolve the issue that adjusting or duplicating a clip resets the timeline view back to the original start position.


**Related Issue:** Closes #4318

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
