### PR TITLE
feat(mentions): publish resolved mentions across surfaces

### DIFF
--- a/docs/superpowers/plans/2026-05-14-unified-mentions-implementation.md
+++ b/docs/superpowers/plans/2026-05-14-unified-mentions-implementation.md
@@ -1,0 +1,119 @@
+# Unified Mentions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish resolved user mentions consistently from comments, video captions/overlays, and profile bios using one small app-layer mention helper.
+
+**Architecture:** Add one shared app-layer helper for resolving mention text and building generic mention `p` tags. Keep UI state local to existing surfaces. Wire comments and videos to emit generic `["p", pubkey, "wss://relay.divine.video", "mention"]` tags, while profile kind 0 canonicalizes bio text to `nostr:npub...` without adding tags.
+
+**Tech Stack:** Flutter/Dart, BLoC, Riverpod legacy paths, Nostr kind 1111 comments, NIP-71 video events, kind 0 profile metadata, existing `ProfileRepository` search APIs.
+
+---
+
+## Task 1: Shared Mention Helper
+
+**Files:**
+- Create: `mobile/lib/services/mention_resolution_service.dart`
+- Test: `mobile/test/services/mention_resolution_service_test.dart`
+
+- [ ] Write failing tests for selected mention canonicalization, typed token parsing, email/Nostr-reference exclusion, exact cached/API matches, ambiguous matches, self-match exclusion, invalid pubkey skipping, collaborator exclusion, and generic mention tag building.
+- [ ] Run `cd mobile && flutter test test/services/mention_resolution_service_test.dart` and confirm the tests fail because the helper does not exist.
+- [ ] Implement one `MentionResolutionService` class plus small value objects in the same file. Keep parsing and tag construction private or static internals unless tests need a public call.
+- [ ] Keep typed remote resolution bounded: dedupe tokens, max five API lookups, one two-second timeout for the resolution pass.
+- [ ] Run `cd mobile && flutter test test/services/mention_resolution_service_test.dart`.
+- [ ] Commit: `feat: add shared mention resolution helper`.
+
+## Task 2: Comment Repository Tags
+
+**Files:**
+- Modify: `mobile/packages/comments_repository/lib/src/comments_repository.dart`
+- Test: `mobile/packages/comments_repository/test/src/comments_repository_test.dart`
+
+- [ ] Write failing repository tests showing `postComment(mentionedPubkeys: [...])` appends generic mention `p` tags after required NIP-22 tags, skips invalid/empty pubkeys, and does not duplicate root/parent author `p` tags.
+- [ ] Run `cd mobile && flutter test packages/comments_repository/test/src/comments_repository_test.dart` and confirm the new tests fail.
+- [ ] Add optional `List<String> mentionedPubkeys = const []` to `postComment`.
+- [ ] Append `["p", pubkey, "wss://relay.divine.video", "mention"]` for valid full hex pubkeys not already used by NIP-22 root/parent tags.
+- [ ] Run `cd mobile && flutter test packages/comments_repository/test/src/comments_repository_test.dart`.
+- [ ] Commit: `feat(comments): publish mention p tags`.
+
+## Task 3: Video Event Publisher Tags
+
+**Files:**
+- Modify: `mobile/lib/services/video_event_publisher.dart`
+- Test: `mobile/test/services/video_event_publisher_test.dart`
+- Test: `mobile/test/services/video_event_publisher_collaborator_tags_test.dart`
+
+- [ ] Write failing publisher tests showing `mentionedPubkeys` adds generic mention `p` tags to kind 34236 publishes, preserves collaborator role tags, excludes collaborator pubkeys from generic mention tags, and skips invalid/empty pubkeys.
+- [ ] Run `cd mobile && flutter test test/services/video_event_publisher_test.dart test/services/video_event_publisher_collaborator_tags_test.dart` and confirm the new tests fail.
+- [ ] Add `mentionedPubkeys` to `publishVideoEvent` and `publishDirectUpload`.
+- [ ] Append generic mention tags separately from collaborator tags, using the same relay hint and role marker as the spec.
+- [ ] Run `cd mobile && flutter test test/services/video_event_publisher_test.dart test/services/video_event_publisher_collaborator_tags_test.dart`.
+- [ ] Commit: `feat(video): publish mention p tags`.
+
+## Task 4: Comments Bloc Wiring
+
+**Files:**
+- Modify: `mobile/lib/blocs/comments/comments_bloc.dart`
+- Modify: `mobile/lib/blocs/comments/comments_event.dart`
+- Modify: `mobile/lib/blocs/comments/comments_state.dart`
+- Modify: `mobile/lib/screens/comments/comments_screen.dart`
+- Modify: `mobile/lib/screens/comments/widgets/comment_input.dart`
+- Modify: `mobile/lib/screens/comments/widgets/mention_overlay.dart`
+- Test: `mobile/test/blocs/comments/comments_bloc_test.dart`
+- Test: `mobile/test/screens/comments/comment_input_test.dart`
+- Test: `mobile/test/screens/comments/widgets/mention_overlay_test.dart`
+
+- [ ] Write failing tests showing selected mentions are resolved to canonical `nostr:npub...` content and passed to `CommentsRepository.postComment(mentionedPubkeys: ...)`.
+- [ ] Write a failing test showing typed-but-unselected `@name` resolves through the helper when there is one exact match.
+- [ ] Run targeted tests and confirm failures.
+- [ ] Inject/use `MentionResolutionService` in `CommentsBloc`.
+- [ ] Preserve existing comment autocomplete UI; pass selected hex pubkeys from overlay/input into bloc state.
+- [ ] Replace ad hoc `displayName -> npub` replacement with helper output.
+- [ ] Run the targeted comments tests.
+- [ ] Commit: `feat(comments): resolve mentions before publish`.
+
+## Task 5: Video Publish Service Wiring
+
+**Files:**
+- Modify: `mobile/lib/services/video_publish/video_publish_service.dart`
+- Modify: `mobile/lib/providers/video_publish_provider.dart`
+- Modify: `mobile/lib/main.dart`
+- Test: `mobile/test/services/video_publish/video_publish_service_test.dart`
+- Test: `mobile/test/providers/video_publish_provider_test.dart`
+
+- [ ] Write failing tests showing video publish resolves typed mentions from draft description and overlay text, excludes collaborators, and passes `mentionedPubkeys` to `VideoEventPublisher`.
+- [ ] Run targeted tests and confirm failures.
+- [ ] Inject/use `MentionResolutionService` in `VideoPublishService`.
+- [ ] Resolve mentions from `draft.description` plus text layer strings recoverable from editor state/history without adding editor metadata.
+- [ ] Keep publish non-blocking on resolution failure: publish without unresolved mention tags.
+- [ ] Run targeted video publish tests.
+- [ ] Commit: `feat(video): resolve mentions during publish`.
+
+## Task 6: Profile Bio Canonicalization
+
+**Files:**
+- Modify: `mobile/lib/blocs/profile_editor/profile_editor_bloc.dart`
+- Test: `mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart`
+- Test: `mobile/test/widgets/profile/profile_header_widget_test.dart`
+- Test: `mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart`
+
+- [ ] Write failing tests showing `ProfileSaved(about: "hi @alice")` saves `about` with canonical `nostr:npub...` when there is one exact match.
+- [ ] Write/assert kind 0 save still uses no tags at repository/client boundary.
+- [ ] Run targeted tests and confirm failures.
+- [ ] Inject/use `MentionResolutionService` in `ProfileEditorBloc`.
+- [ ] Canonicalize profile bio mentions before `ProfileRepository.saveProfileEvent`, preserving unresolved text.
+- [ ] Run targeted profile tests.
+- [ ] Commit: `feat(profile): canonicalize bio mentions`.
+
+## Task 7: Final Verification
+
+**Files:**
+- Review all changed files.
+
+- [ ] Run `cd mobile && flutter test test/services/mention_resolution_service_test.dart`.
+- [ ] Run `cd mobile && flutter test test/blocs/comments/comments_bloc_test.dart packages/comments_repository/test/src/comments_repository_test.dart`.
+- [ ] Run `cd mobile && flutter test test/services/video_publish/video_publish_service_test.dart test/services/video_event_publisher_test.dart test/services/video_event_publisher_collaborator_tags_test.dart`.
+- [ ] Run `cd mobile && flutter test test/blocs/profile_editor/profile_editor_bloc_test.dart test/widgets/profile/profile_header_widget_test.dart test/widgets/linkified_text/linkified_text_span_builder_test.dart`.
+- [ ] Run `cd mobile && flutter analyze`.
+- [ ] Review `git diff` for stray edits, generated junk, logs, and broad refactors.
+- [ ] Commit any integration fixups.

--- a/docs/superpowers/specs/2026-05-14-unified-mentions-design.md
+++ b/docs/superpowers/specs/2026-05-14-unified-mentions-design.md
@@ -8,7 +8,7 @@ Today, comments already have autocomplete and selected mentions are converted fr
 
 ## Goals
 
-- Provide one shared mention parsing, resolution, and tag-building pipeline for mention-capable text surfaces.
+- Provide one shared mention helper for mention-capable text surfaces.
 - Support both selected autocomplete mentions and typed-but-unselected `@name` mentions.
 - Resolve selected mentions exactly and resolve typed mentions conservatively.
 - Emit generic mention `p` tags for comments and videos, without confusing them with collaborator tags.
@@ -48,28 +48,28 @@ Kind 0 profile events should keep their current empty tag list unless another pr
 
 ## KISS Scope Rule
 
-The unified part of this work is the data pipeline, not the editing UI. Each surface should keep its existing text-field state and suggestion UI unless a tiny adapter is enough. Add a shared UI composer only after two surfaces have the same proven needs and the extraction removes real duplication.
+The unified part of this work is the mention behavior, not a framework. Build one small shared helper and keep helper internals private until a real second public abstraction is needed. Each surface should keep its existing text-field state and suggestion UI unless a tiny adapter is enough.
 
 ## Architecture
 
-Add a shared mention module owned by the app layer, because it needs app repositories for profile lookup and app-level publish behavior. The module has three pieces:
+Add one shared mention helper owned by the app layer, because it needs app repositories for profile lookup and app-level publish behavior. Keep it in one file/class unless implementation proves that is awkward.
 
-1. `MentionTokenParser`
-   - Finds plain `@name` tokens using the same token family as linkified text.
-   - Excludes email addresses, Nostr IDs, and existing `nostr:npub...` / `nostr:nprofile...` references.
-   - Returns unique typed tokens with source ranges so callers can canonicalize text only where needed.
+The helper should expose the smallest API the surfaces need:
 
-2. `MentionResolver`
-   - Accepts raw text plus selected bindings.
-   - Finds typed `@name` tokens that were not explicitly selected.
-   - Resolves typed tokens through cached profiles first, then remote profile search.
-   - Returns canonical text, resolved pubkeys, and unresolved tokens.
-   - Only resolves a typed token when exactly one plausible profile match exists.
+1. Resolve text mentions.
+   - Accept raw text plus selected mention bindings.
+   - Find typed `@name` tokens that were not explicitly selected, using the same token family as linkified text.
+   - Exclude email addresses, Nostr IDs, and existing `nostr:npub...` / `nostr:nprofile...` references.
+   - Resolve typed tokens through cached profiles first, then remote profile search.
+   - Return canonical text, resolved pubkeys, and unresolved tokens.
+   - Only resolve a typed token when exactly one plausible profile match exists.
 
-3. `MentionTagBuilder`
-   - Deduplicates full hex pubkeys.
-   - Emits generic mention `p` tags.
-   - Excludes collaborator pubkeys when asked, so video collaborator tags and generic mention tags do not duplicate each other with different roles.
+2. Build generic mention tags.
+   - Deduplicate full hex pubkeys.
+   - Emit generic mention `p` tags.
+   - Exclude collaborator pubkeys when asked, so video collaborator tags and generic mention tags do not duplicate each other with different roles.
+
+Token parsing and tag construction can be private functions inside the helper. Do not split them into separate public services or packages in v1.
 
 Selected mention bindings are simple data objects owned by each surface's existing state: display label, original token/range when available, and full hex pubkey or npub. Comments can keep their current `CommentInput` autocomplete flow, and other surfaces can add the same behavior incrementally without depending on one shared widget/controller.
 
@@ -95,7 +95,7 @@ Overlay mentions should not change the rendered text. Typed unresolved or ambigu
 
 ### Profile Bio
 
-Profile setup/edit bio should use the shared parser and resolver. It can keep its existing editing UI for v1. Resolved mentions should be canonicalized into `nostr:npub...` inside the `about` text before `ProfileRepository.saveProfileEvent`.
+Profile setup/edit bio should use the shared mention helper. It can keep its existing editing UI for v1. Resolved mentions should be canonicalized into `nostr:npub...` inside the `about` text before `ProfileRepository.saveProfileEvent`.
 
 Profile bio rendering already uses linkified text. The shared linkification path should display canonical NIP-27 profile references as friendly tappable `@name` labels when profile data is available, with a full npub/hex fallback handled visually by layout.
 
@@ -123,8 +123,7 @@ If tag building receives invalid or empty pubkeys, it should skip them and prese
 
 Add focused tests for:
 
-- Mention token parsing, email exclusion, Nostr reference exclusion, dedupe, and invalid pubkey skipping.
-- Resolver behavior for selected mentions, exact typed matches, ambiguous typed matches, lookup failure, and self-match handling.
+- Shared mention helper behavior for selected mentions, typed mention parsing, email exclusion, Nostr reference exclusion, exact typed matches, ambiguous typed matches, lookup failure, self-match handling, dedupe, and invalid pubkey skipping.
 - Comment publish events include generic mention `p` tags and preserve NIP-22 root/parent tags.
 - Comments bloc passes selected and typed mention pubkeys through to the repository.
 - Video publisher emits generic mention tags while preserving collaborator tags with the `collaborator` marker.

--- a/docs/superpowers/specs/2026-05-14-unified-mentions-design.md
+++ b/docs/superpowers/specs/2026-05-14-unified-mentions-design.md
@@ -1,0 +1,147 @@
+# Unified Mentions Design
+
+## Context
+
+Issue #3129 asks for user mentions in video text overlays so viewers can open the mentioned account. While investigating it, we found the larger gap: mentions need one app-wide pipeline, not separate behavior for comments, video captions, overlays, and profile bios.
+
+Today, comments already have autocomplete and selected mentions are converted from `@displayName` to `nostr:npub...` content, but the published kind 1111 comment does not include generic mention `p` tags. Video publishing emits hashtag `t` tags and collaborator-marked `p` tags, but not generic mention tags. Profile bios render Nostr profile references, but the profile editor does not use a shared mention composer.
+
+## Goals
+
+- Provide one shared mention model, composer, resolver, and tag builder for mention-capable text surfaces.
+- Support both selected autocomplete mentions and typed-but-unselected `@name` mentions.
+- Resolve selected mentions exactly and resolve typed mentions conservatively.
+- Emit generic mention `p` tags for comments and videos, without confusing them with collaborator tags.
+- Store profile bio mentions as canonical NIP-27 `nostr:npub...` references in kind 0 content, without adding kind 0 `p` tags.
+- Preserve full Nostr IDs in code, logs, tests, and persisted data.
+
+## Non-Goals
+
+- Redesign every text field in the app in one PR.
+- Add `p` tags to kind 0 profile metadata events.
+- Invent new Nostr tag semantics.
+- Treat unresolved or ambiguous `@name` text as a mention.
+- Change collaborator invite or confirmation semantics.
+
+## Protocol Rules
+
+Comments and video posts should include generic mention tags for resolved accounts:
+
+```json
+["p", "<64-char-pubkey>", "wss://relay.divine.video", "mention"]
+```
+
+Collaborators remain role-marked and distinct:
+
+```json
+["p", "<64-char-pubkey>", "wss://relay.divine.video", "collaborator"]
+```
+
+Profile bios should canonicalize resolved mentions inside the `about` field:
+
+```text
+nostr:npub1...
+```
+
+Kind 0 profile events should keep their current empty tag list unless another profile-specific protocol requirement is introduced later.
+
+## Architecture
+
+Add a shared mention module owned by the app layer, because it needs app repositories for profile lookup and UI-friendly composer state. The module has three pieces:
+
+1. `MentionComposer`
+   - Tracks the active `@` query, selected mention bindings, and suggestion list.
+   - Replaces selected text with the display label shown to the user.
+   - Can be embedded by comments, video metadata description, and profile bio editing.
+
+2. `MentionResolver`
+   - Accepts raw text plus selected bindings.
+   - Finds typed `@name` tokens that were not explicitly selected.
+   - Resolves typed tokens through cached profiles first, then remote profile search.
+   - Returns canonical text, resolved pubkeys, and unresolved tokens.
+   - Only resolves a typed token when exactly one plausible profile match exists.
+
+3. `MentionTagBuilder`
+   - Deduplicates full hex pubkeys.
+   - Emits generic mention `p` tags.
+   - Excludes collaborator pubkeys when asked, so video collaborator tags and generic mention tags do not duplicate each other with different roles.
+
+## Surface Integration
+
+### Comments
+
+`CommentsBloc` should stop owning ad hoc `displayName -> npub` conversion logic. It should use the shared resolver before optimistic insertion and before calling `CommentsRepository.postComment`.
+
+`CommentsRepository.postComment` should accept `mentionedPubkeys`. It should append generic mention `p` tags after the required NIP-22 root/parent `p` tags, deduping against root and parent author tags. This avoids redundant tags while still notifying extra mentioned accounts.
+
+### Video Caption And Description
+
+`VideoMetadataFormFields` should use the shared composer for the description/caption field. The editor state and `DivineVideoDraft` should persist selected mention bindings or resolved mention pubkeys so autosave/draft restore does not lose them.
+
+`VideoPublishService` and `VideoEventPublisher` should accept mentioned pubkeys and append generic mention `p` tags in the kind 34236 publish path. Generic mentions should be kept separate from collaborator `p` tags.
+
+### Video Text Overlays
+
+For #3129, overlay text should feed the same resolver. If embedding the composer into `pro_image_editor` is clean, the text editor should offer autocomplete and store selected bindings alongside the layer metadata. If the underlying `TextLayer` cannot carry extra app metadata cleanly, v1 should still resolve typed overlay text at publish time through the shared resolver so published video events contain generic mention `p` tags.
+
+Overlay mentions should not change the rendered text unless the user selected a suggestion. Typed unresolved `@name` remains visual text only.
+
+### Profile Bio
+
+Profile setup/edit bio should use the same mention composer and resolver. Resolved mentions should be canonicalized into `nostr:npub...` inside the `about` text before `ProfileRepository.saveProfileEvent`.
+
+Profile bio rendering already uses linkified text. The shared linkification path should display canonical NIP-27 profile references as friendly tappable `@name` labels when profile data is available, with a full npub/hex fallback handled visually by layout.
+
+No `p` tags should be added to profile kind 0 events.
+
+## Typed Mention Resolution
+
+Typed resolution should be conservative:
+
+- Match the same plain mention token family used by linkified text, avoiding email addresses and Nostr IDs.
+- Search cached candidate profiles first.
+- Use API search only when local candidates do not produce a unique result.
+- Resolve only exact normalized matches first, then a single high-confidence unique match.
+- Leave ambiguous or missing matches unchanged.
+- Never silently resolve to the current user's own pubkey unless the user selected themselves explicitly.
+
+## Error Handling
+
+Mention resolution failure must not block publishing. If lookup fails, publish the text with selected mentions already canonicalized and skip unresolved typed mention tags.
+
+If tag building receives invalid or empty pubkeys, it should skip them and preserve valid entries. It should not truncate or mask values.
+
+## Testing
+
+Add focused tests for:
+
+- Mention token parsing, email exclusion, Nostr reference exclusion, dedupe, and invalid pubkey skipping.
+- Resolver behavior for selected mentions, exact typed matches, ambiguous typed matches, lookup failure, and self-match handling.
+- Comment publish events include generic mention `p` tags and preserve NIP-22 root/parent tags.
+- Comments bloc passes selected and typed mention pubkeys through to the repository.
+- Video publisher emits generic mention tags while preserving collaborator tags with the `collaborator` marker.
+- Video drafts preserve caption mention data through autosave/restore.
+- Profile save canonicalizes resolved bio mentions into `nostr:npub...` content and does not add kind 0 tags.
+- Linkified profile bio renders canonical profile references as tappable account links.
+
+## Verification
+
+Run targeted tests first:
+
+```bash
+cd mobile
+flutter test test/blocs/comments/comments_bloc_test.dart
+flutter test packages/comments_repository/test/src/comments_repository_test.dart
+flutter test test/services/video_event_publisher_test.dart test/services/video_event_publisher_collaborator_tags_test.dart
+flutter test test/providers/video_editor_provider_test.dart test/widgets/video_metadata/video_metadata_form_fields_test.dart
+flutter test packages/profile_repository/test/src/profile_repository_test.dart test/widgets/profile/profile_header_widget_test.dart
+```
+
+Then run:
+
+```bash
+cd mobile
+flutter analyze
+```
+
+Run broader widget/golden checks only if UI layout changes are substantial.

--- a/docs/superpowers/specs/2026-05-14-unified-mentions-design.md
+++ b/docs/superpowers/specs/2026-05-14-unified-mentions-design.md
@@ -4,11 +4,11 @@
 
 Issue #3129 asks for user mentions in video text overlays so viewers can open the mentioned account. While investigating it, we found the larger gap: mentions need one app-wide pipeline, not separate behavior for comments, video captions, overlays, and profile bios.
 
-Today, comments already have autocomplete and selected mentions are converted from `@displayName` to `nostr:npub...` content, but the published kind 1111 comment does not include generic mention `p` tags. Video publishing emits hashtag `t` tags and collaborator-marked `p` tags, but not generic mention tags. Profile bios render Nostr profile references, but the profile editor does not use a shared mention composer.
+Today, comments already have autocomplete and selected mentions are converted from `@displayName` to `nostr:npub...` content, but the published kind 1111 comment does not include generic mention `p` tags. Video publishing emits hashtag `t` tags and collaborator-marked `p` tags, but not generic mention tags. Profile bios render Nostr profile references, but the profile editor does not canonicalize typed or selected mentions through the same resolution rules.
 
 ## Goals
 
-- Provide one shared mention model, composer, resolver, and tag builder for mention-capable text surfaces.
+- Provide one shared mention parsing, resolution, and tag-building pipeline for mention-capable text surfaces.
 - Support both selected autocomplete mentions and typed-but-unselected `@name` mentions.
 - Resolve selected mentions exactly and resolve typed mentions conservatively.
 - Emit generic mention `p` tags for comments and videos, without confusing them with collaborator tags.
@@ -18,6 +18,7 @@ Today, comments already have autocomplete and selected mentions are converted fr
 ## Non-Goals
 
 - Redesign every text field in the app in one PR.
+- Force comments, captions, overlays, and profile bio editing into one shared UI composer abstraction.
 - Add `p` tags to kind 0 profile metadata events.
 - Invent new Nostr tag semantics.
 - Treat unresolved or ambiguous `@name` text as a mention.
@@ -45,14 +46,18 @@ nostr:npub1...
 
 Kind 0 profile events should keep their current empty tag list unless another profile-specific protocol requirement is introduced later.
 
+## KISS Scope Rule
+
+The unified part of this work is the data pipeline, not the editing UI. Each surface should keep its existing text-field state and suggestion UI unless a tiny adapter is enough. Add a shared UI composer only after two surfaces have the same proven needs and the extraction removes real duplication.
+
 ## Architecture
 
-Add a shared mention module owned by the app layer, because it needs app repositories for profile lookup and UI-friendly composer state. The module has three pieces:
+Add a shared mention module owned by the app layer, because it needs app repositories for profile lookup and app-level publish behavior. The module has three pieces:
 
-1. `MentionComposer`
-   - Tracks the active `@` query, selected mention bindings, and suggestion list.
-   - Replaces selected text with the display label shown to the user.
-   - Can be embedded by comments, video metadata description, and profile bio editing.
+1. `MentionTokenParser`
+   - Finds plain `@name` tokens using the same token family as linkified text.
+   - Excludes email addresses, Nostr IDs, and existing `nostr:npub...` / `nostr:nprofile...` references.
+   - Returns unique typed tokens with source ranges so callers can canonicalize text only where needed.
 
 2. `MentionResolver`
    - Accepts raw text plus selected bindings.
@@ -66,29 +71,31 @@ Add a shared mention module owned by the app layer, because it needs app reposit
    - Emits generic mention `p` tags.
    - Excludes collaborator pubkeys when asked, so video collaborator tags and generic mention tags do not duplicate each other with different roles.
 
+Selected mention bindings are simple data objects owned by each surface's existing state: display label, original token/range when available, and full hex pubkey or npub. Comments can keep their current `CommentInput` autocomplete flow, and other surfaces can add the same behavior incrementally without depending on one shared widget/controller.
+
 ## Surface Integration
 
 ### Comments
 
-`CommentsBloc` should stop owning ad hoc `displayName -> npub` conversion logic. It should use the shared resolver before optimistic insertion and before calling `CommentsRepository.postComment`.
+`CommentsBloc` should stop owning ad hoc `displayName -> npub` conversion logic. It should keep the current comment autocomplete UI, pass selected mention bindings into the shared resolver, then use the resolver output before optimistic insertion and before calling `CommentsRepository.postComment`.
 
 `CommentsRepository.postComment` should accept `mentionedPubkeys`. It should append generic mention `p` tags after the required NIP-22 root/parent `p` tags, deduping against root and parent author tags. This avoids redundant tags while still notifying extra mentioned accounts.
 
 ### Video Caption And Description
 
-`VideoMetadataFormFields` should use the shared composer for the description/caption field. The editor state and `DivineVideoDraft` should persist selected mention bindings or resolved mention pubkeys so autosave/draft restore does not lose them.
+`VideoMetadataFormFields` should keep its existing text-field structure for v1. It can add autocomplete through a small local adapter if that is straightforward; otherwise typed mentions are resolved at publish time. The editor state and `DivineVideoDraft` should persist selected mention bindings or resolved mention pubkeys only when autocomplete is added, so autosave/draft restore does not lose them.
 
 `VideoPublishService` and `VideoEventPublisher` should accept mentioned pubkeys and append generic mention `p` tags in the kind 34236 publish path. Generic mentions should be kept separate from collaborator `p` tags.
 
 ### Video Text Overlays
 
-For #3129, overlay text should feed the same resolver. If embedding the composer into `pro_image_editor` is clean, the text editor should offer autocomplete and store selected bindings alongside the layer metadata. If the underlying `TextLayer` cannot carry extra app metadata cleanly, v1 should still resolve typed overlay text at publish time through the shared resolver so published video events contain generic mention `p` tags.
+For #3129 v1, overlay text should feed the same resolver at publish time. Do not embed autocomplete into `pro_image_editor` or add app metadata to `TextLayer` in this pass. Resolving typed overlay text at publish time is enough for published video events to contain generic mention `p` tags without turning this task into an editor integration project.
 
-Overlay mentions should not change the rendered text unless the user selected a suggestion. Typed unresolved `@name` remains visual text only.
+Overlay mentions should not change the rendered text. Typed unresolved or ambiguous `@name` remains visual text only.
 
 ### Profile Bio
 
-Profile setup/edit bio should use the same mention composer and resolver. Resolved mentions should be canonicalized into `nostr:npub...` inside the `about` text before `ProfileRepository.saveProfileEvent`.
+Profile setup/edit bio should use the shared parser and resolver. It can keep its existing editing UI for v1. Resolved mentions should be canonicalized into `nostr:npub...` inside the `about` text before `ProfileRepository.saveProfileEvent`.
 
 Profile bio rendering already uses linkified text. The shared linkification path should display canonical NIP-27 profile references as friendly tappable `@name` labels when profile data is available, with a full npub/hex fallback handled visually by layout.
 
@@ -99,9 +106,10 @@ No `p` tags should be added to profile kind 0 events.
 Typed resolution should be conservative:
 
 - Match the same plain mention token family used by linkified text, avoiding email addresses and Nostr IDs.
+- Deduplicate tokens before lookup and cap remote lookups to five unique tokens per publish action.
 - Search cached candidate profiles first.
-- Use API search only when local candidates do not produce a unique result.
-- Resolve only exact normalized matches first, then a single high-confidence unique match.
+- Use API search only when local candidates do not produce a unique result, with a two-second total timeout for the resolution pass.
+- Resolve only exact normalized matches on username, display name, npub, or hex pubkey.
 - Leave ambiguous or missing matches unchanged.
 - Never silently resolve to the current user's own pubkey unless the user selected themselves explicitly.
 
@@ -120,7 +128,7 @@ Add focused tests for:
 - Comment publish events include generic mention `p` tags and preserve NIP-22 root/parent tags.
 - Comments bloc passes selected and typed mention pubkeys through to the repository.
 - Video publisher emits generic mention tags while preserving collaborator tags with the `collaborator` marker.
-- Video drafts preserve caption mention data through autosave/restore.
+- Video drafts preserve caption mention data through autosave/restore only if caption autocomplete is included in the implementation.
 - Profile save canonicalizes resolved bio mentions into `nostr:npub...` content and does not add kind 0 tags.
 - Linkified profile bio renders canonical profile references as tappable account links.
 

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -16,6 +16,7 @@ import 'package:nostr_sdk/event_kind.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -46,6 +47,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     int? initialTotalCount,
     ProfileRepository? profileRepository,
     FollowRepository? followRepository,
+    MentionResolutionService? mentionResolutionService,
     bool includeVideoReplies = false,
   }) : _commentsRepository = commentsRepository,
        _authService = authService,
@@ -55,6 +57,13 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
        _initialTotalCount = initialTotalCount,
        _profileRepository = profileRepository,
        _followRepository = followRepository,
+       _mentionResolutionService =
+           mentionResolutionService ??
+           (profileRepository == null
+               ? null
+               : MentionResolutionService(
+                   profileRepository: profileRepository,
+                 )),
        _includeVideoReplies = includeVideoReplies,
        super(
          CommentsState(
@@ -111,6 +120,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
   final ContentBlocklistRepository _contentBlocklistRepository;
   final ProfileRepository? _profileRepository;
   final FollowRepository? _followRepository;
+  final MentionResolutionService? _mentionResolutionService;
   final bool _includeVideoReplies;
   bool _isInitialBackfillComplete = true;
 
@@ -295,16 +305,6 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       return;
     }
 
-    // Convert @displayName mentions to nostr:npub format
-    if (state.activeMentions.isNotEmpty) {
-      // Sort by display name length descending to prevent partial replacements
-      final sortedEntries = state.activeMentions.entries.toList()
-        ..sort((a, b) => b.key.length.compareTo(a.key.length));
-      for (final entry in sortedEntries) {
-        text = text.replaceAll('@${entry.key}', 'nostr:${entry.value}');
-      }
-    }
-
     // Snapshot input fields for rollback if the publish fails.
     final previousMain = state.mainInputText;
     final previousReply = state.replyInputText;
@@ -315,6 +315,12 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       emit(state.copyWith(error: CommentsError.notAuthenticated));
       return;
     }
+
+    final resolvedMentions = await _resolveMentionsForText(
+      text,
+      currentUserPubkey: myPubkey,
+    );
+    text = resolvedMentions.canonicalText;
 
     // 1. Optimistic placeholder — comment lands in the list and the input
     // clears before the network call. Mirrors the Follow pattern used for
@@ -360,6 +366,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         rootAddressableId: state.rootAddressableId,
         replyToEventId: event.parentCommentId,
         replyToAuthorPubkey: event.parentAuthorPubkey,
+        mentionedPubkeys: resolvedMentions.resolvedPubkeys,
       );
 
       // If _onNewCommentReceived has already swapped the placeholder for the
@@ -408,6 +415,44 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
               : CommentsError.postCommentFailed,
         ),
       );
+    }
+  }
+
+  Future<_ResolvedCommentMentions> _resolveMentionsForText(
+    String text, {
+    required String currentUserPubkey,
+  }) async {
+    final service = _mentionResolutionService;
+    if (service == null) {
+      return _ResolvedCommentMentions(canonicalText: text);
+    }
+
+    final selectedMentions = state.activeMentions.entries
+        .map(
+          (entry) => MentionBinding(
+            display: entry.key,
+            pubkey: entry.value,
+          ),
+        )
+        .toList();
+
+    try {
+      final result = await service.resolveTextMentions(
+        rawText: text,
+        selectedMentions: selectedMentions,
+        currentUserPubkey: currentUserPubkey,
+      );
+      return _ResolvedCommentMentions(
+        canonicalText: result.canonicalText,
+        resolvedPubkeys: result.resolvedPubkeys,
+      );
+    } catch (e) {
+      Log.warning(
+        'Mention resolution failed: $e',
+        name: 'CommentsBloc',
+        category: LogCategory.ui,
+      );
+      return _ResolvedCommentMentions(canonicalText: text);
     }
   }
 
@@ -740,6 +785,16 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     if (originalComment == null) return;
 
     try {
+      final myPubkey = _authService.currentPublicKeyHex;
+      if (myPubkey == null) {
+        emit(state.copyWith(error: CommentsError.notAuthenticated));
+        return;
+      }
+      final resolvedMentions = await _resolveMentionsForText(
+        editedText,
+        currentUserPubkey: myPubkey,
+      );
+
       // Step 1: Delete the original comment
       await _commentsRepository.deleteComment(
         commentId: originalCommentId,
@@ -748,13 +803,14 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
 
       // Step 2: Post new comment with same threading tags
       final postedComment = await _commentsRepository.postComment(
-        content: editedText,
+        content: resolvedMentions.canonicalText,
         rootEventId: state.rootEventId,
         rootEventKind: state.rootEventKind,
         rootEventAuthorPubkey: state.rootAuthorPubkey,
         rootAddressableId: state.rootAddressableId,
         replyToEventId: originalComment.replyToEventId,
         replyToAuthorPubkey: originalComment.replyToAuthorPubkey,
+        mentionedPubkeys: resolvedMentions.resolvedPubkeys,
       );
 
       // Remove old comment, add new one
@@ -894,7 +950,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     Emitter<CommentsState> emit,
   ) {
     final updatedMentions = Map<String, String>.from(state.activeMentions)
-      ..[event.displayName] = event.npub;
+      ..[event.displayName] = event.pubkey;
     emit(state.copyWith(activeMentions: updatedMentions));
   }
 
@@ -1107,6 +1163,16 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
 
     return lastBatchCount >= _pageSize;
   }
+}
+
+class _ResolvedCommentMentions {
+  const _ResolvedCommentMentions({
+    required this.canonicalText,
+    this.resolvedPubkeys = const [],
+  });
+
+  final String canonicalText;
+  final List<String> resolvedPubkeys;
 }
 
 /// Wraps a [StreamSubscription] so that cancelling it also cancels the

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -284,6 +284,8 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         state.copyWith(
           activeReplyCommentId: event.commentId,
           replyInputText: '',
+          activeMentions: const {},
+          activeMentionBindings: const [],
         ),
       );
     }
@@ -309,6 +311,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     final previousMain = state.mainInputText;
     final previousReply = state.replyInputText;
     final previousMentions = state.activeMentions;
+    final previousMentionBindings = state.activeMentionBindings;
 
     final myPubkey = _authService.currentPublicKeyHex;
     if (myPubkey == null) {
@@ -352,6 +355,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
           commentsById: withPlaceholder,
           mainInputText: '',
           activeMentions: const {},
+          activeMentionBindings: const [],
         ),
       );
     }
@@ -410,6 +414,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
           mainInputText: isReply ? state.mainInputText : previousMain,
           replyInputText: isReply ? previousReply : state.replyInputText,
           activeMentions: previousMentions,
+          activeMentionBindings: previousMentionBindings,
           error: isReply
               ? CommentsError.postReplyFailed
               : CommentsError.postCommentFailed,
@@ -427,14 +432,16 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       return _ResolvedCommentMentions(canonicalText: text);
     }
 
-    final selectedMentions = state.activeMentions.entries
-        .map(
-          (entry) => MentionBinding(
-            display: entry.key,
-            pubkey: entry.value,
-          ),
-        )
-        .toList();
+    final selectedMentions = state.activeMentionBindings.isNotEmpty
+        ? state.activeMentionBindings
+        : state.activeMentions.entries
+              .map(
+                (entry) => MentionBinding(
+                  display: entry.key,
+                  pubkey: entry.value,
+                ),
+              )
+              .toList();
 
     try {
       final result = await service.resolveTextMentions(
@@ -951,7 +958,21 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
   ) {
     final updatedMentions = Map<String, String>.from(state.activeMentions)
       ..[event.displayName] = event.pubkey;
-    emit(state.copyWith(activeMentions: updatedMentions));
+    final updatedBindings = [
+      ...state.activeMentionBindings,
+      MentionBinding(
+        display: event.displayName,
+        pubkey: event.pubkey,
+        start: event.start,
+        end: event.end,
+      ),
+    ];
+    emit(
+      state.copyWith(
+        activeMentions: updatedMentions,
+        activeMentionBindings: updatedBindings,
+      ),
+    );
   }
 
   void _onMentionSuggestionsCleared(

--- a/mobile/lib/blocs/comments/comments_event.dart
+++ b/mobile/lib/blocs/comments/comments_event.dart
@@ -179,13 +179,24 @@ final class MentionSearchRequested extends CommentsEvent {
 /// Register a mention mapping (displayName -> full hex pubkey) for resolution
 /// on submit.
 final class MentionRegistered extends CommentsEvent {
-  const MentionRegistered({required this.displayName, required this.pubkey});
+  const MentionRegistered({
+    required this.displayName,
+    required this.pubkey,
+    this.start,
+    this.end,
+  });
 
   /// The display name shown in the text field (e.g. "Alice")
   final String displayName;
 
   /// The full hex pubkey to resolve on submit.
   final String pubkey;
+
+  /// Start offset of the selected visible mention token in the current input.
+  final int? start;
+
+  /// Exclusive end offset of the selected visible mention token.
+  final int? end;
 }
 
 /// Clear mention suggestions (when @ is removed or input dismissed)

--- a/mobile/lib/blocs/comments/comments_event.dart
+++ b/mobile/lib/blocs/comments/comments_event.dart
@@ -176,15 +176,16 @@ final class MentionSearchRequested extends CommentsEvent {
   final String query;
 }
 
-/// Register a mention mapping (displayName -> npub) for conversion on submit
+/// Register a mention mapping (displayName -> full hex pubkey) for resolution
+/// on submit.
 final class MentionRegistered extends CommentsEvent {
-  const MentionRegistered({required this.displayName, required this.npub});
+  const MentionRegistered({required this.displayName, required this.pubkey});
 
   /// The display name shown in the text field (e.g. "Alice")
   final String displayName;
 
-  /// The npub to convert to on submit (e.g. "npub1abc...")
-  final String npub;
+  /// The full hex pubkey to resolve on submit.
+  final String pubkey;
 }
 
 /// Clear mention suggestions (when @ is removed or input dismissed)

--- a/mobile/lib/blocs/comments/comments_state.dart
+++ b/mobile/lib/blocs/comments/comments_state.dart
@@ -131,6 +131,7 @@ final class CommentsState extends Equatable {
     this.mentionQuery = '',
     this.mentionSuggestions = const [],
     this.activeMentions = const {},
+    this.activeMentionBindings = const [],
     this.activeEditCommentId,
     this.editInputText = '',
     this.newCommentCount = 0,
@@ -186,6 +187,11 @@ final class CommentsState extends Equatable {
   /// Populated when user selects a mention suggestion; consumed on submit
   /// to canonicalize `@displayName` through [MentionResolutionService].
   final Map<String, String> activeMentions;
+
+  /// Selected mention bindings tied to the visible token range at selection
+  /// time. These prevent deleted or cross-input stale selections from
+  /// publishing mention tags.
+  final List<MentionBinding> activeMentionBindings;
 
   /// ID of the comment currently being edited (null = not editing).
   final String? activeEditCommentId;
@@ -318,6 +324,7 @@ final class CommentsState extends Equatable {
     String? mentionQuery,
     List<MentionSuggestion>? mentionSuggestions,
     Map<String, String>? activeMentions,
+    List<MentionBinding>? activeMentionBindings,
     String? activeEditCommentId,
     String? editInputText,
     int? newCommentCount,
@@ -346,6 +353,8 @@ final class CommentsState extends Equatable {
       mentionQuery: mentionQuery ?? this.mentionQuery,
       mentionSuggestions: mentionSuggestions ?? this.mentionSuggestions,
       activeMentions: activeMentions ?? this.activeMentions,
+      activeMentionBindings:
+          activeMentionBindings ?? this.activeMentionBindings,
       activeEditCommentId: activeEditCommentId ?? this.activeEditCommentId,
       editInputText: editInputText ?? this.editInputText,
       newCommentCount: newCommentCount ?? this.newCommentCount,
@@ -382,6 +391,7 @@ final class CommentsState extends Equatable {
 
   /// Creates a copy with edit mode cleared.
   /// Preserves all other state including vote data and reply state.
+  /// Clears mention state because selected mentions are scoped to one composer.
   CommentsState clearEditMode({
     CommentsStatus? status,
     Map<String, Comment>? commentsById,
@@ -406,9 +416,6 @@ final class CommentsState extends Equatable {
       sortMode: sortMode,
       replyCountsByCommentId:
           replyCountsByCommentId ?? this.replyCountsByCommentId,
-      mentionQuery: mentionQuery,
-      mentionSuggestions: mentionSuggestions,
-      activeMentions: activeMentions,
       newCommentCount: newCommentCount,
     );
   }
@@ -436,6 +443,7 @@ final class CommentsState extends Equatable {
     mentionQuery,
     mentionSuggestions,
     activeMentions,
+    activeMentionBindings,
     activeEditCommentId,
     editInputText,
     newCommentCount,

--- a/mobile/lib/blocs/comments/comments_state.dart
+++ b/mobile/lib/blocs/comments/comments_state.dart
@@ -182,9 +182,9 @@ final class CommentsState extends Equatable {
   /// Mention suggestions for autocomplete overlay.
   final List<MentionSuggestion> mentionSuggestions;
 
-  /// Active mention mappings: displayName -> npub.
+  /// Active mention mappings: displayName -> full hex pubkey.
   /// Populated when user selects a mention suggestion; consumed on submit
-  /// to convert `@displayName` back to `nostr:npub` in the posted text.
+  /// to canonicalize `@displayName` through [MentionResolutionService].
   final Map<String, String> activeMentions;
 
   /// ID of the comment currently being edited (null = not editing).

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -14,6 +14,7 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -49,10 +50,14 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     required ProfileRepository profileRepository,
     required BlossomUploadService blossomUploadService,
     required bool hasExistingProfile,
+    MentionResolutionService? mentionResolutionService,
     String? currentUserPubkey,
   }) : _profileRepository = profileRepository,
        _blossomUploadService = blossomUploadService,
        _hasExistingProfile = hasExistingProfile,
+       _mentionResolutionService =
+           mentionResolutionService ??
+           MentionResolutionService(profileRepository: profileRepository),
        _currentUserPubkey = currentUserPubkey,
        super(const ProfileEditorState()) {
     on<InitialUsernameSet>(_onInitialUsernameSet);
@@ -91,6 +96,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
   final ProfileRepository _profileRepository;
   final BlossomUploadService _blossomUploadService;
   final bool _hasExistingProfile;
+  final MentionResolutionService _mentionResolutionService;
   final String? _currentUserPubkey;
 
   void _onInitialUsernameSet(
@@ -776,7 +782,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     emit(state.copyWith(status: ProfileEditorStatus.loading));
 
     final displayName = event.displayName.trim();
-    final about = (event.about?.trim().isEmpty ?? true) ? null : event.about;
+    final about = await _canonicalizeProfileAbout(event);
 
     // Bloc decides which NIP-05 value to use based on current mode
     final isExternal = state.nip05Mode == Nip05Mode.external_;
@@ -903,6 +909,26 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           error: profileError,
         ),
       );
+    }
+  }
+
+  Future<String?> _canonicalizeProfileAbout(ProfileSaved event) async {
+    final rawAbout = event.about;
+    if (rawAbout?.trim().isEmpty ?? true) return null;
+
+    try {
+      final result = await _mentionResolutionService.resolveTextMentions(
+        rawText: rawAbout!,
+        currentUserPubkey: event.pubkey,
+      );
+      return result.canonicalText;
+    } on Object catch (error, stackTrace) {
+      Log.error(
+        'Profile bio mention resolution failed: $error',
+        name: 'ProfileEditorBloc',
+      );
+      addError(error, stackTrace);
+      return rawAbout;
     }
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -76,6 +76,7 @@ import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/logging_config_service.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_service.dart'
     show NotificationPayloadKind, NotificationTapEvent;
@@ -1774,12 +1775,18 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     Future<VideoPublishService> createPublishService({
       required OnProgressChanged onProgress,
     }) async {
+      final profileRepository = ref.read(profileRepositoryProvider);
       return VideoPublishService(
         uploadManager: ref.read(uploadManagerProvider),
         authService: ref.read(authServiceProvider),
         videoEventPublisher: ref.read(videoEventPublisherProvider),
         blossomService: ref.read(blossomUploadServiceProvider),
         draftService: ref.read(draftStorageServiceProvider),
+        mentionResolutionService: profileRepository == null
+            ? null
+            : MentionResolutionService(
+                profileRepository: profileRepository,
+              ),
         collaboratorInviteService: CollaboratorInviteService(
           dmRepository: ref.read(dmRepositoryProvider),
           l10n: currentAppL10n(ref.read(sharedPreferencesProvider)),

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -30,11 +30,13 @@ import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/cawg_verifier_client.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Provider for video publish screen state management.
@@ -51,6 +53,14 @@ final videoPublishProvider =
   ),
   extra: const VideoDetailRouteExtra(autoOpenComments: true),
 );
+
+@visibleForTesting
+MentionResolutionService? createVideoPublishMentionResolutionService(
+  ProfileRepository? profileRepository,
+) {
+  if (profileRepository == null) return null;
+  return MentionResolutionService(profileRepository: profileRepository);
+}
 
 /// Manages video publish screen state including playback and position.
 class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
@@ -127,6 +137,9 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       videoEventPublisher: ref.read(videoEventPublisherProvider),
       blossomService: ref.read(blossomUploadServiceProvider),
       draftService: _draftService,
+      mentionResolutionService: createVideoPublishMentionResolutionService(
+        ref.read(profileRepositoryProvider),
+      ),
       collaboratorInviteService: CollaboratorInviteService(
         dmRepository: ref.read(dmRepositoryProvider),
         l10n: currentAppL10n(ref.read(sharedPreferencesProvider)),

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -342,9 +342,9 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
               context.read<CommentsBloc>().add(MentionSearchRequested(query));
             }
           },
-          onMentionSelected: (npub, displayName) {
+          onMentionSelected: (pubkey, displayName) {
             context.read<CommentsBloc>()
-              ..add(MentionRegistered(displayName: displayName, npub: npub))
+              ..add(MentionRegistered(displayName: displayName, pubkey: pubkey))
               ..add(const MentionSuggestionsCleared());
           },
           onVideoReplyPressed:

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -342,9 +342,16 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
               context.read<CommentsBloc>().add(MentionSearchRequested(query));
             }
           },
-          onMentionSelected: (pubkey, displayName) {
+          onMentionSelected: (pubkey, displayName, start, end) {
             context.read<CommentsBloc>()
-              ..add(MentionRegistered(displayName: displayName, pubkey: pubkey))
+              ..add(
+                MentionRegistered(
+                  displayName: displayName,
+                  pubkey: pubkey,
+                  start: start,
+                  end: end,
+                ),
+              )
               ..add(const MentionSuggestionsCleared());
           },
           onVideoReplyPressed:

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -62,8 +62,8 @@ class CommentInput extends StatefulWidget {
   /// Callback fired with the query text after '@'.
   final ValueChanged<String>? onMentionQuery;
 
-  /// Callback fired with (npub, displayName) when a mention is selected.
-  final void Function(String npub, String displayName)? onMentionSelected;
+  /// Callback fired with (hex pubkey, displayName) when a mention is selected.
+  final void Function(String pubkey, String displayName)? onMentionSelected;
 
   /// Callback fired when the user wants to record a video comment.
   final VoidCallback? onVideoReplyPressed;
@@ -153,7 +153,7 @@ class _CommentInputState extends State<CommentInput> {
     widget.onMentionQuery?.call('');
   }
 
-  void _handleMentionSelected(String npub, String displayName) {
+  void _handleMentionSelected(String pubkey, String displayName) {
     final text = widget.controller.text;
     final cursorPos = widget.controller.selection.baseOffset;
     if (cursorPos < 0) return;
@@ -162,8 +162,8 @@ class _CommentInputState extends State<CommentInput> {
     final atIndex = textBeforeCursor.lastIndexOf('@');
     if (atIndex < 0) return;
 
-    // Replace @query with @displayName (human-readable)
-    // The BLoC will convert @displayName -> nostr:npub on submit
+    // Replace @query with @displayName (human-readable). The BLoC keeps the
+    // selected hex pubkey and canonicalizes the text on submit.
     final mention = '@$displayName ';
     final newText =
         text.substring(0, atIndex) + mention + text.substring(cursorPos);
@@ -172,7 +172,7 @@ class _CommentInputState extends State<CommentInput> {
       offset: atIndex + mention.length,
     );
 
-    widget.onMentionSelected?.call(npub, displayName);
+    widget.onMentionSelected?.call(pubkey, displayName);
     widget.onChanged?.call(newText);
   }
 

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -62,8 +62,15 @@ class CommentInput extends StatefulWidget {
   /// Callback fired with the query text after '@'.
   final ValueChanged<String>? onMentionQuery;
 
-  /// Callback fired with (hex pubkey, displayName) when a mention is selected.
-  final void Function(String pubkey, String displayName)? onMentionSelected;
+  /// Callback fired with (hex pubkey, displayName, start, exclusive end) when a
+  /// mention is selected.
+  final void Function(
+    String pubkey,
+    String displayName,
+    int start,
+    int end,
+  )?
+  onMentionSelected;
 
   /// Callback fired when the user wants to record a video comment.
   final VoidCallback? onVideoReplyPressed;
@@ -172,7 +179,12 @@ class _CommentInputState extends State<CommentInput> {
       offset: atIndex + mention.length,
     );
 
-    widget.onMentionSelected?.call(pubkey, displayName);
+    widget.onMentionSelected?.call(
+      pubkey,
+      displayName,
+      atIndex,
+      atIndex + mention.length - 1,
+    );
     widget.onChanged?.call(newText);
   }
 

--- a/mobile/lib/screens/comments/widgets/mention_overlay.dart
+++ b/mobile/lib/screens/comments/widgets/mention_overlay.dart
@@ -50,8 +50,8 @@ class MentionOverlay extends ConsumerWidget {
   /// List of mention suggestions to display.
   final List<MentionSuggestion> suggestions;
 
-  /// Callback when a suggestion is selected. Returns (npub, displayName).
-  final void Function(String npub, String displayName) onSelect;
+  /// Callback when a suggestion is selected. Returns (hex pubkey, displayName).
+  final void Function(String pubkey, String displayName) onSelect;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -93,7 +93,7 @@ class MentionOverlay extends ConsumerWidget {
                     cachedProfile?.displayName ??
                     cachedProfile?.name ??
                     npub;
-                onSelect(npub, displayName);
+                onSelect(suggestion.pubkey, displayName);
               },
             );
           },

--- a/mobile/lib/services/mention_resolution_service.dart
+++ b/mobile/lib/services/mention_resolution_service.dart
@@ -1,0 +1,392 @@
+import 'dart:async';
+
+import 'package:models/models.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/public_identifier_normalizer.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+const _divineRelayHint = 'wss://relay.divine.video';
+const _mentionMarker = 'mention';
+const _typedRemoteLookupLimit = 5;
+const _profileSearchLimit = 10;
+
+final _linkifiedTokenRegex = RegExp(
+  r'((?:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})|(?:https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?))|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?((?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+)\b|(?<![A-Fa-f0-9])([A-Fa-f0-9]{64})(?![A-Fa-f0-9])|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
+  caseSensitive: false,
+);
+
+class MentionBinding {
+  const MentionBinding({
+    required this.display,
+    required this.pubkey,
+    this.start,
+    this.end,
+  });
+
+  final String display;
+  final String pubkey;
+  final int? start;
+  final int? end;
+}
+
+class MentionResolutionResult {
+  const MentionResolutionResult({
+    required this.canonicalText,
+    required this.resolvedPubkeys,
+    required this.unresolvedTokens,
+  });
+
+  final String canonicalText;
+  final List<String> resolvedPubkeys;
+  final List<String> unresolvedTokens;
+}
+
+class MentionResolutionService {
+  MentionResolutionService({
+    required ProfileRepository profileRepository,
+    Duration typedResolutionTimeout = const Duration(seconds: 2),
+  }) : _profileRepository = profileRepository,
+       _typedResolutionTimeout = typedResolutionTimeout;
+
+  final ProfileRepository _profileRepository;
+  final Duration _typedResolutionTimeout;
+
+  Future<MentionResolutionResult> resolveTextMentions({
+    required String rawText,
+    List<MentionBinding> selectedMentions = const [],
+    String? currentUserPubkey,
+  }) async {
+    final normalizedCurrentUser = currentUserPubkey == null
+        ? null
+        : normalizeToHex(currentUserPubkey);
+    final selectedResult = _canonicalizeSelectedMentions(
+      rawText,
+      selectedMentions,
+    );
+    final typedMentions = _extractTypedMentions(selectedResult.text);
+    if (typedMentions.isEmpty) {
+      return MentionResolutionResult(
+        canonicalText: selectedResult.text,
+        resolvedPubkeys: selectedResult.pubkeys.toList(),
+        unresolvedTokens: const [],
+      );
+    }
+
+    final typedResult =
+        await _resolveTypedMentions(
+          typedMentions,
+          currentUserPubkey: normalizedCurrentUser,
+        ).timeout(
+          _typedResolutionTimeout,
+          onTimeout: () => _TypedResolutionResult.empty(typedMentions),
+        );
+
+    final replacements = <_TextReplacement>[];
+    for (final mention in typedMentions) {
+      final pubkey = typedResult.pubkeyByToken[mention.normalizedToken];
+      if (pubkey == null) continue;
+      replacements.add(
+        _TextReplacement(
+          start: mention.start,
+          end: mention.end,
+          text: _canonicalReferenceForHex(pubkey),
+        ),
+      );
+    }
+
+    final resolvedPubkeys = <String>{
+      ...selectedResult.pubkeys,
+      ...typedResult.pubkeyByToken.values,
+    };
+
+    return MentionResolutionResult(
+      canonicalText: _applyReplacements(selectedResult.text, replacements),
+      resolvedPubkeys: resolvedPubkeys.toList(),
+      unresolvedTokens: typedResult.unresolvedTokens,
+    );
+  }
+
+  List<List<String>> buildGenericMentionPTags({
+    required Iterable<String> pubkeys,
+    Iterable<String> collaboratorPubkeys = const [],
+  }) {
+    final collaboratorHex = collaboratorPubkeys
+        .map(normalizeToHex)
+        .whereType<String>()
+        .where(NostrKeyUtils.isValidKey)
+        .toSet();
+    final seen = <String>{};
+    final tags = <List<String>>[];
+
+    for (final pubkey in pubkeys) {
+      final hex = normalizeToHex(pubkey);
+      if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
+      if (collaboratorHex.contains(hex) || !seen.add(hex)) continue;
+      tags.add(['p', hex, _divineRelayHint, _mentionMarker]);
+    }
+
+    return tags;
+  }
+
+  _SelectedMentionResult _canonicalizeSelectedMentions(
+    String rawText,
+    List<MentionBinding> selectedMentions,
+  ) {
+    var text = rawText;
+    final pubkeys = <String>{};
+    final rangedReplacements = <_TextReplacement>[];
+    final unrangedBindings = <MentionBinding>[];
+
+    for (final binding in selectedMentions) {
+      final hex = normalizeToHex(binding.pubkey);
+      if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
+      pubkeys.add(hex);
+
+      final start = binding.start;
+      final end = binding.end;
+      if (start != null &&
+          end != null &&
+          start >= 0 &&
+          end <= rawText.length &&
+          start < end) {
+        rangedReplacements.add(
+          _TextReplacement(
+            start: start,
+            end: end,
+            text: _canonicalReferenceForHex(hex),
+          ),
+        );
+      } else {
+        unrangedBindings.add(binding);
+      }
+    }
+
+    text = _applyReplacements(text, rangedReplacements);
+
+    for (final binding in unrangedBindings) {
+      final hex = normalizeToHex(binding.pubkey);
+      if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
+      text = _replaceFirstSelectedToken(
+        text,
+        binding.display,
+        _canonicalReferenceForHex(hex),
+      );
+    }
+
+    return _SelectedMentionResult(text: text, pubkeys: pubkeys);
+  }
+
+  Future<_TypedResolutionResult> _resolveTypedMentions(
+    List<_TypedMention> mentions, {
+    required String? currentUserPubkey,
+  }) async {
+    final uniqueTokens = <String>[];
+    for (final mention in mentions) {
+      if (!uniqueTokens.contains(mention.normalizedToken)) {
+        uniqueTokens.add(mention.normalizedToken);
+      }
+    }
+
+    final pubkeyByToken = <String, String>{};
+    final unresolvedTokens = <String>[];
+    var remoteLookups = 0;
+
+    for (final token in uniqueTokens) {
+      String? resolved;
+      try {
+        final localCandidates = await _profileRepository.searchUsersLocally(
+          query: token,
+          limit: _profileSearchLimit,
+        );
+        resolved = _exactSingleMatch(token, localCandidates);
+
+        if (resolved == null && remoteLookups < _typedRemoteLookupLimit) {
+          remoteLookups += 1;
+          final apiCandidates = await _profileRepository.searchUsersFromApi(
+            query: token,
+            limit: _profileSearchLimit,
+          );
+          resolved = _exactSingleMatch(token, apiCandidates);
+        }
+      } on Exception {
+        resolved = null;
+      }
+
+      if (resolved == currentUserPubkey) resolved = null;
+
+      if (resolved == null) {
+        unresolvedTokens.add(token);
+      } else {
+        pubkeyByToken[token] = resolved;
+      }
+    }
+
+    return _TypedResolutionResult(
+      pubkeyByToken: pubkeyByToken,
+      unresolvedTokens: unresolvedTokens,
+    );
+  }
+
+  String? _exactSingleMatch(String token, List<UserProfile> profiles) {
+    final matches = <String>{};
+    for (final profile in profiles) {
+      final hex = normalizeToHex(profile.pubkey);
+      if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
+      if (_profileMatchesToken(token, profile, hex)) {
+        matches.add(hex);
+      }
+    }
+    return matches.length == 1 ? matches.single : null;
+  }
+
+  bool _profileMatchesToken(String token, UserProfile profile, String hex) {
+    final normalizedToken = _normalizeMentionValue(token);
+    if (normalizedToken.isEmpty) return false;
+
+    final values = <String?>[
+      profile.name,
+      profile.displayName,
+      profile.divineUsername,
+      profile.shortDisplayNip05,
+      profile.displayNip05,
+      profile.nip05,
+      hex,
+      NostrKeyUtils.encodePubKey(hex),
+    ];
+
+    return values
+        .whereType<String>()
+        .map(_normalizeMentionValue)
+        .any((value) => value == normalizedToken);
+  }
+}
+
+List<_TypedMention> _extractTypedMentions(String text) {
+  final mentions = <_TypedMention>[];
+  for (final match in _linkifiedTokenRegex.allMatches(text)) {
+    final token = match.group(5);
+    if (token == null) continue;
+    mentions.add(
+      _TypedMention(
+        token: token,
+        start: match.start,
+        end: match.end,
+        normalizedToken: _normalizeMentionValue(token),
+      ),
+    );
+  }
+  return mentions
+      .where((mention) => mention.normalizedToken.isNotEmpty)
+      .toList();
+}
+
+String _replaceFirstSelectedToken(
+  String text,
+  String display,
+  String replacement,
+) {
+  final token = display.startsWith('@') ? display : '@$display';
+  final tokenIndex = text.indexOf(token);
+  if (tokenIndex >= 0) {
+    return text.replaceRange(
+      tokenIndex,
+      tokenIndex + token.length,
+      replacement,
+    );
+  }
+
+  final displayIndex = text.indexOf(display);
+  if (displayIndex < 0) return text;
+  return text.replaceRange(
+    displayIndex,
+    displayIndex + display.length,
+    replacement,
+  );
+}
+
+String _applyReplacements(String text, List<_TextReplacement> replacements) {
+  if (replacements.isEmpty) return text;
+  final sorted = [...replacements]..sort((a, b) => b.start.compareTo(a.start));
+  var next = text;
+  for (final replacement in sorted) {
+    if (replacement.start < 0 ||
+        replacement.end > next.length ||
+        replacement.start >= replacement.end) {
+      continue;
+    }
+    next = next.replaceRange(
+      replacement.start,
+      replacement.end,
+      replacement.text,
+    );
+  }
+  return next;
+}
+
+String _canonicalReferenceForHex(String pubkey) {
+  return 'nostr:${NostrKeyUtils.encodePubKey(pubkey)}';
+}
+
+String _normalizeMentionValue(String value) {
+  final trimmed = value.trim().toLowerCase();
+  final withoutPrefix = trimmed.startsWith('@')
+      ? trimmed.substring(1)
+      : trimmed;
+  return withoutPrefix.replaceAll(RegExp('[^a-z0-9]'), '');
+}
+
+class _SelectedMentionResult {
+  const _SelectedMentionResult({required this.text, required this.pubkeys});
+
+  final String text;
+  final Set<String> pubkeys;
+}
+
+class _TypedResolutionResult {
+  const _TypedResolutionResult({
+    required this.pubkeyByToken,
+    required this.unresolvedTokens,
+  });
+
+  factory _TypedResolutionResult.empty(List<_TypedMention> mentions) {
+    final unresolved = <String>[];
+    for (final mention in mentions) {
+      if (!unresolved.contains(mention.normalizedToken)) {
+        unresolved.add(mention.normalizedToken);
+      }
+    }
+    return _TypedResolutionResult(
+      pubkeyByToken: const {},
+      unresolvedTokens: unresolved,
+    );
+  }
+
+  final Map<String, String> pubkeyByToken;
+  final List<String> unresolvedTokens;
+}
+
+class _TypedMention {
+  const _TypedMention({
+    required this.token,
+    required this.start,
+    required this.end,
+    required this.normalizedToken,
+  });
+
+  final String token;
+  final int start;
+  final int end;
+  final String normalizedToken;
+}
+
+class _TextReplacement {
+  const _TextReplacement({
+    required this.start,
+    required this.end,
+    required this.text,
+  });
+
+  final int start;
+  final int end;
+  final String text;
+}

--- a/mobile/lib/services/mention_resolution_service.dart
+++ b/mobile/lib/services/mention_resolution_service.dart
@@ -27,6 +27,19 @@ class MentionBinding {
   final String pubkey;
   final int? start;
   final int? end;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MentionBinding &&
+          runtimeType == other.runtimeType &&
+          display == other.display &&
+          pubkey == other.pubkey &&
+          start == other.start &&
+          end == other.end;
+
+  @override
+  int get hashCode => Object.hash(display, pubkey, start, end);
 }
 
 class MentionResolutionResult {
@@ -134,44 +147,37 @@ class MentionResolutionService {
   ) {
     var text = rawText;
     final pubkeys = <String>{};
-    final rangedReplacements = <_TextReplacement>[];
-    final unrangedBindings = <MentionBinding>[];
+    final replacementsByRange = <String, _TextReplacement>{};
+    final pubkeyByRange = <String, String>{};
+    final occupiedRanges = <_MentionTokenRange>[];
 
-    for (final binding in selectedMentions) {
+    // Later bindings represent newer user selections. Process newest first so
+    // a re-selected token replaces stale bindings for the same visible range.
+    for (final binding in selectedMentions.reversed) {
       final hex = normalizeToHex(binding.pubkey);
       if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
-      pubkeys.add(hex);
 
-      final start = binding.start;
-      final end = binding.end;
-      if (start != null &&
-          end != null &&
-          start >= 0 &&
-          end <= rawText.length &&
-          start < end) {
-        rangedReplacements.add(
-          _TextReplacement(
-            start: start,
-            end: end,
-            text: _canonicalReferenceForHex(hex),
-          ),
-        );
-      } else {
-        unrangedBindings.add(binding);
-      }
-    }
-
-    text = _applyReplacements(text, rangedReplacements);
-
-    for (final binding in unrangedBindings) {
-      final hex = normalizeToHex(binding.pubkey);
-      if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
-      text = _replaceFirstSelectedToken(
-        text,
-        binding.display,
-        _canonicalReferenceForHex(hex),
+      final range = _currentSelectedTokenRange(
+        rawText,
+        binding,
+        occupiedRanges,
       );
+      if (range == null) {
+        continue;
+      }
+
+      final rangeKey = '${range.start}:${range.end}';
+      replacementsByRange[rangeKey] = _TextReplacement(
+        start: range.start,
+        end: range.end,
+        text: _canonicalReferenceForHex(hex),
+      );
+      pubkeyByRange[rangeKey] = hex;
+      occupiedRanges.add(range);
     }
+
+    text = _applyReplacements(text, replacementsByRange.values.toList());
+    pubkeys.addAll(pubkeyByRange.values);
 
     return _SelectedMentionResult(text: text, pubkeys: pubkeys);
   }
@@ -280,27 +286,66 @@ List<_TypedMention> _extractTypedMentions(String text) {
       .toList();
 }
 
-String _replaceFirstSelectedToken(
+_MentionTokenRange? _currentSelectedTokenRange(
   String text,
-  String display,
-  String replacement,
+  MentionBinding binding,
+  List<_MentionTokenRange> occupiedRanges,
 ) {
-  final token = display.startsWith('@') ? display : '@$display';
-  final tokenIndex = text.indexOf(token);
-  if (tokenIndex >= 0) {
-    return text.replaceRange(
-      tokenIndex,
-      tokenIndex + token.length,
-      replacement,
-    );
+  final start = binding.start;
+  final end = binding.end;
+  if (start != null &&
+      end != null &&
+      start >= 0 &&
+      end <= text.length &&
+      start < end &&
+      _rangeMatchesSelectedToken(text, start, end, binding.display)) {
+    final range = _MentionTokenRange(start: start, end: end);
+    if (!_rangeOverlapsAny(range, occupiedRanges)) return range;
   }
 
-  final displayIndex = text.indexOf(display);
-  if (displayIndex < 0) return text;
-  return text.replaceRange(
-    displayIndex,
-    displayIndex + display.length,
-    replacement,
+  return _findSelectedTokenRange(
+    text,
+    binding.display,
+    occupiedRanges: occupiedRanges,
+  );
+}
+
+bool _rangeMatchesSelectedToken(
+  String text,
+  int start,
+  int end,
+  String display,
+) {
+  final selectedText = text.substring(start, end);
+  final token = display.startsWith('@') ? display : '@$display';
+  return selectedText == token || selectedText == display;
+}
+
+_MentionTokenRange? _findSelectedTokenRange(
+  String text,
+  String display, {
+  required List<_MentionTokenRange> occupiedRanges,
+}) {
+  final token = display.startsWith('@') ? display : '@$display';
+  var searchStart = 0;
+  while (searchStart < text.length) {
+    final index = text.indexOf(token, searchStart);
+    if (index < 0) return null;
+
+    final range = _MentionTokenRange(start: index, end: index + token.length);
+    if (!_rangeOverlapsAny(range, occupiedRanges)) return range;
+    searchStart = index + token.length;
+  }
+
+  return null;
+}
+
+bool _rangeOverlapsAny(
+  _MentionTokenRange range,
+  List<_MentionTokenRange> occupiedRanges,
+) {
+  return occupiedRanges.any(
+    (occupied) => range.start < occupied.end && occupied.start < range.end,
   );
 }
 
@@ -340,6 +385,13 @@ class _SelectedMentionResult {
 
   final String text;
   final Set<String> pubkeys;
+}
+
+class _MentionTokenRange {
+  const _MentionTokenRange({required this.start, required this.end});
+
+  final int start;
+  final int end;
 }
 
 class _TypedResolutionResult {

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -104,6 +104,36 @@ Duration outerPublishTimeoutFor(int relayCount) {
   return derived;
 }
 
+List<List<String>> _buildMentionPTags(
+  Iterable<String> pubkeys, {
+  Iterable<String> excludedPubkeys = const [],
+}) {
+  final excluded = excludedPubkeys
+      .map((pubkey) => pubkey.trim().toLowerCase())
+      .where(NostrHexUtils.isValidPubkey)
+      .toSet();
+  final seen = <String>{};
+  final tags = <List<String>>[];
+
+  for (final pubkey in pubkeys) {
+    final normalizedPubkey = pubkey.trim().toLowerCase();
+    if (!NostrHexUtils.isValidPubkey(normalizedPubkey) ||
+        excluded.contains(normalizedPubkey) ||
+        !seen.add(normalizedPubkey)) {
+      continue;
+    }
+
+    tags.add([
+      'p',
+      normalizedPubkey,
+      collaboratorInviteRelayHint,
+      'mention',
+    ]);
+  }
+
+  return tags;
+}
+
 /// Service for publishing processed videos to Nostr relays
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class VideoEventPublisher {
@@ -454,6 +484,7 @@ class VideoEventPublisher {
     bool allowAudioReuse = false,
     Duration? thumbnailTimestamp,
     List<String> collaboratorPubkeys = const [],
+    List<String> mentionedPubkeys = const [],
     String? inspiredByAddressableId,
     String? inspiredByRelayUrl,
     String? inspiredByNpub,
@@ -476,6 +507,7 @@ class VideoEventPublisher {
       expirationTimestamp: expirationTimestamp,
       allowAudioReuse: allowAudioReuse,
       collaboratorPubkeys: collaboratorPubkeys,
+      mentionedPubkeys: mentionedPubkeys,
       inspiredByAddressableId: inspiredByAddressableId,
       inspiredByRelayUrl: inspiredByRelayUrl,
       inspiredByNpub: inspiredByNpub,
@@ -495,6 +527,7 @@ class VideoEventPublisher {
     int? expirationTimestamp,
     bool allowAudioReuse = false,
     List<String> collaboratorPubkeys = const [],
+    List<String> mentionedPubkeys = const [],
     Duration? thumbnailTimestamp,
     String? inspiredByAddressableId,
     String? inspiredByRelayUrl,
@@ -839,6 +872,12 @@ class VideoEventPublisher {
       }
 
       tags.addAll(buildCollaboratorPTags(collaboratorPubkeys));
+      tags.addAll(
+        _buildMentionPTags(
+          mentionedPubkeys,
+          excludedPubkeys: collaboratorPubkeys,
+        ),
+      );
 
       // Add Inspired By a-tag (specific video reference)
       if (inspiredByAddressableId != null) {

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -760,34 +760,39 @@ List<String> _extractVideoPublishTextOverlayStrings(
   if (editorStateHistory.isEmpty) return const [];
 
   final references = _mapReferences(editorStateHistory['references']);
-  final lastLayerState = <String, Map<String, dynamic>>{...references};
   final history = editorStateHistory['history'];
   if (history is! Iterable) return const [];
 
-  for (final historyItem in history) {
-    if (historyItem is! Map) continue;
-    final layers = historyItem['layers'];
-    if (layers is! Iterable) continue;
+  final historyItems = history.toList();
+  final position = editorStateHistory['position'];
+  if (position == -1) return const [];
 
-    for (final rawLayer in layers) {
-      if (rawLayer is! Map) continue;
-      final layer = Map<String, dynamic>.from(rawLayer);
-      final id = layer['id'];
-      final mergedLayer = id is String
-          ? <String, dynamic>{...?lastLayerState[id], ...layer}
-          : layer;
+  final currentIndex =
+      position is int && position >= 0 && position < historyItems.length
+      ? position
+      : historyItems.length - 1;
+  if (currentIndex < 0) return const [];
 
-      final type = mergedLayer['type'];
-      final text = mergedLayer['text'];
-      if ((type == null || type == 'text') &&
-          text is String &&
-          text.trim().isNotEmpty) {
-        overlays.add(text);
-      }
+  final currentHistoryItem = historyItems[currentIndex];
+  if (currentHistoryItem is! Map) return const [];
 
-      if (id is String) {
-        lastLayerState[id] = mergedLayer;
-      }
+  final layers = currentHistoryItem['layers'];
+  if (layers is! Iterable) return const [];
+
+  for (final rawLayer in layers) {
+    if (rawLayer is! Map) continue;
+    final layer = Map<String, dynamic>.from(rawLayer);
+    final id = layer['id'];
+    final mergedLayer = id is String
+        ? <String, dynamic>{...?references[id], ...layer}
+        : layer;
+
+    final type = mergedLayer['type'];
+    final text = mergedLayer['text'];
+    if ((type == null || type == 'text') &&
+        text is String &&
+        text.trim().isNotEmpty) {
+      overlays.add(text);
     }
   }
 

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -14,8 +14,11 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Result of a publish operation.
@@ -92,6 +95,7 @@ class VideoPublishService {
     required this.onProgressChanged,
     this.collaboratorInviteService,
     this.languagePreferenceService,
+    this.mentionResolutionService,
   });
 
   /// Manages background video uploads.
@@ -117,6 +121,9 @@ class VideoPublishService {
 
   /// Language preference for NIP-32 tagging.
   final LanguagePreferenceService? languagePreferenceService;
+
+  /// Resolves typed mentions before publishing Nostr video events.
+  final MentionResolutionService? mentionResolutionService;
 
   /// Tracks the current background upload ID.
   String? _backgroundUploadId;
@@ -179,6 +186,11 @@ class VideoPublishService {
       // Publish Nostr event
       Log.info('📝 Publishing Nostr event...', category: .video);
 
+      final mentionedPubkeys = await _resolveMentionedPubkeys(
+        draft,
+        currentUserPubkey: pubkey,
+      );
+
       final published = await videoEventPublisher.publishVideoEvent(
         upload: pendingUpload,
         title: draft.title,
@@ -190,6 +202,7 @@ class VideoPublishService {
             : null,
         allowAudioReuse: draft.allowAudioReuse,
         collaboratorPubkeys: draft.collaboratorPubkeys.toList(),
+        mentionedPubkeys: mentionedPubkeys,
         inspiredByAddressableId: draft.inspiredByVideo?.addressableId,
         inspiredByRelayUrl: draft.inspiredByVideo?.relayUrl,
         inspiredByNpub: draft.inspiredByNpub,
@@ -225,6 +238,34 @@ class VideoPublishService {
       return PublishSuccess(inviteWarnings: inviteWarnings);
     } catch (e, stackTrace) {
       return _handleUploadError(e, stackTrace, draft);
+    }
+  }
+
+  Future<List<String>> _resolveMentionedPubkeys(
+    DivineVideoDraft draft, {
+    required String currentUserPubkey,
+  }) async {
+    final resolver = mentionResolutionService;
+    if (resolver == null) return const [];
+
+    final rawText = _videoPublishMentionResolutionText(draft);
+    if (!rawText.contains('@')) return const [];
+
+    try {
+      final result = await resolver.resolveTextMentions(
+        rawText: rawText,
+        currentUserPubkey: currentUserPubkey,
+      );
+      return _excludeCollaboratorPubkeys(
+        result.resolvedPubkeys,
+        draft.collaboratorPubkeys,
+      );
+    } catch (error) {
+      Log.warning(
+        'Mention resolution failed during video publish; continuing without mention tags: $error',
+        category: .video,
+      );
+      return const [];
     }
   }
 
@@ -703,4 +744,88 @@ class VideoPublishService {
 
     return 'Something went wrong. Please try again.';
   }
+}
+
+String _videoPublishMentionResolutionText(DivineVideoDraft draft) {
+  return [
+    draft.description,
+    ..._extractVideoPublishTextOverlayStrings(draft.editorStateHistory),
+  ].where((text) => text.trim().isNotEmpty).join('\n');
+}
+
+List<String> _extractVideoPublishTextOverlayStrings(
+  Map<String, dynamic> editorStateHistory,
+) {
+  final overlays = <String>{};
+  if (editorStateHistory.isEmpty) return const [];
+
+  final references = _mapReferences(editorStateHistory['references']);
+  final lastLayerState = <String, Map<String, dynamic>>{...references};
+  final history = editorStateHistory['history'];
+  if (history is! Iterable) return const [];
+
+  for (final historyItem in history) {
+    if (historyItem is! Map) continue;
+    final layers = historyItem['layers'];
+    if (layers is! Iterable) continue;
+
+    for (final rawLayer in layers) {
+      if (rawLayer is! Map) continue;
+      final layer = Map<String, dynamic>.from(rawLayer);
+      final id = layer['id'];
+      final mergedLayer = id is String
+          ? <String, dynamic>{...?lastLayerState[id], ...layer}
+          : layer;
+
+      final type = mergedLayer['type'];
+      final text = mergedLayer['text'];
+      if ((type == null || type == 'text') &&
+          text is String &&
+          text.trim().isNotEmpty) {
+        overlays.add(text);
+      }
+
+      if (id is String) {
+        lastLayerState[id] = mergedLayer;
+      }
+    }
+  }
+
+  return overlays.toList();
+}
+
+Map<String, Map<String, dynamic>> _mapReferences(Object? rawReferences) {
+  if (rawReferences is! Map) return const {};
+
+  final references = <String, Map<String, dynamic>>{};
+  for (final entry in rawReferences.entries) {
+    final key = entry.key;
+    final value = entry.value;
+    if (key is String && value is Map) {
+      references[key] = Map<String, dynamic>.from(value);
+    }
+  }
+  return references;
+}
+
+List<String> _excludeCollaboratorPubkeys(
+  Iterable<String> pubkeys,
+  Iterable<String> collaboratorPubkeys,
+) {
+  final collaborators = collaboratorPubkeys
+      .map(normalizeToHex)
+      .whereType<String>()
+      .where(NostrKeyUtils.isValidKey)
+      .toSet();
+  final seen = <String>{};
+  final result = <String>[];
+
+  for (final pubkey in pubkeys) {
+    final hex = normalizeToHex(pubkey);
+    if (hex == null || !NostrKeyUtils.isValidKey(hex)) continue;
+    if (collaborators.contains(hex) || !seen.add(hex)) continue;
+    result.add(hex);
+  }
+
+  return result;
 }

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -299,16 +299,14 @@ class CommentsRepository {
         ['k', rootEventKind.toString()],
         ['p', rootEventAuthorPubkey],
       ],
-    ];
-    tags.addAll(
-      _buildMentionTags(
+      ..._buildMentionTags(
         mentionedPubkeys: mentionedPubkeys,
         excludedPubkeys: [
           rootEventAuthorPubkey,
-          if (replyToAuthorPubkey != null) replyToAuthorPubkey,
+          ?replyToAuthorPubkey,
         ],
       ),
-    );
+    ];
 
     // Create the event
     final event = Event(

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -22,10 +22,35 @@ const int _deletionKind = EventKind.eventDeletion;
 /// Default limit for comment queries.
 const _defaultLimit = 100;
 
+/// Relay hint used for diVine mention `p` tags.
+const _divineRelayHint = 'wss://relay.divine.video';
+
+final _hexPubkeyPattern = RegExp(r'^[0-9a-fA-F]{64}$');
+
 List<int> _threadKinds({required bool includeVideoReplies}) => [
   _commentKind,
   if (includeVideoReplies) EventKind.videoVertical,
 ];
+
+List<List<String>> _buildMentionTags({
+  required Iterable<String> mentionedPubkeys,
+  required Iterable<String> excludedPubkeys,
+}) {
+  final seenPubkeys = <String>{
+    for (final pubkey in excludedPubkeys) pubkey.trim().toLowerCase(),
+  };
+  final tags = <List<String>>[];
+
+  for (final pubkey in mentionedPubkeys) {
+    final normalizedPubkey = pubkey.trim().toLowerCase();
+    if (!_hexPubkeyPattern.hasMatch(normalizedPubkey)) continue;
+    if (!seenPubkeys.add(normalizedPubkey)) continue;
+
+    tags.add(['p', normalizedPubkey, _divineRelayHint, 'mention']);
+  }
+
+  return tags;
+}
 
 /// Repository for managing comments and video replies on Nostr events.
 ///
@@ -224,6 +249,8 @@ class CommentsRepository {
   ///   to ensure the comment can be found by clients querying either way.
   /// - [replyToEventId]: ID of parent comment (for nested replies)
   /// - [replyToAuthorPubkey]: Public key of parent comment author
+  /// - [mentionedPubkeys]: Optional full hex pubkeys to publish as generic
+  ///   mention `p` tags.
   ///
   /// Returns the created [Comment] with its event ID.
   ///
@@ -237,6 +264,7 @@ class CommentsRepository {
     String? rootAddressableId,
     String? replyToEventId,
     String? replyToAuthorPubkey,
+    List<String> mentionedPubkeys = const [],
   }) async {
     final trimmedContent = content.trim();
     if (trimmedContent.isEmpty) {
@@ -272,6 +300,15 @@ class CommentsRepository {
         ['p', rootEventAuthorPubkey],
       ],
     ];
+    tags.addAll(
+      _buildMentionTags(
+        mentionedPubkeys: mentionedPubkeys,
+        excludedPubkeys: [
+          rootEventAuthorPubkey,
+          if (replyToAuthorPubkey != null) replyToAuthorPubkey,
+        ],
+      ),
+    );
 
     // Create the event
     final event = Event(

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1142,6 +1142,112 @@ void main() {
         expect(lowercasePTags.first[1], equals(parentAuthorPubkey));
       });
 
+      test('appends mentioned pubkeys after required NIP-22 tags', () async {
+        Event? capturedEvent;
+        const firstMentionPubkey =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const secondMentionPubkey =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishSuccess(event: capturedEvent!);
+        });
+
+        await repository.postComment(
+          content: 'Mentioning @alice and @bob',
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          rootEventAuthorPubkey: testRootAuthorPubkey,
+          mentionedPubkeys: const [
+            firstMentionPubkey,
+            secondMentionPubkey,
+          ],
+        );
+
+        expect(capturedEvent, isNotNull);
+        expect(
+          capturedEvent!.tags,
+          equals([
+            ['E', testRootEventId, '', testRootAuthorPubkey],
+            ['K', _testRootEventKind.toString()],
+            ['P', testRootAuthorPubkey],
+            ['e', testRootEventId, '', testRootAuthorPubkey],
+            ['k', _testRootEventKind.toString()],
+            ['p', testRootAuthorPubkey],
+            [
+              'p',
+              firstMentionPubkey,
+              'wss://relay.divine.video',
+              'mention',
+            ],
+            [
+              'p',
+              secondMentionPubkey,
+              'wss://relay.divine.video',
+              'mention',
+            ],
+          ]),
+        );
+      });
+
+      test(
+        'skips invalid mentioned pubkeys and root or parent author duplicates',
+        () async {
+          Event? capturedEvent;
+          const parentCommentId =
+              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+          const parentAuthorPubkey =
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+          const mentionedPubkey =
+              '3333333333333333333333333333333333333333333333333333333333333333';
+
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+            inv,
+          ) async {
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishSuccess(event: capturedEvent!);
+          });
+
+          await repository.postComment(
+            content: 'Reply with mentions',
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+            rootEventAuthorPubkey: testRootAuthorPubkey,
+            replyToEventId: parentCommentId,
+            replyToAuthorPubkey: parentAuthorPubkey,
+            mentionedPubkeys: const [
+              '',
+              'not-a-pubkey',
+              mentionedPubkey,
+              testRootAuthorPubkey,
+              parentAuthorPubkey,
+              mentionedPubkey,
+            ],
+          );
+
+          expect(capturedEvent, isNotNull);
+          final mentionTags = capturedEvent!.tags
+              .where(
+                (tag) =>
+                    tag.length == 4 &&
+                    tag[0] == 'p' &&
+                    tag[2] == 'wss://relay.divine.video' &&
+                    tag[3] == 'mention',
+              )
+              .toList();
+
+          expect(mentionTags, [
+            [
+              'p',
+              mentionedPubkey,
+              'wss://relay.divine.video',
+              'mention',
+            ],
+          ]);
+        },
+      );
+
       test(
         'posts top-level comment with A/a tags for addressable events',
         () async {

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1196,11 +1196,14 @@ void main() {
         () async {
           Event? capturedEvent;
           const parentCommentId =
-              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
           const parentAuthorPubkey =
-              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+              'ffffffffffffffffffffffffffffffff'
+              'ffffffffffffffffffffffffffffffff';
           const mentionedPubkey =
-              '3333333333333333333333333333333333333333333333333333333333333333';
+              '33333333333333333333333333333333'
+              '33333333333333333333333333333333';
 
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             inv,

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -793,6 +794,40 @@ void main() {
           ),
         ],
       );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'clears selected mentions when switching reply targets',
+        seed: () => CommentsState(
+          activeReplyCommentId: 'comment1',
+          replyInputText: '@Alice ',
+          activeMentions: {'Alice': validId('alice')},
+          activeMentionBindings: [
+            MentionBinding(
+              display: 'Alice',
+              pubkey: validId('alice'),
+              start: 0,
+              end: 6,
+            ),
+          ],
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const CommentReplyToggled('comment2')),
+        expect: () => [
+          isA<CommentsState>()
+              .having(
+                (s) => s.activeReplyCommentId,
+                'activeReplyCommentId',
+                'comment2',
+              )
+              .having((s) => s.replyInputText, 'replyInputText', '')
+              .having((s) => s.activeMentions, 'activeMentions', isEmpty)
+              .having(
+                (s) => s.activeMentionBindings,
+                'activeMentionBindings',
+                isEmpty,
+              ),
+        ],
+      );
     });
 
     group('CommentSubmitted', () {
@@ -835,7 +870,6 @@ void main() {
               rootEventId: any(named: 'rootEventId'),
               rootEventKind: any(named: 'rootEventKind'),
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
-              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -890,7 +924,6 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: 'parent1',
               replyToAuthorPubkey: 'author1',
-              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -1204,7 +1237,6 @@ void main() {
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
               rootAddressableId: any(named: 'rootAddressableId'),
-              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -2793,14 +2825,32 @@ void main() {
         'adds displayName to hex pubkey mapping in activeMentions',
         build: createBloc,
         act: (bloc) => bloc.add(
-          MentionRegistered(displayName: 'Alice', pubkey: validId('alice')),
+          MentionRegistered(
+            displayName: 'Alice',
+            pubkey: validId('alice'),
+            start: 0,
+            end: 6,
+          ),
         ),
         expect: () => [
-          isA<CommentsState>().having(
-            (s) => s.activeMentions,
-            'activeMentions',
-            {'Alice': validId('alice')},
-          ),
+          isA<CommentsState>()
+              .having(
+                (s) => s.activeMentions,
+                'activeMentions',
+                {'Alice': validId('alice')},
+              )
+              .having(
+                (s) => s.activeMentionBindings,
+                'activeMentionBindings',
+                [
+                  MentionBinding(
+                    display: 'Alice',
+                    pubkey: validId('alice'),
+                    start: 0,
+                    end: 6,
+                  ),
+                ],
+              ),
         ],
       );
 
@@ -2812,11 +2862,17 @@ void main() {
           MentionRegistered(displayName: 'Bob', pubkey: validId('bob')),
         ),
         expect: () => [
-          isA<CommentsState>().having(
-            (s) => s.activeMentions,
-            'activeMentions',
-            {'Alice': validId('alice'), 'Bob': validId('bob')},
-          ),
+          isA<CommentsState>()
+              .having(
+                (s) => s.activeMentions,
+                'activeMentions',
+                {'Alice': validId('alice'), 'Bob': validId('bob')},
+              )
+              .having(
+                (s) => s.activeMentionBindings,
+                'activeMentionBindings',
+                [MentionBinding(display: 'Bob', pubkey: validId('bob'))],
+              ),
         ],
       );
     });
@@ -2930,7 +2986,12 @@ void main() {
           isA<CommentsState>()
               .having((s) => s.commentsById.length, 'commentsById', 1)
               .having((s) => s.mainInputText, 'mainInputText', '')
-              .having((s) => s.activeMentions, 'activeMentions', isEmpty),
+              .having((s) => s.activeMentions, 'activeMentions', isEmpty)
+              .having(
+                (s) => s.activeMentionBindings,
+                'activeMentionBindings',
+                isEmpty,
+              ),
           // Second: reconciliation — placeholder swapped for confirmed id.
           isA<CommentsState>()
               .having((s) => s.commentsById.length, 'commentsById', 1)
@@ -2940,6 +3001,65 @@ void main() {
                 true,
               ),
         ],
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'does not publish a selected mention after the visible token is deleted',
+        setUp: () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(validId('currentuser'));
+
+          final postedComment = Comment(
+            id: validId('posted'),
+            content: 'thanks',
+            authorPubkey: validId('currentuser'),
+            createdAt: DateTime.now(),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          when(
+            () => mockCommentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+            ),
+          ).thenAnswer((_) async => postedComment);
+        },
+        seed: () {
+          final alicePubkey = validId('alice');
+          return CommentsState(
+            mainInputText: 'thanks',
+            activeMentions: {'Alice': alicePubkey},
+            activeMentionBindings: [
+              MentionBinding(
+                display: 'Alice',
+                pubkey: alicePubkey,
+                start: 0,
+                end: 6,
+              ),
+            ],
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const CommentSubmitted()),
+        verify: (_) {
+          final captured = verify(
+            () => mockCommentsRepository.postComment(
+              content: 'thanks',
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              mentionedPubkeys: captureAny(named: 'mentionedPubkeys'),
+            ),
+          )..called(1);
+          expect(captured.captured.single, isEmpty);
+        },
       );
 
       blocTest<CommentsBloc, CommentsState>(
@@ -3058,7 +3178,6 @@ void main() {
               rootEventId: any(named: 'rootEventId'),
               rootEventKind: any(named: 'rootEventKind'),
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
-              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -3769,6 +3888,9 @@ void main() {
           mentionQuery: 'test',
           mentionSuggestions: [MentionSuggestion(pubkey: 'abc')],
           activeMentions: {'Alice': 'npub1alice'},
+          activeMentionBindings: [
+            MentionBinding(display: 'Alice', pubkey: 'npub1alice'),
+          ],
         );
 
         final updated = state.clearActiveReply();
@@ -3776,14 +3898,40 @@ void main() {
         expect(updated.mentionQuery, '');
         expect(updated.mentionSuggestions, isEmpty);
         expect(updated.activeMentions, isEmpty);
+        expect(updated.activeMentionBindings, isEmpty);
       },
     );
+
+    test('clearEditMode clears mention state', () {
+      const state = CommentsState(
+        activeEditCommentId: 'comment1',
+        editInputText: '@Alice ',
+        mentionQuery: 'test',
+        mentionSuggestions: [MentionSuggestion(pubkey: 'abc')],
+        activeMentions: {'Alice': 'npub1alice'},
+        activeMentionBindings: [
+          MentionBinding(display: 'Alice', pubkey: 'npub1alice'),
+        ],
+      );
+
+      final updated = state.clearEditMode();
+
+      expect(updated.activeEditCommentId, isNull);
+      expect(updated.editInputText, '');
+      expect(updated.mentionQuery, '');
+      expect(updated.mentionSuggestions, isEmpty);
+      expect(updated.activeMentions, isEmpty);
+      expect(updated.activeMentionBindings, isEmpty);
+    });
 
     test('copyWith preserves mention fields when not specified', () {
       const state = CommentsState(
         mentionQuery: 'test',
         mentionSuggestions: [MentionSuggestion(pubkey: 'abc')],
         activeMentions: {'Alice': 'npub1alice'},
+        activeMentionBindings: [
+          MentionBinding(display: 'Alice', pubkey: 'npub1alice'),
+        ],
       );
 
       final updated = state.copyWith(mainInputText: 'hello');
@@ -3791,6 +3939,10 @@ void main() {
       expect(updated.mentionQuery, 'test');
       expect(updated.mentionSuggestions.length, 1);
       expect(updated.activeMentions, {'Alice': 'npub1alice'});
+      expect(
+        updated.activeMentionBindings,
+        const [MentionBinding(display: 'Alice', pubkey: 'npub1alice')],
+      );
     });
   });
 

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -88,6 +89,12 @@ void main() {
       ).thenAnswer((_) async => null);
       when(
         () => mockProfileRepository.searchUsers(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockProfileRepository.searchUsersLocally(
           query: any(named: 'query'),
           limit: any(named: 'limit'),
         ),
@@ -814,6 +821,7 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenAnswer((_) async => postedComment);
         },
@@ -827,6 +835,7 @@ void main() {
               rootEventId: any(named: 'rootEventId'),
               rootEventKind: any(named: 'rootEventKind'),
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -857,6 +866,7 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenAnswer((_) async => postedComment);
         },
@@ -880,6 +890,7 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: 'parent1',
               replyToAuthorPubkey: 'author1',
+              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -926,6 +937,7 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenThrow(Exception('Network error'));
         },
@@ -961,6 +973,7 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenThrow(Exception('Network error'));
         },
@@ -1133,6 +1146,7 @@ void main() {
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
               rootAddressableId: any(named: 'rootAddressableId'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenAnswer((_) async => editedComment);
         },
@@ -1190,6 +1204,7 @@ void main() {
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
               rootAddressableId: any(named: 'rootAddressableId'),
+              mentionedPubkeys: const [],
             ),
           ).called(1);
         },
@@ -2775,16 +2790,16 @@ void main() {
 
     group('MentionRegistered', () {
       blocTest<CommentsBloc, CommentsState>(
-        'adds displayName to npub mapping in activeMentions',
+        'adds displayName to hex pubkey mapping in activeMentions',
         build: createBloc,
         act: (bloc) => bloc.add(
-          const MentionRegistered(displayName: 'Alice', npub: 'npub1alice'),
+          MentionRegistered(displayName: 'Alice', pubkey: validId('alice')),
         ),
         expect: () => [
           isA<CommentsState>().having(
             (s) => s.activeMentions,
             'activeMentions',
-            {'Alice': 'npub1alice'},
+            {'Alice': validId('alice')},
           ),
         ],
       );
@@ -2792,16 +2807,15 @@ void main() {
       blocTest<CommentsBloc, CommentsState>(
         'accumulates multiple mentions',
         build: createBloc,
-        seed: () =>
-            const CommentsState(activeMentions: {'Alice': 'npub1alice'}),
+        seed: () => CommentsState(activeMentions: {'Alice': validId('alice')}),
         act: (bloc) => bloc.add(
-          const MentionRegistered(displayName: 'Bob', npub: 'npub1bob'),
+          MentionRegistered(displayName: 'Bob', pubkey: validId('bob')),
         ),
         expect: () => [
           isA<CommentsState>().having(
             (s) => s.activeMentions,
             'activeMentions',
-            {'Alice': 'npub1alice', 'Bob': 'npub1bob'},
+            {'Alice': validId('alice'), 'Bob': validId('bob')},
           ),
         ],
       );
@@ -2809,16 +2823,18 @@ void main() {
 
     group('mention conversion on submit', () {
       blocTest<CommentsBloc, CommentsState>(
-        'converts @displayName to nostr:npub in posted text',
+        'resolves selected mentions to canonical content and mentioned pubkeys',
         setUp: () {
           when(() => mockAuthService.isAuthenticated).thenReturn(true);
           when(
             () => mockAuthService.currentPublicKeyHex,
           ).thenReturn(validId('currentuser'));
 
+          final alicePubkey = validId('alice');
+          final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
           final postedComment = Comment(
             id: validId('posted'),
-            content: 'hey nostr:npub1alice what do you think?',
+            content: 'hey nostr:$aliceNpub what do you think?',
             authorPubkey: validId('currentuser'),
             createdAt: DateTime.now(),
             rootEventId: validId('root'),
@@ -2832,22 +2848,41 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenAnswer((_) async => postedComment);
         },
-        seed: () => const CommentsState(
-          mainInputText: 'hey @Alice what do you think?',
-          activeMentions: {'Alice': 'npub1alice'},
-        ),
+        seed: () {
+          final alicePubkey = validId('alice');
+          return CommentsState(
+            mainInputText: 'hey @Alice what do you think?',
+            activeMentions: {'Alice': alicePubkey},
+          );
+        },
         build: createBloc,
         act: (bloc) => bloc.add(const CommentSubmitted()),
+        expect: () {
+          final alicePubkey = validId('alice');
+          final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
+          return [
+            isA<CommentsState>().having(
+              (s) => s.commentsById.values.single.content,
+              'optimistic content',
+              'hey nostr:$aliceNpub what do you think?',
+            ),
+            isA<CommentsState>(),
+          ];
+        },
         verify: (_) {
+          final alicePubkey = validId('alice');
+          final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
           verify(
             () => mockCommentsRepository.postComment(
-              content: 'hey nostr:npub1alice what do you think?',
+              content: 'hey nostr:$aliceNpub what do you think?',
               rootEventId: any(named: 'rootEventId'),
               rootEventKind: any(named: 'rootEventKind'),
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              mentionedPubkeys: [alicePubkey],
             ),
           ).called(1);
         },
@@ -2877,12 +2912,16 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenAnswer((_) async => postedComment);
         },
         seed: () => const CommentsState(
           mainInputText: 'hey @Alice',
-          activeMentions: {'Alice': 'npub1alice'},
+          activeMentions: {
+            'Alice':
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
         ),
         build: createBloc,
         act: (bloc) => bloc.add(const CommentSubmitted()),
@@ -2904,16 +2943,36 @@ void main() {
       );
 
       blocTest<CommentsBloc, CommentsState>(
-        'handles multiple mentions with longest-first replacement',
+        'resolves typed mentions through the mention service',
         setUp: () {
           when(() => mockAuthService.isAuthenticated).thenReturn(true);
           when(
             () => mockAuthService.currentPublicKeyHex,
           ).thenReturn(validId('currentuser'));
 
+          final alicePubkey = validId('alice');
+          when(
+            () => mockProfileRepository.searchUsersLocally(
+              query: 'alice',
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              UserProfile(
+                pubkey: alicePubkey,
+                rawData: const {},
+                createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+                eventId: validId('aliceevent'),
+                name: 'alice',
+                displayName: 'Alice',
+              ),
+            ],
+          );
+
+          final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
           final postedComment = Comment(
             id: validId('posted'),
-            content: 'nostr:npub1ali and nostr:npub1alice',
+            content: 'hey nostr:$aliceNpub',
             authorPubkey: validId('currentuser'),
             createdAt: DateTime.now(),
             rootEventId: validId('root'),
@@ -2927,24 +2986,79 @@ void main() {
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
               replyToEventId: any(named: 'replyToEventId'),
               replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
             ),
           ).thenAnswer((_) async => postedComment);
         },
-        seed: () => const CommentsState(
-          mainInputText: '@Ali and @Alice',
-          activeMentions: {'Alice': 'npub1alice', 'Ali': 'npub1ali'},
-        ),
+        seed: () => const CommentsState(mainInputText: 'hey @alice'),
         build: createBloc,
         act: (bloc) => bloc.add(const CommentSubmitted()),
         verify: (_) {
-          // "Alice" (longer) should be replaced first, preventing
-          // "@Ali" from partially matching "@Alice"
+          final alicePubkey = validId('alice');
+          final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
           verify(
             () => mockCommentsRepository.postComment(
-              content: 'nostr:npub1ali and nostr:npub1alice',
+              content: 'hey nostr:$aliceNpub',
               rootEventId: any(named: 'rootEventId'),
               rootEventKind: any(named: 'rootEventKind'),
               rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              mentionedPubkeys: [alicePubkey],
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'does not block publish when typed mention resolution fails',
+        setUp: () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(validId('currentuser'));
+          when(
+            () => mockProfileRepository.searchUsersLocally(
+              query: 'alice',
+              limit: any(named: 'limit'),
+            ),
+          ).thenThrow(Exception('local search failed'));
+
+          final postedComment = Comment(
+            id: validId('posted'),
+            content: 'hey @alice',
+            authorPubkey: validId('currentuser'),
+            createdAt: DateTime.now(),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          when(
+            () => mockCommentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+            ),
+          ).thenAnswer((_) async => postedComment);
+        },
+        seed: () => const CommentsState(mainInputText: 'hey @alice'),
+        build: createBloc,
+        act: (bloc) => bloc.add(const CommentSubmitted()),
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.searchUsersLocally(
+              query: 'alice',
+              limit: any(named: 'limit'),
+            ),
+          ).called(1);
+          verify(
+            () => mockCommentsRepository.postComment(
+              content: 'hey @alice',
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              mentionedPubkeys: const [],
             ),
           ).called(1);
         },

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
@@ -32,6 +34,8 @@ void main() {
     const testAbout = 'Test bio';
     const testUsername = 'testuser';
     const testPicture = 'https://example.com/avatar.png';
+    const alicePubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
     /// Helper to create a test UserProfile
     UserProfile createTestProfile({String? nip05}) {
@@ -73,12 +77,15 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    ProfileEditorBloc createBloc({bool hasExistingProfile = true}) =>
-        ProfileEditorBloc(
-          profileRepository: mockProfileRepository,
-          blossomUploadService: mockBlossomUploadService,
-          hasExistingProfile: hasExistingProfile,
-        );
+    ProfileEditorBloc createBloc({
+      bool hasExistingProfile = true,
+      MentionResolutionService? mentionResolutionService,
+    }) => ProfileEditorBloc(
+      profileRepository: mockProfileRepository,
+      blossomUploadService: mockBlossomUploadService,
+      hasExistingProfile: hasExistingProfile,
+      mentionResolutionService: mentionResolutionService,
+    );
 
     test('initial state is ProfileEditorStatus.initial', () {
       final bloc = createBloc();
@@ -307,6 +314,134 @@ void main() {
                 about: testAbout,
                 picture: testPicture,
                 clearNip05: true,
+              ),
+            ).called(1);
+          },
+        );
+
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'canonicalizes exact bio mentions before publishing profile metadata',
+          setUp: () {
+            final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
+            when(
+              () => mockProfileRepository.searchUsersLocally(
+                query: 'alice',
+                limit: any(named: 'limit'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                UserProfile(
+                  pubkey: alicePubkey,
+                  name: 'alice',
+                  rawData: const {},
+                  createdAt: DateTime.utc(2026),
+                  eventId: 'event-$alicePubkey',
+                ),
+              ],
+            );
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: 'hi nostr:$aliceNpub',
+                picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
+              ),
+            ).thenAnswer((_) async => createTestProfile());
+          },
+          build: () => createBloc(
+            mentionResolutionService: MentionResolutionService(
+              profileRepository: mockProfileRepository,
+            ),
+          ),
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: 'hi @alice',
+              picture: testPicture,
+            ),
+          ),
+          expect: () => [
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.loading,
+            ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
+          ],
+          verify: (_) {
+            final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
+            verify(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: 'hi nostr:$aliceNpub',
+                picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
+              ),
+            ).called(1);
+          },
+        );
+
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'preserves unresolved bio text when mention resolution fails',
+          setUp: () {
+            when(
+              () => mockProfileRepository.searchUsersLocally(
+                query: 'alice',
+                limit: any(named: 'limit'),
+              ),
+            ).thenThrow(Exception('lookup unavailable'));
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: 'hi @alice',
+                picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
+              ),
+            ).thenAnswer((_) async => createTestProfile());
+          },
+          build: () => createBloc(
+            mentionResolutionService: MentionResolutionService(
+              profileRepository: mockProfileRepository,
+            ),
+          ),
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: 'hi @alice',
+              picture: testPicture,
+            ),
+          ),
+          expect: () => [
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.loading,
+            ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
+          ],
+          verify: (_) {
+            verify(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: 'hi @alice',
+                picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
               ),
             ).called(1);
           },

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -5,12 +5,17 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/cawg_verifier_client.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class MockProfileRepository extends Mock implements ProfileRepository {}
 
 void main() {
   group('VideoPublishNotifier', () {
@@ -96,6 +101,24 @@ void main() {
       expect(state.publishState, VideoPublishState.error);
       expect(state.errorMessage, 'Test error');
     });
+
+    test(
+      'createVideoPublishMentionResolutionService returns null without profile repository',
+      () {
+        expect(createVideoPublishMentionResolutionService(null), isNull);
+      },
+    );
+
+    test(
+      'createVideoPublishMentionResolutionService creates resolver from profile repository',
+      () {
+        final service = createVideoPublishMentionResolutionService(
+          MockProfileRepository(),
+        );
+
+        expect(service, isA<MentionResolutionService>());
+      },
+    );
 
     test('collaborator invite warning message handles singular failure', () {
       expect(

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -3,7 +3,9 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/comments/comments.dart';
 
@@ -402,5 +404,45 @@ void main() {
         }
       },
     );
+
+    testWidgets('selected mention callback receives the hex pubkey', (
+      tester,
+    ) async {
+      const pubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      String? selectedPubkey;
+      String? selectedDisplayName;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: CommentInput(
+                controller: controller,
+                mentionSuggestions: const [
+                  MentionSuggestion(pubkey: pubkey, displayName: 'GaryVee'),
+                ],
+                onMentionSelected: (pubkey, displayName) {
+                  selectedPubkey = pubkey;
+                  selectedDisplayName = displayName;
+                },
+                onSubmit: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), '@gar');
+      await tester.pump();
+      await tester.tap(find.text('GaryVee'));
+      await tester.pump();
+
+      expect(controller.text, '@GaryVee ');
+      expect(selectedPubkey, pubkey);
+      expect(selectedDisplayName, 'GaryVee');
+    });
   });
 }

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -412,6 +412,8 @@ void main() {
           'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       String? selectedPubkey;
       String? selectedDisplayName;
+      int? selectedStart;
+      int? selectedEnd;
 
       await tester.pumpWidget(
         ProviderScope(
@@ -424,9 +426,11 @@ void main() {
                 mentionSuggestions: const [
                   MentionSuggestion(pubkey: pubkey, displayName: 'GaryVee'),
                 ],
-                onMentionSelected: (pubkey, displayName) {
+                onMentionSelected: (pubkey, displayName, start, end) {
                   selectedPubkey = pubkey;
                   selectedDisplayName = displayName;
+                  selectedStart = start;
+                  selectedEnd = end;
                 },
                 onSubmit: () {},
               ),
@@ -443,6 +447,8 @@ void main() {
       expect(controller.text, '@GaryVee ');
       expect(selectedPubkey, pubkey);
       expect(selectedDisplayName, 'GaryVee');
+      expect(selectedStart, 0);
+      expect(selectedEnd, 8);
     });
   });
 }

--- a/mobile/test/screens/comments/widgets/mention_overlay_test.dart
+++ b/mobile/test/screens/comments/widgets/mention_overlay_test.dart
@@ -111,4 +111,35 @@ void main() {
     expect(find.text('garyvee@example.com'), findsNothing);
     expect(find.textContaining('npub'), findsOneWidget);
   });
+
+  testWidgets('selecting a suggestion returns its full hex pubkey', (
+    tester,
+  ) async {
+    String? selectedPubkey;
+    String? selectedDisplayName;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: MentionOverlay(
+              suggestions: const [
+                MentionSuggestion(pubkey: pubkey, displayName: 'GaryVee'),
+              ],
+              onSelect: (pubkey, displayName) {
+                selectedPubkey = pubkey;
+                selectedDisplayName = displayName;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GaryVee'));
+    await tester.pump();
+
+    expect(selectedPubkey, pubkey);
+    expect(selectedDisplayName, 'GaryVee');
+  });
 }

--- a/mobile/test/services/mention_resolution_service_test.dart
+++ b/mobile/test/services/mention_resolution_service_test.dart
@@ -1,0 +1,333 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+const _alicePubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _bobPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _carolPubkey =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _frankPubkey =
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+const _onePubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _twoPubkey =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _threePubkey =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+const _fourPubkey =
+    '4444444444444444444444444444444444444444444444444444444444444444';
+const _fivePubkey =
+    '5555555555555555555555555555555555555555555555555555555555555555';
+
+void main() {
+  late _MockProfileRepository profileRepository;
+  late MentionResolutionService service;
+
+  setUp(() {
+    profileRepository = _MockProfileRepository();
+    service = MentionResolutionService(profileRepository: profileRepository);
+  });
+
+  group('resolveTextMentions', () {
+    test(
+      'canonicalizes selected mentions and records full hex pubkeys',
+      () async {
+        final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);
+
+        final result = await service.resolveTextMentions(
+          rawText: 'hi @alice',
+          selectedMentions: const [
+            MentionBinding(display: 'alice', pubkey: _alicePubkey),
+          ],
+        );
+
+        expect(result.canonicalText, equals('hi nostr:$aliceNpub'));
+        expect(result.resolvedPubkeys, equals([_alicePubkey]));
+        expect(result.unresolvedTokens, isEmpty);
+        verifyNever(
+          () => profileRepository.searchUsersLocally(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+          ),
+        );
+        verifyNever(
+          () => profileRepository.searchUsersFromApi(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'accepts selected npub bindings and canonicalizes with full hex',
+      () async {
+        final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);
+
+        final result = await service.resolveTextMentions(
+          rawText: 'hi @alice',
+          selectedMentions: [
+            MentionBinding(display: '@alice', pubkey: aliceNpub),
+          ],
+        );
+
+        expect(result.canonicalText, equals('hi nostr:$aliceNpub'));
+        expect(result.resolvedPubkeys, equals([_alicePubkey]));
+      },
+    );
+
+    test(
+      'resolves exact cached typed mentions and excludes emails and URLs',
+      () async {
+        final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);
+        when(
+          () => profileRepository.searchUsersLocally(
+            query: 'alice',
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => [_profile(_alicePubkey, name: 'alice')]);
+
+        final result = await service.resolveTextMentions(
+          rawText: 'hi @alice email me@bob.com https://divine.video/@carol',
+        );
+
+        expect(
+          result.canonicalText,
+          equals(
+            'hi nostr:$aliceNpub email me@bob.com https://divine.video/@carol',
+          ),
+        );
+        expect(result.resolvedPubkeys, equals([_alicePubkey]));
+        expect(result.unresolvedTokens, isEmpty);
+        verify(
+          () => profileRepository.searchUsersLocally(
+            query: 'alice',
+            limit: any(named: 'limit'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => profileRepository.searchUsersLocally(
+            query: 'bob',
+            limit: any(named: 'limit'),
+          ),
+        );
+        verifyNever(
+          () => profileRepository.searchUsersLocally(
+            query: 'carol',
+            limit: any(named: 'limit'),
+          ),
+        );
+        verifyNever(
+          () => profileRepository.searchUsersFromApi(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+          ),
+        );
+      },
+    );
+
+    test('leaves ambiguous typed matches unchanged', () async {
+      when(
+        () => profileRepository.searchUsersLocally(
+          query: 'alex',
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          _profile(_alicePubkey, name: 'alex'),
+          _profile(_bobPubkey, displayName: 'Alex'),
+        ],
+      );
+      when(
+        () => profileRepository.searchUsersFromApi(
+          query: 'alex',
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => const []);
+
+      final result = await service.resolveTextMentions(rawText: 'hi @alex');
+
+      expect(result.canonicalText, equals('hi @alex'));
+      expect(result.resolvedPubkeys, isEmpty);
+      expect(result.unresolvedTokens, equals(['alex']));
+    });
+
+    test(
+      'uses exact API matches after cache miss and caps remote lookups at five',
+      () async {
+        final pubkeysByToken = {
+          'one': _onePubkey,
+          'two': _twoPubkey,
+          'three': _threePubkey,
+          'four': _fourPubkey,
+          'five': _fivePubkey,
+          'six': _frankPubkey,
+        };
+        final remoteQueries = <String>[];
+        when(
+          () => profileRepository.searchUsersLocally(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => const []);
+        when(
+          () => profileRepository.searchUsersFromApi(
+            query: any(named: 'query'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((invocation) async {
+          final query = invocation.namedArguments[#query] as String;
+          remoteQueries.add(query);
+          return [_profile(pubkeysByToken[query]!, name: query)];
+        });
+
+        final result = await service.resolveTextMentions(
+          rawText: '@one @two @three @four @five @six',
+        );
+
+        expect(remoteQueries, equals(['one', 'two', 'three', 'four', 'five']));
+        expect(
+          result.resolvedPubkeys,
+          equals([
+            _onePubkey,
+            _twoPubkey,
+            _threePubkey,
+            _fourPubkey,
+            _fivePubkey,
+          ]),
+        );
+        expect(result.canonicalText, contains('@six'));
+        expect(result.unresolvedTokens, equals(['six']));
+      },
+    );
+
+    test(
+      'keeps typed self matches unresolved unless explicitly selected',
+      () async {
+        when(
+          () => profileRepository.searchUsersLocally(
+            query: 'alice',
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => [_profile(_alicePubkey, name: 'alice')]);
+        when(
+          () => profileRepository.searchUsersFromApi(
+            query: 'alice',
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => const []);
+
+        final typed = await service.resolveTextMentions(
+          rawText: 'hi @alice',
+          currentUserPubkey: _alicePubkey,
+        );
+        final selected = await service.resolveTextMentions(
+          rawText: 'hi @alice',
+          selectedMentions: const [
+            MentionBinding(display: 'alice', pubkey: _alicePubkey),
+          ],
+          currentUserPubkey: _alicePubkey,
+        );
+
+        expect(typed.canonicalText, equals('hi @alice'));
+        expect(typed.resolvedPubkeys, isEmpty);
+        expect(typed.unresolvedTokens, equals(['alice']));
+        expect(selected.resolvedPubkeys, equals([_alicePubkey]));
+        expect(selected.canonicalText, contains('nostr:npub1'));
+      },
+    );
+
+    test('returns selected mentions when typed lookup fails', () async {
+      final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);
+      when(
+        () => profileRepository.searchUsersLocally(
+          query: 'bob',
+          limit: any(named: 'limit'),
+        ),
+      ).thenThrow(Exception('cache unavailable'));
+
+      final result = await service.resolveTextMentions(
+        rawText: '@alice @bob',
+        selectedMentions: const [
+          MentionBinding(display: 'alice', pubkey: _alicePubkey),
+        ],
+      );
+
+      expect(result.canonicalText, equals('nostr:$aliceNpub @bob'));
+      expect(result.resolvedPubkeys, equals([_alicePubkey]));
+      expect(result.unresolvedTokens, equals(['bob']));
+    });
+
+    test('bounds typed resolution with one total timeout', () async {
+      final stalledLookup = Completer<List<UserProfile>>();
+      service = MentionResolutionService(
+        profileRepository: profileRepository,
+        typedResolutionTimeout: const Duration(milliseconds: 1),
+      );
+      when(
+        () => profileRepository.searchUsersLocally(
+          query: 'alice',
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) => stalledLookup.future);
+
+      final result = await service.resolveTextMentions(rawText: 'hi @alice');
+
+      expect(result.canonicalText, equals('hi @alice'));
+      expect(result.resolvedPubkeys, isEmpty);
+      expect(result.unresolvedTokens, equals(['alice']));
+    });
+  });
+
+  group('buildGenericMentionPTags', () {
+    test(
+      'dedupes full pubkeys and excludes invalid and collaborator pubkeys',
+      () {
+        final tags = service.buildGenericMentionPTags(
+          pubkeys: const [
+            _alicePubkey,
+            'not-a-pubkey',
+            _bobPubkey,
+            _alicePubkey,
+            _carolPubkey,
+          ],
+          collaboratorPubkeys: const [_bobPubkey],
+        );
+
+        expect(
+          tags,
+          equals(const [
+            ['p', _alicePubkey, 'wss://relay.divine.video', 'mention'],
+            ['p', _carolPubkey, 'wss://relay.divine.video', 'mention'],
+          ]),
+        );
+      },
+    );
+  });
+}
+
+UserProfile _profile(
+  String pubkey, {
+  String? name,
+  String? displayName,
+  String? nip05,
+}) {
+  return UserProfile(
+    pubkey: pubkey,
+    name: name,
+    displayName: displayName,
+    nip05: nip05,
+    rawData: const {},
+    createdAt: DateTime.utc(2026),
+    eventId: 'event-$pubkey',
+  );
+}

--- a/mobile/test/services/mention_resolution_service_test.dart
+++ b/mobile/test/services/mention_resolution_service_test.dart
@@ -86,6 +86,92 @@ void main() {
     );
 
     test(
+      'skips selected bindings whose token is no longer in the text',
+      () async {
+        final result = await service.resolveTextMentions(
+          rawText: 'hi there',
+          selectedMentions: const [
+            MentionBinding(display: 'alice', pubkey: _alicePubkey),
+          ],
+        );
+
+        expect(result.canonicalText, equals('hi there'));
+        expect(result.resolvedPubkeys, isEmpty);
+        expect(result.unresolvedTokens, isEmpty);
+      },
+    );
+
+    test(
+      'skips ranged selected bindings when the range no longer matches',
+      () async {
+        final result = await service.resolveTextMentions(
+          rawText: 'hi xxxx',
+          selectedMentions: const [
+            MentionBinding(
+              display: 'alice',
+              pubkey: _alicePubkey,
+              start: 3,
+              end: 7,
+            ),
+          ],
+        );
+
+        expect(result.canonicalText, equals('hi xxxx'));
+        expect(result.resolvedPubkeys, isEmpty);
+      },
+    );
+
+    test(
+      'uses newest selected binding for the same visible token range',
+      () async {
+        final bobNpub = NostrKeyUtils.encodePubKey(_bobPubkey);
+
+        final result = await service.resolveTextMentions(
+          rawText: 'hi @alice',
+          selectedMentions: const [
+            MentionBinding(
+              display: 'alice',
+              pubkey: _alicePubkey,
+              start: 3,
+              end: 9,
+            ),
+            MentionBinding(
+              display: 'alice',
+              pubkey: _bobPubkey,
+              start: 3,
+              end: 9,
+            ),
+          ],
+        );
+
+        expect(result.canonicalText, equals('hi nostr:$bobNpub'));
+        expect(result.resolvedPubkeys, equals([_bobPubkey]));
+      },
+    );
+
+    test(
+      'keeps selected mention when text is inserted before its old range',
+      () async {
+        final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);
+
+        final result = await service.resolveTextMentions(
+          rawText: 'well hi @alice',
+          selectedMentions: const [
+            MentionBinding(
+              display: 'alice',
+              pubkey: _alicePubkey,
+              start: 3,
+              end: 9,
+            ),
+          ],
+        );
+
+        expect(result.canonicalText, equals('well hi nostr:$aliceNpub'));
+        expect(result.resolvedPubkeys, equals([_alicePubkey]));
+      },
+    );
+
+    test(
       'resolves exact cached typed mentions and excludes emails and URLs',
       () async {
         final aliceNpub = NostrKeyUtils.encodePubKey(_alicePubkey);

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -45,6 +45,10 @@ void main() {
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   const collaboratorPubkey =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const mentionPubkey =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const secondMentionPubkey =
+      'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
@@ -162,6 +166,87 @@ void main() {
           'Collaborator',
         ]),
         isFalse,
+      );
+    },
+  );
+
+  test(
+    'publishes generic mention p-tags while preserving collaborator role tags',
+    () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        collaboratorPubkeys: const [collaboratorPubkey],
+        mentionedPubkeys: const [
+          mentionPubkey,
+          collaboratorPubkey,
+          '',
+          'not-a-valid-pubkey',
+          mentionPubkey,
+          secondMentionPubkey,
+        ],
+      );
+
+      expect(result, isTrue);
+      expect(
+        _containsTag(capturedTags, buildCollaboratorPTag(collaboratorPubkey)),
+        isTrue,
+        reason: 'collaborator pubkeys keep the collaborator role marker',
+      );
+      expect(
+        _containsTag(capturedTags, const [
+          'p',
+          mentionPubkey,
+          'wss://relay.divine.video',
+          'mention',
+        ]),
+        isTrue,
+      );
+      expect(
+        _containsTag(capturedTags, const [
+          'p',
+          secondMentionPubkey,
+          'wss://relay.divine.video',
+          'mention',
+        ]),
+        isTrue,
+      );
+      expect(
+        capturedTags
+            .where(
+              (tag) => _deepEquals.equals(tag, const [
+                'p',
+                mentionPubkey,
+                'wss://relay.divine.video',
+                'mention',
+              ]),
+            )
+            .length,
+        equals(1),
+        reason: 'duplicate full hex mention pubkeys are emitted once',
+      );
+      expect(
+        _containsTag(capturedTags, const [
+          'p',
+          collaboratorPubkey,
+          'wss://relay.divine.video',
+          'mention',
+        ]),
+        isFalse,
+        reason: 'collaborator pubkeys are not duplicated as generic mentions',
+      );
+      expect(
+        capturedTags.any((tag) => tag.length > 1 && tag[1].isEmpty),
+        isFalse,
+        reason: 'empty mention pubkeys are skipped',
+      );
+      expect(
+        capturedTags.any(
+          (tag) => tag.length > 1 && tag[1] == 'not-a-valid-pubkey',
+        ),
+        isFalse,
+        reason: 'invalid mention pubkeys are skipped',
       );
     },
   );

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -4,12 +4,39 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/relay/relay_pool.dart';
+import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockUploadManager extends Mock implements UploadManager {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+const _deepEquals = DeepCollectionEquality();
+
+bool _containsTag(List<List<String>> tags, List<String> expected) {
+  return tags.any((tag) => _deepEquals.equals(tag, expected));
+}
 
 /// Helper class to test imeta tag generation logic
 class ImetaTagGenerator {
@@ -448,6 +475,122 @@ void main() {
         urlComponents.first,
         equals('url $regularUrl'),
         reason: 'Should use original CDN URL',
+      );
+    });
+  });
+
+  group('VideoEventPublisher mention tags', () {
+    late _MockUploadManager uploadManager;
+    late _MockNostrClient nostrClient;
+    late _MockAuthService authService;
+    late _MockVideoEventService videoEventService;
+    late VideoEventPublisher publisher;
+    late List<List<String>> capturedTags;
+
+    const testPubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const mentionPubkey =
+        'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+    setUpAll(() {
+      registerFallbackValue(_FakeEvent());
+      registerFallbackValue(_FakeFilter());
+      registerFallbackValue(<Filter>[]);
+      registerFallbackValue(UploadStatus.pending);
+    });
+
+    setUp(() {
+      uploadManager = _MockUploadManager();
+      nostrClient = _MockNostrClient();
+      authService = _MockAuthService();
+      videoEventService = _MockVideoEventService();
+      capturedTags = [];
+
+      publisher = VideoEventPublisher(
+        uploadManager: uploadManager,
+        nostrService: nostrClient,
+        authService: authService,
+        videoEventService: videoEventService,
+      );
+
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.configuredRelays,
+      ).thenReturn(['wss://relay.divine.video']);
+      when(
+        () => nostrClient.connectedRelays,
+      ).thenReturn(['wss://relay.divine.video']);
+      when(() => nostrClient.publicKey).thenReturn('');
+
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(() => authService.currentPublicKeyHex).thenReturn(testPubkey);
+
+      when(
+        () => uploadManager.updateUploadStatus(
+          any(),
+          any(),
+          nostrEventId: any(named: 'nostrEventId'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    PendingUpload createUpload() {
+      return PendingUpload(
+        id: 'upload-id',
+        localVideoPath: '',
+        nostrPubkey: testPubkey,
+        status: UploadStatus.readyToPublish,
+        createdAt: DateTime.now(),
+        videoId: 'video-id',
+        cdnUrl: 'https://cdn.example.com/video.mp4',
+        fallbackUrl: 'https://cdn.example.com/video.mp4',
+      );
+    }
+
+    void stubSignAndPublish() {
+      late Event publishedEvent;
+
+      when(
+        () => authService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
+        publishedEvent = Event(
+          testPubkey,
+          NIP71VideoKinds.getPreferredAddressableKind(),
+          capturedTags,
+          'test content',
+        );
+        return publishedEvent;
+      });
+
+      when(
+        () => nostrClient.publishEvent(any()),
+      ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
+    }
+
+    test('publishVideoEvent passes generic mention p-tags through', () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishVideoEvent(
+        upload: createUpload(),
+        mentionedPubkeys: const [mentionPubkey],
+      );
+
+      expect(result, isTrue);
+      expect(
+        _containsTag(capturedTags, const [
+          'p',
+          mentionPubkey,
+          'wss://relay.divine.video',
+          'mention',
+        ]),
+        isTrue,
       );
     });
   });

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -11,9 +11,11 @@ import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 // Mock classes
@@ -30,13 +32,24 @@ class MockDraftStorageService extends Mock implements DraftStorageService {}
 class MockCollaboratorInviteService extends Mock
     implements CollaboratorInviteService {}
 
+class MockMentionResolutionService extends Mock
+    implements MentionResolutionService {}
+
 void main() {
+  const descriptionMentionPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const overlayMentionPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const collaboratorPubkey =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
   late MockUploadManager mockUploadManager;
   late MockAuthService mockAuthService;
   late MockVideoEventPublisher mockVideoEventPublisher;
   late MockBlossomUploadService mockBlossomService;
   late MockDraftStorageService mockDraftService;
   late MockCollaboratorInviteService mockCollaboratorInviteService;
+  late MockMentionResolutionService mockMentionResolutionService;
   late VideoPublishService service;
 
   late List<double> progressChanges;
@@ -62,6 +75,7 @@ void main() {
     mockBlossomService = MockBlossomUploadService();
     mockDraftService = MockDraftStorageService();
     mockCollaboratorInviteService = MockCollaboratorInviteService();
+    mockMentionResolutionService = MockMentionResolutionService();
 
     progressChanges = [];
 
@@ -72,6 +86,7 @@ void main() {
       blossomService: mockBlossomService,
       draftService: mockDraftService,
       collaboratorInviteService: mockCollaboratorInviteService,
+      mentionResolutionService: mockMentionResolutionService,
       onProgressChanged:
           ({required double progress, required String draftId}) =>
               progressChanges.add(progress),
@@ -115,6 +130,132 @@ void main() {
         // Assert
         expect(result, isA<PublishSuccess>());
         verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
+      });
+
+      test(
+        'resolves mentions from description and text overlays before publishing',
+        () async {
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+          when(
+            () => mockMentionResolutionService.resolveTextMentions(
+              rawText: any(named: 'rawText'),
+              currentUserPubkey: any(named: 'currentUserPubkey'),
+            ),
+          ).thenAnswer((invocation) async {
+            final rawText = invocation.namedArguments[#rawText] as String;
+            expect(rawText, contains('caption from @alice'));
+            expect(rawText, contains('overlay by @bob'));
+
+            return const MentionResolutionResult(
+              canonicalText: '',
+              resolvedPubkeys: [
+                descriptionMentionPubkey,
+                overlayMentionPubkey,
+                collaboratorPubkey,
+              ],
+              unresolvedTokens: [],
+            );
+          });
+
+          final draft = _createTestDraft(
+            description: 'caption from @alice',
+            collaboratorPubkeys: {collaboratorPubkey},
+            editorStateHistory: {
+              'position': 0,
+              'references': {
+                'text-layer-1': TextLayer(
+                  id: 'text-layer-1',
+                  text: 'overlay by @bob',
+                ).toMap(),
+              },
+              'history': [
+                {
+                  'layers': [
+                    {'id': 'text-layer-1'},
+                  ],
+                },
+              ],
+            },
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishSuccess>());
+          verify(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: 'caption from @alice',
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: [collaboratorPubkey],
+              mentionedPubkeys: const [
+                descriptionMentionPubkey,
+                overlayMentionPubkey,
+              ],
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test('publishes without mention tags when resolution fails', () async {
+        _setupSuccessfulPublish(
+          mockAuthService: mockAuthService,
+          mockUploadManager: mockUploadManager,
+          mockDraftService: mockDraftService,
+          mockVideoEventPublisher: mockVideoEventPublisher,
+        );
+        when(
+          () => mockMentionResolutionService.resolveTextMentions(
+            rawText: any(named: 'rawText'),
+            currentUserPubkey: any(named: 'currentUserPubkey'),
+          ),
+        ).thenThrow(Exception('profile search unavailable'));
+
+        final draft = _createTestDraft(description: 'caption from @alice');
+
+        final result = await service.publishVideo(draft: draft);
+
+        expect(result, isA<PublishSuccess>());
+        final captured = verify(
+          () => mockVideoEventPublisher.publishVideoEvent(
+            upload: any(named: 'upload'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            expirationTimestamp: any(named: 'expirationTimestamp'),
+            allowAudioReuse: any(named: 'allowAudioReuse'),
+            collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+            mentionedPubkeys: captureAny(named: 'mentionedPubkeys'),
+            inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+            inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+            inspiredByNpub: any(named: 'inspiredByNpub'),
+            selectedAudioEventId: any(named: 'selectedAudioEventId'),
+            selectedAudioRelay: any(named: 'selectedAudioRelay'),
+            language: any(named: 'language'),
+            contentWarning: any(named: 'contentWarning'),
+            thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+            replyContext: any(named: 'replyContext'),
+            addReplyToFeed: any(named: 'addReplyToFeed'),
+          ),
+        )..called(1);
+        expect(captured.captured.single, isEmpty);
       });
 
       test('collaborator invites are sent after successful publish', () async {
@@ -1251,15 +1392,18 @@ DivineVideoClip _createTestClip() {
 }
 
 DivineVideoDraft _createTestDraft({
+  String description = 'Test description',
+  Map<String, dynamic> editorStateHistory = const {},
   Set<String> collaboratorPubkeys = const {},
 }) {
   return DivineVideoDraft.create(
     clips: [_createTestClip()],
     title: 'Test Video',
-    description: 'Test description',
+    description: description,
     hashtags: {'test', 'video'},
     selectedApproach: 'test',
     id: 'test_draft_id',
+    editorStateHistory: editorStateHistory,
     collaboratorPubkeys: collaboratorPubkeys,
   );
 }
@@ -1313,6 +1457,7 @@ void _setupSuccessfulPublish({
       expirationTimestamp: any(named: 'expirationTimestamp'),
       allowAudioReuse: any(named: 'allowAudioReuse'),
       collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+      mentionedPubkeys: any(named: 'mentionedPubkeys'),
       inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
       inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
       inspiredByNpub: any(named: 'inspiredByNpub'),
@@ -1320,6 +1465,9 @@ void _setupSuccessfulPublish({
       selectedAudioRelay: any(named: 'selectedAudioRelay'),
       language: any(named: 'language'),
       contentWarning: any(named: 'contentWarning'),
+      thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+      replyContext: any(named: 'replyContext'),
+      addReplyToFeed: any(named: 'addReplyToFeed'),
     ),
   ).thenAnswer((_) async => true);
 }

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -214,6 +214,89 @@ void main() {
         },
       );
 
+      test(
+        'resolves text overlay mentions only from current editor history item',
+        () async {
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+          when(
+            () => mockMentionResolutionService.resolveTextMentions(
+              rawText: any(named: 'rawText'),
+              currentUserPubkey: any(named: 'currentUserPubkey'),
+            ),
+          ).thenAnswer((invocation) async {
+            final rawText = invocation.namedArguments[#rawText] as String;
+            expect(rawText, contains('current @newmention'));
+            expect(rawText, isNot(contains('deleted @oldmention')));
+
+            return const MentionResolutionResult(
+              canonicalText: '',
+              resolvedPubkeys: [overlayMentionPubkey],
+              unresolvedTokens: [],
+            );
+          });
+
+          final draft = _createTestDraft(
+            description: '',
+            editorStateHistory: {
+              'position': 1,
+              'references': {
+                'deleted-layer': TextLayer(
+                  id: 'deleted-layer',
+                  text: 'deleted @oldmention',
+                ).toMap(),
+                'current-layer': TextLayer(
+                  id: 'current-layer',
+                  text: 'current @newmention',
+                ).toMap(),
+              },
+              'history': [
+                {
+                  'layers': [
+                    {'id': 'deleted-layer'},
+                  ],
+                },
+                {
+                  'layers': [
+                    {'id': 'current-layer'},
+                  ],
+                },
+              ],
+            },
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishSuccess>());
+          verify(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: '',
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: const [overlayMentionPubkey],
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          ).called(1);
+        },
+      );
+
       test('publishes without mention tags when resolution fails', () async {
         _setupSuccessfulPublish(
           mockAuthService: mockAuthService,


### PR DESCRIPTION
Fixes #3129

## Summary
- Add a shared mention resolution pipeline for comments, video publish text, and profile bio canonicalization.
- Publish generic `p` mention tags for resolved mentions on comments and videos while excluding required author/collaborator tags.
- Guard against stale mention notifications by tying selected comment mentions to visible tokens and scanning only the current video editor overlay state.

## Test Plan
- `flutter analyze`
- `flutter test test/services/mention_resolution_service_test.dart test/blocs/comments/comments_bloc_test.dart test/screens/comments/comment_input_test.dart test/screens/comments/widgets/mention_overlay_test.dart packages/comments_repository/test/src/comments_repository_test.dart test/services/video_publish/video_publish_service_test.dart test/providers/video_publish_provider_test.dart test/services/video_event_publisher_test.dart test/services/video_event_publisher_collaborator_tags_test.dart test/blocs/profile_editor/profile_editor_bloc_test.dart test/widgets/profile/profile_header_widget_test.dart test/widgets/linkified_text/linkified_text_span_builder_test.dart`
- Pre-push hook: analyzer + changed-file tests