### PR TITLE
fix(safety): persist adult content preference migration

### DIFF
--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -247,10 +247,36 @@ class ContentFilterService extends ChangeNotifier {
     };
 
     if (newPref != null) {
+      final persistedPreferences = <String, String>{};
+      final savedPreferencesJson = prefs.getString(_prefsKey);
+      if (savedPreferencesJson != null) {
+        try {
+          final savedPreferences =
+              jsonDecode(savedPreferencesJson) as Map<String, dynamic>;
+          for (final entry in savedPreferences.entries) {
+            final value = entry.value;
+            if (ContentLabel.fromValue(entry.key) != null &&
+                value is String &&
+                _preferenceFromString(value) != null) {
+              persistedPreferences[entry.key] = value;
+            }
+          }
+        } catch (e) {
+          Log.warning(
+            'Ignoring invalid content filter preferences during migration: $e',
+            name: 'ContentFilterService',
+            category: LogCategory.system,
+          );
+        }
+      }
+
       // Apply to all adult categories
       for (final label in adultCategories) {
         _preferences[label] = newPref;
+        persistedPreferences.putIfAbsent(label.value, () => newPref.name);
       }
+
+      await prefs.setString(_prefsKey, jsonEncode(persistedPreferences));
 
       Log.info(
         'Migrated old adult content preference '

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -369,6 +369,35 @@ void main() {
         );
       });
 
+      test('persists migrated adult categories across restart', () async {
+        SharedPreferences.setMockInitialValues({
+          // Legacy playback preference "alwaysShow" = index 0
+          'adult_content_preference': 0,
+        });
+
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+        final migrationService = ContentFilterService(
+          ageVerificationService: ageService,
+        );
+        await migrationService.initialize();
+
+        final restartedAgeService = AgeVerificationService();
+        await restartedAgeService.initialize();
+        final restartedService = ContentFilterService(
+          ageVerificationService: restartedAgeService,
+        );
+        await restartedService.initialize();
+
+        for (final label in ContentFilterService.adultCategories) {
+          expect(
+            restartedService.getPreference(label),
+            equals(ContentFilterPreference.show),
+            reason: '${label.displayName} should survive restart',
+          );
+        }
+      });
+
       test('migrates askEachTime to warn for adult categories', () async {
         SharedPreferences.setMockInitialValues({
           // Legacy playback preference "askEachTime" = index 1

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -398,6 +398,43 @@ void main() {
         }
       });
 
+      test(
+        'preserves existing adult category preferences during migration',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            // Legacy playback preference "alwaysShow" = index 0
+            'adult_content_preference': 0,
+            'content_filter_prefs':
+                '{"nudity":"hide","sexual":"warn","violence":"hide"}',
+          });
+
+          await ageService.initialize();
+          await ageService.setAdultContentVerified(true);
+
+          final migrationService = ContentFilterService(
+            ageVerificationService: ageService,
+          );
+          await migrationService.initialize();
+
+          expect(
+            migrationService.getPreference(ContentLabel.nudity),
+            equals(ContentFilterPreference.hide),
+          );
+          expect(
+            migrationService.getPreference(ContentLabel.sexual),
+            equals(ContentFilterPreference.warn),
+          );
+          expect(
+            migrationService.getPreference(ContentLabel.porn),
+            equals(ContentFilterPreference.show),
+          );
+          expect(
+            migrationService.getPreference(ContentLabel.violence),
+            equals(ContentFilterPreference.hide),
+          );
+        },
+      );
+
       test('migrates askEachTime to warn for adult categories', () async {
         SharedPreferences.setMockInitialValues({
           // Legacy playback preference "askEachTime" = index 1


### PR DESCRIPTION
Closes #4357

## Summary
- persist migrated legacy adult playback preferences into the content-filter preference map
- preserve existing per-category content-filter settings when filling missing adult categories from the legacy value
- add restart regression coverage so migrated adult settings survive a fresh service instance

## Testing
- `flutter test test/services/content_filter_service_test.dart test/services/media_auth_interceptor_test.dart test/services/media_auth_interceptor_preference_test.dart test/services/video_event_service_adult_filter_test.dart`
- `flutter analyze lib/services/content_filter_service.dart test/services/content_filter_service_test.dart lib/services/media_auth_interceptor.dart lib/providers/app_providers.dart test/services/media_auth_interceptor_test.dart test/services/media_auth_interceptor_preference_test.dart test/services/video_event_service_adult_filter_test.dart`

Follow-up to #4350. Related to #4348.