### PR TITLE
fix(text): linkify user content render gaps

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -210,16 +210,11 @@ class _PreviewOverlay extends ConsumerWidget {
                 children: [
                   const FeedModeSwitch(isPreviewMode: true),
                   VideoOverlayActions(
-                    video: VideoEvent(
-                      id: 'id',
-                      pubkey: publicKey,
-                      timestamp: DateTime.now(),
-                      createdAt: DateTime.now().millisecondsSinceEpoch,
-                      content: metadata.title,
-                      hashtags: metadata.tags.toList(),
-                      originalLikes: 1,
-                      originalComments: 1,
-                      originalReposts: 1,
+                    video: buildVideoMetadataPreviewEvent(
+                      publicKey: publicKey,
+                      title: metadata.title,
+                      description: metadata.description,
+                      tags: metadata.tags,
                     ),
                     isVisible: true,
                     isActive: isActive,
@@ -233,6 +228,30 @@ class _PreviewOverlay extends ConsumerWidget {
       ),
     );
   }
+}
+
+@visibleForTesting
+VideoEvent buildVideoMetadataPreviewEvent({
+  required String publicKey,
+  required String title,
+  required String description,
+  required Set<String> tags,
+  DateTime? now,
+}) {
+  final timestamp = now ?? DateTime.now();
+  final trimmedTitle = title.trim();
+  return VideoEvent(
+    id: 'id',
+    pubkey: publicKey,
+    timestamp: timestamp,
+    createdAt: timestamp.millisecondsSinceEpoch,
+    title: trimmedTitle.isEmpty ? null : trimmedTitle,
+    content: description,
+    hashtags: tags.toList(),
+    originalLikes: 1,
+    originalComments: 1,
+    originalReposts: 1,
+  );
 }
 
 /// Close button positioned at the top-left corner.

--- a/mobile/lib/widgets/list_search_card.dart
+++ b/mobile/lib/widgets/list_search_card.dart
@@ -6,6 +6,7 @@ import 'package:count_formatter/count_formatter.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart' hide AspectRatio;
+import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Number of portrait card slots to display.
@@ -89,8 +90,8 @@ class _ListDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      description,
+    return LinkifiedText(
+      text: description,
       style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
       maxLines: 2,
       overflow: TextOverflow.ellipsis,

--- a/mobile/lib/widgets/profile/profile_comments_grid.dart
+++ b/mobile/lib/widgets/profile/profile_comments_grid.dart
@@ -14,6 +14,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_error_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_more_sliver.dart';
@@ -229,13 +230,23 @@ class _ProfileCommentCard extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    comment.content,
+                  ClickableHashtagText(
+                    text: comment.content,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
                       color: VineTheme.whiteText,
                       fontSize: 14,
+                    ),
+                    hashtagStyle: const TextStyle(
+                      color: VineTheme.info,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    mentionStyle: const TextStyle(
+                      color: VineTheme.info,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
                     ),
                   ),
                   const SizedBox(height: 4),

--- a/mobile/lib/widgets/profile/profile_comments_grid.dart
+++ b/mobile/lib/widgets/profile/profile_comments_grid.dart
@@ -218,6 +218,8 @@ class _ProfileCommentCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final baseStyle = VineTheme.bodyMediumFont();
+
     return GestureDetector(
       onTap: () =>
           context.push(VideoDetailScreen.pathForId(comment.rootEventId)),
@@ -234,18 +236,13 @@ class _ProfileCommentCard extends StatelessWidget {
                     text: comment.content,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: VineTheme.whiteText,
-                      fontSize: 14,
-                    ),
-                    hashtagStyle: const TextStyle(
+                    style: baseStyle,
+                    hashtagStyle: baseStyle.copyWith(
                       color: VineTheme.info,
-                      fontSize: 14,
                       fontWeight: FontWeight.w600,
                     ),
-                    mentionStyle: const TextStyle(
+                    mentionStyle: baseStyle.copyWith(
                       color: VineTheme.info,
-                      fontSize: 14,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -255,9 +252,8 @@ class _ProfileCommentCard extends StatelessWidget {
                       context.l10n,
                       comment.createdAt.millisecondsSinceEpoch ~/ 1000,
                     ),
-                    style: const TextStyle(
+                    style: VineTheme.bodySmallFont(
                       color: VineTheme.onSurfaceMuted,
-                      fontSize: 12,
                     ),
                   ),
                 ],

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -66,6 +66,27 @@ void main() {
   });
 
   group(VideoMetadataPreviewScreen, () {
+    test('preview event maps title and description to feed render fields', () {
+      final event = buildVideoMetadataPreviewEvent(
+        publicKey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        title: 'A title',
+        description:
+            'description with nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+        tags: const {'classic'},
+        now: DateTime.fromMillisecondsSinceEpoch(1234567890000),
+      );
+
+      expect(event.title, equals('A title'));
+      expect(
+        event.content,
+        equals(
+          'description with nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+        ),
+      );
+      expect(event.hashtags, equals(['classic']));
+    });
+
     Widget buildTestWidget({DivineVideoClip? clip}) {
       // Use previewOnly to avoid deep Riverpod dependency chain from
       // the overlay's VideoOverlayActions widget. The overlay is unrelated

--- a/mobile/test/widgets/list_search_card_test.dart
+++ b/mobile/test/widgets/list_search_card_test.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/list_search_card.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -28,20 +32,27 @@ void main() {
     );
   }
 
-  Widget buildSubject({required CuratedList curatedList, VoidCallback? onTap}) {
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(
-        body: Align(
-          alignment: Alignment.topLeft,
-          child: SizedBox(
-            width: 200,
-            height: 300,
-            child: SingleChildScrollView(
-              child: CuratedListSearchCard(
-                curatedList: curatedList,
-                onTap: onTap ?? () {},
+  Widget buildSubject({
+    required CuratedList curatedList,
+    VoidCallback? onTap,
+    List<dynamic> overrides = const [],
+  }) {
+    return ProviderScope(
+      overrides: overrides.cast(),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 200,
+              height: 300,
+              child: SingleChildScrollView(
+                child: CuratedListSearchCard(
+                  curatedList: curatedList,
+                  onTap: onTap ?? () {},
+                ),
               ),
             ),
           ),
@@ -66,6 +77,39 @@ void main() {
         );
 
         expect(find.text('Great videos'), findsOneWidget);
+      });
+
+      testWidgets('linkifies Nostr profile references in descriptions', (
+        tester,
+      ) async {
+        const mentionedPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        final mentionedNpub = NostrKeyUtils.encodePubKey(mentionedPubkey);
+
+        await tester.pumpWidget(
+          buildSubject(
+            curatedList: createList(description: 'by nostr:$mentionedNpub'),
+            overrides: [
+              userProfileReactiveProvider(mentionedPubkey).overrideWith(
+                (ref) => Stream.value(
+                  UserProfile(
+                    pubkey: mentionedPubkey,
+                    displayName: 'Alice',
+                    rawData: const {},
+                    createdAt: DateTime(2026),
+                    eventId:
+                        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(LinkifiedText), findsOneWidget);
+        expect(find.text('by @Alice', findRichText: true), findsOneWidget);
+        expect(find.textContaining('nostr:$mentionedNpub'), findsNothing);
       });
 
       testWidgets('no description when null', (tester) async {

--- a/mobile/test/widgets/list_search_card_test.dart
+++ b/mobile/test/widgets/list_search_card_test.dart
@@ -8,6 +8,7 @@ import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/list_search_card.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 void main() {
   final now = DateTime(2025, 6, 15);
@@ -35,10 +36,10 @@ void main() {
   Widget buildSubject({
     required CuratedList curatedList,
     VoidCallback? onTap,
-    List<dynamic> overrides = const [],
+    List<Override> overrides = const [],
   }) {
     return ProviderScope(
-      overrides: overrides.cast(),
+      overrides: overrides,
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/profile/profile_comments_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_comments_grid_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/profile/profile_comments_grid.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../helpers/go_router.dart';
 
@@ -71,10 +72,10 @@ void main() {
     Widget buildSubject({
       bool isOwnProfile = true,
       MockGoRouter? goRouter,
-      List<dynamic> overrides = const [],
+      List<Override> overrides = const [],
     }) {
       final app = ProviderScope(
-        overrides: overrides.cast(),
+        overrides: overrides,
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/profile/profile_comments_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_comments_grid_test.dart
@@ -4,10 +4,15 @@ import 'package:comments_repository/comments_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/blocs/profile_comments/profile_comments_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/profile/profile_comments_grid.dart';
 
 import '../../helpers/go_router.dart';
@@ -25,10 +30,11 @@ const _testRootAuthorPubkey =
 
 Comment _createTextComment({
   required String id,
+  String? content,
   int createdAtSeconds = 1700000000,
 }) => Comment(
   id: id,
-  content: 'Text comment $id',
+  content: content ?? 'Text comment $id',
   authorPubkey: _testAuthorPubkey,
   createdAt: DateTime.fromMillisecondsSinceEpoch(createdAtSeconds * 1000),
   rootEventId: _testRootEventId,
@@ -62,15 +68,22 @@ void main() {
       ).thenAnswer((_) async => null);
     });
 
-    Widget buildSubject({bool isOwnProfile = true, MockGoRouter? goRouter}) {
-      final app = MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: VineTheme.theme,
-        home: Scaffold(
-          body: BlocProvider<ProfileCommentsBloc>.value(
-            value: mockBloc,
-            child: ProfileCommentsGrid(isOwnProfile: isOwnProfile),
+    Widget buildSubject({
+      bool isOwnProfile = true,
+      MockGoRouter? goRouter,
+      List<dynamic> overrides = const [],
+    }) {
+      final app = ProviderScope(
+        overrides: overrides.cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: BlocProvider<ProfileCommentsBloc>.value(
+              value: mockBloc,
+              child: ProfileCommentsGrid(isOwnProfile: isOwnProfile),
+            ),
           ),
         ),
       );
@@ -173,6 +186,49 @@ void main() {
         expect(find.text('Comments'), findsOneWidget);
         expect(find.text('Text comment t1'), findsOneWidget);
         expect(find.text('Text comment t2'), findsOneWidget);
+      });
+
+      testWidgets('linkifies Nostr profile references in text comments', (
+        tester,
+      ) async {
+        const mentionedPubkey =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+        final mentionedNpub = NostrKeyUtils.encodePubKey(mentionedPubkey);
+        when(() => mockBloc.state).thenReturn(
+          ProfileCommentsState(
+            status: ProfileCommentsStatus.success,
+            textComments: [
+              _createTextComment(
+                id: 't1',
+                content: 'hi nostr:$mentionedNpub',
+              ),
+            ],
+          ),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            overrides: [
+              userProfileReactiveProvider(mentionedPubkey).overrideWith(
+                (ref) => Stream.value(
+                  UserProfile(
+                    pubkey: mentionedPubkey,
+                    displayName: 'Alice',
+                    rawData: const {},
+                    createdAt: DateTime(2026),
+                    eventId:
+                        'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(ClickableHashtagText), findsOneWidget);
+        expect(find.text('hi @Alice', findRichText: true), findsOneWidget);
+        expect(find.textContaining('nostr:$mentionedNpub'), findsNothing);
       });
 
       testWidgets('both sections when both types exist', (tester) async {


### PR DESCRIPTION
## Summary
- reuse shared linkified text rendering for curated list descriptions and profile text comments
- map video metadata preview title/description into the same feed render fields used by real videos
- add regression coverage for Nostr profile refs rendering as resolved profile labels instead of raw nostr:npub text

## Tests
- cd mobile && flutter test test/widgets/profile/profile_comments_grid_test.dart test/widgets/list_search_card_test.dart test/screens/video_metadata_preview_screen_test.dart
- cd mobile && flutter analyze lib/widgets/profile/profile_comments_grid.dart lib/widgets/list_search_card.dart lib/screens/video_metadata/video_metadata_preview_screen.dart test/widgets/profile/profile_comments_grid_test.dart test/widgets/list_search_card_test.dart test/screens/video_metadata_preview_screen_test.dart
- pre-push hook: analyzer + changed-file tests

## Tracking
- Refs #4370
- Follow-ups: #4368, #4369
