### PR TITLE
chore(deep-links): add handoff diagnostics

### DIFF
--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -95,18 +95,33 @@ class DeepLinkService {
         );
         final deepLink = DeepLinkService.parseDeepLink(initialUri.toString());
         _controller.add(deepLink);
-      }
-
-      // Listen for deep links while app is running
-      _subscription = _appLinks.uriLinkStream.listen((uri) {
-        Log.info(
-          '📱 Received deep link while running: ${redactUriStringForLogs(uri.toString())}',
+      } else {
+        Log.debug(
+          'No initial deep link present at startup',
           name: 'DeepLinkService',
           category: LogCategory.ui,
         );
-        final deepLink = DeepLinkService.parseDeepLink(uri.toString());
-        _controller.add(deepLink);
-      });
+      }
+
+      // Listen for deep links while app is running
+      _subscription = _appLinks.uriLinkStream.listen(
+        (uri) {
+          Log.info(
+            '📱 Received deep link while running: ${redactUriStringForLogs(uri.toString())}',
+            name: 'DeepLinkService',
+            category: LogCategory.ui,
+          );
+          final deepLink = DeepLinkService.parseDeepLink(uri.toString());
+          _controller.add(deepLink);
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          Log.error(
+            'Deep link stream error: $error',
+            name: 'DeepLinkService',
+            category: LogCategory.ui,
+          );
+        },
+      );
     } catch (e) {
       Log.error(
         'Error initializing deep link service: $e',
@@ -136,6 +151,16 @@ class DeepLinkService {
         return const DeepLink(type: DeepLinkType.signerCallback);
       }
 
+      if (_isInternalAppRoute(uri, url)) {
+        Log.debug(
+          'Skipping internal app route during deep-link parse: '
+          '${_describeUriForLogs(uri)}',
+          name: 'DeepLinkService',
+          category: LogCategory.ui,
+        );
+        return const DeepLink(type: DeepLinkType.unknown);
+      }
+
       // Accept divine.video itself plus any subdomain
       // (login.divine.video, staging.divine.video, etc.). Sibling and
       // lookalike hosts like notdivine.video or divine.video.evil.com
@@ -144,8 +169,13 @@ class DeepLinkService {
       final isDivineHost =
           host == 'divine.video' || host.endsWith('.divine.video');
       if (!isDivineHost) {
+        final embeddedUri = _extractEmbeddedUri(uri);
+        final wrappedTargetSuffix = embeddedUri == null
+            ? ''
+            : ', embeddedTarget=${_describeUriForLogs(embeddedUri)}';
         Log.warning(
-          'Ignoring deep link from non-divine.video domain: ${uri.host}',
+          'Ignoring deep link from non-divine host: '
+          '${_describeUriForLogs(uri)}$wrappedTargetSuffix',
           name: 'DeepLinkService',
           category: LogCategory.ui,
         );
@@ -267,5 +297,49 @@ class DeepLinkService {
   /// the widget tree can handle it uniformly.
   void pushLink(DeepLink link) {
     _controller.add(link);
+  }
+
+  static bool _isInternalAppRoute(Uri uri, String rawUrl) {
+    return uri.scheme.isEmpty &&
+        uri.host.isEmpty &&
+        rawUrl.startsWith('/') &&
+        uri.path.startsWith('/');
+  }
+
+  static Uri? _extractEmbeddedUri(Uri uri) {
+    const candidateKeys = <String>[
+      'url',
+      'u',
+      'target',
+      'link',
+      'redirect',
+      'redirect_url',
+      'redirectUrl',
+      'deep_link',
+      'deepLink',
+    ];
+
+    for (final key in candidateKeys) {
+      final value = uri.queryParameters[key];
+      if (value == null || value.isEmpty) continue;
+      final parsed = Uri.tryParse(value);
+      if (parsed == null) continue;
+      if (parsed.hasScheme || parsed.host.isNotEmpty) {
+        return parsed;
+      }
+    }
+
+    return null;
+  }
+
+  static String _describeUriForLogs(Uri uri) {
+    final scheme = uri.scheme.isEmpty ? '(none)' : uri.scheme;
+    final host = uri.host.isEmpty ? '(none)' : uri.host;
+    final primaryRoute = uri.pathSegments.isEmpty
+        ? '(root)'
+        : '/${uri.pathSegments.first}${uri.pathSegments.length > 1 ? '/*' : ''}';
+    final queryKeys = uri.queryParameters.keys.toList()..sort();
+    return 'scheme=$scheme, host=$host, route=$primaryRoute, '
+        'segments=${uri.pathSegments.length}, queryKeys=$queryKeys';
   }
 }

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -224,8 +224,25 @@ void main() {
     });
 
     group('Unknown URL Patterns', () {
+      test('ignores internal app route paths', () {
+        const url = '/profile/npub1abc123def456';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
       test('rejects non-divine.video domain', () {
         const url = 'https://example.com/video/abc123';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
+      test('rejects wrapped URL on non-divine host', () {
+        const url =
+            'https://slack-redir.net/link?url=https%3A%2F%2Fdivine.video%2Fprofile%2Fnpub1abc123def456';
 
         final result = DeepLinkService.parseDeepLink(url);
 
@@ -422,10 +439,7 @@ void main() {
     group('$DeepLink toString', () {
       test('formats video deep link', () {
         const link = DeepLink(type: DeepLinkType.video, videoRef: 'abc');
-        expect(
-          link.toString(),
-          equals('DeepLink(type: video, videoRef: abc)'),
-        );
+        expect(link.toString(), equals('DeepLink(type: video, videoRef: abc)'));
       });
 
       test('formats profile deep link with index', () {


### PR DESCRIPTION
Closes #4363

## What changed
- added low-risk deep-link diagnostics in `DeepLinkService` for startup, runtime stream errors, and non-Divine wrapped URLs
- downgraded the noisy internal-route parse case from warning to debug so logs are less misleading
- added targeted tests for internal route inputs and wrapped external URLs

## Why
- Slack and iOS universal-link handoff appears intermittent
- when the next failure happens, these logs will show whether the app received no link, a wrapped redirect URL, or a valid `divine.video` universal link

## Root cause
- current logs confirm the Flutter routing path works once iOS hands Divine a valid universal link
- the investigation points to inconsistent handoff before Flutter gets control, likely from Slack or the OS/browser layer

## Validation
- `flutter analyze lib/services/deep_link_service.dart test/services/deep_link_service_test.dart`
- `flutter test test/services/deep_link_service_test.dart`
