### PR TITLE
fix(safety): hide unknown ML labels in profile feeds

### DIFF
--- a/mobile/lib/services/nsfw_content_filter.dart
+++ b/mobile/lib/services/nsfw_content_filter.dart
@@ -46,7 +46,7 @@ VideoContentFilter createNsfwFilter(
       // every video carrying it, regardless of user preference. The
       // conservative default is correct for safety labels but is too broad
       // if the server starts emitting discovery/taxonomy labels in the same
-      // field. Track at: TBD (open an issue when this PR lands).
+      // field. Track at: #4364.
       //
       // Conservative default: if the server tagged a video with a label
       // we don't recognize, treat it as a hide signal. The alternative —

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -671,6 +671,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
           // Check moderation labels (hide-only — never warn)
           if (modLabels.isNotEmpty) {
+            final hasUnknown = modLabels.any(
+              (label) => ContentLabel.fromValue(label) == null,
+            );
+            if (hasUnknown) return false;
+
             final pref = service.getPreferenceForLabels(modLabels);
             if (pref == ContentFilterPreference.hide) return false;
           }

--- a/mobile/test/services/video_event_service_adult_filter_test.dart
+++ b/mobile/test/services/video_event_service_adult_filter_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/content_filter_service.dart';
@@ -14,6 +15,22 @@ class MockNostrService extends Mock implements NostrClient {}
 class MockSubscriptionManager extends Mock implements SubscriptionManager {}
 
 class MockContentFilterService extends Mock implements ContentFilterService {}
+
+VideoEvent _buildVideo({
+  required String id,
+  List<String> moderationLabels = const [],
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: 'f' * 64,
+    createdAt: 1704067200,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+    title: 'Test Video',
+    videoUrl: 'https://example.com/$id.mp4',
+    moderationLabels: moderationLabels,
+  );
+}
 
 void main() {
   late MockNostrService mockNostrService;
@@ -177,6 +194,60 @@ void main() {
             .filterAdultContentFromExistingVideos();
 
         expect(removedCount, equals(0));
+      },
+    );
+
+    test(
+      'filterVideoList hides videos with unknown sexual-content moderation label',
+      () {
+        when(
+          () => mockContentFilterService.getPreferenceForLabels(any()),
+        ).thenReturn(ContentFilterPreference.show);
+        videoEventService.setContentFilterService(mockContentFilterService);
+
+        final filtered = videoEventService.filterVideoList([
+          _buildVideo(id: '5' * 64, moderationLabels: const ['sexual-content']),
+        ]);
+
+        expect(filtered, isEmpty);
+      },
+    );
+
+    test(
+      'filterVideoList hides videos with any other unknown moderation label',
+      () {
+        when(
+          () => mockContentFilterService.getPreferenceForLabels(any()),
+        ).thenReturn(ContentFilterPreference.show);
+        videoEventService.setContentFilterService(mockContentFilterService);
+
+        final filtered = videoEventService.filterVideoList([
+          _buildVideo(
+            id: '6' * 64,
+            moderationLabels: const ['some-new-server-label'],
+          ),
+        ]);
+
+        expect(filtered, isEmpty);
+      },
+    );
+
+    test(
+      'filterVideoList keeps videos with known moderation labels when preference allows them',
+      () {
+        when(
+          () => mockContentFilterService.getPreferenceForLabels(any()),
+        ).thenReturn(ContentFilterPreference.show);
+        videoEventService.setContentFilterService(mockContentFilterService);
+
+        final video = _buildVideo(
+          id: '7' * 64,
+          moderationLabels: const ['nudity'],
+        );
+
+        final filtered = videoEventService.filterVideoList([video]);
+
+        expect(filtered, [video]);
       },
     );
   });


### PR DESCRIPTION
## Summary
- hide profile-feed videos when `VideoEventService.filterVideoList` sees unknown ML moderation labels
- add focused regression coverage for `sexual-content`, another unknown ML label, and a known-label control case
- link the existing conservative-label TODO to #4364

Closes #4364

## Verification
- `flutter test test/services/video_event_service_adult_filter_test.dart`
- `flutter analyze lib/services/video_event_service.dart lib/services/nsfw_content_filter.dart test/services/video_event_service_adult_filter_test.dart`
- pre-push hook: analyzer + `test/services/nsfw_content_filter_test.dart` + `test/services/video_event_service_adult_filter_test.dart`