### PR TITLE
fix(content-filter): canonicalize sexual-content moderation labels

### DIFF
--- a/mobile/lib/models/content_label.dart
+++ b/mobile/lib/models/content_label.dart
@@ -85,8 +85,25 @@ enum ContentLabel {
   /// Returns `null` if [value] does not match any known label.
   static ContentLabel? fromValue(String? value) {
     if (value == null || value.isEmpty) return null;
+    final normalized = value
+        .trim()
+        .toLowerCase()
+        .replaceAll('_', '-')
+        .replaceAll(RegExp(r'\s+'), '-');
+
+    final canonicalValue = switch (normalized) {
+      'sexual-content' => 'sexual',
+      'pornography' || 'explicit' => 'porn',
+      'graphic-violence' || 'gore' => 'graphic-media',
+      'nsfw' => 'nudity',
+      'offensive' || 'hate-speech' => 'hate',
+      'recreational-drug' => 'drugs',
+      'weapon' => 'violence',
+      _ => normalized,
+    };
+
     for (final label in ContentLabel.values) {
-      if (label.value == value) return label;
+      if (label.value == canonicalValue) return label;
     }
     return null;
   }

--- a/mobile/lib/models/content_label.dart
+++ b/mobile/lib/models/content_label.dart
@@ -82,6 +82,9 @@ enum ContentLabel {
 
   /// Parse a [ContentLabel] from its NIP-32 [value] string.
   ///
+  /// Normalizes casing, whitespace, and separators before resolving known
+  /// moderation-label aliases to their canonical [ContentLabel] values.
+  ///
   /// Returns `null` if [value] does not match any known label.
   static ContentLabel? fromValue(String? value) {
     if (value == null || value.isEmpty) return null;

--- a/mobile/lib/services/effective_content_labels.dart
+++ b/mobile/lib/services/effective_content_labels.dart
@@ -1,4 +1,5 @@
 import 'package:models/models.dart';
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 
 /// Builds the effective moderation label set for a [VideoEvent].
@@ -79,17 +80,5 @@ String? normalizeModerationLabelValue(String? value) {
     return null;
   }
 
-  switch (normalized) {
-    case 'nsfw':
-      return 'nudity';
-    case 'explicit':
-      return 'porn';
-    case 'pornography':
-      return 'porn';
-    case 'graphic-violence':
-    case 'gore':
-      return 'graphic-media';
-    default:
-      return normalized;
-  }
+  return ContentLabel.fromValue(value)?.value ?? normalized;
 }

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -589,6 +589,8 @@ String? _normalizeModerationLabel(String value) {
       .replaceAll('_', '-')
       .replaceAll(RegExp(r'\s+'), '-');
 
+  // Keep this alias mapping in sync with ContentLabel.fromValue, which is the
+  // canonical app-level moderation label parser.
   switch (normalized) {
     case 'sexual-content':
       return 'sexual';

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -590,6 +590,8 @@ String? _normalizeModerationLabel(String value) {
       .replaceAll(RegExp(r'\s+'), '-');
 
   switch (normalized) {
+    case 'sexual-content':
+      return 'sexual';
     case 'pornography':
     case 'explicit':
       return 'porn';

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -981,7 +981,7 @@ void main() {
           buildJson(['sexual content', 'graphic media']),
         );
 
-        expect(stats.moderationLabels, contains('sexual-content'));
+        expect(stats.moderationLabels, contains('sexual'));
         expect(stats.moderationLabels, contains('graphic-media'));
       });
 
@@ -1004,6 +1004,14 @@ void main() {
         expect(stats.moderationLabels, contains('porn'));
         expect(stats.moderationLabels, contains('nudity'));
         expect(stats.moderationLabels, contains('graphic-media'));
+      });
+
+      test('maps sexual-content alias to canonical sexual label', () {
+        final stats = VideoStats.fromJson(
+          buildJson(['sexual-content']),
+        );
+
+        expect(stats.moderationLabels, equals(['sexual']));
       });
 
       test('drops empty strings', () {

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -348,6 +348,28 @@ void main() {
         expect(filter(video), isTrue);
       });
 
+      test(
+        'respects sexual show preference for sexual-content alias',
+        () async {
+          await ageService.initialize();
+          await ageService.setAdultContentVerified(true);
+          await contentFilterService.setPreference(
+            ContentLabel.sexual,
+            ContentFilterPreference.show,
+          );
+
+          final filter = createNsfwFilter(
+            contentFilterService,
+            moderationLabelService: moderationLabelService,
+          );
+          final video = _createVideo(
+            moderationLabels: const ['sexual-content'],
+          );
+
+          expect(filter(video), isFalse);
+        },
+      );
+
       test('does not hide videos with no moderation labels', () {
         final filter = createNsfwFilter(
           contentFilterService,

--- a/mobile/test/services/video_event_service_adult_filter_test.dart
+++ b/mobile/test/services/video_event_service_adult_filter_test.dart
@@ -198,7 +198,7 @@ void main() {
     );
 
     test(
-      'filterVideoList hides videos with unknown sexual-content moderation label',
+      'filterVideoList keeps sexual-content videos when user preference allows sexual content',
       () {
         when(
           () => mockContentFilterService.getPreferenceForLabels(any()),
@@ -209,7 +209,7 @@ void main() {
           _buildVideo(id: '5' * 64, moderationLabels: const ['sexual-content']),
         ]);
 
-        expect(filtered, isEmpty);
+        expect(filtered, hasLength(1));
       },
     );
 


### PR DESCRIPTION
## Summary
- map REST moderation label variants like sexual-content to the canonical sexual label in VideoStats
- normalize app-side content label parsing through ContentLabel.fromValue so the same alias no longer trips the unknown-label hide guard
- add regression coverage for both model parsing and NSFW filtering

## Testing
- flutter test test/src/video_stats_test.dart
- flutter test test/services/nsfw_content_filter_test.dart
- flutter analyze

Closes #4366