### PR TITLE
refactor(preview): remove fake overlay video event

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:models/models.dart' show VideoEvent;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -209,16 +208,14 @@ class _PreviewOverlay extends ConsumerWidget {
                 fit: StackFit.expand,
                 children: [
                   const FeedModeSwitch(isPreviewMode: true),
-                  VideoOverlayActions(
-                    video: buildVideoMetadataPreviewEvent(
-                      publicKey: publicKey,
+                  VideoOverlayActions.preview(
+                    previewData: VideoOverlayPreviewData(
+                      pubkey: publicKey,
                       title: metadata.title,
                       description: metadata.description,
-                      tags: metadata.tags,
                     ),
                     isVisible: true,
                     isActive: isActive,
-                    isPreviewMode: true,
                   ),
                 ],
               );
@@ -228,30 +225,6 @@ class _PreviewOverlay extends ConsumerWidget {
       ),
     );
   }
-}
-
-@visibleForTesting
-VideoEvent buildVideoMetadataPreviewEvent({
-  required String publicKey,
-  required String title,
-  required String description,
-  required Set<String> tags,
-  DateTime? now,
-}) {
-  final timestamp = now ?? DateTime.now();
-  final trimmedTitle = title.trim();
-  return VideoEvent(
-    id: 'id',
-    pubkey: publicKey,
-    timestamp: timestamp,
-    createdAt: timestamp.millisecondsSinceEpoch,
-    title: trimmedTitle.isEmpty ? null : trimmedTitle,
-    content: description,
-    hashtags: tags.toList(),
-    originalLikes: 1,
-    originalComments: 1,
-    originalReposts: 1,
-  );
 }
 
 /// Close button positioned at the top-left corner.

--- a/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
@@ -27,13 +27,21 @@ class CommentActionButton extends ConsumerWidget {
     super.key,
   });
 
-  final VideoEvent video;
+  const CommentActionButton.preview({
+    this.onInteracted,
+    super.key,
+  }) : video = null,
+       isPreviewMode = true;
+
+  final VideoEvent? video;
   final bool isPreviewMode;
   final VoidCallback? onInteracted;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (isPreviewMode) return const _ActionButton();
+    final video = this.video;
+    if (video == null) return const SizedBox.shrink();
 
     return BlocSelector<
       VideoInteractionsBloc,

--- a/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
@@ -33,7 +33,14 @@ class LikeActionButton extends StatelessWidget {
     this.onInteracted,
   });
 
-  final VideoEvent video;
+  const LikeActionButton.preview({
+    super.key,
+    this.onInteracted,
+  }) : video = null,
+       isPreviewMode = true,
+       isOwnVideo = false;
+
+  final VideoEvent? video;
   final bool isPreviewMode;
   final bool isOwnVideo;
   final VoidCallback? onInteracted;
@@ -97,6 +104,7 @@ class _ActionButton extends StatelessWidget {
           _openLikersList(context, video);
           return;
         }
+        if (video == null) return;
         context.read<VideoInteractionsBloc>().add(
           const VideoInteractionsLikeToggled(),
         );

--- a/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
@@ -32,7 +32,14 @@ class RepostActionButton extends StatelessWidget {
     this.onInteracted,
   });
 
-  final VideoEvent video;
+  const RepostActionButton.preview({
+    super.key,
+    this.onInteracted,
+  }) : video = null,
+       isPreviewMode = true,
+       isOwnVideo = false;
+
+  final VideoEvent? video;
   final bool isPreviewMode;
   final bool isOwnVideo;
   final VoidCallback? onInteracted;
@@ -40,6 +47,8 @@ class RepostActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (isPreviewMode) return const _ActionButton();
+    final video = this.video;
+    if (video == null) return const SizedBox.shrink();
 
     // Use relay count when available; fall back to video metadata.
     // Don't sum both — Funnelcake's originalReposts already includes
@@ -101,6 +110,7 @@ class _ActionButton extends StatelessWidget {
           _openRepostersList(context, video);
           return;
         }
+        if (video == null) return;
         context.read<VideoInteractionsBloc>().add(
           const VideoInteractionsRepostToggled(),
         );

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -57,6 +57,18 @@ VideoControllerParams videoControllerParamsFor(
   return VideoControllerParams.fromVideoEvent(video);
 }
 
+class VideoOverlayPreviewData {
+  const VideoOverlayPreviewData({
+    required this.pubkey,
+    required this.title,
+    required this.description,
+  });
+
+  final String pubkey;
+  final String title;
+  final String description;
+}
+
 /// Video overlay actions widget with working functionality
 class VideoOverlayActions extends ConsumerWidget {
   const VideoOverlayActions({
@@ -77,10 +89,31 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showAutoButton = false,
     this.onInteracted,
     this.omitAuthorBlock = false,
-  });
+  }) : previewData = null;
+
+  const VideoOverlayActions.preview({
+    required this.previewData,
+    required this.isVisible,
+    required this.isActive,
+    super.key,
+    this.subtitleLayer,
+    this.hasBottomNavigation = true,
+    this.contextTitle,
+    this.isFullscreen = false,
+    this.listSources,
+    this.showListAttribution = false,
+    this.isPreviewMode = true,
+    this.showBottomGradient = true,
+    this.topOffset = 8.0,
+    this.overlayOpacity = 1.0,
+    this.showAutoButton = false,
+    this.onInteracted,
+    this.omitAuthorBlock = false,
+  }) : video = null;
 
   final Widget? subtitleLayer;
-  final VideoEvent video;
+  final VideoEvent? video;
+  final VideoOverlayPreviewData? previewData;
   final bool isVisible;
   final bool isActive;
   final bool hasBottomNavigation;
@@ -121,11 +154,19 @@ class VideoOverlayActions extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (!isVisible) return const SizedBox();
+    final video = this.video;
+    final previewData = this.previewData;
+    final authorPubkey = previewData?.pubkey ?? video!.pubkey;
+    final trimmedTitle = previewData?.title.trim() ?? video?.title?.trim();
+    final titleText = trimmedTitle == null || trimmedTitle.isEmpty
+        ? null
+        : trimmedTitle;
+    final descriptionText =
+        previewData?.description.trim() ?? video!.displayContent.trim();
 
     // Check if there's meaningful text content to display
     final hasTextContent =
-        video.content.isNotEmpty ||
-        (video.title != null && video.title!.isNotEmpty);
+        descriptionText.isNotEmpty || (titleText?.isNotEmpty ?? false);
 
     // In fullscreen mode, ensure badges clear the status bar icons
     // (battery, wifi, clock). viewPaddingOf may return 0 if a parent
@@ -184,7 +225,8 @@ class VideoOverlayActions extends ConsumerWidget {
                 ),
               ),
             // Content warning badge below back button area
-            if (video.hasContentWarning &&
+            if (video != null &&
+                video.hasContentWarning &&
                 !shouldShowContentWarningOverlay(
                   contentWarningLabels: video.contentWarningLabels,
                   warnLabels: video.warnLabels,
@@ -222,7 +264,9 @@ class VideoOverlayActions extends ConsumerWidget {
                       ?subtitleLayer,
 
                       // Repost banner (if video is a repost)
-                      if (video.isRepost && video.reposterPubkey != null) ...[
+                      if (video != null &&
+                          video.isRepost &&
+                          video.reposterPubkey != null) ...[
                         VideoRepostHeader(
                           reposterPubkey: video.reposterPubkey!,
                         ),
@@ -232,31 +276,31 @@ class VideoOverlayActions extends ConsumerWidget {
                       Consumer(
                         builder: (context, ref, _) {
                           final profile = ref
-                              .watch(userProfileReactiveProvider(video.pubkey))
+                              .watch(userProfileReactiveProvider(authorPubkey))
                               .value;
                           // Use embedded author data from REST API as fallback
                           // This avoids WebSocket profile fetches for videos
                           // that already have author_name/author_avatar embedded
                           final avatarUrl =
-                              profile?.picture ?? video.authorAvatar;
+                              profile?.picture ?? video?.authorAvatar;
                           final displayName =
                               profile?.bestDisplayName ??
-                              video.authorName ??
-                              UserProfile.generatedNameFor(video.pubkey);
+                              video?.authorName ??
+                              UserProfile.generatedNameFor(authorPubkey);
                           final isOgViner = ref.watch(
                             ogVinerCacheServiceProvider.select(
-                              (service) => service.isOgViner(video.pubkey),
+                              (service) => service.isOgViner(authorPubkey),
                             ),
                           );
 
                           void navigateToProfile() {
                             onInteracted?.call();
                             Log.info(
-                              '👤 User tapped profile: videoId=${video.id}, authorPubkey=${video.pubkey}',
+                              '👤 User tapped profile: videoId=${video?.id ?? "preview"}, authorPubkey=$authorPubkey',
                               name: 'VideoFeedItem',
                               category: LogCategory.ui,
                             );
-                            final npub = normalizeToNpub(video.pubkey);
+                            final npub = normalizeToNpub(authorPubkey);
                             if (npub != null) {
                               context.push(
                                 OtherProfileScreen.pathForNpub(npub),
@@ -285,13 +329,14 @@ class VideoOverlayActions extends ConsumerWidget {
                                       onTap: navigateToProfile,
                                     ),
                                     // Follow button positioned at bottom-right of avatar
-                                    PositionedDirectional(
-                                      start: 31,
-                                      top: 31,
-                                      child: VideoFollowButton(
-                                        pubkey: video.pubkey,
+                                    if (video != null)
+                                      PositionedDirectional(
+                                        start: 31,
+                                        top: 31,
+                                        child: VideoFollowButton(
+                                          pubkey: authorPubkey,
+                                        ),
                                       ),
-                                    ),
                                   ],
                                 ),
                               ),
@@ -335,9 +380,9 @@ class VideoOverlayActions extends ConsumerWidget {
                                       Text(
                                         context.l10n.videoFeedLoopCountLine(
                                           StringUtils.formatCompactNumber(
-                                            video.totalLoops,
+                                            video?.totalLoops ?? 0,
                                           ),
-                                          video.totalLoops,
+                                          video?.totalLoops ?? 0,
                                         ),
                                         style: const TextStyle(
                                           fontFamily: 'Inter',
@@ -355,7 +400,8 @@ class VideoOverlayActions extends ConsumerWidget {
                         },
                       ),
                       // List attribution chip (shown when video is from subscribed curated list)
-                      if (showListAttribution &&
+                      if (video != null &&
+                          showListAttribution &&
                           listSources != null &&
                           listSources!.isNotEmpty) ...[
                         const SizedBox(height: 8),
@@ -404,8 +450,7 @@ class VideoOverlayActions extends ConsumerWidget {
                           height: 2,
                         ), // 2px + 10px from avatar container = 12px total
                         // Title (when present)
-                        if (video.title != null &&
-                            video.title!.trim().isNotEmpty)
+                        if (titleText != null)
                           Semantics(
                             identifier: 'video_title',
                             container: true,
@@ -415,12 +460,17 @@ class VideoOverlayActions extends ConsumerWidget {
                                 context.l10n.videoOverlayOpenMetadataFromTitle,
                             child: GestureDetector(
                               behavior: HitTestBehavior.opaque,
-                              onTap: () {
-                                onInteracted?.call();
-                                MetadataExpandedSheet.show(context, video);
-                              },
+                              onTap: video == null
+                                  ? null
+                                  : () {
+                                      onInteracted?.call();
+                                      MetadataExpandedSheet.show(
+                                        context,
+                                        video,
+                                      );
+                                    },
                               child: Text(
-                                video.displayTitle!.trim(),
+                                titleText,
                                 style: VineTheme.labelMediumFont().copyWith(
                                   shadows: VineTheme.buttonShadows,
                                 ),
@@ -431,13 +481,11 @@ class VideoOverlayActions extends ConsumerWidget {
                           ),
                         // 4 px gap between title and description when both
                         // are present (matches the Figma caption spacing).
-                        if (video.title != null &&
-                            video.title!.trim().isNotEmpty &&
-                            video.content.trim().isNotEmpty)
+                        if (titleText != null && descriptionText.isNotEmpty)
                           const SizedBox(height: 4),
                         // Description (only when actual content exists — the
                         // title has its own row above, so no fallback here).
-                        if (video.content.trim().isNotEmpty)
+                        if (descriptionText.isNotEmpty)
                           Semantics(
                             identifier: 'video_description',
                             container: true,
@@ -448,12 +496,17 @@ class VideoOverlayActions extends ConsumerWidget {
                                 .videoOverlayOpenMetadataFromDescription,
                             child: GestureDetector(
                               behavior: HitTestBehavior.opaque,
-                              onTap: () {
-                                onInteracted?.call();
-                                MetadataExpandedSheet.show(context, video);
-                              },
+                              onTap: video == null
+                                  ? null
+                                  : () {
+                                      onInteracted?.call();
+                                      MetadataExpandedSheet.show(
+                                        context,
+                                        video,
+                                      );
+                                    },
                               child: ClickableHashtagText(
-                                text: video.displayContent.trim(),
+                                text: descriptionText,
                                 style: VineTheme.bodySmallFont().copyWith(
                                   shadows: VineTheme.buttonShadows,
                                 ),
@@ -467,11 +520,11 @@ class VideoOverlayActions extends ConsumerWidget {
                             ),
                           ),
                         // Collaborator avatar row (if video has collaborators)
-                        if (video.hasCollaborators) ...[
+                        if (video != null && video.hasCollaborators) ...[
                           const SizedBox(height: 4),
                           CollaboratorAvatarRow(video: video),
                         ],
-                        if (video.isVideoReply) ...[
+                        if (video != null && video.isVideoReply) ...[
                           const SizedBox(height: 4),
                           VideoReplyParentLink(
                             video: video,
@@ -480,7 +533,7 @@ class VideoOverlayActions extends ConsumerWidget {
                           ),
                         ],
                         // Inspired-by attribution row (if video credits another creator)
-                        if (video.hasInspiredBy) ...[
+                        if (video != null && video.hasInspiredBy) ...[
                           const SizedBox(height: 4),
                           InspiredByAttributionRow(
                             video: video,
@@ -490,7 +543,7 @@ class VideoOverlayActions extends ConsumerWidget {
                       ],
                       // Audio attribution row (all videos)
                       const SizedBox(height: 4),
-                      AudioAttributionRow(video: video),
+                      if (video != null) AudioAttributionRow(video: video),
                       const SizedBox(height: 8),
                     ],
                   ),
@@ -509,13 +562,15 @@ class VideoOverlayActions extends ConsumerWidget {
                 duration: const Duration(milliseconds: 200),
                 child: IgnorePointer(
                   ignoring: false, // Action buttons SHOULD receive taps
-                  child: VideoOverlayActionColumn(
-                    video: video,
-                    isFullscreen: isFullscreen,
-                    isPreviewMode: isPreviewMode,
-                    showAutoButton: showAutoButton,
-                    onInteracted: onInteracted,
-                  ),
+                  child: video == null
+                      ? _PreviewOverlayActionColumn(onInteracted: onInteracted)
+                      : VideoOverlayActionColumn(
+                          video: video,
+                          isFullscreen: isFullscreen,
+                          isPreviewMode: isPreviewMode,
+                          showAutoButton: showAutoButton,
+                          onInteracted: onInteracted,
+                        ),
                 ),
               ),
             ),
@@ -533,6 +588,45 @@ class VideoOverlayActions extends ConsumerWidget {
   ) async {
     await context.showVideoPausingDialog<void>(
       builder: (context) => _ContentWarningDetailsSheet(labels: labels),
+    );
+  }
+}
+
+class _PreviewOverlayActionColumn extends StatelessWidget {
+  const _PreviewOverlayActionColumn({this.onInteracted});
+
+  final VoidCallback? onInteracted;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: 20,
+      children: [
+        LikeActionButton.preview(onInteracted: onInteracted),
+        CommentActionButton.preview(onInteracted: onInteracted),
+        RepostActionButton.preview(onInteracted: onInteracted),
+        VideoActionButton(
+          icon: .shareFatDuo,
+          semanticIdentifier: 'share_button',
+          semanticLabel: context.l10n.shareVideoLabel,
+          labelWhenZero: context.l10n.videoActionShareLabel,
+          onPressed: onInteracted,
+        ),
+        VideoActionButton(
+          icon: DivineIconName.flag,
+          semanticIdentifier: 'report_button',
+          semanticLabel: context.l10n.videoActionReport,
+          labelWhenZero: context.l10n.videoActionReportLabel,
+          onPressed: onInteracted,
+        ),
+        VideoActionButton(
+          icon: DivineIconName.info,
+          semanticIdentifier: 'more_button',
+          semanticLabel: context.l10n.videoActionMoreOptions,
+          caption: context.l10n.videoActionAboutLabel,
+          onPressed: onInteracted,
+        ),
+      ],
     );
   }
 }

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/models/video_publish/video_publish_provider_state.dart'
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -66,25 +67,35 @@ void main() {
   });
 
   group(VideoMetadataPreviewScreen, () {
-    test('preview event maps title and description to feed render fields', () {
-      final event = buildVideoMetadataPreviewEvent(
-        publicKey:
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        title: 'A title',
-        description:
-            'description with nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
-        tags: const {'classic'},
-        now: DateTime.fromMillisecondsSinceEpoch(1234567890000),
-      );
-
-      expect(event.title, equals('A title'));
-      expect(
-        event.content,
-        equals(
-          'description with nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+    testWidgets('preview overlay renders metadata without a VideoEvent', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoOverlayActions.preview(
+                previewData: VideoOverlayPreviewData(
+                  pubkey:
+                      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                  title: 'A title',
+                  description:
+                      'description with nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+                ),
+                isVisible: true,
+                isActive: true,
+              ),
+            ),
+          ),
         ),
       );
-      expect(event.hashtags, equals(['classic']));
+
+      expect(find.text('A title'), findsOneWidget);
+      expect(find.textContaining('description with'), findsOneWidget);
+      expect(find.byType(VideoOverlayActions), findsOneWidget);
     });
 
     Widget buildTestWidget({DivineVideoClip? clip}) {

--- a/mobile/test/widgets/video_feed_item/actions/comment_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/comment_action_button_test.dart
@@ -77,6 +77,23 @@ void main() {
         },
       );
 
+      testWidgets('preview constructor renders without a video', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: CommentActionButton.preview()),
+            ),
+          ),
+        );
+
+        expect(find.byType(CommentActionButton), findsOneWidget);
+        expect(find.byType(VideoActionButton), findsOneWidget);
+      });
+
       testWidgets('displays default comment count of 1 in preview mode', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_feed_item/actions/like_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/like_action_button_test.dart
@@ -128,6 +128,21 @@ void main() {
         },
       );
 
+      testWidgets('preview constructor renders without a video', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: LikeActionButton.preview()),
+          ),
+        );
+
+        expect(find.byType(LikeActionButton), findsOneWidget);
+        expect(find.byType(VideoActionButton), findsOneWidget);
+      });
+
       testWidgets('displays default like count of 1 in preview mode', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_feed_item/actions/repost_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/repost_action_button_test.dart
@@ -128,6 +128,21 @@ void main() {
         },
       );
 
+      testWidgets('preview constructor renders without a video', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: RepostActionButton.preview()),
+          ),
+        );
+
+        expect(find.byType(RepostActionButton), findsOneWidget);
+        expect(find.byType(VideoActionButton), findsOneWidget);
+      });
+
       testWidgets('displays default repost count of 1 in preview mode', (
         tester,
       ) async {


### PR DESCRIPTION
## Summary
- add a preview-data path to `VideoOverlayActions` so preview mode no longer needs a synthetic `VideoEvent`
- switch the video metadata preview screen to the new preview path
- add preview constructors for like/comment/repost buttons and render a static preview action column without real event data
- cover the preview path with regression tests

## Why
`VideoMetadataPreviewScreen` was constructing a fake `VideoEvent` just to satisfy overlay rendering. That leaked placeholder IDs and counts into production UI code and kept the preview path coupled to a model that does not really exist before publish.

This refactor keeps the existing preview rendering behavior, but moves preview mode onto an explicit metadata path instead of a fabricated event.

## Impact
- preview overlay caption rendering no longer depends on fake event construction
- preview-only action buttons still render, but they no longer require a backing `VideoEvent`
- the preview author block no longer spins up a follow button for the preview-only path

## Tests
- `cd mobile && flutter test test/screens/video_metadata_preview_screen_test.dart test/widgets/video_feed_item/actions/like_action_button_test.dart test/widgets/video_feed_item/actions/comment_action_button_test.dart test/widgets/video_feed_item/actions/repost_action_button_test.dart`
- `cd mobile && flutter analyze lib/widgets/video_feed_item/video_feed_item.dart lib/widgets/video_feed_item/actions/like_action_button.dart lib/widgets/video_feed_item/actions/comment_action_button.dart lib/widgets/video_feed_item/actions/repost_action_button.dart lib/screens/video_metadata/video_metadata_preview_screen.dart test/screens/video_metadata_preview_screen_test.dart test/widgets/video_feed_item/actions/like_action_button_test.dart test/widgets/video_feed_item/actions/comment_action_button_test.dart test/widgets/video_feed_item/actions/repost_action_button_test.dart`
- pre-push hook: analyzer + changed-file tests

Closes #4368
