### PR TITLE
fix(invites): retry transient invite redemption failures

### DIFF
--- a/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
@@ -38,6 +38,7 @@ class InviteApiClient {
        _forceOpenOnboarding = forceOpenOnboarding;
 
   static const Duration _defaultTimeout = Duration(seconds: 20);
+  static const int _maxConsumeAttempts = 3;
 
   final String _baseUrl;
   final http.Client _client;
@@ -244,39 +245,48 @@ class InviteApiClient {
     final payload = jsonEncode({'code': normalizedCode});
 
     try {
-      final response = await _client
-          .post(
-            uri,
-            headers: await _headers(
-              url: uri.toString(),
-              method: InviteRequestMethod.post,
-              payload: payload,
-              requiresAuth: signer == null,
-              signer: signer,
-            ),
-            body: payload,
-          )
-          .timeout(_defaultTimeout);
+      for (var attempt = 1; attempt <= _maxConsumeAttempts; attempt++) {
+        final response = await _client
+            .post(
+              uri,
+              headers: await _headers(
+                url: uri.toString(),
+                method: InviteRequestMethod.post,
+                payload: payload,
+                requiresAuth: signer == null,
+                signer: signer,
+              ),
+              body: payload,
+            )
+            .timeout(_defaultTimeout);
 
-      if (response.statusCode != 200) {
-        final alreadyJoined =
-            _parseErrorCode(response.body) ==
-            InviteApiErrorCode.userAlreadyJoined;
-        if (alreadyJoined) {
-          return InviteConsumeResult.fromJson({
-            'result': 'user_already_joined',
-            'code': normalizedCode,
-          });
+        if (response.statusCode != 200) {
+          final alreadyJoined =
+              _parseErrorCode(response.body) ==
+              InviteApiErrorCode.userAlreadyJoined;
+          if (alreadyJoined) {
+            return InviteConsumeResult.fromJson({
+              'result': 'user_already_joined',
+              'code': normalizedCode,
+            });
+          }
+
+          final canRetry =
+              attempt < _maxConsumeAttempts && _isRetryable(response);
+          if (canRetry) {
+            await Future<void>.delayed(_retryDelay(response));
+            continue;
+          }
+
+          throw _requestFailed(
+            message: 'Failed to activate invite code',
+            response: response,
+          );
         }
 
-        throw _requestFailed(
-          message: 'Failed to activate invite code',
-          response: response,
-        );
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        return InviteConsumeResult.fromJson(json);
       }
-
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
-      return InviteConsumeResult.fromJson(json);
     } catch (error) {
       throw _wrapClientException(
         error: error,
@@ -284,6 +294,11 @@ class InviteApiClient {
         failureMessage: 'Failed to activate invite code',
       );
     }
+
+    throw const InviteApiException(
+      'Failed to activate invite code',
+      code: InviteApiErrorCode.clientError,
+    );
   }
 
   Future<InviteStatus> getInviteStatus() async {
@@ -549,6 +564,31 @@ class InviteApiClient {
     return _extractString(body, ['code', 'errorCode', 'error_code']);
   }
 
+  bool _isRetryable(http.Response response) {
+    final retryable = _extractBool(response.body, ['retryable']);
+    if (retryable != null) return retryable;
+
+    final errorCode = _parseErrorCode(response.body);
+    return errorCode == InviteApiErrorCode.tooManyRequests ||
+        errorCode == InviteApiErrorCode.storageError ||
+        errorCode == InviteApiErrorCode.internalError ||
+        response.statusCode >= 500;
+  }
+
+  Duration _retryDelay(http.Response response) {
+    final retryAfterHeader = response.headers['retry-after'];
+    final retryAfterSeconds =
+        int.tryParse(retryAfterHeader ?? '') ??
+        _extractInt(response.body, [
+          'retryAfterSeconds',
+          'retry_after_seconds',
+        ]);
+    if (retryAfterSeconds == null || retryAfterSeconds <= 0) {
+      return Duration.zero;
+    }
+    return Duration(seconds: retryAfterSeconds);
+  }
+
   String? _extractString(String body, List<String> keys) {
     try {
       final decoded = jsonDecode(body);
@@ -557,6 +597,40 @@ class InviteApiClient {
           final value = decoded[key];
           if (value is String && value.isNotEmpty) {
             return value;
+          }
+        }
+      }
+    } on Object catch (_) {
+      // Ignore malformed bodies and fall back to null.
+    }
+    return null;
+  }
+
+  bool? _extractBool(String body, List<String> keys) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        for (final key in keys) {
+          final value = decoded[key];
+          if (value is bool) return value;
+        }
+      }
+    } on Object catch (_) {
+      // Ignore malformed bodies and fall back to null.
+    }
+    return null;
+  }
+
+  int? _extractInt(String body, List<String> keys) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        for (final key in keys) {
+          final value = decoded[key];
+          if (value is int) return value;
+          if (value is String) {
+            final parsed = int.tryParse(value);
+            if (parsed != null) return parsed;
           }
         }
       }

--- a/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
@@ -480,6 +480,43 @@ void main() {
     });
 
     test(
+      'retries retryable consume failures before surfacing an error',
+      () async {
+        var attempts = 0;
+        final retryingClient = InviteApiClient(
+          baseUrl: 'https://invites.divine.video',
+          client: MockClient((request) async {
+            attempts++;
+            if (attempts == 1) {
+              return http.Response(
+                jsonEncode({
+                  'error': 'Another consumption is in progress; retry',
+                  'code': InviteApiErrorCode.tooManyRequests,
+                  'status': 429,
+                  'retryable': true,
+                  'retryAfterSeconds': 0,
+                }),
+                429,
+              );
+            }
+            return http.Response(
+              jsonEncode({
+                'message': 'Welcome to diVine!',
+                'codesAllocated': 5,
+              }),
+              200,
+            );
+          }),
+        );
+
+        final result = await retryingClient.consumeInvite('lele-pons');
+
+        expect(result.codesAllocated, 5);
+        expect(attempts, 2);
+      },
+    );
+
+    test(
       'surfaces consumeInvite timeout failures with a structured code',
       () async {
         when(


### PR DESCRIPTION
## Description

Retries transient invite redemption failures inside InviteApiClient._consumeInvite, using Darshan retryable response field and Retry-After / retryAfterSeconds hints before surfacing an activation error.

This covers creator-code claim-lock responses such as 429 too_many_requests / Another consumption is in progress; retry for all mobile consume paths: anonymous key creation, OAuth/session completion, and email verification.

**Related Issue:** Relates to #3795

## Out of Scope

None.

## Verification

- flutter test test/src/invite_api_client_test.dart from mobile/packages/invite_api_client (red before fix, green after)
- flutter test test/src/invite_api_client_test.dart test/src/invite_api_exception_test.dart test/src/invite_models_test.dart from mobile/packages/invite_api_client
- flutter test test/blocs/email_verification/email_verification_cubit_test.dart test/blocs/divine_auth/divine_auth_cubit_test.dart test/utils/invite_error_utils_test.dart from mobile
- flutter analyze from mobile/packages/invite_api_client
- flutter analyze from mobile
- pre-push hook: changed-file analyzer and packages/invite_api_client/test/src/invite_api_client_test.dart

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
