### PR TITLE
feat(collabs): preview videos in invite cards

### DIFF
--- a/docs/superpowers/plans/2026-05-15-collab-invite-video-preview.md
+++ b/docs/superpowers/plans/2026-05-15-collab-invite-video-preview.md
@@ -1,0 +1,461 @@
+# Collaborator Invite Video Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace text-only collaborator invite cards with inline video preview cards whose actions clearly mean "co-post this video" or "this is not mine."
+
+**Architecture:** Keep the existing structured invite parser, `CollaboratorInviteCard`, and `CollaboratorInviteActionsCubit`. Add sender display-name context from the conversation/request preview owners, render a stable portrait thumbnail card when `thumb` exists, and keep the current compact non-thumbnail fallback.
+
+**Tech Stack:** Flutter/Dart, `flutter_test`, `mocktail`, `flutter_bloc`, `go_router`, `divine_ui`, Flutter gen-l10n, existing `VineCachedImage` image cache.
+
+---
+
+## File Structure
+
+- Modify `mobile/test/screens/inbox/conversation/conversation_view_test.dart`: add recipient-side thumbnail/copy assertions and update action-copy expectations.
+- Modify `mobile/test/screens/inbox/message_requests/request_preview_view_test.dart`: add request-preview assertions for thumbnail/copy and update action-copy expectations.
+- Modify `mobile/lib/screens/inbox/conversation/conversation_view.dart`: pass resolved participant display name into `_MessageList`, then into `CollaboratorInviteCard`.
+- Modify `mobile/lib/screens/inbox/message_requests/request_preview_view.dart`: pass resolved display name into `_InvitePreview`, then into `CollaboratorInviteCard`.
+- Modify `mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart`: add thumbnail-first card layout, fallback copy, `senderDisplayName`, new action labels, and existing state behavior.
+- Modify `mobile/lib/l10n/app_en.arb`: add new copy keys while preserving old status keys.
+- Generated `mobile/lib/l10n/generated/*.dart`: regenerate with `flutter gen-l10n`.
+
+## Task 1: Conversation Tests For Thumbnail-First Recipient Card
+
+**Files:**
+- Modify: `mobile/test/screens/inbox/conversation/conversation_view_test.dart`
+
+- [ ] **Step 1: Add failing recipient-card test**
+
+In the existing `group(ConversationView, ...)`, in the loaded-message tests near `renders collaborator invite card instead of plaintext invite copy`, add this test:
+
+```dart
+testWidgets(
+  'renders collaborator invite as an inline video preview with co-post actions',
+  (tester) async {
+    const thumbnailUrl = 'https://cdn.divine.video/thumbs/skate-loop.jpg';
+    final message = DmMessage(
+      id: '9999999999999999999999999999999999999999999999999999999999999999',
+      conversationId:
+          'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+      senderPubkey: otherPubkey,
+      content: 'You were invited to collaborate.',
+      createdAt: now.millisecondsSinceEpoch ~/ 1000,
+      giftWrapId:
+          'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+      tags: const [
+        ['divine', 'collab-invite'],
+        [
+          'a',
+          '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
+          'wss://relay.divine.video',
+        ],
+        ['p', otherPubkey],
+        ['role', 'Collaborator'],
+        ['title', 'Skate loop'],
+        ['thumb', thumbnailUrl],
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildSubject(
+        state: ConversationState(
+          status: ConversationStatus.loaded,
+          messages: [message],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Co-post invite'), findsOneWidget);
+    expect(find.textContaining('Skate loop'), findsOneWidget);
+    expect(
+      find.text(
+        'Co-posting adds this video to your timeline as a collaboration.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Co-post'), findsOneWidget);
+    expect(find.text('Not mine'), findsOneWidget);
+    expect(find.text(l10n.inboxCollabInviteAcceptButton), findsNothing);
+    expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsNothing);
+    expect(find.byKey(const ValueKey('collaborator_invite_thumbnail')), findsOneWidget);
+
+    await tester.tap(find.text('Co-post'));
+    await tester.pump();
+
+    verify(
+      () => mockInviteActionsCubit.acceptInvite(any()),
+    ).called(1);
+  },
+);
+```
+
+- [ ] **Step 2: Update existing action-copy assertions**
+
+In the existing recipient invite test, replace:
+
+```dart
+expect(find.text(l10n.inboxCollabInviteAcceptButton), findsOneWidget);
+expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsOneWidget);
+...
+await tester.tap(find.text(l10n.inboxCollabInviteAcceptButton));
+```
+
+with:
+
+```dart
+expect(find.text('Co-post'), findsOneWidget);
+expect(find.text('Not mine'), findsOneWidget);
+...
+await tester.tap(find.text('Co-post'));
+```
+
+Keep the sender-side test assertions that recipient actions are absent, but update them to assert:
+
+```dart
+expect(find.text('Co-post'), findsNothing);
+expect(find.text('Not mine'), findsNothing);
+```
+
+- [ ] **Step 3: Run conversation red test**
+
+Run:
+
+```bash
+cd mobile
+flutter test --no-pub test/screens/inbox/conversation/conversation_view_test.dart --plain-name "inline video preview"
+```
+
+Expected: FAIL because the current card does not render `Co-post`, `Not mine`, the consequence line, or `collaborator_invite_thumbnail`.
+
+## Task 2: Request Preview Tests For Reused Card Behavior
+
+**Files:**
+- Modify: `mobile/test/screens/inbox/message_requests/request_preview_view_test.dart`
+
+- [ ] **Step 1: Add thumbnail tag to the existing invite request message**
+
+In the existing request-preview collaborator invite test, add:
+
+```dart
+['thumb', 'https://cdn.divine.video/thumbs/skate-loop.jpg'],
+```
+
+to the invite message tags after the `title` tag.
+
+- [ ] **Step 2: Update assertions to new copy and thumbnail behavior**
+
+Replace:
+
+```dart
+expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
+expect(find.text(l10n.inboxCollabInviteAcceptButton), findsOneWidget);
+expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsOneWidget);
+...
+await tester.ensureVisible(
+  find.text(l10n.inboxCollabInviteIgnoreButton),
+);
+await tester.pump();
+await tester.tap(find.text(l10n.inboxCollabInviteIgnoreButton));
+```
+
+with:
+
+```dart
+expect(find.text('Co-post invite'), findsOneWidget);
+expect(find.text('Co-post'), findsOneWidget);
+expect(find.text('Not mine'), findsOneWidget);
+expect(find.byKey(const ValueKey('collaborator_invite_thumbnail')), findsOneWidget);
+expect(
+  find.text(
+    'Co-posting adds this video to your timeline as a collaboration.',
+  ),
+  findsOneWidget,
+);
+...
+await tester.ensureVisible(find.text('Not mine'));
+await tester.pump();
+await tester.tap(find.text('Not mine'));
+```
+
+- [ ] **Step 3: Run request-preview red test**
+
+Run:
+
+```bash
+cd mobile
+flutter test --no-pub test/screens/inbox/message_requests/request_preview_view_test.dart --plain-name "collaborator invite"
+```
+
+Expected: FAIL because the current card still renders the text-only invite and old action labels.
+
+## Task 3: L10n Keys And Generated Accessors
+
+**Files:**
+- Modify: `mobile/lib/l10n/app_en.arb`
+- Generated: `mobile/lib/l10n/generated/*.dart`
+
+- [ ] **Step 1: Add English ARB keys**
+
+In `mobile/lib/l10n/app_en.arb`, near the existing `inboxCollabInvite*` keys, add:
+
+```json
+"inboxCollabInviteCoPostButton": "Co-post",
+"@inboxCollabInviteCoPostButton": {
+  "description": "Primary action on a collaborator invite card. Accepts the invite and co-posts the video to the recipient's timeline as a collaboration."
+},
+"inboxCollabInviteNotMineButton": "Not mine",
+"@inboxCollabInviteNotMineButton": {
+  "description": "Secondary action on a collaborator invite card. Ignores the invite because the recipient does not claim the video as their collaboration."
+},
+"inboxCollabInvitePreviewTitle": "Co-post invite",
+"@inboxCollabInvitePreviewTitle": {
+  "description": "Header label shown over the video preview on a collaborator invite card."
+},
+"inboxCollabInvitePreviewTitleFrom": "Co-post invite from {displayName}",
+"@inboxCollabInvitePreviewTitleFrom": {
+  "description": "Header label shown over the video preview on a collaborator invite card when the inviter's display name is known.",
+  "placeholders": {
+    "displayName": {
+      "type": "String"
+    }
+  }
+},
+"inboxCollabInviteTimelineConsequence": "Co-posting adds this video to your timeline as a collaboration.",
+"@inboxCollabInviteTimelineConsequence": {
+  "description": "Explains what accepting a collaborator invite does."
+},
+```
+
+- [ ] **Step 2: Regenerate l10n**
+
+Run:
+
+```bash
+cd mobile
+flutter gen-l10n
+```
+
+Expected: no errors, generated files under `mobile/lib/l10n/generated/` update.
+
+## Task 4: Implement Inline Video Preview Card
+
+**Files:**
+- Modify: `mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart`
+- Modify: `mobile/lib/screens/inbox/conversation/conversation_view.dart`
+- Modify: `mobile/lib/screens/inbox/message_requests/request_preview_view.dart`
+
+- [ ] **Step 1: Extend `CollaboratorInviteCard` API**
+
+Change the constructor to accept optional sender context:
+
+```dart
+const CollaboratorInviteCard({
+  required this.invite,
+  required this.isSent,
+  this.senderDisplayName,
+  super.key,
+});
+
+final String? senderDisplayName;
+```
+
+Pass `senderDisplayName` into `_CardChrome`.
+
+- [ ] **Step 2: Pass display name from owners**
+
+In `ConversationView`, pass `displayName` to `_MessageList`:
+
+```dart
+_MessageList(
+  messages: selected.messages,
+  currentPubkey: currentPubkey,
+  senderDisplayName: displayName,
+),
+```
+
+Update `_MessageList`:
+
+```dart
+const _MessageList({
+  required this.messages,
+  required this.currentPubkey,
+  required this.senderDisplayName,
+});
+
+final String senderDisplayName;
+```
+
+When rendering the invite:
+
+```dart
+return CollaboratorInviteCard(
+  invite: invite,
+  isSent: isSent,
+  senderDisplayName: isSent ? null : senderDisplayName,
+);
+```
+
+In `RequestPreviewView`, pass `displayName` into `_InvitePreview` and then into `CollaboratorInviteCard`.
+
+- [ ] **Step 3: Add thumbnail rendering helpers**
+
+In `collaborator_invite_card.dart`, import:
+
+```dart
+import 'package:openvine/widgets/vine_cached_image.dart';
+```
+
+Add helper getters/methods to `_CardChrome`:
+
+```dart
+String? get _thumbnailUrl {
+  final value = invite.thumbnailUrl?.trim();
+  return value == null || value.isEmpty ? null : value;
+}
+
+String _previewTitle(BuildContext context) {
+  final name = senderDisplayName?.trim();
+  if (name != null && name.isNotEmpty) {
+    return context.l10n.inboxCollabInvitePreviewTitleFrom(name);
+  }
+  return context.l10n.inboxCollabInvitePreviewTitle;
+}
+```
+
+- [ ] **Step 4: Render thumbnail-first content**
+
+Inside `_CardChrome.build`, keep the existing outer padding/alignment/GestureDetector, but replace the inner column with:
+
+```dart
+child: _thumbnailUrl == null
+    ? _FallbackInviteContent(
+        title: _titleText(context),
+        previewTitle: _previewTitle(context),
+        action: action,
+      )
+    : _ThumbnailInviteContent(
+        thumbnailUrl: _thumbnailUrl!,
+        title: _titleText(context),
+        previewTitle: _previewTitle(context),
+        action: action,
+      ),
+```
+
+Create `_ThumbnailInviteContent` with a stable portrait `AspectRatio`, `VineCachedImage`, overlay text, and the action below the preview. Give the image wrapper this key:
+
+```dart
+key: const ValueKey('collaborator_invite_thumbnail'),
+```
+
+Create `_FallbackInviteContent` with the same `previewTitle`, title, consequence line, and action.
+
+- [ ] **Step 5: Update action labels**
+
+In `_ActionRow`, replace:
+
+```dart
+label: l10n.inboxCollabInviteAcceptButton,
+...
+label: l10n.inboxCollabInviteIgnoreButton,
+```
+
+with:
+
+```dart
+label: l10n.inboxCollabInviteCoPostButton,
+...
+label: l10n.inboxCollabInviteNotMineButton,
+```
+
+Keep the existing accept/ignore cubit calls unchanged.
+
+- [ ] **Step 6: Run green tests**
+
+Run:
+
+```bash
+cd mobile
+flutter test --no-pub test/screens/inbox/conversation/conversation_view_test.dart --plain-name "collaborator invite"
+flutter test --no-pub test/screens/inbox/message_requests/request_preview_view_test.dart --plain-name "collaborator invite"
+```
+
+Expected: both commands PASS.
+
+## Task 5: Format, Analyze, And Commit Implementation
+
+**Files:**
+- Modify/test files from Tasks 1-4.
+
+- [ ] **Step 1: Format touched Dart files**
+
+Run:
+
+```bash
+cd mobile
+dart format \
+  lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart \
+  lib/screens/inbox/conversation/conversation_view.dart \
+  lib/screens/inbox/message_requests/request_preview_view.dart \
+  test/screens/inbox/conversation/conversation_view_test.dart \
+  test/screens/inbox/message_requests/request_preview_view_test.dart \
+  lib/l10n/generated/app_localizations.dart \
+  lib/l10n/generated/app_localizations_en.dart
+```
+
+Expected: formatter exits 0.
+
+- [ ] **Step 2: Run focused analyzer**
+
+Run:
+
+```bash
+cd mobile
+flutter analyze \
+  lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart \
+  lib/screens/inbox/conversation/conversation_view.dart \
+  lib/screens/inbox/message_requests/request_preview_view.dart \
+  test/screens/inbox/conversation/conversation_view_test.dart \
+  test/screens/inbox/message_requests/request_preview_view_test.dart
+```
+
+Expected: no issues for these files.
+
+- [ ] **Step 3: Run final focused tests**
+
+Run:
+
+```bash
+cd mobile
+flutter test --no-pub test/screens/inbox/conversation/conversation_view_test.dart --plain-name "collaborator invite"
+flutter test --no-pub test/screens/inbox/message_requests/request_preview_view_test.dart --plain-name "collaborator invite"
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 4: Review and commit**
+
+Run:
+
+```bash
+git diff --stat
+git status --short
+```
+
+Stage only the plan, implementation, tests, ARB, and generated l10n files:
+
+```bash
+git add \
+  docs/superpowers/plans/2026-05-15-collab-invite-video-preview.md \
+  mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart \
+  mobile/lib/screens/inbox/conversation/conversation_view.dart \
+  mobile/lib/screens/inbox/message_requests/request_preview_view.dart \
+  mobile/lib/l10n/app_en.arb \
+  mobile/lib/l10n/generated/ \
+  mobile/test/screens/inbox/conversation/conversation_view_test.dart \
+  mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+git commit -m "feat(collabs): preview videos in invite cards"
+```
+
+Expected: commit succeeds.

--- a/docs/superpowers/specs/2026-05-15-collab-invite-video-preview-design.md
+++ b/docs/superpowers/specs/2026-05-15-collab-invite-video-preview-design.md
@@ -1,0 +1,132 @@
+# Collaborator Invite Video Preview Design
+
+## Goal
+
+Make collaborator invites understandable at the moment of decision. A recipient
+should be able to see the invited video and understand that accepting will
+co-post that video to their own timeline as a collaboration.
+
+The current card exposes the mechanics of an invite but hides the object being
+accepted. That makes "Accept" ambiguous and pushes users to decide from title
+text alone, often "Untitled video".
+
+## Decision
+
+Use an inline video preview card in the DM thread and message-request preview.
+The video preview is the primary visual element, with the collaboration decision
+attached directly below it.
+
+Approved direction: **Inline Video Card**.
+
+## Product Semantics
+
+This is a collaboration, not a repost. The card copy must describe the action
+as co-posting the creator's video as a collaboration:
+
+- Primary action: `Co-post`
+- Secondary action: `Not mine`
+- Context line: `Co-post invite from @displayName`
+- Consequence line: `Co-posting adds this video to your timeline as a collaboration.`
+
+The exact display name should use the best available sender/profile name from
+the surrounding conversation context. If the card cannot resolve a name, it may
+fall back to the existing generic invite label, but it must not truncate Nostr
+IDs in logs, tests, or debug output.
+
+## UX Shape
+
+The recipient-side card contains:
+
+1. A large portrait thumbnail/preview area when
+   `CollaboratorInvite.thumbnailUrl` is present. Use a stable aspect ratio
+   close to the existing video-card proportions so the card does not resize
+   after image load.
+2. A play affordance over the thumbnail. Tapping the preview opens the existing
+   video detail route so the user can watch the video before deciding.
+3. Overlay text on the preview: invite context, video title, and the consequence
+   line.
+4. Inline actions below the preview: `Co-post` and `Not mine`.
+5. Existing status states after action: accepted, ignored, accepting, failed.
+
+If `thumbnailUrl` is missing, the card must keep a compact fallback that still
+shows the title or "Untitled video", the consequence line, and the same action
+labels. Missing thumbnails must not block invite handling.
+
+Sender-side cards remain static. They should not expose recipient actions.
+
+## Architecture
+
+Keep the change in the existing collaborator invite surface:
+
+- `CollaboratorInviteParser` remains the source for structured invite metadata.
+- `CollaboratorInviteCard` remains the reusable widget for conversation and
+  message-request surfaces.
+- `CollaboratorInviteActionsCubit` remains the owner of accept/ignore local
+  state.
+- `CollaboratorResponseService` remains the publish path for accepting.
+- `VideoDetailScreen.pathForId(invite.videoAddress)` remains the review route.
+
+No new flow, modal, or full-screen review gate is needed. Inline acceptance is
+allowed because the card itself provides enough video context and still supports
+tap-through review.
+
+## Data Flow
+
+1. NIP-17 DM arrives with structured collaborator invite tags.
+2. `CollaboratorInviteParser.parse` extracts `title`, `thumbnailUrl`,
+   `videoAddress`, `creatorPubkey`, `role`, and relay metadata.
+3. Conversation and request-preview surfaces render `CollaboratorInviteCard`.
+4. The card renders thumbnail-first UI when `thumbnailUrl` is non-empty.
+5. `Co-post` calls the existing accept action.
+6. `Not mine` calls the existing ignore action.
+7. Accepted/ignored/failed states render in place.
+
+## Error Handling And Fallbacks
+
+- Thumbnail loading failure: show the non-thumbnail card content and keep the
+  actions available.
+- Missing title: show the existing localized "Untitled video" fallback.
+- Accept failure: preserve the current failed state and retry affordance.
+- Accept in progress: disable both actions and show loading on the primary
+  action as the current card does.
+- Sender-side invite: show sent/static state, no `Co-post` or `Not mine`.
+
+## Copy And Localization
+
+Add or update localized strings for the new English source copy, then regenerate
+localizations as the repo normally requires:
+
+- `Co-post`
+- `Not mine`
+- `Co-post invite`
+- `Co-post invite from {name}`
+- `Co-posting adds this video to your timeline as a collaboration.`
+
+Existing translations may initially mirror English where the repo's current l10n
+workflow does that, but generated localization outputs must be committed if
+source ARB changes require it.
+
+## Testing
+
+Focused tests should cover:
+
+- Recipient card renders a large thumbnail preview when invite tags include
+  `thumb`.
+- Recipient card falls back cleanly when `thumb` is absent.
+- Primary action still calls `acceptInvite`.
+- Secondary action still calls `ignoreInvite`.
+- Sender-side card does not render recipient actions.
+- Message-request preview reuses the same card behavior.
+- Tapping the preview/card still opens the video detail route.
+
+Widget tests should assert user-visible behavior rather than internal layout
+details, but they should verify that the thumbnail path is present in the widget
+tree when available.
+
+## Out Of Scope
+
+- New protocol tags.
+- A full-screen mandatory review gate.
+- Playback inside the card beyond a thumbnail/play affordance.
+- Changes to collaborator acceptance semantics.
+- Feed/profile read-model changes.

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -436,16 +436,16 @@
     "profileSetupNip05AddressLabel": "NIP-05 አድራሻ",
     "profileSetupExternalNip05InvalidFormat": "ልክ ያልሆነ NIP-05 ቅርጸት (ለምሳሌ name@domain.com)",
     "profileSetupExternalNip05DivineDomain": "ለdivine.video ከላይ ያለውን የተጠቃሚ ስም መስክ ይጠቀሙ",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "profileSetupProfilePicturePreview": "የመገለጫ ስዕል ቅድመ እይታ",
     "nostrInfoIntroBuiltOn": "ዳይቪን የተገነባው በNostr ላይ ነው፣",
     "nostrInfoIntroDescription": "ሳንሱርን የሚቋቋም ክፍት ፕሮቶኮል ሰዎች በአንድ ኩባንያ ወይም መድረክ ላይ ሳይመሰረቱ በመስመር ላይ እንዲግባቡ ያስችላቸዋል።",
@@ -2619,22 +2619,16 @@
     "@inboxCollabInviteCardTitle": {
         "description": "Header label on a collaborator invite card in the DM conversation."
     },
-    "inboxCollabInviteCardRoleLabel": "{role} በዚህ ልጥፍ ላይ",
-    "@inboxCollabInviteCardRoleLabel": {
-        "description": "Subtitle on the collaborator invite card describing the offered collaborator role.",
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardUntitledVideo": "ርዕስ የሌለው ቪዲዮ",
     "clickableTextViewVideoLink": "ቪዲዮውን ይመልከቱ",
     "messageExternalLinkDialogTitle": "ውጫዊ ሊንክ ይክፈቱ?",
     "messageExternalLinkDialogBody": "ይህ ሊንክ ወደ ውጫዊ ድረ-ገጽ ይሄዳል እና ደህንነቱ አልተረጋገጠም:\n\n{url}",
     "messageExternalLinkDialogOpen": "ክፈት",
-    "inboxCollabInviteAcceptButton": "ተቀበል",
-    "inboxCollabInviteIgnoreButton": "ችላ በል",
+    "inboxCollabInviteCoPostButton": "አብረህ ለጥፍ",
+    "inboxCollabInviteNotMineButton": "የኔ አይደለም",
+    "inboxCollabInvitePreviewTitle": "የጋራ ልጥፍ ግብዣ",
+    "inboxCollabInvitePreviewTitleFrom": "ከ{displayName} የጋራ ልጥፍ ግብዣ",
+    "inboxCollabInviteTimelineConsequence": "አብሮ መለጠፍ ይህን ቪዲዮ እንደ ትብብር ወደ የጊዜ መስመርህ ያክለዋል።",
     "inboxCollabInviteAcceptedStatus": "ተቀባይነት አግኝቷል",
     "inboxCollabInviteIgnoredStatus": "ችላ ተብሏል",
     "inboxCollabInviteAcceptError": "መቀበል አልተቻለም። እንደገና ይሞክሩ።",
@@ -3602,8 +3596,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "የተረጋገጡ መለያዎች",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2298,19 +2298,14 @@
     "messageExternalLinkDialogTitle": "فتح رابط خارجي؟",
     "messageExternalLinkDialogBody": "هذا الرابط يذهب إلى موقع خارجي وقد لا يكون آمنًا:\n\n{url}",
     "messageExternalLinkDialogOpen": "فتح",
-    "inboxCollabInviteAcceptButton": "قبول",
+    "inboxCollabInviteCoPostButton": "نشر مشترك",
+    "inboxCollabInviteNotMineButton": "ليس لي",
+    "inboxCollabInvitePreviewTitle": "دعوة نشر مشترك",
+    "inboxCollabInvitePreviewTitleFrom": "دعوة نشر مشترك من {displayName}",
+    "inboxCollabInviteTimelineConsequence": "سيضيف النشر المشترك هذا الفيديو إلى يومياتك كتعاون.",
     "inboxCollabInviteAcceptError": "تعذر القبول. حاول مرة أخرى.",
     "inboxCollabInviteAcceptedStatus": "تم القبول",
-    "inboxCollabInviteCardRoleLabel": "{role} على هذا المنشور",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "دعوة للتعاون",
-    "inboxCollabInviteIgnoreButton": "تجاهل",
     "inboxCollabInviteIgnoredStatus": "تم التجاهل",
     "inboxConversationCollabInvitePreview": "دعوة للتعاون",
     "@inboxConversationCollabInvitePreview": {
@@ -3138,16 +3133,16 @@
     "profileSetupImagesTypeGroup": "صور",
     "profileSetupExternalNip05InvalidFormat": "صيغة NIP-05 غير صالحة (مثال: name@domain.com)",
     "profileSetupExternalNip05DivineDomain": "استخدم حقل اسم المستخدم أعلاه لـ divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "الإبلاغ عن المحتوى",
     "contentWarningBlockUserTooltip": "حظر المستخدم",
     "contentWarningBlockedTitle": "تم حظر المحتوى",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "الحسابات الموثّقة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2483,22 +2483,16 @@
     "@inboxCollabInviteCardTitle": {
         "description": "Header label on a collaborator invite card in the DM conversation."
     },
-    "inboxCollabInviteCardRoleLabel": "{role} на тази публикация",
-    "@inboxCollabInviteCardRoleLabel": {
-        "description": "Subtitle on the collaborator invite card describing the offered collaborator role.",
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardUntitledVideo": "Видео без заглавие",
     "clickableTextViewVideoLink": "Виж видеото",
     "messageExternalLinkDialogTitle": "Да се отвори ли външен линк?",
     "messageExternalLinkDialogBody": "Този линк води към външен сайт и може да не е безопасен:\n\n{url}",
     "messageExternalLinkDialogOpen": "Отвори",
-    "inboxCollabInviteAcceptButton": "Приеми",
-    "inboxCollabInviteIgnoreButton": "Игнорирайте",
+    "inboxCollabInviteCoPostButton": "Съвместна публикация",
+    "inboxCollabInviteNotMineButton": "Не е мое",
+    "inboxCollabInvitePreviewTitle": "Покана за съвместна публикация",
+    "inboxCollabInvitePreviewTitleFrom": "Покана за съвместна публикация от {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Съвместното публикуване добавя това видео към хронологията ти като сътрудничество.",
     "inboxCollabInviteAcceptedStatus": "Прието",
     "inboxCollabInviteIgnoredStatus": "Игнорирани",
     "inboxCollabInviteAcceptError": "Не успяхме да приемем. Опитай пак.",
@@ -3293,16 +3287,16 @@
     "profileSetupImagesTypeGroup": "снимки",
     "profileSetupExternalNip05InvalidFormat": "Невалиден NIP-05 формат (напр. name@domain.com)",
     "profileSetupExternalNip05DivineDomain": "За divine.video използвай полето за потребителско име по-горе",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Докладвай съдържанието",
     "contentWarningBlockUserTooltip": "Блокирай потребителя",
     "contentWarningBlockedTitle": "Съдържанието е блокирано",
@@ -3408,8 +3402,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Потвърдени акаунти",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Externen Link öffnen?",
     "messageExternalLinkDialogBody": "Dieser Link führt zu einer externen Website und ist möglicherweise nicht sicher:\n\n{url}",
     "messageExternalLinkDialogOpen": "Öffnen",
-    "inboxCollabInviteAcceptButton": "Annehmen",
+    "inboxCollabInviteCoPostButton": "Mitposten",
+    "inboxCollabInviteNotMineButton": "Nicht meins",
+    "inboxCollabInvitePreviewTitle": "Einladung zum Mitposten",
+    "inboxCollabInvitePreviewTitleFrom": "Einladung zum Mitposten von {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Mitposten fügt dieses Video als Zusammenarbeit zu deiner Timeline hinzu.",
     "inboxCollabInviteAcceptError": "Annahme fehlgeschlagen. Erneut versuchen.",
     "inboxCollabInviteAcceptedStatus": "Angenommen",
-    "inboxCollabInviteCardRoleLabel": "{role} bei diesem Beitrag",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Einladung zur Zusammenarbeit",
-    "inboxCollabInviteIgnoreButton": "Ignorieren",
     "inboxCollabInviteIgnoredStatus": "Ignoriert",
     "inboxConversationCollabInvitePreview": "Einladung zur Zusammenarbeit",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "Bilder",
     "profileSetupExternalNip05InvalidFormat": "Ungültiges NIP-05-Format (z. B. name@domain.com)",
     "profileSetupExternalNip05DivineDomain": "Nutz das Nutzernamen-Feld oben für divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Inhalt melden",
     "contentWarningBlockUserTooltip": "Nutzer blockieren",
     "contentWarningBlockedTitle": "Inhalt blockiert",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Verifizierte Konten",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2809,15 +2809,6 @@
   "@inboxCollabInviteCardTitle": {
     "description": "Header label on a collaborator invite card in the DM conversation."
   },
-  "inboxCollabInviteCardRoleLabel": "{role} on this post",
-  "@inboxCollabInviteCardRoleLabel": {
-    "description": "Subtitle on the collaborator invite card describing the offered collaborator role.",
-    "placeholders": {
-      "role": {
-        "type": "String"
-      }
-    }
-  },
   "inboxCollabInviteCardUntitledVideo": "Untitled video",
   "@inboxCollabInviteCardUntitledVideo": {
     "description": "Fallback shown as the collaborator invite card title when the invited video has no title. Avoids exposing the raw d-tag identifier."
@@ -2869,8 +2860,6 @@
   "@inboxCollabInviteTimelineConsequence": {
     "description": "Explains what accepting a collaborator invite does."
   },
-  "inboxCollabInviteAcceptButton": "Accept",
-  "inboxCollabInviteIgnoreButton": "Ignore",
   "inboxCollabInviteAcceptedStatus": "Accepted",
   "inboxCollabInviteIgnoredStatus": "Ignored",
   "inboxCollabInviteAcceptError": "Could not accept. Try again.",
@@ -2922,7 +2911,6 @@
   "@dmConversationLoadError": {
     "description": "Error text shown in place of the message list when DmRepository.watchMessages emits an error (e.g. local DB read failure). Distinct from send failures (which use `dmSendFailedMessage`)."
   },
-
   "dmMessageInputHint": "Say something…",
   "@dmMessageInputHint": {
     "description": "Placeholder text shown inside the compose field at the bottom of a DM conversation when the user hasn't typed anything yet."
@@ -2963,7 +2951,10 @@
   "@inboxConversationTileLabel": {
     "description": "Accessibility label for a conversation row in the inbox list, read by screen readers when the row receives focus. Use the other participant's display name.",
     "placeholders": {
-      "displayName": { "type": "String", "example": "Alice" }
+      "displayName": {
+        "type": "String",
+        "example": "Alice"
+      }
     }
   },
   "inboxConversationTileLongPressHint": "Show conversation actions",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2844,6 +2844,31 @@
   "@messageExternalLinkDialogOpen": {
     "description": "Confirmation button that opens an untrusted external URL from a DM."
   },
+  "inboxCollabInviteCoPostButton": "Co-post",
+  "@inboxCollabInviteCoPostButton": {
+    "description": "Primary action on a collaborator invite card. Accepts the invite and co-posts the video to the recipient's timeline as a collaboration."
+  },
+  "inboxCollabInviteNotMineButton": "Not mine",
+  "@inboxCollabInviteNotMineButton": {
+    "description": "Secondary action on a collaborator invite card. Ignores the invite because the recipient does not claim the video as their collaboration."
+  },
+  "inboxCollabInvitePreviewTitle": "Co-post invite",
+  "@inboxCollabInvitePreviewTitle": {
+    "description": "Header label shown over the video preview on a collaborator invite card."
+  },
+  "inboxCollabInvitePreviewTitleFrom": "Co-post invite from {displayName}",
+  "@inboxCollabInvitePreviewTitleFrom": {
+    "description": "Header label shown over the video preview on a collaborator invite card when the inviter's display name is known.",
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
+  "inboxCollabInviteTimelineConsequence": "Co-posting adds this video to your timeline as a collaboration.",
+  "@inboxCollabInviteTimelineConsequence": {
+    "description": "Explains what accepting a collaborator invite does."
+  },
   "inboxCollabInviteAcceptButton": "Accept",
   "inboxCollabInviteIgnoreButton": "Ignore",
   "inboxCollabInviteAcceptedStatus": "Accepted",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2310,19 +2310,14 @@
     "messageExternalLinkDialogTitle": "¿Abrir enlace externo?",
     "messageExternalLinkDialogBody": "Este enlace lleva a un sitio externo y puede no ser seguro:\n\n{url}",
     "messageExternalLinkDialogOpen": "Abrir",
-    "inboxCollabInviteAcceptButton": "Aceptar",
+    "inboxCollabInviteCoPostButton": "Co-publicar",
+    "inboxCollabInviteNotMineButton": "No es mío",
+    "inboxCollabInvitePreviewTitle": "Invitación para co-publicar",
+    "inboxCollabInvitePreviewTitleFrom": "Invitación para co-publicar de {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Co-publicar añade este video a tu línea de tiempo como colaboración.",
     "inboxCollabInviteAcceptError": "No se pudo aceptar. Inténtalo de nuevo.",
     "inboxCollabInviteAcceptedStatus": "Aceptada",
-    "inboxCollabInviteCardRoleLabel": "{role} en esta publicación",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Invitación a colaborar",
-    "inboxCollabInviteIgnoreButton": "Ignorar",
     "inboxCollabInviteIgnoredStatus": "Ignorada",
     "inboxConversationCollabInvitePreview": "Invitación a colaborar",
     "@inboxConversationCollabInvitePreview": {
@@ -3153,16 +3148,16 @@
     "profileSetupImagesTypeGroup": "imágenes",
     "profileSetupExternalNip05InvalidFormat": "Formato NIP-05 inválido (ej., nombre@dominio.com)",
     "profileSetupExternalNip05DivineDomain": "Usá el campo de nombre de usuario de arriba para divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Reportar contenido",
     "contentWarningBlockUserTooltip": "Bloquear usuario",
     "contentWarningBlockedTitle": "Contenido bloqueado",
@@ -3277,8 +3272,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Cuentas verificadas",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -216,18 +216,18 @@
     "profileSetupSelectButton": "Piliin",
     "profileSetupUseOwnNip05": "Gamitin ang sarili mong NIP-05 address",
     "profileSetupNip05AddressLabel": "NIP-05 Address",
-"profileSetupExternalNip05InvalidFormat": "Invalid na NIP-05 format (hal. name@domain.com)",
-"profileSetupExternalNip05DivineDomain": "Gamitin ang username field sa itaas para sa divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Gamitin ang divine.video username mo, o ituro ang handle mo sa isang NIP-05 address sa domain na kontrolado mo.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "I-save ang NIP-05",
-"nostrSettingsNip05Saved": "Naisave ang NIP-05",
-"nostrSettingsNip05SaveFailed": "Hindi na-save ang NIP-05. Pakisubukan ulit.",
-"profileSetupNip05ConfirmTitle": "Gamitin ang sarili mong NIP-05?",
-"profileSetupNip05ConfirmBody": "Ini-uugnay ng NIP-05 ang pangalang gaya ng you@yourdomain.com sa iyong Nostr identity. Kailangan mong kontrolado ang domain at naka-host ang verification file sa tamang path. Kapag mali ito, hindi ka mahahanap ng mga tao at mawawala ang verified handle mo. Magpatuloy lang kung na-set up mo na ito.",
-"profileSetupNip05ConfirmContinue": "Magpatuloy",
-"profileSetupNip05ConfirmCancel": "Kanselahin",
+    "profileSetupExternalNip05InvalidFormat": "Invalid NIP-05 format (hal., name@domain.com)",
+    "profileSetupExternalNip05DivineDomain": "Gamitin ang username field sa itaas para sa divine.video",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Gamitin ang divine.video username mo, o ituro ang handle mo sa isang NIP-05 address sa domain na kontrolado mo.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "I-save ang NIP-05",
+    "nostrSettingsNip05Saved": "Naisave ang NIP-05",
+    "nostrSettingsNip05SaveFailed": "Hindi na-save ang NIP-05. Pakisubukan ulit.",
+    "profileSetupNip05ConfirmTitle": "Gamitin ang sarili mong NIP-05?",
+    "profileSetupNip05ConfirmBody": "Ini-uugnay ng NIP-05 ang pangalang gaya ng you@yourdomain.com sa iyong Nostr identity. Kailangan mong kontrolado ang domain at naka-host ang verification file sa tamang path. Kapag mali ito, hindi ka mahahanap ng mga tao at mawawala ang verified handle mo. Magpatuloy lang kung na-set up mo na ito.",
+    "profileSetupNip05ConfirmContinue": "Magpatuloy",
+    "profileSetupNip05ConfirmCancel": "Kanselahin",
     "profileSetupProfilePicturePreview": "Preview ng profile picture",
     "videoMetadataShareReplyToFeedTitle": "Ibahagi rin sa feed ko",
     "videoMetadataShareReplyToFeedSubtitle": "Kapag naka-off, sa thread lang ng komento mananatili ang video na ito.",
@@ -1434,14 +1434,16 @@
     "inboxConversationMuted": "Na-mute ang conversation",
     "inboxConversationUnmuted": "Na-unmute ang conversation",
     "inboxCollabInviteCardTitle": "Imbitasyon bilang collaborator",
-    "inboxCollabInviteCardRoleLabel": "{role} sa post na ito",
     "inboxCollabInviteCardUntitledVideo": "Video na walang pamagat",
     "clickableTextViewVideoLink": "Tingnan ang video",
     "messageExternalLinkDialogTitle": "Buksan ang external na link?",
     "messageExternalLinkDialogBody": "Papunta ang link na ito sa isang external na site at baka hindi ito ligtas:\n\n{url}",
     "messageExternalLinkDialogOpen": "Buksan",
-    "inboxCollabInviteAcceptButton": "Tanggapin",
-    "inboxCollabInviteIgnoreButton": "Balewalain",
+    "inboxCollabInviteCoPostButton": "Co-post",
+    "inboxCollabInviteNotMineButton": "Hindi akin",
+    "inboxCollabInvitePreviewTitle": "Imbitasyon sa co-post",
+    "inboxCollabInvitePreviewTitleFrom": "Imbitasyon sa co-post mula kay {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Idaragdag ng co-posting ang video na ito sa timeline mo bilang collaboration.",
     "inboxCollabInviteAcceptedStatus": "Tinanggap",
     "inboxCollabInviteIgnoredStatus": "Binalewala",
     "inboxCollabInviteAcceptError": "Hindi natanggap. Subukan ulit.",
@@ -1845,19 +1847,19 @@
     "bugReportExpectedBehaviorLabel": "Inaasahang Behavior",
     "bugReportFailedWithError": "Hindi naipadala ang bug report: {error}",
     "bugReportAttachImages": "Attach images",
-  "bugReportImagesCount": "{count} of {max} images selected",
-  "@bugReportImagesCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      },
-      "max": {
-        "type": "int"
-      }
-    }
-  },
-  "bugReportRemoveImage": "Remove image",
-  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+    "bugReportImagesCount": "{count} of {max} images selected",
+    "@bugReportImagesCount": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            },
+            "max": {
+                "type": "int"
+            }
+        }
+    },
+    "bugReportRemoveImage": "Remove image",
+    "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
     "userPickerRemoveSelectionSemantics": "Remove {name}",
     "videoMetadataEditCoverFailedSnackbar": "Couldn't update the cover. Try again.",
     "videoMetadataEditCoverSuccessAnnouncement": "Cover updated",
@@ -1865,7 +1867,7 @@
     "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",
     "videoMetadataEditCoverConfirmSemanticLabel": "Confirm cover selection",
     "videoMetadataEditCoverStripSemanticLabel": "Seek through video to select cover frame",
-  "bugReportSendFailed": "Hindi naipadala ang bug report. Subukan ulit mamaya.",
+    "bugReportSendFailed": "Hindi naipadala ang bug report. Subukan ulit mamaya.",
     "bugReportSendReport": "Ipadala ang Report",
     "bugReportStepsHint": "1. Pumunta sa...\n2. I-tap ang...\n3. Lalabas ang error",
     "bugReportStepsLabel": "Mga Hakbang Para Maulit",
@@ -2009,8 +2011,6 @@
     "safetySettingsWhatYouSee": "ANG NAKIKITA MO",
     "safetySettingsWhatYouPublish": "ANG PINO-POST MO",
     "profileSetupImagesTypeGroup": "mga larawan",
-    "profileSetupExternalNip05InvalidFormat": "Invalid NIP-05 format (hal., name@domain.com)",
-    "profileSetupExternalNip05DivineDomain": "Gamitin ang username field sa itaas para sa divine.video",
     "categoryGalleryNoVideosInCategory": "Walang video sa category na ito",
     "categoriesNoCategoriesAvailable": "Walang available na category",
     "exploreSearchHint": "Maghanap...",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Ouvrir le lien externe ?",
     "messageExternalLinkDialogBody": "Ce lien mène vers un site externe et peut ne pas être sûr :\n\n{url}",
     "messageExternalLinkDialogOpen": "Ouvrir",
-    "inboxCollabInviteAcceptButton": "Accepter",
+    "inboxCollabInviteCoPostButton": "Co-publier",
+    "inboxCollabInviteNotMineButton": "Pas à moi",
+    "inboxCollabInvitePreviewTitle": "Invitation à co-publier",
+    "inboxCollabInvitePreviewTitleFrom": "Invitation à co-publier de {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Co-publier ajoute cette vidéo à votre timeline comme collaboration.",
     "inboxCollabInviteAcceptError": "Impossible d'accepter. Réessayez.",
     "inboxCollabInviteAcceptedStatus": "Acceptée",
-    "inboxCollabInviteCardRoleLabel": "{role} sur cette publication",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Invitation à collaborer",
-    "inboxCollabInviteIgnoreButton": "Ignorer",
     "inboxCollabInviteIgnoredStatus": "Ignorée",
     "inboxConversationCollabInvitePreview": "Invitation à collaborer",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "images",
     "profileSetupExternalNip05InvalidFormat": "Format NIP-05 invalide (ex. : nom@domaine.com)",
     "profileSetupExternalNip05DivineDomain": "Utilise le champ nom d'utilisateur ci-dessus pour divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Signaler le contenu",
     "contentWarningBlockUserTooltip": "Bloquer l'utilisateur",
     "contentWarningBlockedTitle": "Contenu bloqué",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Comptes vérifiés",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2305,19 +2305,14 @@
     "messageExternalLinkDialogTitle": "Buka tautan eksternal?",
     "messageExternalLinkDialogBody": "Tautan ini menuju situs eksternal dan mungkin tidak aman:\n\n{url}",
     "messageExternalLinkDialogOpen": "Buka",
-    "inboxCollabInviteAcceptButton": "Terima",
+    "inboxCollabInviteCoPostButton": "Posting bersama",
+    "inboxCollabInviteNotMineButton": "Bukan milik saya",
+    "inboxCollabInvitePreviewTitle": "Undangan posting bersama",
+    "inboxCollabInvitePreviewTitleFrom": "Undangan posting bersama dari {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Posting bersama menambahkan video ini ke timeline Anda sebagai kolaborasi.",
     "inboxCollabInviteAcceptError": "Tidak bisa menerima. Coba lagi.",
     "inboxCollabInviteAcceptedStatus": "Diterima",
-    "inboxCollabInviteCardRoleLabel": "{role} di postingan ini",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Undangan kolaborasi",
-    "inboxCollabInviteIgnoreButton": "Abaikan",
     "inboxCollabInviteIgnoredStatus": "Diabaikan",
     "inboxConversationCollabInvitePreview": "Undangan kolaborasi",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "gambar",
     "profileSetupExternalNip05InvalidFormat": "Format NIP-05 tidak valid (contoh: nama@domain.com)",
     "profileSetupExternalNip05DivineDomain": "Pakai kolom username di atas untuk divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Laporkan Konten",
     "contentWarningBlockUserTooltip": "Blokir Pengguna",
     "contentWarningBlockedTitle": "Konten Diblokir",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Akun terverifikasi",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Aprire il link esterno?",
     "messageExternalLinkDialogBody": "Questo link porta a un sito esterno e potrebbe non essere sicuro:\n\n{url}",
     "messageExternalLinkDialogOpen": "Apri",
-    "inboxCollabInviteAcceptButton": "Accetta",
+    "inboxCollabInviteCoPostButton": "Co-pubblica",
+    "inboxCollabInviteNotMineButton": "Non è mio",
+    "inboxCollabInvitePreviewTitle": "Invito a co-pubblicare",
+    "inboxCollabInvitePreviewTitleFrom": "Invito a co-pubblicare da {displayName}",
+    "inboxCollabInviteTimelineConsequence": "La co-pubblicazione aggiunge questo video alla tua timeline come collaborazione.",
     "inboxCollabInviteAcceptError": "Impossibile accettare. Riprova.",
     "inboxCollabInviteAcceptedStatus": "Accettato",
-    "inboxCollabInviteCardRoleLabel": "{role} in questo post",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Invito a collaborare",
-    "inboxCollabInviteIgnoreButton": "Ignora",
     "inboxCollabInviteIgnoredStatus": "Ignorato",
     "inboxConversationCollabInvitePreview": "Invito a collaborare",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "immagini",
     "profileSetupExternalNip05InvalidFormat": "Formato NIP-05 non valido (es. nome@dominio.com)",
     "profileSetupExternalNip05DivineDomain": "Usa il campo nome utente qui sopra per divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Segnala contenuto",
     "contentWarningBlockUserTooltip": "Blocca utente",
     "contentWarningBlockedTitle": "Contenuto bloccato",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Account verificati",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2298,19 +2298,14 @@
     "messageExternalLinkDialogTitle": "外部リンクを開きますか？",
     "messageExternalLinkDialogBody": "このリンクは外部サイトに移動します。安全ではない可能性があります:\n\n{url}",
     "messageExternalLinkDialogOpen": "開く",
-    "inboxCollabInviteAcceptButton": "承認",
+    "inboxCollabInviteCoPostButton": "共同投稿",
+    "inboxCollabInviteNotMineButton": "自分のものではない",
+    "inboxCollabInvitePreviewTitle": "共同投稿の招待",
+    "inboxCollabInvitePreviewTitleFrom": "{displayName}からの共同投稿の招待",
+    "inboxCollabInviteTimelineConsequence": "共同投稿すると、この動画がコラボレーションとしてあなたのタイムラインに追加されます。",
     "inboxCollabInviteAcceptError": "承認できなかったよ。もう一度試してね。",
     "inboxCollabInviteAcceptedStatus": "承認済み",
-    "inboxCollabInviteCardRoleLabel": "この投稿で{role}",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "コラボ招待",
-    "inboxCollabInviteIgnoreButton": "無視",
     "inboxCollabInviteIgnoredStatus": "無視済み",
     "inboxConversationCollabInvitePreview": "コラボ招待",
     "@inboxConversationCollabInvitePreview": {
@@ -3138,16 +3133,16 @@
     "profileSetupImagesTypeGroup": "画像",
     "profileSetupExternalNip05InvalidFormat": "NIP-05 の形式が正しくないよ (例: name@domain.com)",
     "profileSetupExternalNip05DivineDomain": "divine.video の場合は上のユーザー名欄を使ってね",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "コンテンツを報告",
     "contentWarningBlockUserTooltip": "ユーザーをブロック",
     "contentWarningBlockedTitle": "ブロック済みのコンテンツ",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "認証済みアカウント",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1594,19 +1594,14 @@
     "messageExternalLinkDialogTitle": "외부 링크를 열까요?",
     "messageExternalLinkDialogBody": "이 링크는 외부 사이트로 이동하며 안전하지 않을 수 있어요:\n\n{url}",
     "messageExternalLinkDialogOpen": "열기",
-    "inboxCollabInviteAcceptButton": "수락",
+    "inboxCollabInviteCoPostButton": "공동 게시",
+    "inboxCollabInviteNotMineButton": "내 것이 아니에요",
+    "inboxCollabInvitePreviewTitle": "공동 게시 초대",
+    "inboxCollabInvitePreviewTitleFrom": "{displayName}님의 공동 게시 초대",
+    "inboxCollabInviteTimelineConsequence": "공동 게시하면 이 동영상이 협업으로 내 타임라인에 추가됩니다.",
     "inboxCollabInviteAcceptError": "수락하지 못했어요. 다시 시도해 주세요.",
     "inboxCollabInviteAcceptedStatus": "수락됨",
-    "inboxCollabInviteCardRoleLabel": "이 게시물의 {role}",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "콜라보 초대",
-    "inboxCollabInviteIgnoreButton": "무시",
     "inboxCollabInviteIgnoredStatus": "무시됨",
     "inboxConversationCollabInvitePreview": "콜라보 초대",
     "@inboxConversationCollabInvitePreview": {
@@ -2434,16 +2429,16 @@
     "profileSetupImagesTypeGroup": "이미지",
     "profileSetupExternalNip05InvalidFormat": "잘못된 NIP-05 형식이에요 (예: name@domain.com)",
     "profileSetupExternalNip05DivineDomain": "divine.video는 위의 사용자명 필드를 사용해주세요",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "콘텐츠 신고",
     "contentWarningBlockUserTooltip": "사용자 차단",
     "contentWarningBlockedTitle": "콘텐츠가 차단됐어요",
@@ -2569,8 +2564,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "인증된 계정",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Externe link openen?",
     "messageExternalLinkDialogBody": "Deze link gaat naar een externe site en is mogelijk niet veilig:\n\n{url}",
     "messageExternalLinkDialogOpen": "Openen",
-    "inboxCollabInviteAcceptButton": "Accepteren",
+    "inboxCollabInviteCoPostButton": "Samen plaatsen",
+    "inboxCollabInviteNotMineButton": "Niet van mij",
+    "inboxCollabInvitePreviewTitle": "Uitnodiging om samen te plaatsen",
+    "inboxCollabInvitePreviewTitleFrom": "Uitnodiging om samen te plaatsen van {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Samen plaatsen voegt deze video als samenwerking toe aan je tijdlijn.",
     "inboxCollabInviteAcceptError": "Accepteren is niet gelukt. Probeer het opnieuw.",
     "inboxCollabInviteAcceptedStatus": "Geaccepteerd",
-    "inboxCollabInviteCardRoleLabel": "{role} bij deze post",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Uitnodiging om samen te werken",
-    "inboxCollabInviteIgnoreButton": "Negeren",
     "inboxCollabInviteIgnoredStatus": "Genegeerd",
     "inboxConversationCollabInvitePreview": "Uitnodiging om samen te werken",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "afbeeldingen",
     "profileSetupExternalNip05InvalidFormat": "Ongeldig NIP-05-formaat (bijv. naam@domein.com)",
     "profileSetupExternalNip05DivineDomain": "Gebruik het gebruikersnaamveld hierboven voor divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Inhoud rapporteren",
     "contentWarningBlockUserTooltip": "Gebruiker blokkeren",
     "contentWarningBlockedTitle": "Inhoud geblokkeerd",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Geverifieerde accounts",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Otworzyć link zewnętrzny?",
     "messageExternalLinkDialogBody": "Ten link prowadzi do zewnętrznej strony i może nie być bezpieczny:\n\n{url}",
     "messageExternalLinkDialogOpen": "Otwórz",
-    "inboxCollabInviteAcceptButton": "Akceptuj",
+    "inboxCollabInviteCoPostButton": "Współopublikuj",
+    "inboxCollabInviteNotMineButton": "Nie moje",
+    "inboxCollabInvitePreviewTitle": "Zaproszenie do współopublikowania",
+    "inboxCollabInvitePreviewTitleFrom": "Zaproszenie do współopublikowania od {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Współopublikowanie doda ten film do Twojej osi czasu jako współpracę.",
     "inboxCollabInviteAcceptError": "Nie udało się zaakceptować. Spróbuj ponownie.",
     "inboxCollabInviteAcceptedStatus": "Zaakceptowano",
-    "inboxCollabInviteCardRoleLabel": "{role} przy tym poście",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Zaproszenie do współpracy",
-    "inboxCollabInviteIgnoreButton": "Ignoruj",
     "inboxCollabInviteIgnoredStatus": "Zignorowano",
     "inboxConversationCollabInvitePreview": "Zaproszenie do współpracy",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "obrazy",
     "profileSetupExternalNip05InvalidFormat": "Nieprawidłowy format NIP-05 (np. nazwa@domena.com)",
     "profileSetupExternalNip05DivineDomain": "Użyj pola nazwy użytkownika powyżej dla divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Zgłoś treść",
     "contentWarningBlockUserTooltip": "Zablokuj użytkownika",
     "contentWarningBlockedTitle": "Treść zablokowana",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Zweryfikowane konta",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Abrir link externo?",
     "messageExternalLinkDialogBody": "Este link leva a um site externo e pode não ser seguro:\n\n{url}",
     "messageExternalLinkDialogOpen": "Abrir",
-    "inboxCollabInviteAcceptButton": "Aceitar",
+    "inboxCollabInviteCoPostButton": "Co-publicar",
+    "inboxCollabInviteNotMineButton": "Não é meu",
+    "inboxCollabInvitePreviewTitle": "Convite para co-publicar",
+    "inboxCollabInvitePreviewTitleFrom": "Convite para co-publicar de {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Co-publicar adiciona este vídeo à sua linha do tempo como uma colaboração.",
     "inboxCollabInviteAcceptError": "Não foi possível aceitar. Tente novamente.",
     "inboxCollabInviteAcceptedStatus": "Aceito",
-    "inboxCollabInviteCardRoleLabel": "{role} nesta publicação",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Convite para colaborar",
-    "inboxCollabInviteIgnoreButton": "Ignorar",
     "inboxCollabInviteIgnoredStatus": "Ignorado",
     "inboxConversationCollabInvitePreview": "Convite para colaborar",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "imagens",
     "profileSetupExternalNip05InvalidFormat": "Formato NIP-05 inválido (ex.: nome@dominio.com)",
     "profileSetupExternalNip05DivineDomain": "Use o campo de nome de usuário acima para divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Denunciar conteúdo",
     "contentWarningBlockUserTooltip": "Bloquear usuário",
     "contentWarningBlockedTitle": "Conteúdo bloqueado",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Contas verificadas",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Deschizi linkul extern?",
     "messageExternalLinkDialogBody": "Acest link duce la un site extern și s-ar putea să nu fie sigur:\n\n{url}",
     "messageExternalLinkDialogOpen": "Deschide",
-    "inboxCollabInviteAcceptButton": "Acceptă",
+    "inboxCollabInviteCoPostButton": "Co-publică",
+    "inboxCollabInviteNotMineButton": "Nu e al meu",
+    "inboxCollabInvitePreviewTitle": "Invitație de co-publicare",
+    "inboxCollabInvitePreviewTitleFrom": "Invitație de co-publicare de la {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Co-publicarea adaugă acest videoclip în cronologia ta ca o colaborare.",
     "inboxCollabInviteAcceptError": "Nu s-a putut accepta. Încearcă din nou.",
     "inboxCollabInviteAcceptedStatus": "Acceptată",
-    "inboxCollabInviteCardRoleLabel": "{role} la această postare",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Invitație de colaborare",
-    "inboxCollabInviteIgnoreButton": "Ignoră",
     "inboxCollabInviteIgnoredStatus": "Ignorată",
     "inboxConversationCollabInvitePreview": "Invitație de colaborare",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "imagini",
     "profileSetupExternalNip05InvalidFormat": "Format NIP-05 invalid (ex.: nume@domeniu.com)",
     "profileSetupExternalNip05DivineDomain": "Folosește câmpul de nume de utilizator de mai sus pentru divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Raportează conținutul",
     "contentWarningBlockUserTooltip": "Blochează utilizatorul",
     "contentWarningBlockedTitle": "Conținut blocat",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Conturi verificate",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2306,19 +2306,14 @@
     "messageExternalLinkDialogTitle": "Öppna extern länk?",
     "messageExternalLinkDialogBody": "Den här länken går till en extern webbplats och kanske inte är säker:\n\n{url}",
     "messageExternalLinkDialogOpen": "Öppna",
-    "inboxCollabInviteAcceptButton": "Acceptera",
+    "inboxCollabInviteCoPostButton": "Sampublicera",
+    "inboxCollabInviteNotMineButton": "Inte min",
+    "inboxCollabInvitePreviewTitle": "Inbjudan att sampublicera",
+    "inboxCollabInvitePreviewTitleFrom": "Inbjudan att sampublicera från {displayName}",
+    "inboxCollabInviteTimelineConsequence": "Sampublicering lägger till den här videon på din tidslinje som ett samarbete.",
     "inboxCollabInviteAcceptError": "Det gick inte att acceptera. Försök igen.",
     "inboxCollabInviteAcceptedStatus": "Accepterad",
-    "inboxCollabInviteCardRoleLabel": "{role} i det här inlägget",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "Inbjudan att samarbeta",
-    "inboxCollabInviteIgnoreButton": "Ignorera",
     "inboxCollabInviteIgnoredStatus": "Ignorerad",
     "inboxConversationCollabInvitePreview": "Inbjudan att samarbeta",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "bilder",
     "profileSetupExternalNip05InvalidFormat": "Ogiltigt NIP-05-format (t.ex. namn@domän.com)",
     "profileSetupExternalNip05DivineDomain": "Använd användarnamnsfältet ovan för divine.video",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "Rapportera innehåll",
     "contentWarningBlockUserTooltip": "Blockera användare",
     "contentWarningBlockedTitle": "Innehåll blockerat",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Verifierade konton",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2305,19 +2305,14 @@
     "messageExternalLinkDialogTitle": "Harici bağlantı açılsın mı?",
     "messageExternalLinkDialogBody": "Bu bağlantı harici bir siteye gidiyor ve güvenli olmayabilir:\n\n{url}",
     "messageExternalLinkDialogOpen": "Aç",
-    "inboxCollabInviteAcceptButton": "Kabul et",
+    "inboxCollabInviteCoPostButton": "Birlikte paylaş",
+    "inboxCollabInviteNotMineButton": "Benim değil",
+    "inboxCollabInvitePreviewTitle": "Birlikte paylaşma daveti",
+    "inboxCollabInvitePreviewTitleFrom": "{displayName} tarafından birlikte paylaşma daveti",
+    "inboxCollabInviteTimelineConsequence": "Birlikte paylaşmak bu videoyu iş birliği olarak zaman çizelgene ekler.",
     "inboxCollabInviteAcceptError": "Kabul edilemedi. Tekrar dene.",
     "inboxCollabInviteAcceptedStatus": "Kabul edildi",
-    "inboxCollabInviteCardRoleLabel": "Bu gönderide {role}",
-    "@inboxCollabInviteCardRoleLabel": {
-        "placeholders": {
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "inboxCollabInviteCardTitle": "İşbirliği daveti",
-    "inboxCollabInviteIgnoreButton": "Yoksay",
     "inboxCollabInviteIgnoredStatus": "Yoksayıldı",
     "inboxConversationCollabInvitePreview": "İşbirliği daveti",
     "@inboxConversationCollabInvitePreview": {
@@ -3145,16 +3140,16 @@
     "profileSetupImagesTypeGroup": "görseller",
     "profileSetupExternalNip05InvalidFormat": "Geçersiz NIP-05 formatı (örn. ad@alanadi.com)",
     "profileSetupExternalNip05DivineDomain": "divine.video için yukarıdaki kullanıcı adı alanını kullan",
-"nostrSettingsNip05Address": "NIP-05 address",
-"nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
-"nostrSettingsNip05AddressHint": "you@example.com",
-"nostrSettingsNip05SaveAction": "Save NIP-05",
-"nostrSettingsNip05Saved": "NIP-05 saved",
-"nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
-"profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
-"profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
-"profileSetupNip05ConfirmContinue": "Continue",
-"profileSetupNip05ConfirmCancel": "Cancel",
+    "nostrSettingsNip05Address": "NIP-05 address",
+    "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+    "nostrSettingsNip05AddressHint": "you@example.com",
+    "nostrSettingsNip05SaveAction": "Save NIP-05",
+    "nostrSettingsNip05Saved": "NIP-05 saved",
+    "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+    "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+    "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+    "profileSetupNip05ConfirmContinue": "Continue",
+    "profileSetupNip05ConfirmCancel": "Cancel",
     "contentWarningReportContentTooltip": "İçeriği Bildir",
     "contentWarningBlockUserTooltip": "Kullanıcıyı Engelle",
     "contentWarningBlockedTitle": "İçerik Engellendi",
@@ -3273,8 +3268,12 @@
     "@verifiedAccountChipSemanticLabel": {
         "description": "Screen reader label for a verified-account chip on a user's profile.",
         "placeholders": {
-            "platform": { "type": "String" },
-            "identity": { "type": "String" }
+            "platform": {
+                "type": "String"
+            },
+            "identity": {
+                "type": "String"
+            }
         }
     },
     "profileEditVerifiedAccountsTitle": "Doğrulanmış hesaplar",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9410,6 +9410,36 @@ abstract class AppLocalizations {
   /// **'Open'**
   String get messageExternalLinkDialogOpen;
 
+  /// Primary action on a collaborator invite card. Accepts the invite and co-posts the video to the recipient's timeline as a collaboration.
+  ///
+  /// In en, this message translates to:
+  /// **'Co-post'**
+  String get inboxCollabInviteCoPostButton;
+
+  /// Secondary action on a collaborator invite card. Ignores the invite because the recipient does not claim the video as their collaboration.
+  ///
+  /// In en, this message translates to:
+  /// **'Not mine'**
+  String get inboxCollabInviteNotMineButton;
+
+  /// Header label shown over the video preview on a collaborator invite card.
+  ///
+  /// In en, this message translates to:
+  /// **'Co-post invite'**
+  String get inboxCollabInvitePreviewTitle;
+
+  /// Header label shown over the video preview on a collaborator invite card when the inviter's display name is known.
+  ///
+  /// In en, this message translates to:
+  /// **'Co-post invite from {displayName}'**
+  String inboxCollabInvitePreviewTitleFrom(String displayName);
+
+  /// Explains what accepting a collaborator invite does.
+  ///
+  /// In en, this message translates to:
+  /// **'Co-posting adds this video to your timeline as a collaboration.'**
+  String get inboxCollabInviteTimelineConsequence;
+
   /// No description provided for @inboxCollabInviteAcceptButton.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9374,12 +9374,6 @@ abstract class AppLocalizations {
   /// **'Collaborator invite'**
   String get inboxCollabInviteCardTitle;
 
-  /// Subtitle on the collaborator invite card describing the offered collaborator role.
-  ///
-  /// In en, this message translates to:
-  /// **'{role} on this post'**
-  String inboxCollabInviteCardRoleLabel(String role);
-
   /// Fallback shown as the collaborator invite card title when the invited video has no title. Avoids exposing the raw d-tag identifier.
   ///
   /// In en, this message translates to:
@@ -9439,18 +9433,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Co-posting adds this video to your timeline as a collaboration.'**
   String get inboxCollabInviteTimelineConsequence;
-
-  /// No description provided for @inboxCollabInviteAcceptButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Accept'**
-  String get inboxCollabInviteAcceptButton;
-
-  /// No description provided for @inboxCollabInviteIgnoreButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Ignore'**
-  String get inboxCollabInviteIgnoreButton;
 
   /// No description provided for @inboxCollabInviteAcceptedStatus.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5203,6 +5203,24 @@ class AppLocalizationsAm extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'ክፈት';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'ተቀበል';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5181,11 +5181,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'የተባባሪ ግብዣ';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role በዚህ ልጥፍ ላይ';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'ርዕስ የሌለው ቪዲዮ';
 
   @override
@@ -5203,28 +5198,22 @@ class AppLocalizationsAm extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'ክፈት';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'አብረህ ለጥፍ';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'የኔ አይደለም';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'የጋራ ልጥፍ ግብዣ';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'ከ$displayName የጋራ ልጥፍ ግብዣ';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'ተቀበል';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'ችላ በል';
+      'አብሮ መለጠፍ ይህን ቪዲዮ እንደ ትብብር ወደ የጊዜ መስመርህ ያክለዋል።';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'ተቀባይነት አግኝቷል';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5262,6 +5262,24 @@ class AppLocalizationsAr extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'فتح';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'قبول';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5240,11 +5240,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'دعوة للتعاون';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role على هذا المنشور';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'فيديو بلا عنوان';
 
   @override
@@ -5262,28 +5257,22 @@ class AppLocalizationsAr extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'فتح';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'نشر مشترك';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'ليس لي';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'دعوة نشر مشترك';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'دعوة نشر مشترك من $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'قبول';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'تجاهل';
+      'سيضيف النشر المشترك هذا الفيديو إلى يومياتك كتعاون.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'تم القبول';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5341,11 +5341,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Покана за сътрудник';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role на тази публикация';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Видео без заглавие';
 
   @override
@@ -5363,28 +5358,22 @@ class AppLocalizationsBg extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Отвори';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Съвместна публикация';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Не е мое';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Покана за съвместна публикация';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Покана за съвместна публикация от $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Приеми';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Игнорирайте';
+      'Съвместното публикуване добавя това видео към хронологията ти като сътрудничество.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Прието';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5363,6 +5363,24 @@ class AppLocalizationsBg extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Отвори';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Приеми';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5375,6 +5375,24 @@ class AppLocalizationsDe extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Öffnen';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Annehmen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5353,11 +5353,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Einladung zur Zusammenarbeit';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role bei diesem Beitrag';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video ohne Titel';
 
   @override
@@ -5375,28 +5370,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Öffnen';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Mitposten';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Nicht meins';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Einladung zum Mitposten';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Einladung zum Mitposten von $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Annehmen';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignorieren';
+      'Mitposten fügt dieses Video als Zusammenarbeit zu deiner Timeline hinzu.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Angenommen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5312,6 +5312,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Open';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Accept';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5290,11 +5290,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Collaborator invite';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role on this post';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Untitled video';
 
   @override
@@ -5328,12 +5323,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get inboxCollabInviteTimelineConsequence =>
       'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Accept';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignore';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Accepted';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5359,6 +5359,24 @@ class AppLocalizationsEs extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Abrir';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Aceptar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5337,11 +5337,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Invitación a colaborar';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role en esta publicación';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video sin título';
 
   @override
@@ -5359,28 +5354,22 @@ class AppLocalizationsEs extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Abrir';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Co-publicar';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'No es mío';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Invitación para co-publicar';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Invitación para co-publicar de $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Aceptar';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignorar';
+      'Co-publicar añade este video a tu línea de tiempo como colaboración.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Aceptada';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5379,6 +5379,24 @@ class AppLocalizationsFil extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Buksan';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Tanggapin';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5357,11 +5357,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Imbitasyon bilang collaborator';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role sa post na ito';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video na walang pamagat';
 
   @override
@@ -5382,25 +5377,19 @@ class AppLocalizationsFil extends AppLocalizations {
   String get inboxCollabInviteCoPostButton => 'Co-post';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Hindi akin';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Imbitasyon sa co-post';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Imbitasyon sa co-post mula kay $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Tanggapin';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Balewalain';
+      'Idaragdag ng co-posting ang video na ito sa timeline mo bilang collaboration.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Tinanggap';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5360,11 +5360,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Invitation à collaborer';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role sur cette publication';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Vidéo sans titre';
 
   @override
@@ -5382,28 +5377,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Ouvrir';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Co-publier';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Pas à moi';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Invitation à co-publier';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Invitation à co-publier de $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Accepter';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignorer';
+      'Co-publier ajoute cette vidéo à votre timeline comme collaboration.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Acceptée';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5382,6 +5382,24 @@ class AppLocalizationsFr extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Ouvrir';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Accepter';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5286,6 +5286,24 @@ class AppLocalizationsId extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Buka';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Terima';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5264,11 +5264,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Undangan kolaborasi';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role di postingan ini';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video tanpa judul';
 
   @override
@@ -5286,28 +5281,22 @@ class AppLocalizationsId extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Buka';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Posting bersama';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Bukan milik saya';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Undangan posting bersama';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Undangan posting bersama dari $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Terima';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Abaikan';
+      'Posting bersama menambahkan video ini ke timeline Anda sebagai kolaborasi.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Diterima';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5359,6 +5359,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Apri';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Accetta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5337,11 +5337,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Invito a collaborare';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role in questo post';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video senza titolo';
 
   @override
@@ -5359,28 +5354,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Apri';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Co-pubblica';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Non è mio';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Invito a co-pubblicare';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Invito a co-pubblicare da $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Accetta';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignora';
+      'La co-pubblicazione aggiunge questo video alla tua timeline come collaborazione.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Accettato';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5089,6 +5089,24 @@ class AppLocalizationsJa extends AppLocalizations {
   String get messageExternalLinkDialogOpen => '開く';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => '承認';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5067,11 +5067,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'コラボ招待';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return 'この投稿で$role';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => '無題の動画';
 
   @override
@@ -5089,28 +5084,22 @@ class AppLocalizationsJa extends AppLocalizations {
   String get messageExternalLinkDialogOpen => '開く';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => '共同投稿';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => '自分のものではない';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => '共同投稿の招待';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return '$displayNameからの共同投稿の招待';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => '承認';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => '無視';
+      '共同投稿すると、この動画がコラボレーションとしてあなたのタイムラインに追加されます。';
 
   @override
   String get inboxCollabInviteAcceptedStatus => '承認済み';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5084,11 +5084,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxCollabInviteCardTitle => '콜라보 초대';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '이 게시물의 $role';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => '제목 없는 동영상';
 
   @override
@@ -5106,28 +5101,22 @@ class AppLocalizationsKo extends AppLocalizations {
   String get messageExternalLinkDialogOpen => '열기';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => '공동 게시';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => '내 것이 아니에요';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => '공동 게시 초대';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return '$displayName님의 공동 게시 초대';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => '수락';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => '무시';
+      '공동 게시하면 이 동영상이 협업으로 내 타임라인에 추가됩니다.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => '수락됨';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5106,6 +5106,24 @@ class AppLocalizationsKo extends AppLocalizations {
   String get messageExternalLinkDialogOpen => '열기';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => '수락';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5309,11 +5309,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Uitnodiging om samen te werken';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role bij deze post';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video zonder titel';
 
   @override
@@ -5331,28 +5326,23 @@ class AppLocalizationsNl extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Openen';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Samen plaatsen';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Niet van mij';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle =>
+      'Uitnodiging om samen te plaatsen';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Uitnodiging om samen te plaatsen van $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Accepteren';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Negeren';
+      'Samen plaatsen voegt deze video als samenwerking toe aan je tijdlijn.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Geaccepteerd';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5331,6 +5331,24 @@ class AppLocalizationsNl extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Openen';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Accepteren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5421,11 +5421,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Zaproszenie do współpracy';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role przy tym poście';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Film bez tytułu';
 
   @override
@@ -5443,28 +5438,23 @@ class AppLocalizationsPl extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Otwórz';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Współopublikuj';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Nie moje';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle =>
+      'Zaproszenie do współopublikowania';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Zaproszenie do współopublikowania od $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Akceptuj';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignoruj';
+      'Współopublikowanie doda ten film do Twojej osi czasu jako współpracę.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Zaakceptowano';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5443,6 +5443,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Otwórz';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Akceptuj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5342,6 +5342,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Abrir';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Aceitar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5320,11 +5320,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Convite para colaborar';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role nesta publicação';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Vídeo sem título';
 
   @override
@@ -5342,28 +5337,22 @@ class AppLocalizationsPt extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Abrir';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Co-publicar';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Não é meu';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Convite para co-publicar';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Convite para co-publicar de $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Aceitar';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignorar';
+      'Co-publicar adiciona este vídeo à sua linha do tempo como uma colaboração.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Aceito';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5436,11 +5436,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Invitație de colaborare';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role la această postare';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Videoclip fără titlu';
 
   @override
@@ -5458,28 +5453,22 @@ class AppLocalizationsRo extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Deschide';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Co-publică';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Nu e al meu';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Invitație de co-publicare';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Invitație de co-publicare de la $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Acceptă';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignoră';
+      'Co-publicarea adaugă acest videoclip în cronologia ta ca o colaborare.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Acceptată';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5458,6 +5458,24 @@ class AppLocalizationsRo extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Deschide';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Acceptă';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5309,6 +5309,24 @@ class AppLocalizationsSv extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Öppna';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Acceptera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5287,11 +5287,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'Inbjudan att samarbeta';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return '$role i det här inlägget';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Video utan titel';
 
   @override
@@ -5309,28 +5304,22 @@ class AppLocalizationsSv extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Öppna';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Sampublicera';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Inte min';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Inbjudan att sampublicera';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return 'Inbjudan att sampublicera från $displayName';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Acceptera';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Ignorera';
+      'Sampublicering lägger till den här videon på din tidslinje som ett samarbete.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Accepterad';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5270,11 +5270,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxCollabInviteCardTitle => 'İşbirliği daveti';
 
   @override
-  String inboxCollabInviteCardRoleLabel(String role) {
-    return 'Bu gönderide $role';
-  }
-
-  @override
   String get inboxCollabInviteCardUntitledVideo => 'Başlıksız video';
 
   @override
@@ -5292,28 +5287,22 @@ class AppLocalizationsTr extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Aç';
 
   @override
-  String get inboxCollabInviteCoPostButton => 'Co-post';
+  String get inboxCollabInviteCoPostButton => 'Birlikte paylaş';
 
   @override
-  String get inboxCollabInviteNotMineButton => 'Not mine';
+  String get inboxCollabInviteNotMineButton => 'Benim değil';
 
   @override
-  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+  String get inboxCollabInvitePreviewTitle => 'Birlikte paylaşma daveti';
 
   @override
   String inboxCollabInvitePreviewTitleFrom(String displayName) {
-    return 'Co-post invite from $displayName';
+    return '$displayName tarafından birlikte paylaşma daveti';
   }
 
   @override
   String get inboxCollabInviteTimelineConsequence =>
-      'Co-posting adds this video to your timeline as a collaboration.';
-
-  @override
-  String get inboxCollabInviteAcceptButton => 'Kabul et';
-
-  @override
-  String get inboxCollabInviteIgnoreButton => 'Yoksay';
+      'Birlikte paylaşmak bu videoyu iş birliği olarak zaman çizelgene ekler.';
 
   @override
   String get inboxCollabInviteAcceptedStatus => 'Kabul edildi';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5292,6 +5292,24 @@ class AppLocalizationsTr extends AppLocalizations {
   String get messageExternalLinkDialogOpen => 'Aç';
 
   @override
+  String get inboxCollabInviteCoPostButton => 'Co-post';
+
+  @override
+  String get inboxCollabInviteNotMineButton => 'Not mine';
+
+  @override
+  String get inboxCollabInvitePreviewTitle => 'Co-post invite';
+
+  @override
+  String inboxCollabInvitePreviewTitleFrom(String displayName) {
+    return 'Co-post invite from $displayName';
+  }
+
+  @override
+  String get inboxCollabInviteTimelineConsequence =>
+      'Co-posting adds this video to your timeline as a collaboration.';
+
+  @override
   String get inboxCollabInviteAcceptButton => 'Kabul et';
 
   @override

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -315,6 +315,7 @@ class _ConversationContent extends StatelessWidget {
                 : _MessageList(
                     messages: selected.messages,
                     currentPubkey: currentPubkey,
+                    senderDisplayName: displayName,
                   ),
         };
       },
@@ -323,10 +324,15 @@ class _ConversationContent extends StatelessWidget {
 }
 
 class _MessageList extends StatelessWidget {
-  const _MessageList({required this.messages, required this.currentPubkey});
+  const _MessageList({
+    required this.messages,
+    required this.currentPubkey,
+    required this.senderDisplayName,
+  });
 
   final List<DmMessage> messages;
   final String currentPubkey;
+  final String senderDisplayName;
 
   Future<void> _onMessageLongPress(
     BuildContext context,
@@ -377,7 +383,11 @@ class _MessageList extends StatelessWidget {
         final isSent = message.senderPubkey == currentPubkey;
         final invite = CollaboratorInviteParser.parse(message);
         if (invite != null) {
-          return CollaboratorInviteCard(invite: invite, isSent: isSent);
+          return CollaboratorInviteCard(
+            invite: invite,
+            isSent: isSent,
+            senderDisplayName: isSent ? null : senderDisplayName,
+          );
         }
 
         // Suppress legacy NIP-04 invite plaintext duplicates (#3559).

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -183,6 +183,9 @@ class _ThumbnailInviteContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final thumbnailSemanticLabel = title.trim().isEmpty
+        ? l10n.notificationsVideoThumbnail
+        : l10n.notificationsVideoThumbnailFor(title);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
@@ -192,14 +195,18 @@ class _ThumbnailInviteContent extends StatelessWidget {
           child: Stack(
             fit: StackFit.expand,
             children: [
-              VineCachedImage(
-                key: const ValueKey('collaborator_invite_thumbnail'),
-                imageUrl: thumbnailUrl,
-                placeholder: (context, url) => const ColoredBox(
-                  color: VineTheme.surfaceContainer,
-                ),
-                errorWidget: (context, url, error) => const ColoredBox(
-                  color: VineTheme.surfaceContainer,
+              Semantics(
+                image: true,
+                label: thumbnailSemanticLabel,
+                child: VineCachedImage(
+                  key: const ValueKey('collaborator_invite_thumbnail'),
+                  imageUrl: thumbnailUrl,
+                  placeholder: (context, url) => const ColoredBox(
+                    color: VineTheme.surfaceContainer,
+                  ),
+                  errorWidget: (context, url, error) => const ColoredBox(
+                    color: VineTheme.surfaceContainer,
+                  ),
                 ),
               ),
               DecoratedBox(
@@ -223,8 +230,8 @@ class _ThumbnailInviteContent extends StatelessWidget {
                   child: SizedBox(
                     width: 48,
                     height: 48,
-                    child: Icon(
-                      Icons.play_arrow_rounded,
+                    child: DivineIcon(
+                      icon: DivineIconName.playFill,
                       color: VineTheme.backgroundColor,
                       size: 32,
                     ),

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -4,11 +4,15 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' hide AspectRatio, LogCategory;
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/collaborator_invite.dart';
-import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
+import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -89,7 +93,7 @@ class _CollaboratorInviteCardState extends State<CollaboratorInviteCard> {
   }
 }
 
-class _CardChrome extends StatelessWidget {
+class _CardChrome extends ConsumerWidget {
   const _CardChrome({
     required this.invite,
     required this.isSent,
@@ -108,7 +112,7 @@ class _CardChrome extends StatelessWidget {
     return context.l10n.inboxCollabInviteCardUntitledVideo;
   }
 
-  String? get _thumbnailUrl {
+  String? get _inviteThumbnailUrl {
     final value = invite.thumbnailUrl?.trim();
     return value == null || value.isEmpty ? null : value;
   }
@@ -123,42 +127,36 @@ class _CardChrome extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final thumbnailUrl = _thumbnailUrl;
+  Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Align(
         alignment: isSent
             ? AlignmentDirectional.centerEnd
             : AlignmentDirectional.centerStart,
-        child: Semantics(
-          button: true,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () =>
-                context.push(VideoDetailScreen.pathForId(invite.videoAddress)),
-            child: Container(
-              constraints: BoxConstraints(
-                maxWidth: MediaQuery.sizeOf(context).width * 0.78,
-              ),
-              decoration: BoxDecoration(
-                color: VineTheme.surfaceContainerHigh,
-                border: Border.all(color: VineTheme.outlineMuted),
-                borderRadius: BorderRadius.circular(16),
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: thumbnailUrl == null
-                  ? _FallbackInviteContent(
-                      title: _titleText(context),
-                      previewTitle: _previewTitle(context),
-                      action: action,
-                    )
-                  : _ThumbnailInviteContent(
-                      thumbnailUrl: thumbnailUrl,
-                      title: _titleText(context),
-                      previewTitle: _previewTitle(context),
-                      action: action,
-                    ),
+        child: Container(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.sizeOf(context).width * 0.78,
+          ),
+          decoration: BoxDecoration(
+            color: VineTheme.surfaceContainerHigh,
+            border: Border.all(color: VineTheme.outlineMuted),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: BlocProvider(
+            create: (_) => VideoLinkPreviewCubit(
+              videoStableId: invite.videoDTag,
+              authorPubkey: invite.creatorPubkey,
+              videoKind: invite.videoKind,
+              videoEventService: ref.read(videoEventServiceProvider),
+              nostrClient: ref.read(nostrServiceProvider),
+            ),
+            child: _InviteVideoContent(
+              inviteThumbnailUrl: _inviteThumbnailUrl,
+              title: _titleText(context),
+              previewTitle: _previewTitle(context),
+              action: action,
             ),
           ),
         ),
@@ -167,18 +165,129 @@ class _CardChrome extends StatelessWidget {
   }
 }
 
-class _ThumbnailInviteContent extends StatelessWidget {
-  const _ThumbnailInviteContent({
-    required this.thumbnailUrl,
+class _InviteVideoContent extends StatelessWidget {
+  const _InviteVideoContent({
+    required this.inviteThumbnailUrl,
     required this.title,
     required this.previewTitle,
     required this.action,
   });
 
-  final String thumbnailUrl;
+  final String? inviteThumbnailUrl;
   final String title;
   final String previewTitle;
   final Widget action;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<VideoLinkPreviewCubit, VideoLinkPreviewState>(
+      builder: (context, state) {
+        final resolvedVideo = switch (state) {
+          VideoLinkPreviewResolved(:final video) => video,
+          _ => null,
+        };
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _InvitePreviewSurface(
+              inviteThumbnailUrl: inviteThumbnailUrl,
+              resolvedVideo: resolvedVideo,
+              isLoading: state is VideoLinkPreviewLoading,
+              title: title,
+              previewTitle: previewTitle,
+            ),
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: action,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _InvitePreviewSurface extends StatelessWidget {
+  const _InvitePreviewSurface({
+    required this.inviteThumbnailUrl,
+    required this.resolvedVideo,
+    required this.isLoading,
+    required this.title,
+    required this.previewTitle,
+  });
+
+  final String? inviteThumbnailUrl;
+  final VideoEvent? resolvedVideo;
+  final bool isLoading;
+  final String title;
+  final String previewTitle;
+
+  String? get _thumbnailUrl {
+    final resolvedThumbnail = resolvedVideo?.thumbnailUrl?.trim();
+    if (resolvedThumbnail != null && resolvedThumbnail.isNotEmpty) {
+      return resolvedThumbnail;
+    }
+    return inviteThumbnailUrl;
+  }
+
+  String? get _videoUrl {
+    final value = resolvedVideo?.videoUrl?.trim();
+    if (value == null || value.isEmpty) return null;
+    final uri = Uri.tryParse(value);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) return null;
+    if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+    return value;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final videoUrl = _videoUrl;
+    final thumbnailUrl = _thumbnailUrl;
+    if (videoUrl != null) {
+      return Stack(
+        children: [
+          VideoCommentPlayer(
+            key: const ValueKey('collaborator_invite_inline_player'),
+            videoUrl: videoUrl,
+            thumbnailUrl: thumbnailUrl,
+          ),
+          PositionedDirectional(
+            start: 12,
+            end: 12,
+            bottom: 12,
+            child: IgnorePointer(
+              child: _InviteGradientCopy(
+                title: title,
+                previewTitle: previewTitle,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return _InviteThumbnailPreview(
+      thumbnailUrl: thumbnailUrl,
+      title: title,
+      previewTitle: previewTitle,
+      isLoading: isLoading,
+    );
+  }
+}
+
+class _InviteThumbnailPreview extends StatelessWidget {
+  const _InviteThumbnailPreview({
+    required this.thumbnailUrl,
+    required this.title,
+    required this.previewTitle,
+    required this.isLoading,
+  });
+
+  final String? thumbnailUrl;
+  final String title;
+  final String previewTitle;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -186,108 +295,155 @@ class _ThumbnailInviteContent extends StatelessWidget {
     final thumbnailSemanticLabel = title.trim().isEmpty
         ? l10n.notificationsVideoThumbnail
         : l10n.notificationsVideoThumbnailFor(title);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      mainAxisSize: MainAxisSize.min,
+    return AspectRatio(
+      aspectRatio: 9 / 16,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (thumbnailUrl == null)
+            const ColoredBox(
+              key: ValueKey('collaborator_invite_video_placeholder'),
+              color: VineTheme.surfaceContainer,
+              child: Center(
+                child: DivineIcon(
+                  icon: DivineIconName.videoCamera,
+                  color: VineTheme.onSurfaceMuted,
+                  size: 32,
+                ),
+              ),
+            )
+          else
+            Semantics(
+              image: true,
+              label: thumbnailSemanticLabel,
+              child: VineCachedImage(
+                key: const ValueKey('collaborator_invite_thumbnail'),
+                imageUrl: thumbnailUrl!,
+                placeholder: (context, url) => const ColoredBox(
+                  color: VineTheme.surfaceContainer,
+                ),
+                errorWidget: (context, url, error) => const ColoredBox(
+                  color: VineTheme.surfaceContainer,
+                ),
+              ),
+            ),
+          _InvitePreviewOverlay(
+            showLoading: isLoading,
+            title: title,
+            previewTitle: previewTitle,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InvitePreviewOverlay extends StatelessWidget {
+  const _InvitePreviewOverlay({
+    required this.showLoading,
+    required this.title,
+    required this.previewTitle,
+  });
+
+  final bool showLoading;
+  final String title;
+  final String previewTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
       children: [
-        AspectRatio(
-          aspectRatio: 9 / 14,
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              Semantics(
-                image: true,
-                label: thumbnailSemanticLabel,
-                child: VineCachedImage(
-                  key: const ValueKey('collaborator_invite_thumbnail'),
-                  imageUrl: thumbnailUrl,
-                  placeholder: (context, url) => const ColoredBox(
-                    color: VineTheme.surfaceContainer,
-                  ),
-                  errorWidget: (context, url, error) => const ColoredBox(
-                    color: VineTheme.surfaceContainer,
-                  ),
-                ),
-              ),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      VineTheme.backgroundColor.withValues(alpha: 0),
-                      VineTheme.backgroundColor.withValues(alpha: 0.82),
-                    ],
-                  ),
-                ),
-              ),
-              const Center(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: VineTheme.primary,
-                    shape: BoxShape.circle,
-                  ),
-                  child: SizedBox(
-                    width: 48,
-                    height: 48,
-                    child: DivineIcon(
-                      icon: DivineIconName.playFill,
-                      color: VineTheme.backgroundColor,
-                      size: 32,
-                    ),
-                  ),
-                ),
-              ),
-              PositionedDirectional(
-                start: 12,
-                end: 12,
-                bottom: 12,
-                child: _InviteCopy(
-                  previewTitle: previewTitle,
-                  title: title,
-                  consequence: l10n.inboxCollabInviteTimelineConsequence,
-                ),
-              ),
-            ],
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                VineTheme.backgroundColor.withValues(alpha: 0),
+                VineTheme.backgroundColor.withValues(alpha: 0.82),
+              ],
+            ),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.all(12),
-          child: action,
+        Center(
+          child: showLoading
+              ? const SizedBox.square(
+                  dimension: 32,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: VineTheme.primary,
+                  ),
+                )
+              : const _InvitePlayBadge(),
+        ),
+        PositionedDirectional(
+          start: 12,
+          end: 12,
+          bottom: 12,
+          child: _InviteCopy(
+            previewTitle: previewTitle,
+            title: title,
+            consequence: context.l10n.inboxCollabInviteTimelineConsequence,
+          ),
         ),
       ],
     );
   }
 }
 
-class _FallbackInviteContent extends StatelessWidget {
-  const _FallbackInviteContent({
+class _InviteGradientCopy extends StatelessWidget {
+  const _InviteGradientCopy({
     required this.title,
     required this.previewTitle,
-    required this.action,
   });
 
   final String title;
   final String previewTitle;
-  final Widget action;
 
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _InviteCopy(
-            previewTitle: previewTitle,
-            title: title,
-            consequence: l10n.inboxCollabInviteTimelineConsequence,
-          ),
-          const SizedBox(height: 16),
-          action,
-        ],
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            VineTheme.backgroundColor.withValues(alpha: 0),
+            VineTheme.backgroundColor.withValues(alpha: 0.72),
+          ],
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 48),
+        child: _InviteCopy(
+          previewTitle: previewTitle,
+          title: title,
+          consequence: context.l10n.inboxCollabInviteTimelineConsequence,
+        ),
+      ),
+    );
+  }
+}
+
+class _InvitePlayBadge extends StatelessWidget {
+  const _InvitePlayBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return const DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.primary,
+        shape: BoxShape.circle,
+      ),
+      child: SizedBox(
+        width: 48,
+        height: 48,
+        child: DivineIcon(
+          icon: DivineIconName.playFill,
+          color: VineTheme.backgroundColor,
+          size: 32,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -10,16 +10,19 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 class CollaboratorInviteCard extends StatefulWidget {
   const CollaboratorInviteCard({
     required this.invite,
     required this.isSent,
+    this.senderDisplayName,
     super.key,
   });
 
   final CollaboratorInvite invite;
   final bool isSent;
+  final String? senderDisplayName;
 
   @override
   State<CollaboratorInviteCard> createState() => _CollaboratorInviteCardState();
@@ -58,6 +61,7 @@ class _CollaboratorInviteCardState extends State<CollaboratorInviteCard> {
       return _CardChrome(
         invite: widget.invite,
         isSent: true,
+        senderDisplayName: widget.senderDisplayName,
         action: _StatusText(
           label: context.l10n.inboxCollabInviteSentStatus,
           color: VineTheme.onSurfaceMuted,
@@ -74,6 +78,7 @@ class _CollaboratorInviteCardState extends State<CollaboratorInviteCard> {
         return _CardChrome(
           invite: widget.invite,
           isSent: false,
+          senderDisplayName: widget.senderDisplayName,
           action: _InviteActions(
             invite: widget.invite,
             state: inviteState,
@@ -89,11 +94,13 @@ class _CardChrome extends StatelessWidget {
     required this.invite,
     required this.isSent,
     required this.action,
+    this.senderDisplayName,
   });
 
   final CollaboratorInvite invite;
   final bool isSent;
   final Widget action;
+  final String? senderDisplayName;
 
   String _titleText(BuildContext context) {
     final title = invite.title?.trim();
@@ -101,9 +108,23 @@ class _CardChrome extends StatelessWidget {
     return context.l10n.inboxCollabInviteCardUntitledVideo;
   }
 
+  String? get _thumbnailUrl {
+    final value = invite.thumbnailUrl?.trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  String _previewTitle(BuildContext context) {
+    if (isSent) return context.l10n.inboxCollabInviteCardTitle;
+    final name = senderDisplayName?.trim();
+    if (name != null && name.isNotEmpty) {
+      return context.l10n.inboxCollabInvitePreviewTitleFrom(name);
+    }
+    return context.l10n.inboxCollabInvitePreviewTitle;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
+    final thumbnailUrl = _thumbnailUrl;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Align(
@@ -120,42 +141,187 @@ class _CardChrome extends StatelessWidget {
               constraints: BoxConstraints(
                 maxWidth: MediaQuery.sizeOf(context).width * 0.78,
               ),
-              padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
                 color: VineTheme.surfaceContainerHigh,
                 border: Border.all(color: VineTheme.outlineMuted),
                 borderRadius: BorderRadius.circular(16),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    l10n.inboxCollabInviteCardTitle,
-                    style: VineTheme.labelLargeFont(color: VineTheme.primary),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    _titleText(context),
-                    style: VineTheme.titleMediumFont(),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    l10n.inboxCollabInviteCardRoleLabel(invite.role),
-                    style: VineTheme.bodySmallFont(
-                      color: VineTheme.onSurfaceMuted,
+              clipBehavior: Clip.antiAlias,
+              child: thumbnailUrl == null
+                  ? _FallbackInviteContent(
+                      title: _titleText(context),
+                      previewTitle: _previewTitle(context),
+                      action: action,
+                    )
+                  : _ThumbnailInviteContent(
+                      thumbnailUrl: thumbnailUrl,
+                      title: _titleText(context),
+                      previewTitle: _previewTitle(context),
+                      action: action,
                     ),
-                  ),
-                  const SizedBox(height: 16),
-                  action,
-                ],
-              ),
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class _ThumbnailInviteContent extends StatelessWidget {
+  const _ThumbnailInviteContent({
+    required this.thumbnailUrl,
+    required this.title,
+    required this.previewTitle,
+    required this.action,
+  });
+
+  final String thumbnailUrl;
+  final String title;
+  final String previewTitle;
+  final Widget action;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AspectRatio(
+          aspectRatio: 9 / 14,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              VineCachedImage(
+                key: const ValueKey('collaborator_invite_thumbnail'),
+                imageUrl: thumbnailUrl,
+                placeholder: (context, url) => const ColoredBox(
+                  color: VineTheme.surfaceContainer,
+                ),
+                errorWidget: (context, url, error) => const ColoredBox(
+                  color: VineTheme.surfaceContainer,
+                ),
+              ),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      VineTheme.backgroundColor.withValues(alpha: 0),
+                      VineTheme.backgroundColor.withValues(alpha: 0.82),
+                    ],
+                  ),
+                ),
+              ),
+              const Center(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: VineTheme.primary,
+                    shape: BoxShape.circle,
+                  ),
+                  child: SizedBox(
+                    width: 48,
+                    height: 48,
+                    child: Icon(
+                      Icons.play_arrow_rounded,
+                      color: VineTheme.backgroundColor,
+                      size: 32,
+                    ),
+                  ),
+                ),
+              ),
+              PositionedDirectional(
+                start: 12,
+                end: 12,
+                bottom: 12,
+                child: _InviteCopy(
+                  previewTitle: previewTitle,
+                  title: title,
+                  consequence: l10n.inboxCollabInviteTimelineConsequence,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(12),
+          child: action,
+        ),
+      ],
+    );
+  }
+}
+
+class _FallbackInviteContent extends StatelessWidget {
+  const _FallbackInviteContent({
+    required this.title,
+    required this.previewTitle,
+    required this.action,
+  });
+
+  final String title;
+  final String previewTitle;
+  final Widget action;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _InviteCopy(
+            previewTitle: previewTitle,
+            title: title,
+            consequence: l10n.inboxCollabInviteTimelineConsequence,
+          ),
+          const SizedBox(height: 16),
+          action,
+        ],
+      ),
+    );
+  }
+}
+
+class _InviteCopy extends StatelessWidget {
+  const _InviteCopy({
+    required this.previewTitle,
+    required this.title,
+    required this.consequence,
+  });
+
+  final String previewTitle;
+  final String title;
+  final String consequence;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          previewTitle,
+          style: VineTheme.labelLargeFont(color: VineTheme.primary),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          title,
+          style: VineTheme.titleMediumFont(),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          consequence,
+          style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceMuted),
+        ),
+      ],
     );
   }
 }
@@ -221,7 +387,7 @@ class _ActionRow extends StatelessWidget {
       children: [
         Expanded(
           child: DivineButton(
-            label: l10n.inboxCollabInviteAcceptButton,
+            label: l10n.inboxCollabInviteCoPostButton,
             size: DivineButtonSize.small,
             isLoading: isAccepting,
             onPressed: isAccepting
@@ -236,7 +402,7 @@ class _ActionRow extends StatelessWidget {
         const SizedBox(width: 8),
         Expanded(
           child: DivineButton(
-            label: l10n.inboxCollabInviteIgnoreButton,
+            label: l10n.inboxCollabInviteNotMineButton,
             type: DivineButtonType.secondary,
             size: DivineButtonSize.small,
             onPressed: isAccepting

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Card UI for structured collaborator invite direct messages.
 // ABOUTME: Keeps invite plaintext fallback hidden and exposes accept/ignore.
 
+import 'dart:math' as math;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -15,6 +17,9 @@ import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+
+const double _collaboratorInviteMaxCardWidth = 420;
+const double _collaboratorInviteMaxViewportHeightFraction = 0.62;
 
 class CollaboratorInviteCard extends StatefulWidget {
   const CollaboratorInviteCard({
@@ -128,6 +133,18 @@ class _CardChrome extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final viewportSize = MediaQuery.sizeOf(context);
+    final maxViewportWidth = viewportSize.width * 0.78;
+    final maxVisibleVideoWidth =
+        viewportSize.height *
+        _collaboratorInviteMaxViewportHeightFraction *
+        9 /
+        16;
+    final maxCardWidth = math.min(
+      math.min(maxViewportWidth, _collaboratorInviteMaxCardWidth),
+      maxVisibleVideoWidth,
+    );
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Align(
@@ -136,7 +153,7 @@ class _CardChrome extends ConsumerWidget {
             : AlignmentDirectional.centerStart,
         child: Container(
           constraints: BoxConstraints(
-            maxWidth: MediaQuery.sizeOf(context).width * 0.78,
+            maxWidth: maxCardWidth,
           ),
           decoration: BoxDecoration(
             color: VineTheme.surfaceContainerHigh,

--- a/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
@@ -47,7 +47,11 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
     required String videoStableId,
     required VideoEventService videoEventService,
     required NostrClient nostrClient,
+    String? authorPubkey,
+    int? videoKind,
   }) : _videoStableId = videoStableId,
+       _authorPubkey = authorPubkey,
+       _videoKind = videoKind,
        _videoEventService = videoEventService,
        _nostrClient = nostrClient,
        super(const VideoLinkPreviewLoading()) {
@@ -57,6 +61,8 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
   }
 
   final String _videoStableId;
+  final String? _authorPubkey;
+  final int? _videoKind;
   final VideoEventService _videoEventService;
   final NostrClient _nostrClient;
 
@@ -79,7 +85,8 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
       if (event == null) {
         final results = await _nostrClient.queryEvents([
           Filter(
-            kinds: const [NIP71VideoKinds.addressableShortVideo],
+            kinds: [_videoKind ?? NIP71VideoKinds.addressableShortVideo],
+            authors: _authorPubkey == null ? null : [_authorPubkey],
             d: [_videoStableId],
             limit: 1,
           ),

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -160,7 +160,10 @@ class _ProfileContent extends StatelessWidget {
                 displayName: displayName,
                 messageCount: messageCount,
               ),
-              _InvitePreview(messages: messages),
+              _InvitePreview(
+                messages: messages,
+                senderDisplayName: displayName,
+              ),
             ],
           ),
         ),
@@ -170,9 +173,13 @@ class _ProfileContent extends StatelessWidget {
 }
 
 class _InvitePreview extends StatelessWidget {
-  const _InvitePreview({required this.messages});
+  const _InvitePreview({
+    required this.messages,
+    required this.senderDisplayName,
+  });
 
   final List<DmMessage> messages;
+  final String senderDisplayName;
 
   @override
   Widget build(BuildContext context) {
@@ -187,6 +194,7 @@ class _InvitePreview extends StatelessWidget {
       child: CollaboratorInviteCard(
         invite: inviteMessages.first,
         isSent: false,
+        senderDisplayName: senderDisplayName,
       ),
     );
   }

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -285,6 +285,7 @@ class VideoPublishService {
 
     final videoKind = NIP71VideoKinds.getPreferredAddressableKind();
     final videoAddress = '$videoKind:$creatorPubkey:$videoId';
+    final thumbnailUrl = _uploadedThumbnailUrl(upload);
     const relayHint = 'wss://relay.divine.video';
 
     try {
@@ -293,6 +294,7 @@ class VideoPublishService {
         creatorPubkey: creatorPubkey,
         videoAddress: videoAddress,
         title: draft.title,
+        thumbnailUrl: thumbnailUrl,
         relayHint: relayHint,
       );
       if (result.hasFailures) {
@@ -309,6 +311,7 @@ class VideoPublishService {
               creatorPubkey: creatorPubkey,
               videoAddress: videoAddress,
               title: draft.title,
+              thumbnailUrl: thumbnailUrl,
               relayHint: relayHint,
               error: entry.value.error,
             ),
@@ -326,6 +329,7 @@ class VideoPublishService {
               creatorPubkey: creatorPubkey,
               videoAddress: videoAddress,
               title: draft.title,
+              thumbnailUrl: thumbnailUrl,
               relayHint: relayHint,
               error: e.toString(),
             ),
@@ -361,6 +365,15 @@ class VideoPublishService {
       );
       return CollaboratorInviteResult(success: false, error: e.toString());
     }
+  }
+
+  String? _uploadedThumbnailUrl(PendingUpload upload) {
+    final value = upload.thumbnailPath?.trim();
+    if (value == null || value.isEmpty) return null;
+    final uri = Uri.tryParse(value);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) return null;
+    if (uri.scheme != 'https' && uri.scheme != 'http') return null;
+    return value;
   }
 
   /// Gets existing upload from background ID, reuses a matching upload

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -402,13 +402,6 @@ const _knownUntranslatedDebt = {
   'inboxConversationActionsSheetLabel',
   'inboxConversationTileLabel',
   'inboxConversationTileLongPressHint',
-  // Added by the collaborator invite card video-preview pass. English ships;
-  // other locales fall back until the next translation pass.
-  'inboxCollabInviteCoPostButton',
-  'inboxCollabInviteNotMineButton',
-  'inboxCollabInvitePreviewTitle',
-  'inboxCollabInvitePreviewTitleFrom',
-  'inboxCollabInviteTimelineConsequence',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -402,6 +402,13 @@ const _knownUntranslatedDebt = {
   'inboxConversationActionsSheetLabel',
   'inboxConversationTileLabel',
   'inboxConversationTileLongPressHint',
+  // Added by the collaborator invite card video-preview pass. English ships;
+  // other locales fall back until the next translation pass.
+  'inboxCollabInviteCoPostButton',
+  'inboxCollabInviteNotMineButton',
+  'inboxCollabInvitePreviewTitle',
+  'inboxCollabInvitePreviewTitleFrom',
+  'inboxCollabInviteTimelineConsequence',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -14,11 +14,14 @@ import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
-import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
+import '../../../builders/video_event_builder.dart';
 import '../../../helpers/go_router.dart';
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -29,6 +32,8 @@ class _MockConversationBloc
 class _MockCollaboratorInviteActionsCubit
     extends MockCubit<CollaboratorInviteActionsState>
     implements CollaboratorInviteActionsCubit {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockAuthService extends MockAuthService {
   _MockAuthService(this._pubkey);
@@ -60,6 +65,8 @@ void main() {
   group(ConversationView, () {
     late _MockConversationBloc mockBloc;
     late _MockCollaboratorInviteActionsCubit mockInviteActionsCubit;
+    late _MockVideoEventService mockVideoEventService;
+    late MockNostrClient mockNostrClient;
     late _MockAuthService mockAuthService;
 
     setUpAll(() {
@@ -77,8 +84,11 @@ void main() {
     });
 
     setUp(() {
+      VisibilityDetectorController.instance.updateInterval = Duration.zero;
       mockBloc = _MockConversationBloc();
       mockInviteActionsCubit = _MockCollaboratorInviteActionsCubit();
+      mockVideoEventService = _MockVideoEventService();
+      mockNostrClient = createMockNostrService();
       mockAuthService = _MockAuthService(currentPubkey);
 
       when(() => mockInviteActionsCubit.state).thenReturn(
@@ -90,6 +100,13 @@ void main() {
       when(
         () => mockInviteActionsCubit.ignoreInvite(any()),
       ).thenAnswer((_) async {});
+      when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.getVideoEventByVineId(any()),
+      ).thenReturn(null);
+      when(
+        () => mockNostrClient.fetchEventById(any()),
+      ).thenAnswer((_) async => null);
     });
 
     Widget buildSubject({
@@ -106,7 +123,9 @@ void main() {
 
       final app = testMaterialApp(
         mockAuthService: mockAuthService,
+        mockNostrService: mockNostrClient,
         additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           fetchUserProfileProvider(
             otherPubkey,
           ).overrideWith((ref) async => otherProfile),
@@ -465,10 +484,21 @@ void main() {
       );
 
       testWidgets(
-        'opens collaborator invite video when card is tapped',
+        'renders collaborator invite video inline without navigating away',
         (tester) async {
           final mockGoRouter = MockGoRouter();
           when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
+          when(
+            () => mockVideoEventService.getVideoEventByVineId('skate-loop'),
+          ).thenReturn(
+            VideoEventBuilder(
+              id: '7777777777777777777777777777777777777777777777777777777777777777',
+              pubkey: otherPubkey,
+              title: 'Skate loop',
+              videoUrl: 'https://cdn.divine.video/videos/skate-loop.mp4',
+              thumbnailUrl: 'https://cdn.divine.video/thumbs/skate-loop.jpg',
+            ).build(),
+          );
 
           final message = DmMessage(
             id: '9999999999999999999999999999999999999999999999999999999999999999',
@@ -502,17 +532,19 @@ void main() {
             ),
           );
           await tester.pump();
-
-          await tester.tap(find.byType(CollaboratorInviteCard));
           await tester.pump();
 
-          verify(
-            () => mockGoRouter.push(
-              VideoDetailScreen.pathForId(
-                '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
-              ),
-            ),
-          ).called(1);
+          expect(
+            find.byKey(const ValueKey('collaborator_invite_inline_player')),
+            findsOneWidget,
+          );
+          expect(find.text(l10n.inboxCollabInviteCoPostButton), findsOneWidget);
+          expect(
+            find.text(l10n.inboxCollabInviteNotMineButton),
+            findsOneWidget,
+          );
+
+          verifyNever(() => mockGoRouter.push(any()));
         },
       );
 

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -486,6 +486,9 @@ void main() {
       testWidgets(
         'renders collaborator invite video inline without navigating away',
         (tester) async {
+          await tester.binding.setSurfaceSize(const Size(1800, 1200));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+
           final mockGoRouter = MockGoRouter();
           when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
           when(
@@ -543,6 +546,11 @@ void main() {
             find.text(l10n.inboxCollabInviteNotMineButton),
             findsOneWidget,
           );
+          final playerSize = tester.getSize(
+            find.byKey(const ValueKey('collaborator_invite_inline_player')),
+          );
+          expect(playerSize.width, lessThanOrEqualTo(420));
+          expect(playerSize.height, lessThanOrEqualTo(748));
 
           verifyNever(() => mockGoRouter.push(any()));
         },

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -284,6 +284,69 @@ void main() {
       });
 
       testWidgets(
+        'renders collaborator invite as an inline video preview with co-post actions',
+        (tester) async {
+          const thumbnailUrl = 'https://cdn.divine.video/thumbs/skate-loop.jpg';
+          final message = DmMessage(
+            id: '9999999999999999999999999999999999999999999999999999999999999999',
+            conversationId:
+                'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            senderPubkey: otherPubkey,
+            content: 'You were invited to collaborate.',
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            giftWrapId:
+                'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+            tags: const [
+              ['divine', 'collab-invite'],
+              [
+                'a',
+                '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
+                'wss://relay.divine.video',
+              ],
+              ['p', otherPubkey],
+              ['role', 'Collaborator'],
+              ['title', 'Skate loop'],
+              ['thumb', thumbnailUrl],
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                messages: [message],
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.textContaining('Co-post invite'), findsOneWidget);
+          expect(find.textContaining('Skate loop'), findsOneWidget);
+          expect(
+            find.text(
+              'Co-posting adds this video to your timeline as a collaboration.',
+            ),
+            findsOneWidget,
+          );
+          expect(find.text('Co-post'), findsOneWidget);
+          expect(find.text('Not mine'), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteAcceptButton), findsNothing);
+          expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsNothing);
+          expect(
+            find.byKey(const ValueKey('collaborator_invite_thumbnail')),
+            findsOneWidget,
+          );
+
+          await tester.tap(find.text('Co-post'));
+          await tester.pump();
+
+          verify(
+            () => mockInviteActionsCubit.acceptInvite(any()),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
         'renders collaborator invite card instead of plaintext invite copy',
         (tester) async {
           final message = DmMessage(
@@ -318,13 +381,13 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
+          expect(find.textContaining('Co-post invite'), findsOneWidget);
           expect(find.textContaining('Skate loop'), findsOneWidget);
-          expect(find.text(l10n.inboxCollabInviteAcceptButton), findsOneWidget);
-          expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsOneWidget);
+          expect(find.text('Co-post'), findsOneWidget);
+          expect(find.text('Not mine'), findsOneWidget);
           expect(find.text('You were invited to collaborate.'), findsNothing);
 
-          await tester.tap(find.text(l10n.inboxCollabInviteAcceptButton));
+          await tester.tap(find.text('Co-post'));
           await tester.pump();
 
           verify(
@@ -476,8 +539,8 @@ void main() {
           expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
           expect(find.textContaining('Skate loop'), findsOneWidget);
           expect(find.text(l10n.inboxCollabInviteSentStatus), findsOneWidget);
-          expect(find.text(l10n.inboxCollabInviteAcceptButton), findsNothing);
-          expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsNothing);
+          expect(find.text('Co-post'), findsNothing);
+          expect(find.text('Not mine'), findsNothing);
           expect(find.text('You were invited to collaborate.'), findsNothing);
 
           // Stronger assertion than "no acceptInvite call": sender-side

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: plus the app bar and input bar rendering.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -320,24 +321,38 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.textContaining('Co-post invite'), findsOneWidget);
+          final previewTitle = l10n.inboxCollabInvitePreviewTitle;
+          expect(find.textContaining(previewTitle), findsOneWidget);
           expect(find.textContaining('Skate loop'), findsOneWidget);
           expect(
-            find.text(
-              'Co-posting adds this video to your timeline as a collaboration.',
-            ),
+            find.text(l10n.inboxCollabInviteTimelineConsequence),
             findsOneWidget,
           );
-          expect(find.text('Co-post'), findsOneWidget);
-          expect(find.text('Not mine'), findsOneWidget);
-          expect(find.text(l10n.inboxCollabInviteAcceptButton), findsNothing);
-          expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsNothing);
+          expect(find.text(l10n.inboxCollabInviteCoPostButton), findsOneWidget);
+          expect(
+            find.text(l10n.inboxCollabInviteNotMineButton),
+            findsOneWidget,
+          );
           expect(
             find.byKey(const ValueKey('collaborator_invite_thumbnail')),
             findsOneWidget,
           );
+          expect(
+            find.bySemanticsLabel(
+              l10n.notificationsVideoThumbnailFor('Skate loop'),
+            ),
+            findsOneWidget,
+          );
+          expect(
+            find.byWidgetPredicate(
+              (widget) =>
+                  widget is DivineIcon &&
+                  widget.icon == DivineIconName.playFill,
+            ),
+            findsOneWidget,
+          );
 
-          await tester.tap(find.text('Co-post'));
+          await tester.tap(find.text(l10n.inboxCollabInviteCoPostButton));
           await tester.pump();
 
           verify(
@@ -381,13 +396,19 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.textContaining('Co-post invite'), findsOneWidget);
+          expect(
+            find.textContaining(l10n.inboxCollabInvitePreviewTitle),
+            findsOneWidget,
+          );
           expect(find.textContaining('Skate loop'), findsOneWidget);
-          expect(find.text('Co-post'), findsOneWidget);
-          expect(find.text('Not mine'), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteCoPostButton), findsOneWidget);
+          expect(
+            find.text(l10n.inboxCollabInviteNotMineButton),
+            findsOneWidget,
+          );
           expect(find.text('You were invited to collaborate.'), findsNothing);
 
-          await tester.tap(find.text('Co-post'));
+          await tester.tap(find.text(l10n.inboxCollabInviteCoPostButton));
           await tester.pump();
 
           verify(

--- a/mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
@@ -143,6 +143,29 @@ void main() {
         build: createCubit,
         expect: () => [isA<VideoLinkPreviewResolved>()],
       );
+
+      blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
+        'queries invite d-tag with creator and kind when provided',
+        build: () => VideoLinkPreviewCubit(
+          videoStableId: 'skate-loop',
+          authorPubkey: testVideo.pubkey,
+          videoKind: 34235,
+          videoEventService: mockVideoEventService,
+          nostrClient: mockNostrClient,
+        ),
+        expect: () => [isA<VideoLinkPreviewNotFound>()],
+        verify: (_) {
+          final captured =
+              verify(
+                    () => mockNostrClient.queryEvents(captureAny()),
+                  ).captured.single
+                  as List<Filter>;
+          final filter = captured.single;
+          expect(filter.kinds, [34235]);
+          expect(filter.authors, [testVideo.pubkey]);
+          expect(filter.d, ['skate-loop']);
+        },
+      );
     });
 
     group('not found', () {

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -13,11 +13,13 @@ import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit
 import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_view.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 import '../../../helpers/go_router.dart';
@@ -33,6 +35,8 @@ class _MockRequestPreviewCubit extends MockCubit<RequestPreviewState>
 class _MockCollaboratorInviteActionsCubit
     extends MockCubit<CollaboratorInviteActionsState>
     implements CollaboratorInviteActionsCubit {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockAuthService extends MockAuthService {
   _MockAuthService(this._pubkey) {
@@ -70,6 +74,8 @@ void main() {
     late _MockMessageRequestActionsCubit mockActionsCubit;
     late _MockRequestPreviewCubit mockPreviewCubit;
     late _MockCollaboratorInviteActionsCubit mockInviteActionsCubit;
+    late _MockVideoEventService mockVideoEventService;
+    late MockNostrClient mockNostrClient;
     late _MockAuthService mockAuthService;
     late MockGoRouter mockGoRouter;
     late UserProfile testProfile;
@@ -82,6 +88,8 @@ void main() {
       mockActionsCubit = _MockMessageRequestActionsCubit();
       mockPreviewCubit = _MockRequestPreviewCubit();
       mockInviteActionsCubit = _MockCollaboratorInviteActionsCubit();
+      mockVideoEventService = _MockVideoEventService();
+      mockNostrClient = createMockNostrService();
       mockAuthService = _MockAuthService(currentPubkey);
       mockGoRouter = MockGoRouter();
 
@@ -107,6 +115,13 @@ void main() {
       when(
         () => mockInviteActionsCubit.ignoreInvite(any()),
       ).thenAnswer((_) async {});
+      when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+      when(
+        () => mockVideoEventService.getVideoEventByVineId(any()),
+      ).thenReturn(null);
+      when(
+        () => mockNostrClient.fetchEventById(any()),
+      ).thenAnswer((_) async => null);
 
       testProfile = UserProfile(
         pubkey: otherPubkey,
@@ -125,8 +140,10 @@ void main() {
 
       return testMaterialApp(
         mockAuthService: mockAuthService,
+        mockNostrService: mockNostrClient,
         additionalOverrides: [
           goRouterProvider.overrideWithValue(mockGoRouter),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           userProfileReactiveProvider(
             otherPubkey,
           ).overrideWith((ref) => Stream.value(testProfile)),

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -11,7 +11,6 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
-import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -64,8 +63,6 @@ void main() {
     videoDTag: 'skate-loop',
     role: 'Collaborator',
   );
-
-  final l10n = lookupAppLocalizations(const Locale('en'));
 
   group(RequestPreviewView, () {
     late _MockMessageRequestActionsCubit mockActionsCubit;
@@ -214,6 +211,7 @@ void main() {
             ['p', otherPubkey],
             ['role', 'Collaborator'],
             ['title', 'Skate loop'],
+            ['thumb', 'https://cdn.divine.video/thumbs/skate-loop.jpg'],
           ],
         );
 
@@ -229,16 +227,24 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
-        expect(find.text(l10n.inboxCollabInviteAcceptButton), findsOneWidget);
-        expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsOneWidget);
+        expect(find.textContaining('Co-post invite'), findsOneWidget);
+        expect(find.text('Co-post'), findsOneWidget);
+        expect(find.text('Not mine'), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('collaborator_invite_thumbnail')),
+          findsOneWidget,
+        );
+        expect(
+          find.text(
+            'Co-posting adds this video to your timeline as a collaboration.',
+          ),
+          findsOneWidget,
+        );
         expect(find.text('You were invited to collaborate.'), findsNothing);
 
-        await tester.ensureVisible(
-          find.text(l10n.inboxCollabInviteIgnoreButton),
-        );
+        await tester.ensureVisible(find.text('Not mine'));
         await tester.pump();
-        await tester.tap(find.text(l10n.inboxCollabInviteIgnoreButton));
+        await tester.tap(find.text('Not mine'));
         await tester.pump();
 
         verify(

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -63,6 +64,7 @@ void main() {
     videoDTag: 'skate-loop',
     role: 'Collaborator',
   );
+  final l10n = lookupAppLocalizations(const Locale('en'));
 
   group(RequestPreviewView, () {
     late _MockMessageRequestActionsCubit mockActionsCubit;
@@ -227,24 +229,34 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.textContaining('Co-post invite'), findsOneWidget);
-        expect(find.text('Co-post'), findsOneWidget);
-        expect(find.text('Not mine'), findsOneWidget);
+        expect(
+          find.text(l10n.inboxCollabInvitePreviewTitleFrom('TestUser')),
+          findsOneWidget,
+        );
+        expect(find.text('Skate loop'), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteCoPostButton), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteNotMineButton), findsOneWidget);
         expect(
           find.byKey(const ValueKey('collaborator_invite_thumbnail')),
           findsOneWidget,
         );
         expect(
-          find.text(
-            'Co-posting adds this video to your timeline as a collaboration.',
+          find.text(l10n.inboxCollabInviteTimelineConsequence),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(
+            l10n.notificationsVideoThumbnailFor('Skate loop'),
           ),
           findsOneWidget,
         );
         expect(find.text('You were invited to collaborate.'), findsNothing);
 
-        await tester.ensureVisible(find.text('Not mine'));
+        await tester.ensureVisible(
+          find.text(l10n.inboxCollabInviteNotMineButton),
+        );
         await tester.pump();
-        await tester.tap(find.text('Not mine'));
+        await tester.tap(find.text(l10n.inboxCollabInviteNotMineButton));
         await tester.pump();
 
         verify(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -382,6 +382,56 @@ void main() {
       });
 
       test(
+        'collaborator invites include the uploaded thumbnail URL',
+        () async {
+          const thumbnailUrl = 'https://cdn.divine.video/thumbs/test_video.jpg';
+          final readyUpload = _createPendingUpload(
+            status: UploadStatus.readyToPublish,
+            thumbnailPath: thumbnailUrl,
+          );
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+            readyUpload: readyUpload,
+          );
+          when(
+            () => mockCollaboratorInviteService.sendInvites(
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              creatorPubkey: any(named: 'creatorPubkey'),
+              videoAddress: any(named: 'videoAddress'),
+              title: any(named: 'title'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              relayHint: any(named: 'relayHint'),
+            ),
+          ).thenAnswer(
+            (_) async => const CollaboratorInviteBatchResult(results: {}),
+          );
+
+          final draft = _createTestDraft(
+            collaboratorPubkeys: {
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            },
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishSuccess>());
+          verify(
+            () => mockCollaboratorInviteService.sendInvites(
+              collaboratorPubkeys: draft.collaboratorPubkeys,
+              creatorPubkey: 'test_pubkey',
+              videoAddress: '34236:test_pubkey:test_video_id',
+              title: 'Test Video',
+              thumbnailUrl: thumbnailUrl,
+              relayHint: 'wss://relay.divine.video',
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'publishes video event before sending collaborator invites',
         () async {
           _setupSuccessfulPublish(
@@ -550,11 +600,17 @@ void main() {
         () async {
           const collaboratorPubkey =
               'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          const thumbnailUrl = 'https://cdn.divine.video/thumbs/test_video.jpg';
+          final readyUpload = _createPendingUpload(
+            status: UploadStatus.readyToPublish,
+            thumbnailPath: thumbnailUrl,
+          );
           _setupSuccessfulPublish(
             mockAuthService: mockAuthService,
             mockUploadManager: mockUploadManager,
             mockDraftService: mockDraftService,
             mockVideoEventPublisher: mockVideoEventPublisher,
+            readyUpload: readyUpload,
           );
           when(
             () => mockCollaboratorInviteService.sendInvites(
@@ -595,6 +651,7 @@ void main() {
             '34236:test_pubkey:test_video_id',
           );
           expect(success.inviteWarnings.single.title, 'Test Video');
+          expect(success.inviteWarnings.single.thumbnailUrl, thumbnailUrl);
           expect(
             success.inviteWarnings.single.relayHint,
             'wss://relay.divine.video',
@@ -1494,6 +1551,7 @@ DivineVideoDraft _createTestDraft({
 PendingUpload _createPendingUpload({
   required UploadStatus status,
   String? errorMessage,
+  String? thumbnailPath,
 }) {
   return PendingUpload(
     id: 'test_upload_id',
@@ -1505,6 +1563,7 @@ PendingUpload _createPendingUpload({
     uploadProgress: status == UploadStatus.readyToPublish ? 1.0 : 0.5,
     videoId: 'test_video_id',
     cdnUrl: 'https://test.cdn/video.mp4',
+    thumbnailPath: thumbnailPath,
   );
 }
 
@@ -1513,7 +1572,13 @@ void _setupSuccessfulPublish({
   required MockUploadManager mockUploadManager,
   required MockDraftStorageService mockDraftService,
   required MockVideoEventPublisher mockVideoEventPublisher,
+  PendingUpload? readyUpload,
 }) {
+  final upload =
+      readyUpload ??
+      _createPendingUpload(
+        status: UploadStatus.readyToPublish,
+      );
   when(() => mockAuthService.isAuthenticated).thenReturn(true);
   when(() => mockAuthService.currentPublicKeyHex).thenReturn('test_pubkey');
   when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
@@ -1526,11 +1591,11 @@ void _setupSuccessfulPublish({
       onProgress: any(named: 'onProgress'),
     ),
   ).thenAnswer(
-    (_) async => _createPendingUpload(status: UploadStatus.readyToPublish),
+    (_) async => upload,
   );
   when(
     () => mockUploadManager.getUpload(any()),
-  ).thenReturn(_createPendingUpload(status: UploadStatus.readyToPublish));
+  ).thenReturn(upload);
   when(
     () => mockVideoEventPublisher.publishVideoEvent(
       upload: any(named: 'upload'),


### PR DESCRIPTION
## Summary
- Redesign collaborator invite cards around the invited video thumbnail so users can decide inline.
- Replace ambiguous Accept/Ignore recipient actions with Co-post/Not mine copy and consequence text.
- Reuse the same card behavior in conversation and message-request preview surfaces, with generated l10n updates.
- Closes #4383.

## Test Plan
- [x] `flutter test --no-pub test/screens/inbox/conversation/conversation_view_test.dart --plain-name "collaborator invite"`
- [x] `flutter test --no-pub test/screens/inbox/message_requests/request_preview_view_test.dart --plain-name "collaborator invite"`
- [x] `flutter analyze lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart lib/screens/inbox/conversation/conversation_view.dart lib/screens/inbox/message_requests/request_preview_view.dart test/screens/inbox/conversation/conversation_view_test.dart test/screens/inbox/message_requests/request_preview_view_test.dart`
- [x] Pre-push hook: merge-conflict check, analyzer, changed-file tests
