### PR TITLE
feat(profile): add Report option to profile more sheet

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -270,6 +270,7 @@
             }
         }
     },
+    "profileReportDisplayName": "{displayName}ን ሪፖርት አድርግ",
     "profileAddToListDisplayName": "{displayName}ን ወደ ዝርዝር ጨምር",
     "@profileAddToListDisplayName": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "أبلغ عن {displayName}",
     "profileAddToListDisplayName": "أضف {displayName} إلى قائمة",
     "profileUserBlockedTitle": "تم حظر المستخدم",
     "profileUserBlockedContent": "لن ترى محتوى من هذا المستخدم في تغذياتك.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -249,6 +249,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Докладвай {displayName}",
     "profileAddToListDisplayName": "Добави {displayName} към списък",
     "@profileAddToListDisplayName": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "{displayName} melden",
     "profileAddToListDisplayName": "{displayName} zu einer Liste hinzufügen",
     "profileUserBlockedTitle": "Nutzer blockiert",
     "profileUserBlockedContent": "Du siehst keine Inhalte von diesem Nutzer mehr in deinen Feeds.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -270,6 +270,14 @@
       }
     }
   },
+  "profileReportDisplayName": "Report {displayName}",
+  "@profileReportDisplayName": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
   "profileAddToListDisplayName": "Add {displayName} to a list",
   "@profileAddToListDisplayName": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Reportar a {displayName}",
     "profileAddToListDisplayName": "Añadir {displayName} a una lista",
     "profileUserBlockedTitle": "Usuario bloqueado",
     "profileUserBlockedContent": "No vas a ver contenido de esta persona en tus feeds.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -102,6 +102,7 @@
     "profileUnfollowDisplayName": "I-unfollow si {displayName}",
     "profileBlockDisplayName": "I-block si {displayName}",
     "profileUnblockDisplayName": "I-unblock si {displayName}",
+    "profileReportDisplayName": "I-report si {displayName}",
     "profileAddToListDisplayName": "Idagdag si {displayName} sa isang list",
     "profileUserBlockedTitle": "Na-block ang User",
     "profileUserBlockedContent": "Hindi mo na makikita ang content ng user na ito sa feed mo.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Signaler {displayName}",
     "profileAddToListDisplayName": "Ajouter {displayName} à une liste",
     "profileUserBlockedTitle": "Utilisateur bloqué",
     "profileUserBlockedContent": "Tu ne verras plus son contenu dans tes fils.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Laporkan {displayName}",
     "profileAddToListDisplayName": "Tambahkan {displayName} ke daftar",
     "profileUserBlockedTitle": "Pengguna Diblokir",
     "profileUserBlockedContent": "Kamu tidak akan melihat konten dari pengguna ini di feed-mu.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Segnala {displayName}",
     "profileAddToListDisplayName": "Aggiungi {displayName} a una lista",
     "profileUserBlockedTitle": "Utente bloccato",
     "profileUserBlockedContent": "Non vedrai più contenuti di questo utente nei tuoi feed.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "{displayName}を報告",
     "profileAddToListDisplayName": "{displayName}をリストに追加",
     "profileUserBlockedTitle": "ブロックしたよ",
     "profileUserBlockedContent": "このユーザーのコンテンツはフィードに出なくなるよ。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -102,6 +102,7 @@
     "profileUnfollowDisplayName": "{displayName}님 언팔로우",
     "profileBlockDisplayName": "{displayName}님 차단",
     "profileUnblockDisplayName": "{displayName}님 차단 해제",
+    "profileReportDisplayName": "{displayName} 신고",
     "profileAddToListDisplayName": "{displayName}을(를) 목록에 추가",
     "profileUserBlockedTitle": "사용자를 차단했어요",
     "profileUserBlockedContent": "이 사용자의 콘텐츠는 피드에서 보이지 않아요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "{displayName} rapporteren",
     "profileAddToListDisplayName": "{displayName} aan een lijst toevoegen",
     "profileUserBlockedTitle": "Gebruiker geblokkeerd",
     "profileUserBlockedContent": "Je ziet geen inhoud meer van deze gebruiker in je feeds.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Zgłoś {displayName}",
     "profileAddToListDisplayName": "Dodaj {displayName} do listy",
     "profileUserBlockedTitle": "Użytkownik zablokowany",
     "profileUserBlockedContent": "Nie będziesz widzieć treści tego użytkownika w swoich kanałach.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Denunciar {displayName}",
     "profileAddToListDisplayName": "Adicionar {displayName} a uma lista",
     "profileUserBlockedTitle": "Usuário bloqueado",
     "profileUserBlockedContent": "Você não vai mais ver conteúdo desse usuário no seu feed.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Raportează-l pe {displayName}",
     "profileAddToListDisplayName": "Adaugă {displayName} la o listă",
     "profileUserBlockedTitle": "Utilizator blocat",
     "profileUserBlockedContent": "Nu vei mai vedea conținut de la acest utilizator în feedurile tale.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "Rapportera {displayName}",
     "profileAddToListDisplayName": "Lägg till {displayName} i en lista",
     "profileUserBlockedTitle": "Användare blockerad",
     "profileUserBlockedContent": "Du kommer inte se innehåll från den här användaren i dina flöden.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -241,6 +241,7 @@
             }
         }
     },
+    "profileReportDisplayName": "{displayName} adlı kullanıcıyı bildir",
     "profileAddToListDisplayName": "{displayName} kişisini listeye ekle",
     "profileUserBlockedTitle": "Kullanıcı Engellendi",
     "profileUserBlockedContent": "Bu kullanıcının içeriğini artık akışında görmeyeceksin.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -880,6 +880,12 @@ abstract class AppLocalizations {
   /// **'Unblock {displayName}'**
   String profileUnblockDisplayName(String displayName);
 
+  /// No description provided for @profileReportDisplayName.
+  ///
+  /// In en, this message translates to:
+  /// **'Report {displayName}'**
+  String profileReportDisplayName(String displayName);
+
   /// No description provided for @profileAddToListDisplayName.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -450,7 +450,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return '$displayNameን ሪፖርት አድርግ';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -449,6 +449,11 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return '$displayNameን ወደ ዝርዝር ጨምር';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -448,7 +448,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'أبلغ عن $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -447,6 +447,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'أضف $displayName إلى قائمة';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -467,6 +467,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Добави $displayName към списък';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -468,7 +468,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Докладвай $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -468,7 +468,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return '$displayName melden';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -467,6 +467,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return '$displayName zu einer Liste hinzufügen';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -463,6 +463,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Add $displayName to a list';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -467,6 +467,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Añadir $displayName a una lista';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -468,7 +468,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Reportar a $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -468,7 +468,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'I-report si $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -467,6 +467,11 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Idagdag si $displayName sa isang list';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -474,6 +474,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Ajouter $displayName à une liste';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -475,7 +475,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Signaler $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -447,7 +447,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Laporkan $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -446,6 +446,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Tambahkan $displayName ke daftar';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -468,6 +468,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Aggiungi $displayName a una lista';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -469,7 +469,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Segnala $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -426,7 +426,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return '$displayNameを報告';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -425,6 +425,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return '$displayNameをリストに追加';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -426,6 +426,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return '$displayName을(를) 목록에 추가';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -427,7 +427,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return '$displayName 신고';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -464,6 +464,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return '$displayName aan een lijst toevoegen';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -465,7 +465,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return '$displayName rapporteren';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -473,6 +473,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Dodaj $displayName do listy';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -474,7 +474,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Zgłoś $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -472,7 +472,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Denunciar $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -471,6 +471,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Adicionar $displayName a uma lista';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -487,7 +487,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Raportează-l pe $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -486,6 +486,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Adaugă $displayName la o listă';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -454,7 +454,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return 'Rapportera $displayName';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -453,6 +453,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return 'Lägg till $displayName i en lista';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -446,7 +446,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String profileReportDisplayName(String displayName) {
-    return 'Report $displayName';
+    return '$displayName adlı kullanıcıyı bildir';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -445,6 +445,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String profileReportDisplayName(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
   String profileAddToListDisplayName(String displayName) {
     return '$displayName kişisini listeye ekle';
   }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -62,6 +62,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         displayName: displayName,
         isFollowing: isFollowing,
         isBlocked: isBlocked,
+        showReport: true,
       ),
       children: const [],
     );
@@ -74,6 +75,9 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         await ClipboardUtils.copyPubkey(context, npub);
       case MoreSheetResult.unfollow:
         await followRepository.toggleFollow(otherPubkey);
+      case MoreSheetResult.report:
+        if (!mounted) return;
+        await ReportContentDialog.showForUser(context, userPubkey: otherPubkey);
       case MoreSheetResult.blockConfirmed:
         await blocklistRepository.blockUser(
           otherPubkey,
@@ -112,9 +116,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     final handle = (profileHandle != null && profileHandle.isNotEmpty)
         ? profileHandle
         : (otherPubkey.isNotEmpty
-              ? truncateNpubForDisplay(
-                  NostrKeyUtils.encodePubKey(otherPubkey),
-                )
+              ? truncateNpubForDisplay(NostrKeyUtils.encodePubKey(otherPubkey))
               : '');
 
     return Scaffold(
@@ -165,9 +167,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                         imageUrl: profile?.picture,
                         nip05: profile?.shortDisplayNip05,
                         onViewProfile: () {
-                          final npub = NostrKeyUtils.encodePubKey(
-                            otherPubkey,
-                          );
+                          final npub = NostrKeyUtils.encodePubKey(otherPubkey);
                           context.push('${OtherProfileScreen.path}/$npub');
                         },
                       ),

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -30,6 +30,7 @@ import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
 import 'package:openvine/widgets/profile/profile_loading_view.dart';
+import 'package:openvine/widgets/report_content_dialog.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -235,6 +236,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
             isFollowing: isFollowing,
             isBlocked: isBlocked,
             showAddToList: showAddToList,
+            showReport: !isOwnProfile,
           );
         },
       ),
@@ -265,13 +267,15 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
             initialCollaborator: profile,
           );
         } else {
-          await showNewPeopleListSheet(
-            context,
-            initialCollaborator: profile,
-          );
+          await showNewPeopleListSheet(context, initialCollaborator: profile);
         }
       case MoreSheetResult.unfollow:
         await _unfollowUser();
+      case MoreSheetResult.report:
+        await ReportContentDialog.showForUser(
+          context,
+          userPubkey: widget.pubkey,
+        );
       case MoreSheetResult.blockConfirmed:
         context.read<OtherProfileBloc>().add(
           const OtherProfileBlockRequested(),

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_content.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_content.dart
@@ -32,6 +32,7 @@ class MoreSheetContent extends StatefulWidget {
     required this.isBlocked,
     this.initialMode = MoreSheetMode.menu,
     this.showAddToList = false,
+    this.showReport = false,
     super.key,
   });
 
@@ -52,6 +53,12 @@ class MoreSheetContent extends StatefulWidget {
 
   /// Whether to show the "Add to list" action (curated-lists feature flag).
   final bool showAddToList;
+
+  /// Whether to show the "Report" action.
+  ///
+  /// Hidden on the current user's own profile, where reporting yourself
+  /// is meaningless.
+  final bool showReport;
 
   @override
   State<MoreSheetContent> createState() => _MoreSheetContentState();
@@ -171,6 +178,9 @@ class _MoreSheetContentState extends State<MoreSheetContent>
       },
       onAddToList: widget.showAddToList
           ? () => Navigator.of(context).pop(MoreSheetResult.addToList)
+          : null,
+      onReport: widget.showReport
+          ? () => Navigator.of(context).pop(MoreSheetResult.report)
           : null,
     );
   }

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_menu.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_menu.dart
@@ -1,12 +1,12 @@
 // ABOUTME: Menu widget for the More sheet with profile actions
-// ABOUTME: Copy public key, unfollow, and block/unblock actions
+// ABOUTME: Copy public key, unfollow, report, and block/unblock actions
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/l10n/l10n.dart';
 
-/// Menu widget for the More sheet with copy, unfollow, and block actions.
+/// Menu widget for the More sheet with copy, unfollow, report, and block
+/// actions.
 class MoreSheetMenu extends StatelessWidget {
   /// Creates a More sheet menu.
   const MoreSheetMenu({
@@ -17,6 +17,7 @@ class MoreSheetMenu extends StatelessWidget {
     required this.onUnfollow,
     required this.onBlockTap,
     this.onAddToList,
+    this.onReport,
     super.key,
   });
 
@@ -43,124 +44,84 @@ class MoreSheetMenu extends StatelessWidget {
   /// When null, the action is hidden (used for feature-flag gating).
   final VoidCallback? onAddToList;
 
+  /// Optional callback for the "Report" action.
+  ///
+  /// When null, the action is hidden (e.g. on own profile, where reporting
+  /// yourself is meaningless).
+  final VoidCallback? onReport;
+
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Column(
       key: const ValueKey('menu'),
       mainAxisSize: MainAxisSize.min,
       children: [
-        // Add to list action (curated lists feature flag gated by the caller)
         if (onAddToList != null)
-          InkWell(
-            onTap: onAddToList,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 16,
-                horizontal: 16,
-              ),
-              child: Row(
-                children: [
-                  SvgPicture.asset(
-                    DivineIconName.listPlus.assetPath,
-                    width: 24,
-                    height: 24,
-                    colorFilter: const ColorFilter.mode(
-                      VineTheme.whiteText,
-                      BlendMode.srcIn,
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Text(
-                    context.l10n.profileAddToListDisplayName(displayName),
-                    style: VineTheme.titleMediumFont(),
-                  ),
-                ],
-              ),
-            ),
+          _MoreSheetMenuItem(
+            icon: DivineIconName.listPlus,
+            label: l10n.profileAddToListDisplayName(displayName),
+            onTap: onAddToList!,
           ),
-        // Copy public key action
-        InkWell(
+        _MoreSheetMenuItem(
+          icon: DivineIconName.copy,
+          label: l10n.profileCopyPublicKey,
           onTap: onCopy,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-            child: Row(
-              children: [
-                SvgPicture.asset(
-                  DivineIconName.copy.assetPath,
-                  width: 24,
-                  height: 24,
-                  colorFilter: const ColorFilter.mode(
-                    VineTheme.whiteText,
-                    BlendMode.srcIn,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Text(
-                  context.l10n.profileCopyPublicKey,
-                  style: VineTheme.titleMediumFont(),
-                ),
-              ],
-            ),
-          ),
         ),
-        // Unfollow action (only if following)
         if (isFollowing)
-          InkWell(
+          _MoreSheetMenuItem(
+            icon: DivineIconName.userMinus,
+            label: l10n.profileUnfollowDisplayName(displayName),
             onTap: onUnfollow,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-              child: Row(
-                children: [
-                  SvgPicture.asset(
-                    DivineIconName.userMinus.assetPath,
-                    width: 24,
-                    height: 24,
-                    colorFilter: const ColorFilter.mode(
-                      VineTheme.whiteText,
-                      BlendMode.srcIn,
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Text(
-                    context.l10n.profileUnfollowDisplayName(displayName),
-                    style: VineTheme.titleMediumFont(),
-                  ),
-                ],
-              ),
-            ),
           ),
-        // Block/Unblock action
-        InkWell(
+        if (onReport != null)
+          _MoreSheetMenuItem(
+            icon: DivineIconName.flag,
+            label: l10n.profileReportDisplayName(displayName),
+            onTap: onReport!,
+          ),
+        _MoreSheetMenuItem(
+          icon: isBlocked
+              ? DivineIconName.prohibitInset
+              : DivineIconName.prohibit,
+          label: isBlocked
+              ? l10n.profileUnblockDisplayName(displayName)
+              : l10n.profileBlockDisplayName(displayName),
           onTap: onBlockTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-            child: Row(
-              children: [
-                SvgPicture.asset(
-                  isBlocked
-                      ? DivineIconName.prohibitInset.assetPath
-                      : DivineIconName.prohibit.assetPath,
-                  width: 24,
-                  height: 24,
-                  colorFilter: ColorFilter.mode(
-                    isBlocked ? VineTheme.onSurface : VineTheme.error,
-                    BlendMode.srcIn,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Text(
-                  isBlocked
-                      ? context.l10n.profileUnblockDisplayName(displayName)
-                      : context.l10n.profileBlockDisplayName(displayName),
-                  style: VineTheme.titleMediumFont(
-                    color: isBlocked ? VineTheme.onSurface : VineTheme.error,
-                  ),
-                ),
-              ],
-            ),
-          ),
+          color: isBlocked ? VineTheme.onSurface : VineTheme.error,
         ),
       ],
+    );
+  }
+}
+
+class _MoreSheetMenuItem extends StatelessWidget {
+  const _MoreSheetMenuItem({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.color = VineTheme.whiteText,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final VoidCallback onTap;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+        child: Row(
+          spacing: 16,
+          children: [
+            DivineIcon(icon: icon, color: color),
+            Text(label, style: VineTheme.titleMediumFont(color: color)),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_menu.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_menu.dart
@@ -110,16 +110,22 @@ class _MoreSheetMenuItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-        child: Row(
-          spacing: 16,
-          children: [
-            DivineIcon(icon: icon, color: color),
-            Text(label, style: VineTheme.titleMediumFont(color: color)),
-          ],
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        onTap: onTap,
+        child: ExcludeSemantics(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+            child: Row(
+              spacing: 16,
+              children: [
+                DivineIcon(icon: icon, color: color),
+                Text(label, style: VineTheme.titleMediumFont(color: color)),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_result.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_result.dart
@@ -3,7 +3,7 @@
 
 /// Type-safe result from the More sheet actions.
 ///
-/// Used to communicate user actions from [MoreSheetPage] back to the caller.
+/// Used to communicate user actions from [MoreSheetContent] back to the caller.
 enum MoreSheetResult {
   /// User tapped copy public key.
   copy,

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_result.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_result.dart
@@ -11,6 +11,9 @@ enum MoreSheetResult {
   /// User confirmed unfollow action.
   unfollow,
 
+  /// User tapped report.
+  report,
+
   /// User confirmed block action.
   blockConfirmed,
 

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -13,7 +13,7 @@ import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-/// Shows a [VineBottomSheet] for reporting content.
+/// Shows a [VineBottomSheet] for reporting content or a user.
 ///
 /// Usage:
 /// ```dart
@@ -23,6 +23,10 @@ import 'package:url_launcher/url_launcher.dart';
 ///   messageId: message.id,
 ///   senderPubkey: message.senderPubkey,
 /// );
+/// await ReportContentDialog.showForUser(
+///   context,
+///   userPubkey: pubkey,
+/// );
 /// ```
 class ReportContentDialog extends ConsumerStatefulWidget {
   ReportContentDialog({
@@ -30,14 +34,18 @@ class ReportContentDialog extends ConsumerStatefulWidget {
     this.video,
     this.eventId,
     this.authorPubkey,
+    this.userPubkey,
     this.moderationKindLabel = 'Content Report',
     this.moderationEventLabel = 'Event',
     this.isFromShareMenu = false,
     this.draggableController,
   }) {
-    if (video == null && (eventId == null || authorPubkey == null)) {
+    final hasVideo = video != null;
+    final hasContent = eventId != null && authorPubkey != null;
+    final hasUser = userPubkey != null;
+    if (!hasVideo && !hasContent && !hasUser) {
       throw ArgumentError(
-        'Provide either a video or both eventId and authorPubkey.',
+        'Provide a video, both eventId and authorPubkey, or a userPubkey.',
       );
     }
   }
@@ -46,12 +54,20 @@ class ReportContentDialog extends ConsumerStatefulWidget {
   /// fall back to `video.id` / `video.pubkey`.
   final VideoEvent? video;
 
-  /// Event id of the content being reported. Required when [video] is null.
+  /// Event id of the content being reported. Required when [video] is null
+  /// and this is not a user-targeted report.
   final String? eventId;
 
   /// Author pubkey of the content being reported. Required when [video]
-  /// is null.
+  /// is null and this is not a user-targeted report.
   final String? authorPubkey;
+
+  /// Pubkey of the user being reported.
+  ///
+  /// When non-null, the report targets the user (no specific event) and
+  /// the dialog routes through [ContentReportingService.reportUser]
+  /// instead of [ContentReportingService.reportContent].
+  final String? userPubkey;
 
   /// Header used in the moderation DM (e.g. "Content Report", "DM
   /// Message Report"). Internal-only — not user-visible.
@@ -114,6 +130,32 @@ class ReportContentDialog extends ConsumerStatefulWidget {
         .whenComplete(controller.dispose);
   }
 
+  /// Shows the bottom sheet for reporting a user account (e.g. for
+  /// harassment, impersonation, or underage account claims).
+  ///
+  /// Routes submission through [ContentReportingService.reportUser], which
+  /// emits a NIP-56 report with the synthetic `user_<pubkey>` event id.
+  static Future<void> showForUser(
+    BuildContext context, {
+    required String userPubkey,
+  }) {
+    final controller = DraggableScrollableController();
+    return context
+        .showVideoPausingVineBottomSheet<void>(
+          initialChildSize: 0.85,
+          maxChildSize: 0.95,
+          minChildSize: 0.5,
+          draggableController: controller,
+          body: ReportContentDialog(
+            userPubkey: userPubkey,
+            moderationKindLabel: 'User Report',
+            moderationEventLabel: 'User Pubkey',
+            draggableController: controller,
+          ),
+        )
+        .whenComplete(controller.dispose);
+  }
+
   @override
   ConsumerState<ReportContentDialog> createState() =>
       _ReportContentDialogState();
@@ -131,8 +173,16 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   bool _scrollWhenKeyboardOpens = false;
   double _previousViewInsetsBottom = 0;
 
-  String get _eventId => widget.eventId ?? widget.video!.id;
-  String get _authorPubkey => widget.authorPubkey ?? widget.video!.pubkey;
+  bool get _isUserReport => widget.userPubkey != null;
+
+  String get _eventId {
+    final userPubkey = widget.userPubkey;
+    if (userPubkey != null) return 'user_$userPubkey';
+    return widget.eventId ?? widget.video!.id;
+  }
+
+  String get _authorPubkey =>
+      widget.userPubkey ?? widget.authorPubkey ?? widget.video!.pubkey;
 
   @override
   void didChangeDependencies() {
@@ -302,14 +352,21 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
       final reportService = await ref.read(
         contentReportingServiceProvider.future,
       );
-      final result = await reportService.reportContent(
-        eventId: _eventId,
-        authorPubkey: _authorPubkey,
-        reason: _selectedReason!,
-        details: _detailsController.text.trim().isEmpty
-            ? selectedReasonTitle
-            : _detailsController.text.trim(),
-      );
+      final details = _detailsController.text.trim().isEmpty
+          ? selectedReasonTitle
+          : _detailsController.text.trim();
+      final result = _isUserReport
+          ? await reportService.reportUser(
+              userPubkey: widget.userPubkey!,
+              reason: _selectedReason!,
+              details: details,
+            )
+          : await reportService.reportContent(
+              eventId: _eventId,
+              authorPubkey: _authorPubkey,
+              reason: _selectedReason!,
+              details: details,
+            );
 
       if (mounted) {
         if (result.success) {

--- a/mobile/test/widgets/profile/more_sheet/more_sheet_menu_test.dart
+++ b/mobile/test/widgets/profile/more_sheet/more_sheet_menu_test.dart
@@ -1,0 +1,144 @@
+// ABOUTME: Widget tests for MoreSheetMenu — verifies which actions render
+// ABOUTME: based on follow / block state and the optional add-to-list/report flags.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/profile/more_sheet/more_sheet_menu.dart';
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+  const displayName = 'Alice';
+
+  Widget buildSubject({
+    bool isFollowing = false,
+    bool isBlocked = false,
+    VoidCallback? onAddToList,
+    VoidCallback? onReport,
+    VoidCallback? onCopy,
+    VoidCallback? onUnfollow,
+    VoidCallback? onBlockTap,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: MoreSheetMenu(
+          displayName: displayName,
+          isFollowing: isFollowing,
+          isBlocked: isBlocked,
+          onCopy: onCopy ?? () {},
+          onUnfollow: onUnfollow ?? () {},
+          onBlockTap: onBlockTap ?? () {},
+          onAddToList: onAddToList,
+          onReport: onReport,
+        ),
+      ),
+    );
+  }
+
+  group(MoreSheetMenu, () {
+    testWidgets('renders copy and block actions in default state', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text(l10n.profileCopyPublicKey), findsOneWidget);
+      expect(
+        find.text(l10n.profileBlockDisplayName(displayName)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides Unfollow when not following', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(
+        find.text(l10n.profileUnfollowDisplayName(displayName)),
+        findsNothing,
+      );
+    });
+
+    testWidgets('renders Unfollow when following', (tester) async {
+      await tester.pumpWidget(buildSubject(isFollowing: true));
+
+      expect(
+        find.text(l10n.profileUnfollowDisplayName(displayName)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders Unblock label when blocked', (tester) async {
+      await tester.pumpWidget(buildSubject(isBlocked: true));
+
+      expect(
+        find.text(l10n.profileUnblockDisplayName(displayName)),
+        findsOneWidget,
+      );
+      expect(
+        find.text(l10n.profileBlockDisplayName(displayName)),
+        findsNothing,
+      );
+    });
+
+    testWidgets('hides Report when onReport is null', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(
+        find.text(l10n.profileReportDisplayName(displayName)),
+        findsNothing,
+      );
+    });
+
+    testWidgets('renders Report when onReport is provided', (tester) async {
+      await tester.pumpWidget(buildSubject(onReport: () {}));
+
+      expect(
+        find.text(l10n.profileReportDisplayName(displayName)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping Report invokes onReport', (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(buildSubject(onReport: () => tapped++));
+
+      await tester.tap(find.text(l10n.profileReportDisplayName(displayName)));
+      await tester.pumpAndSettle();
+
+      expect(tapped, equals(1));
+    });
+
+    testWidgets('hides Add to list when onAddToList is null', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(
+        find.text(l10n.profileAddToListDisplayName(displayName)),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+      'renders Add to list, Copy, Report, and Block when all enabled',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(onAddToList: () {}, onReport: () {}),
+        );
+
+        expect(
+          find.text(l10n.profileAddToListDisplayName(displayName)),
+          findsOneWidget,
+        );
+        expect(find.text(l10n.profileCopyPublicKey), findsOneWidget);
+        expect(
+          find.text(l10n.profileReportDisplayName(displayName)),
+          findsOneWidget,
+        );
+        expect(
+          find.text(l10n.profileBlockDisplayName(displayName)),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/profile/more_sheet/more_sheet_menu_test.dart
+++ b/mobile/test/widgets/profile/more_sheet/more_sheet_menu_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Widget tests for MoreSheetMenu — verifies which actions render
 // ABOUTME: based on follow / block state and the optional add-to-list/report flags.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -107,6 +109,26 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tapped, equals(1));
+    });
+
+    testWidgets('Report action exposes button semantics', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildSubject(onReport: () {}));
+
+      final reportFinder = find.bySemanticsLabel(
+        l10n.profileReportDisplayName(displayName),
+      );
+      expect(reportFinder, findsOneWidget);
+      final semanticsNode = tester.getSemantics(reportFinder);
+      final semanticsData = semanticsNode.getSemanticsData();
+      expect(
+        semanticsNode.label,
+        equals(l10n.profileReportDisplayName(displayName)),
+      );
+      expect(semanticsData.hasFlag(ui.SemanticsFlag.isButton), isTrue);
+      expect(semanticsData.hasAction(ui.SemanticsAction.tap), isTrue);
+      semantics.dispose();
     });
 
     testWidgets('hides Add to list when onAddToList is null', (tester) async {

--- a/mobile/test/widgets/profile/more_sheet/more_sheet_menu_test.dart
+++ b/mobile/test/widgets/profile/more_sheet/more_sheet_menu_test.dart
@@ -126,7 +126,7 @@ void main() {
         semanticsNode.label,
         equals(l10n.profileReportDisplayName(displayName)),
       );
-      expect(semanticsData.hasFlag(ui.SemanticsFlag.isButton), isTrue);
+      expect(semanticsData.flagsCollection.isButton, isTrue);
       expect(semanticsData.hasAction(ui.SemanticsAction.tap), isTrue);
       semantics.dispose();
     });

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -82,6 +82,17 @@ void main() {
     ).thenAnswer((_) async => ReportResult.createSuccess('test_report_id'));
 
     when(
+      () => mockReportingService.reportUser(
+        userPubkey: any(named: 'userPubkey'),
+        reason: any(named: 'reason'),
+        details: any(named: 'details'),
+        relatedEventIds: any(named: 'relatedEventIds'),
+      ),
+    ).thenAnswer(
+      (_) async => ReportResult.createSuccess('test_user_report_id'),
+    );
+
+    when(
       () => mockMuteService.muteUser(
         any(),
         reason: any(named: 'reason'),
@@ -100,6 +111,13 @@ void main() {
         );
       },
     );
+
+    test('does not throw when only a userPubkey is provided', () {
+      expect(
+        () => ReportContentDialog(userPubkey: 'pubkey_hex'),
+        returnsNormally,
+      );
+    });
   });
 
   group('$ReportContentDialog rendering', () {
@@ -897,6 +915,169 @@ void main() {
         );
       },
     );
+  });
+
+  group('user report (showForUser path)', () {
+    late MockNostrClient mockNostrClient;
+    late _MockDmRepository mockDmRepository;
+    late _MockModerationLabelService mockModerationLabelService;
+
+    const testUserPubkey =
+        '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+
+    setUp(() {
+      mockNostrClient = createMockNostrService();
+      mockDmRepository = _MockDmRepository();
+      mockModerationLabelService = _MockModerationLabelService();
+
+      when(() => mockNostrClient.publicKey).thenReturn('test_pubkey_hex');
+      when(
+        () => mockModerationLabelService.divineModerationPubkeyHex,
+      ).thenReturn(ModerationLabelService.fallbackModerationPubkeyHex);
+      when(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: 'dm_rumor_id',
+          messageEventId: 'dm_event_id',
+          recipientPubkey: ModerationLabelService.fallbackModerationPubkeyHex,
+        ),
+      );
+    });
+
+    Widget buildUserReportSubject() {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showDialog<void>(
+                    context: context,
+                    builder: (_) => Material(
+                      child: ReportContentDialog(
+                        userPubkey: testUserPubkey,
+                        moderationKindLabel: 'User Report',
+                        moderationEventLabel: 'User Pubkey',
+                      ),
+                    ),
+                  ),
+                  child: const Text('Open Report'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      return testProviderScope(
+        mockNostrService: mockNostrClient,
+        mockModerationLabelService: mockModerationLabelService,
+        additionalOverrides: [
+          contentReportingServiceProvider.overrideWith(
+            (ref) async => mockReportingService,
+          ),
+          contentBlocklistRepositoryProvider.overrideWith(
+            (ref) => mockBlocklistRepository,
+          ),
+          muteServiceProvider.overrideWith((ref) async => mockMuteService),
+          dmRepositoryProvider.overrideWithValue(mockDmRepository),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    Future<void> openAndSubmitUserReport(WidgetTester tester) async {
+      await tester.pumpWidget(buildUserReportSubject());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open Report'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.reportReasonHarassment));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'submission calls reportUser with the user pubkey and skips reportContent',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        await openAndSubmitUserReport(tester);
+
+        verify(
+          () => mockReportingService.reportUser(
+            userPubkey: testUserPubkey,
+            reason: ContentFilterReason.harassment,
+            details: any(named: 'details'),
+            relatedEventIds: any(named: 'relatedEventIds'),
+          ),
+        ).called(1);
+
+        verifyNever(
+          () => mockReportingService.reportContent(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
+            reason: any(named: 'reason'),
+            details: any(named: 'details'),
+            additionalContext: any(named: 'additionalContext'),
+            hashtags: any(named: 'hashtags'),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'moderation DM body uses User Report header and the synthetic user_<pubkey> event id',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        await openAndSubmitUserReport(tester);
+
+        final captured = verify(
+          () => mockDmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: captureAny(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).captured;
+
+        final dmContent = captured.single as String;
+        expect(
+          dmContent,
+          contains('User Report'),
+          reason: 'header should distinguish user reports from content reports',
+        );
+        expect(
+          dmContent,
+          contains('User Pubkey: user_$testUserPubkey'),
+          reason: 'event-id line should carry the synthetic user_<pubkey> id',
+        );
+        expect(
+          dmContent,
+          isNot(contains('Content Report')),
+          reason: 'content-report header must not leak into user-report body',
+        );
+      },
+    );
+
+    testWidgets('successful user report shows the in-sheet confirmation', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      await openAndSubmitUserReport(tester);
+
+      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
+    });
   });
 
   group('moderation constants', () {


### PR DESCRIPTION
## Description

Users could only report someone from a DM thread; there was no path to report a user account directly (harassment, impersonation, underage). This PR surfaces a Report action in the profile more-sheet and routes it through `ContentReportingService.reportUser` via a new `ReportContentDialog.showForUser` entry point.

**Related Issue:** Closes #4376

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactor

## What changed

**New surface**
- New `MoreSheetResult.report` and `showReport` flag on `MoreSheetContent`.
- `MoreSheetMenu` renders a "Report {displayName}" action (flag icon) when enabled.
- `other_profile_screen.dart` enables it for non-own profiles; `conversation_view.dart` enables it inside DM threads.
- New `ReportContentDialog.showForUser(context, userPubkey: …)` reuses the existing reason-picker UX and routes submission through `ContentReportingService.reportUser` (synthetic `user_<pubkey>` event id, "User Report" moderation-DM header).

**Tech-debt cleanup adjacent to the change**
- `MoreSheetMenu` now wraps each action row in explicit button semantics so screen readers announce the actions correctly.
- Fixed stale doc text in `more_sheet_result.dart` to reference `MoreSheetContent` instead of the old class name.
- Added locale ARB entries for the profile report action so l10n consistency stays green.

## Plain-language summary

This change adds profile reporting in the place people already expect to find it: under the kebab menu on someone else's profile, like every other major social app.

Where reporting lives now:
- On profiles: open someone else's profile, tap the kebab menu (`More`), then tap `Report`.
- On videos: on the right-side action menu on a video, tap on the flag to use the existing `Report` action there.

When reporting is hidden:
- The app hides `Report` on your own profile.
- The app hides `Report` on your own videos.
- In other words, you cannot report yourself.

Under the hood, profile reporting now goes through `ReportContentDialog.showForUser(...)` and `ContentReportingService.reportUser(...)`. Video and other content reporting continue through the existing content reporting path.

## Test plan

- [x] `dart format` clean
- [x] `flutter analyze lib test integration_test` → 0 issues
- [x] 9 new widget tests for `MoreSheetMenu` (conditional rendering of every action + tap callback)
- [x] 4 new tests on `ReportContentDialog` for the `showForUser` path (constructor accepts `userPubkey`, submission calls `reportUser` not `reportContent`, moderation DM uses "User Report" header + `user_<pubkey>` id, success shows in-sheet confirmation)
- [x] Existing `report_content_dialog_test.dart` and `conversation_view_test.dart` still green
- [x] `test/l10n/arb_consistency_test.dart`
- [ ] Manual: open another user's profile → tap More → tap Report → submit each reason category, including Other with details
- [ ] Manual: own profile → tap More → confirm Report is hidden
- [ ] Manual: DM thread more-options → tap Report → verify the same flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
