### PR TITLE
refactor: logging for tag sanitization and improve log clarity

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -192,14 +192,16 @@ class VideoEventPublisher {
       return eventMap;
     }
 
-    final sanitizedTags = rawTags.map((rawTag) {
-      if (rawTag is! List) {
-        return rawTag;
-      }
+    final sanitizedTags = rawTags
+        .map((rawTag) {
+          if (rawTag is! List) {
+            return rawTag;
+          }
 
-      final tagParts = rawTag.map((part) => part.toString()).toList();
-      return sanitizeTagForLog(tagParts);
-    }).toList(growable: false);
+          final tagParts = rawTag.map((part) => part.toString()).toList();
+          return sanitizeTagForLog(tagParts);
+        })
+        .toList(growable: false);
 
     return <String, dynamic>{...eventMap, 'tags': sanitizedTags};
   }

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -124,12 +124,7 @@ List<List<String>> _buildMentionPTags(
       continue;
     }
 
-    tags.add([
-      'p',
-      normalizedPubkey,
-      collaboratorInviteRelayHint,
-      'mention',
-    ]);
+    tags.add(['p', normalizedPubkey, collaboratorInviteRelayHint, 'mention']);
   }
 
   return tags;
@@ -186,26 +181,6 @@ class VideoEventPublisher {
   Duration get currentOuterPublishTimeout =>
       outerPublishTimeoutFor(_nostrService.configuredRelayCount);
 
-  Map<String, dynamic> _sanitizeEventJsonForLog(Map<String, dynamic> eventMap) {
-    final rawTags = eventMap['tags'];
-    if (rawTags is! List) {
-      return eventMap;
-    }
-
-    final sanitizedTags = rawTags
-        .map((rawTag) {
-          if (rawTag is! List) {
-            return rawTag;
-          }
-
-          final tagParts = rawTag.map((part) => part.toString()).toList();
-          return sanitizeTagForLog(tagParts);
-        })
-        .toList(growable: false);
-
-    return <String, dynamic>{...eventMap, 'tags': sanitizedTags};
-  }
-
   void _addReplyTags(List<List<String>> tags, VideoReplyContext context) {
     tags
       ..add(['E', context.rootEventId, '', context.rootAuthorPubkey])
@@ -227,10 +202,7 @@ class VideoEventPublisher {
           context.parentAuthorPubkey ?? context.rootAuthorPubkey,
         ])
         ..add(['k', EventKind.comment.toString()])
-        ..add([
-          'p',
-          context.parentAuthorPubkey ?? context.rootAuthorPubkey,
-        ]);
+        ..add(['p', context.parentAuthorPubkey ?? context.rootAuthorPubkey]);
       return;
     }
 
@@ -365,7 +337,7 @@ class VideoEventPublisher {
 
       // Log the raw JSON representation
       try {
-        final eventMap = _sanitizeEventJsonForLog(event.toJson());
+        final eventMap = sanitizeEventJsonForLog(event.toJson());
         final jsonStr = jsonEncode(eventMap);
         Log.info(
           '📋 FULL EVENT JSON:',
@@ -609,12 +581,10 @@ class VideoEventPublisher {
       if (replyContext != null) {
         _addReplyTags(tags, replyContext);
         if (addReplyToFeed) {
-          tags.add(
-            const [
-              videoReplyVisibilityTagName,
-              videoReplyVisibilityFeedValue,
-            ],
-          );
+          tags.add(const [
+            videoReplyVisibilityTagName,
+            videoReplyVisibilityFeedValue,
+          ]);
         }
       }
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -29,6 +29,7 @@ import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
+import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:openvine/utils/proofmode_publishing_helpers.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -137,12 +138,6 @@ List<List<String>> _buildMentionPTags(
 /// Service for publishing processed videos to Nostr relays
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class VideoEventPublisher {
-  static const Set<String> _redactedTagNames = {
-    'proofmode',
-    'device_attestation',
-  };
-  static const int _maxLoggedTagPartLength = 180;
-
   VideoEventPublisher({
     required UploadManager uploadManager,
     required NostrClient nostrService,
@@ -191,28 +186,6 @@ class VideoEventPublisher {
   Duration get currentOuterPublishTimeout =>
       outerPublishTimeoutFor(_nostrService.configuredRelayCount);
 
-  List<String> _sanitizeTagForLog(List<String> tag) {
-    if (tag.isEmpty) {
-      return tag;
-    }
-
-    final tagName = tag.first;
-    if (_redactedTagNames.contains(tagName)) {
-      return <String>[tagName, '[FILTERED_FROM_LOGS]'];
-    }
-
-    return <String>[
-      tagName,
-      ...tag.skip(1).map((part) {
-        if (part.length <= _maxLoggedTagPartLength) {
-          return part;
-        }
-
-        return '${part.substring(0, _maxLoggedTagPartLength)}...(truncated)';
-      }),
-    ];
-  }
-
   Map<String, dynamic> _sanitizeEventJsonForLog(Map<String, dynamic> eventMap) {
     final rawTags = eventMap['tags'];
     if (rawTags is! List) {
@@ -225,7 +198,7 @@ class VideoEventPublisher {
       }
 
       final tagParts = rawTag.map((part) => part.toString()).toList();
-      return _sanitizeTagForLog(tagParts);
+      return sanitizeTagForLog(tagParts);
     }).toList(growable: false);
 
     return <String, dynamic>{...eventMap, 'tags': sanitizedTags};
@@ -365,7 +338,7 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
       for (final tag in event.tags) {
-        final sanitizedTag = _sanitizeTagForLog(tag);
+        final sanitizedTag = sanitizeTagForLog(tag);
         Log.info(
           '    - ${sanitizedTag.join(", ")}',
           name: 'VideoEventPublisher',

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -137,6 +137,12 @@ List<List<String>> _buildMentionPTags(
 /// Service for publishing processed videos to Nostr relays
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class VideoEventPublisher {
+  static const Set<String> _redactedTagNames = {
+    'proofmode',
+    'device_attestation',
+  };
+  static const int _maxLoggedTagPartLength = 180;
+
   VideoEventPublisher({
     required UploadManager uploadManager,
     required NostrClient nostrService,
@@ -184,6 +190,46 @@ class VideoEventPublisher {
   /// this getter has no side effects.
   Duration get currentOuterPublishTimeout =>
       outerPublishTimeoutFor(_nostrService.configuredRelayCount);
+
+  List<String> _sanitizeTagForLog(List<String> tag) {
+    if (tag.isEmpty) {
+      return tag;
+    }
+
+    final tagName = tag.first;
+    if (_redactedTagNames.contains(tagName)) {
+      return <String>[tagName, '[FILTERED_FROM_LOGS]'];
+    }
+
+    return <String>[
+      tagName,
+      ...tag.skip(1).map((part) {
+        if (part.length <= _maxLoggedTagPartLength) {
+          return part;
+        }
+
+        return '${part.substring(0, _maxLoggedTagPartLength)}...(truncated)';
+      }),
+    ];
+  }
+
+  Map<String, dynamic> _sanitizeEventJsonForLog(Map<String, dynamic> eventMap) {
+    final rawTags = eventMap['tags'];
+    if (rawTags is! List) {
+      return eventMap;
+    }
+
+    final sanitizedTags = rawTags.map((rawTag) {
+      if (rawTag is! List) {
+        return rawTag;
+      }
+
+      final tagParts = rawTag.map((part) => part.toString()).toList();
+      return _sanitizeTagForLog(tagParts);
+    }).toList(growable: false);
+
+    return <String, dynamic>{...eventMap, 'tags': sanitizedTags};
+  }
 
   void _addReplyTags(List<List<String>> tags, VideoReplyContext context) {
     tags
@@ -319,8 +365,9 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
       for (final tag in event.tags) {
+        final sanitizedTag = _sanitizeTagForLog(tag);
         Log.info(
-          '    - ${tag.join(", ")}',
+          '    - ${sanitizedTag.join(", ")}',
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
@@ -343,7 +390,7 @@ class VideoEventPublisher {
 
       // Log the raw JSON representation
       try {
-        final eventMap = event.toJson();
+        final eventMap = _sanitizeEventJsonForLog(event.toJson());
         final jsonStr = jsonEncode(eventMap);
         Log.info(
           '📋 FULL EVENT JSON:',

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2236,7 +2236,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         }
 
         Log.verbose(
-          'Direct event tags: ${event.tags}',
+          'Direct event tags: ${_formatEventTagsForLog(event.tags)}',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -5093,6 +5093,36 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     unsubscribeFromVideoFeed();
     unawaited(_removedVideoIdsController.close());
     super.dispose();
+  }
+
+  /// Generate deterministic subscription ID based on subscription parameters
+  String _formatEventTagsForLog(List<List<String>> tags) {
+    const redactedTagNames = {'proofmode', 'device_attestation'};
+    const maxLoggedTagPartLength = 180;
+
+    final sanitizedTags = tags.map((tag) {
+      if (tag.isEmpty) {
+        return tag;
+      }
+
+      final tagName = tag.first;
+      if (redactedTagNames.contains(tagName)) {
+        return <String>[tagName, '[FILTERED_FROM_LOGS]'];
+      }
+
+      return <String>[
+        tagName,
+        ...tag.skip(1).map((part) {
+          if (part.length <= maxLoggedTagPartLength) {
+            return part;
+          }
+
+          return '${part.substring(0, maxLoggedTagPartLength)}...(truncated)';
+        }),
+      ];
+    }).toList(growable: false);
+
+    return sanitizedTags.toString();
   }
 
   /// Generate deterministic subscription ID based on subscription parameters

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -45,6 +45,7 @@ import 'package:openvine/services/repost_resolver.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_filter_builder.dart';
 import 'package:openvine/utils/log_batcher.dart';
+import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:video_event_cache/video_event_cache.dart';
@@ -5095,34 +5096,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     super.dispose();
   }
 
-  /// Generate deterministic subscription ID based on subscription parameters
+  /// Sanitizes event tags for log output: redacts sensitive tag values and
+  /// truncates long parts to keep log lines manageable.
   String _formatEventTagsForLog(List<List<String>> tags) {
-    const redactedTagNames = {'proofmode', 'device_attestation'};
-    const maxLoggedTagPartLength = 180;
-
-    final sanitizedTags = tags.map((tag) {
-      if (tag.isEmpty) {
-        return tag;
-      }
-
-      final tagName = tag.first;
-      if (redactedTagNames.contains(tagName)) {
-        return <String>[tagName, '[FILTERED_FROM_LOGS]'];
-      }
-
-      return <String>[
-        tagName,
-        ...tag.skip(1).map((part) {
-          if (part.length <= maxLoggedTagPartLength) {
-            return part;
-          }
-
-          return '${part.substring(0, maxLoggedTagPartLength)}...(truncated)';
-        }),
-      ];
-    }).toList(growable: false);
-
-    return sanitizedTags.toString();
+    return tags
+        .map(sanitizeTagForLog)
+        .toList(growable: false)
+        .toString();
   }
 
   /// Generate deterministic subscription ID based on subscription parameters

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -5099,10 +5099,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Sanitizes event tags for log output: redacts sensitive tag values and
   /// truncates long parts to keep log lines manageable.
   String _formatEventTagsForLog(List<List<String>> tags) {
-    return tags
-        .map(sanitizeTagForLog)
-        .toList(growable: false)
-        .toString();
+    return tags.map(sanitizeTagForLog).toList(growable: false).toString();
   }
 
   /// Generate deterministic subscription ID based on subscription parameters

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2405,7 +2405,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             category: LogCategory.video,
           );
           Log.verbose(
-            '  - Tags: ${event.tags}',
+            '  - Tags: ${_formatEventTagsForLog(event.tags)}',
             name: 'VideoEventService',
             category: LogCategory.video,
           );

--- a/mobile/lib/utils/log_tag_sanitizer.dart
+++ b/mobile/lib/utils/log_tag_sanitizer.dart
@@ -1,0 +1,28 @@
+const Set<String> _kRedactedTagNames = {'proofmode', 'device_attestation'};
+const int _kMaxLoggedTagPartLength = 180;
+
+/// Sanitizes a single Nostr event tag for log output.
+///
+/// Redacts the value of privacy-sensitive tags and truncates any part longer
+/// than 180 characters so log lines stay manageable.
+List<String> sanitizeTagForLog(List<String> tag) {
+  if (tag.isEmpty) {
+    return tag;
+  }
+
+  final tagName = tag.first;
+  if (_kRedactedTagNames.contains(tagName)) {
+    return <String>[tagName, '[FILTERED_FROM_LOGS]'];
+  }
+
+  return <String>[
+    tagName,
+    ...tag.skip(1).map((part) {
+      if (part.length <= _kMaxLoggedTagPartLength) {
+        return part;
+      }
+
+      return '${part.substring(0, _kMaxLoggedTagPartLength)}...(truncated)';
+    }),
+  ];
+}

--- a/mobile/lib/utils/log_tag_sanitizer.dart
+++ b/mobile/lib/utils/log_tag_sanitizer.dart
@@ -26,3 +26,27 @@ List<String> sanitizeTagForLog(List<String> tag) {
     }),
   ];
 }
+
+/// Sanitizes an event JSON map for log output.
+///
+/// Redacts privacy-sensitive tag values and truncates oversized tag parts
+/// while preserving non-tag fields exactly as-is.
+Map<String, dynamic> sanitizeEventJsonForLog(Map<String, dynamic> eventMap) {
+  final rawTags = eventMap['tags'];
+  if (rawTags is! List) {
+    return eventMap;
+  }
+
+  final sanitizedTags = rawTags
+      .map((rawTag) {
+        if (rawTag is! List) {
+          return rawTag;
+        }
+
+        final tagParts = rawTag.map((part) => part.toString()).toList();
+        return sanitizeTagForLog(tagParts);
+      })
+      .toList(growable: false);
+
+  return <String, dynamic>{...eventMap, 'tags': sanitizedTags};
+}

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -141,7 +141,7 @@ class VideoEvent {
       final tagValue = (tag.length > 1) ? tag[1] : '';
 
       developer.log(
-        '🔍 DEBUG: Tag [$i]: $tagName = "$tagValue" (${tag.length} elements)',
+        '🔍 DEBUG: Tag [$i]: $tagName (${tag.length} elements)',
         name: 'VideoEvent',
       );
 
@@ -606,9 +606,14 @@ class VideoEvent {
       developer.log('🔍 Event Pubkey: ${event.pubkey}', name: 'VideoEvent');
       developer.log('🔍 Thumbnail URL: $thumbnailUrl', name: 'VideoEvent');
       developer.log('🔍 Video URL: $videoUrl', name: 'VideoEvent');
-      developer.log('🔍 Full Event Tags JSON:', name: 'VideoEvent');
+      developer.log('🔍 Event tag summary:', name: 'VideoEvent');
       for (var i = 0; i < event.tags.length; i++) {
-        developer.log('🔍   Tag[$i]: ${event.tags[i]}', name: 'VideoEvent');
+        final tag = event.tags[i];
+        final tagName = tag.isNotEmpty ? tag.first : '<empty>';
+        developer.log(
+          '🔍   Tag[$i]: $tagName (${tag.length} elements)',
+          name: 'VideoEvent',
+        );
       }
       developer.log('🔍 Event Content: ${event.content}', name: 'VideoEvent');
       developer.log(

--- a/mobile/test/utils/log_tag_sanitizer_test.dart
+++ b/mobile/test/utils/log_tag_sanitizer_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/log_tag_sanitizer.dart';
+
+void main() {
+  group('sanitizeTagForLog', () {
+    test('returns empty tags unchanged', () {
+      expect(sanitizeTagForLog(const []), isEmpty);
+    });
+
+    test('redacts proofmode and device attestation payloads', () {
+      expect(
+        sanitizeTagForLog(const ['proofmode', '{"proof":"secret"}']),
+        equals(const ['proofmode', '[FILTERED_FROM_LOGS]']),
+      );
+      expect(
+        sanitizeTagForLog(const ['device_attestation', 'token-abc']),
+        equals(const ['device_attestation', '[FILTERED_FROM_LOGS]']),
+      );
+    });
+
+    test('leaves ordinary tags unchanged when parts are short', () {
+      expect(
+        sanitizeTagForLog(const ['t', 'cats', 'dogs']),
+        equals(const ['t', 'cats', 'dogs']),
+      );
+    });
+
+    test('truncates oversized non-sensitive tag parts', () {
+      final longPart = 'x' * 181;
+
+      expect(
+        sanitizeTagForLog(['alt', longPart]),
+        equals(['alt', '${'x' * 180}...(truncated)']),
+      );
+    });
+  });
+
+  group('sanitizeEventJsonForLog', () {
+    test('sanitizes nested tags and preserves other fields', () {
+      final eventMap = <String, dynamic>{
+        'id': 'event-123',
+        'content': 'hello',
+        'tags': <dynamic>[
+          <dynamic>['proofmode', '{"proof":"secret"}'],
+          <dynamic>['alt', 'x' * 181],
+          'non-list-tag',
+        ],
+      };
+
+      expect(sanitizeEventJsonForLog(eventMap), <String, dynamic>{
+        'id': 'event-123',
+        'content': 'hello',
+        'tags': <dynamic>[
+          <String>['proofmode', '[FILTERED_FROM_LOGS]'],
+          <String>['alt', '${'x' * 180}...(truncated)'],
+          'non-list-tag',
+        ],
+      });
+    });
+
+    test('returns original map when tags field is absent or not a list', () {
+      final noTags = <String, dynamic>{'id': 'event-123'};
+      final wrongTags = <String, dynamic>{'tags': 'not-a-list'};
+
+      expect(identical(sanitizeEventJsonForLog(noTags), noTags), isTrue);
+      expect(identical(sanitizeEventJsonForLog(wrongTags), wrongTags), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #4386

## Description

At the moment, the logs from users include a lot of metadata from `proofmode` and `device_attestation` for every video, which isn’t really helpful for debugging. This PR reduces the noise from that.


**Related Issue:** 

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore