### PR TITLE
fix(crashlytics): guard malformed media and text inputs

### DIFF
--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -45,10 +45,16 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
           context.contains('image codec') ||
           context.contains('instantiateImageCodecWithSize'));
 
+  final isLocalFilesystemImageFetch =
+      library == 'dart:_http' &&
+      error.contains('No host specified in URI') &&
+      (error.contains('/var/mobile/') || error.contains('file://'));
+
   if (isImage404 ||
       isMediaHostLookup ||
       isInterruptedMediaDownload ||
-      isInvalidImageData) {
+      isInvalidImageData ||
+      isLocalFilesystemImageFetch) {
     return _recoverableMediaLoadReason;
   }
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -263,14 +263,18 @@ class VideoEvent {
                 dimensions ??= value;
               case 'thumb':
                 // Thumbnail URL
-                thumbnailUrl ??= value;
+                if (_isValidRemoteUrl(value)) {
+                  thumbnailUrl ??= value;
+                }
               case 'image':
                 // NIP-92 uses 'image' for thumbnail in imeta
-                thumbnailUrl ??= value;
-                developer.log(
-                  '✅ Set thumbnailUrl from imeta image tag: $value',
-                  name: 'VideoEvent',
-                );
+                if (_isValidRemoteUrl(value)) {
+                  thumbnailUrl ??= value;
+                  developer.log(
+                    '✅ Set thumbnailUrl from imeta image tag: $value',
+                    name: 'VideoEvent',
+                  );
+                }
               case 'blurhash':
                 // Blurhash for progressive loading
                 blurhash ??= value;
@@ -297,7 +301,9 @@ class VideoEvent {
           fileSize = int.tryParse(tagValue);
         case 'thumb':
           // Thumbnail URL - prefer static thumbnails for grid display
-          thumbnailUrl = tagValue as String?;
+          if (_isValidRemoteUrl(tagValue)) {
+            thumbnailUrl = tagValue as String?;
+          }
         case 'preview':
           // Animated GIF preview - store separately, don't use as main
           // thumbnail. GIFs auto-play and would make the grid look chaotic.
@@ -312,7 +318,9 @@ class VideoEvent {
           }
         case 'image':
           // Alternative to 'thumb' tag - some clients use 'image' instead
-          thumbnailUrl ??= tagValue as String?;
+          if (_isValidRemoteUrl(tagValue)) {
+            thumbnailUrl ??= tagValue as String?;
+          }
         case 'd':
           // Replaceable event ID - original vine ID
           vineId = tagValue as String?;
@@ -1495,6 +1503,17 @@ class VideoEvent {
         '🔍 INVALID URL (parse error): $correctedUrl - error: $e',
         name: 'VideoEvent',
       );
+      return false;
+    }
+  }
+
+  static bool _isValidRemoteUrl(String url) {
+    if (url.isEmpty) return false;
+    try {
+      final uri = Uri.parse(url);
+      return (uri.scheme == 'http' || uri.scheme == 'https') &&
+          uri.host.isNotEmpty;
+    } on FormatException {
       return false;
     }
   }

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -82,6 +82,34 @@ void main() {
       },
     );
 
+    test('rejects local filesystem thumbnail paths from relay metadata', () {
+      final nostrEvent = Event(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        34236,
+        [
+          [
+            'thumb',
+            '/var/mobile/Containers/Data/Application/app/tmp/thumb.jpg',
+          ],
+          [
+            'image',
+            'file:///var/mobile/Containers/Data/Application/app/tmp/alt.jpg',
+          ],
+          ['url', 'https://media.divine.video/test/720p.mp4'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.thumbnailUrl, isNull);
+      expect(
+        videoEvent.videoUrl,
+        equals('https://media.divine.video/test/720p.mp4'),
+      );
+    });
+
     test('should accept video URLs from any domain (open protocol)', () {
       // Arrange - test various domains that should all be accepted
       final domains = [

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -11,8 +11,9 @@
 /// Safe for both NFC and NFD-encoded text: NFC precomposed characters (e.g.
 /// U+00E9 é) contain no combining chars and pass through unchanged.
 String stripZalgo(String text, {int maxCombining = 2}) {
+  final safeText = _replaceLoneSurrogates(text);
   final result = StringBuffer();
-  final runes = text.runes.toList();
+  final runes = safeText.runes.toList();
   var i = 0;
   while (i < runes.length) {
     result.writeCharCode(runes[i]);
@@ -28,6 +29,37 @@ String stripZalgo(String text, {int maxCombining = 2}) {
   }
   return result.toString();
 }
+
+String _replaceLoneSurrogates(String text) {
+  final result = StringBuffer();
+  final codeUnits = text.codeUnits;
+  var i = 0;
+  while (i < codeUnits.length) {
+    final unit = codeUnits[i];
+    if (_isHighSurrogate(unit)) {
+      final hasPair =
+          i + 1 < codeUnits.length && _isLowSurrogate(codeUnits[i + 1]);
+      if (hasPair) {
+        result.write(String.fromCharCodes([unit, codeUnits[i + 1]]));
+        i += 2;
+      } else {
+        result.writeCharCode(0xFFFD);
+        i++;
+      }
+    } else if (_isLowSurrogate(unit)) {
+      result.writeCharCode(0xFFFD);
+      i++;
+    } else {
+      result.writeCharCode(unit);
+      i++;
+    }
+  }
+  return result.toString();
+}
+
+bool _isHighSurrogate(int codeUnit) => codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+
+bool _isLowSurrogate(int codeUnit) => codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
 
 bool _isCombining(int cp) =>
     (cp >= 0x0300 && cp <= 0x036F) ||

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -59,5 +59,11 @@ void main() {
       const input = '\u00E9S\u0300\u0301\u0302i';
       expect(stripZalgo(input), equals('\u00E9S\u0300\u0301i'));
     });
+
+    test('replaces lone surrogate code units before display', () {
+      expect(stripZalgo('bad high \uD83D'), equals('bad high \uFFFD'));
+      expect(stripZalgo('bad low \uDC00'), equals('bad low \uFFFD'));
+      expect(stripZalgo('valid pair 😀'), equals('valid pair 😀'));
+    });
   });
 }

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -61,6 +61,24 @@ void main() {
       );
     });
 
+    test(
+      'classifies local filesystem URI image fetch failures as recoverable',
+      () {
+        final details = FlutterErrorDetails(
+          exception: ArgumentError(
+            'No host specified in URI '
+            '/var/mobile/Containers/Data/Application/app/tmp/thumb.jpg',
+          ),
+          library: 'dart:_http',
+        );
+
+        expect(
+          classifyRecoverableFlutterError(details),
+          'Recoverable media load failure',
+        );
+      },
+    );
+
     test('does not classify unrelated gesture errors as recoverable', () {
       final details = FlutterErrorDetails(
         exception: Exception('GoError: There is nothing to pop.'),


### PR DESCRIPTION
Closes #4392

## Summary
- reject non-HTTP(S) thumbnail metadata before it can flow into Flutter network image loading
- classify local filesystem URI image fetch failures as recoverable Crashlytics media errors
- replace unpaired UTF-16 surrogate code units in sanitized display text before Flutter text layout

## Investigation
- Used Divine context plus Divine Brain MCP search for prior Crashlytics/Firebase notifications and related GitHub crash-handling work.
- No Firebase Crashlytics MCP resource is available in this session, so the investigation used the supplied Crashlytics issue text, Divine Brain MCP search results, and local code paths.
- The `_HttpClient.openUrl` issue matches local `/var/mobile/...` or `file://` values being accepted as relay thumbnail metadata, then rendered through network image loading.
- The `_NativeParagraphBuilder.addText` issue matches malformed user/relay text containing lone UTF-16 surrogate code units that survived the existing Zalgo sanitizer.

## Test Plan
- [x] `flutter test test/utils/recoverable_flutter_error_test.dart`
- [x] `flutter test test/src/video_event_parsing_test.dart` from `mobile/packages/models`
- [x] `dart test test/src/text_sanitizer_test.dart` from `mobile/packages/text_sanitizer`
- [x] `dart analyze` from `mobile/packages/text_sanitizer`
- [x] `flutter analyze` from `mobile`
- [x] `git diff --check`
