### PR TITLE
feat(dm): surface swallowed DAO bookkeeping failures via reporter port

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -226,9 +226,15 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
           stillFailing.add(rumorId);
         }
       } on Object catch (e, stackTrace) {
-        // recoverSelfWrap can throw on missing/foreign queue rows or a
-        // missing DAO. Treat each thrown rumor as still-failing so the
-        // user can retry — recording the error for telemetry.
+        if (e is ArgumentError) {
+          // The row was already removed or is no longer valid for this
+          // account. Treat it as terminal and drop it from the retry set.
+          continue;
+        }
+
+        // Missing DAO wiring is an invariant failure; any other throw
+        // is unexpected. Preserve retryability and surface it for
+        // telemetry.
         stillFailing.add(rumorId);
         lastError = e;
         lastStackTrace = stackTrace;

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -10,6 +10,7 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:models/models.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:uuid/uuid.dart';
 
 part 'conversation_event.dart';
@@ -235,7 +236,10 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     }
 
     if (lastError != null) {
-      addError(lastError, lastStackTrace);
+      addError(
+        Reportable(lastError, context: '_onSelfWrapRecoveryRequested'),
+        lastStackTrace,
+      );
     }
 
     if (stillFailing.isEmpty) {

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -71,6 +71,7 @@ import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/crosspost_api_client.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
@@ -2468,6 +2469,15 @@ DmRepository dmRepository(Ref ref) {
     conversationsDao: db.conversationsDao,
     outgoingDmsDao: db.outgoingDmsDao,
     syncState: DmSyncState(prefs),
+    errorReporter: (error, stackTrace, {required site}) {
+      unawaited(
+        CrashReportingService.instance.recordError(
+          error,
+          stackTrace,
+          reason: 'DmRepository.$site',
+        ),
+      );
+    },
   );
 
   ref.onDispose(repository.stopListening);

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -4771,7 +4771,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'667e81afd13949c7b535bd64894c284c79568358';
+String _$dmRepositoryHash() => r'8e673c2c819f25d57a801bee40d3104534bfc682';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:meta/meta.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:openvine/services/outgoing_dm_retry_service_reportable_sites.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Backoff configuration for [OutgoingDmRetryService].
@@ -69,12 +71,14 @@ class OutgoingDmRetryService {
     required Stream<bool> appForegroundStream,
     OutgoingDmRetryConfig retryConfig = const OutgoingDmRetryConfig(),
     DateTime Function() now = DateTime.now,
+    CrashReportingService? crashReporting,
   }) : _dmRepository = dmRepository,
        _dao = outgoingDmsDao,
        _userPubkey = userPubkey,
        _appForegroundStream = appForegroundStream,
        _retryConfig = retryConfig,
-       _now = now;
+       _now = now,
+       _crashReporting = crashReporting ?? CrashReportingService.instance;
 
   final DmRepository _dmRepository;
   final OutgoingDmsDao _dao;
@@ -82,6 +86,7 @@ class OutgoingDmRetryService {
   final Stream<bool> _appForegroundStream;
   final OutgoingDmRetryConfig _retryConfig;
   final DateTime Function() _now;
+  final CrashReportingService _crashReporting;
 
   StreamSubscription<bool>? _foregroundSubscription;
   bool _isInitialized = false;
@@ -217,6 +222,14 @@ class OutgoingDmRetryService {
                 error: e,
                 stackTrace: stackTrace,
               );
+              unawaited(
+                _crashReporting.recordError(
+                  e,
+                  stackTrace,
+                  reason: OutgoingDmRetryServiceReportableSites
+                      .perRowUnexpectedThrow,
+                ),
+              );
             }
           }
         } else if (row.recipientWrapStatus == OutgoingWrapStatus.failed) {
@@ -244,6 +257,13 @@ class OutgoingDmRetryService {
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,
+      );
+      unawaited(
+        _crashReporting.recordError(
+          e,
+          stackTrace,
+          reason: OutgoingDmRetryServiceReportableSites.sweepTopLevel,
+        ),
       );
     } finally {
       _isSweeping = false;

--- a/mobile/lib/services/outgoing_dm_retry_service_reportable_sites.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service_reportable_sites.dart
@@ -1,0 +1,16 @@
+// ABOUTME: Stable site identifiers for swallow points in
+// ABOUTME: OutgoingDmRetryService — used as Crashlytics reason suffix.
+
+/// Stable identifiers for swallowed-failure sites inside
+/// `OutgoingDmRetryService`. Forwarded as the Crashlytics `reason:`
+/// suffix so the dashboard aggregates per site.
+abstract class OutgoingDmRetryServiceReportableSites {
+  /// Per-row throw in the sweep loop — `recoverSelfWrap` raised an
+  /// unexpected exception after `incrementRetry` succeeded.
+  static const String perRowUnexpectedThrow =
+      'OutgoingDmRetryService.perRowUnexpectedThrow';
+
+  /// Top-level sweep catch — the sweep loop or DAO call raised an
+  /// exception before per-row dispatch completed.
+  static const String sweepTopLevel = 'OutgoingDmRetryService.sweepTopLevel';
+}

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -1,4 +1,5 @@
 export 'src/dm_decryption_worker.dart';
 export 'src/dm_repository.dart';
+export 'src/dm_repository_reportable_sites.dart';
 export 'src/dm_sync_state.dart';
 export 'src/nip17_message_service.dart' hide GiftWrapBuilder;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -11,6 +11,7 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
+import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
 import 'package:dm_repository/src/dm_sync_state.dart';
 import 'package:dm_repository/src/nip17_message_service.dart';
 import 'package:flutter/foundation.dart';
@@ -41,6 +42,27 @@ typedef RumorDecryptor = Future<Event?> Function(Nostr nostr, Event giftWrap);
 typedef Nip04Decryptor =
     Future<String?> Function(String peerPubkey, String ciphertext);
 
+/// Forwarder for DAO-bookkeeping failures inside [DmRepository].
+///
+/// The repository swallows these failures after [Log.error] to keep the
+/// recovery primitive idempotent on doubly-degraded paths (publish
+/// landed, bookkeeping write failed — see #4127). Wiring an
+/// implementation routes the same signal to Crashlytics without
+/// crossing the `dm_repository` → app package boundary.
+///
+/// [site] is one of `DmRepositoryReportableSites`'s constants and is
+/// used as the Crashlytics `reason:` suffix so the dashboard aggregates
+/// per swallow site.
+///
+/// Implementations MUST NOT throw — the repository invokes after the
+/// existing `Log.error` and any throw would defeat the swallow.
+typedef DmRepositoryErrorReporter =
+    void Function(
+      Object error,
+      StackTrace stackTrace, {
+      required String site,
+    });
+
 /// Supported NIP-17 rumor event kinds.
 const Set<int> _supportedDmKinds = {
   EventKind.privateDirectMessage, // 14
@@ -64,6 +86,12 @@ const Set<int> _supportedDmKinds = {
 /// disposed when the user logs out.
 class DmRepository {
   /// Creates a [DmRepository] with the given dependencies.
+  ///
+  /// [errorReporter] is invoked from each DAO-bookkeeping swallow site
+  /// (see [DmRepositoryErrorReporter] and `DmRepositoryReportableSites`)
+  /// after the in-repo [Log.error] call. Defaults to `null` so existing
+  /// test fixtures keep working without rewiring; production wires it
+  /// through `dmRepositoryProvider` to forward to Crashlytics.
   DmRepository({
     required NostrClient nostrClient,
     required DirectMessagesDao directMessagesDao,
@@ -75,6 +103,7 @@ class DmRepository {
     NostrSigner? signer,
     RumorDecryptor? rumorDecryptor,
     Nip04Decryptor? nip04Decryptor,
+    DmRepositoryErrorReporter? errorReporter,
   }) : _nostrClient = nostrClient,
        _directMessagesDao = directMessagesDao,
        _conversationsDao = conversationsDao,
@@ -84,7 +113,8 @@ class DmRepository {
        _userPubkey = userPubkey ?? '',
        _signer = signer,
        _rumorDecryptor = rumorDecryptor ?? GiftWrapUtil.getRumorEvent,
-       _nip04Decryptor = nip04Decryptor;
+       _nip04Decryptor = nip04Decryptor,
+       _errorReporter = errorReporter;
 
   final NostrClient _nostrClient;
   final DirectMessagesDao _directMessagesDao;
@@ -104,6 +134,7 @@ class DmRepository {
   NostrSigner? _signer;
   RumorDecryptor _rumorDecryptor;
   Nip04Decryptor? _nip04Decryptor;
+  final DmRepositoryErrorReporter? _errorReporter;
 
   StreamSubscription<Event>? _giftWrapSubscription;
   Timer? _reconnectTimer;
@@ -934,6 +965,11 @@ class DmRepository {
           error: e,
           stackTrace: stackTrace,
         );
+        _errorReporter?.call(
+          e,
+          stackTrace,
+          site: DmRepositoryReportableSites.sendMessageOuterTransaction,
+        );
         // Don't rethrow — the message was published successfully.
         // Local persistence failure is a degraded state, not a send failure.
       }
@@ -1022,6 +1058,11 @@ class DmRepository {
         error: e,
         stackTrace: stackTrace,
       );
+      _errorReporter?.call(
+        e,
+        stackTrace,
+        site: DmRepositoryReportableSites.recoverSelfWrapRumorJsonParse,
+      );
       // Mark the self-wrap status failed so the row surfaces in the
       // next retry sweep with a record of the parse failure.
       try {
@@ -1030,7 +1071,20 @@ class DmRepository {
           status: OutgoingWrapStatus.failed,
           lastError: 'rumor JSON parse failed: $e',
         );
-      } on Object {
+      } on Object catch (markError, markStack) {
+        Log.error(
+          'Failed to mark self-wrap failed after JSON parse error for '
+          '$rumorId: $markError',
+          category: LogCategory.system,
+          error: markError,
+          stackTrace: markStack,
+        );
+        _errorReporter?.call(
+          markError,
+          markStack,
+          site: DmRepositoryReportableSites
+              .recoverSelfWrapMarkFailedAfterJsonParse,
+        );
         // Swallow — caller still gets the failure result below.
       }
       return NIP17SendResult.failure('rumor JSON parse failed: $e');
@@ -1051,6 +1105,11 @@ class DmRepository {
           error: e,
           stackTrace: stackTrace,
         );
+        _errorReporter?.call(
+          e,
+          stackTrace,
+          site: DmRepositoryReportableSites.recoverSelfWrapDeleteAfterPublish,
+        );
         // Publish landed but the row is still here. Mark
         // self_wrap_status=sent with the published event id so the next
         // recovery sweep short-circuits via the idempotent guard above
@@ -1068,6 +1127,12 @@ class DmRepository {
             category: LogCategory.system,
             error: markError,
             stackTrace: markStack,
+          );
+          _errorReporter?.call(
+            markError,
+            markStack,
+            site: DmRepositoryReportableSites
+                .recoverSelfWrapBookkeepingDoubleFailure,
           );
           // Both bookkeeping writes failed. The row stays
           // `recipient: sent / self: failed` and the next sweep
@@ -1090,6 +1155,12 @@ class DmRepository {
           category: LogCategory.system,
           error: e,
           stackTrace: stackTrace,
+        );
+        _errorReporter?.call(
+          e,
+          stackTrace,
+          site: DmRepositoryReportableSites
+              .recoverSelfWrapMarkFailedAfterPublishFailure,
         );
         // Don't rethrow — caller already gets the failure result.
       }
@@ -1150,6 +1221,11 @@ class DmRepository {
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,
+      );
+      _errorReporter?.call(
+        e,
+        stackTrace,
+        site: DmRepositoryReportableSites.finalizeAfterRecipientFailure,
       );
       // Don't rethrow — caller already gets the failure result. The
       // queue row stays retryable and the next sweep can pick it up.

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Stable identifiers for the swallow sites in DmRepository.
+// ABOUTME: Used as the `site:` annotation on DmRepositoryErrorReporter calls.
+
+/// Stable site identifiers for the DAO-bookkeeping swallow points in
+/// `DmRepository`. The wiring layer forwards each call to Crashlytics
+/// with `reason: 'DmRepository.<site>'` so the dashboard aggregates per
+/// site.
+abstract class DmRepositoryReportableSites {
+  /// `recoverSelfWrap`: `Event.fromJson(row.rumorEventJson)` threw.
+  /// Programming-invariant violation — the repository wrote that JSON.
+  static const String recoverSelfWrapRumorJsonParse =
+      'recoverSelfWrap.rumorJsonParse';
+
+  /// `recoverSelfWrap`: the salvage `markSelfWrapStatus(failed)` after
+  /// a JSON parse failure also threw. Silent inner swallow today.
+  static const String recoverSelfWrapMarkFailedAfterJsonParse =
+      'recoverSelfWrap.markFailedAfterJsonParse';
+
+  /// `recoverSelfWrap`: publish landed; `deleteById` threw. The
+  /// fallback `markSelfWrapStatus(sent)` is attempted next.
+  static const String recoverSelfWrapDeleteAfterPublish =
+      'recoverSelfWrap.deleteAfterPublish';
+
+  /// `recoverSelfWrap`: publish landed; both `deleteById` and the
+  /// fallback `markSelfWrapStatus(sent)` threw. The doubly-degraded
+  /// path — primary target of #4127.
+  static const String recoverSelfWrapBookkeepingDoubleFailure =
+      'recoverSelfWrap.bookkeepingDoubleFailure';
+
+  /// `recoverSelfWrap`: publish failed; the salvage
+  /// `markSelfWrapStatus(failed)` threw.
+  static const String recoverSelfWrapMarkFailedAfterPublishFailure =
+      'recoverSelfWrap.markFailedAfterPublishFailure';
+
+  /// `_finalizeAfterRecipientFailure`: marking the queue row failed
+  /// threw. Caller already has the publish-failure result.
+  static const String finalizeAfterRecipientFailure =
+      'finalizeAfterRecipientFailure';
+
+  /// `sendMessage` outer transaction catch: persisting the local
+  /// message row or running `_finalizeAfterRecipientSuccess` threw
+  /// after the recipient publish landed.
+  static const String sendMessageOuterTransaction =
+      'sendMessage.outerTransaction';
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -73,6 +73,15 @@ class _FakeDmSyncState implements DmSyncState {
   }
 }
 
+/// Records each invocation of a [DmRepositoryErrorReporter] so tests can
+/// assert which swallow site emitted.
+class _ReporterCall {
+  _ReporterCall(this.error, this.stackTrace, this.site);
+  final Object error;
+  final StackTrace stackTrace;
+  final String site;
+}
+
 // Valid 64-character hex pubkeys for testing
 const _validPubkeyA =
     'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
@@ -98,6 +107,7 @@ void main() {
     late _MockNIP17MessageService mockMessageService;
     late _MockDirectMessagesDao mockDirectMessagesDao;
     late _MockConversationsDao mockConversationsDao;
+    late List<_ReporterCall> reporterCalls;
 
     setUpAll(() {
       registerFallbackValue(_FakeEvent());
@@ -110,6 +120,7 @@ void main() {
       mockMessageService = _MockNIP17MessageService();
       mockDirectMessagesDao = _MockDirectMessagesDao();
       mockConversationsDao = _MockConversationsDao();
+      reporterCalls = <_ReporterCall>[];
 
       // Stub relay properties used by startListening() log.
       when(() => mockNostrClient.connectedRelayCount).thenReturn(3);
@@ -189,6 +200,7 @@ void main() {
       Nip04Decryptor? nip04Decryptor,
       DmSyncState? syncState,
       OutgoingDmsDao? outgoingDmsDao,
+      bool wireErrorReporter = true,
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -201,6 +213,11 @@ void main() {
         rumorDecryptor: rumorDecryptor,
         nip04Decryptor: nip04Decryptor,
         syncState: syncState,
+        errorReporter: wireErrorReporter
+            ? (error, stackTrace, {required site}) {
+                reporterCalls.add(_ReporterCall(error, stackTrace, site));
+              }
+            : null,
       );
     }
 
@@ -7888,6 +7905,105 @@ void main() {
           verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
         },
       );
+
+      test(
+        'on publish failure: when markRecipientWrapStatus throws inside '
+        '_finalizeAfterRecipientFailure, the swallow is reported and '
+        'the failure result still surfaces',
+        () async {
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.failure('relay unavailable'),
+          );
+          when(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'this will fail',
+          );
+
+          expect(result.success, isFalse);
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            equals(
+              DmRepositoryReportableSites.finalizeAfterRecipientFailure,
+            ),
+          );
+        },
+      );
+
+      test(
+        'on publish success: when local persistence inside the outer '
+        'transaction throws, the swallow is reported and the publish '
+        'success result still surfaces',
+        () async {
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+          // Force the outer try/catch in sendMessage by failing the
+          // local insertMessage inside the transaction.
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'local persistence will fail',
+          );
+
+          // Publish succeeded — caller still sees success even though
+          // local persistence threw.
+          expect(result.success, isTrue);
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            equals(
+              DmRepositoryReportableSites.sendMessageOuterTransaction,
+            ),
+          );
+        },
+      );
     });
 
     group('sendGroupMessage with outgoing_dms queue wired in', () {
@@ -8404,6 +8520,17 @@ void main() {
               eventId: _giftWrapEventId2,
             ),
           ).called(1);
+
+          // The swallowed deleteById failure is reported via the
+          // errorReporter so production has a Crashlytics signal even
+          // though the recovery path returned success.
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            equals(
+              DmRepositoryReportableSites.recoverSelfWrapDeleteAfterPublish,
+            ),
+          );
         },
       );
 
@@ -8451,6 +8578,15 @@ void main() {
           // idempotent on receive (NIP-17 dedup keys), so the
           // doubly-degraded path is safe.
           expect(result.success, isTrue);
+
+          // Both swallowed failures surface via the errorReporter so
+          // the doubly-degraded path is visible in Crashlytics. The
+          // recovery path is "safe via NIP-17 dedup" only because we
+          // now measure the rate at which it fires.
+          expect(reporterCalls.map((c) => c.site), <String>[
+            DmRepositoryReportableSites.recoverSelfWrapDeleteAfterPublish,
+            DmRepositoryReportableSites.recoverSelfWrapBookkeepingDoubleFailure,
+          ]);
         },
       );
 
@@ -8618,6 +8754,104 @@ void main() {
           verifyNever(
             () => mockMessageService.publishSelfWrap(
               rumorEvent: any(named: 'rumorEvent'),
+            ),
+          );
+
+          // Programming-invariant violation (we wrote that JSON) is
+          // reported even though the recovery returned a non-throwing
+          // failure result.
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            equals(DmRepositoryReportableSites.recoverSelfWrapRumorJsonParse),
+          );
+        },
+      );
+
+      test(
+        'on rumor JSON parse failure: when the salvage markSelfWrapStatus '
+        'also throws, reports both the parse failure and the salvage '
+        'failure and still returns a non-throwing failure result',
+        () async {
+          final corruptedRow = OutgoingDm(
+            id: _rumorEventId,
+            conversationId: 'conv',
+            recipientPubkey: _validPubkeyB,
+            content: 'queued message',
+            createdAt: 1700000000,
+            rumorEventJson: 'this is not json',
+            recipientWrapStatus: OutgoingWrapStatus.sent,
+            selfWrapStatus: OutgoingWrapStatus.failed,
+            queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
+            ownerPubkey: _validPubkeyA,
+          );
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => corruptedRow);
+          when(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          expect(reporterCalls.map((c) => c.site), <String>[
+            DmRepositoryReportableSites.recoverSelfWrapRumorJsonParse,
+            DmRepositoryReportableSites.recoverSelfWrapMarkFailedAfterJsonParse,
+          ]);
+        },
+      );
+
+      test(
+        'on self-wrap publish failure: when the salvage markSelfWrapStatus '
+        'throws, reports the salvage failure and still returns the '
+        'publish-failure result',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          when(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure('relay timeout'),
+          );
+          when(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverSelfWrap(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            equals(
+              DmRepositoryReportableSites
+                  .recoverSelfWrapMarkFailedAfterPublishFailure,
             ),
           );
         },

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -200,7 +200,6 @@ void main() {
       Nip04Decryptor? nip04Decryptor,
       DmSyncState? syncState,
       OutgoingDmsDao? outgoingDmsDao,
-      bool wireErrorReporter = true,
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -213,11 +212,9 @@ void main() {
         rumorDecryptor: rumorDecryptor,
         nip04Decryptor: nip04Decryptor,
         syncState: syncState,
-        errorReporter: wireErrorReporter
-            ? (error, stackTrace, {required site}) {
-                reporterCalls.add(_ReporterCall(error, stackTrace, site));
-              }
-            : null,
+        errorReporter: (error, stackTrace, {required site}) {
+          reporterCalls.add(_ReporterCall(error, stackTrace, site));
+        },
       );
     }
 

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -1459,6 +1459,46 @@ void main() {
       );
 
       blocTest<ConversationBloc, ConversationState>(
+        'treats missing queue rows as terminal and clears them from the '
+        'retry set without reporting',
+        setUp: () {
+          when(
+            () => mockDmRepository.recoverSelfWrap(rumorId: rumorId1),
+          ).thenThrow(
+            ArgumentError.value(
+              rumorId1,
+              'rumorId',
+              'no queued outgoing DM with this id',
+            ),
+          );
+        },
+        seed: () => const ConversationState(
+          status: ConversationStatus.loaded,
+          sendStatus: SendStatus.sentPartial,
+          lastPartialSend: PartialSend(rumorIds: [rumorId1]),
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const ConversationSelfWrapRecoveryRequested(rumorIds: [rumorId1]),
+        ),
+        expect: () => [
+          isA<ConversationState>().having(
+            (s) => s.sendStatus,
+            'sendStatus',
+            SendStatus.sending,
+          ),
+          isA<ConversationState>()
+              .having((s) => s.sendStatus, 'sendStatus', SendStatus.sent)
+              .having(
+                (s) => s.lastPartialSend,
+                'clears terminal retry payload',
+                isNull,
+              ),
+        ],
+        errors: () => const <Object>[],
+      );
+
+      blocTest<ConversationBloc, ConversationState>(
         'is a no-op when rumorIds is empty',
         seed: () => const ConversationState(
           status: ConversationStatus.loaded,

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
 
@@ -1448,7 +1449,13 @@ void main() {
                 equals([rumorId1]),
               ),
         ],
-        errors: () => [isA<StateError>()],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
       );
 
       blocTest<ConversationBloc, ConversationState>(

--- a/mobile/test/providers/web_feed_provider_compatibility_test.dart
+++ b/mobile/test/providers/web_feed_provider_compatibility_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -10,11 +10,16 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NIP17SendResult;
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/outgoing_dm_retry_service.dart';
+import 'package:openvine/services/outgoing_dm_retry_service_reportable_sites.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
 
 class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+class _MockCrashReportingService extends Mock
+    implements CrashReportingService {}
 
 const _ownerPubkey =
     '0000000000000000000000000000000000000000000000000000000000000001';
@@ -61,6 +66,10 @@ void main() {
   late _MockOutgoingDmsDao dao;
   late StreamController<bool> foregroundController;
 
+  setUpAll(() {
+    registerFallbackValue(StackTrace.empty);
+  });
+
   setUp(() {
     dmRepository = _MockDmRepository();
     dao = _MockOutgoingDmsDao();
@@ -83,6 +92,7 @@ void main() {
   OutgoingDmRetryService buildService({
     OutgoingDmRetryConfig retryConfig = const OutgoingDmRetryConfig(),
     DateTime Function()? now,
+    CrashReportingService? crashReporting,
   }) {
     return OutgoingDmRetryService(
       dmRepository: dmRepository,
@@ -91,6 +101,7 @@ void main() {
       appForegroundStream: foregroundController.stream,
       retryConfig: retryConfig,
       now: now ?? () => DateTime.utc(2026, 5, 10, 12),
+      crashReporting: crashReporting,
     );
   }
 
@@ -629,6 +640,76 @@ void main() {
             () => dao.getRetryableForOwner(
               ownerPubkey: _otherOwner,
               maxRetries: any(named: 'maxRetries'),
+            ),
+          ).called(1);
+        },
+      );
+    });
+
+    group('crash reporting', () {
+      late _MockCrashReportingService crashReporting;
+
+      setUp(() {
+        crashReporting = _MockCrashReportingService();
+        when(
+          () => crashReporting.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ).thenAnswer((_) async {});
+      });
+
+      test(
+        'per-row recoverSelfWrap throw reports to CrashReportingService',
+        () async {
+          final row = _row(
+            id: 'rumor-boom',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenThrow(Exception('drift busy'));
+
+          final service = buildService(crashReporting: crashReporting);
+          await service.sweep();
+
+          verify(
+            () => crashReporting.recordError(
+              any<dynamic>(),
+              any<StackTrace?>(),
+              reason:
+                  OutgoingDmRetryServiceReportableSites.perRowUnexpectedThrow,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'sweep-level throw reports to CrashReportingService',
+        () async {
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenThrow(Exception('drift connection lost'));
+
+          final service = buildService(crashReporting: crashReporting);
+          await service.sweep();
+
+          verify(
+            () => crashReporting.recordError(
+              any<dynamic>(),
+              any<StackTrace?>(),
+              reason: OutgoingDmRetryServiceReportableSites.sweepTopLevel,
             ),
           ).called(1);
         },

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'dart:async';
 import 'dart:io';
 


### PR DESCRIPTION
## Description

`DmRepository.recoverSelfWrap` and `_finalizeAfterRecipient{Success,Failure}` swallow DAO write failures via `Log.error` only. Today there's no production signal for how often these doubly-degraded paths fire — Crashlytics never sees them, because (a) the catches live in repository code (not a Bloc), and (b) the `dm_repository` package can't depend on `openvine/observability` without inverting the layer boundary.

This PR introduces an **error-reporter port** on `DmRepository` that the app wires through to `CrashReportingService.recordError`, and applies the matching service-layer and bloc-layer signals so the full DM retry chain becomes observable.

**How it works**

1. `DmRepository` gains a `DmRepositoryErrorReporter?` typedef constructor parameter — a `void Function(Object, StackTrace, {required String site})`. Each of the 7 swallow sites invokes the reporter after the existing `Log.error`. Sites are addressed via the new `DmRepositoryReportableSites` constants so Crashlytics aggregates by `reason: 'DmRepository.<site>'`.
2. `dmRepositoryProvider` (in `app_providers.dart`) wires the closure to forward to `CrashReportingService.instance.recordError(...)`. The singleton is captured by reference — stable across `ref.watch` rebuilds, no `ValueKey`-on-identity treatment needed.
3. `OutgoingDmRetryService` gains an optional `CrashReportingService?` constructor parameter (singleton-default, mirroring `DivineBlocObserver`) and reports its two existing `Log.error`-only catches — per-row throw and top-level sweep failure.
4. `ConversationBloc._onSelfWrapRecoveryRequested`'s raw `addError(lastError, …)` is upgraded to `addError(Reportable(lastError, context: '_onSelfWrapRecoveryRequested'), …)` so the bloc-level failure also flows to Crashlytics through `DivineBlocObserver`.

The previously-silent inner swallow inside `recoverSelfWrap`'s JSON-parse error handler also gains a matching `Log.error` so the unified log stays consistent across all 7 sites.

**Related Issue:** Closes #4127

## Out of Scope

- Durable counter on `outgoing_dms` (rejected — schema migration risk; in-app counter defeats the "invisible without proactive checking" purpose of the issue).
- Sibling swallows in `nip17_message_service.dart` (different scope; tracked separately).
- Extracting a shared `openvine_observability` package (correct long-term move, but YAGNI for one repo today).
- `recoverFullSend` observability — will reuse the same port when #4240 lands.
- Lifting `_finalizeAfterRecipientSuccess` out of the outer transaction — changes atomicity semantics; the outer-catch site at line 962 is sufficient for the rate signal.

## Verification

From `mobile/`:

- ` ✅ dart format --output=none --set-exit-if-changed` on all 10 touched files (no diffs)
- ` ✅ flutter analyze lib test integration_test` — No issues found
- ` ✅ flutter analyze` in `packages/dm_repository` — No issues found
- ` ✅ flutter test packages/dm_repository` — 227 tests pass
- ` ✅ flutter test test/services/outgoing_dm_retry_service_test.dart` — 24 tests pass (2 new)
- ` ✅ flutter test test/blocs/dm/conversation/conversation_bloc_test.dart` — 55 tests pass (1 assertion migrated)
- ` ✅ flutter test test/providers/` — 554 tests pass (sanity on provider wiring)
- ` ✅ dm_repository line coverage: 94.21%` (above the 93% CI gate)

## Test plan

- [x] Phase 1 commit reviewable independently: only repo-layer changes, default-null reporter keeps existing fixtures green.
- [x] Phase 2 commit wires the closure and applies the service/bloc reporting.
- [ ] After merge: verify Crashlytics dashboard surfaces a new `DmRepository.*` reason taxonomy.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)