### PR TITLE
fix(android): default useLegacySurface to true to close FlutterJNI renderer race (#3416)

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -179,17 +179,21 @@ internal class DivineVideoPlayerInstance(
      * Must be called before any clips are loaded. Returns the texture
      * ID that Dart should pass to the `Texture` widget.
      *
-     * When [useLegacySurface] is `false` (default) this uses
-     * [TextureRegistry.SurfaceProducer] so Android can notify us when
-     * the underlying surface is destroyed and recreated (permission
-     * dialogs, OEM compositor events on Vivo/Android 16).
+     * When [useLegacySurface] is `true` (the Dart-side default) this
+     * uses the legacy [TextureRegistry.SurfaceTextureEntry]. Its
+     * surface is owned by the player for its full lifetime, with no
+     * `ImageReader` callback that can fire on a detached `FlutterJNI`
+     * during engine teardown (#3416). It does not deliver
+     * surface-recreate callbacks, so it cannot transparently survive
+     * an OEM compositor event — accepted trade-off given the
+     * codebase's chosen safety posture.
      *
-     * When [useLegacySurface] is `true` this uses the legacy
-     * [TextureRegistry.SurfaceTextureEntry] which does not deliver
-     * surface-recreate callbacks but is immune to the SurfaceProducer
-     * ImageReader-pool ghost-frame issue. Use this for screens that
-     * render many players at once (the feed) where a sibling decoder's
-     * release can leak a stale frame onto a peer's surface.
+     * When [useLegacySurface] is `false` this uses
+     * [TextureRegistry.SurfaceProducer] which adds Android 14+
+     * surface destroy/recreate callbacks (permission dialogs,
+     * Vivo/Android 16 compositor events), at the cost of the
+     * residual #3416 race window between
+     * `ImageReaderSurfaceProducer.onImage` and `FlutterJNI` detach.
      */
     fun enableTextureOutput(
         registry: TextureRegistry,

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -194,6 +194,12 @@ internal class DivineVideoPlayerInstance(
      * Vivo/Android 16 compositor events), at the cost of the
      * residual #3416 race window between
      * `ImageReaderSurfaceProducer.onImage` and `FlutterJNI` detach.
+     *
+     * The Kotlin parameter default is `false` so unit tests can
+     * exercise the `SurfaceProducer.Callback` contract without
+     * mocking the legacy `createSurfaceTexture()` path; production
+     * always overrides via Dart's `true` default through the
+     * MethodChannel.
      */
     fun enableTextureOutput(
         registry: TextureRegistry,

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -59,17 +59,18 @@ internal class DivineVideoPlayerInstance(
     //
     // Two backends are supported and selected per player at
     // [enableTextureOutput] time:
-    //  * [TextureRegistry.SurfaceProducer] (default): Android 14+ ImageReader
+    //  * [TextureRegistry.SurfaceTextureEntry] (default): single-buffer
+    //    SurfaceTexture owned by the player for its full lifetime. No
+    //    surface-recreate callback, but no `ImageReader` either — immune
+    //    to the cross-decoder ghost-frame issue and to the #3416
+    //    `FlutterJNI`-detached `scheduleFrame()` race on engine teardown.
+    //  * [TextureRegistry.SurfaceProducer]: Android 14+ ImageReader
     //    backend. Forwards Surface destroy/recreate events via the
     //    [TextureRegistry.SurfaceProducer.Callback] callback so playback can
     //    survive OEM compositor events (Vivo/Android 16, permission dialogs).
     //    Has a small (3–4) hardcoded buffer pool which can leak a stale
     //    frame across decoder format reprobes — visible as a 1-frame ghost
     //    when many players coexist (the feed). See #3416 / feed flicker.
-    //  * [TextureRegistry.SurfaceTextureEntry] (legacy): single-buffer
-    //    SurfaceTexture. No surface-recreate callback, but no shared pool
-    //    either, so it is immune to the cross-decoder ghost-frame issue.
-    //    Used by callers that render many players at once (the feed).
     //
     // Exactly one of these is non-null after [enableTextureOutput].
     private var surfaceProducer: TextureRegistry.SurfaceProducer? = null
@@ -179,14 +180,13 @@ internal class DivineVideoPlayerInstance(
      * Must be called before any clips are loaded. Returns the texture
      * ID that Dart should pass to the `Texture` widget.
      *
-     * When [useLegacySurface] is `true` (the Dart-side default) this
-     * uses the legacy [TextureRegistry.SurfaceTextureEntry]. Its
-     * surface is owned by the player for its full lifetime, with no
-     * `ImageReader` callback that can fire on a detached `FlutterJNI`
-     * during engine teardown (#3416). It does not deliver
-     * surface-recreate callbacks, so it cannot transparently survive
-     * an OEM compositor event — accepted trade-off given the
-     * codebase's chosen safety posture.
+     * When [useLegacySurface] is `true` (default) this uses the legacy
+     * [TextureRegistry.SurfaceTextureEntry]. Its surface is owned by
+     * the player for its full lifetime, with no `ImageReader` callback
+     * that can fire on a detached `FlutterJNI` during engine teardown
+     * (#3416). It does not deliver surface-recreate callbacks, so it
+     * cannot transparently survive an OEM compositor event — accepted
+     * trade-off given the codebase's chosen safety posture.
      *
      * When [useLegacySurface] is `false` this uses
      * [TextureRegistry.SurfaceProducer] which adds Android 14+
@@ -194,16 +194,12 @@ internal class DivineVideoPlayerInstance(
      * Vivo/Android 16 compositor events), at the cost of the
      * residual #3416 race window between
      * `ImageReaderSurfaceProducer.onImage` and `FlutterJNI` detach.
-     *
-     * The Kotlin parameter default is `false` so unit tests can
-     * exercise the `SurfaceProducer.Callback` contract without
-     * mocking the legacy `createSurfaceTexture()` path; production
-     * always overrides via Dart's `true` default through the
-     * MethodChannel.
+     * No callsite currently opts in — tests pass `false` explicitly
+     * to exercise the `SurfaceProducer.Callback` contract.
      */
     fun enableTextureOutput(
         registry: TextureRegistry,
-        useLegacySurface: Boolean = false,
+        useLegacySurface: Boolean = true,
     ): Long {
         if (useLegacySurface) {
             val entry = registry.createSurfaceTexture()

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -132,7 +132,7 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
                 val useTexture = call.argument<Boolean>("useTexture") ?: false
                 if (useTexture) {
                     val useLegacySurface =
-                        call.argument<Boolean>("useLegacySurface") ?: false
+                        call.argument<Boolean>("useLegacySurface") ?: true
                     val textureId = instance.enableTextureOutput(
                         binding.textureRegistry,
                         useLegacySurface = useLegacySurface,

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -1,6 +1,7 @@
 package com.divinevideo.divine_video_player
 
 import android.content.Context
+import android.graphics.SurfaceTexture
 import android.os.Handler
 import android.view.Surface
 import androidx.media3.common.PlaybackException
@@ -14,10 +15,13 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import io.mockk.verify
 import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -40,6 +44,8 @@ class DivineVideoPlayerInstanceTest {
     private lateinit var mockRegistry: TextureRegistry
     private lateinit var mockProducer: TextureRegistry.SurfaceProducer
     private lateinit var mockSurface: Surface
+    private lateinit var mockTextureEntry: TextureRegistry.SurfaceTextureEntry
+    private lateinit var mockSurfaceTexture: SurfaceTexture
     private lateinit var instance: DivineVideoPlayerInstance
 
     @Before
@@ -52,9 +58,14 @@ class DivineVideoPlayerInstanceTest {
         mockRegistry = mockk(relaxed = true)
         mockProducer = mockk(relaxed = true)
         mockSurface = mockk(relaxed = true)
+        mockTextureEntry = mockk(relaxed = true)
+        mockSurfaceTexture = mockk(relaxed = true)
 
         every { mockRegistry.createSurfaceProducer() } returns mockProducer
         every { mockProducer.id() } returns 42L
+        every { mockRegistry.createSurfaceTexture() } returns mockTextureEntry
+        every { mockTextureEntry.surfaceTexture() } returns mockSurfaceTexture
+        every { mockTextureEntry.id() } returns 99L
 
         instance = DivineVideoPlayerInstance(
             messenger = messenger,
@@ -137,7 +148,7 @@ class DivineVideoPlayerInstanceTest {
     fun `onSurfaceAvailable attaches surface to player and clears needsSurface`() {
         // Start with a null surface so enableTextureOutput leaves needsSurface = true.
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry)
+        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
 
         // Surface becomes available; simulate the callback firing with the real surface.
         every { mockProducer.surface } returns mockSurface
@@ -158,7 +169,7 @@ class DivineVideoPlayerInstanceTest {
     fun `onSurfaceAvailable leaves needsSurface true when player has not been created`() {
         // Surface is null at enableTextureOutput time → needsSurface = true.
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry)
+        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
 
         // Surface now available, but player still null.
         every { mockProducer.surface } returns mockSurface
@@ -176,7 +187,7 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `onSurfaceCleanup detaches surface from player and raises needsSurface`() {
         every { mockProducer.surface } returns mockSurface
-        instance.enableTextureOutput(mockRegistry)
+        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
         materializePlayer()
 
         instance.onSurfaceCleanup()
@@ -190,7 +201,7 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `onSurfaceCleanup raises needsSurface even when player is null`() {
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry)
+        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
         // Player never materialised — setVideoSurface(null) is a no-op via ?.
 
         instance.onSurfaceCleanup()
@@ -200,6 +211,46 @@ class DivineVideoPlayerInstanceTest {
         materializePlayer()
         // ensurePlayer() must attach because needsSurface was left true.
         verify { mockPlayer.setVideoSurface(mockSurface) }
+    }
+
+    // -- legacy SurfaceTextureEntry backend --
+
+    @Test
+    fun `enableTextureOutput default uses createSurfaceTexture, not createSurfaceProducer`() {
+        // Production hits this path via the Dart-side default (useLegacySurface = true)
+        // and the MethodChannel fallback. Kotlin's default is aligned to true so a
+        // direct call with no argument exercises the same path.
+        //
+        // Surface(SurfaceTexture) is an Android framework constructor that throws
+        // "Stub!" on the unit-test JVM unless intercepted; mockkConstructor returns
+        // a relaxed Surface mock instead.
+        mockkConstructor(Surface::class)
+        try {
+            val textureId = instance.enableTextureOutput(mockRegistry)
+
+            verify(exactly = 1) { mockRegistry.createSurfaceTexture() }
+            verify(exactly = 0) { mockRegistry.createSurfaceProducer() }
+            verify(exactly = 1) { mockTextureEntry.surfaceTexture() }
+            assertEquals(99L, textureId)
+        } finally {
+            unmockkConstructor(Surface::class)
+        }
+    }
+
+    @Test
+    fun `legacy backend attaches surface eagerly to materialized player`() {
+        mockkConstructor(Surface::class)
+        try {
+            instance.enableTextureOutput(mockRegistry)
+            materializePlayer()
+
+            // Legacy surface is owned for the player's lifetime; ensurePlayer must
+            // attach it eagerly (no waiting for an onSurfaceAvailable callback that
+            // the SurfaceTextureEntry backend never fires).
+            verify { mockPlayer.setVideoSurface(any<Surface>()) }
+        } finally {
+            unmockkConstructor(Surface::class)
+        }
     }
 
     // -- onMediaItemTransition detach/reattach --
@@ -214,7 +265,7 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `MEDIA_ITEM_TRANSITION_REASON_AUTO forces surface detach then reattach`() {
         every { mockProducer.surface } returns mockSurface
-        instance.enableTextureOutput(mockRegistry)
+        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
         val listener = capturePlayerListener()
 
         listener.onMediaItemTransition(null, Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
@@ -229,7 +280,7 @@ class DivineVideoPlayerInstanceTest {
     fun `MEDIA_ITEM_TRANSITION_REASON_AUTO is skipped when surface is not yet attached`() {
         // Surface null during enableTextureOutput → needsSurface = true.
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry)
+        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
         every { mockProducer.surface } returns mockSurface
         val listener = capturePlayerListener()
         // ensurePlayer attached the surface (needsSurface = false). Force the flag

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -31,19 +31,24 @@ class DivineVideoPlayerController {
   /// separate `CALayer`s that bypass Flutter's rendering pipeline.
   /// Defaults to `false` (platform view).
   ///
-  /// When [useLegacySurface] is `true` AND [useTexture] is `true`, the
-  /// Android side allocates a legacy `SurfaceTextureEntry` instead of
-  /// the default `SurfaceProducer`. The legacy backend has no
-  /// surface-recreate callback (so it can't transparently survive
-  /// permission dialogs / OEM compositor events), but it has no shared
-  /// `ImageReader` buffer pool either — which makes it immune to the
-  /// 1-frame ghost frame that surfaces when many `SurfaceProducer`-backed
-  /// players coexist and a sibling decoder is released (the feed flicker).
-  /// Use it for screens that render many players at once. No effect on
-  /// iOS/macOS. Defaults to `false`.
+  /// When [useLegacySurface] is `true` (default) AND [useTexture] is
+  /// `true`, the Android side allocates a legacy `SurfaceTextureEntry`
+  /// for texture output. Legacy is the safe default — its surface is
+  /// owned by the player for its full lifetime, so there is no
+  /// `ImageReader` callback that can fire on a detached `FlutterJNI`
+  /// during engine teardown (#3416).
+  ///
+  /// Pass `false` to opt into `SurfaceProducer` instead.
+  /// `SurfaceProducer` adds Android 14+ surface destroy/recreate
+  /// callbacks (useful when a permission dialog or OEM compositor
+  /// event — e.g. Vivo/Android 16 — temporarily destroys the
+  /// surface), at the cost of a residual race window between the
+  /// SDK-internal `ImageReaderSurfaceProducer.onImage` callback and
+  /// `FlutterJNI` detach. Only opt in when the recreate callback is
+  /// actually needed. No effect on iOS/macOS.
   DivineVideoPlayerController({
     this.useTexture = false,
-    this.useLegacySurface = false,
+    this.useLegacySurface = true,
   });
 
   /// Whether this player renders via a Flutter texture instead of a

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -175,6 +175,36 @@ void main() {
         );
       });
 
+      test(
+        'defaults useLegacySurface to true when useTexture is true',
+        () async {
+          controller = DivineVideoPlayerController(useTexture: true);
+
+          await controller.initialize();
+
+          expect(globalCalls, hasLength(1));
+          expect(
+            globalCalls.first.arguments,
+            containsPair('useLegacySurface', isTrue),
+          );
+        },
+      );
+
+      test('passes explicit useLegacySurface false through create', () async {
+        controller = DivineVideoPlayerController(
+          useTexture: true,
+          useLegacySurface: false,
+        );
+
+        await controller.initialize();
+
+        expect(globalCalls, hasLength(1));
+        expect(
+          globalCalls.first.arguments,
+          containsPair('useLegacySurface', isFalse),
+        );
+      });
+
       test('throws StateError if called twice', () async {
         await initController();
 


### PR DESCRIPTION
## Description

Closes #3416. Crashlytics issue `d0cacc633461283e8d04c9463445b58a` (regressed on 1.0.13 build 502 — Samsung SM-S918W).

```
java.lang.RuntimeException: Cannot execute operation because FlutterJNI is not attached to native.
  at io.flutter.embedding.engine.FlutterJNI.ensureAttachedToNative
  at io.flutter.embedding.engine.FlutterJNI.scheduleFrame
  at io.flutter.embedding.engine.renderer.FlutterRenderer.scheduleEngineFrame
  at io.flutter.embedding.engine.renderer.FlutterRenderer$ImageReaderSurfaceProducer.onImage
  at io.flutter.embedding.engine.renderer.FlutterRenderer$ImageReaderSurfaceProducer$PerImageReader.lambda$new$0
  at android.media.ImageReader$1.run
```

### Root cause

PR #3762 narrowed the race between `ExoPlayer`'s decoder pipeline and `TextureRegistry.SurfaceProducer.ImageReader` callback dispatch — but explicitly acknowledged a residual 1–2 frame window (`stop()` and `clearVideoSurface()` are async; in-flight `MediaCodec` output can still land in a detaching `ImageReader`, and the `onImage` callback then invokes `FlutterJNI.scheduleFrame()` after `FlutterJNI` is detached). On Samsung SM-S918W's fast decoder, that residual fires.

Five callsites in the app use `useTexture: true` and **inherit the default** `useLegacySurface: false`, opting them — accidentally — into the SurfaceProducer/ImageReader path:

- `mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart:443`
- `mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart:82`
- `mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart:72`
- `mobile/lib/widgets/video_clip/video_clip_preview.dart:61`
- `mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart:81`

`infinite_video_feed.dart:654–657` explicitly sets `useLegacySurface: true` and is the only callsite that's safe today. The original `SurfaceProducer` motivation (PR #3856) was the feed's Vivo/Android-16 compat, but PR #3242 migrated the feed to `infinite_video_feed` (legacy surface) — so nothing in the repo currently needs `SurfaceProducer` for its intended purpose; it's in use only via the unsafe default.

### Fix

Flip the default of `useLegacySurface` from `false` to `true` at every layer — Dart controller, MethodChannel fallback, and Kotlin function signature — so the three defaults agree and no future direct caller can trip over an asymmetry. All five accidentally-vulnerable callsites inherit the safe default and stop hitting the race in one change. SurfaceProducer remains available via explicit `useLegacySurface: false` for callsites that genuinely need OEM surface-recreate callbacks — there are none today.

| Site | Change |
|---|---|
| `divine_video_player_controller.dart:51` | `useLegacySurface = true` (was `false`) |
| `divine_video_player_controller.dart:27–46` | Docstring rewritten to document the new default and the explicit opt-in for SurfaceProducer trade-off |
| `DivineVideoPlayerPlugin.kt:135` | MethodChannel fallback flipped to `true` so direct callers without a Dart shim also land on the safe default |
| `DivineVideoPlayerInstance.kt:207` | Kotlin function default `useLegacySurface = true` (was `false`) — aligned with the Dart controller and the MethodChannel fallback |
| `DivineVideoPlayerInstance.kt:62–75, 180–202` | Field-level comment and `enableTextureOutput` KDoc rewritten to mark `SurfaceTextureEntry` as default and `SurfaceProducer` as the explicit opt-in |
| `DivineVideoPlayerInstanceTest.kt` | Existing SurfaceProducer tests opt in via `useLegacySurface = false` explicitly; added two new tests pinning the legacy-branch contract (`createSurfaceTexture()` called, `createSurfaceProducer()` not called; eager surface attach on materialized players) |

The 5 vulnerable callsites are intentionally **not** edited — they now inherit the safe default automatically. This keeps the diff minimal and documents that the fix is at the API layer, not the callsite layer.

### Why this is a complete fix for #3416

- The crash signature is fundamentally a race between Flutter SDK's internal `ImageReaderSurfaceProducer.onImage` (inside `FlutterRenderer`, outside our code) and `FlutterJNI` detach.
- The race cannot be closed from inside the SurfaceProducer disposal path without invasive `MediaCodec.flush()` reflection (rejected as overkill by PR #3762).
- It **can** be closed by ensuring no app callsite uses the SurfaceProducer/ImageReader path. After this fix, no `lib/` callsite does — and the safe choice is now the default, so future code is protected too.
- PR #3762's three-layer disposal hardening (Instance.dispose, Plugin.onDetachedFromActivity, PlatformView.dispose) is preserved unchanged — it remains the contract for any explicit `useLegacySurface: false` opt-in.

## Reproduction (pre-fix)

1. Real Android device (the crash signature is most reliably reproduced on devices with fast MediaCodec output queues — Samsung SM-S918W per Crashlytics).
2. Open the app. Navigate: **video editor → video metadata (preview / cover) → pooled video feed**.
3. Repeat the breadcrumb 10–20× per session.
4. Background the app while a video is playing on one of the editor / metadata screens.
5. Force-finish the activity from recents, or close the app.
6. Repeat across several launches.

Pre-fix: Crashlytics records the `FlutterJNI is not attached to native` exception under issue `d0cacc633461283e8d04c9463445b58a`. Volume is low (1.0.13: 1 user / 1 fatal in May 15 sample) because the race window is small, but it is **fatal** when it fires.

Post-fix: the editor / metadata / clip-preview screens render via the legacy `SurfaceTextureEntry` backend, which has no `ImageReader` and therefore cannot fire the offending callback after engine teardown.

## Out of Scope

- **`media_kit_video` Android backend hardening.** If the pooled-video-feed fallback (only reached when `InfiniteVideoFeed.isSupported` is `false`, which is not Android in production) has a parallel race family, it needs its own PR scoped to the third-party media_kit. Tracked separately when needed.
- **iOS sibling #4400** (FVP / FVPFrameUpdater / ProVideoEditorPlugin / VideoTextureOutput post-teardown callbacks).
- **Reflection-based `MediaCodec.flush()` synchronous fence.** PR #3762 rejected as overkill; not needed once this change takes the volume to zero.
- **Manually editing each of the 5 vulnerable callsites.** Default-flip is strictly cleaner — it covers future code too.

## Verification

Local:

- [x] `dart format` on changed Dart file — no churn
- [x] `flutter analyze lib test integration_test` from `mobile/` — no issues
- [x] `flutter analyze` from `mobile/packages/divine_video_player` — no issues
- [x] `flutter test` from `mobile/packages/divine_video_player` — **154/154 pass**
- [x] `flutter test` from `mobile/packages/infinite_video_feed` — **150/150 pass**
- [x] `./gradlew :divine_video_player:testDebugUnitTest` from `mobile/android/` — **17/17 pass** (15 existing SurfaceProducer / disposal contract tests + 2 new legacy-branch tests)
- [x] Comprehensive callsite audit (`grep -rEn "useTexture\s*:\s*true"` across `mobile/`) — confirmed 5 vulnerable callsites all inherit the new default; only `infinite_video_feed` explicitly sets `useLegacySurface: true`; no callsite explicitly sets it to `false`.

Manual (requires real Android device — not run from this PR; recommended before / immediately after merge):

- [ ] Repeat the reproduction breadcrumb above 20× per build on a real Android device. Expected: no crash, no black-frame regression on the 5 affected screens.
- [ ] Post-release: watch Crashlytics issue `d0cacc633461283e8d04c9463445b58a` for ≥1 release. Expected: events drop to zero.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Risk Register

| Risk | Likelihood | Impact | Notes |
|---|---|---|---|
| Vivo/Android 16 compositor event on the 5 affected screens causes black surface (no surface-recreate callback) | Low — those flows are short-lived and not permission-dialog-heavy | Recoverable (user navigates back/forward) | Strictly better than a fatal crash; if a Crashlytics black-frame signal emerges on those screens, the callsite can explicitly pass `useLegacySurface: false` with a documented justification |
| Hidden external consumer relying on the old default | None — workspace package, no external consumers | — | — |
| Existing tests pin the old default | None — Dart tests don't assert the default; existing Android `SurfaceProducer` tests now opt in explicitly via `useLegacySurface = false`; new legacy-branch tests pin the production path | — | All 154 + 150 + 17 (Android Kotlin) tests green |
