### PR TITLE
perf(inbox): remove N+1 latest-message overlay queries in DmRepository

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -25,6 +25,19 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
 
   /// Upsert a conversation (create or update last-message metadata).
   ///
+  /// When [forceUpdateLastMessage] is `false` (the default), the three
+  /// last-message columns (`last_message_content`, `last_message_timestamp`,
+  /// `last_message_sender_pubkey`) are **only** updated on conflict if the
+  /// incoming [lastMessageTimestamp] is strictly greater than the stored one.
+  /// This prevents out-of-order gift-wrap arrivals (e.g. during backfill)
+  /// from overwriting a newer denormalized preview with stale data — which
+  /// was the root cause of the drift described in issue #4296.
+  ///
+  /// Pass `forceUpdateLastMessage: true` only when the caller explicitly
+  /// needs to overwrite the preview regardless of order, for example when
+  /// refreshing the conversation preview after a message deletion (where
+  /// the replacement message is by definition the newest *remaining* one).
+  ///
   /// Throws:
   ///
   /// * [InvalidDataException] if a column constraint is violated.
@@ -41,22 +54,84 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
     bool currentUserHasSent = false,
     String? ownerPubkey,
     String? dmProtocol,
-  }) {
-    return into(conversations).insertOnConflictUpdate(
-      ConversationsCompanion.insert(
-        id: id,
-        participantPubkeys: participantPubkeys,
-        isGroup: Value(isGroup),
-        createdAt: createdAt,
-        lastMessageContent: Value(lastMessageContent),
-        lastMessageTimestamp: Value(lastMessageTimestamp),
-        lastMessageSenderPubkey: Value(lastMessageSenderPubkey),
-        subject: Value(subject),
-        isRead: Value(isRead),
-        currentUserHasSent: Value(currentUserHasSent),
-        ownerPubkey: Value(ownerPubkey),
-        dmProtocol: Value(dmProtocol),
-      ),
+    bool forceUpdateLastMessage = false,
+  }) async {
+    if (forceUpdateLastMessage) {
+      // Unconditional path — caller asserts correctness of the preview.
+      await into(conversations).insertOnConflictUpdate(
+        ConversationsCompanion.insert(
+          id: id,
+          participantPubkeys: participantPubkeys,
+          isGroup: Value(isGroup),
+          createdAt: createdAt,
+          lastMessageContent: Value(lastMessageContent),
+          lastMessageTimestamp: Value(lastMessageTimestamp),
+          lastMessageSenderPubkey: Value(lastMessageSenderPubkey),
+          subject: Value(subject),
+          isRead: Value(isRead),
+          currentUserHasSent: Value(currentUserHasSent),
+          ownerPubkey: Value(ownerPubkey),
+          dmProtocol: Value(dmProtocol),
+        ),
+      );
+      return;
+    }
+
+    // Conditional path — only update last-message preview columns when the
+    // incoming timestamp is newer than whatever is already stored.
+    // Other fields (participants, flags, protocol) are always updated.
+    //
+    // The CASE expression uses COALESCE so that a NULL stored timestamp is
+    // treated as 0, meaning any real timestamp beats it.
+    await customInsert(
+      '''
+      INSERT INTO conversations (
+        id, participant_pubkeys, is_group, created_at,
+        last_message_content, last_message_timestamp, last_message_sender_pubkey,
+        subject, is_read, current_user_has_sent, owner_pubkey, dm_protocol
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        participant_pubkeys = excluded.participant_pubkeys,
+        is_group = excluded.is_group,
+        subject = COALESCE(excluded.subject, subject),
+        is_read = excluded.is_read,
+        current_user_has_sent = CASE
+          WHEN excluded.current_user_has_sent = 1 THEN 1
+          ELSE current_user_has_sent
+        END,
+        owner_pubkey = COALESCE(excluded.owner_pubkey, owner_pubkey),
+        dm_protocol = COALESCE(excluded.dm_protocol, dm_protocol),
+        last_message_timestamp = CASE
+          WHEN excluded.last_message_timestamp > COALESCE(last_message_timestamp, 0)
+            THEN excluded.last_message_timestamp
+          ELSE last_message_timestamp
+        END,
+        last_message_content = CASE
+          WHEN excluded.last_message_timestamp > COALESCE(last_message_timestamp, 0)
+            THEN excluded.last_message_content
+          ELSE last_message_content
+        END,
+        last_message_sender_pubkey = CASE
+          WHEN excluded.last_message_timestamp > COALESCE(last_message_timestamp, 0)
+            THEN excluded.last_message_sender_pubkey
+          ELSE last_message_sender_pubkey
+        END
+      ''',
+      variables: [
+        Variable.withString(id),
+        Variable.withString(participantPubkeys),
+        Variable.withBool(isGroup),
+        Variable.withInt(createdAt),
+        Variable(lastMessageContent),
+        Variable(lastMessageTimestamp),
+        Variable(lastMessageSenderPubkey),
+        Variable(subject),
+        Variable.withBool(isRead),
+        Variable.withBool(currentUserHasSent),
+        Variable(ownerPubkey),
+        Variable(dmProtocol),
+      ],
+      updates: {conversations},
     );
   }
 

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -25,22 +25,26 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
 
   /// Upsert a conversation (create or update last-message metadata).
   ///
-  /// When [forceUpdateLastMessage] is `false` (the default), the three
-  /// last-message columns (`last_message_content`, `last_message_timestamp`,
-  /// `last_message_sender_pubkey`) are **only** updated on conflict if the
-  /// incoming [lastMessageTimestamp] is strictly greater than the stored one.
-  /// This prevents out-of-order gift-wrap arrivals (e.g. during backfill)
-  /// from overwriting a newer denormalized preview with stale data — which
-  /// was the root cause of the drift described in issue #4296.
+  /// On conflict the following update semantics apply in **both** branches:
   ///
-  /// Pass `forceUpdateLastMessage: true` only when the caller explicitly
-  /// needs to overwrite the preview regardless of order, for example when
-  /// refreshing the conversation preview after a message deletion (where
-  /// the replacement message is by definition the newest *remaining* one).
+  /// * `participantPubkeys`, `isGroup`, `isRead` — always overwritten.
+  /// * `subject`, `ownerPubkey`, `dmProtocol` — updated only when the
+  ///   incoming value is non-null; existing non-null value is preserved.
+  /// * `currentUserHasSent` — one-way ratchet: once `true` it is never
+  ///   cleared back to `false` by an incoming `false`.
+  /// * `lastMessageContent`, `lastMessageTimestamp`,
+  ///   `lastMessageSenderPubkey` — conditionally updated:
+  ///   - When [forceUpdateLastMessage] is `false` (default), these are only
+  ///     written if the incoming [lastMessageTimestamp] is strictly newer
+  ///     than the stored one. This prevents out-of-order gift-wrap arrivals
+  ///     during backfill from overwriting a fresher denormalized preview.
+  ///   - When [forceUpdateLastMessage] is `true`, these are always written.
+  ///     Use this only when the caller has already established that the
+  ///     incoming values are the correct current preview — e.g. after a
+  ///     deletion when the replacement message may be older than the one
+  ///     that was removed.
   ///
-  /// Throws:
-  ///
-  /// * [InvalidDataException] if a column constraint is violated.
+  /// Throws [InvalidDataException] if a column constraint is violated.
   Future<void> upsertConversation({
     required String id,
     required String participantPubkeys,
@@ -55,83 +59,67 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
     String? ownerPubkey,
     String? dmProtocol,
     bool forceUpdateLastMessage = false,
-  }) async {
-    if (forceUpdateLastMessage) {
-      // Unconditional path — caller asserts correctness of the preview.
-      await into(conversations).insertOnConflictUpdate(
-        ConversationsCompanion.insert(
-          id: id,
-          participantPubkeys: participantPubkeys,
-          isGroup: Value(isGroup),
-          createdAt: createdAt,
-          lastMessageContent: Value(lastMessageContent),
-          lastMessageTimestamp: Value(lastMessageTimestamp),
-          lastMessageSenderPubkey: Value(lastMessageSenderPubkey),
-          subject: Value(subject),
-          isRead: Value(isRead),
-          currentUserHasSent: Value(currentUserHasSent),
-          ownerPubkey: Value(ownerPubkey),
-          dmProtocol: Value(dmProtocol),
-        ),
-      );
-      return;
-    }
+  }) {
+    final row = ConversationsCompanion.insert(
+      id: id,
+      participantPubkeys: participantPubkeys,
+      isGroup: Value(isGroup),
+      createdAt: createdAt,
+      lastMessageContent: Value(lastMessageContent),
+      lastMessageTimestamp: Value(lastMessageTimestamp),
+      lastMessageSenderPubkey: Value(lastMessageSenderPubkey),
+      subject: Value(subject),
+      isRead: Value(isRead),
+      currentUserHasSent: Value(currentUserHasSent),
+      ownerPubkey: Value(ownerPubkey),
+      dmProtocol: Value(dmProtocol),
+    );
 
-    // Conditional path — only update last-message preview columns when the
-    // incoming timestamp is newer than whatever is already stored.
-    // Other fields (participants, flags, protocol) are always updated.
-    //
-    // The CASE expression uses COALESCE so that a NULL stored timestamp is
-    // treated as 0, meaning any real timestamp beats it.
-    await customInsert(
-      '''
-      INSERT INTO conversations (
-        id, participant_pubkeys, is_group, created_at,
-        last_message_content, last_message_timestamp, last_message_sender_pubkey,
-        subject, is_read, current_user_has_sent, owner_pubkey, dm_protocol
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET
-        participant_pubkeys = excluded.participant_pubkeys,
-        is_group = excluded.is_group,
-        subject = COALESCE(excluded.subject, subject),
-        is_read = excluded.is_read,
-        current_user_has_sent = CASE
-          WHEN excluded.current_user_has_sent = 1 THEN 1
-          ELSE current_user_has_sent
-        END,
-        owner_pubkey = COALESCE(excluded.owner_pubkey, owner_pubkey),
-        dm_protocol = COALESCE(excluded.dm_protocol, dm_protocol),
-        last_message_timestamp = CASE
-          WHEN excluded.last_message_timestamp > COALESCE(last_message_timestamp, 0)
-            THEN excluded.last_message_timestamp
-          ELSE last_message_timestamp
-        END,
-        last_message_content = CASE
-          WHEN excluded.last_message_timestamp > COALESCE(last_message_timestamp, 0)
-            THEN excluded.last_message_content
-          ELSE last_message_content
-        END,
-        last_message_sender_pubkey = CASE
-          WHEN excluded.last_message_timestamp > COALESCE(last_message_timestamp, 0)
-            THEN excluded.last_message_sender_pubkey
-          ELSE last_message_sender_pubkey
-        END
-      ''',
-      variables: [
-        Variable.withString(id),
-        Variable.withString(participantPubkeys),
-        Variable.withBool(isGroup),
-        Variable.withInt(createdAt),
-        Variable(lastMessageContent),
-        Variable(lastMessageTimestamp),
-        Variable(lastMessageSenderPubkey),
-        Variable(subject),
-        Variable.withBool(isRead),
-        Variable.withBool(currentUserHasSent),
-        Variable(ownerPubkey),
-        Variable(dmProtocol),
-      ],
-      updates: {conversations},
+    return into(conversations).insert(
+      row,
+      onConflict: DoUpdate.withExcluded(
+        (old, excl) {
+          // Determine whether the incoming preview columns should win.
+          // When forced, always take the incoming values. Otherwise only
+          // update when the incoming timestamp is strictly newer than the
+          // stored one (NULL stored timestamp counts as 0 via COALESCE).
+          final incomingIsNewer = excl.lastMessageTimestamp.isBiggerThan(
+            coalesce([old.lastMessageTimestamp, const Constant(0)]),
+          );
+          final previewCondition = forceUpdateLastMessage
+              ? const Constant<bool>(true)
+              : incomingIsNewer;
+
+          return ConversationsCompanion.custom(
+            // Always updated.
+            participantPubkeys: excl.participantPubkeys,
+            isGroup: excl.isGroup,
+            isRead: excl.isRead,
+            // Preserve existing non-null value; only update when incoming
+            // value is non-null.
+            subject: coalesce([excl.subject, old.subject]),
+            ownerPubkey: coalesce([excl.ownerPubkey, old.ownerPubkey]),
+            dmProtocol: coalesce([excl.dmProtocol, old.dmProtocol]),
+            // One-way ratchet: never clear true back to false.
+            currentUserHasSent:
+                old.currentUserHasSent | excl.currentUserHasSent,
+            // Preview columns: conditional on timestamp guard.
+            // iif(condition, ifFalse) is called on the ifTrue expression.
+            lastMessageTimestamp: excl.lastMessageTimestamp.iif(
+              previewCondition,
+              old.lastMessageTimestamp,
+            ),
+            lastMessageContent: excl.lastMessageContent.iif(
+              previewCondition,
+              old.lastMessageContent,
+            ),
+            lastMessageSenderPubkey: excl.lastMessageSenderPubkey.iif(
+              previewCondition,
+              old.lastMessageSenderPubkey,
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -105,6 +105,132 @@ void main() {
         expect(result!.isGroup, isTrue);
         expect(result.subject, equals('Group Chat'));
       });
+
+      test(
+        'does not overwrite newer preview with older timestamp (out-of-order '
+        'gift-wrap protection)',
+        () async {
+          // Simulate newer message arriving first.
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'Newer message',
+            lastMessageTimestamp: 1700000200,
+            lastMessageSenderPubkey: 'pubkey_b',
+          );
+
+          // Out-of-order older message arrives — must NOT overwrite preview.
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'Older stale message',
+            lastMessageTimestamp: 1700000100,
+            lastMessageSenderPubkey: 'pubkey_a',
+          );
+
+          final result = await dao.getConversation('conv_1');
+          expect(result, isNotNull);
+          expect(result!.lastMessageContent, equals('Newer message'));
+          expect(result.lastMessageTimestamp, equals(1700000200));
+          expect(result.lastMessageSenderPubkey, equals('pubkey_b'));
+        },
+      );
+
+      test(
+        'updates preview when new timestamp is strictly newer',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'First message',
+            lastMessageTimestamp: 1700000100,
+            lastMessageSenderPubkey: 'pubkey_a',
+          );
+
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'Second message',
+            lastMessageTimestamp: 1700000200,
+            lastMessageSenderPubkey: 'pubkey_b',
+          );
+
+          final result = await dao.getConversation('conv_1');
+          expect(result, isNotNull);
+          expect(result!.lastMessageContent, equals('Second message'));
+          expect(result.lastMessageTimestamp, equals(1700000200));
+          expect(result.lastMessageSenderPubkey, equals('pubkey_b'));
+        },
+      );
+
+      test(
+        'forceUpdateLastMessage overwrites even with older timestamp',
+        () async {
+          // Simulate newer preview already stored.
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'Newer message',
+            lastMessageTimestamp: 1700000200,
+            lastMessageSenderPubkey: 'pubkey_b',
+          );
+
+          // Force refresh with older-but-correct remaining message
+          // (post-delete).
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'Remaining older message',
+            lastMessageTimestamp: 1700000100,
+            lastMessageSenderPubkey: 'pubkey_a',
+            forceUpdateLastMessage: true,
+          );
+
+          final result = await dao.getConversation('conv_1');
+          expect(result, isNotNull);
+          expect(result!.lastMessageContent, equals('Remaining older message'));
+          expect(result.lastMessageTimestamp, equals(1700000100));
+          expect(result.lastMessageSenderPubkey, equals('pubkey_a'));
+        },
+      );
+
+      test(
+        'currentUserHasSent is only ever flipped true, never back to false',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            currentUserHasSent: true,
+          );
+
+          // Incoming message from other party with currentUserHasSent: false
+          // must not clear the existing true value.
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+          );
+
+          final result = await dao.getConversation('conv_1');
+          expect(result, isNotNull);
+          expect(result!.currentUserHasSent, isTrue);
+        },
+      );
     });
 
     group('getAllConversations', () {

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -231,6 +231,85 @@ void main() {
           expect(result!.currentUserHasSent, isTrue);
         },
       );
+
+      test(
+        'preserves existing nullable fields when conflict update omits them',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: true,
+            createdAt: 1700000000,
+            subject: 'Original Subject',
+            ownerPubkey: 'owner_a',
+            dmProtocol: 'nip04',
+          );
+
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b","pubkey_c"]',
+            isGroup: true,
+            createdAt: 1700000100,
+          );
+
+          final result = await dao.getConversation('conv_1');
+          expect(result, isNotNull);
+          expect(result!.subject, equals('Original Subject'));
+          expect(result.ownerPubkey, equals('owner_a'));
+          expect(result.dmProtocol, equals('nip04'));
+        },
+      );
+
+      test(
+        'overwrites nullable fields when conflict update provides values',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            subject: 'Original Subject',
+            ownerPubkey: 'owner_a',
+            dmProtocol: 'nip04',
+          );
+
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000100,
+            subject: 'Updated Subject',
+            ownerPubkey: 'owner_b',
+            dmProtocol: 'nip17',
+          );
+
+          final result = await dao.getConversation('conv_1');
+          expect(result, isNotNull);
+          expect(result!.subject, equals('Updated Subject'));
+          expect(result.ownerPubkey, equals('owner_b'));
+          expect(result.dmProtocol, equals('nip17'));
+        },
+      );
+
+      test('preserves original createdAt on conflict update', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["pubkey_a","pubkey_b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+        );
+
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["pubkey_a","pubkey_b"]',
+          isGroup: false,
+          createdAt: 1700000100,
+        );
+
+        final result = await dao.getConversation('conv_1');
+        expect(result, isNotNull);
+        expect(result!.createdAt, equals(1700000000));
+      });
     });
 
     group('getAllConversations', () {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1422,7 +1422,9 @@ class DmRepository {
     if (conversation == null) return;
 
     if (remaining.isEmpty) {
-      // All messages deleted — clear the preview.
+      // All messages deleted — clear the preview. Force the update so the
+      // conditional timestamp check in upsertConversation does not block
+      // a null timestamp from overwriting the existing value.
       await _conversationsDao.upsertConversation(
         id: conversationId,
         participantPubkeys: conversation.participantPubkeys,
@@ -1438,6 +1440,7 @@ class DmRepository {
         currentUserHasSent: conversation.currentUserHasSent,
         ownerPubkey: conversation.ownerPubkey,
         dmProtocol: conversation.dmProtocol,
+        forceUpdateLastMessage: true,
       );
     } else {
       final latest = remaining.first;
@@ -1445,6 +1448,9 @@ class DmRepository {
           ? _filePreviewText(latest.fileType)
           : latest.content;
 
+      // Force the update: after a deletion the replacement message is the
+      // newest *remaining* one, but its timestamp may be older than the
+      // deleted message that was previously shown.
       await _conversationsDao.upsertConversation(
         id: conversationId,
         participantPubkeys: conversation.participantPubkeys,
@@ -1456,6 +1462,7 @@ class DmRepository {
         currentUserHasSent: conversation.currentUserHasSent,
         ownerPubkey: conversation.ownerPubkey,
         dmProtocol: conversation.dmProtocol,
+        forceUpdateLastMessage: true,
       );
     }
   }
@@ -1670,12 +1677,21 @@ class DmRepository {
         .asyncMap(_overlayLatestMessages);
   }
 
-  /// Replaces each row's denormalized last-message fields with the actual
-  /// latest message from `direct_messages`, then re-sorts by that
-  /// timestamp. The conversations table's `lastMessageContent` /
-  /// `lastMessageTimestamp` columns can drift out of sync (e.g. an older
-  /// gift wrap arriving after a newer one writes back during backfill),
-  /// so the messages table is the source of truth for the inbox preview.
+  /// Overlays each conversation row with the actual latest message from
+  /// `direct_messages` using a single batched query, then re-sorts by that
+  /// timestamp.
+  ///
+  /// This is a read-path safety net for existing user databases that may
+  /// contain stale `lastMessageContent` / `lastMessageTimestamp` values
+  /// written by app versions prior to the write-path fix in
+  /// `upsertConversation`. New writes are protected by that fix and will
+  /// never drift, but already-stale rows need this correction until a
+  /// backfill migration repairs them.
+  ///
+  // TODO(perf4407): Remove this method and the two asyncMap calls above once
+  // a one-time backfill migration has shipped that corrects any stale
+  // conversation rows in existing user databases.
+  // Tracking: divinevideo/divine-mobile#4407.
   Future<List<DmConversation>> _overlayLatestMessages(
     List<ConversationRow> rows,
   ) async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -4411,6 +4411,7 @@ void main() {
               currentUserHasSent: any(named: 'currentUserHasSent'),
               ownerPubkey: any(named: 'ownerPubkey'),
               dmProtocol: any(named: 'dmProtocol'),
+              forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5807,6 +5808,7 @@ void main() {
             currentUserHasSent: any(named: 'currentUserHasSent'),
             ownerPubkey: any(named: 'ownerPubkey'),
             dmProtocol: any(named: 'dmProtocol'),
+            forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
           ),
         ).thenAnswer((_) async {});
 
@@ -6070,6 +6072,7 @@ void main() {
               currentUserHasSent: any(named: 'currentUserHasSent'),
               ownerPubkey: any(named: 'ownerPubkey'),
               dmProtocol: any(named: 'dmProtocol'),
+              forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
             ),
           ).thenAnswer((_) async {});
 
@@ -6088,6 +6091,7 @@ void main() {
               currentUserHasSent: any(named: 'currentUserHasSent'),
               ownerPubkey: any(named: 'ownerPubkey'),
               dmProtocol: any(named: 'dmProtocol'),
+              forceUpdateLastMessage: true,
             ),
           ).called(1);
         },
@@ -6178,6 +6182,7 @@ void main() {
               currentUserHasSent: any(named: 'currentUserHasSent'),
               ownerPubkey: any(named: 'ownerPubkey'),
               dmProtocol: any(named: 'dmProtocol'),
+              forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
             ),
           ).thenAnswer((_) async {});
 
@@ -6196,6 +6201,7 @@ void main() {
               currentUserHasSent: any(named: 'currentUserHasSent'),
               ownerPubkey: any(named: 'ownerPubkey'),
               dmProtocol: any(named: 'dmProtocol'),
+              forceUpdateLastMessage: true,
             ),
           ).called(1);
         },
@@ -8713,6 +8719,7 @@ void main() {
                 currentUserHasSent: any(named: 'currentUserHasSent'),
                 ownerPubkey: any(named: 'ownerPubkey'),
                 dmProtocol: any(named: 'dmProtocol'),
+                forceUpdateLastMessage: any(named: 'forceUpdateLastMessage'),
               ),
             ).thenAnswer((_) async {});
 


### PR DESCRIPTION
## Summary

Closes #4296 

PR #4286 introduced a correctness fix for stale inbox previews but created an N+1 read-path problem: every `watchAcceptedConversations` / `watchPotentialRequests` emission performed one `getMessagesForConversation(limit: 1)` query per conversation. This PR removes that fan-out while keeping the correctness guarantee.

## Changes

### Option A — batched overlay query (`db_client`)
`getLatestMessagesForConversations` was already added in the review feedback of #4286. `_overlayLatestMessages` now issues a **single** batched query per emit regardless of conversation count, down from N.

### Option B — write-path drift fix (`ConversationsDao`)
Root cause of the original staleness: `upsertConversation` used `insertOnConflictUpdate` which unconditionally overwrote `last_message_*` columns on every gift-wrap arrival, including older out-of-order ones during backfill.

`upsertConversation` now uses a conditional `ON CONFLICT DO UPDATE` that only updates the three last-message columns when the incoming `last_message_timestamp` is **strictly newer** than the stored value. A `forceUpdateLastMessage` parameter bypasses the guard for `_refreshConversationPreview` (post-deletion), where the replacement message is by definition the newest remaining one.

`current_user_has_sent` is also now a write-once ratchet at the SQL level (`false → true` only, never reversed).

The `DoUpdate.withExcluded` rewrite also makes the rest of the conflict contract explicit and typed: `subject`, `ownerPubkey`, and `dmProtocol` preserve the existing non-null value when an incoming upsert omits them, while incoming non-null values still overwrite; `createdAt` remains immutable after the row is first created.

### Transitional overlay
`_overlayLatestMessages` is kept as a read-path safety net for existing user databases that may have stale rows written before the write-path fix shipped. Removal is tracked in #4407 (requires a backfill migration).

## Tests

- **7 `ConversationsDao` tests**: out-of-order upsert does not overwrite a newer preview; in-order upsert does update; `forceUpdateLastMessage: true` bypasses the guard; `currentUserHasSent` is never flipped back to false; nullable conflict fields preserve existing values when omitted; nullable conflict fields overwrite when provided; `createdAt` stays immutable on conflict.
- **Existing overlay regression tests** from #4286 remain intact: overlay preview, re-sort by timestamp, file-message preview.
- Updated `dm_repository_test` stubs/verify calls to include the new `forceUpdateLastMessage` parameter.

## Acceptance criteria

- [x] Inbox streams no longer perform one `getMessagesForConversation(limit: 1)` per conversation per emit
- [x] Inbox preview still shows true latest message even when the conversation row is stale
- [x] Ordering remains based on the real latest message timestamp
- [x] Existing regression coverage intact
- [x] Transitional code has a linked `TODO(perf4407)` pointing at #4407 with a clear removal plan
