### PR TITLE
feat(dm): recoverFullSend primitive + auto-sweep wiring for recipient-failed DMs

### DIFF
--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -56,11 +56,12 @@ class OutgoingDmRetryConfig {
 /// only on a real publish failure so transient repo-not-ready states
 /// don't burn the retry budget.
 ///
-/// **Scope today:** only `recipient: sent / self: failed` rows are
-/// dispatched. `recipient: failed` rows are enumerated and counted in
-/// logs — issue #4240 will add the `recoverFullSend` primitive and
-/// wire it as the second strategy entry. App-killed `pending: pending`
-/// rows are not in this filter (see [OutgoingDmsDao.getStillPendingForOwner]).
+/// **Scope today:** `recipient: sent / self: failed` rows dispatch to
+/// [DmRepository.recoverSelfWrap]; `recipient: failed` rows dispatch
+/// to [DmRepository.recoverFullSend]. App-killed `pending: pending`
+/// rows are not in this filter (see
+/// [OutgoingDmsDao.getStillPendingForOwner]) and remain the concern of
+/// a separate interrupted-send recovery path.
 class OutgoingDmRetryService {
   OutgoingDmRetryService({
     required DmRepository dmRepository,
@@ -143,8 +144,9 @@ class OutgoingDmRetryService {
 
       var processedSelfWrap = 0;
       var failedSelfWrap = 0;
+      var processedFullSend = 0;
+      var failedFullSend = 0;
       var skippedBackoff = 0;
-      var recipientFailedCount = 0;
       var abortedNotReady = false;
 
       for (final row in retryable) {
@@ -220,10 +222,61 @@ class OutgoingDmRetryService {
             }
           }
         } else if (row.recipientWrapStatus == OutgoingWrapStatus.failed) {
-          // State B: recipient publish itself failed. Recovery primitive
-          // lands in #4240; today we only enumerate so we have
-          // production rate-of-occurrence data before designing it.
-          recipientFailedCount++;
+          // State B: recipient publish itself failed. Replay the
+          // full send. NIP-17 receiver-side dedup keys on the rumor
+          // id (preserved across retries via `rumor_event_json`), so
+          // re-publishing is safe even when the original publish
+          // actually landed but the local persist failed.
+          try {
+            final result = await _dmRepository.recoverFullSend(
+              rumorId: row.id,
+            );
+            if (result.success) {
+              // recoverFullSend's success path either deletes the row
+              // (full delivery) or promotes it to
+              // `recipient: sent / self: failed` (partial). Either
+              // way the row exits the recipient-failed filter, so
+              // skip incrementRetry.
+              processedFullSend++;
+            } else {
+              // Publish failed again. recoverFullSend already
+              // re-marked both wraps failed with the new error via
+              // _finalizeAfterRecipientFailure (which writes
+              // lastAttemptAt through the DAO codec). Bump the retry
+              // counter so backoff applies and the row eventually
+              // exits the retryable filter at maxRetries.
+              await _dao.incrementRetry(row.id);
+              failedFullSend++;
+            }
+          } on Object catch (e, stackTrace) {
+            // Same error policy as the recoverSelfWrap dispatch
+            // above. recoverFullSend's contract documents StateError
+            // (repo or DAO not initialized) and ArgumentError (row
+            // missing / foreign owner) as part of its public surface.
+            if (e is StateError) {
+              Log.warning(
+                'repo not ready during sweep; aborting pass: $e',
+                name: 'OutgoingDmRetryService',
+                category: LogCategory.system,
+              );
+              abortedNotReady = true;
+            } else if (e is ArgumentError) {
+              Log.warning(
+                'skipping row ${row.id}: $e',
+                name: 'OutgoingDmRetryService',
+                category: LogCategory.system,
+              );
+            } else {
+              await _dao.incrementRetry(row.id);
+              Log.error(
+                'recoverFullSend threw for ${row.id}: $e',
+                name: 'OutgoingDmRetryService',
+                category: LogCategory.system,
+                error: e,
+                stackTrace: stackTrace,
+              );
+            }
+          }
         }
       }
 
@@ -231,8 +284,9 @@ class OutgoingDmRetryService {
         'sweep complete: '
         'self-wrap-recovered=$processedSelfWrap '
         'self-wrap-failed=$failedSelfWrap '
+        'full-send-recovered=$processedFullSend '
+        'full-send-failed=$failedFullSend '
         'skipped-backoff=$skippedBackoff '
-        'recipient-failed=$recipientFailedCount '
         'aborted-not-ready=$abortedNotReady',
         name: 'OutgoingDmRetryService',
         category: LogCategory.system,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1104,6 +1104,182 @@ class DmRepository {
     return result;
   }
 
+  /// Re-publish both gift wraps for a stored rumor whose recipient
+  /// publish previously failed.
+  ///
+  /// Used by `OutgoingDmRetryService`'s strategy-table dispatch for
+  /// rows in `recipient_wrap_status == failed`. Re-publishing the
+  /// rumor against a relay that already accepted the original wire
+  /// copy is safe: NIP-17 receiver-side dedup keys on the rumor id
+  /// (preserved verbatim via `rumor_event_json`), so the receiver sees
+  /// one logical message even when the wire copy was sent twice.
+  ///
+  /// Looks up the queue row for [rumorId] (must have been enqueued by
+  /// [sendMessage] / [sendGroupMessage]), rebuilds the rumor from the
+  /// stored JSON, calls [NIP17MessageService.sendRumor], and
+  /// transitions the queue row by outcome:
+  ///
+  /// - Full success: delete the row in the same transaction that
+  ///   inserts `direct_messages`. Same atomicity contract as
+  ///   [sendMessage]'s happy path.
+  /// - Partial success (recipient sent, self failed): mark recipient
+  ///   `sent` and self `failed` so the next sweep replays only the
+  ///   missing self-wrap via [recoverSelfWrap].
+  /// - Recipient failure: re-mark both wraps `failed` so the row
+  ///   stays retryable.
+  ///
+  /// Idempotent: if the row's `recipientWrapStatus` is already
+  /// [OutgoingWrapStatus.sent] (a concurrent recovery raced ahead or
+  /// the row was already mid-recovery), defers to [recoverSelfWrap]
+  /// so the recipient wrap is never republished.
+  ///
+  /// Returns the underlying [NIP17SendResult] so callers can chain a
+  /// per-rumor recovery and aggregate the result.
+  ///
+  /// Throws [StateError] if the repository or its queue DAO are not
+  /// wired in. Throws [ArgumentError] if no row exists for [rumorId]
+  /// or the row belongs to a different account.
+  Future<NIP17SendResult> recoverFullSend({required String rumorId}) async {
+    _assertInitialized();
+    final dao = _outgoingDmsDao;
+    if (dao == null) {
+      throw StateError(
+        'recoverFullSend requires the outgoing_dms queue DAO; '
+        'wire OutgoingDmsDao into DmRepository before calling.',
+      );
+    }
+    final row = await dao.getById(rumorId);
+    if (row == null) {
+      throw ArgumentError.value(
+        rumorId,
+        'rumorId',
+        'no queued outgoing DM with this id',
+      );
+    }
+    if (row.ownerPubkey != _userPubkey) {
+      throw ArgumentError.value(
+        rumorId,
+        'rumorId',
+        'queue row belongs to a different account',
+      );
+    }
+
+    // Idempotent guard: if a concurrent recovery (or the original
+    // send's partial-success path) already promoted the recipient
+    // wrap to sent, defer to recoverSelfWrap so the recipient wrap
+    // is never republished. The two recovery primitives share the
+    // same per-row state machine; this branch keeps them composable.
+    if (row.recipientWrapStatus == OutgoingWrapStatus.sent) {
+      return recoverSelfWrap(rumorId: rumorId);
+    }
+
+    final Event rumor;
+    try {
+      final json = jsonDecode(row.rumorEventJson) as Map<String, dynamic>;
+      rumor = Event.fromJson(json);
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to parse rumor JSON for $rumorId: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      // Mark both wraps failed with the parse error so the row stays
+      // visible to the retry sweep with a record of why this attempt
+      // produced no publish.
+      await _finalizeAfterRecipientFailure(
+        outgoingDao: dao,
+        rumorId: rumorId,
+        errorMessage: 'rumor JSON parse failed: $e',
+      );
+      return NIP17SendResult.failure('rumor JSON parse failed: $e');
+    }
+
+    final result = await _messageService!.sendRumor(
+      rumorEvent: rumor,
+      recipientPubkey: row.recipientPubkey,
+    );
+
+    if (result.success) {
+      // Mirror sendMessage's happy-path transaction: persist
+      // direct_messages + conversation upsert + queue finalize
+      // atomically so a watcher never sees a window where the message
+      // is in neither table, and so a partial delivery preserves the
+      // retry row.
+      try {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final participants = [_userPubkey, row.recipientPubkey]..sort();
+        await _conversationsDao.runInTransaction(() async {
+          await _directMessagesDao.insertMessage(
+            id: result.rumorEventId!,
+            conversationId: row.conversationId,
+            senderPubkey: _userPubkey,
+            content: row.content,
+            createdAt: now,
+            giftWrapId: result.messageEventId!,
+            messageKind: row.messageKind,
+            replyToId: row.replyToId,
+            ownerPubkey: _userPubkey,
+          );
+
+          final existing = await _conversationsDao.getConversation(
+            row.conversationId,
+            ownerPubkey: _userPubkey,
+          );
+          // Mirror sendMessage: once we successfully publish a NIP-17
+          // message ourselves, mark the conversation NIP-17 so the
+          // legacy NIP-04 fallback path doesn't fire on future sends.
+          final nextProtocol = existing?.dmProtocol ?? 'nip17';
+          await _conversationsDao.upsertConversation(
+            id: row.conversationId,
+            participantPubkeys: jsonEncode(participants),
+            isGroup: false,
+            createdAt: existing?.createdAt ?? now,
+            lastMessageContent: row.content,
+            lastMessageTimestamp: now,
+            lastMessageSenderPubkey: _userPubkey,
+            currentUserHasSent: true,
+            ownerPubkey: _userPubkey,
+            dmProtocol: nextProtocol,
+          );
+
+          await _finalizeAfterRecipientSuccess(
+            outgoingDao: dao,
+            rumorId: rumorId,
+            result: result,
+          );
+        });
+
+        Log.debug(
+          'Recovered full send and persisted locally in conversation '
+          '${row.conversationId}',
+          category: LogCategory.system,
+        );
+      } on Object catch (e, stackTrace) {
+        Log.error(
+          'Failed to persist recovered send locally for $rumorId: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        // Publish landed but local persistence failed — degraded
+        // state. Don't rethrow: the caller still gets the success
+        // result. The retry sweep will not pick this row up again
+        // because the publish succeeded; missing local persistence
+        // surfaces only as a sender-side gap until the self-wrap
+        // arrives via the receive pipeline.
+      }
+    } else {
+      await _finalizeAfterRecipientFailure(
+        outgoingDao: dao,
+        rumorId: rumorId,
+        errorMessage: result.error ?? 'Unknown publish failure',
+      );
+    }
+
+    return result;
+  }
+
   /// Apply the queue-row transition for a successful per-recipient
   /// rumor publish. Shared between [sendMessage] and [sendGroupMessage]
   /// so both call sites agree on the partial-vs-full delivery

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8642,6 +8642,542 @@ void main() {
       );
     });
 
+    group('recoverFullSend', () {
+      late _MockOutgoingDmsDao mockOutgoingDmsDao;
+
+      // A fixed rumor JSON that Event.fromJson can parse — the
+      // recoverFullSend path rebuilds the rumor from this payload to
+      // preserve the receiver-side dedup key across retries.
+      final queuedRumorJson = jsonEncode({
+        'id': _rumorEventId,
+        'pubkey': _validPubkeyA,
+        'created_at': 1700000000,
+        'kind': EventKind.privateDirectMessage,
+        'tags': [
+          ['p', _validPubkeyB],
+        ],
+        'content': 'queued message',
+        'sig': '',
+      });
+
+      OutgoingDm queuedRow({
+        OutgoingWrapStatus recipientWrapStatus = OutgoingWrapStatus.failed,
+        OutgoingWrapStatus selfWrapStatus = OutgoingWrapStatus.failed,
+        String ownerPubkey = _validPubkeyA,
+        String? recipientWrapEventId,
+        String? selfWrapEventId,
+      }) {
+        return OutgoingDm(
+          id: _rumorEventId,
+          conversationId: 'conv',
+          recipientPubkey: _validPubkeyB,
+          content: 'queued message',
+          createdAt: 1700000000,
+          rumorEventJson: queuedRumorJson,
+          recipientWrapStatus: recipientWrapStatus,
+          selfWrapStatus: selfWrapStatus,
+          queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
+          ownerPubkey: ownerPubkey,
+          recipientWrapEventId: recipientWrapEventId,
+          selfWrapEventId: selfWrapEventId,
+        );
+      }
+
+      setUp(() {
+        mockOutgoingDmsDao = _MockOutgoingDmsDao();
+        // Default stubs cover every DAO write recoverFullSend exercises
+        // across its branches (success / partial / failure / parse-fail).
+        when(
+          () => mockOutgoingDmsDao.deleteById(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockOutgoingDmsDao.markRecipientWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockOutgoingDmsDao.markSelfWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+
+        // Local persistence stubs for the happy-path transaction.
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+      });
+
+      test(
+        'on full delivery: deletes the queue row, inserts '
+        'direct_messages, and surfaces the success result',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isTrue);
+          // Full delivery deletes the row in the same transaction as
+          // the local message persist.
+          verify(
+            () => mockOutgoingDmsDao.deleteById(_rumorEventId),
+          ).called(1);
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: 'conv',
+              senderPubkey: _validPubkeyA,
+              content: 'queued message',
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: _giftWrapEventId2,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: _validPubkeyA,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'on partial delivery: keeps the queue row, marks recipient '
+        'sent and self failed, still inserts direct_messages',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: recipientPubkey,
+              selfWrapPublished: false,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isFalse);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.sent,
+              eventId: _giftWrapEventId2,
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'Recipient delivered, but self-wrap publish failed',
+            ),
+          ).called(1);
+          // Local persistence still fires — the recipient received the
+          // message, so the sender side must show it.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: _giftWrapEventId2,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'on recipient publish failure: re-marks both wraps failed and '
+        'does NOT touch direct_messages',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, _) async =>
+                const NIP17SendResult.failure('relay still unavailable'),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, equals('relay still unavailable'));
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay still unavailable',
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay still unavailable',
+            ),
+          ).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'idempotent: when recipient_wrap_status is already sent, '
+        'defers to recoverSelfWrap and never republishes the recipient '
+        'wrap',
+        () async {
+          // Row promoted to recipient: sent / self: failed before this
+          // recoverFullSend call (e.g. a concurrent retry, or the
+          // original sendMessage hit the partial-success path).
+          when(() => mockOutgoingDmsDao.getById(_rumorEventId)).thenAnswer(
+            (_) async => queuedRow(
+              recipientWrapStatus: OutgoingWrapStatus.sent,
+              recipientWrapEventId: _giftWrapEventId,
+            ),
+          );
+          when(
+            () => mockMessageService.publishSelfWrap(
+              rumorEvent: any(named: 'rumorEvent'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _rumorEventId,
+              recipientPubkey: _validPubkeyA,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isTrue);
+          // Critical invariant: no recipient publish on this branch.
+          verifyNever(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          );
+          verifyNever(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          );
+          // recoverSelfWrap landed: it deletes the row after a clean
+          // publish.
+          verify(
+            () => mockOutgoingDmsDao.deleteById(_rumorEventId),
+          ).called(1);
+        },
+      );
+
+      test(
+        'throws ArgumentError when no queue row exists for the rumor id',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(any()),
+          ).thenAnswer((_) async => null);
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          expect(
+            () => repository.recoverFullSend(rumorId: _rumorEventId),
+            throwsArgumentError,
+          );
+        },
+      );
+
+      test(
+        'throws ArgumentError when the queue row belongs to a '
+        'different account',
+        () async {
+          when(() => mockOutgoingDmsDao.getById(_rumorEventId)).thenAnswer(
+            (_) async => queuedRow(ownerPubkey: _validPubkeyD),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          expect(
+            () => repository.recoverFullSend(rumorId: _rumorEventId),
+            throwsArgumentError,
+          );
+          verifyNever(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'throws StateError when the outgoing_dms DAO is not wired in',
+        () async {
+          final repository = createRepository();
+
+          expect(
+            () => repository.recoverFullSend(rumorId: _rumorEventId),
+            throwsStateError,
+          );
+        },
+      );
+
+      test(
+        'on rumor JSON parse failure: marks both wraps failed with '
+        'the parse error and never attempts to publish',
+        () async {
+          final corruptedRow = OutgoingDm(
+            id: _rumorEventId,
+            conversationId: 'conv',
+            recipientPubkey: _validPubkeyB,
+            content: 'queued message',
+            createdAt: 1700000000,
+            rumorEventJson: 'this is not json',
+            recipientWrapStatus: OutgoingWrapStatus.failed,
+            selfWrapStatus: OutgoingWrapStatus.failed,
+            queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
+            ownerPubkey: _validPubkeyA,
+          );
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => corruptedRow);
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, contains('rumor JSON parse failed'));
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: any(
+                named: 'lastError',
+                that: contains('rumor JSON parse failed'),
+              ),
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: _rumorEventId,
+              status: OutgoingWrapStatus.failed,
+              lastError: any(
+                named: 'lastError',
+                that: contains('rumor JSON parse failed'),
+              ),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'when local persistence throws after a successful publish: '
+        'still returns the publish-success result (degraded state, '
+        'no rethrow)',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          // Publish landed → caller sees success even though local
+          // bookkeeping inside the transaction failed.
+          expect(result.success, isTrue);
+        },
+      );
+    });
+
     group(
       '_mergeDuplicateConversations creates canonical row from phantoms',
       () {

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -1,7 +1,8 @@
 // ABOUTME: Unit tests for OutgoingDmRetryService — pinned contracts:
 // ABOUTME: dispatches recipient: sent / self: failed rows to recoverSelfWrap,
-// ABOUTME: never republishes recipient wraps, applies per-row backoff,
-// ABOUTME: enumerates recipient: failed rows without acting on them.
+// ABOUTME: dispatches recipient: failed rows to recoverFullSend,
+// ABOUTME: never republishes recipient wraps for already-sent rows,
+// ABOUTME: applies per-row backoff.
 
 import 'dart:async';
 
@@ -189,7 +190,8 @@ void main() {
       );
 
       test(
-        'does NOT dispatch recipient: failed rows to recoverSelfWrap',
+        'dispatches recipient: failed rows to recoverFullSend (not '
+        'recoverSelfWrap)',
         () async {
           final row = _row(
             id: 'rumor2',
@@ -202,14 +204,55 @@ void main() {
               maxRetries: any(named: 'maxRetries'),
             ),
           ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) async => _successResult('rumor2'));
 
           final service = buildService();
           await service.sweep();
 
+          verify(
+            () => dmRepository.recoverFullSend(rumorId: 'rumor2'),
+          ).called(1);
+          // recoverSelfWrap is reserved for the recipient-sent / self-failed
+          // case; recipient-failed rows must go through recoverFullSend so
+          // the recipient publish is replayed alongside the self-wrap.
           verifyNever(
             () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
           );
+          // recoverFullSend's success path finalizes the row by either
+          // deleting it (full delivery) or marking recipient sent / self
+          // failed (partial). Either way no retry bump is needed.
           verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test(
+        'recoverFullSend publish-failure path bumps incrementRetry once',
+        () async {
+          final row = _row(
+            id: 'rumor2b',
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+            retryCount: 1,
+            lastAttemptAt: DateTime.utc(2025),
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) async => _failureResult('relay still down'));
+
+          await buildService().sweep();
+
+          verify(
+            () => dmRepository.recoverFullSend(rumorId: 'rumor2b'),
+          ).called(1);
+          verify(() => dao.incrementRetry('rumor2b')).called(1);
         },
       );
 
@@ -503,11 +546,16 @@ void main() {
       );
     });
 
-    group('contract: never republishes recipient wraps', () {
-      // Pinning #4106's invariant — the sweep must only ever invoke
-      // recoverSelfWrap, never sendMessage / sendGroupMessage / sendRumor.
+    group('contract: dispatches the correct primitive per row state', () {
+      // Pin the strategy table: recipient: sent / self: failed →
+      // recoverSelfWrap (never republishes recipient); recipient: failed
+      // → recoverFullSend (replays both wraps; safe via NIP-17 receiver
+      // dedup). The sweep must never reach for sendMessage /
+      // sendGroupMessage / sendPrivateMessage which would mint a fresh
+      // rumor and zombify the queue row.
       test(
-        'a full pass over assorted retryable rows only calls recoverSelfWrap',
+        'a full pass over assorted retryable rows dispatches each row to '
+        'the right primitive',
         () async {
           final rows = [
             _row(
@@ -538,9 +586,18 @@ void main() {
             final id = inv.namedArguments[#rumorId] as String;
             return _successResult(id);
           });
+          when(
+            () => dmRepository.recoverFullSend(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((inv) async {
+            final id = inv.namedArguments[#rumorId] as String;
+            return _successResult(id);
+          });
 
           await buildService().sweep();
 
+          // The sweep never mints a fresh rumor via the user-facing send
+          // primitives — that would zombify the queue row by enqueueing a
+          // new one with a different id.
           verifyNever(
             () => dmRepository.sendMessage(
               recipientPubkey: any(named: 'recipientPubkey'),
@@ -553,9 +610,155 @@ void main() {
               content: any(named: 'content'),
             ),
           );
+
+          // Strategy A: recipient: sent / self: failed → recoverSelfWrap.
           verify(() => dmRepository.recoverSelfWrap(rumorId: 'a')).called(1);
           verify(() => dmRepository.recoverSelfWrap(rumorId: 'c')).called(1);
           verifyNever(() => dmRepository.recoverSelfWrap(rumorId: 'b'));
+
+          // Strategy B: recipient: failed → recoverFullSend.
+          verify(() => dmRepository.recoverFullSend(rumorId: 'b')).called(1);
+          verifyNever(() => dmRepository.recoverFullSend(rumorId: 'a'));
+          verifyNever(() => dmRepository.recoverFullSend(rumorId: 'c'));
+        },
+      );
+
+      test(
+        'recoverFullSend is never invoked for rows where recipient is '
+        'already sent',
+        () async {
+          // Any row where recipientWrapStatus == sent must route through
+          // recoverSelfWrap, never recoverFullSend. recoverFullSend's
+          // idempotent guard would defer to recoverSelfWrap internally
+          // anyway, but the dispatcher should not even hand it those
+          // rows — keeps the strategy table readable.
+          final row = _row(
+            id: 'sent-row',
+            recipient: OutgoingWrapStatus.sent,
+            self: OutgoingWrapStatus.failed,
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverSelfWrap(rumorId: any(named: 'rumorId')),
+          ).thenAnswer((_) async => _successResult('sent-row'));
+
+          await buildService().sweep();
+
+          verifyNever(
+            () => dmRepository.recoverFullSend(rumorId: any(named: 'rumorId')),
+          );
+        },
+      );
+    });
+
+    group('recoverFullSend error handling', () {
+      test(
+        'StateError from recoverFullSend aborts the pass without bumping '
+        'retry',
+        () async {
+          final rows = [
+            _row(
+              id: 'a',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'b',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+          ];
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => rows);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: 'a'),
+          ).thenThrow(StateError('repo not initialized'));
+
+          await buildService().sweep();
+
+          verify(() => dmRepository.recoverFullSend(rumorId: 'a')).called(1);
+          verifyNever(() => dmRepository.recoverFullSend(rumorId: 'b'));
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test(
+        'ArgumentError from recoverFullSend skips the row and continues',
+        () async {
+          final rows = [
+            _row(
+              id: 'a',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'b',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+          ];
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => rows);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: 'a'),
+          ).thenThrow(ArgumentError.value('a', 'rumorId', 'no queued row'));
+          when(
+            () => dmRepository.recoverFullSend(rumorId: 'b'),
+          ).thenAnswer((_) async => _successResult('b'));
+
+          await buildService().sweep();
+
+          verify(() => dmRepository.recoverFullSend(rumorId: 'a')).called(1);
+          verify(() => dmRepository.recoverFullSend(rumorId: 'b')).called(1);
+          verifyNever(() => dao.incrementRetry('a'));
+        },
+      );
+
+      test(
+        'unexpected throw from recoverFullSend bumps retry and continues',
+        () async {
+          final rows = [
+            _row(
+              id: 'a',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+            _row(
+              id: 'b',
+              recipient: OutgoingWrapStatus.failed,
+              self: OutgoingWrapStatus.failed,
+            ),
+          ];
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => rows);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: 'a'),
+          ).thenThrow(Exception('relay disconnected'));
+          when(
+            () => dmRepository.recoverFullSend(rumorId: 'b'),
+          ).thenAnswer((_) async => _successResult('b'));
+
+          await buildService().sweep();
+
+          verify(() => dao.incrementRetry('a')).called(1);
+          verify(() => dmRepository.recoverFullSend(rumorId: 'b')).called(1);
         },
       );
     });


### PR DESCRIPTION
## Description

Closes #4240. Final follow-up in the #3909 stack for the durable
outgoing-DM queue. With this change, `outgoing_dms` rows that finalize
as `recipient_wrap_status: failed` are auto-recovered by the
`OutgoingDmRetryService` foreground sweep instead of sitting idle on
the queue.

**Related Issue:** Closes #4240. Relates to #3909, epic #3912.

### What the gap looked like

`OutgoingDmRetryService` (PR #4241) shipped with a counting-only branch
for `recipient: failed` rows — the inline comment said `recovery
primitive lands in #4240`. Without that primitive, an app kill or
relay reject that finalized as recipient-failed left the row queued
indefinitely (only manual SnackBar retry, which mints a new rumor and
zombifies the original row, could recover).

### What this PR ships

Two commits, layered bottom-up:

**1. `feat(dm): add recoverFullSend primitive` — repository layer**

`DmRepository.recoverFullSend(rumorId)` mirrors `recoverSelfWrap`'s
shape:

- Validates ownership against `_userPubkey` (multi-account isolation).
- Idempotent: if `recipientWrapStatus == sent` already (concurrent
  recovery raced ahead, or the original partial-success path promoted
  the row), defers to `recoverSelfWrap` so the recipient wrap is
  never republished.
- Rebuilds the rumor from `rumor_event_json` (preserves receiver-side
  dedup key across retries — minting a fresh rumor would defeat it).
- Calls `_messageService.sendRumor`, then finalizes via the existing
  `_finalizeAfterRecipientSuccess` / `_finalizeAfterRecipientFailure`
  helpers.
- On full success: inserts `direct_messages` + upserts the
  conversation row + deletes the queue row inside one
  `runInTransaction` — same atomicity contract as `sendMessage`'s
  happy path.
- On partial success: keeps the row at `recipient: sent / self:
  failed` so the next sweep replays the missing self-wrap via
  `recoverSelfWrap`.
- On recipient failure: re-marks both wraps failed with the new error.

Re-publishing a rumor whose original wire copy actually landed is
safe at the protocol level: NIP-17 receiver-side dedup keys on the
rumor id, preserved verbatim through `rumor_event_json`.

**2. `feat(dm): wire recoverFullSend into OutgoingDmRetryService` — service layer**

Strategy table after this change:

| Row state                          | Recovery primitive    |
|------------------------------------|-----------------------|
| `recipient: sent / self: failed`   | `recoverSelfWrap`     |
| `recipient: failed`                | `recoverFullSend`     |
| `pending: pending`                 | not in retryable filter; deferred |

The dispatch reuses the existing per-row backoff, `_isSweeping`
re-entrancy guard, and the `StateError` / `ArgumentError` /
unexpected-throw error policy from the `recoverSelfWrap` branch.

Sweep summary log gains `full-send-recovered=N full-send-failed=N`,
replacing the now-acted-on `recipient-failed=N` line. The class doc
comment is updated to state both strategy entries.

## Out of scope (follow-ups)

These came up during the design but are explicitly deferred:

- **Pending-row recovery.** `pending: pending` rows (true app-kill
  mid-publish, no finalize wrote) remain out of
  `getRetryableForOwner`'s filter and are not handled here. The DAO's
  `getStillPendingForOwner` is the read primitive for that path; the
  open design questions (queuedAt time-gate to avoid stealing
  in-flight sends, cold-start-only trigger, whether to reuse
  `recoverFullSend` or split) belong in their own issue. Will file
  under epic #3912.
- **Observability for `recoverFullSend`'s swallowed paths.** PR #4402
  is wiring the `DmRepositoryErrorReporter` port across the existing
  7 swallow sites; once that merges, adding the 1-2 new sites in
  `recoverFullSend` is a one-line follow-up. Out of this PR to avoid
  a coordination dependency.
- **Manual-retry zombie cleanup.** Today, tapping Retry on the
  `failed` SnackBar (#3908) dispatches `ConversationMessageSent`,
  which mints a fresh rumor and a fresh queue row, zombifying the
  original failed row until auto-sweep exhausts its retries. Routing
  that path through `recoverFullSend(rumorId)` on the existing row is
  the right cleanup but expands UX surface beyond #4240's scope —
  separate PR.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Verification

From `mobile/`:

- [x] `dart format` — no diffs.
- [x] `flutter analyze lib test integration_test` — clean.
- [x] `flutter analyze packages/dm_repository` — clean.
- [x] `flutter test packages/dm_repository` — **232 / 232 passing**
  (10 new `recoverFullSend` tests).
- [x] `flutter test test/services/outgoing_dm_retry_service_test.dart`
  — **27 / 27 passing** (6 new tests + 1 reworked).
- [x] `flutter test test/blocs/dm test/screens/inbox
  test/services/outgoing_dm_retry_service_test.dart` — **359 / 359
  passing** (no regressions in adjacent DM bloc / view tests).

### Pinning contracts added

- `recoverFullSend` never invokes `sendRumor` when `recipientWrapStatus
  == sent` (idempotent guard defers to `recoverSelfWrap`).
- `recoverFullSend` never inserts into `direct_messages` on recipient
  publish failure.
- Sweep dispatches `recoverFullSend` for `recipient: failed` rows.
- Sweep dispatches `recoverSelfWrap` for `recipient: sent / self:
  failed` rows.
- Sweep never invokes `sendMessage` / `sendGroupMessage` for any
  retryable row (would zombify the queue row by enqueueing a new id).
- `recoverFullSend` is never invoked for rows where `recipient: sent`
  (those route through `recoverSelfWrap`).

### Manual verification (please confirm during review)

- [ ] Force a recipient publish failure on a 1:1 send (e.g. block the
      first `publishEvent` round in a debug build). Row finalizes at
      `recipient: failed / self: failed`. Background then re-foreground
      the app → row is recovered automatically → `direct_messages` row
      appears → queue row deleted.
- [ ] Same scenario but with sustained relay reject → row exhausts
      retries (5 attempts with 2s → 5min backoff) → falls out of
      `getRetryableForOwner`.
- [ ] Cross-account safety: send from account A, switch to account B,
      foreground → A's failed row is **not** recovered while B is
      active.
- [ ] Partial-delivery recovery still works (#4106 + #4241
      regression): force a self-wrap-only failure → SnackBar offers
      Retry → next foreground also sweeps it via `recoverSelfWrap` if
      the user dismisses the SnackBar.

## Acceptance check for closing #3909

After this PR lands:

| AC                                                       | Status |
|----------------------------------------------------------|--------|
| 1. Survives app kill mid-send + auto-recovers           | ✅ for `recipient: failed`. Pending-row case deferred to follow-up. |
| 2. Partial-delivery visibly distinguished + recoverable | ✅ (#4106) |
| 3. #3908 tests stay green                                | ✅ |
| 4. New tests cover the matrix (DAO / repo / service)    | ✅ |
| 5. No regression in the SnackBar retry flow             | ✅ |