### PR TITLE
fix(search): define explore search focus contract

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1485,6 +1485,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
               if (deepLink.searchTerm != null) {
                 final targetPath = SearchResultsPage.pathForQuery(
                   deepLink.searchTerm!,
+                  requestFocusOnMount: false,
                 );
                 Log.info(
                   '📱 Navigating to search: $targetPath',

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -487,7 +487,12 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (ctx, st) {
           // See note above: do not double-decode path parameters.
           final query = st.pathParameters['query'] ?? '';
-          return SearchResultsPage(initialQuery: query);
+          return SearchResultsPage(
+            initialQuery: query,
+            requestFocusOnMount: SearchResultsPage.requestFocusOnMountForRoute(
+              st.uri,
+            ),
+          );
         },
       ),
 

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -38,7 +38,10 @@ String? divineUrlToPushRoute(Uri uri) {
     case DeepLinkType.search:
       final term = deepLink.searchTerm;
       if (term == null || term.isEmpty) return null;
-      return SearchResultsPage.pathForQuery(term);
+      return SearchResultsPage.pathForQuery(
+        term,
+        requestFocusOnMount: false,
+      );
     case DeepLinkType.invite:
     case DeepLinkType.signerCallback:
     case DeepLinkType.unknown:

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -279,7 +279,9 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
     _searchDebounce = Timer(const Duration(milliseconds: 300), () {
       if (!mounted) return;
       _searchController.clear();
-      context.push(SearchResultsPage.pathForQuery(query));
+      context.push(
+        SearchResultsPage.pathForQuery(query, requestFocusOnMount: true),
+      );
     });
   }
 

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -18,7 +18,7 @@ import 'package:openvine/screens/search_results/widgets/search_results_app_bar.d
 class SearchResultsPage extends ConsumerWidget {
   const SearchResultsPage({
     this.initialQuery,
-    this.requestFocusOnMount = true,
+    this.requestFocusOnMount = false,
     super.key,
   });
 
@@ -34,9 +34,22 @@ class SearchResultsPage extends ConsumerWidget {
   /// Route path pattern for GoRouter.
   static const path = '$pathPrefix/:query';
 
-  /// Build a path with the given query.
-  static String pathForQuery(String query) =>
-      '$pathPrefix/${Uri.encodeComponent(query)}';
+  /// Query parameter used to opt a prefilled route into mount focus.
+  static const requestFocusQueryParameter = 'focus';
+
+  /// Build a path with the given query and explicit mount-focus intent.
+  static String pathForQuery(
+    String query, {
+    required bool requestFocusOnMount,
+  }) {
+    final encodedQuery = Uri.encodeComponent(query);
+    if (!requestFocusOnMount) return '$pathPrefix/$encodedQuery';
+    return '$pathPrefix/$encodedQuery?$requestFocusQueryParameter=1';
+  }
+
+  /// Returns whether a routed prefilled search should claim keyboard focus.
+  static bool requestFocusOnMountForRoute(Uri uri) =>
+      uri.queryParameters[requestFocusQueryParameter] == '1';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -16,10 +16,17 @@ import 'package:openvine/screens/search_results/widgets/search_results_app_bar.d
 /// Page that creates and wires the search BLoCs, then renders
 /// [SearchResultsView].
 class SearchResultsPage extends ConsumerWidget {
-  const SearchResultsPage({this.initialQuery, super.key});
+  const SearchResultsPage({
+    this.initialQuery,
+    this.requestFocusOnMount = true,
+    super.key,
+  });
 
   /// Optional pre-filled search query from the route.
   final String? initialQuery;
+
+  /// Whether the search field should claim keyboard focus on first paint.
+  final bool requestFocusOnMount;
 
   /// Base path prefix (used for route matching and normalization skips).
   static const pathPrefix = '/search-results';
@@ -67,7 +74,10 @@ class SearchResultsPage extends ConsumerWidget {
         // app bar area (which doesn't paint its own background) doesn't
         // show through to the root scaffold's darker default.
         backgroundColor: VineTheme.surfaceBackground,
-        body: _SearchResultsBody(initialQuery: initialQuery ?? ''),
+        body: _SearchResultsBody(
+          initialQuery: initialQuery ?? '',
+          requestFocusOnMount: requestFocusOnMount,
+        ),
       ),
     );
   }
@@ -75,15 +85,22 @@ class SearchResultsPage extends ConsumerWidget {
 
 /// Wires the app bar and body together.
 class _SearchResultsBody extends StatelessWidget {
-  const _SearchResultsBody({required this.initialQuery});
+  const _SearchResultsBody({
+    required this.initialQuery,
+    required this.requestFocusOnMount,
+  });
 
   final String initialQuery;
+  final bool requestFocusOnMount;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        SearchResultsAppBar(initialQuery: initialQuery),
+        SearchResultsAppBar(
+          initialQuery: initialQuery,
+          requestFocusOnMount: requestFocusOnMount,
+        ),
         const Expanded(child: SearchResultsView()),
       ],
     );

--- a/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
+++ b/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
@@ -15,18 +15,19 @@ import 'package:openvine/screens/search_results/widgets/search_filter_pill.dart'
 class SearchResultsAppBar extends StatefulWidget {
   const SearchResultsAppBar({
     required this.initialQuery,
-    this.requestFocusOnMount = true,
+    this.requestFocusOnMount = false,
     super.key,
   });
 
   /// Pre-filled search text.
   final String initialQuery;
 
-  /// When true, the search field claims focus after the first frame.
+  /// When true, a prefilled search field claims focus after the first frame.
   ///
-  /// This is the canonical focus contract for Explore -> Search Results:
-  /// route transitions triggered during typing must transfer keyboard focus to
-  /// the destination field rather than relying on `initialQuery` heuristics.
+  /// Route call sites must opt in explicitly so prefilled destinations like
+  /// mention taps and search deep links can keep the keyboard dismissed.
+  ///
+  /// Empty-query mounts still request focus by default.
   final bool requestFocusOnMount;
 
   @override
@@ -48,7 +49,7 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
       _controller.text = widget.initialQuery;
     }
 
-    if (widget.requestFocusOnMount) {
+    if (widget.requestFocusOnMount || widget.initialQuery.isEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _focusNode.requestFocus();
       });

--- a/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
+++ b/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -15,10 +13,21 @@ import 'package:openvine/screens/search_results/widgets/search_filter_pill.dart'
 /// Owns the [TextEditingController] and [FocusNode] lifecycle. Dispatches
 /// [VideoSearchQueryChanged] to [VideoSearchBloc] on text changes.
 class SearchResultsAppBar extends StatefulWidget {
-  const SearchResultsAppBar({required this.initialQuery, super.key});
+  const SearchResultsAppBar({
+    required this.initialQuery,
+    this.requestFocusOnMount = true,
+    super.key,
+  });
 
-  /// Pre-filled search text. If empty the field requests focus instead.
+  /// Pre-filled search text.
   final String initialQuery;
+
+  /// When true, the search field claims focus after the first frame.
+  ///
+  /// This is the canonical focus contract for Explore -> Search Results:
+  /// route transitions triggered during typing must transfer keyboard focus to
+  /// the destination field rather than relying on `initialQuery` heuristics.
+  final bool requestFocusOnMount;
 
   @override
   State<SearchResultsAppBar> createState() => _SearchResultsAppBarState();
@@ -27,7 +36,6 @@ class SearchResultsAppBar extends StatefulWidget {
 class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
   late final TextEditingController _controller;
   late final FocusNode _focusNode;
-  Timer? _debounce;
 
   @override
   void initState() {
@@ -38,7 +46,9 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
 
     if (widget.initialQuery.isNotEmpty) {
       _controller.text = widget.initialQuery;
-    } else {
+    }
+
+    if (widget.requestFocusOnMount) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _focusNode.requestFocus();
       });
@@ -47,7 +57,6 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
 
   @override
   void dispose() {
-    _debounce?.cancel();
     _controller
       ..removeListener(_onSearchChanged)
       ..dispose();
@@ -56,15 +65,11 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
   }
 
   void _onSearchChanged() {
-    _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 300), () {
-      if (!mounted) return;
-      final query = _controller.text;
-      context.read<VideoSearchBloc>().add(VideoSearchQueryChanged(query));
-      context.read<UserSearchBloc>().add(UserSearchQueryChanged(query));
-      context.read<HashtagSearchBloc>().add(HashtagSearchQueryChanged(query));
-      context.read<ListSearchBloc>().add(ListSearchQueryChanged(query));
-    });
+    final query = _controller.text;
+    context.read<VideoSearchBloc>().add(VideoSearchQueryChanged(query));
+    context.read<UserSearchBloc>().add(UserSearchQueryChanged(query));
+    context.read<HashtagSearchBloc>().add(HashtagSearchQueryChanged(query));
+    context.read<ListSearchBloc>().add(ListSearchQueryChanged(query));
   }
 
   @override

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -129,7 +129,9 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
 
   void _navigateToSearch(BuildContext context, String username) {
     widget.onVideoStateChange?.call();
-    context.go(SearchResultsPage.pathForQuery(username));
+    context.go(
+      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+    );
   }
 
   Future<void> _handleUrlTap(String rawUrl) async {

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -110,7 +110,9 @@ class _SelectableLinkifiedTextState
   }
 
   void _navigateToSearch(BuildContext context, String username) {
-    context.go(SearchResultsPage.pathForQuery(username));
+    context.go(
+      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+    );
   }
 
   Future<void> _handleUrlTap(String rawUrl) async {

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -92,12 +92,20 @@ void main() {
   // string passed to pathForTag/pathForQuery" — can be exercised without
   // pulling in the full app provider graph.
   group('Path-parameter round-trip (#3413)', () {
-    Future<({String? capturedTag, String? capturedQuery})> navigateAndCapture(
+    Future<
+      ({
+        String? capturedTag,
+        String? capturedQuery,
+        bool? requestFocusOnMount,
+      })
+    >
+    navigateAndCapture(
       WidgetTester tester,
       String location,
     ) async {
       String? capturedTag;
       String? capturedQuery;
+      bool? requestFocusOnMount;
 
       final router = GoRouter(
         initialLocation: '/',
@@ -117,6 +125,10 @@ void main() {
             path: SearchResultsPage.path,
             builder: (ctx, st) {
               capturedQuery = st.pathParameters['query'];
+              requestFocusOnMount =
+                  SearchResultsPage.requestFocusOnMountForRoute(
+                    st.uri,
+                  );
               return const SizedBox.shrink();
             },
           ),
@@ -128,7 +140,11 @@ void main() {
       router.go(location);
       await tester.pumpAndSettle();
 
-      return (capturedTag: capturedTag, capturedQuery: capturedQuery);
+      return (
+        capturedTag: capturedTag,
+        capturedQuery: capturedQuery,
+        requestFocusOnMount: requestFocusOnMount,
+      );
     }
 
     testWidgets(
@@ -165,7 +181,10 @@ void main() {
         const original = '100%';
         final result = await navigateAndCapture(
           tester,
-          SearchResultsPage.pathForQuery(original),
+          SearchResultsPage.pathForQuery(
+            original,
+            requestFocusOnMount: false,
+          ),
         );
 
         expect(tester.takeException(), isNull);
@@ -179,11 +198,50 @@ void main() {
         const original = '50% off deals';
         final result = await navigateAndCapture(
           tester,
-          SearchResultsPage.pathForQuery(original),
+          SearchResultsPage.pathForQuery(
+            original,
+            requestFocusOnMount: false,
+          ),
         );
 
         expect(tester.takeException(), isNull);
         expect(result.capturedQuery, equals(original));
+      },
+    );
+
+    testWidgets(
+      'pathForQuery can opt a prefilled route into mount focus',
+      (tester) async {
+        const original = 'alice';
+        final result = await navigateAndCapture(
+          tester,
+          SearchResultsPage.pathForQuery(
+            original,
+            requestFocusOnMount: true,
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedQuery, equals(original));
+        expect(result.requestFocusOnMount, isTrue);
+      },
+    );
+
+    testWidgets(
+      'pathForQuery keeps a prefilled route unfocused when not opted in',
+      (tester) async {
+        const original = 'alice';
+        final result = await navigateAndCapture(
+          tester,
+          SearchResultsPage.pathForQuery(
+            original,
+            requestFocusOnMount: false,
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedQuery, equals(original));
+        expect(result.requestFocusOnMount, isFalse);
       },
     );
   });
@@ -250,6 +308,22 @@ void main() {
         searchRegion.contains('Uri.decodeComponent'),
         isFalse,
         reason: 'Search-results builder must not double-decode. $guard',
+      );
+      expect(
+        searchRegion.contains('requestFocusOnMount:'),
+        isTrue,
+        reason:
+            'Search-results builder must forward route-level focus intent '
+            'instead of relying on widget defaults.',
+      );
+      expect(
+        searchRegion.contains(
+          'SearchResultsPage.requestFocusOnMountForRoute(',
+        ),
+        isTrue,
+        reason:
+            'Search-results builder must derive focus from the routed URI so '
+            'Explore, mentions, and deep links can express distinct intent.',
       );
     });
   });

--- a/mobile/test/screens/search_results/view/search_results_page_test.dart
+++ b/mobile/test/screens/search_results/view/search_results_page_test.dart
@@ -59,6 +59,11 @@ void main() {
         ),
         findsOneWidget,
       );
+
+      // Dispose the page and advance past debounce windows owned by the
+      // search blocs so no pending timers leak across tests.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 400));
     });
   });
 }

--- a/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
@@ -57,7 +57,7 @@ void main() {
 
     Widget createTestWidget({
       String initialQuery = 'test',
-      bool requestFocusOnMount = true,
+      bool requestFocusOnMount = false,
     }) {
       return testMaterialApp(
         home: MultiBlocProvider(
@@ -96,9 +96,21 @@ void main() {
     });
 
     testWidgets(
-      'requests focus for a prefilled query when mounted from a route push',
+      'keeps keyboard dismissed for a prefilled query by default',
       (tester) async {
         await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+
+        final textField = tester.widget<TextField>(find.byType(TextField));
+
+        expect(textField.focusNode?.hasFocus, isFalse);
+      },
+    );
+
+    testWidgets(
+      'requests focus for a prefilled query when the route opts in',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget(requestFocusOnMount: true));
         await tester.pump();
 
         final textField = tester.widget<TextField>(find.byType(TextField));
@@ -107,13 +119,15 @@ void main() {
       },
     );
 
-    testWidgets('can opt out of mount focus', (tester) async {
-      await tester.pumpWidget(createTestWidget(requestFocusOnMount: false));
+    testWidgets('still focuses the empty query state', (tester) async {
+      await tester.pumpWidget(
+        createTestWidget(initialQuery: ''),
+      );
       await tester.pump();
 
       final textField = tester.widget<TextField>(find.byType(TextField));
 
-      expect(textField.focusNode?.hasFocus, isFalse);
+      expect(textField.focusNode?.hasFocus, isTrue);
     });
   });
 }

--- a/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/hashtag_search/hashtag_search_bloc.dart';
+import 'package:openvine/blocs/list_search/list_search_bloc.dart';
 import 'package:openvine/blocs/search_results_filter/search_results_filter.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
@@ -25,18 +26,23 @@ class _MockHashtagSearchBloc
     extends MockBloc<HashtagSearchEvent, HashtagSearchState>
     implements HashtagSearchBloc {}
 
+class _MockListSearchBloc extends MockBloc<ListSearchEvent, ListSearchState>
+    implements ListSearchBloc {}
+
 void main() {
   group(SearchResultsAppBar, () {
     late _MockSearchResultsFilterCubit mockFilterCubit;
     late _MockUserSearchBloc mockUserSearchBloc;
     late _MockVideoSearchBloc mockVideoSearchBloc;
     late _MockHashtagSearchBloc mockHashtagSearchBloc;
+    late _MockListSearchBloc mockListSearchBloc;
 
     setUp(() {
       mockFilterCubit = _MockSearchResultsFilterCubit();
       mockUserSearchBloc = _MockUserSearchBloc();
       mockVideoSearchBloc = _MockVideoSearchBloc();
       mockHashtagSearchBloc = _MockHashtagSearchBloc();
+      mockListSearchBloc = _MockListSearchBloc();
 
       when(() => mockFilterCubit.state).thenReturn(SearchResultsFilter.all);
       when(() => mockUserSearchBloc.state).thenReturn(const UserSearchState());
@@ -46,9 +52,13 @@ void main() {
       when(
         () => mockHashtagSearchBloc.state,
       ).thenReturn(const HashtagSearchState());
+      when(() => mockListSearchBloc.state).thenReturn(const ListSearchState());
     });
 
-    Widget createTestWidget() {
+    Widget createTestWidget({
+      String initialQuery = 'test',
+      bool requestFocusOnMount = true,
+    }) {
       return testMaterialApp(
         home: MultiBlocProvider(
           providers: [
@@ -58,9 +68,13 @@ void main() {
             BlocProvider<UserSearchBloc>.value(value: mockUserSearchBloc),
             BlocProvider<VideoSearchBloc>.value(value: mockVideoSearchBloc),
             BlocProvider<HashtagSearchBloc>.value(value: mockHashtagSearchBloc),
+            BlocProvider<ListSearchBloc>.value(value: mockListSearchBloc),
           ],
-          child: const Scaffold(
-            body: SearchResultsAppBar(initialQuery: 'test'),
+          child: Scaffold(
+            body: SearchResultsAppBar(
+              initialQuery: initialQuery,
+              requestFocusOnMount: requestFocusOnMount,
+            ),
           ),
         ),
         mockAuthService: createMockAuthService(),
@@ -79,6 +93,27 @@ void main() {
       await tester.pump();
 
       expect(find.text('test'), findsOneWidget);
+    });
+
+    testWidgets(
+      'requests focus for a prefilled query when mounted from a route push',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+
+        final textField = tester.widget<TextField>(find.byType(TextField));
+
+        expect(textField.focusNode?.hasFocus, isTrue);
+      },
+    );
+
+    testWidgets('can opt out of mount focus', (tester) async {
+      await tester.pumpWidget(createTestWidget(requestFocusOnMount: false));
+      await tester.pump();
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+
+      expect(textField.focusNode?.hasFocus, isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary
- define an explicit focus-transfer contract for Explore -> Search Results
- keep keyboard continuity for prefilled search routes instead of keying focus off an empty query check
- cover the contract and timer cleanup with widget tests

## Why
Explore currently routes into Search Results while the user is still typing. The destination field was only requesting focus when the query was empty, which made the keyboard collapse during the transition and left the focus model implicit.

## Validation
- flutter test test/screens/search_results/view/search_results_page_test.dart test/screens/search_results/widgets/search_results_app_bar_test.dart
- pre-push analyzer for touched files

Closes #3803
Fixes #3020
