### PR TITLE
fix(search): audit list search filtering consistency

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1794,9 +1794,18 @@ FollowRepository followRepository(Ref ref) {
 /// until the repository owns its own persistence (Phase 1b).
 @Riverpod(keepAlive: true)
 CuratedListRepository curatedListRepository(Ref ref) {
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+  final flagService = ref.watch(featureFlagServiceProvider);
+  final engine = ref.watch(contentPolicyEngineProvider);
+
+  final blockFilter = flagService.isEnabled(FeatureFlag.contentPolicyV2)
+      ? createPolicyEngineFilter(engine, () => blocklistRepository.currentState)
+      : createBlocklistFilter(blocklistRepository);
+
   final repository = CuratedListRepository(
     nostrClient: ref.watch(nostrServiceProvider),
     funnelcakeApiClient: ref.watch(funnelcakeApiClientProvider),
+    blockFilter: blockFilter,
   );
 
   // Bridge: push curated list updates from legacy service into repository
@@ -2303,7 +2312,19 @@ PeopleListsRepository peopleListsRepository(Ref ref) {
   final cache = LocalPeopleListsCache(
     openBox: () => Hive.openBox<dynamic>(_peopleListsBoxName),
   );
-  return PeopleListsRepositoryImpl(nostrClient: nostrClient, cache: cache);
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+  final flagService = ref.watch(featureFlagServiceProvider);
+  final engine = ref.watch(contentPolicyEngineProvider);
+
+  final blockFilter = flagService.isEnabled(FeatureFlag.contentPolicyV2)
+      ? createPolicyEngineFilter(engine, () => blocklistRepository.currentState)
+      : createBlocklistFilter(blocklistRepository);
+
+  return PeopleListsRepositoryImpl(
+    nostrClient: nostrClient,
+    cache: cache,
+    blockFilter: blockFilter,
+  );
 }
 
 /// Bookmark service for NIP-51 bookmarks

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -137,6 +137,20 @@ ContentPolicyEngine contentPolicyEngine(Ref ref) {
   return ContentPolicyEngine.defaultRules();
 }
 
+BlockedVideoFilter _createBlockedAuthorFilter(Ref ref) {
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+  final flagService = ref.watch(featureFlagServiceProvider);
+  if (flagService.isEnabled(FeatureFlag.contentPolicyV2)) {
+    final engine = ref.watch(contentPolicyEngineProvider);
+    return createPolicyEngineFilter(
+      engine,
+      () => blocklistRepository.currentState,
+    );
+  }
+
+  return createBlocklistFilter(blocklistRepository);
+}
+
 final nostrAppDirectoryServiceProvider = Provider<NostrAppDirectoryService>((
   ref,
 ) {
@@ -1794,18 +1808,10 @@ FollowRepository followRepository(Ref ref) {
 /// until the repository owns its own persistence (Phase 1b).
 @Riverpod(keepAlive: true)
 CuratedListRepository curatedListRepository(Ref ref) {
-  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
-  final flagService = ref.watch(featureFlagServiceProvider);
-  final engine = ref.watch(contentPolicyEngineProvider);
-
-  final blockFilter = flagService.isEnabled(FeatureFlag.contentPolicyV2)
-      ? createPolicyEngineFilter(engine, () => blocklistRepository.currentState)
-      : createBlocklistFilter(blocklistRepository);
-
   final repository = CuratedListRepository(
     nostrClient: ref.watch(nostrServiceProvider),
     funnelcakeApiClient: ref.watch(funnelcakeApiClientProvider),
-    blockFilter: blockFilter,
+    blockFilter: _createBlockedAuthorFilter(ref),
   );
 
   // Bridge: push curated list updates from legacy service into repository
@@ -2312,18 +2318,11 @@ PeopleListsRepository peopleListsRepository(Ref ref) {
   final cache = LocalPeopleListsCache(
     openBox: () => Hive.openBox<dynamic>(_peopleListsBoxName),
   );
-  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
-  final flagService = ref.watch(featureFlagServiceProvider);
-  final engine = ref.watch(contentPolicyEngineProvider);
-
-  final blockFilter = flagService.isEnabled(FeatureFlag.contentPolicyV2)
-      ? createPolicyEngineFilter(engine, () => blocklistRepository.currentState)
-      : createBlocklistFilter(blocklistRepository);
 
   return PeopleListsRepositoryImpl(
     nostrClient: nostrClient,
     cache: cache,
-    blockFilter: blockFilter,
+    blockFilter: _createBlockedAuthorFilter(ref),
   );
 }
 
@@ -2596,7 +2595,6 @@ VideoLocalStorage videoLocalStorage(Ref ref) {
 VideosRepository videosRepository(Ref ref) {
   final nostrClient = ref.watch(nostrServiceProvider);
   final localStorage = ref.watch(videoLocalStorageProvider);
-  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
   final contentFilterService = ref.watch(contentFilterServiceProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
   final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
@@ -2604,22 +2602,16 @@ VideosRepository videosRepository(Ref ref) {
   final feedAspectRatioPreference = ref.watch(
     feedAspectRatioPreferenceServiceProvider,
   );
-  final flagService = ref.watch(featureFlagServiceProvider);
-  final engine = ref.watch(contentPolicyEngineProvider);
 
   final nsfwFilter = createNsfwFilter(
     contentFilterService,
     moderationLabelService: moderationLabelService,
   );
 
-  final blockFilter = flagService.isEnabled(FeatureFlag.contentPolicyV2)
-      ? createPolicyEngineFilter(engine, () => blocklistRepository.currentState)
-      : createBlocklistFilter(blocklistRepository);
-
   return VideosRepository(
     nostrClient: nostrClient,
     localStorage: localStorage,
-    blockFilter: blockFilter,
+    blockFilter: _createBlockedAuthorFilter(ref),
     contentFilter: (video) =>
         nsfwFilter(video) ||
         (divineHostFilterService.showDivineHostedOnly &&

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -3151,7 +3151,7 @@ final class CuratedListRepositoryProvider
 }
 
 String _$curatedListRepositoryHash() =>
-    r'21aee8babc20a3b93a38c41c1905e0f04f1d877a';
+    r'230cebbd57db166644b05510b23987fe7fa5547e';
 
 /// Provider for HashtagRepository instance.
 ///
@@ -4246,7 +4246,7 @@ final class PeopleListsRepositoryProvider
 }
 
 String _$peopleListsRepositoryHash() =>
-    r'1b80c4d4b9229393068846048b6596a0c1688e45';
+    r'5d1d88d9b9cd3b3feee51edd95eb8db9dfbf2371';
 
 /// Bookmark service for NIP-51 bookmarks
 
@@ -4996,7 +4996,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'5be6c793ce13803c1740fffa7301be0cfca6028d';
+String _$videosRepositoryHash() => r'23565018788d961099e00b121cd79a285476e56e';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
@@ -11,6 +11,11 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:rxdart/rxdart.dart';
 
+/// Filter callback for search surfaces owned by a list author.
+///
+/// Returns `true` when content from [pubkey] should be hidden.
+typedef BlockedCuratedListFilter = bool Function(String pubkey);
+
 /// NIP-51 kind for curated video lists.
 const _curatedListKind = 30005;
 
@@ -34,11 +39,14 @@ class CuratedListRepository {
   CuratedListRepository({
     required NostrClient nostrClient,
     required FunnelcakeApiClient funnelcakeApiClient,
+    BlockedCuratedListFilter? blockFilter,
   }) : _nostrClient = nostrClient,
-       _funnelcakeApiClient = funnelcakeApiClient;
+       _funnelcakeApiClient = funnelcakeApiClient,
+       _blockFilter = blockFilter;
 
   final NostrClient _nostrClient;
   final FunnelcakeApiClient _funnelcakeApiClient;
+  final BlockedCuratedListFilter? _blockFilter;
   final Map<String, CuratedList> _subscribedLists = {};
 
   // BehaviorSubject replays last value to late subscribers, fixing race
@@ -137,6 +145,7 @@ class CuratedListRepository {
         .where(
           (list) =>
               list.isPublic &&
+              !_isBlocked(list.pubkey) &&
               (list.name.toLowerCase().contains(lowerQuery) ||
                   (list.description?.toLowerCase().contains(lowerQuery) ??
                       false) ||
@@ -150,9 +159,7 @@ class CuratedListRepository {
   /// Returns subscribed public lists that contain the given [tag].
   List<CuratedList> getListsByTag(String tag) {
     return _subscribedLists.values
-        .where(
-          (list) => list.isPublic && list.tags.contains(tag.toLowerCase()),
-        )
+        .where((list) => list.isPublic && list.tags.contains(tag.toLowerCase()))
         .toList();
   }
 
@@ -228,14 +235,13 @@ class CuratedListRepository {
     final lowerQuery = query.toLowerCase();
     final excluded = excludeIds ?? const {};
 
-    final events = await _nostrClient.queryEvents(
-      [
-        Filter(kinds: [_curatedListKind], limit: limit),
-      ],
-    );
+    final events = await _nostrClient.queryEvents([
+      Filter(kinds: [_curatedListKind], limit: limit),
+    ]);
 
     final seen = <String, CuratedList>{};
     for (final event in events) {
+      if (_isBlocked(event.pubkey)) continue;
       final list = CuratedListConverter.fromEvent(event);
       if (list == null) continue;
       if (excluded.contains(list.id)) continue;
@@ -258,6 +264,14 @@ class CuratedListRepository {
     }
 
     return seen.values.toList();
+  }
+
+  bool _isBlocked(String? pubkey) {
+    final blockFilter = _blockFilter;
+    if (blockFilter == null || pubkey == null || pubkey.isEmpty) {
+      return false;
+    }
+    return blockFilter(pubkey);
   }
 
   /// Searches both local subscribed lists and relay lists for [query].
@@ -373,9 +387,7 @@ class CuratedListRepository {
     final candidates = list.videoEventIds.take(maxThumbnails).toList();
 
     // Phase 1: Try FunnelCake for each hex ID (parallel HTTP calls).
-    final fcResults = await Future.wait(
-      candidates.map(_tryFunnelcake),
-    );
+    final fcResults = await Future.wait(candidates.map(_tryFunnelcake));
 
     // Phase 2: Collect refs needing relay fallback, batch into one query.
     final needsRelay = <String>[];
@@ -421,9 +433,7 @@ class CuratedListRepository {
   /// individual filters in the same request.
   ///
   /// Returns a map from video ref → thumbnail URL for refs that resolved.
-  Future<Map<String, String?>> _batchRelayThumbnails(
-    List<String> refs,
-  ) async {
+  Future<Map<String, String?>> _batchRelayThumbnails(List<String> refs) async {
     if (refs.isEmpty) return {};
 
     final hexIds = <String>[];
@@ -460,10 +470,7 @@ class CuratedListRepository {
 
     for (final event in events) {
       try {
-        final videoEvent = VideoEvent.fromNostrEvent(
-          event,
-          permissive: true,
-        );
+        final videoEvent = VideoEvent.fromNostrEvent(event, permissive: true);
         final thumb = videoEvent.effectiveThumbnailUrl;
         if (thumb == null) continue;
 
@@ -506,12 +513,7 @@ class CuratedListRepository {
     final pubkey = parts[1];
     final dTag = parts.sublist(2).join(':');
 
-    return Filter(
-      kinds: [kind],
-      authors: [pubkey],
-      d: [dTag],
-      limit: 1,
-    );
+    return Filter(kinds: [kind], authors: [pubkey], d: [dTag], limit: 1);
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
@@ -25,6 +25,9 @@ const _videoEventId2 =
     '2222222222222222222222222222222222222222222222222222222222222222';
 const _videoEventId3 =
     '3333333333333333333333333333333333333333333333333333333333333333';
+const _blockedPubkey =
+    'ffffffffffffffffffffffffffffffff'
+    'ffffffffffffffffffffffffffffffff';
 
 /// Creates a kind 30005 Nostr event with the given [tags] and [content].
 Event _makeEvent({
@@ -90,6 +93,7 @@ void main() {
       String name = 'Test List',
       List<String> videoEventIds = const [],
       String? description,
+      String? pubkey,
       bool isPublic = true,
       List<String> tags = const [],
       PlayOrder playOrder = PlayOrder.chronological,
@@ -100,6 +104,7 @@ void main() {
         videoEventIds: videoEventIds,
         createdAt: now,
         updatedAt: now,
+        pubkey: pubkey,
         description: description,
         isPublic: isPublic,
         tags: tags,
@@ -132,10 +137,7 @@ void main() {
 
     group('subscribedListsStream', () {
       test('emits initial empty list', () async {
-        await expectLater(
-          repository.subscribedListsStream,
-          emits(isEmpty),
-        );
+        await expectLater(repository.subscribedListsStream, emits(isEmpty));
       });
 
       test('emits after setSubscribedLists', () async {
@@ -213,14 +215,8 @@ void main() {
         const addressableCoord = '34236:pubkey123:my-vine';
 
         repository.setSubscribedLists([
-          createList(
-            id: 'list-a',
-            videoEventIds: [eventId, addressableCoord],
-          ),
-          createList(
-            id: 'list-b',
-            videoEventIds: [addressableCoord],
-          ),
+          createList(id: 'list-a', videoEventIds: [eventId, addressableCoord]),
+          createList(id: 'list-b', videoEventIds: [addressableCoord]),
         ]);
 
         final refs = repository.getSubscribedListVideoRefs();
@@ -250,10 +246,7 @@ void main() {
 
         final refs = repository.getSubscribedListVideoRefs();
 
-        expect(
-          () => refs['new-key'] = [],
-          throwsA(isA<UnsupportedError>()),
-        );
+        expect(() => refs['new-key'] = [], throwsA(isA<UnsupportedError>()));
       });
 
       test('returns unmodifiable video ID lists', () {
@@ -276,9 +269,7 @@ void main() {
       });
 
       test('returns null for unknown ID', () {
-        repository.setSubscribedLists([
-          createList(id: 'list-a'),
-        ]);
+        repository.setSubscribedLists([createList(id: 'list-a')]);
 
         expect(repository.getListById('unknown'), isNull);
       });
@@ -399,9 +390,7 @@ void main() {
       });
 
       test('returns true when default list exists', () {
-        repository.setSubscribedLists([
-          createList(id: defaultListId),
-        ]);
+        repository.setSubscribedLists([createList(id: defaultListId)]);
 
         expect(repository.hasDefaultList(), isTrue);
       });
@@ -512,10 +501,7 @@ void main() {
           createList(id: 'c', tags: ['secret'], isPublic: false),
         ]);
 
-        expect(
-          repository.getAllTags(),
-          equals(['cooking', 'dance', 'music']),
-        );
+        expect(repository.getAllTags(), equals(['cooking', 'dance', 'music']));
       });
     });
 
@@ -549,10 +535,7 @@ void main() {
 
       test('returns chronological order', () {
         repository.setSubscribedLists([
-          createList(
-            id: 'list',
-            videoEventIds: ['v1', 'v2', 'v3'],
-          ),
+          createList(id: 'list', videoEventIds: ['v1', 'v2', 'v3']),
         ]);
 
         expect(
@@ -629,17 +612,11 @@ void main() {
       });
 
       test('emits nothing for blank query', () async {
-        await expectLater(
-          repository.searchAllLists(''),
-          emitsDone,
-        );
+        await expectLater(repository.searchAllLists(''), emitsDone);
       });
 
       test('emits nothing for whitespace-only query', () async {
-        await expectLater(
-          repository.searchAllLists('   '),
-          emitsDone,
-        );
+        await expectLater(repository.searchAllLists('   '), emitsDone);
       });
 
       test('emits 4 progressive yields with thumbnails', () async {
@@ -692,9 +669,7 @@ void main() {
           createList(id: 'shared-id', name: 'Dance Local'),
         ]);
 
-        when(() => nostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [],
-        );
+        when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
 
         await repository.searchAllLists('dance').toList();
 
@@ -726,6 +701,68 @@ void main() {
         expect(emissions, hasLength(4));
         // Yield 3: local + relay (no duplicates)
         expect(emissions[2], hasLength(2));
+      });
+
+      test('filters blocked owners from local and relay list search', () async {
+        final blockedRepository = CuratedListRepository(
+          nostrClient: nostrClient,
+          funnelcakeApiClient: funnelcakeApiClient,
+          blockFilter: (pubkey) => pubkey == _blockedPubkey,
+        );
+        addTearDown(blockedRepository.dispose);
+
+        blockedRepository.setSubscribedLists([
+          createList(
+            id: 'allowed-local',
+            name: 'Dance Local',
+            pubkey: _testPubkey,
+          ),
+          createList(
+            id: 'blocked-local',
+            name: 'Dance Hidden',
+            pubkey: _blockedPubkey,
+          ),
+        ]);
+
+        when(() => nostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              _blockedPubkey,
+              30005,
+              [
+                ['d', 'blocked-relay'],
+                ['title', 'Dance Hidden Relay'],
+                ['e', 'video-1'],
+              ],
+              '',
+              createdAt: 1718400000,
+            ),
+            _makeEvent(
+              tags: [
+                ['d', 'allowed-relay'],
+                ['title', 'Dance Relay'],
+                ['e', 'video-1'],
+              ],
+            ),
+          ],
+        );
+
+        final emissions = await blockedRepository
+            .searchAllLists('dance')
+            .toList();
+
+        expect(
+          emissions.last.map((list) => list.id),
+          containsAll(['allowed-local', 'allowed-relay']),
+        );
+        expect(
+          emissions.last.map((list) => list.id),
+          isNot(contains('blocked-local')),
+        );
+        expect(
+          emissions.last.map((list) => list.id),
+          isNot(contains('blocked-relay')),
+        );
       });
 
       test('resolves thumbnails from FunnelCake API', () async {
@@ -1022,25 +1059,16 @@ void main() {
 
       test('filters out private lists from all emissions', () async {
         repository.setSubscribedLists([
-          createList(
-            id: 'private-1',
-            name: 'Dance Secret',
-            isPublic: false,
-          ),
+          createList(id: 'private-1', name: 'Dance Secret', isPublic: false),
           createList(id: 'public-1', name: 'Dance Public'),
         ]);
 
-        when(() => nostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [],
-        );
+        when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
 
         final emissions = await repository.searchAllLists('dance').toList();
 
         for (final emission in emissions) {
-          expect(
-            emission.every((l) => l.id != 'private-1'),
-            isTrue,
-          );
+          expect(emission.every((l) => l.id != 'private-1'), isTrue);
         }
       });
 
@@ -1106,9 +1134,7 @@ void main() {
           createList(id: 'local-1', name: 'Dance Local'),
         ]);
 
-        when(() => nostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [],
-        );
+        when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
 
         final emissions = await repository.searchAllLists('dance').toList();
 
@@ -1130,9 +1156,7 @@ void main() {
         ]);
 
         // FunnelCake: ref1 → thumbnail, ref2 → null, ref3 → throws
-        when(
-          () => funnelcakeApiClient.getVideoStats(_videoEventId),
-        ).thenAnswer(
+        when(() => funnelcakeApiClient.getVideoStats(_videoEventId)).thenAnswer(
           (_) async => VideoStats(
             id: _videoEventId,
             pubkey: _testPubkey,
@@ -1192,9 +1216,7 @@ void main() {
           createList(id: 'local-1', name: 'Dance Local'),
         ]);
 
-        when(() => nostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [],
-        );
+        when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
 
         final emissions = await repository.searchAllLists('dance').toList();
 
@@ -1217,11 +1239,7 @@ void main() {
 
       test('returns single list name', () {
         repository.setSubscribedLists([
-          createList(
-            id: 'a',
-            name: 'My Favorites',
-            videoEventIds: ['v1'],
-          ),
+          createList(id: 'a', name: 'My Favorites', videoEventIds: ['v1']),
         ]);
 
         expect(
@@ -1250,10 +1268,7 @@ void main() {
           createList(id: 'd', name: 'D', videoEventIds: ['v1']),
         ]);
 
-        expect(
-          repository.getVideoListSummary('v1'),
-          equals('In 4 lists'),
-        );
+        expect(repository.getVideoListSummary('v1'), equals('In 4 lists'));
       });
     });
   });

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -19,6 +19,11 @@ const String _logName = 'people_lists_repository.impl';
 /// Log level for recoverable warnings. `dart:developer`'s convention is 900.
 const int _logLevelWarning = 900;
 
+/// Filter callback for owner-authored people-list search results.
+///
+/// Returns `true` when content from [ownerPubkey] should be hidden.
+typedef BlockedPeopleListOwnerFilter = bool Function(String ownerPubkey);
+
 /// Concrete [PeopleListsRepository] backed by a [NostrClient] and a
 /// [LocalPeopleListsCache].
 ///
@@ -36,11 +41,14 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
   PeopleListsRepositoryImpl({
     required NostrClient nostrClient,
     required LocalPeopleListsCache cache,
+    BlockedPeopleListOwnerFilter? blockFilter,
   }) : _nostrClient = nostrClient,
-       _cache = cache;
+       _cache = cache,
+       _blockFilter = blockFilter;
 
   final NostrClient _nostrClient;
   final LocalPeopleListsCache _cache;
+  final BlockedPeopleListOwnerFilter? _blockFilter;
 
   @override
   Stream<List<UserList>> watchLists({required String ownerPubkey}) {
@@ -204,11 +212,9 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
 
     final List<Event> events;
     try {
-      events = await _nostrClient.queryEvents(
-        [
-          Filter(kinds: const [Nip51PeopleListCodec.kind], limit: limit),
-        ],
-      );
+      events = await _nostrClient.queryEvents([
+        Filter(kinds: const [Nip51PeopleListCodec.kind], limit: limit),
+      ]);
     } on Object catch (error, stackTrace) {
       developer.log(
         'Failed to query public people lists for "$trimmed"',
@@ -222,6 +228,9 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
 
     final seen = <String, PeopleListSearchResult>{};
     for (final event in events) {
+      final blockFilter = _blockFilter;
+      if (blockFilter != null && blockFilter(event.pubkey)) continue;
+
       final list = Nip51PeopleListCodec.decode(event);
       if (list == null) continue;
       if (list.pubkeys.isEmpty) continue;

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -24,6 +24,8 @@ const _memberA =
     '2222222222222222222222222222222222222222222222222222222222222222';
 const _memberB =
     '3333333333333333333333333333333333333333333333333333333333333333';
+const _blockedOwnerPubkey =
+    '4444444444444444444444444444444444444444444444444444444444444444';
 
 const int _peopleListKind = 30000;
 const int _deletionKind = 5;
@@ -61,10 +63,12 @@ void main() {
     PeopleListsRepositoryImpl buildRepository({
       required NostrClient nostrClient,
       LocalPeopleListsCache? cache,
+      BlockedPeopleListOwnerFilter? blockFilter,
     }) {
       return PeopleListsRepositoryImpl(
         nostrClient: nostrClient,
         cache: cache ?? LocalPeopleListsCache(openBox: makeOpener()),
+        blockFilter: blockFilter,
       );
     }
 
@@ -74,13 +78,7 @@ void main() {
       String content = '',
       int? createdAt,
     }) {
-      return Event(
-          _ownerPubkey,
-          kind,
-          tags,
-          content,
-          createdAt: createdAt,
-        )
+      return Event(_ownerPubkey, kind, tags, content, createdAt: createdAt)
         // Mark as signed for callers that check sig presence.
         ..sig =
             'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
@@ -434,10 +432,7 @@ void main() {
         expect(
           deletion.tags,
           containsOnce(
-            equals(<String>[
-              'a',
-              '$_peopleListKind:$_ownerPubkey:$listId',
-            ]),
+            equals(<String>['a', '$_peopleListKind:$_ownerPubkey:$listId']),
           ),
         );
         expect(
@@ -449,51 +444,48 @@ void main() {
         expect(stored, isEmpty);
       });
 
-      test(
-        'does not tombstone locally when publish does not return '
-        'PublishSuccess',
-        () async {
-          final client = _MockNostrClient();
-          when(() => client.publicKey).thenReturn(_ownerPubkey);
+      test('does not tombstone locally when publish does not return '
+          'PublishSuccess', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
 
-          // First call for createList succeeds, second (deleteList) fails.
-          var publishCalls = 0;
-          when(() => client.publishEvent(any())).thenAnswer((invocation) async {
-            publishCalls++;
-            if (publishCalls == 1) {
-              final event = invocation.positionalArguments.first as Event;
-              return PublishSuccess(
-                event: signedEvent(
-                  kind: event.kind,
-                  tags: event.tags,
-                  content: event.content,
-                  createdAt: event.createdAt,
-                ),
-              );
-            }
-            return const PublishFailed();
-          });
-          final repository = buildRepository(nostrClient: client);
+        // First call for createList succeeds, second (deleteList) fails.
+        var publishCalls = 0;
+        when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+          publishCalls++;
+          if (publishCalls == 1) {
+            final event = invocation.positionalArguments.first as Event;
+            return PublishSuccess(
+              event: signedEvent(
+                kind: event.kind,
+                tags: event.tags,
+                content: event.content,
+                createdAt: event.createdAt,
+              ),
+            );
+          }
+          return const PublishFailed();
+        });
+        final repository = buildRepository(nostrClient: client);
 
-          await repository.createList(
-            ownerPubkey: _ownerPubkey,
-            name: 'Besties',
-            initialPubkeys: const [_memberA],
-          );
-          final listId = (await repository.readLists(
-            ownerPubkey: _ownerPubkey,
-          )).single.id;
+        await repository.createList(
+          ownerPubkey: _ownerPubkey,
+          name: 'Besties',
+          initialPubkeys: const [_memberA],
+        );
+        final listId = (await repository.readLists(
+          ownerPubkey: _ownerPubkey,
+        )).single.id;
 
-          final result = await repository.deleteList(
-            ownerPubkey: _ownerPubkey,
-            listId: listId,
-          );
+        final result = await repository.deleteList(
+          ownerPubkey: _ownerPubkey,
+          listId: listId,
+        );
 
-          expect(result.status, equals(PeopleListPublishStatus.failed));
-          final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
-          expect(stored, hasLength(1));
-        },
-      );
+        expect(result.status, equals(PeopleListPublishStatus.failed));
+        final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
+        expect(stored, hasLength(1));
+      });
     });
 
     group('syncOwner', () {
@@ -513,10 +505,7 @@ void main() {
           );
 
           when(
-            () => client.queryEvents(
-              any(),
-              useCache: any(named: 'useCache'),
-            ),
+            () => client.queryEvents(any(), useCache: any(named: 'useCache')),
           ).thenAnswer((_) async => [remoteEvent]);
 
           final repository = buildRepository(nostrClient: client);
@@ -562,10 +551,7 @@ void main() {
         );
 
         when(
-          () => client.queryEvents(
-            any(),
-            useCache: any(named: 'useCache'),
-          ),
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
         ).thenAnswer((_) async => [crewEvent, blockEvent]);
 
         final repository = buildRepository(nostrClient: client);
@@ -625,10 +611,7 @@ void main() {
           );
 
           when(
-            () => client.queryEvents(
-              any(),
-              useCache: any(named: 'useCache'),
-            ),
+            () => client.queryEvents(any(), useCache: any(named: 'useCache')),
           ).thenAnswer((_) async => [staleEvent]);
 
           await repository.syncOwner(ownerPubkey: _ownerPubkey);
@@ -671,34 +654,28 @@ void main() {
         );
       }
 
-      test(
-        'issues a kind 30000 relay query with the given limit',
-        () async {
-          final client = _MockNostrClient();
-          when(() => client.publicKey).thenReturn(_ownerPubkey);
-          when(
-            () => client.queryEvents(
-              any(),
-              useCache: any(named: 'useCache'),
-            ),
-          ).thenAnswer((_) async => const []);
+      test('issues a kind 30000 relay query with the given limit', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
+        when(
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
+        ).thenAnswer((_) async => const []);
 
-          final repository = buildRepository(nostrClient: client);
+        final repository = buildRepository(nostrClient: client);
 
-          await repository.searchPublicLists('anything', limit: 25).toList();
+        await repository.searchPublicLists('anything', limit: 25).toList();
 
-          final capturedFilters = verify(
-            () => client.queryEvents(
-              captureAny(),
-              useCache: any(named: 'useCache'),
-            ),
-          ).captured.cast<List<Filter>>();
-          expect(capturedFilters, hasLength(1));
-          final filter = capturedFilters.single.single;
-          expect(filter.kinds, equals(const [_peopleListKind]));
-          expect(filter.limit, equals(25));
-        },
-      );
+        final capturedFilters = verify(
+          () => client.queryEvents(
+            captureAny(),
+            useCache: any(named: 'useCache'),
+          ),
+        ).captured.cast<List<Filter>>();
+        expect(capturedFilters, hasLength(1));
+        final filter = capturedFilters.single.single;
+        expect(filter.kinds, equals(const [_peopleListKind]));
+        expect(filter.limit, equals(25));
+      });
 
       test('emits empty stream for a blank query', () async {
         final client = _MockNostrClient();
@@ -708,10 +685,7 @@ void main() {
 
         expect(emissions, isEmpty);
         verifyNever(
-          () => client.queryEvents(
-            any(),
-            useCache: any(named: 'useCache'),
-          ),
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
         );
       });
 
@@ -735,10 +709,7 @@ void main() {
           pubkeys: const [_memberA, _memberB],
         );
         when(
-          () => client.queryEvents(
-            any(),
-            useCache: any(named: 'useCache'),
-          ),
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
         ).thenAnswer((_) async => [event]);
 
         final repository = buildRepository(nostrClient: client);
@@ -777,10 +748,7 @@ void main() {
           pubkeys: const [_memberA],
         );
         when(
-          () => client.queryEvents(
-            any(),
-            useCache: any(named: 'useCache'),
-          ),
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
         ).thenAnswer((_) async => [empty, full]);
 
         final repository = buildRepository(nostrClient: client);
@@ -803,10 +771,7 @@ void main() {
           pubkeys: const [_memberA],
         );
         when(
-          () => client.queryEvents(
-            any(),
-            useCache: any(named: 'useCache'),
-          ),
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
         ).thenAnswer((_) async => [block]);
 
         final repository = buildRepository(nostrClient: client);
@@ -814,6 +779,38 @@ void main() {
         final emissions = await repository.searchPublicLists('crew').toList();
 
         expect(emissions, isEmpty);
+      });
+
+      test('filters out blocked list owners', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
+
+        final blocked = peopleEvent(
+          pubkey: _blockedOwnerPubkey,
+          dTag: 'blocked',
+          title: 'Crew',
+          pubkeys: const [_memberA],
+        );
+        final allowed = peopleEvent(
+          pubkey: _ownerPubkey,
+          dTag: 'allowed',
+          title: 'Crew',
+          pubkeys: const [_memberB],
+        );
+        when(
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
+        ).thenAnswer((_) async => [blocked, allowed]);
+
+        final repository = buildRepository(
+          nostrClient: client,
+          blockFilter: (pubkey) => pubkey == _blockedOwnerPubkey,
+        );
+
+        final emissions = await repository.searchPublicLists('crew').toList();
+
+        expect(emissions, hasLength(1));
+        expect(emissions.single, hasLength(1));
+        expect(emissions.single.single.ownerPubkey, equals(_ownerPubkey));
       });
 
       test(
@@ -842,10 +839,7 @@ void main() {
             pubkeys: const [_memberA],
           );
           when(
-            () => client.queryEvents(
-              any(),
-              useCache: any(named: 'useCache'),
-            ),
+            () => client.queryEvents(any(), useCache: any(named: 'useCache')),
           ).thenAnswer((_) async => [byName, byDescription, nonMatching]);
 
           final repository = buildRepository(nostrClient: client);
@@ -859,96 +853,84 @@ void main() {
         },
       );
 
-      test(
-        'deduplicates by addressable coordinate, not d tag alone',
-        () async {
-          // Two different owners both publish `d=friends` — these are
-          // distinct addressable events and must both survive.
-          final client = _MockNostrClient();
-          when(() => client.publicKey).thenReturn(_ownerPubkey);
+      test('deduplicates by addressable coordinate, not d tag alone', () async {
+        // Two different owners both publish `d=friends` — these are
+        // distinct addressable events and must both survive.
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
 
-          final fromOwner = peopleEvent(
-            pubkey: _ownerPubkey,
-            dTag: 'friends',
-            title: 'Owner Friends',
-            pubkeys: const [_memberA],
-          );
-          final fromSecondOwner = peopleEvent(
-            pubkey: secondOwner,
-            dTag: 'friends',
-            title: 'Second Friends',
-            pubkeys: const [_memberB],
-          );
-          when(
-            () => client.queryEvents(
-              any(),
-              useCache: any(named: 'useCache'),
-            ),
-          ).thenAnswer((_) async => [fromOwner, fromSecondOwner]);
+        final fromOwner = peopleEvent(
+          pubkey: _ownerPubkey,
+          dTag: 'friends',
+          title: 'Owner Friends',
+          pubkeys: const [_memberA],
+        );
+        final fromSecondOwner = peopleEvent(
+          pubkey: secondOwner,
+          dTag: 'friends',
+          title: 'Second Friends',
+          pubkeys: const [_memberB],
+        );
+        when(
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
+        ).thenAnswer((_) async => [fromOwner, fromSecondOwner]);
 
-          final repository = buildRepository(nostrClient: client);
+        final repository = buildRepository(nostrClient: client);
 
-          final emissions = await repository
-              .searchPublicLists('friends')
-              .toList();
+        final emissions = await repository
+            .searchPublicLists('friends')
+            .toList();
 
-          expect(emissions, hasLength(1));
-          final results = emissions.single;
-          expect(results, hasLength(2));
-          final owners = results.map((r) => r.ownerPubkey).toSet();
-          expect(owners, equals({_ownerPubkey, secondOwner}));
-          final coordinates = results.map((r) => r.addressableId).toSet();
-          expect(
-            coordinates,
-            equals({
-              '$_peopleListKind:$_ownerPubkey:friends',
-              '$_peopleListKind:$secondOwner:friends',
-            }),
-          );
-        },
-      );
+        expect(emissions, hasLength(1));
+        final results = emissions.single;
+        expect(results, hasLength(2));
+        final owners = results.map((r) => r.ownerPubkey).toSet();
+        expect(owners, equals({_ownerPubkey, secondOwner}));
+        final coordinates = results.map((r) => r.addressableId).toSet();
+        expect(
+          coordinates,
+          equals({
+            '$_peopleListKind:$_ownerPubkey:friends',
+            '$_peopleListKind:$secondOwner:friends',
+          }),
+        );
+      });
 
-      test(
-        'keeps the newest event when duplicates share an addressable '
-        'coordinate',
-        () async {
-          final client = _MockNostrClient();
-          when(() => client.publicKey).thenReturn(_ownerPubkey);
+      test('keeps the newest event when duplicates share an addressable '
+          'coordinate', () async {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
 
-          final older = peopleEvent(
-            pubkey: _ownerPubkey,
-            dTag: 'crew',
-            title: 'Crew',
-            pubkeys: const [_memberA],
-            createdAt: 1710000000,
-          );
-          final newer = peopleEvent(
-            pubkey: _ownerPubkey,
-            dTag: 'crew',
-            title: 'Crew Updated',
-            pubkeys: const [_memberA, _memberB],
-            createdAt: 1710000500,
-          );
-          when(
-            () => client.queryEvents(
-              any(),
-              useCache: any(named: 'useCache'),
-            ),
-          ).thenAnswer((_) async => [older, newer]);
+        final older = peopleEvent(
+          pubkey: _ownerPubkey,
+          dTag: 'crew',
+          title: 'Crew',
+          pubkeys: const [_memberA],
+          createdAt: 1710000000,
+        );
+        final newer = peopleEvent(
+          pubkey: _ownerPubkey,
+          dTag: 'crew',
+          title: 'Crew Updated',
+          pubkeys: const [_memberA, _memberB],
+          createdAt: 1710000500,
+        );
+        when(
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
+        ).thenAnswer((_) async => [older, newer]);
 
-          final repository = buildRepository(nostrClient: client);
+        final repository = buildRepository(nostrClient: client);
 
-          final emissions = await repository.searchPublicLists('crew').toList();
+        final emissions = await repository.searchPublicLists('crew').toList();
 
-          expect(emissions, hasLength(1));
-          expect(emissions.single, hasLength(1));
-          expect(emissions.single.single.list.name, equals('Crew Updated'));
-          expect(
-            emissions.single.single.list.pubkeys,
-            equals(const [_memberA, _memberB]),
-          );
-        },
-      );
+        expect(emissions, hasLength(1));
+        expect(emissions.single, hasLength(1));
+        expect(emissions.single.single.list.name, equals('Crew Updated'));
+        expect(
+          emissions.single.single.list.pubkeys,
+          equals(const [_memberA, _memberB]),
+        );
+      });
 
       test('does not yield when no events match the query', () async {
         final client = _MockNostrClient();
@@ -961,10 +943,7 @@ void main() {
           pubkeys: const [_memberA],
         );
         when(
-          () => client.queryEvents(
-            any(),
-            useCache: any(named: 'useCache'),
-          ),
+          () => client.queryEvents(any(), useCache: any(named: 'useCache')),
         ).thenAnswer((_) async => [event]);
 
         final repository = buildRepository(nostrClient: client);


### PR DESCRIPTION
## Summary
- apply repository-level blocklist filtering to curated list search and public people-list search
- wire the existing content-policy/blocklist filters into the list-search providers
- add regression tests for blocked owners across both list search surfaces

## Why
Video and people search already enforced blocklist visibility rules in the repository layer, but list search still relied on unfiltered owners. This left search correctness inconsistent across result types.

## Validation
- flutter test test/src/curated_list_repository_test.dart
- flutter test test/people_lists_repository_impl_test.dart
- pre-push analyzer and generated-file verification for touched filtering paths

Closes #3805
