### PR TITLE
fix(inbox): backfill stale conversation previews

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -13,6 +13,20 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
     with _$ConversationsDaoMixin {
   ConversationsDao(super.attachedDatabase);
 
+  static const String _latestMessagePreviewCase = '''
+CASE
+  WHEN dm.message_kind = 15 THEN
+    CASE
+      WHEN dm.file_type IS NULL THEN 'Sent a file'
+      WHEN dm.file_type LIKE 'image/%' THEN 'Sent a photo'
+      WHEN dm.file_type LIKE 'video/%' THEN 'Sent a video'
+      WHEN dm.file_type LIKE 'audio/%' THEN 'Sent an audio message'
+      ELSE 'Sent a file'
+    END
+  ELSE dm.content
+END
+''';
+
   /// Build a filter expression that returns rows owned by [ownerPubkey]
   /// **or** legacy rows with no owner (NULL).
   Expression<bool> _ownedOrLegacy(
@@ -77,49 +91,46 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
 
     return into(conversations).insert(
       row,
-      onConflict: DoUpdate.withExcluded(
-        (old, excl) {
-          // Determine whether the incoming preview columns should win.
-          // When forced, always take the incoming values. Otherwise only
-          // update when the incoming timestamp is strictly newer than the
-          // stored one (NULL stored timestamp counts as 0 via COALESCE).
-          final incomingIsNewer = excl.lastMessageTimestamp.isBiggerThan(
-            coalesce([old.lastMessageTimestamp, const Constant(0)]),
-          );
-          final previewCondition = forceUpdateLastMessage
-              ? const Constant<bool>(true)
-              : incomingIsNewer;
+      onConflict: DoUpdate.withExcluded((old, excl) {
+        // Determine whether the incoming preview columns should win.
+        // When forced, always take the incoming values. Otherwise only
+        // update when the incoming timestamp is strictly newer than the
+        // stored one (NULL stored timestamp counts as 0 via COALESCE).
+        final incomingIsNewer = excl.lastMessageTimestamp.isBiggerThan(
+          coalesce([old.lastMessageTimestamp, const Constant(0)]),
+        );
+        final previewCondition = forceUpdateLastMessage
+            ? const Constant<bool>(true)
+            : incomingIsNewer;
 
-          return ConversationsCompanion.custom(
-            // Always updated.
-            participantPubkeys: excl.participantPubkeys,
-            isGroup: excl.isGroup,
-            isRead: excl.isRead,
-            // Preserve existing non-null value; only update when incoming
-            // value is non-null.
-            subject: coalesce([excl.subject, old.subject]),
-            ownerPubkey: coalesce([excl.ownerPubkey, old.ownerPubkey]),
-            dmProtocol: coalesce([excl.dmProtocol, old.dmProtocol]),
-            // One-way ratchet: never clear true back to false.
-            currentUserHasSent:
-                old.currentUserHasSent | excl.currentUserHasSent,
-            // Preview columns: conditional on timestamp guard.
-            // iif(condition, ifFalse) is called on the ifTrue expression.
-            lastMessageTimestamp: excl.lastMessageTimestamp.iif(
-              previewCondition,
-              old.lastMessageTimestamp,
-            ),
-            lastMessageContent: excl.lastMessageContent.iif(
-              previewCondition,
-              old.lastMessageContent,
-            ),
-            lastMessageSenderPubkey: excl.lastMessageSenderPubkey.iif(
-              previewCondition,
-              old.lastMessageSenderPubkey,
-            ),
-          );
-        },
-      ),
+        return ConversationsCompanion.custom(
+          // Always updated.
+          participantPubkeys: excl.participantPubkeys,
+          isGroup: excl.isGroup,
+          isRead: excl.isRead,
+          // Preserve existing non-null value; only update when incoming
+          // value is non-null.
+          subject: coalesce([excl.subject, old.subject]),
+          ownerPubkey: coalesce([excl.ownerPubkey, old.ownerPubkey]),
+          dmProtocol: coalesce([excl.dmProtocol, old.dmProtocol]),
+          // One-way ratchet: never clear true back to false.
+          currentUserHasSent: old.currentUserHasSent | excl.currentUserHasSent,
+          // Preview columns: conditional on timestamp guard.
+          // iif(condition, ifFalse) is called on the ifTrue expression.
+          lastMessageTimestamp: excl.lastMessageTimestamp.iif(
+            previewCondition,
+            old.lastMessageTimestamp,
+          ),
+          lastMessageContent: excl.lastMessageContent.iif(
+            previewCondition,
+            old.lastMessageContent,
+          ),
+          lastMessageSenderPubkey: excl.lastMessageSenderPubkey.iif(
+            previewCondition,
+            old.lastMessageSenderPubkey,
+          ),
+        );
+      }),
     );
   }
 
@@ -222,10 +233,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Get a single conversation by ID.
-  Future<ConversationRow?> getConversation(
-    String id, {
-    String? ownerPubkey,
-  }) {
+  Future<ConversationRow?> getConversation(String id, {String? ownerPubkey}) {
     return (select(conversations)..where(
           (t) => t.id.equals(id) & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
         ))
@@ -233,10 +241,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Watch a single conversation by ID.
-  Stream<ConversationRow?> watchConversation(
-    String id, {
-    String? ownerPubkey,
-  }) {
+  Stream<ConversationRow?> watchConversation(String id, {String? ownerPubkey}) {
     return (select(conversations)..where(
           (t) => t.id.equals(id) & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
         ))
@@ -250,10 +255,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   /// Throws:
   ///
   /// * [InvalidDataException] if a column constraint is violated.
-  Future<bool> markAsRead(
-    String id, {
-    String? ownerPubkey,
-  }) async {
+  Future<bool> markAsRead(String id, {String? ownerPubkey}) async {
     final rows =
         await (update(conversations)..where(
               (t) =>
@@ -319,10 +321,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Delete a conversation by ID.
-  Future<int> deleteConversation(
-    String id, {
-    String? ownerPubkey,
-  }) {
+  Future<int> deleteConversation(String id, {String? ownerPubkey}) {
     return (delete(conversations)..where(
           (t) => t.id.equals(id) & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
         ))
@@ -330,10 +329,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Delete multiple conversations in a single batch.
-  Future<int> deleteMultiple(
-    List<String> ids, {
-    String? ownerPubkey,
-  }) {
+  Future<int> deleteMultiple(List<String> ids, {String? ownerPubkey}) {
     if (ids.isEmpty) return Future.value(0);
     return (delete(conversations)..where(
           (t) => t.id.isIn(ids) & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
@@ -379,6 +375,77 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
         Variable(userPubkey),
         Variable(userPubkey),
       ],
+      updates: {attachedDatabase.conversations},
+      updateKind: UpdateKind.update,
+    );
+  }
+
+  /// Backfills denormalized latest-message preview columns from
+  /// `direct_messages`.
+  ///
+  /// Fixes stale conversation previews written by app versions prior to the
+  /// write-path timestamp guard in [upsertConversation]. Idempotent: once a
+  /// conversation row matches the newest non-deleted message (or correctly has
+  /// no preview because no messages remain), subsequent runs are no-ops.
+  ///
+  /// Returns the number of conversations updated.
+  Future<int> backfillLatestMessagePreviews({String? ownerPubkey}) {
+    final scopedConversationFilter = ownerPubkey == null
+        ? '1 = 1'
+        : '(c.owner_pubkey = ? OR c.owner_pubkey IS NULL)';
+    const latestMessageOwnerFilter = '''
+((c.owner_pubkey IS NULL AND dm.owner_pubkey IS NULL) OR
+ dm.owner_pubkey = c.owner_pubkey OR
+ dm.owner_pubkey IS NULL)
+''';
+    const latestPreviewContentSubquery =
+        '''
+SELECT $_latestMessagePreviewCase
+FROM direct_messages dm
+WHERE dm.conversation_id = c.id
+  AND dm.is_deleted = 0
+  AND $latestMessageOwnerFilter
+ORDER BY dm.created_at DESC, dm.id DESC
+LIMIT 1
+''';
+    const latestTimestampSubquery =
+        '''
+SELECT dm.created_at
+FROM direct_messages dm
+WHERE dm.conversation_id = c.id
+  AND dm.is_deleted = 0
+  AND $latestMessageOwnerFilter
+ORDER BY dm.created_at DESC, dm.id DESC
+LIMIT 1
+''';
+    const latestSenderSubquery =
+        '''
+SELECT dm.sender_pubkey
+FROM direct_messages dm
+WHERE dm.conversation_id = c.id
+  AND dm.is_deleted = 0
+  AND $latestMessageOwnerFilter
+ORDER BY dm.created_at DESC, dm.id DESC
+LIMIT 1
+''';
+
+    return customUpdate(
+      '''
+      UPDATE conversations AS c
+      SET last_message_content = ($latestPreviewContentSubquery),
+          last_message_timestamp = ($latestTimestampSubquery),
+          last_message_sender_pubkey = ($latestSenderSubquery)
+      WHERE $scopedConversationFilter
+        AND (
+          COALESCE(c.last_message_content, '') !=
+              COALESCE(($latestPreviewContentSubquery), '') OR
+          COALESCE(c.last_message_timestamp, -1) !=
+              COALESCE(($latestTimestampSubquery), -1) OR
+          COALESCE(c.last_message_sender_pubkey, '') !=
+              COALESCE(($latestSenderSubquery), '')
+        )
+      ''',
+      variables: [if (ownerPubkey != null) Variable(ownerPubkey)],
       updates: {attachedDatabase.conversations},
       updateKind: UpdateKind.update,
     );

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -393,6 +393,8 @@ END
     final scopedConversationFilter = ownerPubkey == null
         ? '1 = 1'
         : '(c.owner_pubkey = ? OR c.owner_pubkey IS NULL)';
+    // Legacy conversation rows may still be ownerless, but scoped reads expose
+    // them to the current user alongside that user's messages.
     final latestMessageOwnerFilter = ownerPubkey == null
         ? '1 = 1'
         : '(dm.owner_pubkey = ? OR dm.owner_pubkey IS NULL)';

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -393,12 +393,10 @@ END
     final scopedConversationFilter = ownerPubkey == null
         ? '1 = 1'
         : '(c.owner_pubkey = ? OR c.owner_pubkey IS NULL)';
-    const latestMessageOwnerFilter = '''
-((c.owner_pubkey IS NULL AND dm.owner_pubkey IS NULL) OR
- dm.owner_pubkey = c.owner_pubkey OR
- dm.owner_pubkey IS NULL)
-''';
-    const latestPreviewContentSubquery =
+    final latestMessageOwnerFilter = ownerPubkey == null
+        ? '1 = 1'
+        : '(dm.owner_pubkey = ? OR dm.owner_pubkey IS NULL)';
+    final latestPreviewContentSubquery =
         '''
 SELECT $_latestMessagePreviewCase
 FROM direct_messages dm
@@ -408,7 +406,7 @@ WHERE dm.conversation_id = c.id
 ORDER BY dm.created_at DESC, dm.id DESC
 LIMIT 1
 ''';
-    const latestTimestampSubquery =
+    final latestTimestampSubquery =
         '''
 SELECT dm.created_at
 FROM direct_messages dm
@@ -418,7 +416,7 @@ WHERE dm.conversation_id = c.id
 ORDER BY dm.created_at DESC, dm.id DESC
 LIMIT 1
 ''';
-    const latestSenderSubquery =
+    final latestSenderSubquery =
         '''
 SELECT dm.sender_pubkey
 FROM direct_messages dm
@@ -445,7 +443,17 @@ LIMIT 1
               COALESCE(($latestSenderSubquery), '')
         )
       ''',
-      variables: [if (ownerPubkey != null) Variable(ownerPubkey)],
+      variables: [
+        if (ownerPubkey != null) ...[
+          Variable(ownerPubkey),
+          Variable(ownerPubkey),
+          Variable(ownerPubkey),
+          Variable(ownerPubkey),
+          Variable(ownerPubkey),
+          Variable(ownerPubkey),
+          Variable(ownerPubkey),
+        ],
+      ],
       updates: {attachedDatabase.conversations},
       updateKind: UpdateKind.update,
     );

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -1074,6 +1074,43 @@ void main() {
         expect(convA!.lastMessageContent, equals('fresh a'));
         expect(convB!.lastMessageContent, equals('stale b'));
       });
+
+      test(
+        'backfills legacy ownerless conversations from scoped owner messages',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_legacy',
+            participantPubkeys: '["$userA","$userB"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'stale legacy preview',
+            lastMessageTimestamp: 1700000001,
+            lastMessageSenderPubkey: userA,
+          );
+          await database.directMessagesDao.insertMessage(
+            id: 'msg_legacy',
+            conversationId: 'conv_legacy',
+            senderPubkey: userB,
+            content: 'fresh legacy message',
+            createdAt: 1700000002,
+            giftWrapId: 'gw_legacy',
+            ownerPubkey: userA,
+          );
+
+          final updated = await dao.backfillLatestMessagePreviews(
+            ownerPubkey: userA,
+          );
+
+          expect(updated, equals(1));
+          final conv = await dao.getConversation(
+            'conv_legacy',
+            ownerPubkey: userA,
+          );
+          expect(conv!.lastMessageContent, equals('fresh legacy message'));
+          expect(conv.lastMessageTimestamp, equals(1700000002));
+          expect(conv.lastMessageSenderPubkey, equals(userB));
+        },
+      );
     });
   });
 }

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/event_kind.dart';
 
 void main() {
   late AppDatabase database;
@@ -50,10 +51,7 @@ void main() {
         final result = await dao.getConversation('conv_1');
         expect(result, isNotNull);
         expect(result!.id, equals('conv_1'));
-        expect(
-          result.participantPubkeys,
-          equals('["pubkey_a","pubkey_b"]'),
-        );
+        expect(result.participantPubkeys, equals('["pubkey_a","pubkey_b"]'));
         expect(result.isGroup, isFalse);
         expect(result.lastMessageContent, equals('Hello!'));
         expect(result.lastMessageTimestamp, equals(1700000100));
@@ -140,36 +138,33 @@ void main() {
         },
       );
 
-      test(
-        'updates preview when new timestamp is strictly newer',
-        () async {
-          await dao.upsertConversation(
-            id: 'conv_1',
-            participantPubkeys: '["pubkey_a","pubkey_b"]',
-            isGroup: false,
-            createdAt: 1700000000,
-            lastMessageContent: 'First message',
-            lastMessageTimestamp: 1700000100,
-            lastMessageSenderPubkey: 'pubkey_a',
-          );
+      test('updates preview when new timestamp is strictly newer', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["pubkey_a","pubkey_b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageContent: 'First message',
+          lastMessageTimestamp: 1700000100,
+          lastMessageSenderPubkey: 'pubkey_a',
+        );
 
-          await dao.upsertConversation(
-            id: 'conv_1',
-            participantPubkeys: '["pubkey_a","pubkey_b"]',
-            isGroup: false,
-            createdAt: 1700000000,
-            lastMessageContent: 'Second message',
-            lastMessageTimestamp: 1700000200,
-            lastMessageSenderPubkey: 'pubkey_b',
-          );
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["pubkey_a","pubkey_b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageContent: 'Second message',
+          lastMessageTimestamp: 1700000200,
+          lastMessageSenderPubkey: 'pubkey_b',
+        );
 
-          final result = await dao.getConversation('conv_1');
-          expect(result, isNotNull);
-          expect(result!.lastMessageContent, equals('Second message'));
-          expect(result.lastMessageTimestamp, equals(1700000200));
-          expect(result.lastMessageSenderPubkey, equals('pubkey_b'));
-        },
-      );
+        final result = await dao.getConversation('conv_1');
+        expect(result, isNotNull);
+        expect(result!.lastMessageContent, equals('Second message'));
+        expect(result.lastMessageTimestamp, equals(1700000200));
+        expect(result.lastMessageSenderPubkey, equals('pubkey_b'));
+      });
 
       test(
         'forceUpdateLastMessage overwrites even with older timestamp',
@@ -310,6 +305,33 @@ void main() {
         expect(result, isNotNull);
         expect(result!.createdAt, equals(1700000000));
       });
+
+      test(
+        'covers every mutable conversation column in the conflict contract',
+        () {
+          final schemaColumns = database.conversations.$columns
+              .map((column) => column.$name)
+              .toSet();
+          const immutableColumns = {'id', 'created_at'};
+          const handledColumns = {
+            'participant_pubkeys',
+            'is_group',
+            'last_message_content',
+            'last_message_timestamp',
+            'last_message_sender_pubkey',
+            'subject',
+            'is_read',
+            'current_user_has_sent',
+            'owner_pubkey',
+            'dm_protocol',
+          };
+
+          expect(
+            handledColumns,
+            unorderedEquals(schemaColumns.difference(immutableColumns)),
+          );
+        },
+      );
     });
 
     group('getAllConversations', () {
@@ -881,6 +903,176 @@ void main() {
         expect(updated, equals(1));
         final conv = await dao.getConversation('conv_1');
         expect(conv!.currentUserHasSent, isTrue);
+      });
+    });
+
+    group('backfillLatestMessagePreviews', () {
+      const userA = 'pubkey_a';
+      const userB = 'pubkey_b';
+
+      test(
+        'updates stale preview columns to the newest non-deleted message',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["$userA","$userB"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'stale older message',
+            lastMessageTimestamp: 1700000001,
+            lastMessageSenderPubkey: userA,
+            ownerPubkey: userA,
+          );
+          await database.directMessagesDao.insertMessage(
+            id: 'msg_old',
+            conversationId: 'conv_1',
+            senderPubkey: userA,
+            content: 'first',
+            createdAt: 1700000001,
+            giftWrapId: 'gw_old',
+            ownerPubkey: userA,
+          );
+          await database.directMessagesDao.insertMessage(
+            id: 'msg_new',
+            conversationId: 'conv_1',
+            senderPubkey: userB,
+            content: 'latest',
+            createdAt: 1700000002,
+            giftWrapId: 'gw_new',
+            ownerPubkey: userA,
+          );
+
+          final updated = await dao.backfillLatestMessagePreviews(
+            ownerPubkey: userA,
+          );
+
+          expect(updated, equals(1));
+          final conv = await dao.getConversation('conv_1', ownerPubkey: userA);
+          expect(conv!.lastMessageContent, equals('latest'));
+          expect(conv.lastMessageTimestamp, equals(1700000002));
+          expect(conv.lastMessageSenderPubkey, equals(userB));
+        },
+      );
+
+      test('converts file messages to human-readable preview text', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          ownerPubkey: userA,
+        );
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_file',
+          conversationId: 'conv_1',
+          senderPubkey: userB,
+          content: 'https://cdn.example.com/video.mp4',
+          createdAt: 1700000002,
+          giftWrapId: 'gw_file',
+          messageKind: EventKind.fileMessage,
+          fileType: 'video/mp4',
+          ownerPubkey: userA,
+        );
+
+        final updated = await dao.backfillLatestMessagePreviews(
+          ownerPubkey: userA,
+        );
+
+        expect(updated, equals(1));
+        final conv = await dao.getConversation('conv_1', ownerPubkey: userA);
+        expect(conv!.lastMessageContent, equals('Sent a video'));
+        expect(conv.lastMessageTimestamp, equals(1700000002));
+        expect(conv.lastMessageSenderPubkey, equals(userB));
+      });
+
+      test(
+        'clears stale preview when no non-deleted messages remain',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["$userA","$userB"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'stale preview',
+            lastMessageTimestamp: 1700000002,
+            lastMessageSenderPubkey: userB,
+            ownerPubkey: userA,
+          );
+          await database.directMessagesDao.insertMessage(
+            id: 'msg_deleted',
+            conversationId: 'conv_1',
+            senderPubkey: userB,
+            content: 'latest',
+            createdAt: 1700000002,
+            giftWrapId: 'gw_deleted',
+            ownerPubkey: userA,
+          );
+          await database.directMessagesDao.markMessageDeleted(
+            'msg_deleted',
+            ownerPubkey: userA,
+          );
+
+          final updated = await dao.backfillLatestMessagePreviews(
+            ownerPubkey: userA,
+          );
+
+          expect(updated, equals(1));
+          final conv = await dao.getConversation('conv_1', ownerPubkey: userA);
+          expect(conv!.lastMessageContent, isNull);
+          expect(conv.lastMessageTimestamp, isNull);
+          expect(conv.lastMessageSenderPubkey, isNull);
+        },
+      );
+
+      test('only updates conversations in the requested owner scope', () async {
+        await dao.upsertConversation(
+          id: 'conv_a',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageContent: 'stale a',
+          lastMessageTimestamp: 1700000001,
+          lastMessageSenderPubkey: userA,
+          ownerPubkey: userA,
+        );
+        await dao.upsertConversation(
+          id: 'conv_b',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageContent: 'stale b',
+          lastMessageTimestamp: 1700000001,
+          lastMessageSenderPubkey: userA,
+          ownerPubkey: userB,
+        );
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_a',
+          conversationId: 'conv_a',
+          senderPubkey: userB,
+          content: 'fresh a',
+          createdAt: 1700000002,
+          giftWrapId: 'gw_a',
+          ownerPubkey: userA,
+        );
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_b',
+          conversationId: 'conv_b',
+          senderPubkey: userB,
+          content: 'fresh b',
+          createdAt: 1700000002,
+          giftWrapId: 'gw_b',
+          ownerPubkey: userB,
+        );
+
+        final updated = await dao.backfillLatestMessagePreviews(
+          ownerPubkey: userA,
+        );
+
+        expect(updated, equals(1));
+        final convA = await dao.getConversation('conv_a', ownerPubkey: userA);
+        final convB = await dao.getConversation('conv_b', ownerPubkey: userB);
+        expect(convA!.lastMessageContent, equals('fresh a'));
+        expect(convB!.lastMessageContent, equals('stale b'));
       });
     });
   });

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1663,7 +1663,7 @@ class DmRepository {
   Stream<List<DmConversation>> watchAcceptedConversations({int? limit}) {
     return _conversationsDao
         .watchAcceptedConversations(limit: limit, ownerPubkey: _ownerPubkey)
-        .asyncMap(_overlayLatestMessages);
+        .map((rows) => rows.map(_conversationFromRow).toList());
   }
 
   /// Watch conversations where the user has never sent a message.
@@ -1674,48 +1674,7 @@ class DmRepository {
   Stream<List<DmConversation>> watchPotentialRequests() {
     return _conversationsDao
         .watchPotentialRequestConversations(ownerPubkey: _ownerPubkey)
-        .asyncMap(_overlayLatestMessages);
-  }
-
-  /// Overlays each conversation row with the actual latest message from
-  /// `direct_messages` using a single batched query, then re-sorts by that
-  /// timestamp.
-  ///
-  /// This is a read-path safety net for existing user databases that may
-  /// contain stale `lastMessageContent` / `lastMessageTimestamp` values
-  /// written by app versions prior to the write-path fix in
-  /// `upsertConversation`. New writes are protected by that fix and will
-  /// never drift, but already-stale rows need this correction until a
-  /// backfill migration repairs them.
-  ///
-  // TODO(perf4407): Remove this method and the two asyncMap calls above once
-  // a one-time backfill migration has shipped that corrects any stale
-  // conversation rows in existing user databases.
-  // Tracking: divinevideo/divine-mobile#4407.
-  Future<List<DmConversation>> _overlayLatestMessages(
-    List<ConversationRow> rows,
-  ) async {
-    final latestMessages = await _directMessagesDao
-        .getLatestMessagesForConversations(
-          rows.map((row) => row.id),
-          ownerPubkey: _ownerPubkey,
-        );
-    final overlaid = rows.map((row) {
-      final base = _conversationFromRow(row);
-      final latest = latestMessages[row.id];
-      if (latest == null) return base;
-      final preview = latest.messageKind == EventKind.fileMessage
-          ? _filePreviewText(latest.fileType)
-          : latest.content;
-      return base.copyWith(
-        lastMessageContent: preview,
-        lastMessageTimestamp: latest.createdAt,
-        lastMessageSenderPubkey: latest.senderPubkey,
-      );
-    }).toList();
-    return overlaid..sort(
-      (a, b) => b.effectiveTimestamp.compareTo(a.effectiveTimestamp),
-    );
+        .map((rows) => rows.map(_conversationFromRow).toList());
   }
 
   /// Classifies potential request conversations by follow state.
@@ -2002,6 +1961,7 @@ class DmRepository {
     await _mergeDuplicateConversations();
     await _cleanupSelfConversations();
     await _backfillCurrentUserHasSent();
+    await _backfillConversationPreviews();
   }
 
   /// Backfills `currentUserHasSent` for conversations where the column
@@ -2026,6 +1986,31 @@ class DmRepository {
     } on Object catch (e, stackTrace) {
       Log.error(
         'Failed to backfill currentUserHasSent: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  /// Backfills denormalized latest-message preview columns in conversations.
+  ///
+  /// Fixes stale previews created before the write-path timestamp guard landed,
+  /// after which conversation rows become the source of truth again.
+  Future<void> _backfillConversationPreviews() async {
+    try {
+      final updated = await _conversationsDao.backfillLatestMessagePreviews(
+        ownerPubkey: _ownerPubkey,
+      );
+      if (updated > 0) {
+        Log.info(
+          'Backfilled latest message previews for $updated conversations',
+          category: LogCategory.system,
+        );
+      }
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to backfill latest message previews: $e',
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -113,6 +113,10 @@ class DmRepository {
   /// never race into the dedup/insert path.
   Future<void>? _eventLock;
 
+  /// Tracks the first post-auth cleanup pass so conversation queries can avoid
+  /// emitting stale denormalized previews before repairs land.
+  Future<void>? _postAuthMaintenance;
+
   /// User-scoped subscription ID to prevent collision when the provider
   /// rebuilds during auth transitions (old unsubscribe won't kill new sub).
   String _subscriptionId = 'dm_inbox';
@@ -170,7 +174,8 @@ class DmRepository {
 
     // Run post-auth maintenance sequentially so each step operates on the
     // final state of the previous one (e.g. backfill runs after merge).
-    unawaited(_runPostAuthMaintenance());
+    _postAuthMaintenance = _runPostAuthMaintenance();
+    unawaited(_postAuthMaintenance);
   }
 
   /// Reset internal state so the repository can be re-initialized for a
@@ -192,6 +197,7 @@ class DmRepository {
     } on Object {
       // Ignore if subscription doesn't exist
     }
+    _postAuthMaintenance = null;
     _userPubkey = '';
     _signer = null;
     _messageService = null;
@@ -1632,15 +1638,19 @@ class DmRepository {
   /// When [limit] is provided, only the top [limit] conversations are
   /// watched. Omit for all conversations.
   Stream<List<DmConversation>> watchConversations({int? limit}) {
-    return _conversationsDao
-        .watchAllConversations(limit: limit, ownerPubkey: _ownerPubkey)
-        .map((rows) => rows.map(_conversationFromRow).toList());
+    return _watchConversationRows(
+      () => _conversationsDao.watchAllConversations(
+        limit: limit,
+        ownerPubkey: _ownerPubkey,
+      ),
+    );
   }
 
   /// Get a single conversation by ID.
   ///
   /// Returns `null` if no conversation with the given ID exists.
   Future<DmConversation?> getConversation(String conversationId) async {
+    await _awaitInitialConversationMaintenance();
     final row = await _conversationsDao.getConversation(
       conversationId,
       ownerPubkey: _ownerPubkey,
@@ -1650,6 +1660,7 @@ class DmRepository {
 
   /// Get all conversations.
   Future<List<DmConversation>> getConversations() async {
+    await _awaitInitialConversationMaintenance();
     final rows = await _conversationsDao.getAllConversations(
       ownerPubkey: _ownerPubkey,
     );
@@ -1661,9 +1672,12 @@ class DmRepository {
   /// Supports pagination via [limit]. These conversations are never
   /// message requests.
   Stream<List<DmConversation>> watchAcceptedConversations({int? limit}) {
-    return _conversationsDao
-        .watchAcceptedConversations(limit: limit, ownerPubkey: _ownerPubkey)
-        .map((rows) => rows.map(_conversationFromRow).toList());
+    return _watchConversationRows(
+      () => _conversationsDao.watchAcceptedConversations(
+        limit: limit,
+        ownerPubkey: _ownerPubkey,
+      ),
+    );
   }
 
   /// Watch conversations where the user has never sent a message.
@@ -1672,9 +1686,11 @@ class DmRepository {
   /// follow state) is applied by [classifyPotentialRequests]. Returned
   /// without pagination since the list is typically small and needed in full.
   Stream<List<DmConversation>> watchPotentialRequests() {
-    return _conversationsDao
-        .watchPotentialRequestConversations(ownerPubkey: _ownerPubkey)
-        .map((rows) => rows.map(_conversationFromRow).toList());
+    return _watchConversationRows(
+      () => _conversationsDao.watchPotentialRequestConversations(
+        ownerPubkey: _ownerPubkey,
+      ),
+    );
   }
 
   /// Classifies potential request conversations by follow state.
@@ -1827,6 +1843,22 @@ class DmRepository {
       ownerPubkey: _ownerPubkey,
     );
     return rows.map(_messageFromRow).toList();
+  }
+
+  Future<void> _awaitInitialConversationMaintenance() async {
+    await _postAuthMaintenance;
+  }
+
+  Stream<List<DmConversation>> _watchConversationRows(
+    Stream<List<ConversationRow>> Function() watchRows,
+  ) {
+    final maintenance = _postAuthMaintenance;
+    final gatedRows = maintenance == null
+        ? watchRows()
+        : Stream.fromFuture(maintenance).asyncExpand((_) => watchRows());
+    return gatedRows.map((streamRows) {
+      return streamRows.map(_conversationFromRow).toList();
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5445,6 +5445,79 @@ void main() {
     });
 
     group('watchAcceptedConversations', () {
+      test(
+        'waits for post-auth maintenance before subscribing to conversations',
+        () async {
+          final maintenanceCompleter = Completer<int>();
+          final participants = [_validPubkeyA, _validPubkeyB]..sort();
+          final convId = DmRepository.computeConversationId(participants);
+
+          when(
+            () => mockConversationsDao.backfillLatestMessagePreviews(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) => maintenanceCompleter.future);
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockConversationsDao.watchAcceptedConversations(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value([
+              ConversationRow(
+                id: convId,
+                participantPubkeys: jsonEncode(participants),
+                isGroup: false,
+                isRead: true,
+                currentUserHasSent: true,
+                createdAt: 1700000000,
+              ),
+            ]),
+          );
+
+          final repository =
+              DmRepository(
+                nostrClient: mockNostrClient,
+                directMessagesDao: mockDirectMessagesDao,
+                conversationsDao: mockConversationsDao,
+              )..setCredentials(
+                userPubkey: _validPubkeyA,
+                signer: LocalNostrSigner(_validPrivateKey),
+                messageService: mockMessageService,
+              );
+
+          final conversationsFuture = repository
+              .watchAcceptedConversations()
+              .first;
+
+          verifyNever(
+            () => mockConversationsDao.watchAcceptedConversations(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+
+          maintenanceCompleter.complete(0);
+
+          await untilCalled(
+            () => mockConversationsDao.watchAcceptedConversations(
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+
+          final conversations = await conversationsFuture;
+          expect(conversations, hasLength(1));
+          expect(conversations.first.id, equals(convId));
+        },
+      );
+
       test('maps $ConversationRow stream to $DmConversation stream', () async {
         final participants = [_validPubkeyA, _validPubkeyB]..sort();
         final convId = DmRepository.computeConversationId(participants);

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -133,6 +133,11 @@ void main() {
       when(
         () => mockConversationsDao.backfillCurrentUserHasSent(any()),
       ).thenAnswer((_) async => 0);
+      when(
+        () => mockConversationsDao.backfillLatestMessagePreviews(
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => 0);
 
       // Global stub for runInTransaction — executes the callback directly.
       // Stub both <void> and <Null> since Dart infers different type args
@@ -5461,13 +5466,6 @@ void main() {
             ),
           ]),
         );
-        when(
-          () => mockDirectMessagesDao.getLatestMessagesForConversations(
-            any(),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        ).thenAnswer((_) async => const {});
-
         final repository = createRepository();
         final conversations = await repository
             .watchAcceptedConversations()
@@ -5479,15 +5477,8 @@ void main() {
       });
 
       test(
-        'overlays the latest message from $DirectMessageRow over the '
-        'denormalized row preview',
+        'uses the conversation row preview as the source of truth',
         () async {
-          // The conversations row carries a stale "first message" preview
-          // (typical when an older gift wrap arrived after a newer one
-          // and stomped the denormalized columns during backfill). The
-          // direct_messages table still has every message, so the inbox
-          // preview should reflect the most recent one — not the stale
-          // column.
           final participants = [_validPubkeyA, _validPubkeyB]..sort();
           final convId = DmRepository.computeConversationId(participants);
 
@@ -5504,31 +5495,12 @@ void main() {
                 isGroup: false,
                 isRead: true,
                 currentUserHasSent: true,
-                createdAt: 1699999000,
-                lastMessageContent: 'Stale: first message ever',
-                lastMessageTimestamp: 1699999000,
-                lastMessageSenderPubkey: _validPubkeyB,
+                createdAt: 1700000000,
+                lastMessageContent: 'Latest reply',
+                lastMessageTimestamp: 1700000500,
+                lastMessageSenderPubkey: _validPubkeyA,
               ),
             ]),
-          );
-          when(
-            () => mockDirectMessagesDao.getLatestMessagesForConversations(
-              any(),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer(
-            (_) async => {
-              convId: DirectMessageRow(
-                id: _rumorEventId,
-                conversationId: convId,
-                senderPubkey: _validPubkeyA,
-                content: 'Latest reply',
-                createdAt: 1700000500,
-                giftWrapId: _giftWrapEventId,
-                messageKind: EventKind.privateDirectMessage,
-                isDeleted: false,
-              ),
-            },
           );
 
           final repository = createRepository();
@@ -5549,15 +5521,18 @@ void main() {
             conversations.first.lastMessageSenderPubkey,
             equals(_validPubkeyA),
           );
+          verifyNever(
+            () => mockDirectMessagesDao.getLatestMessagesForConversations(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
         },
       );
 
       test(
-        're-sorts conversations by the actual latest message timestamp',
+        'preserves DAO ordering',
         () async {
-          // A and B are stored with DAO-order [A then B] (because the
-          // denormalized lastMessageTimestamp is stale). After overlay, B
-          // has the newer real message and must be listed first.
           final participantsA = [_validPubkeyA, _validPubkeyB]..sort();
           final participantsB = [_validPubkeyA, _validPubkeyC]..sort();
           final convA = DmRepository.computeConversationId(participantsA);
@@ -5577,8 +5552,8 @@ void main() {
                 isRead: true,
                 currentUserHasSent: true,
                 createdAt: 1700000000,
-                lastMessageContent: 'Stale A',
-                lastMessageTimestamp: 1700000200,
+                lastMessageContent: 'B latest',
+                lastMessageTimestamp: 1700000900,
               ),
               ConversationRow(
                 id: convB,
@@ -5587,39 +5562,10 @@ void main() {
                 isRead: true,
                 currentUserHasSent: true,
                 createdAt: 1700000000,
-                lastMessageContent: 'Stale B',
-                lastMessageTimestamp: 1700000100,
+                lastMessageContent: 'A latest',
+                lastMessageTimestamp: 1700000300,
               ),
             ]),
-          );
-          when(
-            () => mockDirectMessagesDao.getLatestMessagesForConversations(
-              any(),
-              ownerPubkey: any(named: 'ownerPubkey'),
-            ),
-          ).thenAnswer(
-            (_) async => {
-              convA: DirectMessageRow(
-                id: 'rumor-A',
-                conversationId: convA,
-                senderPubkey: _validPubkeyB,
-                content: 'A latest',
-                createdAt: 1700000300,
-                giftWrapId: 'wrap-A',
-                messageKind: EventKind.privateDirectMessage,
-                isDeleted: false,
-              ),
-              convB: DirectMessageRow(
-                id: 'rumor-B',
-                conversationId: convB,
-                senderPubkey: _validPubkeyC,
-                content: 'B latest',
-                createdAt: 1700000900,
-                giftWrapId: 'wrap-B',
-                messageKind: EventKind.privateDirectMessage,
-                isDeleted: false,
-              ),
-            },
           );
 
           final repository = createRepository();
@@ -5629,7 +5575,7 @@ void main() {
 
           expect(
             conversations.map((c) => c.id).toList(),
-            equals([convB, convA]),
+            equals([convA, convB]),
           );
         },
       );
@@ -5656,13 +5602,6 @@ void main() {
             ),
           ]),
         );
-        when(
-          () => mockDirectMessagesDao.getLatestMessagesForConversations(
-            any(),
-            ownerPubkey: any(named: 'ownerPubkey'),
-          ),
-        ).thenAnswer((_) async => const {});
-
         final repository = createRepository();
         final requests = await repository.watchPotentialRequests().first;
 
@@ -8822,6 +8761,45 @@ void main() {
         verify(
           () => mockConversationsDao.backfillCurrentUserHasSent(
             _validPubkeyA,
+          ),
+        ).called(1);
+      });
+    });
+
+    group('_backfillConversationPreviews', () {
+      test('runs during post-auth maintenance', () async {
+        when(
+          () => mockConversationsDao.backfillLatestMessagePreviews(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => 2);
+
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        when(
+          () => mockNostrClient.unsubscribe(any()),
+        ).thenAnswer((_) async {});
+
+        DmRepository(
+          nostrClient: mockNostrClient,
+          directMessagesDao: mockDirectMessagesDao,
+          conversationsDao: mockConversationsDao,
+        ).setCredentials(
+          userPubkey: _validPubkeyA,
+          signer: LocalNostrSigner(_validPrivateKey),
+          messageService: mockMessageService,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verify(
+          () => mockConversationsDao.backfillLatestMessagePreviews(
+            ownerPubkey: _validPubkeyA,
           ),
         ).called(1);
       });

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8795,7 +8795,11 @@ void main() {
           messageService: mockMessageService,
         );
 
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await untilCalled(
+          () => mockConversationsDao.backfillLatestMessagePreviews(
+            ownerPubkey: _validPubkeyA,
+          ),
+        );
 
         verify(
           () => mockConversationsDao.backfillLatestMessagePreviews(


### PR DESCRIPTION
Closes #4416

## Summary
- backfill stale conversation preview columns from direct_messages during post-auth maintenance
- remove the transitional inbox latest-message overlay so conversation rows are the source of truth again
- add a schema-contract test for ConversationsDao upsert conflict handling plus preview backfill coverage

## Verification
- flutter test test/src/database/daos/conversations_dao_test.dart
- flutter test test/src/dm_repository_test.dart
- flutter analyze