### PR TITLE
fix(push): send push control events to Divine relay with relay OK handling

### DIFF
--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -43,6 +43,8 @@ class PushNotificationService {
   /// Number of days until a registration event expires.
   static const pushTokenExpirationDays = 90;
 
+  static const _pushControlPublishTimeout = Duration(seconds: 5);
+
   PushNotificationService({
     required AuthService authService,
     required NostrClient nostrClient,
@@ -221,21 +223,11 @@ class PushNotificationService {
     Event event, {
     NostrClient? publishClient,
   }) async {
-    final published = await (publishClient ?? _nostrClient).publishEvent(event);
-    final failureReason = published.failureReason;
-    if (failureReason != null) {
-      Log.error(
-        'Failed to publish deregistration event: $failureReason',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-    } else {
-      Log.info(
-        'Push notification deregistration published',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-    }
+    await _publishPushControlEvent(
+      event,
+      'deregistration',
+      publishClient: publishClient,
+    );
   }
 
   List<List<String>> _deregistrationTags(String pushServicePubkey) => [
@@ -293,23 +285,7 @@ class PushNotificationService {
     }
     if (!await _isPublishCurrent(null)) return false;
 
-    final published = await _nostrClient.publishEvent(event);
-    final failureReason = published.failureReason;
-    if (failureReason != null) {
-      Log.error(
-        'Failed to publish preferences event: $failureReason',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-      return false;
-    } else {
-      Log.info(
-        'Push notification preferences updated',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
-      return true;
-    }
+    return _publishPushControlEvent(event, 'preferences');
   }
 
   /// Handles a foreground FCM message by displaying a local notification.
@@ -390,21 +366,39 @@ class PushNotificationService {
     }
     if (!await _isPublishCurrent(isCurrent)) return;
 
-    final published = await _nostrClient.publishEvent(event);
-    final failureReason = published.failureReason;
-    if (failureReason != null) {
-      Log.error(
-        'Failed to publish registration event: $failureReason',
+    await _publishPushControlEvent(event, 'registration');
+  }
+
+  Future<bool> _publishPushControlEvent(
+    Event event,
+    String action, {
+    NostrClient? publishClient,
+  }) async {
+    final relayUrl = _environmentConfig.relayUrl;
+    final outcome = await (publishClient ?? _nostrClient).publishEventAwaitOk(
+      event,
+      targetRelays: [relayUrl],
+      timeout: _pushControlPublishTimeout,
+    );
+
+    final outcomeDetails =
+        'eventId=${event.id}, relay=$relayUrl, acceptedBy=${outcome.acceptedBy}, '
+        'rejectedBy=${outcome.rejectedBy}, noResponseFrom=${outcome.noResponseFrom}';
+
+    if (outcome.confirmed) {
+      Log.info(
+        'Push notification $action accepted by relay: $outcomeDetails',
         name: 'PushNotificationService',
         category: LogCategory.system,
       );
     } else {
-      Log.info(
-        'Push notification registration published',
+      Log.error(
+        'Push notification $action not accepted by relay: $outcomeDetails',
         name: 'PushNotificationService',
         category: LogCategory.system,
       );
     }
+    return outcome.confirmed;
   }
 
   Future<Event?> _createAndSignEventWithIdentity(

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -379,6 +379,8 @@ class PushNotificationService {
       event,
       targetRelays: [relayUrl],
       timeout: _pushControlPublishTimeout,
+      // TODO(#4437): Remove rollout-only push-control relay diagnostics.
+      diagnosticTag: 'push-control',
     );
 
     final outcomeDetails =

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -62,6 +62,7 @@ class _FakeRelay extends RelayBase {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     // Only throw on CLOSE messages (not REQ sent by onConnected)
     if (throwOnSend && message.isNotEmpty && message[0] == 'CLOSE') {

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -651,10 +651,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     // Trade-off: no surface-recreate callback (e.g. permission dialogs);
     // acceptable for the feed because the screen is always foregrounded
     // while videos are playing. No effect on iOS/macOS.
-    final controller = DivineVideoPlayerController(
-      useTexture: true,
-      useLegacySurface: true,
-    );
+    final controller = DivineVideoPlayerController(useTexture: true);
     _controllers[index] = controller;
 
     bool ownsInit() {

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -373,9 +373,11 @@ class NostrClient {
       return outcome;
     }
 
+    final hasExplicitTargets = targetRelays != null && targetRelays.isNotEmpty;
+
     if (_relayManager.connectedRelays.isEmpty) {
       await retryDisconnectedRelays();
-      if (_relayManager.connectedRelays.isEmpty) {
+      if (_relayManager.connectedRelays.isEmpty && !hasExplicitTargets) {
         return rollbackOnFailure(
           PublishOutcome(
             eventId: event.id,

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -359,6 +359,7 @@ class NostrClient {
     Event event, {
     List<String>? targetRelays,
     Duration timeout = const Duration(seconds: 15),
+    String? diagnosticTag,
   }) async {
     final useOptimisticCache = _canOptimisticallyCache(event.kind);
 
@@ -390,12 +391,20 @@ class NostrClient {
     }
 
     final outcome =
-        await _nostr.sendEventAwaitOk(
-          event,
-          targetRelays: targetRelays,
-          tempRelays: targetRelays,
-          timeout: timeout,
-        ) ??
+        await (diagnosticTag == null
+            ? _nostr.sendEventAwaitOk(
+                event,
+                targetRelays: targetRelays,
+                tempRelays: targetRelays,
+                timeout: timeout,
+              )
+            : _nostr.sendEventAwaitOk(
+                event,
+                targetRelays: targetRelays,
+                tempRelays: targetRelays,
+                timeout: timeout,
+                diagnosticTag: diagnosticTag,
+              )) ??
         PublishOutcome(
           eventId: event.id,
           acceptedBy: const [],

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -375,9 +375,9 @@ class NostrClient {
 
     final hasExplicitTargets = targetRelays != null && targetRelays.isNotEmpty;
 
-    if (_relayManager.connectedRelays.isEmpty) {
+    if (_relayManager.connectedRelays.isEmpty && !hasExplicitTargets) {
       await retryDisconnectedRelays();
-      if (_relayManager.connectedRelays.isEmpty && !hasExplicitTargets) {
+      if (_relayManager.connectedRelays.isEmpty) {
         return rollbackOnFailure(
           PublishOutcome(
             eventId: event.id,

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -487,6 +487,44 @@ void main() {
       );
 
       test(
+        'attempts explicit target relays even when no pool relay is connected',
+        () async {
+          final event = _createTestEvent();
+          const targetRelays = ['wss://relay.divine.video'];
+          const timeout = Duration(seconds: 5);
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
+          when(
+            () => mockNostr.sendEventAwaitOk(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(event.id));
+
+          final outcome = await client.publishEventAwaitOk(
+            event,
+            targetRelays: targetRelays,
+            timeout: timeout,
+          );
+
+          expect(outcome.confirmed, isTrue);
+          verify(mockRelayManager.retryDisconnectedRelays).called(1);
+          verify(
+            () => mockNostr.sendEventAwaitOk(
+              event,
+              targetRelays: targetRelays,
+              tempRelays: targetRelays,
+              timeout: timeout,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'removes target events from cache after confirmed deletion',
         () async {
           final mockDbClient = _MockAppDbClient();

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -487,7 +487,8 @@ void main() {
       );
 
       test(
-        'attempts explicit target relays even when no pool relay is connected',
+        'attempts explicit target relays without retrying disconnected pool '
+        'relays',
         () async {
           final event = _createTestEvent();
           const targetRelays = ['wss://relay.divine.video'];
@@ -512,7 +513,7 @@ void main() {
           );
 
           expect(outcome.confirmed, isTrue);
-          verify(mockRelayManager.retryDisconnectedRelays).called(1);
+          verifyNever(mockRelayManager.retryDisconnectedRelays);
           verify(
             () => mockNostr.sendEventAwaitOk(
               event,

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -525,6 +525,39 @@ void main() {
         },
       );
 
+      test('forwards caller diagnostic tag to the SDK publish path', () async {
+        final event = _createTestEvent();
+        const targetRelays = ['wss://relay.divine.video'];
+        const timeout = Duration(seconds: 5);
+        when(() => mockRelayManager.connectedRelays).thenReturn([]);
+        when(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
+          ),
+        ).thenAnswer((_) async => accepted(event.id));
+
+        await client.publishEventAwaitOk(
+          event,
+          targetRelays: targetRelays,
+          timeout: timeout,
+          diagnosticTag: 'push-control',
+        );
+
+        verify(
+          () => mockNostr.sendEventAwaitOk(
+            event,
+            targetRelays: targetRelays,
+            tempRelays: targetRelays,
+            timeout: timeout,
+            diagnosticTag: 'push-control',
+          ),
+        ).called(1);
+      });
+
       test(
         'removes target events from cache after confirmed deletion',
         () async {

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -214,6 +214,7 @@ class Nostr {
     List<String>? tempRelays,
     List<String>? targetRelays,
     Duration timeout = const Duration(seconds: 15),
+    String? diagnosticTag,
   }) async {
     if (StringUtil.isBlank(event.sig)) {
       await signEvent(event);
@@ -229,6 +230,7 @@ class Nostr {
       tempRelays: tempRelays,
       targetRelays: targetRelays,
       timeout: timeout,
+      diagnosticTag: diagnosticTag,
     );
   }
 

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -225,6 +225,7 @@ class Nostr {
     return _pool.sendEventAwaitOk(
       ["EVENT", event.toJson()],
       eventId: event.id,
+      eventKind: event.kind,
       tempRelays: tempRelays,
       targetRelays: targetRelays,
       timeout: timeout,

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -20,6 +20,10 @@ class PublishOutcome {
   final String eventId;
 
   /// The event kind that was published, when known.
+  ///
+  /// Set by `RelayPool.sendEventAwaitOk` callers or inferred from the `EVENT`
+  /// message envelope. Null when callers do not provide a kind and it cannot be
+  /// inferred from the message.
   final int? eventKind;
 
   /// Relay URLs that returned `OK true`.
@@ -67,6 +71,7 @@ class PublishTracker {
   PublishTracker({
     required this.eventId,
     this.eventKind,
+    this.diagnosticTag,
     required this.expectedRelays,
     required Duration timeout,
   }) {
@@ -79,8 +84,8 @@ class PublishTracker {
   /// The event kind we are waiting on, when known.
   final int? eventKind;
 
-  bool get isPushControlEvent =>
-      eventKind == 3079 || eventKind == 3080 || eventKind == 3083;
+  /// Caller-supplied tag for temporary publish diagnostics, when enabled.
+  final String? diagnosticTag;
 
   /// Relay URLs we expect responses from.
   final Set<String> expectedRelays;

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 class PublishOutcome {
   const PublishOutcome({
     required this.eventId,
+    this.eventKind,
     required this.acceptedBy,
     required this.rejectedBy,
     required this.noResponseFrom,
@@ -17,6 +18,9 @@ class PublishOutcome {
 
   /// The id of the event that was published.
   final String eventId;
+
+  /// The event kind that was published, when known.
+  final int? eventKind;
 
   /// Relay URLs that returned `OK true`.
   final List<String> acceptedBy;
@@ -62,6 +66,7 @@ class PublishOutcome {
 class PublishTracker {
   PublishTracker({
     required this.eventId,
+    this.eventKind,
     required this.expectedRelays,
     required Duration timeout,
   }) {
@@ -70,6 +75,12 @@ class PublishTracker {
 
   /// The event id we are waiting on.
   final String eventId;
+
+  /// The event kind we are waiting on, when known.
+  final int? eventKind;
+
+  bool get isPushControlEvent =>
+      eventKind == 3079 || eventKind == 3080 || eventKind == 3083;
 
   /// Relay URLs we expect responses from.
   final Set<String> expectedRelays;
@@ -127,6 +138,7 @@ class PublishTracker {
     _completer.complete(
       PublishOutcome(
         eventId: eventId,
+        eventKind: eventKind,
         acceptedBy: _accepted.toList(growable: false),
         rejectedBy: Map<String, String>.unmodifiable(_rejected),
         noResponseFrom: noResponse,
@@ -143,6 +155,7 @@ class PublishTracker {
       _completer.complete(
         PublishOutcome(
           eventId: eventId,
+          eventKind: eventKind,
           acceptedBy: _accepted.toList(growable: false),
           rejectedBy: Map<String, String>.unmodifiable(_rejected),
           noResponseFrom: expectedRelays.toList(growable: false),

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -96,11 +96,16 @@ abstract class Relay {
     info ??= await RelayInfoUtil.get(url);
   }
 
+  /// Sends [message] to this relay.
+  ///
+  /// [deadline] is a hard send deadline: implementations must not write or
+  /// queue the message after it has expired.
   Future<bool> send(
     List<dynamic> message, {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   });
 
   Future<void> disconnect();

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -132,6 +132,7 @@ class RelayBase extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     if (_connectionManager == null) {
       return false;
@@ -148,6 +149,7 @@ class RelayBase extends Relay {
       final result = await _connectionManager!.sendJson(
         sanitizedMessage,
         skipReconnect: skipReconnect,
+        deadline: deadline,
       );
       if (!result && queueIfFailed) {
         pendingMessages.add(message);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart
@@ -101,7 +101,12 @@ class RelayIsolate extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
+    if (deadline != null && !DateTime.now().isBefore(deadline)) {
+      return false;
+    }
+
     if (mainToSubSendPort == null) {
       if (queueIfFailed) {
         pendingMessages.add(message);
@@ -113,6 +118,9 @@ class RelayIsolate extends Relay {
       // Defensive serialization: Ensure all data is JSON-serializable
       final sanitizedMessage = sanitizeForJson(message);
       final encoded = jsonEncode(sanitizedMessage);
+      if (deadline != null && !DateTime.now().isBefore(deadline)) {
+        return false;
+      }
       mainToSubSendPort!.send(encoded);
       return true;
     } catch (e) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -105,6 +105,31 @@ class RelayPool {
   List<MapEntry<String, Relay>> _cacheRelayEntriesSnapshot() =>
       _cacheRelays.entries.toList(growable: false);
 
+  bool _isPushControlKind(int? kind) =>
+      kind == 3079 || kind == 3080 || kind == 3083;
+
+  int? _eventKindFromMessage(List<dynamic> message) {
+    if (message.length < 2 || message[0] != 'EVENT' || message[1] is! Map) {
+      return null;
+    }
+    final kind = (message[1] as Map)['kind'];
+    if (kind is int) return kind;
+    if (kind is num) return kind.toInt();
+    return null;
+  }
+
+  String? _eventIdFromMessage(List<dynamic> message) {
+    if (message.length < 2 || message[0] != 'EVENT' || message[1] is! Map) {
+      return null;
+    }
+    final id = (message[1] as Map)['id'];
+    return id is String ? id : null;
+  }
+
+  void _logPushControlDiagnostic(String message) {
+    log('📲 Push control relay diagnostic: $message');
+  }
+
   Future<bool> add(
     Relay relay, {
     bool autoSubscribe = false,
@@ -394,8 +419,20 @@ class RelayPool {
         if (publishTracker != null) {
           if (success) {
             publishTracker.onAccepted(relay.url);
+            if (publishTracker.isPushControlEvent) {
+              _logPushControlDiagnostic(
+                'OK accepted kind=${publishTracker.eventKind} '
+                'eventId=$eventId relay=${relay.url}',
+              );
+            }
           } else {
             publishTracker.onRejected(relay.url, message);
+            if (publishTracker.isPushControlEvent) {
+              _logPushControlDiagnostic(
+                'OK rejected kind=${publishTracker.eventKind} '
+                'eventId=$eventId relay=${relay.url} reason=$message',
+              );
+            }
           }
         }
 
@@ -896,10 +933,26 @@ class RelayPool {
     List<String>? targetRelays,
   }) async {
     final sentTo = <String>[];
+    final eventKind = _eventKindFromMessage(message);
+    final eventId = _eventIdFromMessage(message);
+    final isPushControlEvent = _isPushControlKind(eventKind);
+
+    if (isPushControlEvent) {
+      _logPushControlDiagnostic(
+        'send start kind=$eventKind eventId=$eventId '
+        'targetRelays=$targetRelays tempRelays=$tempRelays',
+      );
+    }
 
     for (final relay in _relaysSnapshot()) {
       if (message[0] == "EVENT") {
         if (!relay.relayStatus.writeAccess) {
+          if (isPushControlEvent) {
+            _logPushControlDiagnostic(
+              'send skipped kind=$eventKind eventId=$eventId relay=${relay.url} '
+              'reason=writeAccessDisabled',
+            );
+          }
           continue;
         }
       }
@@ -944,11 +997,22 @@ class RelayPool {
             if (result) {
               sentTo.add(relay.url);
             }
+            if (isPushControlEvent) {
+              _logPushControlDiagnostic(
+                'auth-trigger send kind=$eventKind eventId=$eventId '
+                'relay=${relay.url} sent=$result',
+              );
+            }
             // Don't queue this message since we're sending it
           } else {
             log('🔐 Queueing message for authentication: ${message[0]}');
             relay.pendingAuthedMessages.add(message);
             sentTo.add(relay.url);
+            if (isPushControlEvent) {
+              _logPushControlDiagnostic(
+                'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
+              );
+            }
           }
           log(
             '🔐 Pending authed messages count: ${relay.pendingAuthedMessages.length}',
@@ -977,8 +1041,18 @@ class RelayPool {
           if (result) {
             sentTo.add(relay.url);
           }
+          if (isPushControlEvent) {
+            _logPushControlDiagnostic(
+              'send kind=$eventKind eventId=$eventId relay=${relay.url} sent=$result',
+            );
+          }
         }
       } catch (err) {
+        if (isPushControlEvent) {
+          _logPushControlDiagnostic(
+            'send error kind=$eventKind eventId=$eventId relay=${relay.url} error=$err',
+          );
+        }
         log(err.toString());
         relay.relayStatus.onError();
       }
@@ -1005,7 +1079,18 @@ class RelayPool {
         if (result) {
           sentTo.add(tempRelay.url);
         }
+        if (isPushControlEvent) {
+          _logPushControlDiagnostic(
+            'temp send kind=$eventKind eventId=$eventId relay=${tempRelay.url} sent=$result',
+          );
+        }
       }
+    }
+
+    if (isPushControlEvent) {
+      _logPushControlDiagnostic(
+        'send complete kind=$eventKind eventId=$eventId sentTo=$sentTo',
+      );
     }
 
     return sentTo;
@@ -1026,6 +1111,7 @@ class RelayPool {
   Future<PublishOutcome> sendEventAwaitOk(
     List<dynamic> message, {
     required String eventId,
+    int? eventKind,
     List<String>? tempRelays,
     List<String>? targetRelays,
     Duration timeout = const Duration(seconds: 15),
@@ -1038,6 +1124,7 @@ class RelayPool {
     }
     final tracker = PublishTracker(
       eventId: eventId,
+      eventKind: eventKind ?? _eventKindFromMessage(message),
       expectedRelays: <String>{},
       timeout: timeout,
     );
@@ -1055,7 +1142,17 @@ class RelayPool {
     }
 
     unawaited(
-      tracker.future.whenComplete(() => _pendingPublishes.remove(eventId)),
+      tracker.future
+          .then((outcome) {
+            if (tracker.isPushControlEvent) {
+              _logPushControlDiagnostic(
+                'OK outcome kind=${tracker.eventKind} eventId=$eventId '
+                'acceptedBy=${outcome.acceptedBy} rejectedBy=${outcome.rejectedBy} '
+                'noResponseFrom=${outcome.noResponseFrom}',
+              );
+            }
+          })
+          .whenComplete(() => _pendingPublishes.remove(eventId)),
     );
     return tracker.future;
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1011,6 +1011,7 @@ class RelayPool {
             // the AUTH handshake requires a real send. Per-relay timeout
             // still applies so a stuck auth-trigger send cannot block the
             // rest of the fan-out.
+            var timedOut = false;
             var result = await relay
                 .send(
                   message,
@@ -1021,6 +1022,7 @@ class RelayPool {
                 .timeout(
                   timeout,
                   onTimeout: () {
+                    timedOut = true;
                     log(
                       '⏱️ Per-relay auth-trigger send timeout for ${relay.url} '
                       '(connected=${relay.relayStatus.connected}, '
@@ -1029,9 +1031,11 @@ class RelayPool {
                     return false;
                   },
                 );
+            if (result || timedOut || deadlineExpired()) {
+              attemptedRelayUrls.add(relay.url);
+            }
             if (result) {
               sentTo.add(relay.url);
-              attemptedRelayUrls.add(relay.url);
               onSent?.call(relay.url);
             }
             logDiagnostic(
@@ -1069,6 +1073,7 @@ class RelayPool {
           // while one dead relay tries exponential backoff (can hang the
           // publish for many minutes). Same convention as relayDoQuery /
           // relayDoSubscribe above.
+          var timedOut = false;
           var result = await relay
               .send(
                 message,
@@ -1079,6 +1084,7 @@ class RelayPool {
               .timeout(
                 timeout,
                 onTimeout: () {
+                  timedOut = true;
                   log(
                     '⏱️ Per-relay send timeout for ${relay.url} '
                     '(connected=${relay.relayStatus.connected}, '
@@ -1087,9 +1093,11 @@ class RelayPool {
                   return false;
                 },
               );
+          if (result || timedOut || deadlineExpired()) {
+            attemptedRelayUrls.add(relay.url);
+          }
           if (result) {
             sentTo.add(relay.url);
-            attemptedRelayUrls.add(relay.url);
             onSent?.call(relay.url);
           }
           logDiagnostic(

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -17,6 +17,7 @@ import 'client_connected.dart';
 import 'event_filter.dart';
 import 'publish_outcome.dart';
 import 'relay.dart';
+import 'relay_base.dart';
 import 'relay_type.dart';
 
 class RelayPool {
@@ -1230,6 +1231,12 @@ class RelayPool {
 
   Relay checkAndGenTempRelay(String addr) {
     var tempRelay = _tempRelays[addr];
+    if (tempRelay != null && _shouldReplaceTempRelay(tempRelay)) {
+      _tempRelays.remove(addr);
+      unawaited(tempRelay.disconnect());
+      tempRelay.dispose();
+      tempRelay = null;
+    }
     if (tempRelay == null) {
       tempRelay = tempRelayGener(addr);
       tempRelay.onMessage = _onEvent;
@@ -1238,6 +1245,15 @@ class RelayPool {
     }
 
     return tempRelay;
+  }
+
+  bool _shouldReplaceTempRelay(Relay relay) {
+    if (relay.relayStatus.connected == ClientConnected.disconnect) {
+      return true;
+    }
+    return relay.relayStatus.connected == ClientConnected.connected &&
+        relay is RelayBase &&
+        !relay.checkHealth();
   }
 
   List<String> getExtralReadableRelays(

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -931,11 +931,25 @@ class RelayPool {
     List<dynamic> message, {
     List<String>? tempRelays,
     List<String>? targetRelays,
+    DateTime? deadline,
+    void Function(String relayUrl)? onSent,
   }) async {
     final sentTo = <String>[];
+    final attemptedRelayUrls = <String>{};
     final eventKind = _eventKindFromMessage(message);
     final eventId = _eventIdFromMessage(message);
     final isPushControlEvent = _isPushControlKind(eventKind);
+
+    Duration sendTimeout() {
+      final remaining = deadline?.difference(DateTime.now());
+      if (remaining == null || remaining > perRelaySendTimeout) {
+        return perRelaySendTimeout;
+      }
+      if (remaining.isNegative || remaining == Duration.zero) {
+        return Duration.zero;
+      }
+      return remaining;
+    }
 
     if (isPushControlEvent) {
       _logPushControlDiagnostic(
@@ -945,6 +959,9 @@ class RelayPool {
     }
 
     for (final relay in _relaysSnapshot()) {
+      final timeout = sendTimeout();
+      if (timeout == Duration.zero) break;
+
       if (message[0] == "EVENT") {
         if (!relay.relayStatus.writeAccess) {
           if (isPushControlEvent) {
@@ -963,6 +980,8 @@ class RelayPool {
           continue;
         }
       }
+
+      attemptedRelayUrls.add(relay.url);
 
       try {
         // Check if relay requires authentication
@@ -984,7 +1003,7 @@ class RelayPool {
             var result = await relay
                 .send(message, forceSend: true)
                 .timeout(
-                  perRelaySendTimeout,
+                  timeout,
                   onTimeout: () {
                     log(
                       '⏱️ Per-relay auth-trigger send timeout for ${relay.url} '
@@ -996,6 +1015,7 @@ class RelayPool {
                 );
             if (result) {
               sentTo.add(relay.url);
+              onSent?.call(relay.url);
             }
             if (isPushControlEvent) {
               _logPushControlDiagnostic(
@@ -1008,6 +1028,7 @@ class RelayPool {
             log('🔐 Queueing message for authentication: ${message[0]}');
             relay.pendingAuthedMessages.add(message);
             sentTo.add(relay.url);
+            onSent?.call(relay.url);
             if (isPushControlEvent) {
               _logPushControlDiagnostic(
                 'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
@@ -1028,7 +1049,7 @@ class RelayPool {
           var result = await relay
               .send(message, skipReconnect: true)
               .timeout(
-                perRelaySendTimeout,
+                timeout,
                 onTimeout: () {
                   log(
                     '⏱️ Per-relay send timeout for ${relay.url} '
@@ -1040,6 +1061,7 @@ class RelayPool {
               );
           if (result) {
             sentTo.add(relay.url);
+            onSent?.call(relay.url);
           }
           if (isPushControlEvent) {
             _logPushControlDiagnostic(
@@ -1060,6 +1082,13 @@ class RelayPool {
 
     if (tempRelays != null) {
       for (var tempRelayAddr in tempRelays) {
+        if (attemptedRelayUrls.contains(tempRelayAddr)) {
+          continue;
+        }
+        attemptedRelayUrls.add(tempRelayAddr);
+        final timeout = sendTimeout();
+        if (timeout == Duration.zero) break;
+
         var tempRelay = checkAndGenTempRelay(tempRelayAddr);
         // Same skipReconnect rationale as the main loop above: a fresh
         // tempRelay whose initial connection is still in-flight must not
@@ -1067,7 +1096,7 @@ class RelayPool {
         var result = await tempRelay
             .send(message, skipReconnect: true)
             .timeout(
-              perRelaySendTimeout,
+              timeout,
               onTimeout: () {
                 log(
                   '⏱️ Per-relay send timeout for tempRelay ${tempRelay.url} '
@@ -1078,6 +1107,7 @@ class RelayPool {
             );
         if (result) {
           sentTo.add(tempRelay.url);
+          onSent?.call(tempRelay.url);
         }
         if (isPushControlEvent) {
           _logPushControlDiagnostic(
@@ -1134,8 +1164,9 @@ class RelayPool {
       message,
       tempRelays: tempRelays,
       targetRelays: targetRelays,
+      deadline: DateTime.now().add(timeout),
+      onSent: (relayUrl) => tracker.expectedRelays.add(relayUrl),
     );
-    tracker.expectedRelays.addAll(sentTo);
 
     if (sentTo.isEmpty) {
       tracker.cancel();

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -951,6 +951,16 @@ class RelayPool {
       return remaining;
     }
 
+    bool deadlineExpired() {
+      return deadline != null && !DateTime.now().isBefore(deadline);
+    }
+
+    void removeExpiredTempRelay(Relay relay) {
+      if (!deadlineExpired()) return;
+      unawaited(relay.disconnect());
+      removeTempRelay(relay.url);
+    }
+
     if (isPushControlEvent) {
       _logPushControlDiagnostic(
         'send start kind=$eventKind eventId=$eventId '
@@ -999,7 +1009,12 @@ class RelayPool {
             // still applies so a stuck auth-trigger send cannot block the
             // rest of the fan-out.
             var result = await relay
-                .send(message, forceSend: true)
+                .send(
+                  message,
+                  forceSend: true,
+                  queueIfFailed: deadline == null,
+                  deadline: deadline,
+                )
                 .timeout(
                   timeout,
                   onTimeout: () {
@@ -1024,14 +1039,21 @@ class RelayPool {
             }
             // Don't queue this message since we're sending it
           } else {
-            log('🔐 Queueing message for authentication: ${message[0]}');
-            relay.pendingAuthedMessages.add(message);
-            sentTo.add(relay.url);
-            attemptedRelayUrls.add(relay.url);
-            onSent?.call(relay.url);
-            if (isPushControlEvent) {
+            if (deadline == null) {
+              log('🔐 Queueing message for authentication: ${message[0]}');
+              relay.pendingAuthedMessages.add(message);
+              sentTo.add(relay.url);
+              attemptedRelayUrls.add(relay.url);
+              onSent?.call(relay.url);
+              if (isPushControlEvent) {
+                _logPushControlDiagnostic(
+                  'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
+                );
+              }
+            } else if (isPushControlEvent) {
               _logPushControlDiagnostic(
-                'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
+                'auth queue skipped kind=$eventKind eventId=$eventId relay=${relay.url} '
+                'reason=deadlineBoundSend',
               );
             }
           }
@@ -1047,7 +1069,12 @@ class RelayPool {
           // publish for many minutes). Same convention as relayDoQuery /
           // relayDoSubscribe above.
           var result = await relay
-              .send(message, skipReconnect: true)
+              .send(
+                message,
+                skipReconnect: true,
+                queueIfFailed: deadline == null,
+                deadline: deadline,
+              )
               .timeout(
                 timeout,
                 onTimeout: () {
@@ -1095,7 +1122,12 @@ class RelayPool {
         // tempRelay whose initial connection is still in-flight must not
         // block the publish.
         var result = await tempRelay
-            .send(message, skipReconnect: true)
+            .send(
+              message,
+              skipReconnect: true,
+              queueIfFailed: false,
+              deadline: deadline,
+            )
             .timeout(
               timeout,
               onTimeout: () {
@@ -1103,9 +1135,13 @@ class RelayPool {
                   '⏱️ Per-relay send timeout for tempRelay ${tempRelay.url} '
                   '(connected=${tempRelay.relayStatus.connected})',
                 );
+                removeExpiredTempRelay(tempRelay);
                 return false;
               },
             );
+        if (!result) {
+          removeExpiredTempRelay(tempRelay);
+        }
         if (result) {
           sentTo.add(tempRelay.url);
           onSent?.call(tempRelay.url);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -105,9 +105,6 @@ class RelayPool {
   List<MapEntry<String, Relay>> _cacheRelayEntriesSnapshot() =>
       _cacheRelays.entries.toList(growable: false);
 
-  bool _isPushControlKind(int? kind) =>
-      kind == 3079 || kind == 3080 || kind == 3083;
-
   int? _eventKindFromMessage(List<dynamic> message) {
     if (message.length < 2 || message[0] != 'EVENT' || message[1] is! Map) {
       return null;
@@ -126,8 +123,8 @@ class RelayPool {
     return id is String ? id : null;
   }
 
-  void _logPushControlDiagnostic(String message) {
-    log('📲 Push control relay diagnostic: $message');
+  void _logPublishDiagnostic(String diagnosticTag, String message) {
+    log('$diagnosticTag relay diagnostic: $message');
   }
 
   Future<bool> add(
@@ -419,16 +416,20 @@ class RelayPool {
         if (publishTracker != null) {
           if (success) {
             publishTracker.onAccepted(relay.url);
-            if (publishTracker.isPushControlEvent) {
-              _logPushControlDiagnostic(
+            final diagnosticTag = publishTracker.diagnosticTag;
+            if (diagnosticTag != null) {
+              _logPublishDiagnostic(
+                diagnosticTag,
                 'OK accepted kind=${publishTracker.eventKind} '
                 'eventId=$eventId relay=${relay.url}',
               );
             }
           } else {
             publishTracker.onRejected(relay.url, message);
-            if (publishTracker.isPushControlEvent) {
-              _logPushControlDiagnostic(
+            final diagnosticTag = publishTracker.diagnosticTag;
+            if (diagnosticTag != null) {
+              _logPublishDiagnostic(
+                diagnosticTag,
                 'OK rejected kind=${publishTracker.eventKind} '
                 'eventId=$eventId relay=${relay.url} reason=$message',
               );
@@ -932,13 +933,18 @@ class RelayPool {
     List<String>? tempRelays,
     List<String>? targetRelays,
     DateTime? deadline,
+    String? diagnosticTag,
     void Function(String relayUrl)? onSent,
   }) async {
     final sentTo = <String>[];
     final attemptedRelayUrls = <String>{};
     final eventKind = _eventKindFromMessage(message);
     final eventId = _eventIdFromMessage(message);
-    final isPushControlEvent = _isPushControlKind(eventKind);
+
+    void logDiagnostic(String message) {
+      if (diagnosticTag == null) return;
+      _logPublishDiagnostic(diagnosticTag, message);
+    }
 
     Duration sendTimeout() {
       final remaining = deadline?.difference(DateTime.now());
@@ -961,12 +967,10 @@ class RelayPool {
       removeTempRelay(relay.url);
     }
 
-    if (isPushControlEvent) {
-      _logPushControlDiagnostic(
-        'send start kind=$eventKind eventId=$eventId '
-        'targetRelays=$targetRelays tempRelays=$tempRelays',
-      );
-    }
+    logDiagnostic(
+      'send start kind=$eventKind eventId=$eventId '
+      'targetRelays=$targetRelays tempRelays=$tempRelays',
+    );
 
     for (final relay in _relaysSnapshot()) {
       final timeout = sendTimeout();
@@ -974,12 +978,10 @@ class RelayPool {
 
       if (message[0] == "EVENT") {
         if (!relay.relayStatus.writeAccess) {
-          if (isPushControlEvent) {
-            _logPushControlDiagnostic(
-              'send skipped kind=$eventKind eventId=$eventId relay=${relay.url} '
-              'reason=writeAccessDisabled',
-            );
-          }
+          logDiagnostic(
+            'send skipped kind=$eventKind eventId=$eventId relay=${relay.url} '
+            'reason=writeAccessDisabled',
+          );
           continue;
         }
       }
@@ -1031,27 +1033,25 @@ class RelayPool {
               attemptedRelayUrls.add(relay.url);
               onSent?.call(relay.url);
             }
-            if (isPushControlEvent) {
-              _logPushControlDiagnostic(
-                'auth-trigger send kind=$eventKind eventId=$eventId '
-                'relay=${relay.url} sent=$result',
-              );
-            }
+            logDiagnostic(
+              'auth-trigger send kind=$eventKind eventId=$eventId '
+              'relay=${relay.url} sent=$result',
+            );
             // Don't queue this message since we're sending it
           } else {
+            // Deadline-bound sends intentionally do not queue for AUTH: a queued
+            // frame could publish after the caller already returned failure.
             if (deadline == null) {
               log('🔐 Queueing message for authentication: ${message[0]}');
               relay.pendingAuthedMessages.add(message);
               sentTo.add(relay.url);
               attemptedRelayUrls.add(relay.url);
               onSent?.call(relay.url);
-              if (isPushControlEvent) {
-                _logPushControlDiagnostic(
-                  'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
-                );
-              }
-            } else if (isPushControlEvent) {
-              _logPushControlDiagnostic(
+              logDiagnostic(
+                'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
+              );
+            } else {
+              logDiagnostic(
                 'auth queue skipped kind=$eventKind eventId=$eventId relay=${relay.url} '
                 'reason=deadlineBoundSend',
               );
@@ -1091,18 +1091,14 @@ class RelayPool {
             attemptedRelayUrls.add(relay.url);
             onSent?.call(relay.url);
           }
-          if (isPushControlEvent) {
-            _logPushControlDiagnostic(
-              'send kind=$eventKind eventId=$eventId relay=${relay.url} sent=$result',
-            );
-          }
-        }
-      } catch (err) {
-        if (isPushControlEvent) {
-          _logPushControlDiagnostic(
-            'send error kind=$eventKind eventId=$eventId relay=${relay.url} error=$err',
+          logDiagnostic(
+            'send kind=$eventKind eventId=$eventId relay=${relay.url} sent=$result',
           );
         }
+      } catch (err) {
+        logDiagnostic(
+          'send error kind=$eventKind eventId=$eventId relay=${relay.url} error=$err',
+        );
         log(err.toString());
         relay.relayStatus.onError();
       }
@@ -1146,19 +1142,15 @@ class RelayPool {
           sentTo.add(tempRelay.url);
           onSent?.call(tempRelay.url);
         }
-        if (isPushControlEvent) {
-          _logPushControlDiagnostic(
-            'temp send kind=$eventKind eventId=$eventId relay=${tempRelay.url} sent=$result',
-          );
-        }
+        logDiagnostic(
+          'temp send kind=$eventKind eventId=$eventId relay=${tempRelay.url} sent=$result',
+        );
       }
     }
 
-    if (isPushControlEvent) {
-      _logPushControlDiagnostic(
-        'send complete kind=$eventKind eventId=$eventId sentTo=$sentTo',
-      );
-    }
+    logDiagnostic(
+      'send complete kind=$eventKind eventId=$eventId sentTo=$sentTo',
+    );
 
     return sentTo;
   }
@@ -1182,6 +1174,7 @@ class RelayPool {
     List<String>? tempRelays,
     List<String>? targetRelays,
     Duration timeout = const Duration(seconds: 15),
+    String? diagnosticTag,
   }) async {
     // Register tracker BEFORE sending so a fast relay can't respond with OK
     // before we start listening.
@@ -1192,6 +1185,7 @@ class RelayPool {
     final tracker = PublishTracker(
       eventId: eventId,
       eventKind: eventKind ?? _eventKindFromMessage(message),
+      diagnosticTag: diagnosticTag,
       expectedRelays: <String>{},
       timeout: timeout,
     );
@@ -1202,6 +1196,7 @@ class RelayPool {
       tempRelays: tempRelays,
       targetRelays: targetRelays,
       deadline: DateTime.now().add(timeout),
+      diagnosticTag: diagnosticTag,
       onSent: (relayUrl) => tracker.expectedRelays.add(relayUrl),
     );
 
@@ -1212,8 +1207,10 @@ class RelayPool {
     unawaited(
       tracker.future
           .then((outcome) {
-            if (tracker.isPushControlEvent) {
-              _logPushControlDiagnostic(
+            final diagnosticTag = tracker.diagnosticTag;
+            if (diagnosticTag != null) {
+              _logPublishDiagnostic(
+                diagnosticTag,
                 'OK outcome kind=${tracker.eventKind} eventId=$eventId '
                 'acceptedBy=${outcome.acceptedBy} rejectedBy=${outcome.rejectedBy} '
                 'noResponseFrom=${outcome.noResponseFrom}',

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -981,8 +981,6 @@ class RelayPool {
         }
       }
 
-      attemptedRelayUrls.add(relay.url);
-
       try {
         // Check if relay requires authentication
         if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
@@ -1015,6 +1013,7 @@ class RelayPool {
                 );
             if (result) {
               sentTo.add(relay.url);
+              attemptedRelayUrls.add(relay.url);
               onSent?.call(relay.url);
             }
             if (isPushControlEvent) {
@@ -1028,6 +1027,7 @@ class RelayPool {
             log('🔐 Queueing message for authentication: ${message[0]}');
             relay.pendingAuthedMessages.add(message);
             sentTo.add(relay.url);
+            attemptedRelayUrls.add(relay.url);
             onSent?.call(relay.url);
             if (isPushControlEvent) {
               _logPushControlDiagnostic(
@@ -1061,6 +1061,7 @@ class RelayPool {
               );
           if (result) {
             sentTo.add(relay.url);
+            attemptedRelayUrls.add(relay.url);
             onSent?.call(relay.url);
           }
           if (isPushControlEvent) {

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -311,7 +311,13 @@ class WebSocketConnectionManager {
   /// is true). Set [skipReconnect] to true for query fan-out paths where
   /// blocking on reconnection would delay all other relay queries.
   /// Returns true if message was sent, false if send failed.
-  Future<bool> send(String message, {bool skipReconnect = false}) async {
+  Future<bool> send(
+    String message, {
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    if (_deadlineExpired(deadline)) return false;
+
     // Try to reconnect if disconnected
     if (_state == ConnectionState.disconnected) {
       if (skipReconnect) {
@@ -319,7 +325,8 @@ class WebSocketConnectionManager {
         return false;
       }
       log('Disconnected, attempting reconnect before send');
-      final connected = await _tryReconnect();
+      final connected = await _tryReconnect(deadline: deadline);
+      if (_deadlineExpired(deadline)) return false;
       if (!connected) {
         log('Reconnect failed, cannot send');
         return false;
@@ -329,14 +336,20 @@ class WebSocketConnectionManager {
     // Wait if currently connecting
     if (_state == ConnectionState.connecting) {
       log('Connecting, waiting before send');
-      final connected = await _waitForConnection();
+      final connected = await _waitForConnection(deadline: deadline);
+      if (_deadlineExpired(deadline)) return false;
       if (!connected) {
         log('Connection failed, cannot send');
         return false;
       }
     }
 
+    if (_deadlineExpired(deadline)) return false;
     return _doSend(message);
+  }
+
+  bool _deadlineExpired(DateTime? deadline) {
+    return deadline != null && !DateTime.now().isBefore(deadline);
   }
 
   /// Send a message synchronously (no reconnection attempt).
@@ -358,10 +371,15 @@ class WebSocketConnectionManager {
   }
 
   /// Send a JSON-encodable message asynchronously (with reconnection)
-  Future<bool> sendJson(dynamic data, {bool skipReconnect = false}) async {
+  Future<bool> sendJson(
+    dynamic data, {
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
     try {
+      if (_deadlineExpired(deadline)) return false;
       final encoded = jsonEncode(data);
-      return send(encoded, skipReconnect: skipReconnect);
+      return send(encoded, skipReconnect: skipReconnect, deadline: deadline);
     } catch (e) {
       log('JSON encode error: $e');
       _errorController.add('JSON encode error: $e');
@@ -373,8 +391,9 @@ class WebSocketConnectionManager {
 
   // --- Reconnection ---
 
-  Future<bool> _tryReconnect() async {
+  Future<bool> _tryReconnect({DateTime? deadline}) async {
     while (_shouldReconnect && _state == ConnectionState.disconnected) {
+      if (_deadlineExpired(deadline)) return false;
       if (_reconnectAttempts >= config.maxReconnectAttempts) {
         log('Max reconnect attempts reached for $url');
         _errorController.add('Max reconnect attempts reached');
@@ -393,9 +412,11 @@ class WebSocketConnectionManager {
         'Reconnecting in ${delay.inSeconds}s (attempt $_reconnectAttempts/${config.maxReconnectAttempts})',
       );
 
-      await Future<void>.delayed(delay);
+      final wait = _remainingOr(delay, deadline);
+      if (wait == Duration.zero) return false;
+      await Future<void>.delayed(wait);
 
-      if (!_shouldReconnect) return false;
+      if (!_shouldReconnect || _deadlineExpired(deadline)) return false;
 
       final connected = await _doConnect();
       if (connected) return true;
@@ -404,7 +425,20 @@ class WebSocketConnectionManager {
     return _state == ConnectionState.connected;
   }
 
-  Future<bool> _waitForConnection() async {
+  Duration _remainingOr(Duration fallback, DateTime? deadline) {
+    if (deadline == null) return fallback;
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining.isNegative || remaining == Duration.zero) {
+      return Duration.zero;
+    }
+    if (remaining < fallback) return remaining;
+    return fallback;
+  }
+
+  Future<bool> _waitForConnection({DateTime? deadline}) async {
+    final waitTimeout = _connectionWaitTimeout(deadline);
+    if (waitTimeout == Duration.zero) return false;
+
     // Wait up to connectionTimeout for connection to complete
     final completer = Completer<bool>();
     StreamSubscription<ConnectionState>? sub;
@@ -426,7 +460,7 @@ class WebSocketConnectionManager {
     }
 
     final result = await completer.future.timeout(
-      config.connectionTimeout,
+      waitTimeout,
       onTimeout: () {
         sub?.cancel();
         return false;
@@ -434,6 +468,16 @@ class WebSocketConnectionManager {
     );
 
     return result;
+  }
+
+  Duration _connectionWaitTimeout(DateTime? deadline) {
+    if (deadline == null) return config.connectionTimeout;
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining.isNegative || remaining == Duration.zero) {
+      return Duration.zero;
+    }
+    if (remaining < config.connectionTimeout) return remaining;
+    return config.connectionTimeout;
   }
 
   /// Reset reconnection state, allowing fresh attempts

--- a/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
@@ -66,6 +66,7 @@ class _MockRelay extends RelayBase {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
 

--- a/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
@@ -18,6 +18,7 @@ class MockRelay extends RelayBase {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
 

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -86,5 +86,50 @@ void main() {
         expect(outcome.noResponseFrom, equals(['wss://only.example']));
       });
     });
+
+    group('push control diagnostics metadata', () {
+      test(
+        'marks push registration, deregistration, and preferences kinds',
+        () {
+          for (final kind in [3079, 3080, 3083]) {
+            final tracker = PublishTracker(
+              eventId: 'push-control-$kind',
+              eventKind: kind,
+              expectedRelays: {'wss://relay.divine.video'},
+              timeout: const Duration(seconds: 30),
+            );
+
+            expect(tracker.isPushControlEvent, isTrue);
+            tracker.cancel();
+          }
+        },
+      );
+
+      test('does not mark unrelated event kinds as push control events', () {
+        final tracker = PublishTracker(
+          eventId: 'note-1',
+          eventKind: 1,
+          expectedRelays: {'wss://relay.divine.video'},
+          timeout: const Duration(seconds: 30),
+        );
+
+        expect(tracker.isPushControlEvent, isFalse);
+        tracker.cancel();
+      });
+
+      test('propagates event kind to publish outcome', () async {
+        final tracker = PublishTracker(
+          eventId: 'push-control-accepted',
+          eventKind: 3079,
+          expectedRelays: {'wss://relay.divine.video'},
+          timeout: const Duration(seconds: 30),
+        );
+
+        tracker.onAccepted('wss://relay.divine.video');
+        final outcome = await tracker.future;
+
+        expect(outcome.eventKind, equals(3079));
+      });
+    });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/publish_outcome_test.dart
@@ -87,40 +87,24 @@ void main() {
       });
     });
 
-    group('push control diagnostics metadata', () {
-      test(
-        'marks push registration, deregistration, and preferences kinds',
-        () {
-          for (final kind in [3079, 3080, 3083]) {
-            final tracker = PublishTracker(
-              eventId: 'push-control-$kind',
-              eventKind: kind,
-              expectedRelays: {'wss://relay.divine.video'},
-              timeout: const Duration(seconds: 30),
-            );
-
-            expect(tracker.isPushControlEvent, isTrue);
-            tracker.cancel();
-          }
-        },
-      );
-
-      test('does not mark unrelated event kinds as push control events', () {
+    group('publish diagnostics metadata', () {
+      test('keeps diagnostic tag caller-supplied and domain-neutral', () {
         final tracker = PublishTracker(
           eventId: 'note-1',
           eventKind: 1,
+          diagnosticTag: 'rollout-diagnostic',
           expectedRelays: {'wss://relay.divine.video'},
           timeout: const Duration(seconds: 30),
         );
 
-        expect(tracker.isPushControlEvent, isFalse);
+        expect(tracker.diagnosticTag, equals('rollout-diagnostic'));
         tracker.cancel();
       });
 
       test('propagates event kind to publish outcome', () async {
         final tracker = PublishTracker(
-          eventId: 'push-control-accepted',
-          eventKind: 3079,
+          eventId: 'accepted-event',
+          eventKind: 1,
           expectedRelays: {'wss://relay.divine.video'},
           timeout: const Duration(seconds: 30),
         );
@@ -128,7 +112,7 @@ void main() {
         tracker.onAccepted('wss://relay.divine.video');
         final outcome = await tracker.future;
 
-        expect(outcome.eventKind, equals(3079));
+        expect(outcome.eventKind, equals(1));
       });
     });
   });

--- a/mobile/packages/nostr_sdk/test/unit/relay_count_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_count_test.dart
@@ -20,6 +20,7 @@ class TestRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async => true;
 }
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -57,6 +57,7 @@ class _AuthFakeRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
     return true;

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Regression tests for RelayPool concurrent modification hazards.
 // ABOUTME: Ensures autoSubscribe tolerates subscription changes during resend.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
@@ -30,6 +32,7 @@ class _MutatingRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
 
@@ -65,6 +68,7 @@ class _SucceedingRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
     // Simulate EOSE after a short delay so saveQuery runs first
@@ -105,6 +109,7 @@ class _CountRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
     if (message.isNotEmpty && message.first == 'COUNT') {
@@ -147,6 +152,7 @@ class _FailingSendRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
     return false; // Always fail
@@ -187,6 +193,7 @@ class _StallingReconnectRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
     if (skipReconnect) {
@@ -229,11 +236,51 @@ class _AlwaysHangingRelay extends Relay {
     bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
+    DateTime? deadline,
   }) async {
     sentMessages.add(message);
     // Hang far longer than any reasonable per-relay timeout. The pool's
     // `.timeout(...)` wrap must surface this as `false` and move on.
     await Future<void>.delayed(const Duration(minutes: 1));
+    return true;
+  }
+}
+
+class _DeferredSendRelay extends Relay {
+  _DeferredSendRelay(String url) : super(url, RelayStatus(url));
+
+  final releaseSend = Completer<void>();
+  final List<List<dynamic>> sentMessages = [];
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    await releaseSend.future;
+
+    if (deadline != null && !DateTime.now().isBefore(deadline)) {
+      if (queueIfFailed) {
+        pendingMessages.add(message);
+      }
+      return false;
+    }
+
+    sentMessages.add(message);
     return true;
   }
 }
@@ -527,6 +574,43 @@ void main() {
         reason: 'a failed normal send should not suppress temp relay fallback',
       );
     });
+
+    test(
+      'sendEventAwaitOk does not write or queue an event after the deadline',
+      () async {
+        final relayUrl = 'wss://relay.divine.video';
+        final deferred = _DeferredSendRelay(relayUrl);
+        await nostr.relayPool.add(deferred);
+
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': 'push-control-event-id', 'kind': 3079},
+          ],
+          eventId: 'push-control-event-id',
+          eventKind: 3079,
+          targetRelays: [relayUrl],
+          timeout: const Duration(milliseconds: 10),
+        );
+
+        expect(outcome.failed, isTrue);
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        deferred.releaseSend.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          deferred.sentMessages,
+          isEmpty,
+          reason: 'the EVENT must not be written after the publish deadline',
+        );
+        expect(
+          deferred.pendingMessages,
+          isEmpty,
+          reason: 'deadline-bound await-OK sends must not queue stale EVENTs',
+        );
+      },
+    );
 
     test(
       'RelayPool.perRelaySendTimeout is exposed as a stable public contract',

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -297,6 +297,38 @@ class _TrackingTempRelay extends _SucceedingRelay {
   }
 }
 
+class _ConnectionAwareTempRelay extends Relay {
+  _ConnectionAwareTempRelay(String url, {required this.onCreated})
+    : super(url, RelayStatus(url));
+
+  final void Function(_ConnectionAwareTempRelay relay) onCreated;
+  final List<List<dynamic>> sentMessages = [];
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    onCreated(this);
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    sentMessages.add(message);
+    return relayStatus.connected == ClientConnected.connected;
+  }
+}
+
 void main() {
   group('RelayPool concurrency', () {
     late Nostr nostr;
@@ -573,6 +605,49 @@ void main() {
         contains(relayUrl),
         reason: 'a failed normal send should not suppress temp relay fallback',
       );
+    });
+
+    test('sendEventAwaitOk recreates a disconnected cached temp relay before '
+        'deadline-bound fallback send', () async {
+      final relayUrl = 'wss://relay.divine.video';
+      final failing = _FailingSendRelay(relayUrl);
+      final tempRelaysCreated = <_ConnectionAwareTempRelay>[];
+      final tempNostr = Nostr(
+        signer,
+        [],
+        (url) =>
+            _ConnectionAwareTempRelay(url, onCreated: tempRelaysCreated.add),
+      );
+      await tempNostr.refreshPublicKey();
+
+      final staleTempRelay = tempNostr.relayPool.checkAndGenTempRelay(relayUrl);
+      await staleTempRelay.disconnect();
+      await tempNostr.relayPool.add(failing);
+
+      final outcome = await tempNostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': 'recreated-temp-event-id', 'kind': 1},
+        ],
+        eventId: 'recreated-temp-event-id',
+        eventKind: 1,
+        targetRelays: [relayUrl],
+        tempRelays: [relayUrl],
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(outcome.failed, isTrue);
+      expect(
+        tempRelaysCreated,
+        hasLength(2),
+        reason: 'disconnected cached temp relay must be replaced before send',
+      );
+      expect(
+        tempRelaysCreated.first.sentMessages,
+        isEmpty,
+        reason: 'stale disconnected temp relay must not be reused for send',
+      );
+      expect(tempRelaysCreated.last.sentMessages, hasLength(1));
     });
 
     test(

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -128,6 +128,8 @@ class _CountRelay extends Relay {
 class _FailingSendRelay extends Relay {
   _FailingSendRelay(String url) : super(url, RelayStatus(url));
 
+  final List<List<dynamic>> sentMessages = [];
+
   @override
   Future<bool> doConnect() async {
     relayStatus.connected = ClientConnected.connected;
@@ -146,6 +148,7 @@ class _FailingSendRelay extends Relay {
     bool queueIfFailed = true,
     bool skipReconnect = false,
   }) async {
+    sentMessages.add(message);
     return false; // Always fail
   }
 }
@@ -481,6 +484,47 @@ void main() {
         tempRelaysCreated,
         isEmpty,
         reason: 'same target URL must not be attempted again as a temp relay',
+      );
+    });
+
+    test('sendEventAwaitOk falls back to a same-URL temp relay when the normal '
+        'target send fails immediately', () async {
+      final relayUrl = 'wss://relay.divine.video';
+      final failing = _FailingSendRelay(relayUrl);
+      final tempRelaysCreated = <String>[];
+      final tempNostr = Nostr(
+        signer,
+        [],
+        (url) => _TrackingTempRelay(url, onCreated: tempRelaysCreated.add),
+      );
+      await tempNostr.refreshPublicKey();
+      await tempNostr.relayPool.add(failing);
+
+      final stopwatch = Stopwatch()..start();
+      final outcome = await tempNostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': 'push-control-event-id', 'kind': 3079},
+        ],
+        eventId: 'push-control-event-id',
+        eventKind: 3079,
+        targetRelays: [relayUrl],
+        tempRelays: [relayUrl],
+        timeout: const Duration(milliseconds: 50),
+      );
+      stopwatch.stop();
+
+      expect(outcome.failed, isTrue);
+      expect(
+        stopwatch.elapsedMilliseconds,
+        lessThan(1000),
+        reason: 'same-URL temp fallback must use the shared publish timeout',
+      );
+      expect(failing.sentMessages, hasLength(1));
+      expect(
+        tempRelaysCreated,
+        contains(relayUrl),
+        reason: 'a failed normal send should not suppress temp relay fallback',
       );
     });
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -235,6 +235,18 @@ class _AlwaysHangingRelay extends Relay {
   }
 }
 
+class _TrackingTempRelay extends _SucceedingRelay {
+  _TrackingTempRelay(super.url, {required this.onCreated});
+
+  final void Function(String url) onCreated;
+
+  @override
+  Future<bool> doConnect() async {
+    onCreated(url);
+    return super.doConnect();
+  }
+}
+
 void main() {
   group('RelayPool concurrency', () {
     late Nostr nostr;
@@ -429,6 +441,47 @@ void main() {
       // The hanging relay's send was invoked but did not contribute
       // to sentTo because its future timed out.
       expect(hanging.sentMessages, isNotEmpty);
+    });
+
+    test('sendEventAwaitOk bounds target sends with the requested timeout and '
+        'does not retry the same URL as a temp relay', () async {
+      final relayUrl = 'wss://relay.divine.video';
+      final hanging = _AlwaysHangingRelay(relayUrl);
+      final tempRelaysCreated = <String>[];
+      final tempNostr = Nostr(
+        signer,
+        [],
+        (url) => _TrackingTempRelay(url, onCreated: tempRelaysCreated.add),
+      );
+      await tempNostr.refreshPublicKey();
+      await tempNostr.relayPool.add(hanging);
+
+      final stopwatch = Stopwatch()..start();
+      final outcome = await tempNostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': 'push-control-event-id', 'kind': 3079},
+        ],
+        eventId: 'push-control-event-id',
+        eventKind: 3079,
+        targetRelays: [relayUrl],
+        tempRelays: [relayUrl],
+        timeout: const Duration(milliseconds: 50),
+      );
+      stopwatch.stop();
+
+      expect(outcome.failed, isTrue);
+      expect(
+        stopwatch.elapsedMilliseconds,
+        lessThan(1000),
+        reason: 'requested timeout must bound _sendCollect plus OK waiting',
+      );
+      expect(hanging.sentMessages, hasLength(1));
+      expect(
+        tempRelaysCreated,
+        isEmpty,
+        reason: 'same target URL must not be attempted again as a temp relay',
+      );
     });
 
     test(

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -510,10 +510,10 @@ void main() {
       final outcome = await tempNostr.relayPool.sendEventAwaitOk(
         [
           'EVENT',
-          {'id': 'push-control-event-id', 'kind': 3079},
+          {'id': 'deadline-event-id', 'kind': 1},
         ],
-        eventId: 'push-control-event-id',
-        eventKind: 3079,
+        eventId: 'deadline-event-id',
+        eventKind: 1,
         targetRelays: [relayUrl],
         tempRelays: [relayUrl],
         timeout: const Duration(milliseconds: 50),
@@ -551,10 +551,10 @@ void main() {
       final outcome = await tempNostr.relayPool.sendEventAwaitOk(
         [
           'EVENT',
-          {'id': 'push-control-event-id', 'kind': 3079},
+          {'id': 'fallback-event-id', 'kind': 1},
         ],
-        eventId: 'push-control-event-id',
-        eventKind: 3079,
+        eventId: 'fallback-event-id',
+        eventKind: 1,
         targetRelays: [relayUrl],
         tempRelays: [relayUrl],
         timeout: const Duration(milliseconds: 50),
@@ -585,10 +585,10 @@ void main() {
         final outcome = await nostr.relayPool.sendEventAwaitOk(
           [
             'EVENT',
-            {'id': 'push-control-event-id', 'kind': 3079},
+            {'id': 'deferred-event-id', 'kind': 1},
           ],
-          eventId: 'push-control-event-id',
-          eventKind: 3079,
+          eventId: 'deferred-event-id',
+          eventKind: 1,
           targetRelays: [relayUrl],
           timeout: const Duration(milliseconds: 10),
         );

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -258,6 +258,7 @@ void main() {
         any(),
         targetRelays: any(named: 'targetRelays'),
         timeout: any(named: 'timeout'),
+        diagnosticTag: any(named: 'diagnosticTag'),
       ),
     ).thenAnswer(
       (invocation) async => _acceptedOutcome(
@@ -379,6 +380,7 @@ void main() {
             event,
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         ).thenAnswer(
           (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
@@ -424,6 +426,7 @@ void main() {
             any(),
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         );
       },
@@ -1380,6 +1383,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).thenAnswer(
           (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
@@ -1432,6 +1436,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).called(1);
       },
@@ -1467,6 +1472,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).thenAnswer(
           (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
@@ -1517,6 +1523,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).called(1);
       },
@@ -1553,6 +1560,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).thenAnswer(
           (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
@@ -1609,6 +1617,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         );
 
@@ -1620,6 +1629,7 @@ void main() {
             event,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).called(1);
         verify(cleanupClient.dispose).called(1);
@@ -1628,6 +1638,7 @@ void main() {
             event,
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         );
       },
@@ -1680,6 +1691,7 @@ void main() {
             any(),
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         ).thenAnswer(
           (invocation) async => _acceptedOutcome(
@@ -1739,6 +1751,7 @@ void main() {
             registrationEvent,
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         );
       },
@@ -1795,6 +1808,7 @@ void main() {
             registrationEvent,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).thenAnswer((_) async {
           events.add('registration publish started');
@@ -1809,6 +1823,7 @@ void main() {
             deregistrationEvent,
             targetRelays: [pushEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
+            diagnosticTag: 'push-control',
           ),
         ).thenAnswer((_) async {
           events.add('deregister');

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -35,7 +35,10 @@ class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _MockNotificationService extends Mock implements NotificationService {}
 
-class _FakeEvent extends Fake implements Event {}
+class _FakeEvent extends Fake implements Event {
+  @override
+  String get id => 'fake-event-id';
+}
 
 class _MockEvent extends Mock implements Event {}
 
@@ -142,6 +145,13 @@ NotificationSettings _settings(AuthorizationStatus status) =>
 NostrIdentity _identity(String pubkey) =>
     KeycastNostrIdentity(pubkey: pubkey, rpcSigner: _MockNostrSigner());
 
+PublishOutcome _acceptedOutcome(Event event, String relayUrl) => PublishOutcome(
+  eventId: event.id,
+  acceptedBy: [relayUrl],
+  rejectedBy: const {},
+  noResponseFrom: const [],
+);
+
 void main() {
   late _MockFirebaseMessaging messaging;
   late _MockAuthService authService;
@@ -168,6 +178,8 @@ void main() {
     registerFallbackValue(const NotificationPreferences());
     registerFallbackValue(_FakeEvent());
     registerFallbackValue(_identity(pubkeyA));
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -242,8 +254,17 @@ void main() {
     when(() => defaultCleanupClient.initialize()).thenAnswer((_) async {});
     when(() => defaultCleanupClient.dispose()).thenAnswer((_) async {});
     when(
-      () => defaultCleanupClient.publishEvent(any()),
-    ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+      () => defaultCleanupClient.publishEventAwaitOk(
+        any(),
+        targetRelays: any(named: 'targetRelays'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (invocation) async => _acceptedOutcome(
+        invocation.positionalArguments.single as Event,
+        pushEnvironment.relayUrl,
+      ),
+    );
   });
 
   tearDown(() async {
@@ -354,8 +375,14 @@ void main() {
           ),
         ).thenAnswer((_) async => event);
         when(
-          () => nostrClient.publishEvent(event),
-        ).thenAnswer((_) async => PublishSuccess(event: event));
+          () => nostrClient.publishEventAwaitOk(
+            event,
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
+        );
 
         final nostrSession = _TestNostrSession(
           const NostrSessionReadiness.signedOut(),
@@ -392,7 +419,13 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
-        verifyNever(() => nostrClient.publishEvent(any()));
+        verifyNever(
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
       },
     );
 
@@ -1338,12 +1371,19 @@ void main() {
         ).thenAnswer((_) => tokenRefreshController.stream);
         when(() => authService.currentIdentity).thenReturn(identity);
         when(() => authService.currentPublicKeyHex).thenReturn(pubkeyA);
+        when(() => event.id).thenReturn('same-pubkey-deregistration-event-id');
         when(() => event.isSigned).thenReturn(true);
         when(() => event.isValid).thenReturn(true);
         when(() => signer.signEvent(any())).thenAnswer((_) async => event);
         when(
-          () => nostrClient.publishEvent(event),
-        ).thenAnswer((_) async => PublishSuccess(event: event));
+          () => defaultCleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).thenAnswer(
+          (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
+        );
 
         final nostrSession = _TestNostrSession(
           const NostrSessionReadiness.signedOut(),
@@ -1387,7 +1427,13 @@ void main() {
         await beforeSessionTeardownCallback!();
 
         verify(() => signer.signEvent(any())).called(1);
-        verify(() => defaultCleanupClient.publishEvent(event)).called(1);
+        verify(
+          () => defaultCleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).called(1);
       },
     );
 
@@ -1410,12 +1456,21 @@ void main() {
         ).thenAnswer((_) => tokenRefreshController.stream);
         when(() => authService.currentIdentity).thenReturn(identity);
         when(() => authService.currentPublicKeyHex).thenReturn(pubkeyA);
+        when(
+          () => event.id,
+        ).thenReturn('captured-pubkey-deregistration-event-id');
         when(() => event.isSigned).thenReturn(true);
         when(() => event.isValid).thenReturn(true);
         when(() => signer.signEvent(any())).thenAnswer((_) async => event);
         when(
-          () => nostrClient.publishEvent(event),
-        ).thenAnswer((_) async => PublishSuccess(event: event));
+          () => defaultCleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).thenAnswer(
+          (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
+        );
 
         final nostrSession = _TestNostrSession(
           const NostrSessionReadiness.signedOut(),
@@ -1457,7 +1512,13 @@ void main() {
         await beforeSessionTeardownCallback!();
 
         verify(() => signer.signEvent(any())).called(1);
-        verify(() => defaultCleanupClient.publishEvent(event)).called(1);
+        verify(
+          () => defaultCleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).called(1);
       },
     );
 
@@ -1481,12 +1542,21 @@ void main() {
         ).thenAnswer((_) => tokenRefreshController.stream);
         when(() => authService.currentIdentity).thenReturn(identity);
         when(() => authService.currentPublicKeyHex).thenReturn(pubkeyA);
+        when(
+          () => event.id,
+        ).thenReturn('direct-cleanup-deregistration-event-id');
         when(() => event.isSigned).thenReturn(true);
         when(() => event.isValid).thenReturn(true);
         when(() => signer.signEvent(any())).thenAnswer((_) async => event);
         when(
-          () => cleanupClient.publishEvent(event),
-        ).thenAnswer((_) async => PublishSuccess(event: event));
+          () => cleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).thenAnswer(
+          (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
+        );
         final initializeCompleter = Completer<void>();
         when(cleanupClient.initialize).thenAnswer(
           (_) => initializeCompleter.future,
@@ -1534,14 +1604,32 @@ void main() {
 
         verify(() => signer.signEvent(any())).called(1);
         verify(cleanupClient.initialize).called(1);
-        verifyNever(() => cleanupClient.publishEvent(event));
+        verifyNever(
+          () => cleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        );
 
         initializeCompleter.complete();
         await teardownFuture;
 
-        verify(() => cleanupClient.publishEvent(event)).called(1);
+        verify(
+          () => cleanupClient.publishEventAwaitOk(
+            event,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).called(1);
         verify(cleanupClient.dispose).called(1);
-        verifyNever(() => nostrClient.publishEvent(event));
+        verifyNever(
+          () => nostrClient.publishEventAwaitOk(
+            event,
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
       },
     );
 
@@ -1576,14 +1664,29 @@ void main() {
             tags: any(named: 'tags'),
           ),
         ).thenAnswer((_) async => registrationEvent);
+        when(
+          () => registrationEvent.id,
+        ).thenReturn('teardown-registration-event-id');
+        when(
+          () => deregistrationEvent.id,
+        ).thenReturn('teardown-deregistration-event-id');
         when(() => deregistrationEvent.isSigned).thenReturn(true);
         when(() => deregistrationEvent.isValid).thenReturn(true);
         when(
           () => signer.signEvent(any()),
         ).thenAnswer((_) async => deregistrationEvent);
         when(
-          () => nostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => _acceptedOutcome(
+            invocation.positionalArguments.single as Event,
+            pushEnvironment.relayUrl,
+          ),
+        );
 
         final nostrSession = _TestNostrSession(
           const NostrSessionReadiness.signedOut(),
@@ -1631,7 +1734,13 @@ void main() {
             tags: any(named: 'tags'),
           ),
         );
-        verifyNever(() => nostrClient.publishEvent(registrationEvent));
+        verifyNever(
+          () => nostrClient.publishEventAwaitOk(
+            registrationEvent,
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
       },
     );
 
@@ -1641,7 +1750,7 @@ void main() {
         const encryptedPayload = 'encrypted-refreshed-token';
         final events = <String>[];
         final tokenRefreshController = StreamController<String>.broadcast();
-        final registrationPublishCompleter = Completer<PublishResult>();
+        final registrationPublishCompleter = Completer<PublishOutcome>();
         addTearDown(tokenRefreshController.close);
         final signer = _MockNostrSigner();
         final identity = KeycastNostrIdentity(
@@ -1670,14 +1779,24 @@ void main() {
             tags: any(named: 'tags'),
           ),
         ).thenAnswer((_) async => registrationEvent);
+        when(
+          () => registrationEvent.id,
+        ).thenReturn('in-flight-registration-event-id');
+        when(
+          () => deregistrationEvent.id,
+        ).thenReturn('in-flight-deregistration-event-id');
         when(() => deregistrationEvent.isSigned).thenReturn(true);
         when(() => deregistrationEvent.isValid).thenReturn(true);
         when(
           () => signer.signEvent(any()),
         ).thenAnswer((_) async => deregistrationEvent);
-        when(() => nostrClient.publishEvent(registrationEvent)).thenAnswer((
-          _,
-        ) async {
+        when(
+          () => nostrClient.publishEventAwaitOk(
+            registrationEvent,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
+        ).thenAnswer((_) async {
           events.add('registration publish started');
           final result = await registrationPublishCompleter.future;
           events.add('registration publish completed');
@@ -1686,10 +1805,17 @@ void main() {
         when(() => defaultCleanupClient.initialize()).thenAnswer((_) async {});
         when(() => defaultCleanupClient.dispose()).thenAnswer((_) async {});
         when(
-          () => defaultCleanupClient.publishEvent(deregistrationEvent),
+          () => defaultCleanupClient.publishEventAwaitOk(
+            deregistrationEvent,
+            targetRelays: [pushEnvironment.relayUrl],
+            timeout: const Duration(seconds: 5),
+          ),
         ).thenAnswer((_) async {
           events.add('deregister');
-          return PublishSuccess(event: deregistrationEvent);
+          return _acceptedOutcome(
+            deregistrationEvent,
+            pushEnvironment.relayUrl,
+          );
         });
 
         final nostrSession = _TestNostrSession(
@@ -1737,7 +1863,7 @@ void main() {
         expect(events, ['registration publish started']);
 
         registrationPublishCompleter.complete(
-          PublishSuccess(event: registrationEvent),
+          _acceptedOutcome(registrationEvent, pushEnvironment.relayUrl),
         );
         await teardownFuture;
 

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/notification_preferences.dart';
@@ -23,7 +24,10 @@ class _MockNotificationService extends Mock implements NotificationService {}
 
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
-class _FakeEvent extends Fake implements Event {}
+class _FakeEvent extends Fake implements Event {
+  @override
+  String get id => 'push-control-event-id';
+}
 
 class _MockEvent extends Mock implements Event {}
 
@@ -49,6 +53,7 @@ void main() {
       'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
   const testToken = 'fcm-test-token-abc123';
   const encryptedPayload = 'encrypted-payload-xyz';
+  const pushPublishTimeout = Duration(seconds: 5);
 
   const configuredPushServicePubkey =
       '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
@@ -72,6 +77,8 @@ void main() {
     when(() => mockNostrClient.signer).thenReturn(mockNostrSigner);
 
     registerFallbackValue(_FakeEvent());
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(Duration.zero);
   });
 
   PushNotificationService buildService({
@@ -90,48 +97,68 @@ void main() {
 
   group(PushNotificationService, () {
     group('register', () {
-      test('encrypts token JSON and publishes kind 3079 event', () async {
-        when(
-          () => mockNostrSigner.nip44Encrypt(
-            testEnvironment.pushServicePubkey,
-            any(),
-          ),
-        ).thenAnswer((_) async => encryptedPayload);
+      test(
+        'encrypts token JSON and publishes kind 3079 event to environment relay with OK timeout',
+        () async {
+          when(
+            () => mockNostrSigner.nip44Encrypt(
+              testEnvironment.pushServicePubkey,
+              any(),
+            ),
+          ).thenAnswer((_) async => encryptedPayload);
 
-        final fakeEvent = _FakeEvent();
-        when(
-          () => mockAuthService.createAndSignEvent(
-            kind: PushNotificationService.pushRegistrationKind,
-            content: encryptedPayload,
-            tags: any(named: 'tags'),
-          ),
-        ).thenAnswer((_) async => fakeEvent);
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushRegistrationKind,
+              content: encryptedPayload,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
 
-        when(
-          () => mockNostrClient.publishEvent(fakeEvent),
-        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
 
-        final service = buildService();
-        await service.register(testPubkey);
+          final service = buildService();
+          await service.register(testPubkey);
 
-        verify(
-          () => mockNostrSigner.nip44Encrypt(
-            testEnvironment.pushServicePubkey,
-            '{"token":"$testToken"}',
-          ),
-        ).called(1);
+          verify(
+            () => mockNostrSigner.nip44Encrypt(
+              testEnvironment.pushServicePubkey,
+              '{"token":"$testToken"}',
+            ),
+          ).called(1);
 
-        verify(
-          () => mockAuthService.createAndSignEvent(
-            kind: PushNotificationService.pushRegistrationKind,
-            content: encryptedPayload,
-            tags: any(named: 'tags'),
-          ),
-        ).called(1);
+          verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushRegistrationKind,
+              content: encryptedPayload,
+              tags: any(named: 'tags'),
+            ),
+          ).called(1);
 
-        verify(() => mockNostrClient.publishEvent(fakeEvent)).called(1);
-        service.dispose();
-      });
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).called(1);
+          service.dispose();
+        },
+      );
 
       test('includes required tags on registration event', () async {
         List<List<String>>? capturedTags;
@@ -155,8 +182,19 @@ void main() {
         });
 
         when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: fakeEvent.id,
+            acceptedBy: [testEnvironment.relayUrl],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
 
         final service = buildService();
         await service.register(testPubkey);
@@ -264,12 +302,18 @@ void main() {
         final service = buildService();
         await service.register(testPubkey);
 
-        verifyNever(() => mockNostrClient.publishEvent(any()));
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
         service.dispose();
       });
 
       test(
-        'completes without error when registration publish returns PublishNoRelays',
+        'completes without error when registration publish receives no OK response',
         () async {
           when(
             () => mockNostrSigner.nip44Encrypt(any(), any()),
@@ -285,8 +329,19 @@ void main() {
           ).thenAnswer((_) async => fakeEvent);
 
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => const PublishNoRelays());
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: const [],
+              rejectedBy: const {},
+              noResponseFrom: [testEnvironment.relayUrl],
+            ),
+          );
 
           final service = buildService();
           await expectLater(service.register(testPubkey), completes);
@@ -295,7 +350,7 @@ void main() {
       );
 
       test(
-        'completes without error when registration publish returns PublishFailed',
+        'completes without error when registration publish is rejected',
         () async {
           when(
             () => mockNostrSigner.nip44Encrypt(any(), any()),
@@ -311,8 +366,19 @@ void main() {
           ).thenAnswer((_) async => fakeEvent);
 
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => const PublishFailed());
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: const [],
+              rejectedBy: {testEnvironment.relayUrl: 'blocked'},
+              noResponseFrom: const [],
+            ),
+          );
 
           final service = buildService();
           await expectLater(service.register(testPubkey), completes);
@@ -322,34 +388,54 @@ void main() {
     });
 
     group('deregister', () {
-      test('publishes kind 3080 event with app tag', () async {
-        final fakeEvent = _FakeEvent();
-        when(
-          () => mockAuthService.createAndSignEvent(
-            kind: PushNotificationService.pushDeregistrationKind,
-            content: '',
-            tags: any(named: 'tags'),
-          ),
-        ).thenAnswer((_) async => fakeEvent);
+      test(
+        'publishes kind 3080 event to environment relay with OK timeout',
+        () async {
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushDeregistrationKind,
+              content: '',
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
 
-        when(
-          () => mockNostrClient.publishEvent(fakeEvent),
-        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
 
-        final service = buildService();
-        await service.deregister(testPubkey);
+          final service = buildService();
+          await service.deregister(testPubkey);
 
-        verify(
-          () => mockAuthService.createAndSignEvent(
-            kind: PushNotificationService.pushDeregistrationKind,
-            content: '',
-            tags: any(named: 'tags'),
-          ),
-        ).called(1);
+          verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushDeregistrationKind,
+              content: '',
+              tags: any(named: 'tags'),
+            ),
+          ).called(1);
 
-        verify(() => mockNostrClient.publishEvent(fakeEvent)).called(1);
-        service.dispose();
-      });
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).called(1);
+          service.dispose();
+        },
+      );
 
       test('does not publish when event signing fails', () async {
         when(
@@ -363,11 +449,17 @@ void main() {
         final service = buildService();
         await service.deregister(testPubkey);
 
-        verifyNever(() => mockNostrClient.publishEvent(any()));
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
         service.dispose();
       });
       test(
-        'completes without error when deregistration publish returns PublishNoRelays',
+        'completes without error when deregistration publish receives no OK response',
         () async {
           final fakeEvent = _FakeEvent();
           when(
@@ -379,8 +471,19 @@ void main() {
           ).thenAnswer((_) async => fakeEvent);
 
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => const PublishNoRelays());
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: const [],
+              rejectedBy: const {},
+              noResponseFrom: [testEnvironment.relayUrl],
+            ),
+          );
 
           final service = buildService();
           await expectLater(service.deregister(testPubkey), completes);
@@ -389,7 +492,7 @@ void main() {
       );
 
       test(
-        'completes without error when deregistration publish returns PublishFailed',
+        'completes without error when deregistration publish is rejected',
         () async {
           final fakeEvent = _FakeEvent();
           when(
@@ -401,8 +504,19 @@ void main() {
           ).thenAnswer((_) async => fakeEvent);
 
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => const PublishFailed());
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: const [],
+              rejectedBy: {testEnvironment.relayUrl: 'blocked'},
+              noResponseFrom: const [],
+            ),
+          );
 
           final service = buildService();
           await expectLater(service.deregister(testPubkey), completes);
@@ -434,6 +548,9 @@ void main() {
         () async {
           var current = true;
           final fakeEvent = _MockEvent();
+          when(
+            () => fakeEvent.id,
+          ).thenReturn('captured-deregistration-event-id');
           when(() => fakeEvent.isSigned).thenReturn(true);
           when(() => fakeEvent.isValid).thenReturn(true);
           when(
@@ -472,14 +589,28 @@ void main() {
             rpcSigner: capturedSigner,
           );
           final fakeEvent = _MockEvent();
+          when(
+            () => fakeEvent.id,
+          ).thenReturn('captured-deregistration-event-id');
           when(() => fakeEvent.isSigned).thenReturn(true);
           when(() => fakeEvent.isValid).thenReturn(true);
           when(
             () => capturedSigner.signEvent(any()),
           ).thenAnswer((_) async => fakeEvent);
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
 
           final service = buildService(isCurrent: () => false);
           await service.deregister(
@@ -495,7 +626,13 @@ void main() {
             ),
           );
           verify(() => capturedSigner.signEvent(any())).called(1);
-          verify(() => mockNostrClient.publishEvent(fakeEvent)).called(1);
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).called(1);
           service.dispose();
         },
       );
@@ -510,14 +647,28 @@ void main() {
           );
           final cleanupClient = _MockNostrClient();
           final fakeEvent = _MockEvent();
+          when(
+            () => fakeEvent.id,
+          ).thenReturn('cleanup-deregistration-event-id');
           when(() => fakeEvent.isSigned).thenReturn(true);
           when(() => fakeEvent.isValid).thenReturn(true);
           when(
             () => capturedSigner.signEvent(any()),
           ).thenAnswer((_) async => fakeEvent);
           when(
-            () => cleanupClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+            () => cleanupClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
 
           final service = buildService(isCurrent: () => false);
           await service.deregister(
@@ -527,71 +678,103 @@ void main() {
           );
 
           verify(() => capturedSigner.signEvent(any())).called(1);
-          verifyNever(() => mockNostrClient.publishEvent(any()));
-          verify(() => cleanupClient.publishEvent(fakeEvent)).called(1);
+          verifyNever(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          );
+          verify(
+            () => cleanupClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).called(1);
           service.dispose();
         },
       );
     });
 
     group('updatePreferences', () {
-      test('encrypts kinds JSON and publishes kind 3083 event', () async {
-        const prefs = NotificationPreferences(
-          commentsEnabled: false,
-          mentionsEnabled: false,
-          repostsEnabled: false,
-        );
+      test(
+        'encrypts kinds JSON and publishes kind 3083 event to environment relay with OK timeout',
+        () async {
+          const prefs = NotificationPreferences(
+            commentsEnabled: false,
+            mentionsEnabled: false,
+            repostsEnabled: false,
+          );
 
-        when(
-          () => mockNostrSigner.nip44Encrypt(
-            testEnvironment.pushServicePubkey,
-            any(),
-          ),
-        ).thenAnswer((_) async => encryptedPayload);
+          when(
+            () => mockNostrSigner.nip44Encrypt(
+              testEnvironment.pushServicePubkey,
+              any(),
+            ),
+          ).thenAnswer((_) async => encryptedPayload);
 
-        final fakeEvent = _FakeEvent();
-        when(
-          () => mockAuthService.createAndSignEvent(
-            kind: PushNotificationService.pushPreferencesKind,
-            content: encryptedPayload,
-            tags: any(named: 'tags'),
-          ),
-        ).thenAnswer((_) async => fakeEvent);
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushPreferencesKind,
+              content: encryptedPayload,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
 
-        when(
-          () => mockNostrClient.publishEvent(fakeEvent),
-        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
 
-        final service = buildService();
-        await service.updatePreferences(prefs);
+          final service = buildService();
+          await service.updatePreferences(prefs);
 
-        final captureResult = verify(
-          () => mockNostrSigner.nip44Encrypt(
-            testEnvironment.pushServicePubkey,
-            captureAny(),
-          ),
-        );
-        captureResult.called(1);
+          final captureResult = verify(
+            () => mockNostrSigner.nip44Encrypt(
+              testEnvironment.pushServicePubkey,
+              captureAny(),
+            ),
+          );
+          captureResult.called(1);
 
-        final capturedJson = captureResult.captured.first as String;
-        expect(capturedJson, contains('"kinds"'));
+          final capturedJson = captureResult.captured.first as String;
+          expect(capturedJson, contains('"kinds"'));
 
-        final kinds = prefs.toKindsList();
-        for (final kind in kinds) {
-          expect(capturedJson, contains(kind.toString()));
-        }
+          final kinds = prefs.toKindsList();
+          for (final kind in kinds) {
+            expect(capturedJson, contains(kind.toString()));
+          }
 
-        verify(
-          () => mockAuthService.createAndSignEvent(
-            kind: PushNotificationService.pushPreferencesKind,
-            content: encryptedPayload,
-            tags: any(named: 'tags'),
-          ),
-        ).called(1);
+          verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushPreferencesKind,
+              content: encryptedPayload,
+              tags: any(named: 'tags'),
+            ),
+          ).called(1);
 
-        verify(() => mockNostrClient.publishEvent(fakeEvent)).called(1);
-        service.dispose();
-      });
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).called(1);
+          service.dispose();
+        },
+      );
 
       test(
         'skips preferences update when push service pubkey is placeholder',
@@ -619,7 +802,7 @@ void main() {
         },
       );
       test(
-        'completes without error when preferences publish returns PublishNoRelays',
+        'completes without error when preferences publish receives no OK response',
         () async {
           const prefs = NotificationPreferences();
 
@@ -637,8 +820,19 @@ void main() {
           ).thenAnswer((_) async => fakeEvent);
 
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => const PublishNoRelays());
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: const [],
+              rejectedBy: const {},
+              noResponseFrom: [testEnvironment.relayUrl],
+            ),
+          );
 
           final service = buildService();
           await expectLater(service.updatePreferences(prefs), completes);
@@ -647,7 +841,7 @@ void main() {
       );
 
       test(
-        'completes without error when preferences publish returns PublishFailed',
+        'completes without error when preferences publish is rejected',
         () async {
           const prefs = NotificationPreferences();
 
@@ -665,8 +859,19 @@ void main() {
           ).thenAnswer((_) async => fakeEvent);
 
           when(
-            () => mockNostrClient.publishEvent(fakeEvent),
-          ).thenAnswer((_) async => const PublishFailed());
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: const [],
+              rejectedBy: {testEnvironment.relayUrl: 'blocked'},
+              noResponseFrom: const [],
+            ),
+          );
 
           final service = buildService();
           await expectLater(service.updatePreferences(prefs), completes);
@@ -768,40 +973,65 @@ void main() {
     });
 
     group('registerToken', () {
-      test('publishes provided refreshed token', () async {
-        when(
-          () => mockNostrSigner.nip44Encrypt(any(), any()),
-        ).thenAnswer((_) async => encryptedPayload);
-        when(() => mockAuthService.currentIdentity).thenReturn(
-          KeycastNostrIdentity(pubkey: testPubkey, rpcSigner: mockNostrSigner),
-        );
+      test(
+        'publishes provided refreshed token through environment relay OK publish',
+        () async {
+          when(
+            () => mockNostrSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
+          when(() => mockAuthService.currentIdentity).thenReturn(
+            KeycastNostrIdentity(
+              pubkey: testPubkey,
+              rpcSigner: mockNostrSigner,
+            ),
+          );
 
-        final fakeEvent = _FakeEvent();
-        when(
-          () => mockAuthService.createAndSignEvent(
-            kind: any(named: 'kind'),
-            content: any(named: 'content'),
-            tags: any(named: 'tags'),
-          ),
-        ).thenAnswer((_) async => fakeEvent);
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
 
-        when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => PublishSuccess(event: fakeEvent));
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
 
-        final service = buildService();
+          final service = buildService();
 
-        await service.registerToken(testPubkey, 'new-refreshed-token');
+          await service.registerToken(testPubkey, 'new-refreshed-token');
 
-        verify(
-          () => mockNostrSigner.nip44Encrypt(
-            testEnvironment.pushServicePubkey,
-            '{"token":"new-refreshed-token"}',
-          ),
-        ).called(1);
+          verify(
+            () => mockNostrSigner.nip44Encrypt(
+              testEnvironment.pushServicePubkey,
+              '{"token":"new-refreshed-token"}',
+            ),
+          ).called(1);
 
-        service.dispose();
-      });
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+            ),
+          ).called(1);
+
+          service.dispose();
+        },
+      );
 
       test(
         'drops refreshed token registration when session is stale',

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -121,6 +121,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -154,6 +155,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).called(1);
           service.dispose();
@@ -186,6 +188,7 @@ void main() {
             any(),
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         ).thenAnswer(
           (_) async => PublishOutcome(
@@ -307,6 +310,7 @@ void main() {
             any(),
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         );
         service.dispose();
@@ -333,6 +337,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -370,6 +375,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -405,6 +411,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -431,6 +438,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).called(1);
           service.dispose();
@@ -454,6 +462,7 @@ void main() {
             any(),
             targetRelays: any(named: 'targetRelays'),
             timeout: any(named: 'timeout'),
+            diagnosticTag: any(named: 'diagnosticTag'),
           ),
         );
         service.dispose();
@@ -475,6 +484,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -508,6 +518,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -602,6 +613,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -631,6 +643,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).called(1);
           service.dispose();
@@ -660,6 +673,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -683,6 +697,7 @@ void main() {
               any(),
               targetRelays: any(named: 'targetRelays'),
               timeout: any(named: 'timeout'),
+              diagnosticTag: any(named: 'diagnosticTag'),
             ),
           );
           verify(
@@ -690,6 +705,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).called(1);
           service.dispose();
@@ -728,6 +744,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -770,6 +787,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).called(1);
           service.dispose();
@@ -824,6 +842,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -863,6 +882,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -1000,6 +1020,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).thenAnswer(
             (_) async => PublishOutcome(
@@ -1026,6 +1047,7 @@ void main() {
               fakeEvent,
               targetRelays: [testEnvironment.relayUrl],
               timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
             ),
           ).called(1);
 


### PR DESCRIPTION
## Summary

Push registration could look successful even when the Divine relay never accepted the event.
This change sends push registration, deregistration, and preference events directly to the configured Divine relay and waits for a relay OK response.
It also keeps the publish bounded so a late relay connection cannot write or queue a stale push-control event after the timeout.

## What Changed

Push control events now use the same targeted OK-confirmed publish path.
The relay layer now treats the caller timeout as one deadline for both sending and waiting for OK responses.
Same-URL fallback now distinguishes a failed send from a sent frame, and deadline-bound sends cannot queue stale EVENT messages.

- Route kinds 3079, 3080, and 3083 through `publishEventAwaitOk` with `targetRelays: [EnvironmentConfig.relayUrl]`.
- Let explicit target-relay OK publishes run even when the general relay pool has no connected relays.
- Skip the generic disconnected-relay retry when explicit target relays are provided.
- Bound `RelayPool.sendEventAwaitOk` with one deadline across `_sendCollect` plus OK waiting.
- Thread that deadline through `Relay.send`, `RelayBase.send`, and `WebSocketConnectionManager.sendJson`.
- Disable pending-message queueing for deadline-bound await-OK sends.
- Do not queue pending-auth messages for deadline-bound await-OK sends.
- Remove expired temp relays after deadline timeout so their connection waiters cannot flush stale control events.
- Track expected relays as soon as each send succeeds, so timeouts report the relays that actually received the frame.
- Avoid retrying a stalled same-URL normal target as a temp relay after the shared deadline is consumed.
- Allow same-URL temp fallback when the normal target path returns `false` immediately without sending.
- Log accepted, rejected, and no-response relay outcomes without logging encrypted push-control content.

**Related Issue:** Closes #4411

## Testing

I tested the push-control service paths, the client OK-publish wrapper, and the relay-pool timeout and fallback behavior.
I also verified the touched packages and the app analyzer after the SDK API change.

- `dart format packages/nostr_client/lib/src/nostr_client.dart packages/nostr_client/test/src/nostr_client_test.dart packages/nostr_sdk/lib/relay/relay_pool.dart packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart`
- `dart format --output=none --set-exit-if-changed lib/relay/relay.dart lib/relay/relay_base.dart lib/relay/relay_isolate.dart lib/relay/web_socket_connection_manager.dart lib/relay/relay_pool.dart test/unit/relay_pool_concurrency_test.dart test/unit/relay_pool_auth_test.dart test/unit/relay_count_test.dart test/integration/relay_auth_test.dart test/integration/nip50_search_test.dart`
- `dart format --output=none --set-exit-if-changed test/src/follow_repository_test.dart`
- `flutter test --no-pub test/src/nostr_client_test.dart --plain-name "publishEventAwaitOk"`
- `flutter test --no-pub test/unit/relay_pool_concurrency_test.dart --plain-name "sendEventAwaitOk"`
- `flutter test --no-pub test/unit/relay_pool_concurrency_test.dart`
- `dart test test/unit/publish_outcome_test.dart`
- `flutter test --no-pub test/services/push_notification_service_test.dart`
- `flutter test --no-pub test/providers/push_notification_sync_test.dart`
- `dart analyze` in `mobile/packages/nostr_sdk`
- `flutter analyze --no-pub` in `mobile/packages/nostr_client`
- `flutter analyze --no-pub` in `mobile/packages/follow_repository`
- `flutter analyze --no-pub` in `mobile`
- `flutter test --no-pub` in `mobile`
- `git diff --check`

## Risks

The main behavior change is that explicit target publishes no longer wait for unrelated pool reconnects, and deadline-bound OK publishes no longer queue messages for later delivery.
That is intentional for push control events because a late queued control event can make the app report a failed publish while still mutating relay-side push state later.
The SDK `Relay.send` interface now accepts an optional deadline, so custom test relays and package-local fake relays were updated to match.

- A target URL already present in the normal relay pool is not retried as a temp relay after the normal path sends or queues the frame.
- A normal target path that returns `false` immediately can still fall back to a same-URL temp relay within the caller timeout.
- If the normal target path stalls until the shared deadline is exhausted, the publish fails fast instead of trying the same URL a second way.
- If a relay connects after the deadline, the deadline-aware send path returns false before writing the stale EVENT.
- This does not prove the push service processed the event after relay acceptance; it only confirms relay acceptance.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore