### PR TITLE
feat(fullscreen): inline comment composer + layout polish

### DIFF
--- a/mobile/lib/blocs/inline_comment_composer/inline_comment_composer_cubit.dart
+++ b/mobile/lib/blocs/inline_comment_composer/inline_comment_composer_cubit.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Cubit for the inline comment composer bar shown at the bottom of
+// ABOUTME: the fullscreen video player on Explore / Search / Profile surfaces.
+
+import 'dart:async';
+
+import 'package:comments_repository/comments_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+part 'inline_comment_composer_state.dart';
+
+/// Lightweight cubit that owns the publish flow for the inline comment bar
+/// at the bottom of [PooledFullscreenVideoFeedScreen].
+///
+/// Unlike the full [CommentsBloc], this cubit does not load, paginate, or
+/// hold a list of comments — the bar's UX is "tap, type, send" and never
+/// surfaces other people's comments. State is therefore just a single
+/// [InlineCommentComposerStatus] enum; the active video is supplied
+/// per-call to [submit] so the cubit holds no mutable video reference.
+class InlineCommentComposerCubit extends Cubit<InlineCommentComposerState> {
+  InlineCommentComposerCubit({required CommentsRepository commentsRepository})
+    : _commentsRepository = commentsRepository,
+      super(const InlineCommentComposerState());
+
+  final CommentsRepository _commentsRepository;
+
+  /// Posts [content] as a top-level comment on [video].
+  ///
+  /// Trims and validates input locally; empty submissions are a no-op so
+  /// the UI can wire this to a button without guarding emptiness itself.
+  /// Errors from the repository are caught and reported via [addError]
+  /// (gated through [Reportable] is unnecessary here — comment-publish
+  /// failures are an expected domain error path, see
+  /// `rules/error_handling.md`).
+  Future<void> submit({
+    required VideoEvent video,
+    required String content,
+  }) async {
+    final trimmed = content.trim();
+    if (trimmed.isEmpty) return;
+    if (state.status == InlineCommentComposerStatus.submitting) return;
+
+    emit(state.copyWith(status: InlineCommentComposerStatus.submitting));
+
+    try {
+      await _commentsRepository.postComment(
+        content: trimmed,
+        rootEventId: video.id,
+        rootEventKind: NIP71VideoKinds.addressableShortVideo,
+        rootEventAuthorPubkey: video.pubkey,
+        rootAddressableId: video.addressableId,
+      );
+      emit(state.copyWith(status: InlineCommentComposerStatus.submitted));
+    } catch (error, stackTrace) {
+      Log.error(
+        'Inline comment publish failed',
+        name: 'InlineCommentComposerCubit',
+        category: LogCategory.ui,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      addError(error, stackTrace);
+      emit(state.copyWith(status: InlineCommentComposerStatus.failure));
+    }
+  }
+
+  /// Returns the cubit to [InlineCommentComposerStatus.idle].
+  ///
+  /// Called by the bar after the success / failure snackbar has been shown
+  /// so the next tap-and-send cycle starts from a clean state.
+  void acknowledge() {
+    if (state.status == InlineCommentComposerStatus.idle) return;
+    emit(state.copyWith(status: InlineCommentComposerStatus.idle));
+  }
+}

--- a/mobile/lib/blocs/inline_comment_composer/inline_comment_composer_state.dart
+++ b/mobile/lib/blocs/inline_comment_composer/inline_comment_composer_state.dart
@@ -1,0 +1,41 @@
+part of 'inline_comment_composer_cubit.dart';
+
+/// Lifecycle of a single submit-and-confirm round-trip for the inline
+/// comment composer bar.
+enum InlineCommentComposerStatus {
+  /// No publish is in flight; the bar can accept a new submission.
+  idle,
+
+  /// A publish call is awaiting a relay response.
+  submitting,
+
+  /// The most recent publish succeeded; the bar should show its success
+  /// affordance and then call [InlineCommentComposerCubit.acknowledge].
+  submitted,
+
+  /// The most recent publish failed; the bar should show its failure
+  /// affordance and then call [InlineCommentComposerCubit.acknowledge].
+  failure,
+}
+
+/// State for [InlineCommentComposerCubit].
+///
+/// Holds nothing but the lifecycle status. The composed text lives in the
+/// widget's [TextEditingController] (a transient UI concern), and the
+/// active video is supplied per-call to [InlineCommentComposerCubit.submit]
+/// so the cubit never holds a stale [VideoEvent] reference across
+/// page-changes in the fullscreen feed.
+class InlineCommentComposerState extends Equatable {
+  const InlineCommentComposerState({
+    this.status = InlineCommentComposerStatus.idle,
+  });
+
+  final InlineCommentComposerStatus status;
+
+  InlineCommentComposerState copyWith({InlineCommentComposerStatus? status}) {
+    return InlineCommentComposerState(status: status ?? this.status);
+  }
+
+  @override
+  List<Object?> get props => [status];
+}

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -808,6 +808,26 @@
   "@videoOverlayOpenMetadataFromDescription": {
     "description": "Screen-reader label for the tappable description row on the video overlay. Action-oriented: describes what tapping does (opens the metadata sheet), not the description text itself — that's already read aloud by the underlying Text widget."
   },
+  "videoOverlayCommentBarHint": "Add comment...",
+  "@videoOverlayCommentBarHint": {
+    "description": "Placeholder shown inside the inline comment field at the bottom of the fullscreen video player (used by Explore, Search, and Profile entry points). Tapping the field opens the keyboard so the user can post a comment without opening the full comments sheet."
+  },
+  "videoOverlayCommentBarSemanticLabel": "Add a comment",
+  "@videoOverlayCommentBarSemanticLabel": {
+    "description": "Screen-reader label for the inline comment field at the bottom of the fullscreen video player. Action-oriented: describes what the field is for."
+  },
+  "videoOverlayCommentBarSendLabel": "Send comment",
+  "@videoOverlayCommentBarSendLabel": {
+    "description": "Screen-reader label for the send button next to the inline comment field at the bottom of the fullscreen video player."
+  },
+  "videoOverlayCommentPostedSnackbar": "Comment posted",
+  "@videoOverlayCommentPostedSnackbar": {
+    "description": "Snackbar confirmation shown after the user posts a comment from the inline comment field at the bottom of the fullscreen video player."
+  },
+  "videoOverlayCommentPostFailedSnackbar": "Couldn't post comment",
+  "@videoOverlayCommentPostFailedSnackbar": {
+    "description": "Snackbar shown when posting a comment from the inline comment field fails (e.g. relay unreachable)."
+  },
   "videoDescriptionLoops": "{count} loops",
   "@videoDescriptionLoops": {
     "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2782,6 +2782,36 @@ abstract class AppLocalizations {
   /// **'Open video details'**
   String get videoOverlayOpenMetadataFromDescription;
 
+  /// Placeholder shown inside the inline comment field at the bottom of the fullscreen video player (used by Explore, Search, and Profile entry points). Tapping the field opens the keyboard so the user can post a comment without opening the full comments sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Add comment...'**
+  String get videoOverlayCommentBarHint;
+
+  /// Screen-reader label for the inline comment field at the bottom of the fullscreen video player. Action-oriented: describes what the field is for.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a comment'**
+  String get videoOverlayCommentBarSemanticLabel;
+
+  /// Screen-reader label for the send button next to the inline comment field at the bottom of the fullscreen video player.
+  ///
+  /// In en, this message translates to:
+  /// **'Send comment'**
+  String get videoOverlayCommentBarSendLabel;
+
+  /// Snackbar confirmation shown after the user posts a comment from the inline comment field at the bottom of the fullscreen video player.
+  ///
+  /// In en, this message translates to:
+  /// **'Comment posted'**
+  String get videoOverlayCommentPostedSnackbar;
+
+  /// Snackbar shown when posting a comment from the inline comment field fails (e.g. relay unreachable).
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t post comment'**
+  String get videoOverlayCommentPostFailedSnackbar;
+
   /// No description provided for @videoDescriptionLoops.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1502,6 +1502,21 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'የቪዲዮ ዝርዝሮችን ይክፈቱ';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count ሉፖች';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1522,6 +1522,21 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'فتح تفاصيل الفيديو';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count تكرار';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1565,6 +1565,21 @@ class AppLocalizationsBg extends AppLocalizations {
       'Отвори подробностите за видеото';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count лупа';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1561,6 +1561,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Videodetails öffnen';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count Loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1539,6 +1539,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Open video details';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1560,6 +1560,21 @@ class AppLocalizationsEs extends AppLocalizations {
       'Abrir detalles del video';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1567,6 +1567,21 @@ class AppLocalizationsFil extends AppLocalizations {
       'Buksan ang video details';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1569,6 +1569,21 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ouvrir les détails de la vidéo';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1515,6 +1515,21 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Buka detail video';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loop';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1563,6 +1563,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Apri dettagli video';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loop';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1449,6 +1449,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => '動画の詳細を開く';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$countループ';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1457,6 +1457,21 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => '영상 세부 정보 열기';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '루프 $count회';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1549,6 +1549,21 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Videodetails openen';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1563,6 +1563,21 @@ class AppLocalizationsPl extends AppLocalizations {
       'Otwórz szczegóły filmu';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count pętli';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1558,6 +1558,21 @@ class AppLocalizationsPt extends AppLocalizations {
       'Abrir detalhes do vídeo';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loops';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1577,6 +1577,21 @@ class AppLocalizationsRo extends AppLocalizations {
       'Deschide detaliile videoclipului';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count bucle';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1536,6 +1536,21 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Öppna videodetaljer';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count loopar';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1522,6 +1522,21 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoOverlayOpenMetadataFromDescription => 'Video detaylarını aç';
 
   @override
+  String get videoOverlayCommentBarHint => 'Add comment...';
+
+  @override
+  String get videoOverlayCommentBarSemanticLabel => 'Add a comment';
+
+  @override
+  String get videoOverlayCommentBarSendLabel => 'Send comment';
+
+  @override
+  String get videoOverlayCommentPostedSnackbar => 'Comment posted';
+
+  @override
+  String get videoOverlayCommentPostFailedSnackbar => 'Couldn\'t post comment';
+
+  @override
   String videoDescriptionLoops(String count) {
     return '$count döngü';
   }

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -7,13 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
-/// More icon button + playback-controls popover for the home feed top bar.
+/// More icon button + playback-controls popover for feed surfaces.
 ///
-/// Renders a 40 px scrim-15 [DivineIconButton] (48 px tap target) intended
-/// to be placed as the trailing sibling of the feed-mode selector inside the
-/// home feed's top-bar [Row]. Tapping opens a popover anchored 16 px below
-/// the button's bottom-right corner with three scrim-toggled controls:
-/// playback mode (auto-advance), audio mute, and closed captions.
+/// Renders a 40 px scrim-15 [DivineIconButton] (48 px tap target). Used on
+/// the home feed's top bar (as the trailing sibling of the feed-mode
+/// selector) and on the fullscreen video screen (as a `customActions`
+/// entry on its [DiVineAppBar]). Tapping opens a popover anchored 16 px
+/// below the button's bottom-right corner with three scrim-toggled
+/// controls: playback mode (auto-advance), audio mute, and closed captions.
 ///
 /// The popover content is the shared [FeedPlaybackTogglesPill] widget, which
 /// reads and writes app-wide state (`FeedAutoAdvanceCubit`,

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -95,25 +95,37 @@ class _FeedSettingsOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: onClose,
+    // Wrap the *entire* overlay in a [TextFieldTapRegion]. While the
+    // popover is open, every tap inside it — the pill (toggling
+    // mute / captions / ...), the empty backdrop (which fires
+    // [onClose] to dismiss the popover), and the area behind the
+    // popover's X-button trigger in the app bar that the backdrop
+    // catcher overlays — is treated as part of the focused
+    // TextField's tap-region group. That keeps the inline comment
+    // composer's keyboard up while the user adjusts playback, and
+    // lets them close the popover (via X or backdrop tap) without
+    // also losing the keyboard.
+    return TextFieldTapRegion(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onClose,
+            ),
           ),
-        ),
-        CompositedTransformFollower(
-          link: link,
-          targetAnchor: Alignment.bottomRight,
-          followerAnchor: Alignment.topRight,
-          offset: const Offset(0, 16),
-          child: const Material(
-            color: VineTheme.transparent,
-            child: FeedPlaybackTogglesPill(),
+          CompositedTransformFollower(
+            link: link,
+            targetAnchor: Alignment.bottomRight,
+            followerAnchor: Alignment.topRight,
+            offset: const Offset(0, 16),
+            child: const Material(
+              color: VineTheme.transparent,
+              child: FeedPlaybackTogglesPill(),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -825,6 +825,16 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   ],
                   style: DiVineAppBarStyle.transparentStyle.copyWith(
                     horizontalPadding: 8,
+                    // With the default 48 px icon button and 8 px
+                    // [horizontalPadding], a 68 px leading slot leaves
+                    // 12 px between the back button's right edge and
+                    // the title text (68 − 8 − 48 = 12).
+                    leadingWidth: 68,
+                    // Figma `title/medium` token (Bricolage Grotesque
+                    // 800, 16 / 24 / 0.15) — overrides the default
+                    // [VineTheme.titleLargeFont] (22) used by the
+                    // shared app bar.
+                    titleStyle: VineTheme.titleMediumFont(),
                   ),
                 ),
                 body: Column(

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -841,159 +841,163 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       // is the same token the comment bar paints. The
                       // result is a continuous green seam between the
                       // video's bottom-corner cutouts and the bar.
-                      child: _MaybeRoundFeedBottom(
-                        roundCorners: showCommentBar,
-                        child:
-                            InfiniteVideoFeed.isSupported &&
-                                ref.watch(
-                                  isFeatureEnabledProvider(
-                                    .nativeFeedPlayer,
-                                  ),
+                      child: VideoTapShield(
+                        child: _MaybeRoundFeedBottom(
+                          roundCorners: showCommentBar,
+                          child:
+                              InfiniteVideoFeed.isSupported &&
+                                  ref.watch(
+                                    isFeatureEnabledProvider(
+                                      .nativeFeedPlayer,
+                                    ),
+                                  )
+                              ? FeedVideos(
+                                  key: _feedVideosKey,
+                                  videos: state.videos,
+                                  contextTitle: widget.contextTitle,
+                                  currentIndex: state.currentIndex,
+                                  shouldPortraitExpand: false,
+                                  hasMore: state.canLoadMore,
+                                  isLoadingMore: state.isLoadingMore,
+                                  onActiveVideoChanged: (video, index) {
+                                    _resumeAutoAdvanceAfterSwipe();
+                                    FeedPerformanceTracker()
+                                        .startVideoSwipeTracking(
+                                          video.id,
+                                        );
+                                    context.read<FullscreenFeedBloc>().add(
+                                      FullscreenFeedIndexChanged(index),
+                                    );
+                                    widget.onPageChanged?.call(index);
+                                  },
+                                  onNearEnd: () {
+                                    if (state.canLoadMore) {
+                                      _triggerLoadMore();
+                                    }
+                                  },
                                 )
-                            ? FeedVideos(
-                                key: _feedVideosKey,
-                                videos: state.videos,
-                                contextTitle: widget.contextTitle,
-                                currentIndex: state.currentIndex,
-                                shouldPortraitExpand: false,
-                                hasMore: state.canLoadMore,
-                                isLoadingMore: state.isLoadingMore,
-                                onActiveVideoChanged: (video, index) {
-                                  _resumeAutoAdvanceAfterSwipe();
-                                  FeedPerformanceTracker()
-                                      .startVideoSwipeTracking(
-                                        video.id,
-                                      );
-                                  context.read<FullscreenFeedBloc>().add(
-                                    FullscreenFeedIndexChanged(index),
-                                  );
-                                  widget.onPageChanged?.call(index);
-                                },
-                                onNearEnd: () {
-                                  if (state.canLoadMore) {
-                                    _triggerLoadMore();
-                                  }
-                                },
-                              )
-                            : kIsWeb
-                            ? WebVideoFeed(
-                                key: _webFeedKey,
-                                videos: state.videos
-                                    .where((v) => v.videoUrl != null)
-                                    .toList(),
-                                initialIndex: state.currentIndex,
-                                controllerFactory:
-                                    widget.webControllerFactory ??
-                                    defaultWebVideoPlayerControllerFactory,
-                                authHeaderProvider: webAuthHeaderProvider,
-                                initialVolume: context
-                                    .read<VideoVolumeCubit>()
-                                    .state
-                                    .volume,
-                                onActiveVideoChanged: (video, index) {
-                                  _pagePosition.value = index.toDouble();
-                                  _resumeAutoAdvanceAfterSwipe();
-                                  FeedPerformanceTracker()
-                                      .startVideoSwipeTracking(
-                                        video.id,
-                                      );
-                                  context.read<FullscreenFeedBloc>().add(
-                                    FullscreenFeedIndexChanged(index),
-                                  );
-                                  widget.onPageChanged?.call(index);
-                                },
-                                onCompleted: (_) =>
-                                    _handleAutoAdvanceCompleted(),
-                                onErrored: _handleWebPlayerErrored,
-                                onRequiresAuth: _handleWebPlayerRequiresAuth,
-                                onNearEnd: (index) => _onNearEnd(state, index),
-                                itemBuilder:
-                                    (
-                                      context,
-                                      video,
-                                      index, {
-                                      required isActive,
-                                      controller,
-                                    }) {
-                                      return _WebFullscreenItem(
-                                        video: video,
-                                        isActive: isActive,
-                                        isOwnVideo:
-                                            currentUserPubkey == video.pubkey,
-                                        controller: controller,
-                                        contextTitle: widget.contextTitle,
-                                        onInteracted: _suppressAutoAdvance,
-                                      );
-                                    },
-                              )
-                            : PooledVideoFeed(
-                                key: _feedKey,
-                                videos: state.pooledVideos,
-                                controller: _controller,
-                                initialIndex: state.currentIndex,
-                                onActiveVideoChanged: (video, index) {
-                                  _resumeAutoAdvanceAfterSwipe();
-                                  FeedPerformanceTracker()
-                                      .startVideoSwipeTracking(
-                                        video.id,
-                                      );
-                                  context.read<FullscreenFeedBloc>().add(
-                                    FullscreenFeedIndexChanged(index),
-                                  );
-                                  widget.onPageChanged?.call(index);
-                                },
-                                onNearEnd: (index) => _onNearEnd(state, index),
-                                nearEndThreshold: 0,
-                                onScrollOffsetChanged: (page) =>
-                                    _pagePosition.value = page,
-                                maxLoopDuration:
-                                    VideoEditorConstants.maxDuration,
-                                itemBuilder: (context, video, index, {required isActive}) {
-                                  if (state.videos.isEmpty) {
-                                    debugPrint(
-                                      'FullscreenFeed: itemBuilder called with empty '
-                                      'state.videos! index=$index, '
-                                      'video.id=${video.id}',
+                              : kIsWeb
+                              ? WebVideoFeed(
+                                  key: _webFeedKey,
+                                  videos: state.videos
+                                      .where((v) => v.videoUrl != null)
+                                      .toList(),
+                                  initialIndex: state.currentIndex,
+                                  controllerFactory:
+                                      widget.webControllerFactory ??
+                                      defaultWebVideoPlayerControllerFactory,
+                                  authHeaderProvider: webAuthHeaderProvider,
+                                  initialVolume: context
+                                      .read<VideoVolumeCubit>()
+                                      .state
+                                      .volume,
+                                  onActiveVideoChanged: (video, index) {
+                                    _pagePosition.value = index.toDouble();
+                                    _resumeAutoAdvanceAfterSwipe();
+                                    FeedPerformanceTracker()
+                                        .startVideoSwipeTracking(
+                                          video.id,
+                                        );
+                                    context.read<FullscreenFeedBloc>().add(
+                                      FullscreenFeedIndexChanged(index),
                                     );
-                                    return const ColoredBox(
-                                      color: VineTheme.backgroundColor,
+                                    widget.onPageChanged?.call(index);
+                                  },
+                                  onCompleted: (_) =>
+                                      _handleAutoAdvanceCompleted(),
+                                  onErrored: _handleWebPlayerErrored,
+                                  onRequiresAuth: _handleWebPlayerRequiresAuth,
+                                  onNearEnd: (index) =>
+                                      _onNearEnd(state, index),
+                                  itemBuilder:
+                                      (
+                                        context,
+                                        video,
+                                        index, {
+                                        required isActive,
+                                        controller,
+                                      }) {
+                                        return _WebFullscreenItem(
+                                          video: video,
+                                          isActive: isActive,
+                                          isOwnVideo:
+                                              currentUserPubkey == video.pubkey,
+                                          controller: controller,
+                                          contextTitle: widget.contextTitle,
+                                          onInteracted: _suppressAutoAdvance,
+                                        );
+                                      },
+                                )
+                              : PooledVideoFeed(
+                                  key: _feedKey,
+                                  videos: state.pooledVideos,
+                                  controller: _controller,
+                                  initialIndex: state.currentIndex,
+                                  onActiveVideoChanged: (video, index) {
+                                    _resumeAutoAdvanceAfterSwipe();
+                                    FeedPerformanceTracker()
+                                        .startVideoSwipeTracking(
+                                          video.id,
+                                        );
+                                    context.read<FullscreenFeedBloc>().add(
+                                      FullscreenFeedIndexChanged(index),
                                     );
-                                  }
-                                  final originalEvent = state.videos.firstWhere(
-                                    (v) => v.id == video.id,
-                                    orElse: () {
-                                      final clamped = index.clamp(
-                                        0,
-                                        state.videos.length - 1,
-                                      );
+                                    widget.onPageChanged?.call(index);
+                                  },
+                                  onNearEnd: (index) =>
+                                      _onNearEnd(state, index),
+                                  nearEndThreshold: 0,
+                                  onScrollOffsetChanged: (page) =>
+                                      _pagePosition.value = page,
+                                  maxLoopDuration:
+                                      VideoEditorConstants.maxDuration,
+                                  itemBuilder: (context, video, index, {required isActive}) {
+                                    if (state.videos.isEmpty) {
                                       debugPrint(
-                                        'FullscreenFeed: video ID lookup miss! '
-                                        'video.id=${video.id}, index=$index, '
-                                        'clamped=$clamped, '
-                                        'state.videos.length='
-                                        '${state.videos.length}, '
-                                        'pooledVideos.length='
-                                        '${state.pooledVideos.length}',
+                                        'FullscreenFeed: itemBuilder called with empty '
+                                        'state.videos! index=$index, '
+                                        'video.id=${video.id}',
                                       );
-                                      return state.videos[clamped];
-                                    },
-                                  );
-                                  return _PooledFullscreenItem(
-                                    video: originalEvent,
-                                    index: index,
-                                    isActive: isActive,
-                                    pagePosition: _pagePosition,
-                                    contextTitle: widget.contextTitle,
-                                    trafficSource: widget.trafficSource,
-                                    sourceDetail: widget.sourceDetail,
-                                    isOwnVideo: isOwnVideo,
-                                    isAutoAdvanceActive: effectiveAutoActive,
-                                    onInteracted: _suppressAutoAdvance,
-                                    onAutoAdvanceCompleted:
-                                        _handleAutoAdvanceCompleted,
-                                  );
-                                },
-                              ),
+                                      return const ColoredBox(
+                                        color: VineTheme.backgroundColor,
+                                      );
+                                    }
+                                    final originalEvent = state.videos.firstWhere(
+                                      (v) => v.id == video.id,
+                                      orElse: () {
+                                        final clamped = index.clamp(
+                                          0,
+                                          state.videos.length - 1,
+                                        );
+                                        debugPrint(
+                                          'FullscreenFeed: video ID lookup miss! '
+                                          'video.id=${video.id}, index=$index, '
+                                          'clamped=$clamped, '
+                                          'state.videos.length='
+                                          '${state.videos.length}, '
+                                          'pooledVideos.length='
+                                          '${state.pooledVideos.length}',
+                                        );
+                                        return state.videos[clamped];
+                                      },
+                                    );
+                                    return _PooledFullscreenItem(
+                                      video: originalEvent,
+                                      index: index,
+                                      isActive: isActive,
+                                      pagePosition: _pagePosition,
+                                      contextTitle: widget.contextTitle,
+                                      trafficSource: widget.trafficSource,
+                                      sourceDetail: widget.sourceDetail,
+                                      isOwnVideo: isOwnVideo,
+                                      isAutoAdvanceActive: effectiveAutoActive,
+                                      onInteracted: _suppressAutoAdvance,
+                                      onAutoAdvanceCompleted:
+                                          _handleAutoAdvanceCompleted,
+                                    );
+                                  },
+                                ),
+                        ),
                       ),
                     ),
                     if (showCommentBar) const InlineCommentComposerBar(),
@@ -1666,6 +1670,99 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
     return NavRoundedShell(
       innerColor: VineTheme.backgroundColor,
       child: child,
+    );
+  }
+}
+
+/// Wraps the video feed so that taps on the video are *consumed*
+/// while a text input on this screen has primary focus.
+///
+/// Without this shield, tapping outside the inline comment composer's
+/// text field while the keyboard is up both (a) dismisses the
+/// keyboard — the intended effect — and (b) reaches the video's
+/// play / pause gesture recognizer underneath, toggling playback as
+/// a side-effect of typing.
+///
+/// The fix is layered:
+///
+/// * The shield's `GestureDetector(behavior: opaque)` claims the tap
+///   in the gesture arena, so the video's recognizer never sees it.
+/// * Keyboard dismissal still happens because [TextField.onTapOutside]
+///   is wired through [TapRegion] / `TapRegionSurface`, which reads
+///   pointer events at the surface level *independent* of the
+///   gesture arena — so the claim above does not prevent the
+///   onTapOutside callback from firing on the inline composer.
+///
+/// The shield only mounts the overlay while a text input has primary
+/// focus, so it's a passthrough on the steady-state feed.
+@visibleForTesting
+class VideoTapShield extends StatefulWidget {
+  @visibleForTesting
+  const VideoTapShield({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<VideoTapShield> createState() => _VideoTapShieldState();
+}
+
+class _VideoTapShieldState extends State<VideoTapShield> {
+  bool _textInputFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    FocusManager.instance.addListener(_onFocusChanged);
+    // Sync initial state in case a text input is already focused
+    // when this widget mounts (rare — e.g. screen recreated mid-
+    // composition).
+    _onFocusChanged();
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeListener(_onFocusChanged);
+    super.dispose();
+  }
+
+  void _onFocusChanged() {
+    if (!mounted) return;
+    final focused = _primaryFocusIsTextInput();
+    if (focused == _textInputFocused) return;
+    setState(() => _textInputFocused = focused);
+  }
+
+  /// Mirror the check used by [KeyboardAwareTopFade] /
+  /// `_primaryFocusIsTextInput` over in this file's other helpers:
+  /// the primary focus is "text input" iff its FocusNode's context
+  /// has an [EditableText] ancestor (the widget that actually owns
+  /// the platform TextInput connection).
+  static bool _primaryFocusIsTextInput() {
+    final focus = FocusManager.instance.primaryFocus;
+    final ctx = focus?.context;
+    if (ctx == null) return false;
+    return ctx.findAncestorWidgetOfExactType<EditableText>() != null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        if (_textInputFocused)
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              // Empty handler — see class docstring. The GD's job
+              // is to claim the tap so the video's play / pause
+              // recognizer never sees it; keyboard dismissal is
+              // delivered by the composer's onTapOutside via
+              // TapRegionSurface.
+              onTap: () {},
+            ),
+          ),
+      ],
     );
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -63,14 +63,14 @@ import 'package:pooled_video_player/pooled_video_player.dart'
 import 'package:unified_logger/unified_logger.dart';
 import 'package:video_player/video_player.dart';
 
-/// Letterboxed (non-portrait) videos previously top-aligned in the
-/// available viewport — which left a tall band of empty space below
-/// 1 × 1 classic reposts. Always centering instead keeps 1 × 1 and
-/// landscape sources visually in the middle of the screen, with
-/// symmetric bands above and below filled by
-/// [VineTheme.surfaceBackground] (the same green the comment bar
-/// paints, see [_MaybeRoundFeedBottom]). Portrait videos cover the
-/// whole viewport so alignment is a no-op for them.
+/// Always centers — including contain-fit (non-portrait) videos.
+/// Returning [Alignment.topCenter] for non-portrait used to jam 1 × 1
+/// classic Vine reposts against the AppBar; centering keeps them
+/// symmetric with the bands the caller paints around them (see
+/// [_MaybeRoundFeedBottom] / [_PooledFullscreenItemContent] for the
+/// canvas and [_BlurredVideoBackdrop] for the blurred-thumbnail
+/// layer). Portrait videos cover the whole viewport so alignment is
+/// a no-op for them.
 @visibleForTesting
 Alignment fullscreenVideoMediaAlignment({required bool isPortrait}) {
   return Alignment.center;
@@ -867,10 +867,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       // Match the home feed: when the comment bar is on
                       // screen, the video carries the same rounded
                       // bottom corners as `video_feed_page.dart`, so
-                      // the corners reveal [VineTheme.navGreen] which
-                      // is the same token the comment bar paints. The
-                      // result is a continuous green seam between the
-                      // video's bottom-corner cutouts and the bar.
+                      // the corners reveal [VineTheme.navGreen] (the
+                      // outer color [NavRoundedShell] paints). It
+                      // shares its hex (`#00150D`) with the comment
+                      // bar's [VineTheme.surfaceBackground], so the
+                      // rounded cutouts seam continuously into the bar.
                       child: VideoTapShield(
                         child: _MaybeRoundFeedBottom(
                           roundCorners: showCommentBar,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1152,6 +1152,10 @@ class _WebFullscreenItem extends ConsumerWidget {
             // same bottom anchor as the author info below and the two
             // cannot vertically drift apart.
             omitActionColumn: true,
+            // Top-of-screen scrim so the transparent app bar's white
+            // title / back button / More popover stay readable over
+            // light video frames.
+            showTopGradient: true,
           ),
           // 20 px above the Stack bottom (= comment-bar top). See
           // _PooledFullscreenItemContent.build for why we drop the
@@ -1458,6 +1462,11 @@ class _PooledFullscreenItemContentState
                         // keeps "About" vertically aligned with the
                         // bottom of the caption block.
                         omitActionColumn: true,
+                        // Top-of-screen scrim so the transparent app
+                        // bar's white title / back button / More
+                        // popover stay readable over light video
+                        // frames.
+                        showTopGradient: true,
                       );
                     },
                   ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -812,24 +812,18 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   onBackPressed: () => _handleBack(context),
                   backgroundMode: DiVineAppBarBackgroundMode.transparent,
                   forceMaterialTransparency: true,
-                  // Back button sits 8 px from the left edge of the screen
-                  // (4 px tighter than the previous 12). The More popover on
-                  // the trailing side keeps its 12 px gap by wrapping the
-                  // FeedSettingsMenu in an extra `end: 4` padding inside the
-                  // customActions slot.
-                  customActions: const [
-                    Padding(
-                      padding: EdgeInsetsDirectional.only(end: 4),
-                      child: FeedSettingsMenu(),
-                    ),
-                  ],
+                  // Stretch the back-button tap target to the full
+                  // leading slot. The fullscreen feed sits over playing
+                  // video so a small icon hit-target is easy to miss.
+                  expandLeadingHitArea: true,
+                  customActions: const [FeedSettingsMenu()],
                   style: DiVineAppBarStyle.transparentStyle.copyWith(
-                    horizontalPadding: 8,
-                    // With the default 48 px icon button and 8 px
-                    // [horizontalPadding], a 68 px leading slot leaves
+                    horizontalPadding: 12,
+                    // With the default 48 px icon button and 12 px
+                    // [horizontalPadding], a 72 px leading slot leaves
                     // 12 px between the back button's right edge and
-                    // the title text (68 − 8 − 48 = 12).
-                    leadingWidth: 68,
+                    // the title text (72 − 12 − 48 = 12).
+                    leadingWidth: 72,
                     // Figma `title/medium` token (Bricolage Grotesque
                     // 800, 16 / 24 / 0.15) — overrides the default
                     // [VineTheme.titleLargeFont] (22) used by the

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -823,17 +823,21 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               );
 
               return Scaffold(
-                // Match the comment bar's [VineTheme.surfaceBackground]
-                // (= [VineTheme.navGreen]) so anything peeking around
-                // the bar — the device's curved-corner cutouts or the
-                // safe-area sliver below the keyboard — is the same
-                // green as the bar itself, not the default black.
-                backgroundColor: VineTheme.surfaceBackground,
+                // Paint the Scaffold with [VineTheme.cardBackground]
+                // (`#1A1A1A`, the same neutral dark grey the Messages
+                // inbox uses on its scaffold). This is the canvas
+                // around 1 × 1 / landscape / unknown contain-fit videos
+                // and shows wherever the body leaks — the device's
+                // curved-corner cutouts or the safe-area sliver below
+                // the keyboard. Reads as a clearly distinct surface
+                // from the comment bar's
+                // [VineTheme.surfaceBackground] (`#00150D` dark green).
+                backgroundColor: VineTheme.cardBackground,
                 // Always edge-to-edge: the video fills the screen and the
                 // (transparent) AppBar overlays it, matching the home feed.
                 // 1 × 1 / landscape / dimensions-less videos are rendered
                 // with `BoxFit.contain`, so their letterbox bars sit on
-                // the [VineTheme.surfaceBackground] above — the
+                // the [VineTheme.cardBackground] above — the
                 // transparent AppBar reads cleanly against that surface
                 // colour, no carve-out needed.
                 extendBodyBehindAppBar: true,
@@ -1694,18 +1698,19 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!roundCorners) return child;
-    // Default [NavRoundedShell.innerColor] is
-    // [VineTheme.surfaceBackground] — the same `#00150D` green the
-    // comment bar paints. That's exactly what we want here: on the
-    // fullscreen feed we render contain-fit videos (1 × 1 classics,
-    // landscape, anything without dimensions metadata) which leave
-    // letterbox bands inside the rounded shell. The bands sit on top
-    // of [innerColor], so leaving it at the green default gives the
-    // user the same "video centered on green canvas" reading the
-    // comment bar already establishes. The home feed picks a black
-    // inner explicitly because it only renders portrait covers that
-    // hide the inner colour entirely.
-    return NavRoundedShell(child: child);
+    // Inside the rounded shell, paint
+    // [VineTheme.cardBackground] (`#1A1A1A`) — the same neutral dark
+    // grey the Messages inbox uses. That's the canvas around
+    // contain-fit videos (1 × 1 classics, landscape, anything without
+    // dimensions metadata) which leave letterbox bands the user can
+    // see. The shell's *outer* colour is the comment-bar green
+    // ([VineTheme.surfaceBackground], `#00150D`) by [NavRoundedShell]
+    // construction, so the rounded bottom corners reveal that green
+    // and seam the dark video region into the bar visually.
+    return NavRoundedShell(
+      innerColor: VineTheme.cardBackground,
+      child: child,
+    );
   }
 }
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -788,6 +788,32 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                     )
                   : null;
 
+              final appBar = DiVineAppBar(
+                title: widget.contextTitle ?? '',
+                showBackButton: true,
+                onBackPressed: () => _handleBack(context),
+                backgroundMode: DiVineAppBarBackgroundMode.transparent,
+                forceMaterialTransparency: true,
+                // Stretch the back-button tap target to the full
+                // leading slot. The fullscreen feed sits over playing
+                // video so a small icon hit-target is easy to miss.
+                expandLeadingHitArea: true,
+                customActions: const [FeedSettingsMenu()],
+                style: DiVineAppBarStyle.transparentStyle.copyWith(
+                  horizontalPadding: 12,
+                  // With the default 48 px icon button and 12 px
+                  // [horizontalPadding], a 72 px leading slot leaves
+                  // 12 px between the back button's right edge and
+                  // the title text (72 − 12 − 48 = 12).
+                  leadingWidth: 72,
+                  // Figma `title/medium` token (Bricolage Grotesque
+                  // 800, 16 / 24 / 0.15) — overrides the default
+                  // [VineTheme.titleLargeFont] (22) used by the
+                  // shared app bar.
+                  titleStyle: VineTheme.titleMediumFont(),
+                ),
+              );
+
               return Scaffold(
                 // Match the comment bar's [VineTheme.surfaceBackground]
                 // (= [VineTheme.navGreen]) so anything peeking around
@@ -806,30 +832,22 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 // that letterbox no longer exists and the carve-out is
                 // moot.
                 extendBodyBehindAppBar: true,
-                appBar: DiVineAppBar(
-                  title: widget.contextTitle ?? '',
-                  showBackButton: true,
-                  onBackPressed: () => _handleBack(context),
-                  backgroundMode: DiVineAppBarBackgroundMode.transparent,
-                  forceMaterialTransparency: true,
-                  // Stretch the back-button tap target to the full
-                  // leading slot. The fullscreen feed sits over playing
-                  // video so a small icon hit-target is easy to miss.
-                  expandLeadingHitArea: true,
-                  customActions: const [FeedSettingsMenu()],
-                  style: DiVineAppBarStyle.transparentStyle.copyWith(
-                    horizontalPadding: 12,
-                    // With the default 48 px icon button and 12 px
-                    // [horizontalPadding], a 72 px leading slot leaves
-                    // 12 px between the back button's right edge and
-                    // the title text (72 − 12 − 48 = 12).
-                    leadingWidth: 72,
-                    // Figma `title/medium` token (Bricolage Grotesque
-                    // 800, 16 / 24 / 0.15) — overrides the default
-                    // [VineTheme.titleLargeFont] (22) used by the
-                    // shared app bar.
-                    titleStyle: VineTheme.titleMediumFont(),
-                  ),
+                // Wrap the AppBar in a [TextFieldTapRegion] so taps on
+                // the back button / title / [FeedSettingsMenu] popover
+                // trigger don't dismiss the inline composer's keyboard.
+                // That lets users toggle playback (mute, captions, ...)
+                // mid-comment without losing what they're typing.
+                // [TapRegion] is independent of the gesture arena, so
+                // the back button and the More popover still fire their
+                // own handlers — only the "tap outside" unfocus
+                // callback is suppressed for taps inside this region.
+                // The popover's pill content is wrapped in its own
+                // [TextFieldTapRegion] inside [_FeedSettingsOverlay] so
+                // taps on the playback controls (which render outside
+                // this widget tree via [OverlayPortal]) are covered too.
+                appBar: PreferredSize(
+                  preferredSize: appBar.preferredSize,
+                  child: TextFieldTapRegion(child: appBar),
                 ),
                 body: Column(
                   children: [

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -3,6 +3,7 @@
 // ABOUTME: Uses FullscreenFeedBloc for state management
 
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
@@ -823,7 +824,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               );
 
               return Scaffold(
-                // Paint the Scaffold with [VineTheme.cardBackground]
+                // Paint the Scaffold with [VineTheme.surfaceContainerHigh]
                 // (`#1A1A1A`, the same neutral dark grey the Messages
                 // inbox uses on its scaffold). This is the canvas
                 // around 1 × 1 / landscape / unknown contain-fit videos
@@ -832,12 +833,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 // the keyboard. Reads as a clearly distinct surface
                 // from the comment bar's
                 // [VineTheme.surfaceBackground] (`#00150D` dark green).
-                backgroundColor: VineTheme.cardBackground,
+                backgroundColor: VineTheme.surfaceContainerHigh,
                 // Always edge-to-edge: the video fills the screen and the
                 // (transparent) AppBar overlays it, matching the home feed.
                 // 1 × 1 / landscape / dimensions-less videos are rendered
                 // with `BoxFit.contain`, so their letterbox bars sit on
-                // the [VineTheme.cardBackground] above — the
+                // the [VineTheme.surfaceContainerHigh] above — the
                 // transparent AppBar reads cleanly against that surface
                 // colour, no carve-out needed.
                 extendBodyBehindAppBar: true,
@@ -1359,202 +1360,276 @@ class _PooledFullscreenItemContentState
       warnLabels: video.warnLabels,
     );
 
+    final thumbnailUrl = video.thumbnailUrl;
+    final showBlurBackdrop =
+        !isPortrait && thumbnailUrl != null && thumbnailUrl.isNotEmpty;
+
     return FeedAutoAdvancePastErrorListener(
       videoId: video.id,
       isActive: widget.isActive,
       isAutoAdvanceActive: widget.isAutoAdvanceActive,
       onSkipBrokenVideo: widget.onAutoAdvanceCompleted ?? () {},
       child: ColoredBox(
-        color: VineTheme.backgroundColor,
-        child: PooledVideoPlayer(
-          index: widget.index,
-          isActive: widget.isActive,
-          thumbnailUrl: video.thumbnailUrl,
-          enableTapToPause: widget.isActive,
-          onTap: _handlePlayerTap,
-          onDoubleTap: _handleDoubleTapLike,
-          videoBuilder: (context, videoController, player) =>
-              PooledVideoMetricsTracker(
-                key: ValueKey('metrics-${video.id}'),
-                video: video,
-                player: player,
-                isActive: widget.isActive,
-                trafficSource: widget.trafficSource,
-                sourceDetail: widget.sourceDetail,
-                child: _FittedVideoPlayer(
-                  videoController: videoController,
-                  isPortrait: isPortrait,
-                  videoWidth: video.width?.toDouble(),
-                  videoHeight: video.height?.toDouble(),
-                ),
+        // [VineTheme.surfaceContainerHigh] (`#000A06`) — the canvas
+        // colour we want behind contain-fit videos (1 × 1 / landscape
+        // / dimensions-less). The previous `VineTheme.backgroundColor`
+        // (`#000000`) was overpainting the Scaffold + NavRoundedShell
+        // background here, so the surrounding letterbox bands always
+        // rendered pure black regardless of what the outer surfaces
+        // were set to.
+        color: VineTheme.surfaceContainerHigh,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            // Blurred thumbnail backdrop for contain-fit videos. The
+            // thumbnail fills the screen (BoxFit.cover) and is heavily
+            // blurred, so 1 × 1 / landscape sources are surrounded by
+            // a diffused colour-cloud derived from their own first
+            // frame — much closer to the Instagram / TikTok "blurred
+            // poster" look than a flat dark surface. One image decode
+            // + one GPU blur pass, no ongoing cost. Portrait videos
+            // cover the screen entirely and would never reveal the
+            // backdrop, so we skip it for them.
+            if (showBlurBackdrop)
+              Positioned.fill(
+                child: _BlurredVideoBackdrop(url: thumbnailUrl),
               ),
-          loadingBuilder: (context) => _VideoLoadingPlaceholder(
-            thumbnailUrl: video.thumbnailUrl,
-            isPortrait: isPortrait,
-          ),
-          errorBuilder: (context, onRetry, errorType) {
-            // Map pooled_video_player.VideoErrorType to the canonical
-            // infinite_video_feed.VideoErrorType used by playbackStatusFromError
-            // and PooledVideoErrorOverlay.
-            final feedErrorType = _toFeedErrorType(errorType);
-            // Dedupe at the call site so rebuilds don't schedule a
-            // post-frame callback every frame. See _lastReportedError doc.
-            if (_lastReportedError != feedErrorType) {
-              _lastReportedError = feedErrorType;
-              // Capture the cubit eagerly so the post-frame callback doesn't
-              // walk the ancestor tree on a potentially-deactivated element.
-              final cubit = context.read<VideoPlaybackStatusCubit>();
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (!mounted) return;
-                cubit.report(video.id, playbackStatusFromError(feedErrorType));
-              });
-            }
-            return PooledVideoErrorOverlay(
-              video: video,
-              onRetry: onRetry,
-              errorType: feedErrorType,
-            );
-          },
-          overlayBuilder: (context, videoController, player, feedController) {
-            final playbackStatus = context.select(
-              (VideoPlaybackStatusCubit cubit) =>
-                  cubit.state.statusFor(video.id),
-            );
-            if (playbackStatus == PlaybackStatus.forbidden ||
-                playbackStatus == PlaybackStatus.ageRestricted) {
-              return ModeratedContentOverlay(
-                status: playbackStatus,
-                onSkip: () => _skipToNextVideo(context),
-                onVerifyAge: playbackStatus == PlaybackStatus.ageRestricted
-                    ? () => _verifyAgeForVideo(context, video)
-                    : null,
-              );
-            }
-            if (showContentWarningOverlay && !_contentWarningRevealed) {
-              return ContentWarningBlurOverlay(
-                labels: overlayLabels,
-                onReveal: () => setState(() {
-                  _contentWarningRevealed = true;
-                }),
-                onHideSimilar: () {
-                  hideContentWarningsLikeThese(
-                    context: context,
-                    ref: ref,
-                    labels: overlayLabels,
-                  );
-                },
-              );
-            }
-            // No `MediaQuery(data: MediaQueryData.fromView(...))` wrap
-            // here: `MediaQueryData.fromView` is a *snapshot* taken when
-            // this builder runs, so the subtree wouldn't see live
-            // `viewInsets` updates when the soft keyboard slides up or
-            // down. That breaks any descendant that needs to react to
-            // the keyboard (e.g. [KeyboardAwareTopFade]). The inherited
-            // MediaQuery from above is already correct — Scaffold only
-            // modifies `padding`, not `viewInsets`.
-            return FeedAutoAdvanceCompletionListener(
-              player: player,
-              isEnabled: widget.isActive && widget.isAutoAdvanceActive,
-              onCompleted: widget.onAutoAdvanceCompleted ?? () {},
-              child: Stack(
-                children: [
-                  if (player != null)
-                    PausedVideoPlayOverlay(
-                      player: player,
-                      firstFrameFuture:
-                          videoController?.waitUntilFirstFrameRendered,
-                      isVisible: widget.isActive,
+            PooledVideoPlayer(
+              index: widget.index,
+              isActive: widget.isActive,
+              thumbnailUrl: video.thumbnailUrl,
+              enableTapToPause: widget.isActive,
+              onTap: _handlePlayerTap,
+              onDoubleTap: _handleDoubleTapLike,
+              videoBuilder: (context, videoController, player) =>
+                  PooledVideoMetricsTracker(
+                    key: ValueKey('metrics-${video.id}'),
+                    video: video,
+                    player: player,
+                    isActive: widget.isActive,
+                    trafficSource: widget.trafficSource,
+                    sourceDetail: widget.sourceDetail,
+                    child: _FittedVideoPlayer(
+                      videoController: videoController,
+                      isPortrait: isPortrait,
+                      videoWidth: video.width?.toDouble(),
+                      videoHeight: video.height?.toDouble(),
                     ),
-                  ValueListenableBuilder<double>(
-                    valueListenable: widget.pagePosition,
-                    builder: (context, page, _) {
-                      final distance = (page - widget.index).abs().clamp(
-                        0.0,
-                        1.0,
-                      );
-                      return VideoOverlayActions(
-                        video: video,
-                        // isVisible:true — scroll opacity handles fading;
-                        // the hard-cut guard is not needed in fullscreen.
-                        isVisible: true,
-                        isActive: widget.isActive,
-                        overlayOpacity: scrollDrivenOpacity(distance),
-                        hasBottomNavigation: false,
-                        contextTitle: widget.contextTitle,
-                        isFullscreen: true,
-                        topOffset: widget.isOwnVideo ? 64 : 8,
-                        onInteracted: widget.onInteracted,
-                        // The shared [VideoAuthorInfoSection] below renders
-                        // the author block + inline caption pill, matching
-                        // the home feed overlay exactly. Suppress the
-                        // legacy inline column so they don't double up.
-                        omitAuthorBlock: true,
-                        // The action column lives in this widget's outer
-                        // Stack alongside the author info so both are
-                        // anchored to the same Stack bottom — matches the
-                        // home feed pattern in [FeedVideoOverlay] and
-                        // keeps "About" vertically aligned with the
-                        // bottom of the caption block.
-                        omitActionColumn: true,
-                        // Top-of-screen scrim so the transparent app
-                        // bar's white title / back button / More
-                        // popover stay readable over light video
-                        // frames.
-                        showTopGradient: true,
+                  ),
+              loadingBuilder: (context) => _VideoLoadingPlaceholder(
+                thumbnailUrl: video.thumbnailUrl,
+                isPortrait: isPortrait,
+              ),
+              errorBuilder: (context, onRetry, errorType) {
+                // Map pooled_video_player.VideoErrorType to the canonical
+                // infinite_video_feed.VideoErrorType used by playbackStatusFromError
+                // and PooledVideoErrorOverlay.
+                final feedErrorType = _toFeedErrorType(errorType);
+                // Dedupe at the call site so rebuilds don't schedule a
+                // post-frame callback every frame. See _lastReportedError doc.
+                if (_lastReportedError != feedErrorType) {
+                  _lastReportedError = feedErrorType;
+                  // Capture the cubit eagerly so the post-frame callback doesn't
+                  // walk the ancestor tree on a potentially-deactivated element.
+                  final cubit = context.read<VideoPlaybackStatusCubit>();
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (!mounted) return;
+                    cubit.report(
+                      video.id,
+                      playbackStatusFromError(feedErrorType),
+                    );
+                  });
+                }
+                return PooledVideoErrorOverlay(
+                  video: video,
+                  onRetry: onRetry,
+                  errorType: feedErrorType,
+                );
+              },
+              overlayBuilder: (context, videoController, player, feedController) {
+                final playbackStatus = context.select(
+                  (VideoPlaybackStatusCubit cubit) =>
+                      cubit.state.statusFor(video.id),
+                );
+                if (playbackStatus == PlaybackStatus.forbidden ||
+                    playbackStatus == PlaybackStatus.ageRestricted) {
+                  return ModeratedContentOverlay(
+                    status: playbackStatus,
+                    onSkip: () => _skipToNextVideo(context),
+                    onVerifyAge: playbackStatus == PlaybackStatus.ageRestricted
+                        ? () => _verifyAgeForVideo(context, video)
+                        : null,
+                  );
+                }
+                if (showContentWarningOverlay && !_contentWarningRevealed) {
+                  return ContentWarningBlurOverlay(
+                    labels: overlayLabels,
+                    onReveal: () => setState(() {
+                      _contentWarningRevealed = true;
+                    }),
+                    onHideSimilar: () {
+                      hideContentWarningsLikeThese(
+                        context: context,
+                        ref: ref,
+                        labels: overlayLabels,
                       );
                     },
-                  ),
-                  // Bottom-left metadata container — author avatar/name,
-                  // optional inline caption pill, and title/description.
-                  // 20 px above the Stack bottom (= comment-bar top). No
-                  // `viewPadding.bottom` term: the [InlineCommentComposerBar]
-                  // already absorbs the device home-indicator inset, so
-                  // adding it here would double-pad. The home feed's
-                  // matching `bottom: 20 + safeAreaBottom` line works
-                  // because there the inherited `viewPadding.bottom`
-                  // collapses to 0 below the [VineBottomNav]'s `SafeArea`.
-                  PositionedDirectional(
-                    bottom: 20,
-                    start: 16,
-                    end: 80,
-                    child: AnimatedOpacity(
-                      opacity: widget.isActive ? 1.0 : 0.0,
-                      duration: const Duration(milliseconds: 200),
-                      child: VideoAuthorInfoSection(
-                        video: video,
-                        hasTextContent:
-                            video.content.isNotEmpty ||
-                            (video.title != null && video.title!.isNotEmpty),
-                        player: player,
-                        onInteracted: widget.onInteracted,
+                  );
+                }
+                // No `MediaQuery(data: MediaQueryData.fromView(...))` wrap
+                // here: `MediaQueryData.fromView` is a *snapshot* taken when
+                // this builder runs, so the subtree wouldn't see live
+                // `viewInsets` updates when the soft keyboard slides up or
+                // down. That breaks any descendant that needs to react to
+                // the keyboard (e.g. [KeyboardAwareTopFade]). The inherited
+                // MediaQuery from above is already correct — Scaffold only
+                // modifies `padding`, not `viewInsets`.
+                return FeedAutoAdvanceCompletionListener(
+                  player: player,
+                  isEnabled: widget.isActive && widget.isAutoAdvanceActive,
+                  onCompleted: widget.onAutoAdvanceCompleted ?? () {},
+                  child: Stack(
+                    children: [
+                      if (player != null)
+                        PausedVideoPlayOverlay(
+                          player: player,
+                          firstFrameFuture:
+                              videoController?.waitUntilFirstFrameRendered,
+                          isVisible: widget.isActive,
+                        ),
+                      ValueListenableBuilder<double>(
+                        valueListenable: widget.pagePosition,
+                        builder: (context, page, _) {
+                          final distance = (page - widget.index).abs().clamp(
+                            0.0,
+                            1.0,
+                          );
+                          return VideoOverlayActions(
+                            video: video,
+                            // isVisible:true — scroll opacity handles fading;
+                            // the hard-cut guard is not needed in fullscreen.
+                            isVisible: true,
+                            isActive: widget.isActive,
+                            overlayOpacity: scrollDrivenOpacity(distance),
+                            hasBottomNavigation: false,
+                            contextTitle: widget.contextTitle,
+                            isFullscreen: true,
+                            topOffset: widget.isOwnVideo ? 64 : 8,
+                            onInteracted: widget.onInteracted,
+                            // The shared [VideoAuthorInfoSection] below renders
+                            // the author block + inline caption pill, matching
+                            // the home feed overlay exactly. Suppress the
+                            // legacy inline column so they don't double up.
+                            omitAuthorBlock: true,
+                            // The action column lives in this widget's outer
+                            // Stack alongside the author info so both are
+                            // anchored to the same Stack bottom — matches the
+                            // home feed pattern in [FeedVideoOverlay] and
+                            // keeps "About" vertically aligned with the
+                            // bottom of the caption block.
+                            omitActionColumn: true,
+                            // Top-of-screen scrim so the transparent app
+                            // bar's white title / back button / More
+                            // popover stay readable over light video
+                            // frames.
+                            showTopGradient: true,
+                          );
+                        },
                       ),
-                    ),
-                  ),
-                  // Action column — sibling of the author info, both
-                  // anchored to the same Stack bottom at `bottom: 20`.
-                  PositionedDirectional(
-                    bottom: 20,
-                    end: 12,
-                    child: AnimatedOpacity(
-                      opacity: widget.isActive ? 1.0 : 0.0,
-                      duration: const Duration(milliseconds: 200),
-                      child: KeyboardAwareTopFade(
-                        child: VideoOverlayActionColumn(
-                          video: video,
-                          isFullscreen: true,
-                          onInteracted: widget.onInteracted,
+                      // Bottom-left metadata container — author avatar/name,
+                      // optional inline caption pill, and title/description.
+                      // 20 px above the Stack bottom (= comment-bar top). No
+                      // `viewPadding.bottom` term: the [InlineCommentComposerBar]
+                      // already absorbs the device home-indicator inset, so
+                      // adding it here would double-pad. The home feed's
+                      // matching `bottom: 20 + safeAreaBottom` line works
+                      // because there the inherited `viewPadding.bottom`
+                      // collapses to 0 below the [VineBottomNav]'s `SafeArea`.
+                      PositionedDirectional(
+                        bottom: 20,
+                        start: 16,
+                        end: 80,
+                        child: AnimatedOpacity(
+                          opacity: widget.isActive ? 1.0 : 0.0,
+                          duration: const Duration(milliseconds: 200),
+                          child: VideoAuthorInfoSection(
+                            video: video,
+                            hasTextContent:
+                                video.content.isNotEmpty ||
+                                (video.title != null &&
+                                    video.title!.isNotEmpty),
+                            player: player,
+                            onInteracted: widget.onInteracted,
+                          ),
                         ),
                       ),
-                    ),
+                      // Action column — sibling of the author info, both
+                      // anchored to the same Stack bottom at `bottom: 20`.
+                      PositionedDirectional(
+                        bottom: 20,
+                        end: 12,
+                        child: AnimatedOpacity(
+                          opacity: widget.isActive ? 1.0 : 0.0,
+                          duration: const Duration(milliseconds: 200),
+                          child: KeyboardAwareTopFade(
+                            child: VideoOverlayActionColumn(
+                              video: video,
+                              isFullscreen: true,
+                              onInteracted: widget.onInteracted,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Positioned.fill(
+                        child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                      ),
+                    ],
                   ),
-                  Positioned.fill(
-                    child: DoubleTapHeartOverlay(trigger: _heartTrigger),
-                  ),
-                ],
-              ),
-            );
-          },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Heavily-blurred copy of a video's poster thumbnail, stretched to
+/// `BoxFit.cover` the entire fullscreen area. Painted behind the video
+/// in `_PooledFullscreenItemContent` so contain-fit videos (1 × 1 /
+/// landscape) sit on a diffused colour cloud derived from their own
+/// first frame instead of a flat dark surface — matches the
+/// Instagram / TikTok "blurred poster" look.
+///
+/// Cost: one image decode + one GPU blur pass via [ImageFiltered].
+/// The decoded image lives in Flutter's image cache, so revisiting
+/// the same video re-uses it. No ongoing per-frame cost once the
+/// image is rasterised.
+class _BlurredVideoBackdrop extends StatelessWidget {
+  const _BlurredVideoBackdrop({required this.url});
+
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      // `ImageFiltered` applies the blur on the GPU side; `ClipRect`
+      // keeps the bleeding edge of the blur kernel from leaking
+      // outside the widget's box and over the surrounding chrome.
+      child: ImageFiltered(
+        imageFilter: ui.ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+        child: Image.network(
+          url,
+          fit: BoxFit.cover,
+          // 50 % opacity via [Image.opacity] (an animation) rather
+          // than an [Opacity] wrapper — the latter forces a full-
+          // screen save-layer, the former blends per-pixel during
+          // paint and is essentially free.
+          opacity: const AlwaysStoppedAnimation(0.5),
+          // Fall back to nothing on error — the parent
+          // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
+          errorBuilder: (_, _, _) => const SizedBox.shrink(),
         ),
       ),
     );
@@ -1699,7 +1774,7 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
   Widget build(BuildContext context) {
     if (!roundCorners) return child;
     // Inside the rounded shell, paint
-    // [VineTheme.cardBackground] (`#1A1A1A`) — the same neutral dark
+    // [VineTheme.surfaceContainerHigh] (`#1A1A1A`) — the same neutral dark
     // grey the Messages inbox uses. That's the canvas around
     // contain-fit videos (1 × 1 classics, landscape, anything without
     // dimensions metadata) which leave letterbox bands the user can
@@ -1708,7 +1783,7 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
     // construction, so the rounded bottom corners reveal that green
     // and seam the dark video region into the bar visually.
     return NavRoundedShell(
-      innerColor: VineTheme.cardBackground,
+      innerColor: VineTheme.surfaceContainerHigh,
       child: child,
     );
   }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -14,6 +14,7 @@ import 'package:infinite_video_feed/infinite_video_feed.dart'
     show InfiniteVideoFeed, VideoErrorType;
 import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
@@ -41,6 +42,7 @@ import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
+import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_play_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
@@ -62,23 +64,6 @@ import 'package:video_player/video_player.dart';
 @visibleForTesting
 Alignment fullscreenVideoMediaAlignment({required bool isPortrait}) {
   return isPortrait ? Alignment.center : Alignment.topCenter;
-}
-
-@visibleForTesting
-double fullscreenContainedVideoTopInset({
-  required double safeAreaTop,
-  bool isPortrait = false,
-  bool hasHeader = false,
-}) {
-  // When the screen has a context header, the Scaffold no longer extends the
-  // body behind the AppBar (see `extendBodyBehindAppBar: !hasHeader` below),
-  // so the body is already laid out beneath the header — applying a
-  // leaf-level Padding here would double-pad. The leaf-level inset only
-  // applies on the headerless fullscreen feed, where the body extends
-  // behind a transparent AppBar and contained videos need to be pushed
-  // down to avoid overlapping with it.
-  if (hasHeader) return 0;
-  return isPortrait ? 0 : safeAreaTop + DiVineAppBarStyle.defaultStyle.height;
 }
 
 /// Arguments for navigating to PooledFullscreenVideoFeedScreen.
@@ -599,359 +584,401 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: _autoAdvanceCubit,
-      child: MultiBlocListener(
-        listeners: [
-          // Sync volume when hardware buttons change system volume.
-          // Also forward to the web feed so the in-pause mute toggle in
-          // the paused overlay reaches WebVideoPlayer instances.
-          BlocListener<VideoVolumeCubit, VideoVolumeState>(
-            listener: (_, state) {
-              _controller?.setVolume(state.volume);
-              _webFeedKey.currentState?.setVolume(state.volume);
-            },
-          ),
-          // Initialize controller when videos first become available
-          BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
-            listenWhen: (prev, curr) =>
-                !prev.hasPooledVideos && curr.hasPooledVideos,
-            listener: (context, state) =>
-                _initializeControllerIfNeeded(triggerRebuild: true),
-          ),
-          // Handle new videos from pagination
-          BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
-            listenWhen: (prev, curr) =>
-                prev.videoUpdateSignature != curr.videoUpdateSignature,
-            listener: (context, state) => _handleVideosChanged(state),
-          ),
-          BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
-            listenWhen: (prev, curr) =>
-                prev.videos.length != curr.videos.length ||
-                prev.isLoadingMore != curr.isLoadingMore ||
-                prev.canLoadMore != curr.canLoadMore,
-            listener: (context, state) => _continuePendingAutoAdvance(state),
-          ),
-          // Open comments sheet once the first video is ready (notification deep-link)
-          if (widget.autoOpenComments)
-            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
-              listenWhen: (prev, curr) =>
-                  prev.currentVideo == null && curr.currentVideo != null,
-              listener: (context, state) {
-                final video = state.currentVideo;
-                if (video != null) CommentsScreen.show(context, video);
+    // Owned at the screen level so the inline comment composer bar at the
+    // bottom of the Scaffold has a single cubit shared across page swipes —
+    // re-creating it per-item would lose any in-flight publish during a
+    // swipe. Keyed on the comments repository so an auth flip / account
+    // switch closes the cubit and a fresh one captures the new repo
+    // identity (see `rules/state_management.md`).
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+
+    return BlocProvider<InlineCommentComposerCubit>(
+      key: ValueKey(commentsRepository),
+      create: (_) =>
+          InlineCommentComposerCubit(commentsRepository: commentsRepository),
+      child: BlocProvider.value(
+        value: _autoAdvanceCubit,
+        child: MultiBlocListener(
+          listeners: [
+            // Sync volume when hardware buttons change system volume.
+            // Also forward to the web feed so the in-pause mute toggle in
+            // the paused overlay reaches WebVideoPlayer instances.
+            BlocListener<VideoVolumeCubit, VideoVolumeState>(
+              listener: (_, state) {
+                _controller?.setVolume(state.volume);
+                _webFeedKey.currentState?.setVolume(state.volume);
               },
             ),
-          // Dispatch FullscreenFeedVideoUnavailable when the active video's
-          // playback status becomes notFound. The BLoC owns the HEAD-confirm,
-          // removal, and dedupe logic — this listener is the screen-level
-          // bridge that replaces the per-item post-frame callback.
-          BlocListener<VideoPlaybackStatusCubit, VideoPlaybackStatusState>(
-            listener: (context, state) =>
-                _dispatchVideoUnavailableIfActive(state),
-          ),
-          // Animate the feed when the BLoC signals a pending skip after a
-          // confirmed 404 removal.
-          BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
-            listenWhen: (prev, curr) =>
-                prev.pendingSkipTarget != curr.pendingSkipTarget &&
-                curr.pendingSkipTarget != null,
-            listener: (context, state) {
-              final target = state.pendingSkipTarget;
-              if (target != null) unawaited(_handlePendingSkip(target));
-            },
-          ),
-          // Pop the route when the last visible video has been removed
-          // by deletion (or, soon, block / mute). When `maybePop`
-          // returns false (cold deep-link into the fullscreen with no
-          // parent route in the stack), the BlocBuilder below renders
-          // an explicit `emptyAfterRemoval` branch so the user is not
-          // left looking at a perpetual loading spinner.
-          BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
-            listenWhen: (prev, curr) =>
-                prev.status != curr.status &&
-                curr.status == FullscreenFeedStatus.emptyAfterRemoval,
-            listener: (context, _) {
-              unawaited(Navigator.of(context).maybePop());
-            },
-          ),
-        ],
-        child: BlocBuilder<FullscreenFeedBloc, FullscreenFeedState>(
-          builder: (context, state) {
-            // The BlocListener above tries to pop on this status; when
-            // it can (parent route exists) the route is gone before this
-            // branch renders. When `maybePop` is a no-op, we land here
-            // and show an explicit empty-state with a back button rather
-            // than the loading spinner below.
-            if (state.status == FullscreenFeedStatus.emptyAfterRemoval) {
-              return Scaffold(
-                backgroundColor: VineTheme.backgroundColor,
-                appBar: DiVineAppBar(
-                  title: widget.contextTitle ?? '',
-                  showBackButton: true,
-                  // The BlocListener above already tried `maybePop` and
-                  // failed (otherwise we wouldn't be rendering this
-                  // branch). Keep the same root-route fallback here so
-                  // cold-start deep links never strand the user.
-                  onBackPressed: () => _handleBack(context),
-                  backgroundMode: DiVineAppBarBackgroundMode.transparent,
-                  forceMaterialTransparency: true,
-                ),
-                body: Center(
-                  child: Text(
-                    context.l10n.fullscreenFeedRemovedMessage,
-                    style: VineTheme.bodyMediumFont(),
-                  ),
-                ),
-              );
-            }
-
-            if (state.status == FullscreenFeedStatus.initial ||
-                !state.hasVideos) {
-              return Scaffold(
-                backgroundColor: VineTheme.backgroundColor,
-                appBar: DiVineAppBar(
-                  title: widget.contextTitle ?? '',
-                  showBackButton: true,
-                  onBackPressed: () => _handleBack(context),
-                  backgroundMode: DiVineAppBarBackgroundMode.transparent,
-                  forceMaterialTransparency: true,
-                ),
-                body: const Center(child: BrandedLoadingIndicator(size: 60)),
-              );
-            }
-
-            if (!state.hasPooledVideos) {
-              return Scaffold(
-                backgroundColor: VineTheme.backgroundColor,
-                appBar: DiVineAppBar(
-                  title: widget.contextTitle ?? '',
-                  showBackButton: true,
-                  onBackPressed: () => _handleBack(context),
-                  backgroundMode: DiVineAppBarBackgroundMode.transparent,
-                  forceMaterialTransparency: true,
-                ),
-                body: const Center(
-                  child: Text(
-                    'No videos available',
-                    style: TextStyle(color: VineTheme.whiteText),
-                  ),
-                ),
-              );
-            }
-
-            final authService = ref.watch(authServiceProvider);
-            final currentUserPubkey = authService.currentPublicKeyHex;
-            final isOwnVideo =
-                currentUserPubkey != null &&
-                currentUserPubkey == state.currentVideo?.pubkey;
-
-            // Subscribe to Auto state so items rebuild on toggle/suppress/resume.
-            final autoState = context.watch<FeedAutoAdvanceCubit>().state;
-
-            // Gate the rail + runtime on the user's reduced-motion
-            // preference. When Auto is unavailable,
-            // force it "off" at the view layer regardless of cubit state.
-            final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(
-              context,
-            );
-            final effectiveAutoActive =
-                autoAdvanceAvailable && autoState.isEffectivelyActive;
-
-            // Wire the NIP-98 auth header provider into WebVideoFeed only
-            // when running on web AND the HLS auth web player flag is on.
-            // When either condition is false, authHeaderProvider stays null
-            // and the legacy VideoPlayerController path is used unchanged.
-            final hlsAuthWebPlayerEnabled = ref.watch(
-              isFeatureEnabledProvider(FeatureFlag.hlsAuthWebPlayer),
-            );
-            final webAuthHeaderProvider = kIsWeb && hlsAuthWebPlayerEnabled
-                ? buildWebVideoAuthHeaderProvider(
-                    ref.watch(mediaViewerAuthServiceProvider),
-                  )
-                : null;
-
-            // When this screen is opened with a context header (Popular
-            // Videos, hashtag, search, liked, etc.) the header is meaningful
-            // chrome and the video must sit beneath it. We let the Scaffold
-            // own the layout (`extendBodyBehindAppBar: false`) instead of
-            // applying a leaf-level Padding inside `_FittedVideoPlayer` —
-            // the leaf approach is fragile around the media_kit `Video`
-            // widget and was unreliable for square Vine reposts whose
-            // baked-in letterbox bars made them appear to "slip under" the
-            // header. Headerless usages keep the TikTok-style edge-to-edge
-            // layout.
-            final hasHeader =
-                widget.contextTitle != null && widget.contextTitle!.isNotEmpty;
-
-            return Scaffold(
-              backgroundColor: VineTheme.backgroundColor,
-              extendBodyBehindAppBar: !hasHeader,
-              appBar: DiVineAppBar(
-                title: widget.contextTitle ?? '',
-                showBackButton: true,
-                onBackPressed: () => _handleBack(context),
-                backgroundMode: DiVineAppBarBackgroundMode.transparent,
-                forceMaterialTransparency: true,
-                // Back button sits 8 px from the left edge of the screen
-                // (4 px tighter than the previous 12). The More popover on
-                // the trailing side keeps its 12 px gap by wrapping the
-                // FeedSettingsMenu in an extra `end: 4` padding inside the
-                // customActions slot.
-                customActions: const [
-                  Padding(
-                    padding: EdgeInsetsDirectional.only(end: 4),
-                    child: FeedSettingsMenu(),
-                  ),
-                ],
-                style: DiVineAppBarStyle.transparentStyle.copyWith(
-                  horizontalPadding: 8,
-                ),
+            // Initialize controller when videos first become available
+            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+              listenWhen: (prev, curr) =>
+                  !prev.hasPooledVideos && curr.hasPooledVideos,
+              listener: (context, state) =>
+                  _initializeControllerIfNeeded(triggerRebuild: true),
+            ),
+            // Handle new videos from pagination
+            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+              listenWhen: (prev, curr) =>
+                  prev.videoUpdateSignature != curr.videoUpdateSignature,
+              listener: (context, state) => _handleVideosChanged(state),
+            ),
+            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+              listenWhen: (prev, curr) =>
+                  prev.videos.length != curr.videos.length ||
+                  prev.isLoadingMore != curr.isLoadingMore ||
+                  prev.canLoadMore != curr.canLoadMore,
+              listener: (context, state) => _continuePendingAutoAdvance(state),
+            ),
+            // Open comments sheet once the first video is ready (notification deep-link)
+            if (widget.autoOpenComments)
+              BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+                listenWhen: (prev, curr) =>
+                    prev.currentVideo == null && curr.currentVideo != null,
+                listener: (context, state) {
+                  final video = state.currentVideo;
+                  if (video != null) CommentsScreen.show(context, video);
+                },
               ),
-              body:
-                  InfiniteVideoFeed.isSupported &&
-                      ref.watch(isFeatureEnabledProvider(.nativeFeedPlayer))
-                  ? FeedVideos(
-                      key: _feedVideosKey,
-                      videos: state.videos,
-                      contextTitle: widget.contextTitle,
-                      currentIndex: state.currentIndex,
-                      shouldPortraitExpand: false,
-                      hasMore: state.canLoadMore,
-                      isLoadingMore: state.isLoadingMore,
-                      onActiveVideoChanged: (video, index) {
-                        _resumeAutoAdvanceAfterSwipe();
-                        FeedPerformanceTracker().startVideoSwipeTracking(
-                          video.id,
-                        );
-                        context.read<FullscreenFeedBloc>().add(
-                          FullscreenFeedIndexChanged(index),
-                        );
-                        widget.onPageChanged?.call(index);
-                      },
-                      onNearEnd: () {
-                        if (state.canLoadMore) {
-                          _triggerLoadMore();
-                        }
-                      },
-                    )
-                  : kIsWeb
-                  ? WebVideoFeed(
-                      key: _webFeedKey,
-                      videos: state.videos
-                          .where((v) => v.videoUrl != null)
-                          .toList(),
-                      initialIndex: state.currentIndex,
-                      controllerFactory:
-                          widget.webControllerFactory ??
-                          defaultWebVideoPlayerControllerFactory,
-                      authHeaderProvider: webAuthHeaderProvider,
-                      initialVolume: context
-                          .read<VideoVolumeCubit>()
-                          .state
-                          .volume,
-                      onActiveVideoChanged: (video, index) {
-                        _pagePosition.value = index.toDouble();
-                        _resumeAutoAdvanceAfterSwipe();
-                        FeedPerformanceTracker().startVideoSwipeTracking(
-                          video.id,
-                        );
-                        context.read<FullscreenFeedBloc>().add(
-                          FullscreenFeedIndexChanged(index),
-                        );
-                        widget.onPageChanged?.call(index);
-                      },
-                      onCompleted: (_) => _handleAutoAdvanceCompleted(),
-                      onErrored: _handleWebPlayerErrored,
-                      onRequiresAuth: _handleWebPlayerRequiresAuth,
-                      onNearEnd: (index) => _onNearEnd(state, index),
-                      itemBuilder:
-                          (
-                            context,
-                            video,
-                            index, {
-                            required isActive,
-                            controller,
-                          }) {
-                            return _WebFullscreenItem(
-                              video: video,
-                              isActive: isActive,
-                              isOwnVideo: currentUserPubkey == video.pubkey,
-                              controller: controller,
-                              contextTitle: widget.contextTitle,
-                              onInteracted: _suppressAutoAdvance,
-                            );
-                          },
-                    )
-                  : PooledVideoFeed(
-                      key: _feedKey,
-                      videos: state.pooledVideos,
-                      controller: _controller,
-                      initialIndex: state.currentIndex,
-                      onActiveVideoChanged: (video, index) {
-                        _resumeAutoAdvanceAfterSwipe();
-                        FeedPerformanceTracker().startVideoSwipeTracking(
-                          video.id,
-                        );
-                        context.read<FullscreenFeedBloc>().add(
-                          FullscreenFeedIndexChanged(index),
-                        );
-                        widget.onPageChanged?.call(index);
-                      },
-                      onNearEnd: (index) => _onNearEnd(state, index),
-                      nearEndThreshold: 0,
-                      onScrollOffsetChanged: (page) =>
-                          _pagePosition.value = page,
-                      maxLoopDuration: VideoEditorConstants.maxDuration,
-                      itemBuilder:
-                          (context, video, index, {required isActive}) {
-                            if (state.videos.isEmpty) {
-                              debugPrint(
-                                'FullscreenFeed: itemBuilder called with empty '
-                                'state.videos! index=$index, '
-                                'video.id=${video.id}',
-                              );
-                              return const ColoredBox(
-                                color: VineTheme.backgroundColor,
-                              );
-                            }
-                            final originalEvent = state.videos.firstWhere(
-                              (v) => v.id == video.id,
-                              orElse: () {
-                                final clamped = index.clamp(
-                                  0,
-                                  state.videos.length - 1,
-                                );
-                                debugPrint(
-                                  'FullscreenFeed: video ID lookup miss! '
-                                  'video.id=${video.id}, index=$index, '
-                                  'clamped=$clamped, '
-                                  'state.videos.length='
-                                  '${state.videos.length}, '
-                                  'pooledVideos.length='
-                                  '${state.pooledVideos.length}',
-                                );
-                                return state.videos[clamped];
-                              },
-                            );
-                            return _PooledFullscreenItem(
-                              video: originalEvent,
-                              index: index,
-                              isActive: isActive,
-                              pagePosition: _pagePosition,
-                              contextTitle: widget.contextTitle,
-                              trafficSource: widget.trafficSource,
-                              sourceDetail: widget.sourceDetail,
-                              isOwnVideo: isOwnVideo,
-                              isAutoAdvanceActive: effectiveAutoActive,
-                              onInteracted: _suppressAutoAdvance,
-                              onAutoAdvanceCompleted:
-                                  _handleAutoAdvanceCompleted,
-                            );
-                          },
+            // Dispatch FullscreenFeedVideoUnavailable when the active video's
+            // playback status becomes notFound. The BLoC owns the HEAD-confirm,
+            // removal, and dedupe logic — this listener is the screen-level
+            // bridge that replaces the per-item post-frame callback.
+            BlocListener<VideoPlaybackStatusCubit, VideoPlaybackStatusState>(
+              listener: (context, state) =>
+                  _dispatchVideoUnavailableIfActive(state),
+            ),
+            // Animate the feed when the BLoC signals a pending skip after a
+            // confirmed 404 removal.
+            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+              listenWhen: (prev, curr) =>
+                  prev.pendingSkipTarget != curr.pendingSkipTarget &&
+                  curr.pendingSkipTarget != null,
+              listener: (context, state) {
+                final target = state.pendingSkipTarget;
+                if (target != null) unawaited(_handlePendingSkip(target));
+              },
+            ),
+            // Pop the route when the last visible video has been removed
+            // by deletion (or, soon, block / mute). When `maybePop`
+            // returns false (cold deep-link into the fullscreen with no
+            // parent route in the stack), the BlocBuilder below renders
+            // an explicit `emptyAfterRemoval` branch so the user is not
+            // left looking at a perpetual loading spinner.
+            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+              listenWhen: (prev, curr) =>
+                  prev.status != curr.status &&
+                  curr.status == FullscreenFeedStatus.emptyAfterRemoval,
+              listener: (context, _) {
+                unawaited(Navigator.of(context).maybePop());
+              },
+            ),
+          ],
+          child: BlocBuilder<FullscreenFeedBloc, FullscreenFeedState>(
+            builder: (context, state) {
+              // The BlocListener above tries to pop on this status; when
+              // it can (parent route exists) the route is gone before this
+              // branch renders. When `maybePop` is a no-op, we land here
+              // and show an explicit empty-state with a back button rather
+              // than the loading spinner below.
+              if (state.status == FullscreenFeedStatus.emptyAfterRemoval) {
+                return Scaffold(
+                  backgroundColor: VineTheme.backgroundColor,
+                  appBar: DiVineAppBar(
+                    title: widget.contextTitle ?? '',
+                    showBackButton: true,
+                    // The BlocListener above already tried `maybePop` and
+                    // failed (otherwise we wouldn't be rendering this
+                    // branch). Keep the same root-route fallback here so
+                    // cold-start deep links never strand the user.
+                    onBackPressed: () => _handleBack(context),
+                    backgroundMode: DiVineAppBarBackgroundMode.transparent,
+                    forceMaterialTransparency: true,
+                  ),
+                  body: Center(
+                    child: Text(
+                      context.l10n.fullscreenFeedRemovedMessage,
+                      style: VineTheme.bodyMediumFont(),
                     ),
-            );
-          },
+                  ),
+                );
+              }
+
+              if (state.status == FullscreenFeedStatus.initial ||
+                  !state.hasVideos) {
+                return Scaffold(
+                  backgroundColor: VineTheme.backgroundColor,
+                  appBar: DiVineAppBar(
+                    title: widget.contextTitle ?? '',
+                    showBackButton: true,
+                    onBackPressed: () => _handleBack(context),
+                    backgroundMode: DiVineAppBarBackgroundMode.transparent,
+                    forceMaterialTransparency: true,
+                  ),
+                  body: const Center(child: BrandedLoadingIndicator(size: 60)),
+                );
+              }
+
+              if (!state.hasPooledVideos) {
+                return Scaffold(
+                  backgroundColor: VineTheme.backgroundColor,
+                  appBar: DiVineAppBar(
+                    title: widget.contextTitle ?? '',
+                    showBackButton: true,
+                    onBackPressed: () => _handleBack(context),
+                    backgroundMode: DiVineAppBarBackgroundMode.transparent,
+                    forceMaterialTransparency: true,
+                  ),
+                  body: const Center(
+                    child: Text(
+                      'No videos available',
+                      style: TextStyle(color: VineTheme.whiteText),
+                    ),
+                  ),
+                );
+              }
+
+              final authService = ref.watch(authServiceProvider);
+              final currentUserPubkey = authService.currentPublicKeyHex;
+              final isOwnVideo =
+                  currentUserPubkey != null &&
+                  currentUserPubkey == state.currentVideo?.pubkey;
+
+              // The inline comment composer bar sits at the bottom of the
+              // Scaffold body (inside a Column with `Expanded(child:
+              // feed)`) whenever there's an active video AND a signed-in
+              // user. The bar lives in the body — NOT in
+              // `Scaffold.bottomNavigationBar` — because Scaffold pins
+              // bottomNavigationBar to `size.height - barHeight` and does
+              // not push it above the keyboard. Putting the bar inside
+              // the body lets Scaffold's default `resizeToAvoidBottomInset`
+              // shrink the body when the keyboard opens, which slides the
+              // bar up with it. The feed's MediaQuery is intentionally
+              // left untouched: the home feed's overlays sit at
+              // `bottom: 20 + viewPadding.bottom (= 34) = 54` above the
+              // nav bar, and the fullscreen overlays use the same formula
+              // so the action column / author info land at the same gap
+              // above the comment bar. The bar's own `SafeArea`-style
+              // padding handles the home-indicator visually.
+              final showCommentBar =
+                  currentUserPubkey != null && state.currentVideo != null;
+
+              // Subscribe to Auto state so items rebuild on toggle/suppress/resume.
+              final autoState = context.watch<FeedAutoAdvanceCubit>().state;
+
+              // Gate the rail + runtime on the user's reduced-motion
+              // preference. When Auto is unavailable,
+              // force it "off" at the view layer regardless of cubit state.
+              final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(
+                context,
+              );
+              final effectiveAutoActive =
+                  autoAdvanceAvailable && autoState.isEffectivelyActive;
+
+              // Wire the NIP-98 auth header provider into WebVideoFeed only
+              // when running on web AND the HLS auth web player flag is on.
+              // When either condition is false, authHeaderProvider stays null
+              // and the legacy VideoPlayerController path is used unchanged.
+              final hlsAuthWebPlayerEnabled = ref.watch(
+                isFeatureEnabledProvider(FeatureFlag.hlsAuthWebPlayer),
+              );
+              final webAuthHeaderProvider = kIsWeb && hlsAuthWebPlayerEnabled
+                  ? buildWebVideoAuthHeaderProvider(
+                      ref.watch(mediaViewerAuthServiceProvider),
+                    )
+                  : null;
+
+              return Scaffold(
+                backgroundColor: VineTheme.backgroundColor,
+                // Always edge-to-edge: the video fills the screen and the
+                // (transparent) AppBar overlays it, matching the home feed.
+                // The previous `extendBodyBehindAppBar: !hasHeader`
+                // exception existed because square Vine reposts (rendered
+                // with `BoxFit.contain`) had their baked-in letterbox
+                // bars "slip under" the transparent header. Since the
+                // missing-dimensions branch in `_PooledFullscreenItemContent`
+                // now treats those videos as portrait (`BoxFit.cover`),
+                // that letterbox no longer exists and the carve-out is
+                // moot.
+                extendBodyBehindAppBar: true,
+                appBar: DiVineAppBar(
+                  title: widget.contextTitle ?? '',
+                  showBackButton: true,
+                  onBackPressed: () => _handleBack(context),
+                  backgroundMode: DiVineAppBarBackgroundMode.transparent,
+                  forceMaterialTransparency: true,
+                  // Back button sits 8 px from the left edge of the screen
+                  // (4 px tighter than the previous 12). The More popover on
+                  // the trailing side keeps its 12 px gap by wrapping the
+                  // FeedSettingsMenu in an extra `end: 4` padding inside the
+                  // customActions slot.
+                  customActions: const [
+                    Padding(
+                      padding: EdgeInsetsDirectional.only(end: 4),
+                      child: FeedSettingsMenu(),
+                    ),
+                  ],
+                  style: DiVineAppBarStyle.transparentStyle.copyWith(
+                    horizontalPadding: 8,
+                  ),
+                ),
+                body: Column(
+                  children: [
+                    Expanded(
+                      child:
+                          InfiniteVideoFeed.isSupported &&
+                              ref.watch(
+                                isFeatureEnabledProvider(.nativeFeedPlayer),
+                              )
+                          ? FeedVideos(
+                              key: _feedVideosKey,
+                              videos: state.videos,
+                              contextTitle: widget.contextTitle,
+                              currentIndex: state.currentIndex,
+                              shouldPortraitExpand: false,
+                              hasMore: state.canLoadMore,
+                              isLoadingMore: state.isLoadingMore,
+                              onActiveVideoChanged: (video, index) {
+                                _resumeAutoAdvanceAfterSwipe();
+                                FeedPerformanceTracker()
+                                    .startVideoSwipeTracking(
+                                      video.id,
+                                    );
+                                context.read<FullscreenFeedBloc>().add(
+                                  FullscreenFeedIndexChanged(index),
+                                );
+                                widget.onPageChanged?.call(index);
+                              },
+                              onNearEnd: () {
+                                if (state.canLoadMore) {
+                                  _triggerLoadMore();
+                                }
+                              },
+                            )
+                          : kIsWeb
+                          ? WebVideoFeed(
+                              key: _webFeedKey,
+                              videos: state.videos
+                                  .where((v) => v.videoUrl != null)
+                                  .toList(),
+                              initialIndex: state.currentIndex,
+                              controllerFactory:
+                                  widget.webControllerFactory ??
+                                  defaultWebVideoPlayerControllerFactory,
+                              authHeaderProvider: webAuthHeaderProvider,
+                              initialVolume: context
+                                  .read<VideoVolumeCubit>()
+                                  .state
+                                  .volume,
+                              onActiveVideoChanged: (video, index) {
+                                _pagePosition.value = index.toDouble();
+                                _resumeAutoAdvanceAfterSwipe();
+                                FeedPerformanceTracker()
+                                    .startVideoSwipeTracking(
+                                      video.id,
+                                    );
+                                context.read<FullscreenFeedBloc>().add(
+                                  FullscreenFeedIndexChanged(index),
+                                );
+                                widget.onPageChanged?.call(index);
+                              },
+                              onCompleted: (_) => _handleAutoAdvanceCompleted(),
+                              onErrored: _handleWebPlayerErrored,
+                              onRequiresAuth: _handleWebPlayerRequiresAuth,
+                              onNearEnd: (index) => _onNearEnd(state, index),
+                              itemBuilder:
+                                  (
+                                    context,
+                                    video,
+                                    index, {
+                                    required isActive,
+                                    controller,
+                                  }) {
+                                    return _WebFullscreenItem(
+                                      video: video,
+                                      isActive: isActive,
+                                      isOwnVideo:
+                                          currentUserPubkey == video.pubkey,
+                                      controller: controller,
+                                      contextTitle: widget.contextTitle,
+                                      onInteracted: _suppressAutoAdvance,
+                                    );
+                                  },
+                            )
+                          : PooledVideoFeed(
+                              key: _feedKey,
+                              videos: state.pooledVideos,
+                              controller: _controller,
+                              initialIndex: state.currentIndex,
+                              onActiveVideoChanged: (video, index) {
+                                _resumeAutoAdvanceAfterSwipe();
+                                FeedPerformanceTracker()
+                                    .startVideoSwipeTracking(
+                                      video.id,
+                                    );
+                                context.read<FullscreenFeedBloc>().add(
+                                  FullscreenFeedIndexChanged(index),
+                                );
+                                widget.onPageChanged?.call(index);
+                              },
+                              onNearEnd: (index) => _onNearEnd(state, index),
+                              nearEndThreshold: 0,
+                              onScrollOffsetChanged: (page) =>
+                                  _pagePosition.value = page,
+                              maxLoopDuration: VideoEditorConstants.maxDuration,
+                              itemBuilder:
+                                  (context, video, index, {required isActive}) {
+                                    if (state.videos.isEmpty) {
+                                      debugPrint(
+                                        'FullscreenFeed: itemBuilder called with empty '
+                                        'state.videos! index=$index, '
+                                        'video.id=${video.id}',
+                                      );
+                                      return const ColoredBox(
+                                        color: VineTheme.backgroundColor,
+                                      );
+                                    }
+                                    final originalEvent = state.videos.firstWhere(
+                                      (v) => v.id == video.id,
+                                      orElse: () {
+                                        final clamped = index.clamp(
+                                          0,
+                                          state.videos.length - 1,
+                                        );
+                                        debugPrint(
+                                          'FullscreenFeed: video ID lookup miss! '
+                                          'video.id=${video.id}, index=$index, '
+                                          'clamped=$clamped, '
+                                          'state.videos.length='
+                                          '${state.videos.length}, '
+                                          'pooledVideos.length='
+                                          '${state.pooledVideos.length}',
+                                        );
+                                        return state.videos[clamped];
+                                      },
+                                    );
+                                    return _PooledFullscreenItem(
+                                      video: originalEvent,
+                                      index: index,
+                                      isActive: isActive,
+                                      pagePosition: _pagePosition,
+                                      contextTitle: widget.contextTitle,
+                                      trafficSource: widget.trafficSource,
+                                      sourceDetail: widget.sourceDetail,
+                                      isOwnVideo: isOwnVideo,
+                                      isAutoAdvanceActive: effectiveAutoActive,
+                                      onInteracted: _suppressAutoAdvance,
+                                      onAutoAdvanceCompleted:
+                                          _handleAutoAdvanceCompleted,
+                                    );
+                                  },
+                            ),
+                    ),
+                    if (showCommentBar) const InlineCommentComposerBar(),
+                  ],
+                ),
+              );
+            },
+          ),
         ),
       ),
     );
@@ -1097,9 +1124,17 @@ class _WebFullscreenItem extends ConsumerWidget {
             topOffset: isOwnVideo ? 64 : 8,
             onInteracted: onInteracted,
             omitAuthorBlock: true,
+            // See _PooledFullscreenItemContent.build for the rationale —
+            // the action column lives in this outer Stack so it shares the
+            // same bottom anchor as the author info below and the two
+            // cannot vertically drift apart.
+            omitActionColumn: true,
           ),
+          // 20 px above the Stack bottom (= comment-bar top). See
+          // _PooledFullscreenItemContent.build for why we drop the
+          // `viewPadding.bottom` term that the home feed uses.
           PositionedDirectional(
-            bottom: 20 + MediaQuery.viewPaddingOf(context).bottom,
+            bottom: 20,
             start: 16,
             end: 80,
             child: AnimatedOpacity(
@@ -1116,6 +1151,19 @@ class _WebFullscreenItem extends ConsumerWidget {
                         controller: controller!,
                       )
                     : null,
+                onInteracted: onInteracted,
+              ),
+            ),
+          ),
+          PositionedDirectional(
+            bottom: 20,
+            end: 12,
+            child: AnimatedOpacity(
+              opacity: isActive ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: VideoOverlayActionColumn(
+                video: video,
+                isFullscreen: true,
                 onInteracted: onInteracted,
               ),
             ),
@@ -1231,9 +1279,13 @@ class _PooledFullscreenItemContentState
   @override
   Widget build(BuildContext context) {
     final video = widget.video;
-    final isPortrait = video.dimensions != null && video.isPortrait;
-    final hasHeader =
-        widget.contextTitle != null && widget.contextTitle!.isNotEmpty;
+    // Match the home feed's policy (see `video_feed_page.dart`): treat
+    // videos without dimensions metadata as portrait so they cover the
+    // available area instead of landscape-letterboxing. Older Vine
+    // reposts arrive without dimensions and were previously rendered
+    // with `BoxFit.contain`, leaving large black bands above and below
+    // the content once the comment bar shrank the available height.
+    final isPortrait = video.dimensions == null || video.isPortrait;
     final overlayLabels = contentWarningOverlayLabels(
       contentWarningLabels: video.contentWarningLabels,
       warnLabels: video.warnLabels,
@@ -1268,7 +1320,6 @@ class _PooledFullscreenItemContentState
                 child: _FittedVideoPlayer(
                   videoController: videoController,
                   isPortrait: isPortrait,
-                  hasHeader: hasHeader,
                   videoWidth: video.width?.toDouble(),
                   videoHeight: video.height?.toDouble(),
                 ),
@@ -1276,7 +1327,6 @@ class _PooledFullscreenItemContentState
           loadingBuilder: (context) => _VideoLoadingPlaceholder(
             thumbnailUrl: video.thumbnailUrl,
             isPortrait: isPortrait,
-            hasHeader: hasHeader,
           ),
           errorBuilder: (context, onRetry, errorType) {
             // Map pooled_video_player.VideoErrorType to the canonical
@@ -1370,16 +1420,27 @@ class _PooledFullscreenItemContentState
                           // the home feed overlay exactly. Suppress the
                           // legacy inline column so they don't double up.
                           omitAuthorBlock: true,
+                          // The action column lives in this widget's outer
+                          // Stack alongside the author info so both are
+                          // anchored to the same Stack bottom — matches the
+                          // home feed pattern in [FeedVideoOverlay] and
+                          // keeps "About" vertically aligned with the
+                          // bottom of the caption block.
+                          omitActionColumn: true,
                         );
                       },
                     ),
                     // Bottom-left metadata container — author avatar/name,
                     // optional inline caption pill, and title/description.
-                    // Positioned to match the home feed overlay's baseline
-                    // (20 px above the safe-area bottom, 16 px from the
-                    // start, 80 px from the end to clear the action column).
+                    // 20 px above the Stack bottom (= comment-bar top). No
+                    // `viewPadding.bottom` term: the [InlineCommentComposerBar]
+                    // already absorbs the device home-indicator inset, so
+                    // adding it here would double-pad. The home feed's
+                    // matching `bottom: 20 + safeAreaBottom` line works
+                    // because there the inherited `viewPadding.bottom`
+                    // collapses to 0 below the [VineBottomNav]'s `SafeArea`.
                     PositionedDirectional(
-                      bottom: 20 + MediaQuery.viewPaddingOf(context).bottom,
+                      bottom: 20,
                       start: 16,
                       end: 80,
                       child: AnimatedOpacity(
@@ -1391,6 +1452,21 @@ class _PooledFullscreenItemContentState
                               video.content.isNotEmpty ||
                               (video.title != null && video.title!.isNotEmpty),
                           player: player,
+                          onInteracted: widget.onInteracted,
+                        ),
+                      ),
+                    ),
+                    // Action column — sibling of the author info, both
+                    // anchored to the same Stack bottom at `bottom: 20`.
+                    PositionedDirectional(
+                      bottom: 20,
+                      end: 12,
+                      child: AnimatedOpacity(
+                        opacity: widget.isActive ? 1.0 : 0.0,
+                        duration: const Duration(milliseconds: 200),
+                        child: VideoOverlayActionColumn(
+                          video: video,
+                          isFullscreen: true,
                           onInteracted: widget.onInteracted,
                         ),
                       ),
@@ -1413,14 +1489,12 @@ class _FittedVideoPlayer extends StatelessWidget {
   const _FittedVideoPlayer({
     required this.videoController,
     this.isPortrait = true,
-    this.hasHeader = false,
     this.videoWidth,
     this.videoHeight,
   });
 
   final VideoController videoController;
   final bool isPortrait;
-  final bool hasHeader;
   final double? videoWidth;
   final double? videoHeight;
 
@@ -1428,16 +1502,11 @@ class _FittedVideoPlayer extends StatelessWidget {
   Widget build(BuildContext context) {
     final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
     final alignment = fullscreenVideoMediaAlignment(isPortrait: isPortrait);
-    final topInset = fullscreenContainedVideoTopInset(
-      safeAreaTop: MediaQuery.viewPaddingOf(context).top,
-      isPortrait: isPortrait,
-      hasHeader: hasHeader,
-    );
 
     // Do not set filterQuality to high — on Android the bicubic
     // interpolation causes visible blur on the Texture widget when
     // the video resolution doesn't match the display size exactly.
-    final video = Video(
+    return Video(
       controller: videoController,
       fit: boxFit,
       alignment: alignment,
@@ -1446,11 +1515,6 @@ class _FittedVideoPlayer extends StatelessWidget {
       height: videoHeight,
       fill: const Color(0x00000000),
     );
-    if (topInset == 0) return video;
-    return Padding(
-      padding: EdgeInsets.only(top: topInset),
-      child: video,
-    );
   }
 }
 
@@ -1458,25 +1522,18 @@ class _VideoLoadingPlaceholder extends StatelessWidget {
   const _VideoLoadingPlaceholder({
     this.thumbnailUrl,
     this.isPortrait = true,
-    this.hasHeader = false,
   });
 
   final String? thumbnailUrl;
   final bool isPortrait;
-  final bool hasHeader;
 
   @override
   Widget build(BuildContext context) {
     final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
     final alignment = fullscreenVideoMediaAlignment(isPortrait: isPortrait);
-    final topInset = fullscreenContainedVideoTopInset(
-      safeAreaTop: MediaQuery.viewPaddingOf(context).top,
-      isPortrait: isPortrait,
-      hasHeader: hasHeader,
-    );
     final url = thumbnailUrl;
 
-    final placeholder = Stack(
+    return Stack(
       fit: StackFit.expand,
       children: [
         // Thumbnail background (if available)
@@ -1493,11 +1550,6 @@ class _VideoLoadingPlaceholder extends StatelessWidget {
         // Loading indicator overlay
         const _LoadingIndicator(),
       ],
-    );
-    if (topInset == 0) return placeholder;
-    return Padding(
-      padding: EdgeInsets.only(top: topInset),
-      child: placeholder,
     );
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -824,16 +824,18 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               );
 
               return Scaffold(
-                // Paint the Scaffold with [VineTheme.surfaceContainerHigh]
-                // (`#1A1A1A`, the same neutral dark grey the Messages
-                // inbox uses on its scaffold). This is the canvas
-                // around 1 × 1 / landscape / unknown contain-fit videos
-                // and shows wherever the body leaks — the device's
-                // curved-corner cutouts or the safe-area sliver below
-                // the keyboard. Reads as a clearly distinct surface
-                // from the comment bar's
-                // [VineTheme.surfaceBackground] (`#00150D` dark green).
-                backgroundColor: VineTheme.surfaceContainerHigh,
+                // Paint the Scaffold with [VineTheme.surfaceBackground]
+                // (`#00150D`, the same green the comment bar uses).
+                // This is what shows wherever the Scaffold body leaks
+                // around its content — most importantly the strip
+                // below the soft keyboard (above the home indicator)
+                // and the device's curved-corner cutouts at the
+                // bottom edges. Keeping it green continues the comment
+                // bar's surface visually around the keyboard. The
+                // video item's own [ColoredBox] paints
+                // [VineTheme.surfaceContainerHigh] on top of this so
+                // the video area itself reads as a darker canvas.
+                backgroundColor: VineTheme.surfaceBackground,
                 // Always edge-to-edge: the video fills the screen and the
                 // (transparent) AppBar overlays it, matching the home feed.
                 // 1 × 1 / landscape / dimensions-less videos are rendered
@@ -1645,27 +1647,57 @@ class _FittedVideoPlayer extends StatelessWidget {
   });
 
   final VideoController videoController;
+
+  /// Metadata-derived hint used until the controller reports the
+  /// actual decoded video's rect. We can't trust the VideoEvent
+  /// dimensions alone: classic Vine reposts arrive with no
+  /// dimensions, and some new posts have stale / incorrect tags.
+  /// The reactive [VideoController.rect] in [build] is the source
+  /// of truth once the first frame lands.
   final bool isPortrait;
+
   final double? videoWidth;
   final double? videoHeight;
 
   @override
   Widget build(BuildContext context) {
-    final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
-    final alignment = fullscreenVideoMediaAlignment(isPortrait: isPortrait);
-
-    // Do not set filterQuality to high — on Android the bicubic
-    // interpolation causes visible blur on the Texture widget when
-    // the video resolution doesn't match the display size exactly.
-    return Video(
-      controller: videoController,
-      fit: boxFit,
-      alignment: alignment,
-      controls: null,
-      width: videoWidth,
-      height: videoHeight,
-      fill: const Color(0x00000000),
+    // [VideoController.rect] is a `ValueNotifier<Rect?>` populated
+    // once the platform side reports the texture rect (i.e., once
+    // the video is decoded and known). Listening here lets the
+    // [BoxFit] decision react to the actual aspect ratio: 1 × 1 →
+    // [BoxFit.contain] (centered with bands), portrait (height >
+    // width) → [BoxFit.cover] (fills the screen), landscape →
+    // [BoxFit.contain]. Until `rect` lands we fall back to the
+    // metadata hint in [isPortrait].
+    return ValueListenableBuilder<Rect?>(
+      valueListenable: videoController.rect,
+      builder: (context, rect, _) {
+        final detected = _detectPortrait(rect, fallback: isPortrait);
+        final boxFit = detected ? BoxFit.cover : BoxFit.contain;
+        final alignment = fullscreenVideoMediaAlignment(
+          isPortrait: detected,
+        );
+        // Do not set filterQuality to high — on Android the bicubic
+        // interpolation causes visible blur on the Texture widget
+        // when the video resolution doesn't match the display size
+        // exactly.
+        return Video(
+          controller: videoController,
+          fit: boxFit,
+          alignment: alignment,
+          controls: null,
+          width: videoWidth,
+          height: videoHeight,
+          fill: const Color(0x00000000),
+        );
+      },
     );
+  }
+
+  static bool _detectPortrait(Rect? rect, {required bool fallback}) {
+    if (rect == null) return fallback;
+    if (rect.width <= 0 || rect.height <= 0) return fallback;
+    return rect.height > rect.width;
   }
 }
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1615,7 +1615,7 @@ VideoErrorType? _toFeedErrorType(pvp.VideoErrorType? t) => switch (t) {
 };
 
 /// Wraps the right-side action column so that its top fades to
-/// transparent whenever the soft keyboard is on screen.
+/// transparent while the soft keyboard is on screen.
 ///
 /// When the inline comment composer pulls the keyboard up,
 /// [Scaffold.resizeToAvoidBottomInset] shrinks the body and the action
@@ -1623,16 +1623,32 @@ VideoErrorType? _toFeedErrorType(pvp.VideoErrorType? t) => switch (t) {
 /// can end up sitting under the More popover and the back button. The
 /// [ShaderMask] erases the top of the column with a [BlendMode.dstIn]
 /// gradient: fully transparent through the top 20 %, then a linear
-/// fade to fully opaque at the bottom edge. Pass-through when no keyboard is visible
-/// so we don't pay the save-layer cost on the steady-state feed.
+/// fade to fully opaque at the bottom edge. The mask snaps on when
+/// the keyboard begins to show, and fades out linearly over 100 ms
+/// the moment the keyboard begins to hide, then drops the ShaderMask
+/// wrapper entirely so the steady-state feed doesn't carry a save
+/// layer.
 ///
-/// We can't read keyboard visibility from `MediaQuery.viewInsetsOf` here
-/// because Scaffold's `resizeToAvoidBottomInset: true` (the default)
-/// strips `viewInsets.bottom` from the body's MediaQuery (it has already
-/// shrunk the body to avoid the keyboard, so "the body shouldn't need to
-/// know"). Reading the inset off the [FlutterView] via [WidgetsBinding]
-/// — combined with [WidgetsBindingObserver.didChangeMetrics] — is the
-/// supported escape hatch.
+/// The trigger is the *direction* of `viewInsets.bottom`, not whether
+/// it's zero. On iOS and Android the platform animates the keyboard
+/// inset over the OS's own animation curve (~250 ms) and Flutter
+/// fires [WidgetsBindingObserver.didChangeMetrics] each frame.
+/// "First decrease after a steady non-zero" is the start of the hide
+/// animation, "first rise from zero" is the start of the show
+/// animation — that lines the column fade up with the platform
+/// keyboard animation in parallel rather than running it sequentially
+/// after the keyboard is already gone.
+///
+/// Focus alone isn't a usable signal: on macOS / desktop a text
+/// input can take focus by click without the platform keyboard ever
+/// appearing, so a focus-driven mask would activate when the column
+/// hasn't actually slid up.
+///
+/// We read the inset off the [FlutterView] rather than `MediaQuery`
+/// because Scaffold's `resizeToAvoidBottomInset: true` strips
+/// `viewInsets.bottom` from the body's MediaQuery (the body has
+/// already shrunk to avoid the keyboard, so "the body shouldn't need
+/// to know").
 @visibleForTesting
 class KeyboardAwareTopFade extends StatefulWidget {
   @visibleForTesting
@@ -1645,60 +1661,123 @@ class KeyboardAwareTopFade extends StatefulWidget {
 }
 
 class _KeyboardAwareTopFadeState extends State<KeyboardAwareTopFade>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, SingleTickerProviderStateMixin {
+  /// Linear fade-out applied to the mask when the keyboard begins to
+  /// hide. Picked to overlap the platform keyboard's dismiss
+  /// animation (~250 ms) — the column is fully unmasked well before
+  /// the keyboard finishes sliding off-screen. The fade-in is
+  /// instantaneous because the AppBar collision happens immediately
+  /// as the column slides up.
+  static const Duration _fadeOutDuration = Duration(milliseconds: 100);
+
+  /// Last sampled keyboard inset, used to infer the direction of
+  /// change between [didChangeMetrics] frames.
+  double _lastInset = 0;
+
+  /// Whether the keyboard is currently visible (or animating in).
+  /// Flips back to `false` the moment the inset starts decreasing
+  /// from a non-zero value.
   bool _keyboardVisible = false;
+
+  late final AnimationController _maskStrength;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _maskStrength = AnimationController(
+      vsync: this,
+      duration: _fadeOutDuration,
+      value: 0,
+    )..addStatusListener(_onMaskStatusChanged);
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _refreshKeyboardVisibility();
+    // Sync initial state in case the keyboard is already up when
+    // this widget mounts (rare — screen recreated mid-animation).
+    final inset = View.of(context).viewInsets.bottom;
+    if (inset > 0 && !_keyboardVisible) {
+      _lastInset = inset;
+      _keyboardVisible = true;
+      _maskStrength.value = 1;
+    }
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _maskStrength
+      ..removeStatusListener(_onMaskStatusChanged)
+      ..dispose();
     super.dispose();
   }
 
   @override
   void didChangeMetrics() {
-    _refreshKeyboardVisibility();
+    if (!mounted) return;
+    final inset = View.of(context).viewInsets.bottom;
+    final previous = _lastInset;
+    _lastInset = inset;
+
+    if (_keyboardVisible) {
+      // Already up — only react to the first decrease, which is the
+      // start of the hide animation. Subsequent decreasing frames
+      // during the same animation no-op.
+      if (inset < previous) {
+        setState(() => _keyboardVisible = false);
+        _maskStrength.reverse();
+      }
+    } else {
+      // Hidden — any rise from a lower value into the positive range
+      // is the start of the show animation. Snap the mask on so the
+      // column is masked by the time it finishes sliding up.
+      if (inset > previous && inset > 0) {
+        setState(() => _keyboardVisible = true);
+        _maskStrength.value = 1;
+      }
+    }
   }
 
-  void _refreshKeyboardVisibility() {
-    if (!mounted) return;
-    final visible = View.of(context).viewInsets.bottom > 0;
-    if (visible != _keyboardVisible) {
-      setState(() => _keyboardVisible = visible);
+  void _onMaskStatusChanged(AnimationStatus status) {
+    // Drop the ShaderMask wrapper once the fade-out completes so the
+    // steady-state feed isn't paying for an idle save layer.
+    if (status == AnimationStatus.dismissed && mounted) {
+      setState(() {});
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!_keyboardVisible) return widget.child;
+    if (_maskStrength.value == 0) return widget.child;
 
-    return ShaderMask(
-      blendMode: BlendMode.dstIn,
-      shaderCallback: (Rect bounds) {
-        return const LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          // Only the alpha matters with BlendMode.dstIn — the
-          // gradient's colors are otherwise irrelevant. The opaque
-          // colour at the bottom keeps the column fully visible;
-          // transparent at the top erases the part that would
-          // collide with the AppBar.
-          colors: [Colors.transparent, VineTheme.whiteText],
-          stops: [0.2, 1.0],
-        ).createShader(bounds);
-      },
+    return AnimatedBuilder(
+      animation: _maskStrength,
       child: widget.child,
+      builder: (context, child) {
+        // Only the alpha matters with BlendMode.dstIn. Interpolating the
+        // top stop between opaque-white (no fade) and transparent
+        // (full fade) lets a single animation value drive the strength
+        // of the mask without changing the gradient shape.
+        final topColor = Color.lerp(
+          VineTheme.whiteText,
+          Colors.transparent,
+          _maskStrength.value,
+        )!;
+        return ShaderMask(
+          blendMode: BlendMode.dstIn,
+          shaderCallback: (Rect bounds) {
+            return LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [topColor, VineTheme.whiteText],
+              stops: const [0.2, 1.0],
+            ).createShader(bounds);
+          },
+          child: child,
+        );
+      },
     );
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -38,6 +38,7 @@ import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/pooled_player_logger.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/nav_rounded_shell.dart';
 import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
@@ -788,7 +789,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   : null;
 
               return Scaffold(
-                backgroundColor: VineTheme.backgroundColor,
+                // Match the comment bar's [VineTheme.surfaceBackground]
+                // (= [VineTheme.navGreen]) so anything peeking around
+                // the bar — the device's curved-corner cutouts or the
+                // safe-area sliver below the keyboard — is the same
+                // green as the bar itself, not the default black.
+                backgroundColor: VineTheme.surfaceBackground,
                 // Always edge-to-edge: the video fills the screen and the
                 // (transparent) AppBar overlays it, matching the home feed.
                 // The previous `extendBodyBehindAppBar: !hasHeader`
@@ -824,154 +830,167 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 body: Column(
                   children: [
                     Expanded(
-                      child:
-                          InfiniteVideoFeed.isSupported &&
-                              ref.watch(
-                                isFeatureEnabledProvider(.nativeFeedPlayer),
+                      // Match the home feed: when the comment bar is on
+                      // screen, the video carries the same rounded
+                      // bottom corners as `video_feed_page.dart`, so
+                      // the corners reveal [VineTheme.navGreen] which
+                      // is the same token the comment bar paints. The
+                      // result is a continuous green seam between the
+                      // video's bottom-corner cutouts and the bar.
+                      child: _MaybeRoundFeedBottom(
+                        roundCorners: showCommentBar,
+                        child:
+                            InfiniteVideoFeed.isSupported &&
+                                ref.watch(
+                                  isFeatureEnabledProvider(
+                                    .nativeFeedPlayer,
+                                  ),
+                                )
+                            ? FeedVideos(
+                                key: _feedVideosKey,
+                                videos: state.videos,
+                                contextTitle: widget.contextTitle,
+                                currentIndex: state.currentIndex,
+                                shouldPortraitExpand: false,
+                                hasMore: state.canLoadMore,
+                                isLoadingMore: state.isLoadingMore,
+                                onActiveVideoChanged: (video, index) {
+                                  _resumeAutoAdvanceAfterSwipe();
+                                  FeedPerformanceTracker()
+                                      .startVideoSwipeTracking(
+                                        video.id,
+                                      );
+                                  context.read<FullscreenFeedBloc>().add(
+                                    FullscreenFeedIndexChanged(index),
+                                  );
+                                  widget.onPageChanged?.call(index);
+                                },
+                                onNearEnd: () {
+                                  if (state.canLoadMore) {
+                                    _triggerLoadMore();
+                                  }
+                                },
                               )
-                          ? FeedVideos(
-                              key: _feedVideosKey,
-                              videos: state.videos,
-                              contextTitle: widget.contextTitle,
-                              currentIndex: state.currentIndex,
-                              shouldPortraitExpand: false,
-                              hasMore: state.canLoadMore,
-                              isLoadingMore: state.isLoadingMore,
-                              onActiveVideoChanged: (video, index) {
-                                _resumeAutoAdvanceAfterSwipe();
-                                FeedPerformanceTracker()
-                                    .startVideoSwipeTracking(
-                                      video.id,
+                            : kIsWeb
+                            ? WebVideoFeed(
+                                key: _webFeedKey,
+                                videos: state.videos
+                                    .where((v) => v.videoUrl != null)
+                                    .toList(),
+                                initialIndex: state.currentIndex,
+                                controllerFactory:
+                                    widget.webControllerFactory ??
+                                    defaultWebVideoPlayerControllerFactory,
+                                authHeaderProvider: webAuthHeaderProvider,
+                                initialVolume: context
+                                    .read<VideoVolumeCubit>()
+                                    .state
+                                    .volume,
+                                onActiveVideoChanged: (video, index) {
+                                  _pagePosition.value = index.toDouble();
+                                  _resumeAutoAdvanceAfterSwipe();
+                                  FeedPerformanceTracker()
+                                      .startVideoSwipeTracking(
+                                        video.id,
+                                      );
+                                  context.read<FullscreenFeedBloc>().add(
+                                    FullscreenFeedIndexChanged(index),
+                                  );
+                                  widget.onPageChanged?.call(index);
+                                },
+                                onCompleted: (_) =>
+                                    _handleAutoAdvanceCompleted(),
+                                onErrored: _handleWebPlayerErrored,
+                                onRequiresAuth: _handleWebPlayerRequiresAuth,
+                                onNearEnd: (index) => _onNearEnd(state, index),
+                                itemBuilder:
+                                    (
+                                      context,
+                                      video,
+                                      index, {
+                                      required isActive,
+                                      controller,
+                                    }) {
+                                      return _WebFullscreenItem(
+                                        video: video,
+                                        isActive: isActive,
+                                        isOwnVideo:
+                                            currentUserPubkey == video.pubkey,
+                                        controller: controller,
+                                        contextTitle: widget.contextTitle,
+                                        onInteracted: _suppressAutoAdvance,
+                                      );
+                                    },
+                              )
+                            : PooledVideoFeed(
+                                key: _feedKey,
+                                videos: state.pooledVideos,
+                                controller: _controller,
+                                initialIndex: state.currentIndex,
+                                onActiveVideoChanged: (video, index) {
+                                  _resumeAutoAdvanceAfterSwipe();
+                                  FeedPerformanceTracker()
+                                      .startVideoSwipeTracking(
+                                        video.id,
+                                      );
+                                  context.read<FullscreenFeedBloc>().add(
+                                    FullscreenFeedIndexChanged(index),
+                                  );
+                                  widget.onPageChanged?.call(index);
+                                },
+                                onNearEnd: (index) => _onNearEnd(state, index),
+                                nearEndThreshold: 0,
+                                onScrollOffsetChanged: (page) =>
+                                    _pagePosition.value = page,
+                                maxLoopDuration:
+                                    VideoEditorConstants.maxDuration,
+                                itemBuilder: (context, video, index, {required isActive}) {
+                                  if (state.videos.isEmpty) {
+                                    debugPrint(
+                                      'FullscreenFeed: itemBuilder called with empty '
+                                      'state.videos! index=$index, '
+                                      'video.id=${video.id}',
                                     );
-                                context.read<FullscreenFeedBloc>().add(
-                                  FullscreenFeedIndexChanged(index),
-                                );
-                                widget.onPageChanged?.call(index);
-                              },
-                              onNearEnd: () {
-                                if (state.canLoadMore) {
-                                  _triggerLoadMore();
-                                }
-                              },
-                            )
-                          : kIsWeb
-                          ? WebVideoFeed(
-                              key: _webFeedKey,
-                              videos: state.videos
-                                  .where((v) => v.videoUrl != null)
-                                  .toList(),
-                              initialIndex: state.currentIndex,
-                              controllerFactory:
-                                  widget.webControllerFactory ??
-                                  defaultWebVideoPlayerControllerFactory,
-                              authHeaderProvider: webAuthHeaderProvider,
-                              initialVolume: context
-                                  .read<VideoVolumeCubit>()
-                                  .state
-                                  .volume,
-                              onActiveVideoChanged: (video, index) {
-                                _pagePosition.value = index.toDouble();
-                                _resumeAutoAdvanceAfterSwipe();
-                                FeedPerformanceTracker()
-                                    .startVideoSwipeTracking(
-                                      video.id,
+                                    return const ColoredBox(
+                                      color: VineTheme.backgroundColor,
                                     );
-                                context.read<FullscreenFeedBloc>().add(
-                                  FullscreenFeedIndexChanged(index),
-                                );
-                                widget.onPageChanged?.call(index);
-                              },
-                              onCompleted: (_) => _handleAutoAdvanceCompleted(),
-                              onErrored: _handleWebPlayerErrored,
-                              onRequiresAuth: _handleWebPlayerRequiresAuth,
-                              onNearEnd: (index) => _onNearEnd(state, index),
-                              itemBuilder:
-                                  (
-                                    context,
-                                    video,
-                                    index, {
-                                    required isActive,
-                                    controller,
-                                  }) {
-                                    return _WebFullscreenItem(
-                                      video: video,
-                                      isActive: isActive,
-                                      isOwnVideo:
-                                          currentUserPubkey == video.pubkey,
-                                      controller: controller,
-                                      contextTitle: widget.contextTitle,
-                                      onInteracted: _suppressAutoAdvance,
-                                    );
-                                  },
-                            )
-                          : PooledVideoFeed(
-                              key: _feedKey,
-                              videos: state.pooledVideos,
-                              controller: _controller,
-                              initialIndex: state.currentIndex,
-                              onActiveVideoChanged: (video, index) {
-                                _resumeAutoAdvanceAfterSwipe();
-                                FeedPerformanceTracker()
-                                    .startVideoSwipeTracking(
-                                      video.id,
-                                    );
-                                context.read<FullscreenFeedBloc>().add(
-                                  FullscreenFeedIndexChanged(index),
-                                );
-                                widget.onPageChanged?.call(index);
-                              },
-                              onNearEnd: (index) => _onNearEnd(state, index),
-                              nearEndThreshold: 0,
-                              onScrollOffsetChanged: (page) =>
-                                  _pagePosition.value = page,
-                              maxLoopDuration: VideoEditorConstants.maxDuration,
-                              itemBuilder:
-                                  (context, video, index, {required isActive}) {
-                                    if (state.videos.isEmpty) {
+                                  }
+                                  final originalEvent = state.videos.firstWhere(
+                                    (v) => v.id == video.id,
+                                    orElse: () {
+                                      final clamped = index.clamp(
+                                        0,
+                                        state.videos.length - 1,
+                                      );
                                       debugPrint(
-                                        'FullscreenFeed: itemBuilder called with empty '
-                                        'state.videos! index=$index, '
-                                        'video.id=${video.id}',
+                                        'FullscreenFeed: video ID lookup miss! '
+                                        'video.id=${video.id}, index=$index, '
+                                        'clamped=$clamped, '
+                                        'state.videos.length='
+                                        '${state.videos.length}, '
+                                        'pooledVideos.length='
+                                        '${state.pooledVideos.length}',
                                       );
-                                      return const ColoredBox(
-                                        color: VineTheme.backgroundColor,
-                                      );
-                                    }
-                                    final originalEvent = state.videos.firstWhere(
-                                      (v) => v.id == video.id,
-                                      orElse: () {
-                                        final clamped = index.clamp(
-                                          0,
-                                          state.videos.length - 1,
-                                        );
-                                        debugPrint(
-                                          'FullscreenFeed: video ID lookup miss! '
-                                          'video.id=${video.id}, index=$index, '
-                                          'clamped=$clamped, '
-                                          'state.videos.length='
-                                          '${state.videos.length}, '
-                                          'pooledVideos.length='
-                                          '${state.pooledVideos.length}',
-                                        );
-                                        return state.videos[clamped];
-                                      },
-                                    );
-                                    return _PooledFullscreenItem(
-                                      video: originalEvent,
-                                      index: index,
-                                      isActive: isActive,
-                                      pagePosition: _pagePosition,
-                                      contextTitle: widget.contextTitle,
-                                      trafficSource: widget.trafficSource,
-                                      sourceDetail: widget.sourceDetail,
-                                      isOwnVideo: isOwnVideo,
-                                      isAutoAdvanceActive: effectiveAutoActive,
-                                      onInteracted: _suppressAutoAdvance,
-                                      onAutoAdvanceCompleted:
-                                          _handleAutoAdvanceCompleted,
-                                    );
-                                  },
-                            ),
+                                      return state.videos[clamped];
+                                    },
+                                  );
+                                  return _PooledFullscreenItem(
+                                    video: originalEvent,
+                                    index: index,
+                                    isActive: isActive,
+                                    pagePosition: _pagePosition,
+                                    contextTitle: widget.contextTitle,
+                                    trafficSource: widget.trafficSource,
+                                    sourceDetail: widget.sourceDetail,
+                                    isOwnVideo: isOwnVideo,
+                                    isAutoAdvanceActive: effectiveAutoActive,
+                                    onInteracted: _suppressAutoAdvance,
+                                    onAutoAdvanceCompleted:
+                                        _handleAutoAdvanceCompleted,
+                                  );
+                                },
+                              ),
+                      ),
                     ),
                     if (showCommentBar) const InlineCommentComposerBar(),
                   ],
@@ -1613,6 +1632,30 @@ VideoErrorType? _toFeedErrorType(pvp.VideoErrorType? t) => switch (t) {
   pvp.VideoErrorType.notFound => VideoErrorType.notFound,
   pvp.VideoErrorType.generic => VideoErrorType.generic,
 };
+
+/// Wraps the fullscreen video feed in a [NavRoundedShell] when the
+/// inline comment composer bar is on screen, so the bottom of the
+/// video carries the same rounded-corner treatment as the home feed.
+/// Without the bar there's nothing to seam into, so the shell is
+/// skipped and the feed renders edge-to-edge.
+class _MaybeRoundFeedBottom extends StatelessWidget {
+  const _MaybeRoundFeedBottom({
+    required this.roundCorners,
+    required this.child,
+  });
+
+  final bool roundCorners;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!roundCorners) return child;
+    return NavRoundedShell(
+      innerColor: VineTheme.backgroundColor,
+      child: child,
+    );
+  }
+}
 
 /// Wraps the right-side action column so that its top fades to
 /// transparent while the soft keyboard is on screen.

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1161,10 +1161,12 @@ class _WebFullscreenItem extends ConsumerWidget {
             child: AnimatedOpacity(
               opacity: isActive ? 1.0 : 0.0,
               duration: const Duration(milliseconds: 200),
-              child: VideoOverlayActionColumn(
-                video: video,
-                isFullscreen: true,
-                onInteracted: onInteracted,
+              child: KeyboardAwareTopFade(
+                child: VideoOverlayActionColumn(
+                  video: video,
+                  isFullscreen: true,
+                  onInteracted: onInteracted,
+                ),
               ),
             ),
           ),
@@ -1381,89 +1383,96 @@ class _PooledFullscreenItemContentState
                 },
               );
             }
-            return MediaQuery(
-              data: MediaQueryData.fromView(View.of(context)),
-              child: FeedAutoAdvanceCompletionListener(
-                player: player,
-                isEnabled: widget.isActive && widget.isAutoAdvanceActive,
-                onCompleted: widget.onAutoAdvanceCompleted ?? () {},
-                child: Stack(
-                  children: [
-                    if (player != null)
-                      PausedVideoPlayOverlay(
+            // No `MediaQuery(data: MediaQueryData.fromView(...))` wrap
+            // here: `MediaQueryData.fromView` is a *snapshot* taken when
+            // this builder runs, so the subtree wouldn't see live
+            // `viewInsets` updates when the soft keyboard slides up or
+            // down. That breaks any descendant that needs to react to
+            // the keyboard (e.g. [KeyboardAwareTopFade]). The inherited
+            // MediaQuery from above is already correct — Scaffold only
+            // modifies `padding`, not `viewInsets`.
+            return FeedAutoAdvanceCompletionListener(
+              player: player,
+              isEnabled: widget.isActive && widget.isAutoAdvanceActive,
+              onCompleted: widget.onAutoAdvanceCompleted ?? () {},
+              child: Stack(
+                children: [
+                  if (player != null)
+                    PausedVideoPlayOverlay(
+                      player: player,
+                      firstFrameFuture:
+                          videoController?.waitUntilFirstFrameRendered,
+                      isVisible: widget.isActive,
+                    ),
+                  ValueListenableBuilder<double>(
+                    valueListenable: widget.pagePosition,
+                    builder: (context, page, _) {
+                      final distance = (page - widget.index).abs().clamp(
+                        0.0,
+                        1.0,
+                      );
+                      return VideoOverlayActions(
+                        video: video,
+                        // isVisible:true — scroll opacity handles fading;
+                        // the hard-cut guard is not needed in fullscreen.
+                        isVisible: true,
+                        isActive: widget.isActive,
+                        overlayOpacity: scrollDrivenOpacity(distance),
+                        hasBottomNavigation: false,
+                        contextTitle: widget.contextTitle,
+                        isFullscreen: true,
+                        topOffset: widget.isOwnVideo ? 64 : 8,
+                        onInteracted: widget.onInteracted,
+                        // The shared [VideoAuthorInfoSection] below renders
+                        // the author block + inline caption pill, matching
+                        // the home feed overlay exactly. Suppress the
+                        // legacy inline column so they don't double up.
+                        omitAuthorBlock: true,
+                        // The action column lives in this widget's outer
+                        // Stack alongside the author info so both are
+                        // anchored to the same Stack bottom — matches the
+                        // home feed pattern in [FeedVideoOverlay] and
+                        // keeps "About" vertically aligned with the
+                        // bottom of the caption block.
+                        omitActionColumn: true,
+                      );
+                    },
+                  ),
+                  // Bottom-left metadata container — author avatar/name,
+                  // optional inline caption pill, and title/description.
+                  // 20 px above the Stack bottom (= comment-bar top). No
+                  // `viewPadding.bottom` term: the [InlineCommentComposerBar]
+                  // already absorbs the device home-indicator inset, so
+                  // adding it here would double-pad. The home feed's
+                  // matching `bottom: 20 + safeAreaBottom` line works
+                  // because there the inherited `viewPadding.bottom`
+                  // collapses to 0 below the [VineBottomNav]'s `SafeArea`.
+                  PositionedDirectional(
+                    bottom: 20,
+                    start: 16,
+                    end: 80,
+                    child: AnimatedOpacity(
+                      opacity: widget.isActive ? 1.0 : 0.0,
+                      duration: const Duration(milliseconds: 200),
+                      child: VideoAuthorInfoSection(
+                        video: video,
+                        hasTextContent:
+                            video.content.isNotEmpty ||
+                            (video.title != null && video.title!.isNotEmpty),
                         player: player,
-                        firstFrameFuture:
-                            videoController?.waitUntilFirstFrameRendered,
-                        isVisible: widget.isActive,
-                      ),
-                    ValueListenableBuilder<double>(
-                      valueListenable: widget.pagePosition,
-                      builder: (context, page, _) {
-                        final distance = (page - widget.index).abs().clamp(
-                          0.0,
-                          1.0,
-                        );
-                        return VideoOverlayActions(
-                          video: video,
-                          // isVisible:true — scroll opacity handles fading;
-                          // the hard-cut guard is not needed in fullscreen.
-                          isVisible: true,
-                          isActive: widget.isActive,
-                          overlayOpacity: scrollDrivenOpacity(distance),
-                          hasBottomNavigation: false,
-                          contextTitle: widget.contextTitle,
-                          isFullscreen: true,
-                          topOffset: widget.isOwnVideo ? 64 : 8,
-                          onInteracted: widget.onInteracted,
-                          // The shared [VideoAuthorInfoSection] below renders
-                          // the author block + inline caption pill, matching
-                          // the home feed overlay exactly. Suppress the
-                          // legacy inline column so they don't double up.
-                          omitAuthorBlock: true,
-                          // The action column lives in this widget's outer
-                          // Stack alongside the author info so both are
-                          // anchored to the same Stack bottom — matches the
-                          // home feed pattern in [FeedVideoOverlay] and
-                          // keeps "About" vertically aligned with the
-                          // bottom of the caption block.
-                          omitActionColumn: true,
-                        );
-                      },
-                    ),
-                    // Bottom-left metadata container — author avatar/name,
-                    // optional inline caption pill, and title/description.
-                    // 20 px above the Stack bottom (= comment-bar top). No
-                    // `viewPadding.bottom` term: the [InlineCommentComposerBar]
-                    // already absorbs the device home-indicator inset, so
-                    // adding it here would double-pad. The home feed's
-                    // matching `bottom: 20 + safeAreaBottom` line works
-                    // because there the inherited `viewPadding.bottom`
-                    // collapses to 0 below the [VineBottomNav]'s `SafeArea`.
-                    PositionedDirectional(
-                      bottom: 20,
-                      start: 16,
-                      end: 80,
-                      child: AnimatedOpacity(
-                        opacity: widget.isActive ? 1.0 : 0.0,
-                        duration: const Duration(milliseconds: 200),
-                        child: VideoAuthorInfoSection(
-                          video: video,
-                          hasTextContent:
-                              video.content.isNotEmpty ||
-                              (video.title != null && video.title!.isNotEmpty),
-                          player: player,
-                          onInteracted: widget.onInteracted,
-                        ),
+                        onInteracted: widget.onInteracted,
                       ),
                     ),
-                    // Action column — sibling of the author info, both
-                    // anchored to the same Stack bottom at `bottom: 20`.
-                    PositionedDirectional(
-                      bottom: 20,
-                      end: 12,
-                      child: AnimatedOpacity(
-                        opacity: widget.isActive ? 1.0 : 0.0,
-                        duration: const Duration(milliseconds: 200),
+                  ),
+                  // Action column — sibling of the author info, both
+                  // anchored to the same Stack bottom at `bottom: 20`.
+                  PositionedDirectional(
+                    bottom: 20,
+                    end: 12,
+                    child: AnimatedOpacity(
+                      opacity: widget.isActive ? 1.0 : 0.0,
+                      duration: const Duration(milliseconds: 200),
+                      child: KeyboardAwareTopFade(
                         child: VideoOverlayActionColumn(
                           video: video,
                           isFullscreen: true,
@@ -1471,11 +1480,11 @@ class _PooledFullscreenItemContentState
                         ),
                       ),
                     ),
-                    Positioned.fill(
-                      child: DoubleTapHeartOverlay(trigger: _heartTrigger),
-                    ),
-                  ],
-                ),
+                  ),
+                  Positioned.fill(
+                    child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                  ),
+                ],
               ),
             );
           },
@@ -1604,3 +1613,92 @@ VideoErrorType? _toFeedErrorType(pvp.VideoErrorType? t) => switch (t) {
   pvp.VideoErrorType.notFound => VideoErrorType.notFound,
   pvp.VideoErrorType.generic => VideoErrorType.generic,
 };
+
+/// Wraps the right-side action column so that its top fades to
+/// transparent whenever the soft keyboard is on screen.
+///
+/// When the inline comment composer pulls the keyboard up,
+/// [Scaffold.resizeToAvoidBottomInset] shrinks the body and the action
+/// column slides up toward the transparent app bar — the Like button
+/// can end up sitting under the More popover and the back button. The
+/// [ShaderMask] erases the top of the column with a [BlendMode.dstIn]
+/// gradient: fully transparent through the top 20 %, then a linear
+/// fade to fully opaque at the bottom edge. Pass-through when no keyboard is visible
+/// so we don't pay the save-layer cost on the steady-state feed.
+///
+/// We can't read keyboard visibility from `MediaQuery.viewInsetsOf` here
+/// because Scaffold's `resizeToAvoidBottomInset: true` (the default)
+/// strips `viewInsets.bottom` from the body's MediaQuery (it has already
+/// shrunk the body to avoid the keyboard, so "the body shouldn't need to
+/// know"). Reading the inset off the [FlutterView] via [WidgetsBinding]
+/// — combined with [WidgetsBindingObserver.didChangeMetrics] — is the
+/// supported escape hatch.
+@visibleForTesting
+class KeyboardAwareTopFade extends StatefulWidget {
+  @visibleForTesting
+  const KeyboardAwareTopFade({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<KeyboardAwareTopFade> createState() => _KeyboardAwareTopFadeState();
+}
+
+class _KeyboardAwareTopFadeState extends State<KeyboardAwareTopFade>
+    with WidgetsBindingObserver {
+  bool _keyboardVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _refreshKeyboardVisibility();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _refreshKeyboardVisibility();
+  }
+
+  void _refreshKeyboardVisibility() {
+    if (!mounted) return;
+    final visible = View.of(context).viewInsets.bottom > 0;
+    if (visible != _keyboardVisible) {
+      setState(() => _keyboardVisible = visible);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_keyboardVisible) return widget.child;
+
+    return ShaderMask(
+      blendMode: BlendMode.dstIn,
+      shaderCallback: (Rect bounds) {
+        return const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          // Only the alpha matters with BlendMode.dstIn — the
+          // gradient's colors are otherwise irrelevant. The opaque
+          // colour at the bottom keeps the column fully visible;
+          // transparent at the top erases the part that would
+          // collide with the AppBar.
+          colors: [Colors.transparent, VineTheme.whiteText],
+          stops: [0.2, 1.0],
+        ).createShader(bounds);
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -62,9 +62,17 @@ import 'package:pooled_video_player/pooled_video_player.dart'
 import 'package:unified_logger/unified_logger.dart';
 import 'package:video_player/video_player.dart';
 
+/// Letterboxed (non-portrait) videos previously top-aligned in the
+/// available viewport — which left a tall band of empty space below
+/// 1 × 1 classic reposts. Always centering instead keeps 1 × 1 and
+/// landscape sources visually in the middle of the screen, with
+/// symmetric bands above and below filled by
+/// [VineTheme.surfaceBackground] (the same green the comment bar
+/// paints, see [_MaybeRoundFeedBottom]). Portrait videos cover the
+/// whole viewport so alignment is a no-op for them.
 @visibleForTesting
 Alignment fullscreenVideoMediaAlignment({required bool isPortrait}) {
-  return isPortrait ? Alignment.center : Alignment.topCenter;
+  return Alignment.center;
 }
 
 /// Arguments for navigating to PooledFullscreenVideoFeedScreen.
@@ -823,14 +831,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 backgroundColor: VineTheme.surfaceBackground,
                 // Always edge-to-edge: the video fills the screen and the
                 // (transparent) AppBar overlays it, matching the home feed.
-                // The previous `extendBodyBehindAppBar: !hasHeader`
-                // exception existed because square Vine reposts (rendered
-                // with `BoxFit.contain`) had their baked-in letterbox
-                // bars "slip under" the transparent header. Since the
-                // missing-dimensions branch in `_PooledFullscreenItemContent`
-                // now treats those videos as portrait (`BoxFit.cover`),
-                // that letterbox no longer exists and the carve-out is
-                // moot.
+                // 1 × 1 / landscape / dimensions-less videos are rendered
+                // with `BoxFit.contain`, so their letterbox bars sit on
+                // the [VineTheme.surfaceBackground] above — the
+                // transparent AppBar reads cleanly against that surface
+                // colour, no carve-out needed.
                 extendBodyBehindAppBar: true,
                 // Wrap the AppBar in a [TextFieldTapRegion] so taps on
                 // the back button / title / [FeedSettingsMenu] popover
@@ -1330,13 +1335,17 @@ class _PooledFullscreenItemContentState
   @override
   Widget build(BuildContext context) {
     final video = widget.video;
-    // Match the home feed's policy (see `video_feed_page.dart`): treat
-    // videos without dimensions metadata as portrait so they cover the
-    // available area instead of landscape-letterboxing. Older Vine
-    // reposts arrive without dimensions and were previously rendered
-    // with `BoxFit.contain`, leaving large black bands above and below
-    // the content once the comment bar shrank the available height.
-    final isPortrait = video.dimensions == null || video.isPortrait;
+    // Use [BoxFit.cover] *only* for videos we can prove are portrait
+    // — i.e. ones with a dimensions tag whose height > width. Anything
+    // else (1 × 1 classic Vine reposts, landscape videos, posts with
+    // no dimensions metadata at all) falls into [BoxFit.contain] so it
+    // sits centered on the screen instead of being stretched. Classic
+    // 1 × 1 reposts arrive without dimensions; rendering them as
+    // [BoxFit.cover] previously stretched the frame vertically to
+    // fill the available height, distorting the image. Letterboxing
+    // (the alternative) keeps the source proportions intact and
+    // matches user expectations for square content.
+    final isPortrait = video.isPortrait;
     final overlayLabels = contentWarningOverlayLabels(
       contentWarningLabels: video.contentWarningLabels,
       warnLabels: video.warnLabels,
@@ -1685,10 +1694,18 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!roundCorners) return child;
-    return NavRoundedShell(
-      innerColor: VineTheme.backgroundColor,
-      child: child,
-    );
+    // Default [NavRoundedShell.innerColor] is
+    // [VineTheme.surfaceBackground] — the same `#00150D` green the
+    // comment bar paints. That's exactly what we want here: on the
+    // fullscreen feed we render contain-fit videos (1 × 1 classics,
+    // landscape, anything without dimensions metadata) which leave
+    // letterbox bands inside the rounded shell. The bands sit on top
+    // of [innerColor], so leaving it at the green default gives the
+    // user the same "video centered on green canvas" reading the
+    // comment bar already establishes. The home feed picks a black
+    // inner explicitly because it only renders portrait covers that
+    // hide the inner colour entirely.
+    return NavRoundedShell(child: child);
   }
 }
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1807,14 +1807,15 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
   Widget build(BuildContext context) {
     if (!roundCorners) return child;
     // Inside the rounded shell, paint
-    // [VineTheme.surfaceContainerHigh] (`#1A1A1A`) — the same neutral dark
-    // grey the Messages inbox uses. That's the canvas around
-    // contain-fit videos (1 × 1 classics, landscape, anything without
-    // dimensions metadata) which leave letterbox bands the user can
-    // see. The shell's *outer* colour is the comment-bar green
-    // ([VineTheme.surfaceBackground], `#00150D`) by [NavRoundedShell]
-    // construction, so the rounded bottom corners reveal that green
-    // and seam the dark video region into the bar visually.
+    // [VineTheme.surfaceContainerHigh] (`#000A06`) — a near-black with
+    // a faint green tint. That's the canvas around contain-fit videos
+    // (1 × 1 classics, landscape, anything without dimensions
+    // metadata) which leave letterbox bands the user can see. The
+    // shell's outer colour is [VineTheme.navGreen] (the color
+    // [NavRoundedShell] paints by construction); it shares its hex
+    // (`#00150D`) with the comment bar's [VineTheme.surfaceBackground],
+    // so the rounded bottom corners reveal a colour that seams
+    // continuously into the bar.
     return NavRoundedShell(
       innerColor: VineTheme.surfaceContainerHigh,
       child: child,

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -1,0 +1,241 @@
+// ABOUTME: Inline comment composer bar shown at the bottom of the fullscreen
+// ABOUTME: video player on Explore / Search / Profile entry points.
+
+import 'dart:math' as math;
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Comment composer pinned to the bottom of [PooledFullscreenVideoFeedScreen].
+///
+/// Tapping the field opens the keyboard so the user can type and post a
+/// comment without ever opening the full comments sheet — the goal is "drop
+/// a comment without reading the others". On send, the keyboard dismisses
+/// and a snackbar confirms the outcome.
+///
+/// Designed to be used as [Scaffold.bottomNavigationBar]; total visible
+/// height above the home indicator matches the home-feed [VineBottomNav]
+/// (72 px content + safe-area bottom). Visibility is owned by the parent
+/// screen, which gates on "active video present" and "user signed in".
+class InlineCommentComposerBar extends StatefulWidget {
+  const InlineCommentComposerBar({super.key});
+
+  /// Content height above the safe-area bottom inset. Matches
+  /// `VineBottomNav._kTabSlotHeight` so the comment-bar variant of the
+  /// fullscreen feed lines up with the home-feed nav vertically.
+  static const double contentHeight = 72.0;
+
+  @override
+  State<InlineCommentComposerBar> createState() =>
+      _InlineCommentComposerBarState();
+}
+
+class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+  bool _hasText = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_handleTextChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_handleTextChanged)
+      ..dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleTextChanged() {
+    final hasText = _controller.text.trim().isNotEmpty;
+    if (hasText != _hasText) {
+      setState(() => _hasText = hasText);
+    }
+  }
+
+  void _handleSubmit() {
+    final video = context.read<FullscreenFeedBloc>().state.currentVideo;
+    if (video == null) return;
+    final text = _controller.text;
+    if (text.trim().isEmpty) return;
+
+    // Optimistic UX: clear the field and drop the keyboard immediately so
+    // the user moves on while the publish lands in the background. The
+    // cubit owns the snackbar via the BlocListener wired below.
+    context.read<InlineCommentComposerCubit>().submit(
+      video: video,
+      content: text,
+    );
+    _controller.clear();
+    _focusNode.unfocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<InlineCommentComposerCubit, InlineCommentComposerState>(
+      listenWhen: (prev, curr) =>
+          prev.status != curr.status &&
+          (curr.status == InlineCommentComposerStatus.submitted ||
+              curr.status == InlineCommentComposerStatus.failure),
+      listener: (context, state) {
+        final message = state.status == InlineCommentComposerStatus.submitted
+            ? context.l10n.videoOverlayCommentPostedSnackbar
+            : context.l10n.videoOverlayCommentPostFailedSnackbar;
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(message),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        context.read<InlineCommentComposerCubit>().acknowledge();
+      },
+      child: ColoredBox(
+        color: VineTheme.surfaceBackground,
+        // Manually compute the bottom inset instead of using SafeArea
+        // because the bar lives inside the Scaffold body (so it can ride
+        // above the keyboard). When the keyboard is up, viewInsets.bottom
+        // grows by the keyboard height while viewPadding.bottom stays at
+        // the device's home-indicator size — leaving a SafeArea-driven
+        // gap of empty surface color above the keyboard. Clamping to
+        // `max(0, viewPadding - viewInsets)` collapses the inset to 0 in
+        // that case so the input pill sits flush against the keyboard.
+        child: Padding(
+          padding: EdgeInsets.only(
+            bottom: math.max(
+              0,
+              MediaQuery.viewPaddingOf(context).bottom -
+                  MediaQuery.viewInsetsOf(context).bottom,
+            ),
+          ),
+          child: SizedBox(
+            height: InlineCommentComposerBar.contentHeight,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 12,
+              ),
+              child: _ComposerField(
+                controller: _controller,
+                focusNode: _focusNode,
+                hasText: _hasText,
+                onSubmit: _handleSubmit,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Pill-shaped text field that fills the bar content area.
+///
+/// The send button appears only when [hasText] is true so an empty bar
+/// shows just the "Add comment…" hint — matching the Figma spec
+/// (node 15222:192143).
+class _ComposerField extends StatelessWidget {
+  const _ComposerField({
+    required this.controller,
+    required this.focusNode,
+    required this.hasText,
+    required this.onSubmit,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool hasText;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.iconButtonBackground,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(start: 16, end: 8),
+              child: Semantics(
+                identifier: 'inline_comment_composer_field',
+                textField: true,
+                label: context.l10n.videoOverlayCommentBarSemanticLabel,
+                child: TextField(
+                  controller: controller,
+                  focusNode: focusNode,
+                  textInputAction: TextInputAction.send,
+                  onSubmitted: (_) => onSubmit(),
+                  // Tap anywhere outside the field (the video, the action
+                  // column, the app bar) dismisses the keyboard — matches
+                  // the DM ConversationView convention.
+                  onTapOutside: (_) =>
+                      FocusManager.instance.primaryFocus?.unfocus(),
+                  cursorColor: VineTheme.tabIndicatorGreen,
+                  style: VineTheme.bodyLargeFont(),
+                  decoration: InputDecoration(
+                    hintText: context.l10n.videoOverlayCommentBarHint,
+                    hintStyle: VineTheme.bodyLargeFont(
+                      color: VineTheme.onSurfaceMuted55,
+                    ),
+                    border: InputBorder.none,
+                    contentPadding: EdgeInsets.zero,
+                    isDense: true,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (hasText) _SendButton(onPressed: onSubmit),
+        ],
+      ),
+    );
+  }
+}
+
+class _SendButton extends StatelessWidget {
+  const _SendButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(end: 4),
+      child: Semantics(
+        identifier: 'inline_comment_composer_send_button',
+        button: true,
+        label: context.l10n.videoOverlayCommentBarSendLabel,
+        child: SizedBox.square(
+          dimension: 40,
+          child: DecoratedBox(
+            decoration: const BoxDecoration(
+              color: VineTheme.tabIndicatorGreen,
+              shape: BoxShape.circle,
+            ),
+            child: IconButton(
+              onPressed: onPressed,
+              padding: EdgeInsets.zero,
+              icon: const Icon(
+                Icons.arrow_upward,
+                color: VineTheme.whiteText,
+                size: 20,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -17,10 +17,11 @@ import 'package:openvine/l10n/l10n.dart';
 /// a comment without reading the others". On send, the keyboard dismisses
 /// and a snackbar confirms the outcome.
 ///
-/// Designed to be used as [Scaffold.bottomNavigationBar]; total visible
-/// height above the home indicator matches the home-feed [VineBottomNav]
-/// (72 px content + safe-area bottom). Visibility is owned by the parent
-/// screen, which gates on "active video present" and "user signed in".
+/// Lives inside the Scaffold body (not [Scaffold.bottomNavigationBar]) so
+/// the keyboard can push it up rather than stranding it below the keyboard.
+/// The pill grows with the [TextField]'s 1–5-line range — there is no fixed
+/// bar height. Visibility is owned by the parent screen, which gates on
+/// "active video present" and "user signed in".
 class InlineCommentComposerBar extends StatefulWidget {
   const InlineCommentComposerBar({super.key});
 

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -220,17 +220,42 @@ class _SendButton extends StatelessWidget {
         child: SizedBox.square(
           dimension: 40,
           child: DecoratedBox(
-            decoration: const BoxDecoration(
-              color: VineTheme.tabIndicatorGreen,
-              shape: BoxShape.circle,
+            // Spec: Figma node 2018:29838 ("primary"). Native size is
+            // 48 with 20 radius / 32 icon / 8 padding. The composition
+            // at node 14368:75902 scales it to a 40 px slot at
+            // 40 / 48 = 0.833 × — radius becomes 16.667, icon becomes
+            // 26.667. The 20 / 48 = 41.7 % radius ratio is a heavily
+            // rounded rectangle, not a circle (a circle would need
+            // 50 %). Background is `primary/primary` (#27C58B =
+            // [VineTheme.primary]). Two stacked sub-pixel drop shadows
+            // give a faint elevation cue against the pill.
+            decoration: BoxDecoration(
+              color: VineTheme.primary,
+              borderRadius: BorderRadius.circular(16.667),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x1A000000),
+                  offset: Offset(0.333, 0.333),
+                  blurRadius: 0.25,
+                ),
+                BoxShadow(
+                  color: Color(0x1A000000),
+                  offset: Offset(0.833, 0.833),
+                  blurRadius: 0.417,
+                ),
+              ],
             ),
             child: IconButton(
               onPressed: onPressed,
               padding: EdgeInsets.zero,
-              icon: const Icon(
-                Icons.arrow_upward,
-                color: VineTheme.whiteText,
-                size: 20,
+              icon: const DivineIcon(
+                icon: DivineIconName.arrowUp,
+                // The Figma vector at node 2018:29838 fills with
+                // `primary/on-primary` (#003824 = dark green), the
+                // M3-convention contrast color on a primary surface —
+                // NOT white. Tested against the rendered Figma asset.
+                color: VineTheme.onPrimaryButton,
+                size: 26.667,
               ),
             ),
           ),

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -35,6 +35,15 @@ class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
   final FocusNode _focusNode = FocusNode();
   bool _hasText = false;
 
+  /// Snapshot of the field's text taken at submit-time so the
+  /// [BlocListener] can restore it if the cubit emits `failure`.
+  /// Mirrors [CommentsBloc]'s rollback of `mainInputText` on publish
+  /// error — without it the optimistic clear permanently loses the
+  /// draft when the network call fails. Empty string means "nothing
+  /// pending"; [_handleSubmit] early-returns on empty input so the
+  /// field can only ever hold a real, non-empty draft.
+  String _pendingDraft = '';
+
   @override
   void initState() {
     super.initState();
@@ -65,7 +74,9 @@ class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
 
     // Optimistic UX: clear the field and drop the keyboard immediately so
     // the user moves on while the publish lands in the background. The
-    // cubit owns the snackbar via the BlocListener wired below.
+    // cubit owns the snackbar via the BlocListener wired below, which
+    // also restores [_pendingDraft] into the field on failure.
+    _pendingDraft = text;
     context.read<InlineCommentComposerCubit>().submit(
       video: video,
       content: text,
@@ -82,6 +93,23 @@ class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
           (curr.status == InlineCommentComposerStatus.submitted ||
               curr.status == InlineCommentComposerStatus.failure),
       listener: (context, state) {
+        final draft = _pendingDraft;
+        _pendingDraft = '';
+
+        // Restore the typed draft when the publish fails so the user
+        // can retry without retyping. The `controller.text.isEmpty`
+        // guard prevents clobbering any text the user already started
+        // typing after the optimistic clear.
+        if (state.status == InlineCommentComposerStatus.failure &&
+            draft.isNotEmpty &&
+            _controller.text.isEmpty) {
+          _controller.text = draft;
+          _controller.selection = TextSelection.collapsed(
+            offset: draft.length,
+          );
+          _focusNode.requestFocus();
+        }
+
         final message = state.status == InlineCommentComposerStatus.submitted
             ? context.l10n.videoOverlayCommentPostedSnackbar
             : context.l10n.videoOverlayCommentPostFailedSnackbar;

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -24,11 +24,6 @@ import 'package:openvine/l10n/l10n.dart';
 class InlineCommentComposerBar extends StatefulWidget {
   const InlineCommentComposerBar({super.key});
 
-  /// Content height above the safe-area bottom inset. Matches
-  /// `VineBottomNav._kTabSlotHeight` so the comment-bar variant of the
-  /// fullscreen feed lines up with the home-feed nav vertically.
-  static const double contentHeight = 72.0;
-
   @override
   State<InlineCommentComposerBar> createState() =>
       _InlineCommentComposerBarState();
@@ -117,19 +112,20 @@ class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
                   MediaQuery.viewInsetsOf(context).bottom,
             ),
           ),
-          child: SizedBox(
-            height: InlineCommentComposerBar.contentHeight,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 12,
-              ),
-              child: _ComposerField(
-                controller: _controller,
-                focusNode: _focusNode,
-                hasText: _hasText,
-                onSubmit: _handleSubmit,
-              ),
+          // Outer pill spacing mirrors the comments-sheet `CommentInput`
+          // (`start: 16, end: 16, top: 16, bottom: 8`) so the inline
+          // composer's vertical rhythm — and its 1-to-5-line growth —
+          // matches exactly. The bar's intrinsic height is no longer
+          // fixed: the pill inside grows with the text field's
+          // `minLines: 1, maxLines: 5` and the surrounding Column resizes
+          // accordingly.
+          child: Padding(
+            padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 16, 8),
+            child: _ComposerField(
+              controller: _controller,
+              focusNode: _focusNode,
+              hasText: _hasText,
+              onSubmit: _handleSubmit,
             ),
           ),
         ),
@@ -158,47 +154,68 @@ class _ComposerField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Pill geometry mirrors `CommentInput` in the comments-sheet
+    // composer at `lib/screens/comments/widgets/comment_input.dart`:
+    // a 20-radius DecoratedBox with `minHeight: 48`, a Row aligned to
+    // [CrossAxisAlignment.end] so the send button stays anchored at
+    // the bottom of the pill as the text field grows multi-line, and
+    // a TextField with `TextInputType.multiline` + `minLines: 1,
+    // maxLines: 5` so long comments wrap up to five lines inside the
+    // pill instead of being clipped to a single line.
     return DecoratedBox(
       decoration: BoxDecoration(
         color: VineTheme.iconButtonBackground,
         borderRadius: BorderRadius.circular(20),
       ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsetsDirectional.only(start: 16, end: 8),
-              child: Semantics(
-                identifier: 'inline_comment_composer_field',
-                textField: true,
-                label: context.l10n.videoOverlayCommentBarSemanticLabel,
-                child: TextField(
-                  controller: controller,
-                  focusNode: focusNode,
-                  textInputAction: TextInputAction.send,
-                  onSubmitted: (_) => onSubmit(),
-                  // Tap anywhere outside the field (the video, the action
-                  // column, the app bar) dismisses the keyboard — matches
-                  // the DM ConversationView convention.
-                  onTapOutside: (_) =>
-                      FocusManager.instance.primaryFocus?.unfocus(),
-                  cursorColor: VineTheme.tabIndicatorGreen,
-                  style: VineTheme.bodyLargeFont(),
-                  decoration: InputDecoration(
-                    hintText: context.l10n.videoOverlayCommentBarHint,
-                    hintStyle: VineTheme.bodyLargeFont(
-                      color: VineTheme.onSurfaceMuted55,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 48),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(
+                  start: 16,
+                  end: 8,
+                  top: 14,
+                  bottom: 14,
+                ),
+                child: Semantics(
+                  identifier: 'inline_comment_composer_field',
+                  textField: true,
+                  label: context.l10n.videoOverlayCommentBarSemanticLabel,
+                  child: TextField(
+                    controller: controller,
+                    focusNode: focusNode,
+                    keyboardType: TextInputType.multiline,
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => onSubmit(),
+                    // Tap anywhere outside the field (the video, the
+                    // action column, the app bar) dismisses the
+                    // keyboard — matches the DM ConversationView
+                    // convention.
+                    onTapOutside: (_) =>
+                        FocusManager.instance.primaryFocus?.unfocus(),
+                    cursorColor: VineTheme.tabIndicatorGreen,
+                    style: VineTheme.bodyLargeFont(),
+                    decoration: InputDecoration(
+                      hintText: context.l10n.videoOverlayCommentBarHint,
+                      hintStyle: VineTheme.bodyLargeFont(
+                        color: VineTheme.onSurfaceMuted55,
+                      ),
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.zero,
+                      isDense: true,
                     ),
-                    border: InputBorder.none,
-                    contentPadding: EdgeInsets.zero,
-                    isDense: true,
+                    minLines: 1,
+                    maxLines: 5,
                   ),
                 ),
               ),
             ),
-          ),
-          if (hasText) _SendButton(onPressed: onSubmit),
-        ],
+            if (hasText) _SendButton(onPressed: onSubmit),
+          ],
+        ),
       ),
     );
   }
@@ -212,7 +229,11 @@ class _SendButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsetsDirectional.only(end: 4),
+      // `bottom: 4` floats the button 4 px above the pill's bottom
+      // edge so it stays anchored to the bottom-right corner with a
+      // consistent inset when the pill grows multi-line (matches
+      // `_SendButton` in the comments-sheet composer).
+      padding: const EdgeInsetsDirectional.only(end: 4, bottom: 4),
       child: Semantics(
         identifier: 'inline_comment_composer_send_button',
         button: true,

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -174,11 +174,17 @@ class _ComposerField extends StatelessWidget {
           children: [
             Expanded(
               child: Padding(
+                // 12 / 12 vertical padding around a 24-line-height
+                // text field gives the pill an exact 48 px single-line
+                // height (12 + 24 + 12), matching Figma node
+                // 15222:192139. The pill grows past 48 when the field
+                // wraps onto a second line via `minLines: 1,
+                // maxLines: 5` below.
                 padding: const EdgeInsetsDirectional.only(
                   start: 16,
                   end: 8,
-                  top: 14,
-                  bottom: 14,
+                  top: 12,
+                  bottom: 12,
                 ),
                 child: Semantics(
                   identifier: 'inline_comment_composer_field',

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -84,6 +84,7 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showListAttribution = false,
     this.isPreviewMode = false,
     this.showBottomGradient = true,
+    this.showTopGradient = false,
     this.topOffset = 8.0,
     this.overlayOpacity = 1.0,
     this.showAutoButton = false,
@@ -105,6 +106,7 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showListAttribution = false,
     this.isPreviewMode = true,
     this.showBottomGradient = true,
+    this.showTopGradient = false,
     this.topOffset = 8.0,
     this.overlayOpacity = 1.0,
     this.showAutoButton = false,
@@ -149,6 +151,13 @@ class VideoOverlayActions extends ConsumerWidget {
   /// Whether to render the bottom darkening gradient behind the caption
   /// block. Disabled in preview / editor flows that have their own chrome.
   final bool showBottomGradient;
+
+  /// Whether to render a symmetric top darkening gradient behind the
+  /// app bar region. Useful on fullscreen overlays so the white title
+  /// and back/More buttons stay readable over light video frames.
+  /// Defaults to `false` — opt in per surface so the home feed (which
+  /// doesn't have a transparent AppBar over the video) is unaffected.
+  final bool showTopGradient;
 
   /// Opacity for the entire overlay, driven by scroll position.
   ///
@@ -205,6 +214,40 @@ class VideoOverlayActions extends ConsumerWidget {
         ignoring: overlayOpacity < 0.01,
         child: Stack(
           children: [
+            // Top gradient overlay — sits behind the (transparent) app
+            // bar so the white title / back button / More popover stay
+            // readable over light video frames. Lives inside the body's
+            // Stack so it overlays the video, NOT the app bar (Scaffold
+            // paints the app bar above the body) and is wrapped in
+            // [IgnorePointer] so tapping the gradient region falls
+            // through to the video (or, in the top strip, to the
+            // already-z-above app bar's controls).
+            if (showTopGradient)
+              Positioned(
+                left: 0,
+                right: 0,
+                top: 0,
+                child: IgnorePointer(
+                  child: FractionallySizedBox(
+                    widthFactor: 1.0,
+                    child: SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.2,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              VineTheme.backgroundColor.withValues(alpha: 0.35),
+                              VineTheme.backgroundColor.withValues(alpha: 0.0),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
             // Bottom gradient overlay (sits below UI elements, only overlays video)
             if (showBottomGradient)
               Positioned(

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -89,6 +89,7 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showAutoButton = false,
     this.onInteracted,
     this.omitAuthorBlock = false,
+    this.omitActionColumn = false,
   }) : previewData = null;
 
   const VideoOverlayActions.preview({
@@ -109,6 +110,7 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showAutoButton = false,
     this.onInteracted,
     this.omitAuthorBlock = false,
+    this.omitActionColumn = false,
   }) : video = null;
 
   final Widget? subtitleLayer;
@@ -126,6 +128,12 @@ class VideoOverlayActions extends ConsumerWidget {
   /// (e.g. the shared [VideoAuthorInfoSection]). The bottom gradient and
   /// the action column on the right are still rendered.
   final bool omitAuthorBlock;
+
+  /// When true, suppresses the right-side action column so the caller can
+  /// render it themselves alongside their own author info block (matches
+  /// the home feed pattern of placing both in a single shared Stack so
+  /// they cannot vertically drift apart).
+  final bool omitActionColumn;
 
   /// Displays the overlay in preview mode during video creation.
   /// When true, users can preview how their video will appear to other users
@@ -553,26 +561,32 @@ class VideoOverlayActions extends ConsumerWidget {
             // the trailing inset on the fullscreen app bar's More popover.
             // Other consumers (video metadata preview, video editor preview)
             // keep the legacy 16 px so their layouts are unaffected.
-            PositionedDirectional(
-              bottom: isFullscreen ? bottomOffset : bottomOffset - 6,
-              end: isFullscreen ? 12 : 16,
-              child: AnimatedOpacity(
-                opacity: isActive ? 1.0 : 0.0,
-                duration: const Duration(milliseconds: 200),
-                child: IgnorePointer(
-                  ignoring: false, // Action buttons SHOULD receive taps
-                  child: video == null
-                      ? _PreviewOverlayActionColumn(onInteracted: onInteracted)
-                      : VideoOverlayActionColumn(
-                          video: video,
-                          isFullscreen: isFullscreen,
-                          isPreviewMode: isPreviewMode,
-                          showAutoButton: showAutoButton,
-                          onInteracted: onInteracted,
-                        ),
+            // Suppressed when [omitActionColumn] is true — the caller
+            // renders the column in their own Stack to keep it vertically
+            // aligned with their own author info block.
+            if (!omitActionColumn)
+              PositionedDirectional(
+                bottom: isFullscreen ? bottomOffset : bottomOffset - 6,
+                end: isFullscreen ? 12 : 16,
+                child: AnimatedOpacity(
+                  opacity: isActive ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 200),
+                  child: IgnorePointer(
+                    ignoring: false, // Action buttons SHOULD receive taps
+                    child: video == null
+                        ? _PreviewOverlayActionColumn(
+                            onInteracted: onInteracted,
+                          )
+                        : VideoOverlayActionColumn(
+                            video: video,
+                            isFullscreen: isFullscreen,
+                            isPreviewMode: isPreviewMode,
+                            showAutoButton: showAutoButton,
+                            onInteracted: onInteracted,
+                          ),
+                  ),
                 ),
               ),
-            ),
           ],
         ),
       ),

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
@@ -68,6 +68,7 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.leadingIcon,
     this.onLeadingPressed,
     this.leadingActionSemanticLabel = 'Leading action',
+    this.expandLeadingHitArea = false,
     this.actions = const [],
     this.customActions = const [],
     this.backgroundMode = DiVineAppBarBackgroundMode.solid,
@@ -205,6 +206,16 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// Defaults to `'Leading action'`. Pass a localized string to override.
   final String leadingActionSemanticLabel;
 
+  /// When `true`, the entire leading slot becomes the tap target
+  /// for the back / menu / leading button — useful on app bars
+  /// over busy backgrounds where the smaller button is easy to
+  /// miss. The visible button still renders at its configured size
+  /// and position; only the hit-test surface expands.
+  ///
+  /// Defaults to `false` so existing call sites keep the historical
+  /// "tap only on the visible button" behavior.
+  final bool expandLeadingHitArea;
+
   /// Action buttons displayed on the right side.
   ///
   /// Defaults to an empty list.
@@ -304,6 +315,7 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
               onLeadingPressed: onLeadingPressed,
               leadingActionSemanticLabel: leadingActionSemanticLabel,
               style: effectiveStyle,
+              expandHitArea: expandLeadingHitArea,
             )
           : null,
       title: DiVineAppBarTitle(

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_leading.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_leading.dart
@@ -24,6 +24,7 @@ class DiVineAppBarLeading extends StatelessWidget {
     this.menuButtonSemanticLabel = 'Open menu',
     this.menuButtonTooltip = 'Menu',
     this.leadingActionSemanticLabel = 'Leading action',
+    this.expandHitArea = false,
     super.key,
   });
 
@@ -77,6 +78,13 @@ class DiVineAppBarLeading extends StatelessWidget {
   /// Style configuration.
   final DiVineAppBarStyle style;
 
+  /// When `true`, the entire leading slot becomes the tap target
+  /// instead of just the visible icon button — useful for app bars
+  /// over busy backgrounds where the smaller button is easier to
+  /// miss. The visible button still renders at its configured size
+  /// and position; only the hit-test surface expands.
+  final bool expandHitArea;
+
   /// Asset path for the back button icon.
   static const String backIconAsset = 'assets/icon/CaretLeft.svg';
 
@@ -92,6 +100,7 @@ class DiVineAppBarLeading extends StatelessWidget {
         semanticLabel: backButtonSemanticLabel ?? 'Go back',
         tooltip: backButtonSemanticLabel == null ? backButtonTooltip : null,
         style: style,
+        expandHitArea: expandHitArea,
       );
       if (backButtonHeroTag != null) {
         return Hero(tag: backButtonHeroTag!, child: button);
@@ -106,6 +115,7 @@ class DiVineAppBarLeading extends StatelessWidget {
         semanticLabel: menuButtonSemanticLabel,
         tooltip: menuButtonTooltip,
         style: style,
+        expandHitArea: expandHitArea,
       );
     }
 
@@ -115,6 +125,7 @@ class DiVineAppBarLeading extends StatelessWidget {
         onPressed: onLeadingPressed,
         semanticLabel: leadingActionSemanticLabel,
         style: style,
+        expandHitArea: expandHitArea,
       );
     }
 
@@ -129,6 +140,7 @@ class _LeadingIconButton extends StatelessWidget {
     required this.onPressed,
     required this.semanticLabel,
     required this.style,
+    required this.expandHitArea,
     this.tooltip,
   });
 
@@ -137,10 +149,11 @@ class _LeadingIconButton extends StatelessWidget {
   final String semanticLabel;
   final String? tooltip;
   final DiVineAppBarStyle style;
+  final bool expandHitArea;
 
   @override
   Widget build(BuildContext context) {
-    return Align(
+    final visibleButton = Align(
       alignment: AlignmentDirectional.centerStart,
       child: Padding(
         padding: EdgeInsetsDirectional.only(start: style.horizontalPadding),
@@ -157,6 +170,19 @@ class _LeadingIconButton extends StatelessWidget {
           borderRadius: style.iconButtonBorderRadius,
         ),
       ),
+    );
+
+    if (!expandHitArea) return visibleButton;
+
+    // Stretch the tap target to the whole leading slot. The inner
+    // [DiVineAppBarIconButton] keeps its semantics for screen readers
+    // but [AbsorbPointer] stops it from receiving pointer events, so
+    // taps don't double-fire and the outer [GestureDetector] is the
+    // single source of truth for hit testing.
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onPressed,
+      child: AbsorbPointer(child: visibleButton),
     );
   }
 }

--- a/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
@@ -19,6 +19,7 @@ void main() {
       VoidCallback? onMenuPressed,
       IconSource? leadingIcon,
       VoidCallback? onLeadingPressed,
+      bool expandLeadingHitArea = false,
       List<DiVineAppBarAction> actions = const [],
       List<Widget> customActions = const [],
       DiVineAppBarBackgroundMode backgroundMode =
@@ -44,6 +45,7 @@ void main() {
             onMenuPressed: onMenuPressed,
             leadingIcon: leadingIcon,
             onLeadingPressed: onLeadingPressed,
+            expandLeadingHitArea: expandLeadingHitArea,
             actions: actions,
             customActions: customActions,
             backgroundMode: backgroundMode,
@@ -262,6 +264,65 @@ void main() {
 
         expect(find.byType(DiVineAppBarIconButton), findsNothing);
       });
+
+      testWidgets(
+        'expandLeadingHitArea routes taps in the empty part of the '
+        'leading slot to onBackPressed',
+        (tester) async {
+          var pressed = false;
+          await tester.pumpWidget(
+            buildTestWidget(
+              title: 'Test',
+              showBackButton: true,
+              onBackPressed: () => pressed = true,
+              expandLeadingHitArea: true,
+              style: DiVineAppBarStyle.transparentStyle.copyWith(
+                horizontalPadding: 12,
+                leadingWidth: 72,
+              ),
+            ),
+          );
+
+          // Tap inside the slot but outside the visible 48 × 48 icon
+          // button (which lives at x ∈ [12, 60]).
+          final iconButtonRect = tester.getRect(
+            find.byType(DiVineAppBarIconButton),
+          );
+          final tapPoint = Offset(
+            iconButtonRect.right + 4,
+            iconButtonRect.center.dy,
+          );
+          await tester.tapAt(tapPoint);
+          expect(pressed, isTrue);
+        },
+      );
+
+      testWidgets(
+        'default behavior: taps outside the visible button do NOT fire '
+        'onBackPressed',
+        (tester) async {
+          var pressed = false;
+          await tester.pumpWidget(
+            buildTestWidget(
+              title: 'Test',
+              showBackButton: true,
+              onBackPressed: () => pressed = true,
+              style: DiVineAppBarStyle.transparentStyle.copyWith(
+                horizontalPadding: 12,
+                leadingWidth: 72,
+              ),
+            ),
+          );
+
+          final iconButtonRect = tester.getRect(
+            find.byType(DiVineAppBarIconButton),
+          );
+          await tester.tapAt(
+            Offset(iconButtonRect.right + 4, iconButtonRect.center.dy),
+          );
+          expect(pressed, isFalse);
+        },
+      );
     });
 
     group('actions', () {

--- a/mobile/test/blocs/inline_comment_composer/inline_comment_composer_cubit_test.dart
+++ b/mobile/test/blocs/inline_comment_composer/inline_comment_composer_cubit_test.dart
@@ -1,0 +1,272 @@
+// ABOUTME: Tests for InlineCommentComposerCubit — the publish flow behind
+// ABOUTME: the inline comment bar at the bottom of the fullscreen feed.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:comments_repository/comments_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
+
+class _MockCommentsRepository extends Mock implements CommentsRepository {}
+
+void main() {
+  group(InlineCommentComposerCubit, () {
+    late _MockCommentsRepository commentsRepository;
+
+    VideoEvent buildVideo({
+      String id = 'video-id',
+      String pubkey = 'author-pubkey',
+    }) {
+      final now = DateTime.now();
+      return VideoEvent(
+        id: id,
+        pubkey: pubkey,
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        timestamp: now,
+        content: 'caption',
+        videoUrl: 'https://example.com/v.mp4',
+      );
+    }
+
+    Comment buildComment() {
+      return Comment(
+        id: 'comment-id',
+        content: 'hello world',
+        authorPubkey: 'commenter-pubkey',
+        createdAt: DateTime.now(),
+        rootEventId: 'video-id',
+        rootAuthorPubkey: 'author-pubkey',
+      );
+    }
+
+    setUp(() {
+      commentsRepository = _MockCommentsRepository();
+    });
+
+    test('starts in idle status', () {
+      final cubit = InlineCommentComposerCubit(
+        commentsRepository: commentsRepository,
+      );
+      addTearDown(cubit.close);
+      expect(cubit.state.status, InlineCommentComposerStatus.idle);
+    });
+
+    group('submit', () {
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'emits [submitting, submitted] on successful publish',
+        setUp: () {
+          when(
+            () => commentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).thenAnswer((_) async => buildComment());
+        },
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) =>
+            cubit.submit(video: buildVideo(), content: 'hello world'),
+        expect: () => const [
+          InlineCommentComposerState(
+            status: InlineCommentComposerStatus.submitting,
+          ),
+          InlineCommentComposerState(
+            status: InlineCommentComposerStatus.submitted,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => commentsRepository.postComment(
+              content: 'hello world',
+              rootEventId: 'video-id',
+              rootEventKind: NIP71VideoKinds.addressableShortVideo,
+              rootEventAuthorPubkey: 'author-pubkey',
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'trims whitespace before publishing',
+        setUp: () {
+          when(
+            () => commentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).thenAnswer((_) async => buildComment());
+        },
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) =>
+            cubit.submit(video: buildVideo(), content: '   hi there  \n'),
+        verify: (_) {
+          verify(
+            () => commentsRepository.postComment(
+              content: 'hi there',
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'is a no-op for empty / whitespace-only content',
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) async {
+          await cubit.submit(video: buildVideo(), content: '');
+          await cubit.submit(video: buildVideo(), content: '   ');
+          await cubit.submit(video: buildVideo(), content: '\n\t');
+        },
+        expect: () => <InlineCommentComposerState>[],
+        verify: (_) {
+          verifyNever(
+            () => commentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          );
+        },
+      );
+
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'emits [submitting, failure] when the repository throws',
+        setUp: () {
+          when(
+            () => commentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).thenThrow(
+            const PostCommentFailedException('Failed to publish comment'),
+          );
+        },
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) => cubit.submit(video: buildVideo(), content: 'oops'),
+        expect: () => const [
+          InlineCommentComposerState(
+            status: InlineCommentComposerStatus.submitting,
+          ),
+          InlineCommentComposerState(
+            status: InlineCommentComposerStatus.failure,
+          ),
+        ],
+        errors: () => [isA<PostCommentFailedException>()],
+      );
+
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'drops re-entrant submits while one is in flight',
+        setUp: () {
+          // Long-running future so the first call stays in `submitting`.
+          when(
+            () => commentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).thenAnswer(
+            (_) => Future.delayed(
+              const Duration(milliseconds: 100),
+              buildComment,
+            ),
+          );
+        },
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) async {
+          // Fire-and-forget the first submit so the cubit reaches submitting
+          // before the second call is dispatched.
+          unawaited(
+            cubit.submit(video: buildVideo(), content: 'first'),
+          );
+          await Future<void>.delayed(Duration.zero);
+          await cubit.submit(video: buildVideo(), content: 'second');
+        },
+        verify: (_) {
+          // Only the first publish should reach the repository.
+          verify(
+            () => commentsRepository.postComment(
+              content: 'first',
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => commentsRepository.postComment(
+              content: 'second',
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+            ),
+          );
+        },
+      );
+    });
+
+    group('acknowledge', () {
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'returns to idle from submitted',
+        seed: () => const InlineCommentComposerState(
+          status: InlineCommentComposerStatus.submitted,
+        ),
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) => cubit.acknowledge(),
+        expect: () => const [InlineCommentComposerState()],
+      );
+
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'returns to idle from failure',
+        seed: () => const InlineCommentComposerState(
+          status: InlineCommentComposerStatus.failure,
+        ),
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) => cubit.acknowledge(),
+        expect: () => const [InlineCommentComposerState()],
+      );
+
+      blocTest<InlineCommentComposerCubit, InlineCommentComposerState>(
+        'is a no-op when already idle',
+        build: () => InlineCommentComposerCubit(
+          commentsRepository: commentsRepository,
+        ),
+        act: (cubit) => cubit.acknowledge(),
+        expect: () => <InlineCommentComposerState>[],
+      );
+    });
+  });
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -406,6 +406,15 @@ const _knownUntranslatedDebt = {
   // screen-reader hint. Existing locales fall back to English until the
   // next full translation pass.
   'metadataHashtagChipTapHint',
+  // Added by the inline comment composer bar on the fullscreen video
+  // feed (Explore / Search / Profile playback). Translators will pick
+  // these up in a follow-up pass; until then non-English locales fall
+  // back to the English source.
+  'videoOverlayCommentBarHint',
+  'videoOverlayCommentBarSemanticLabel',
+  'videoOverlayCommentBarSendLabel',
+  'videoOverlayCommentPostedSnackbar',
+  'videoOverlayCommentPostFailedSnackbar',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/feed/keyboard_aware_top_fade_test.dart
+++ b/mobile/test/screens/feed/keyboard_aware_top_fade_test.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Tests for KeyboardAwareTopFade — the ShaderMask wrapper that
+// ABOUTME: fades the top of the fullscreen action column while the keyboard
+// ABOUTME: is up, so the Like button doesn't sit under the AppBar.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+
+void main() {
+  group(KeyboardAwareTopFade, () {
+    // KeyboardAwareTopFade reads keyboard visibility off the underlying
+    // FlutterView (not MediaQuery) and rebuilds via
+    // WidgetsBindingObserver.didChangeMetrics — Scaffold strips
+    // viewInsets from its body's MediaQuery, so the FlutterView is the
+    // only source of truth. Drive the tests the same way the real
+    // platform would: by setting `tester.view.viewInsets`.
+
+    const subject = Directionality(
+      textDirection: TextDirection.ltr,
+      child: KeyboardAwareTopFade(
+        child: SizedBox(
+          key: ValueKey('child'),
+          width: 48,
+          height: 200,
+        ),
+      ),
+    );
+
+    testWidgets('passes the child through with no ShaderMask when the '
+        'keyboard is hidden (viewInsets.bottom == 0)', (tester) async {
+      tester.view.viewInsets = FakeViewPadding.zero;
+      addTearDown(tester.view.resetViewInsets);
+
+      await tester.pumpWidget(subject);
+
+      expect(find.byType(ShaderMask), findsNothing);
+      expect(find.byKey(const ValueKey('child')), findsOneWidget);
+    });
+
+    testWidgets('wraps the child in a ShaderMask when the keyboard '
+        'is visible (viewInsets.bottom > 0)', (tester) async {
+      tester.view.viewInsets = const FakeViewPadding(bottom: 280);
+      addTearDown(tester.view.resetViewInsets);
+
+      await tester.pumpWidget(subject);
+
+      expect(find.byType(ShaderMask), findsOneWidget);
+      expect(find.byKey(const ValueKey('child')), findsOneWidget);
+    });
+
+    testWidgets('rebuilds and removes the ShaderMask when the keyboard '
+        'closes', (tester) async {
+      addTearDown(tester.view.resetViewInsets);
+
+      tester.view.viewInsets = const FakeViewPadding(bottom: 280);
+      await tester.pumpWidget(subject);
+      expect(find.byType(ShaderMask), findsOneWidget);
+
+      tester.view.viewInsets = FakeViewPadding.zero;
+      await tester.pump();
+      expect(find.byType(ShaderMask), findsNothing);
+    });
+
+    testWidgets(
+      'uses BlendMode.dstIn so the gradient acts as an alpha mask',
+      (tester) async {
+        tester.view.viewInsets = const FakeViewPadding(bottom: 280);
+        addTearDown(tester.view.resetViewInsets);
+
+        await tester.pumpWidget(subject);
+
+        final mask = tester.widget<ShaderMask>(find.byType(ShaderMask));
+        expect(mask.blendMode, BlendMode.dstIn);
+      },
+    );
+  });
+}

--- a/mobile/test/screens/feed/keyboard_aware_top_fade_test.dart
+++ b/mobile/test/screens/feed/keyboard_aware_top_fade_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for KeyboardAwareTopFade — the ShaderMask wrapper that
-// ABOUTME: fades the top of the fullscreen action column while the keyboard
-// ABOUTME: is up, so the Like button doesn't sit under the AppBar.
+// ABOUTME: fades the top of the fullscreen action column while the soft
+// ABOUTME: keyboard is on screen. Drives the platform's viewInsets
+// ABOUTME: animation directly since that's the signal the widget reads.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,12 +9,11 @@ import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 
 void main() {
   group(KeyboardAwareTopFade, () {
-    // KeyboardAwareTopFade reads keyboard visibility off the underlying
-    // FlutterView (not MediaQuery) and rebuilds via
-    // WidgetsBindingObserver.didChangeMetrics — Scaffold strips
-    // viewInsets from its body's MediaQuery, so the FlutterView is the
-    // only source of truth. Drive the tests the same way the real
-    // platform would: by setting `tester.view.viewInsets`.
+    // The mask is driven by the *direction* of viewInsets.bottom, not
+    // by its value. On iOS/Android the platform animates the inset
+    // over the OS keyboard curve (~250 ms) and Flutter fires
+    // didChangeMetrics each frame — first rise from 0 = show starting,
+    // first decrease from a non-zero value = hide starting.
 
     const subject = Directionality(
       textDirection: TextDirection.ltr,
@@ -26,40 +26,85 @@ void main() {
       ),
     );
 
-    testWidgets('passes the child through with no ShaderMask when the '
-        'keyboard is hidden (viewInsets.bottom == 0)', (tester) async {
-      tester.view.viewInsets = FakeViewPadding.zero;
-      addTearDown(tester.view.resetViewInsets);
+    testWidgets(
+      'passes the child through with no ShaderMask when viewInsets are 0',
+      (tester) async {
+        tester.view.viewInsets = FakeViewPadding.zero;
+        addTearDown(tester.view.resetViewInsets);
 
-      await tester.pumpWidget(subject);
+        await tester.pumpWidget(subject);
 
-      expect(find.byType(ShaderMask), findsNothing);
-      expect(find.byKey(const ValueKey('child')), findsOneWidget);
-    });
+        expect(find.byType(ShaderMask), findsNothing);
+        expect(find.byKey(const ValueKey('child')), findsOneWidget);
+      },
+    );
 
-    testWidgets('wraps the child in a ShaderMask when the keyboard '
-        'is visible (viewInsets.bottom > 0)', (tester) async {
-      tester.view.viewInsets = const FakeViewPadding(bottom: 280);
-      addTearDown(tester.view.resetViewInsets);
+    testWidgets(
+      'snaps the ShaderMask on as soon as viewInsets begin rising from 0',
+      (tester) async {
+        tester.view.viewInsets = FakeViewPadding.zero;
+        addTearDown(tester.view.resetViewInsets);
 
-      await tester.pumpWidget(subject);
+        await tester.pumpWidget(subject);
+        expect(find.byType(ShaderMask), findsNothing);
 
-      expect(find.byType(ShaderMask), findsOneWidget);
-      expect(find.byKey(const ValueKey('child')), findsOneWidget);
-    });
+        // First frame of the keyboard show animation — inset is still
+        // well below the eventual target.
+        tester.view.viewInsets = const FakeViewPadding(bottom: 40);
+        await tester.pump();
 
-    testWidgets('rebuilds and removes the ShaderMask when the keyboard '
-        'closes', (tester) async {
-      addTearDown(tester.view.resetViewInsets);
+        expect(find.byType(ShaderMask), findsOneWidget);
+        expect(find.byKey(const ValueKey('child')), findsOneWidget);
+      },
+    );
 
-      tester.view.viewInsets = const FakeViewPadding(bottom: 280);
-      await tester.pumpWidget(subject);
-      expect(find.byType(ShaderMask), findsOneWidget);
+    testWidgets(
+      'starts the fade-out on the FIRST decrease in viewInsets, not at 0',
+      (tester) async {
+        tester.view.viewInsets = const FakeViewPadding(bottom: 280);
+        addTearDown(tester.view.resetViewInsets);
 
-      tester.view.viewInsets = FakeViewPadding.zero;
-      await tester.pump();
-      expect(find.byType(ShaderMask), findsNothing);
-    });
+        await tester.pumpWidget(subject);
+        expect(find.byType(ShaderMask), findsOneWidget);
+
+        // First frame of the keyboard hide animation. The inset is
+        // still very much non-zero — but the fade-out must already
+        // be running because the platform keyboard is now sliding
+        // off-screen in parallel.
+        tester.view.viewInsets = const FakeViewPadding(bottom: 270);
+        await tester.pump();
+        expect(find.byType(ShaderMask), findsOneWidget);
+
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(find.byType(ShaderMask), findsOneWidget);
+
+        // Past the 100 ms fade — wrapper drops while viewInsets are
+        // still mid-animation (in real iOS this is ~150 ms before
+        // the keyboard has finished sliding down).
+        await tester.pump(const Duration(milliseconds: 60));
+        expect(find.byType(ShaderMask), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'ignores rising viewInsets while already visible (no re-trigger '
+      'mid-show animation)',
+      (tester) async {
+        tester.view.viewInsets = FakeViewPadding.zero;
+        addTearDown(tester.view.resetViewInsets);
+
+        await tester.pumpWidget(subject);
+
+        // Successive frames of the keyboard show animation — each
+        // frame the inset rises further. The mask should stay on
+        // throughout, not flicker.
+        for (final inset in const [40.0, 120.0, 220.0, 280.0]) {
+          tester.view.viewInsets = FakeViewPadding(bottom: inset);
+          await tester.pump();
+          expect(find.byType(ShaderMask), findsOneWidget);
+        }
+      },
+    );
 
     testWidgets(
       'uses BlendMode.dstIn so the gradient acts as an alpha mask',

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -220,10 +220,10 @@ class _PopCountingObserver extends NavigatorObserver {
 void main() {
   group('PooledFullscreenVideoFeedScreen', () {
     group('fullscreen video media alignment', () {
-      test('top-aligns contained square and landscape videos', () {
+      test('centers contained 1 × 1 / landscape videos in the viewport', () {
         expect(
           fullscreenVideoMediaAlignment(isPortrait: false),
-          Alignment.topCenter,
+          Alignment.center,
         );
       });
 

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -233,37 +233,6 @@ void main() {
           Alignment.center,
         );
       });
-
-      test('places contained videos below the fullscreen app header', () {
-        expect(
-          fullscreenContainedVideoTopInset(safeAreaTop: 54),
-          54 + DiVineAppBarStyle.defaultStyle.height,
-        );
-      });
-
-      test('does not offset portrait videos that cover the viewport', () {
-        expect(
-          fullscreenContainedVideoTopInset(safeAreaTop: 54, isPortrait: true),
-          0,
-        );
-      });
-
-      test('returns 0 when a context header is present — the Scaffold lays out '
-          'the body beneath the AppBar, so the leaf-level Padding would '
-          'double-pad. Applies to both portrait and contained videos.', () {
-        expect(
-          fullscreenContainedVideoTopInset(
-            safeAreaTop: 54,
-            isPortrait: true,
-            hasHeader: true,
-          ),
-          0,
-        );
-        expect(
-          fullscreenContainedVideoTopInset(safeAreaTop: 54, hasHeader: true),
-          0,
-        );
-      });
     });
 
     late MockFullscreenFeedBloc mockBloc;

--- a/mobile/test/screens/feed/video_tap_shield_test.dart
+++ b/mobile/test/screens/feed/video_tap_shield_test.dart
@@ -1,0 +1,125 @@
+// ABOUTME: Tests for VideoTapShield — the transparent overlay that
+// ABOUTME: claims taps on the fullscreen video area while a text
+// ABOUTME: input has primary focus, so dismissing the keyboard does
+// ABOUTME: not also toggle video playback.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+
+void main() {
+  group(VideoTapShield, () {
+    // The shield's contract: while a text input has primary focus,
+    // taps on its child are claimed by an overlay GestureDetector
+    // instead of reaching the child's own gesture recognizers. The
+    // setup below stands in for the real "video + composer" layout
+    // with two minimal widgets — a tap-counting box where the video
+    // would sit, plus a TextField that drives focus.
+
+    Widget buildSubject({
+      required FocusNode textFieldFocus,
+      required void Function() onVideoTap,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              Expanded(
+                child: VideoTapShield(
+                  child: GestureDetector(
+                    onTap: onVideoTap,
+                    behavior: HitTestBehavior.opaque,
+                    child: const ColoredBox(
+                      key: ValueKey('fake-video'),
+                      color: Color(0xFF222222),
+                      child: SizedBox.expand(),
+                    ),
+                  ),
+                ),
+              ),
+              TextField(focusNode: textFieldFocus),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'passes taps through to the video when no text input is focused',
+      (tester) async {
+        final textFieldFocus = FocusNode();
+        addTearDown(textFieldFocus.dispose);
+        var videoTapCount = 0;
+
+        await tester.pumpWidget(
+          buildSubject(
+            textFieldFocus: textFieldFocus,
+            onVideoTap: () => videoTapCount++,
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('fake-video')));
+        expect(videoTapCount, 1);
+      },
+    );
+
+    testWidgets(
+      'absorbs taps on the video while a text input has focus, '
+      'so playback does not toggle',
+      (tester) async {
+        final textFieldFocus = FocusNode();
+        addTearDown(textFieldFocus.dispose);
+        var videoTapCount = 0;
+
+        await tester.pumpWidget(
+          buildSubject(
+            textFieldFocus: textFieldFocus,
+            onVideoTap: () => videoTapCount++,
+          ),
+        );
+
+        textFieldFocus.requestFocus();
+        await tester.pump();
+
+        // `warnIfMissed: false` because the *intent* is that the
+        // inner recognizer doesn't receive the tap — the overlay
+        // claims it before the gesture arena resolves on the child.
+        await tester.tap(
+          find.byKey(const ValueKey('fake-video')),
+          warnIfMissed: false,
+        );
+        expect(videoTapCount, 0);
+      },
+    );
+
+    testWidgets(
+      'releases taps back to the video once focus moves away',
+      (tester) async {
+        final textFieldFocus = FocusNode();
+        addTearDown(textFieldFocus.dispose);
+        var videoTapCount = 0;
+
+        await tester.pumpWidget(
+          buildSubject(
+            textFieldFocus: textFieldFocus,
+            onVideoTap: () => videoTapCount++,
+          ),
+        );
+
+        textFieldFocus.requestFocus();
+        await tester.pump();
+        await tester.tap(
+          find.byKey(const ValueKey('fake-video')),
+          warnIfMissed: false,
+        );
+        expect(videoTapCount, 0);
+
+        textFieldFocus.unfocus();
+        await tester.pump();
+
+        await tester.tap(find.byKey(const ValueKey('fake-video')));
+        expect(videoTapCount, 1);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
@@ -123,6 +123,25 @@ void main() {
     });
 
     testWidgets(
+      'configures the field to grow from 1 to 5 lines on long input, '
+      'matching the comments-sheet composer',
+      (tester) async {
+        await tester.pumpWidget(buildBar());
+
+        final field = tester.widget<TextField>(
+          find.descendant(
+            of: find.bySemanticsIdentifier('inline_comment_composer_field'),
+            matching: find.byType(TextField),
+          ),
+        );
+
+        expect(field.minLines, 1);
+        expect(field.maxLines, 5);
+        expect(field.keyboardType, TextInputType.multiline);
+      },
+    );
+
+    testWidgets(
       'still hides the send button when the field only has whitespace',
       (tester) async {
         await tester.pumpWidget(buildBar());

--- a/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: comment field used by the fullscreen video player on
 // ABOUTME: Explore / Search / Profile entry points.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -283,6 +285,126 @@ void main() {
           findsOneWidget,
         );
         verify(() => composerCubit.acknowledge()).called(1);
+      },
+    );
+
+    testWidgets(
+      'restores the draft and re-shows the send button when the cubit '
+      'emits failure after an optimistic clear',
+      (tester) async {
+        // Reproduces the full submit-then-fail loop the user sees in
+        // production: type → tap send (optimistic clear) → cubit emits
+        // failure → bar restores the typed text from `_pendingDraft`
+        // so the user can retry without retyping. Matches the
+        // `CommentsBloc` rollback of `mainInputText` on publish error.
+        // Uses a [StreamController] so the failure emits AFTER the tap
+        // — `whenListen` with `Stream.fromIterable` would drain the
+        // sequence on subscription, before the test has had a chance
+        // to capture a draft.
+        final activeVideo = buildVideo();
+        when(
+          () => fullscreenBloc.state,
+        ).thenReturn(stateWithVideo(activeVideo));
+        when(
+          () => composerCubit.submit(
+            video: any(named: 'video'),
+            content: any(named: 'content'),
+          ),
+        ).thenAnswer((_) async {});
+        final stateController = StreamController<InlineCommentComposerState>();
+        addTearDown(stateController.close);
+        whenListen<InlineCommentComposerState>(
+          composerCubit,
+          stateController.stream,
+          initialState: const InlineCommentComposerState(),
+        );
+
+        await tester.pumpWidget(buildBar());
+
+        const draft = 'lost in the void';
+        await tester.enterText(
+          find.bySemanticsIdentifier('inline_comment_composer_field'),
+          draft,
+        );
+        await tester.pump();
+        await tester.tap(
+          find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+        );
+        await tester.pump();
+
+        // Now drive the failure through.
+        stateController.add(
+          const InlineCommentComposerState(
+            status: InlineCommentComposerStatus.failure,
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        // Draft is back in the field and the send affordance is back
+        // along with it (since `_hasText` flips true on the restored
+        // controller value).
+        expect(find.text(draft), findsOneWidget);
+        expect(
+          find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'does not clobber freshly-typed text if the user starts a new '
+      'draft before the failure arrives',
+      (tester) async {
+        final activeVideo = buildVideo();
+        when(
+          () => fullscreenBloc.state,
+        ).thenReturn(stateWithVideo(activeVideo));
+        when(
+          () => composerCubit.submit(
+            video: any(named: 'video'),
+            content: any(named: 'content'),
+          ),
+        ).thenAnswer((_) async {});
+        final stateController = StreamController<InlineCommentComposerState>();
+        addTearDown(stateController.close);
+        whenListen<InlineCommentComposerState>(
+          composerCubit,
+          stateController.stream,
+          initialState: const InlineCommentComposerState(),
+        );
+
+        await tester.pumpWidget(buildBar());
+        await tester.enterText(
+          find.bySemanticsIdentifier('inline_comment_composer_field'),
+          'first draft',
+        );
+        await tester.pump();
+        await tester.tap(
+          find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+        );
+        await tester.pump();
+
+        // User starts typing a new comment before the failure lands.
+        await tester.enterText(
+          find.bySemanticsIdentifier('inline_comment_composer_field'),
+          'new thought',
+        );
+        await tester.pump();
+
+        // Now the publish fails. The bar must NOT overwrite "new
+        // thought" with the stale "first draft" — the guard on
+        // `_controller.text.isEmpty` is what protects us.
+        stateController.add(
+          const InlineCommentComposerState(
+            status: InlineCommentComposerStatus.failure,
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(find.text('new thought'), findsOneWidget);
+        expect(find.text('first draft'), findsNothing);
       },
     );
 

--- a/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
@@ -1,0 +1,296 @@
+// ABOUTME: Widget tests for InlineCommentComposerBar — the bottom-of-screen
+// ABOUTME: comment field used by the fullscreen video player on
+// ABOUTME: Explore / Search / Profile entry points.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
+
+class _MockFullscreenFeedBloc
+    extends MockBloc<FullscreenFeedEvent, FullscreenFeedState>
+    implements FullscreenFeedBloc {}
+
+class _MockInlineCommentComposerCubit
+    extends MockCubit<InlineCommentComposerState>
+    implements InlineCommentComposerCubit {}
+
+void main() {
+  group(InlineCommentComposerBar, () {
+    late _MockFullscreenFeedBloc fullscreenBloc;
+    late _MockInlineCommentComposerCubit composerCubit;
+
+    VideoEvent buildVideo() {
+      final now = DateTime.now();
+      return VideoEvent(
+        id: 'video-id',
+        pubkey: 'author-pubkey',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        timestamp: now,
+        content: 'caption',
+        videoUrl: 'https://example.com/v.mp4',
+      );
+    }
+
+    FullscreenFeedState stateWithVideo(VideoEvent video) {
+      return FullscreenFeedState(
+        status: FullscreenFeedStatus.ready,
+        videos: [video],
+      );
+    }
+
+    setUpAll(() {
+      registerFallbackValue(buildVideo());
+    });
+
+    setUp(() {
+      fullscreenBloc = _MockFullscreenFeedBloc();
+      composerCubit = _MockInlineCommentComposerCubit();
+
+      when(
+        () => fullscreenBloc.state,
+      ).thenReturn(stateWithVideo(buildVideo()));
+      when(
+        () => composerCubit.state,
+      ).thenReturn(const InlineCommentComposerState());
+    });
+
+    tearDown(() {
+      fullscreenBloc.close();
+      composerCubit.close();
+    });
+
+    Widget buildBar() {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MultiBlocProvider(
+            providers: [
+              BlocProvider<FullscreenFeedBloc>.value(value: fullscreenBloc),
+              BlocProvider<InlineCommentComposerCubit>.value(
+                value: composerCubit,
+              ),
+            ],
+            child: const Align(
+              alignment: Alignment.bottomCenter,
+              child: InlineCommentComposerBar(),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the "Add comment..." hint', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.videoOverlayCommentBarHint), findsOneWidget);
+    });
+
+    testWidgets('hides the send button when the field is empty', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildBar());
+
+      expect(
+        find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+        findsNothing,
+      );
+    });
+
+    testWidgets('shows the send button once the user types text', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(
+        find.bySemanticsIdentifier('inline_comment_composer_field'),
+        'hello',
+      );
+      await tester.pump();
+
+      expect(
+        find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+      'still hides the send button when the field only has whitespace',
+      (tester) async {
+        await tester.pumpWidget(buildBar());
+
+        await tester.enterText(
+          find.bySemanticsIdentifier('inline_comment_composer_field'),
+          '   \n  ',
+        );
+        await tester.pump();
+
+        expect(
+          find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'tapping send forwards the text + active video to the cubit and '
+      'clears the field',
+      (tester) async {
+        final activeVideo = buildVideo();
+        when(
+          () => fullscreenBloc.state,
+        ).thenReturn(stateWithVideo(activeVideo));
+        when(
+          () => composerCubit.submit(
+            video: any(named: 'video'),
+            content: any(named: 'content'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(buildBar());
+        await tester.enterText(
+          find.bySemanticsIdentifier('inline_comment_composer_field'),
+          'great video!',
+        );
+        await tester.pump();
+        await tester.tap(
+          find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+        );
+        await tester.pump();
+
+        verify(
+          () => composerCubit.submit(
+            video: activeVideo,
+            content: 'great video!',
+          ),
+        ).called(1);
+
+        // Field is cleared after submit so the send affordance disappears.
+        expect(
+          find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'submitting via the keyboard send action triggers the cubit',
+      (tester) async {
+        when(
+          () => composerCubit.submit(
+            video: any(named: 'video'),
+            content: any(named: 'content'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(buildBar());
+        await tester.enterText(
+          find.bySemanticsIdentifier('inline_comment_composer_field'),
+          'hi',
+        );
+        await tester.testTextInput.receiveAction(TextInputAction.send);
+        await tester.pump();
+
+        verify(
+          () => composerCubit.submit(
+            video: any(named: 'video'),
+            content: 'hi',
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'shows the success snackbar when the cubit emits submitted',
+      (tester) async {
+        whenListen<InlineCommentComposerState>(
+          composerCubit,
+          Stream.fromIterable(const [
+            InlineCommentComposerState(
+              status: InlineCommentComposerStatus.submitting,
+            ),
+            InlineCommentComposerState(
+              status: InlineCommentComposerStatus.submitted,
+            ),
+          ]),
+          initialState: const InlineCommentComposerState(),
+        );
+
+        await tester.pumpWidget(buildBar());
+        await tester.pump();
+        // Allow the snackbar entrance animation to settle.
+        await tester.pump(const Duration(seconds: 1));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoOverlayCommentPostedSnackbar),
+          findsOneWidget,
+        );
+        verify(() => composerCubit.acknowledge()).called(1);
+      },
+    );
+
+    testWidgets(
+      'shows the failure snackbar when the cubit emits failure',
+      (tester) async {
+        whenListen<InlineCommentComposerState>(
+          composerCubit,
+          Stream.fromIterable(const [
+            InlineCommentComposerState(
+              status: InlineCommentComposerStatus.submitting,
+            ),
+            InlineCommentComposerState(
+              status: InlineCommentComposerStatus.failure,
+            ),
+          ]),
+          initialState: const InlineCommentComposerState(),
+        );
+
+        await tester.pumpWidget(buildBar());
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoOverlayCommentPostFailedSnackbar),
+          findsOneWidget,
+        );
+        verify(() => composerCubit.acknowledge()).called(1);
+      },
+    );
+
+    testWidgets('does nothing on send when there is no active video', (
+      tester,
+    ) async {
+      when(
+        () => fullscreenBloc.state,
+      ).thenReturn(const FullscreenFeedState());
+
+      await tester.pumpWidget(buildBar());
+      await tester.enterText(
+        find.bySemanticsIdentifier('inline_comment_composer_field'),
+        'orphan',
+      );
+      await tester.pump();
+      await tester.tap(
+        find.bySemanticsIdentifier('inline_comment_composer_send_button'),
+      );
+      await tester.pump();
+
+      verifyNever(
+        () => composerCubit.submit(
+          video: any(named: 'video'),
+          content: any(named: 'content'),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #4426

## Description

Adds an inline comment composer pinned to the bottom of the fullscreen video player on Explore / Search / Profile so users can drop a quick comment without opening the full comments sheet. Along the way, the surrounding fullscreen surface got a polish pass — app bar typography and spacing, square / classic videos now sit centered on a blurred-thumbnail backdrop instead of stretching, and keyboard interactions stay out of the way of playback.

## Screenshots

### Inline comment composer

<table>
  <tr>
    <th width="400">Main</th>
    <th width="400">This branch</th>
  </tr>
  <tr>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-16 at 09 46 35" src="https://github.com/user-attachments/assets/48dee23c-c4c0-412b-af37-95e6e7b22019" />
    </td>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-16 at 09 16 16" src="https://github.com/user-attachments/assets/8cdd5f84-2e90-4f72-b470-2200a698a9ec" />
    </td>
  </tr>
  <tr>
    <td valign="top">Fullscreen video player on Profile / Explore / Search has no comment input — to drop a comment you have to open the full comments sheet first.</td>
    <td valign="top">A pinned composer bar sits at the bottom of the screen with an "Add comment..." hint, so users can drop a quick comment without ever opening the sheet.</td>
  </tr>
</table>

### Composer with text + send button

<table>
  <tr>
    <th width="400">Main</th>
    <th width="400">This branch</th>
  </tr>
  <tr>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-16 at 09 48 14" src="https://github.com/user-attachments/assets/03ae2770-41a1-4d81-9fd4-1ab30e66eda5" />
    </td>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-16 at 08 34 46" src="https://github.com/user-attachments/assets/dd52e190-63e8-4209-a85a-17dec34d5ba6" />
    </td>
  </tr>
  <tr>
    <td valign="top">n/a — composer doesn't exist on main.</td>
    <td valign="top">As soon as the user types, the send button appears (40 × 40, 16.667 px radius, `primary/primary` green with the dark-green Phosphor `arrow_up` glyph — matches Figma node 2018:29838). The pill grows from 1 line up to 5 lines (then scrolls), mirroring the comments-sheet composer.</td>
  </tr>
</table>

### Top app bar (typography + leading gap + expanded hit area)

<table>
  <tr>
    <th width="400">Main</th>
    <th width="400">This branch</th>
  </tr>
  <tr>
    <td>
      <img width="1206" height="405" alt="Simulator Screenshot - iPhone 17 - 2026-05-16 at 09 49 43" src="https://github.com/user-attachments/assets/b2f6942c-aff4-4cd4-be7a-0ef401bbcfe8" />
    </td>
    <td>
      <img width="1206" height="405" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-16 at 09 22 00" src="https://github.com/user-attachments/assets/0e8cef32-4341-4000-a8a0-5532559c7055" />
    </td>
  </tr>
  <tr>
    <td valign="top">Title rendered at `titleLargeFont` (22 / 28 / 0). Default 80 px leading slot, so the title sits 24 px from the back-button edge. Back-button tap target is the visible 48 × 48 icon only.</td>
    <td valign="top">Title rendered at `titleMediumFont` (16 / 24 / 0.15 — Figma `title/medium`). 72 px leading slot, so the title sits 12 px from the back-button edge. Back-button tap target expanded to the full 72 × 72 leading slot via the new opt-in `expandLeadingHitArea` on `DiVineAppBar`.</td>
  </tr>
</table>

### 1 × 1 / classic videos — centered with blurred backdrop

<table>
  <tr>
    <th width="400">Main</th>
    <th width="400">This branch</th>
  </tr>
  <tr>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-16 at 09 55 59" src="https://github.com/user-attachments/assets/7a972622-a6f7-4edb-9f4e-e28779eaab08" />
    </td>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-16 at 09 20 07" src="https://github.com/user-attachments/assets/9b4d2934-c8eb-4b72-a011-138a10b5bdda" />
    </td>
  </tr>
  <tr>
    <td valign="top">Classic Vine reposts (1 × 1 source, no dimensions metadata) get vertically stretched to fill the screen — proportions distorted.</td>
    <td valign="top">Same source rendered at its native 1 × 1 via `BoxFit.contain`, centered. A 50 %-alpha blurred copy of its own thumbnail fills the surrounding canvas above and below; `surfaceContainerHigh` (`#000A06`) is the fallback while the thumbnail loads. Detection now goes through the live `VideoController.rect` so portrait videos that lack dimensions metadata still cover the screen correctly.</td>
  </tr>
</table>

### Keyboard-up state — fade + popover + tap shielding

<table>
  <tr>
    <th width="400">Main</th>
    <th width="400">This branch</th>
  </tr>
  <tr>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-16 at 09 46 35" src="https://github.com/user-attachments/assets/4014addc-9b9a-4744-83f9-b93e361c1e4a" />
    </td>
    <td>
      <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-16 at 09 18 53" src="https://github.com/user-attachments/assets/24e19b7e-91f8-493e-b11b-ed9c6690c397" />
    </td>
  </tr>
  <tr>
    <td valign="top">n/a — keyboard was never raised on the fullscreen feed before this PR.</td>
    <td valign="top">Composer focused, keyboard up. The right-side action column's top alpha-fades to transparent so the Like icon doesn't collide with the back / More buttons. The top 20 % of the video gets a 35 %-alpha scrim so the white app-bar title still reads over light frames. Tapping the video dismisses the keyboard without toggling playback (a transparent `VideoTapShield` claims the tap); tapping the More button or any toggle inside its popover keeps the keyboard up (the AppBar + popover overlay are wrapped in `TextFieldTapRegion`).</td>
  </tr>
</table>

**Related Issue:** 

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [ ] **Direct visual verification — inline comment composer.** Open Profile → tap a video. Composer pinned at the bottom ("Add comment..."). Tap to focus → keyboard rises and the bar rides above it. Type a long comment → the field grows to a maximum of 5 lines, then scrolls. Tap send → keyboard dismisses, snackbar confirms "Comment posted". The same flow on Explore and Search.
- [ ] **Tap-outside dismissal preserves playback.** With keyboard up, tap the video → keyboard dismisses, video keeps doing what it was doing (playing stays playing, paused stays paused). No play / pause toggle as a side effect of dismissing the keyboard.
- [ ] **App-bar interactions keep the keyboard up.** With keyboard up, tap the More button → popover opens, keyboard stays. Toggle mute / captions / auto-advance → controls fire, keyboard stays. Close the popover (via the X trigger or by tapping the backdrop) → popover closes, keyboard stays. The intent: change playback mid-comment without losing your typed text.
- [ ] **Square / 1 × 1 videos.** Open a classic Vine repost (no dimensions metadata) → video centers at its native aspect, with a 50%-alpha blurred copy of its own first frame filling the bands above and below on a `surfaceContainerHigh` (`#000A06`) canvas. NOT stretched.
- [ ] **Portrait videos still cover the full screen.** Open a vertical-orientation new post → video fills the entire viewport (no letterboxing) since the actual decoded `VideoController.rect` reports `h > w`.
- [ ] **Top scrim.** Frame the screen on a video with a bright opening (sky, white wall) → the AppBar's white title / back button / More popover still read clearly thanks to the 35%-alpha scrim covering the top 20 % of the screen.
- [ ] **Action-column fade on keyboard rise.** With keyboard up, the right-side action column's top fades to transparent (20–100 % gradient) so the Like icon doesn't collide visually with the back button or More popover in the app bar.
- [ ] **Cross-surface consistency — FeedSettingsMenu.** The same `FeedSettingsMenu` widget renders on the home feed's top bar AND on the fullscreen app bar's trailing slot. Open both — same popover, same toggles, same visual treatment.
- [ ] **Touch targets.** The expanded leading hit area on the fullscreen back button covers the full 72 × 72 leading slot, not just the visible 48 × 48 icon button (`expandLeadingHitArea: true`). Tap anywhere in that area → back nav fires.
- [ ] **Screen reader (VoiceOver / TalkBack).** Focus on every new interactive element. Composer field announces "Inline comment composer field" (or localized variant); send button announces "Send comment"; back button announces "Go back". The expanded-hit-area shim doesn't break semantics — the visible `DiVineAppBarIconButton` still carries the label.
- [ ] **Font scaling.** Maximize system text size. Composer text doesn't clip; title text doesn't clip; multi-line composer still grows to 5 visible lines.
- [ ] **CI green.** Format, Analyze, Tests, Generated Files. `arb_consistency_test.dart` passes thanks to the 5 new composer keys being added to `_knownUntranslatedDebt` (English ships; translators will pick up in a follow-up pass).