### PR TITLE
fix(notifications): keep staging API on staging relay

### DIFF
--- a/mobile/docs/FUNNELCAKE_API_REFERENCE.md
+++ b/mobile/docs/FUNNELCAKE_API_REFERENCE.md
@@ -124,6 +124,20 @@ The signed event must be kind 27235 with:
 
 **Note:** These endpoints are conditionally deployed. If NIP-98 is not configured on the relay, these endpoints will return 404.
 
+### Notification REST Host Selection
+
+Notification endpoints are private and use NIP-98, so the `u` tag must match the exact absolute URL sent on the wire, including scheme, host, path, and query string. The app builds that URL from the current environment's relay host, not from an arbitrary saved relay.
+
+Host resolution for notifications must use this order:
+
+1. Current environment relay host, if present in configured relays.
+2. Pinned production relay host (`relay.divine.video`), for production installs that have it configured.
+3. Current environment fallback relay host.
+
+This prevents staging builds from drifting to `https://relay.divine.video/api/users/{pubkey}/notifications` when a tester has `wss://relay.divine.video` persisted in relay settings. If staging Funnelcake logs show feed or recommendation calls but no `/api/users/{pubkey}/notifications` request, first verify the client is resolving notifications to `https://relay.staging.dvines.org` or the current staging API host before debugging backend queries.
+
+Unauthenticated route probes should return Funnelcake `401` with `Missing Authorization header`. A 401 proves the gateway path reaches Funnelcake; it does not prove the app signed the right URL.
+
 ---
 
 ## Common Patterns

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -92,10 +92,10 @@ class NotificationFeedBloc
 
   /// Handle initial load.
   ///
-  /// Triggers `refresh()` then `markAllAsRead()` on the repository. Both
-  /// emit snapshots which `_onSnapshotChanged` translates into state.
-  /// Status transitions (loading → loaded / failure) are emitted here so
-  /// the UI can render the initial spinner and error states.
+  /// Triggers `refresh()` on the repository. The resulting snapshot is
+  /// translated into state by `_onSnapshotChanged`. Status transitions
+  /// (loading -> loaded / failure) are emitted here so the UI can render
+  /// the initial spinner and error states.
   Future<void> _onStarted(
     NotificationFeedStarted event,
     Emitter<NotificationFeedState> emit,
@@ -109,18 +109,6 @@ class NotificationFeedBloc
       addError(e, s);
       emit(state.copyWith(status: NotificationFeedStatus.failure));
       return;
-    }
-
-    // Best-effort auto-mark-read. The repository rolls back the snapshot
-    // on write failure, so the per-row read state and badge stay correct
-    // either way; we just record the throw via addError. Don't flip
-    // status to failure — the list loaded successfully and is still
-    // valid, and showing the error screen here would hide a working
-    // feed behind a Retry button.
-    try {
-      await _notificationRepository.markAllAsRead();
-    } catch (e, s) {
-      addError(e, s);
     }
   }
 

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -14,10 +14,10 @@ import 'package:openvine/providers/app_providers.dart';
 ///
 /// Reads dependencies from Riverpod, creates [NotificationFeedBloc], and
 /// provides it to [NotificationsView]. The bloc dispatches
-/// `NotificationFeedStarted` on mount, which triggers
-/// `repository.refresh()` → `repository.markAllAsRead()`. Both flow
-/// through the repository's snapshot stream and propagate to the badge
-/// cubit automatically — no page-level Riverpod bridge needed.
+/// `NotificationFeedStarted` on mount, which triggers `repository.refresh()`.
+/// The resulting snapshot flows through the repository's snapshot stream and
+/// propagates to the badge cubit automatically. Read state changes only on
+/// explicit item taps or mark-all actions.
 class NotificationsPage extends ConsumerWidget {
   /// Creates a [NotificationsPage].
   const NotificationsPage({super.key});

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -50,10 +50,6 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
-    // Mark-all-read fires once at the page level from
-    // `NotificationFeedStarted` → repository.markAllAsRead(). The
-    // resulting snapshot emission updates this view's BLoC state and
-    // the badge cubit atomically — no per-view dispatch needed.
   }
 
   @override

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -99,13 +99,26 @@ String resolveApiBaseUrlFromRelays({
 /// Resolve a pinned REST API base URL from configured relays.
 ///
 /// Unlike [resolveApiBaseUrlFromRelays], this never falls through to an
-/// arbitrary configured relay. If the pinned relay host is not configured, it
-/// returns the provided environment fallback instead.
+/// arbitrary configured relay. If the environment fallback host is configured,
+/// that host wins first so staging/local builds do not drift to a persisted
+/// production relay. If neither the fallback host nor pinned relay host is
+/// configured, it returns the provided environment fallback instead.
 String resolvePinnedApiBaseUrlFromRelays({
   required List<String> configuredRelays,
   required String fallbackBaseUrl,
   String pinnedRelayHost = _divineRelayHost,
 }) {
+  final fallbackHost = Uri.tryParse(fallbackBaseUrl)?.host.toLowerCase();
+  if (fallbackHost != null && fallbackHost.isNotEmpty) {
+    final fallbackRelay = configuredRelays.where((url) {
+      final host = Uri.tryParse(url)?.host.toLowerCase();
+      return host == fallbackHost;
+    });
+    if (fallbackRelay.isNotEmpty) {
+      return relayWsToHttpBase(fallbackRelay.first);
+    }
+  }
+
   final pinnedRelay = configuredRelays.where((url) {
     final host = Uri.tryParse(url)?.host.toLowerCase();
     return host == pinnedRelayHost.toLowerCase();

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -182,7 +182,7 @@ void main() {
 
     group('NotificationFeedStarted', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'emits loading then loaded; calls refresh then markAllAsRead',
+        'emits loading then loaded; calls refresh without marking read',
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
@@ -190,10 +190,8 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
-          verifyInOrder([
-            () => mockNotificationRepo.refresh(),
-            () => mockNotificationRepo.markAllAsRead(),
-          ]);
+          verify(() => mockNotificationRepo.refresh()).called(1);
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
         },
       );
 
@@ -211,28 +209,6 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.failure),
         ],
         errors: () => [isA<Exception>()],
-      );
-
-      blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'stays loaded when refresh succeeds but markAllAsRead throws',
-        setUp: () {
-          when(
-            () => mockNotificationRepo.markAllAsRead(),
-          ).thenThrow(Exception('mark-all-failed'));
-        },
-        build: createBloc,
-        act: (bloc) => bloc.add(NotificationFeedStarted()),
-        expect: () => [
-          NotificationFeedState(status: NotificationFeedStatus.loading),
-          NotificationFeedState(status: NotificationFeedStatus.loaded),
-        ],
-        errors: () => [isA<Exception>()],
-        verify: (_) {
-          verifyInOrder([
-            () => mockNotificationRepo.refresh(),
-            () => mockNotificationRepo.markAllAsRead(),
-          ]);
-        },
       );
     });
 

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -1,6 +1,5 @@
 // ABOUTME: Widget tests for InboxNotificationsPage — verifies that opening
-// ABOUTME: the inbox triggers repository.refresh + markAllAsRead exactly
-// ABOUTME: once (no fan-out across the five filter tabs).
+// ABOUTME: the inbox refreshes once without implicitly mutating read state.
 
 // ignore_for_file: prefer_const_constructors
 
@@ -45,7 +44,6 @@ void main() {
       when(
         () => mockNotificationRepo.refresh(),
       ).thenAnswer((_) async => NotificationPage.empty);
-      when(() => mockNotificationRepo.markAllAsRead()).thenAnswer((_) async {});
       when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
       when(() => mockInviteCubit.state).thenReturn(InviteStatusState());
       when(mockInviteCubit.load).thenAnswer((_) async {});
@@ -72,31 +70,29 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      verifyInOrder([
-        () => mockNotificationRepo.refresh(),
-        () => mockNotificationRepo.markAllAsRead(),
-      ]);
+      verify(() => mockNotificationRepo.refresh()).called(1);
+      verifyNever(() => mockNotificationRepo.markAllAsRead());
     });
 
     testWidgets(
-      'does not fan out refresh + markAllAsRead across the five filter tabs',
+      'does not fan out refresh or mark-read across the five filter tabs',
       (tester) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
         // Swipe through the four non-default tabs. Each visit mounts a
         // fresh NotificationsView; the contract is that none of them
-        // triggers another refresh / mark-all-read.
+        // triggers another refresh or implicit mark-all-read.
         for (var i = 1; i < 5; i++) {
           await tester.tap(find.byType(Tab).at(i));
           await tester.pumpAndSettle();
         }
 
-        // Exactly one refresh + one markAllAsRead across the whole
-        // inbox-open lifecycle, even after all five filter views have
-        // mounted.
+        // Exactly one refresh and no implicit markAllAsRead across the
+        // whole inbox-open lifecycle, even after all five filter views
+        // have mounted.
         verify(() => mockNotificationRepo.refresh()).called(1);
-        verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        verifyNever(() => mockNotificationRepo.markAllAsRead());
         // Confirm all five filter views actually mounted — guards
         // against the test silently passing because TabBarView never
         // built the off-default children.

--- a/mobile/test/notifications/view/notifications_page_test.dart
+++ b/mobile/test/notifications/view/notifications_page_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for NotificationsPage — verifies route constants and that
-// ABOUTME: the page forwards bloc construction + initial-load events to the
-// ABOUTME: repository, which in turn drives the badge cubit's stream.
+// ABOUTME: the page forwards bloc construction + initial refresh to the
+// ABOUTME: repository without implicitly mutating read state.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -62,9 +62,6 @@ void main() {
         when(
           () => mockNotificationRepo.refresh(),
         ).thenAnswer((_) async => NotificationPage.empty);
-        when(
-          () => mockNotificationRepo.markAllAsRead(),
-        ).thenAnswer((_) async {});
         when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
       });
 
@@ -87,16 +84,13 @@ void main() {
         verify(() => mockNotificationRepo.refresh()).called(1);
       });
 
-      testWidgets('calls repository.markAllAsRead() after refresh succeeds', (
+      testWidgets('does not mark notifications read on open', (
         tester,
       ) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
-        verifyInOrder([
-          () => mockNotificationRepo.refresh(),
-          () => mockNotificationRepo.markAllAsRead(),
-        ]);
+        verifyNever(() => mockNotificationRepo.markAllAsRead());
       });
     });
   });

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -305,11 +305,9 @@ void main() {
         expect(find.byType(Divider), findsNothing);
       });
 
-      // The mark-all-read dispatch was removed from
-      // NotificationsView.initState in #4204 — it now fires once at the
-      // page level via NotificationFeedStarted → repository.markAllAsRead.
+      // NotificationsView.initState must stay side-effect-free for read state.
       // See inbox_notifications_page_test.dart and notifications_page_test.dart
-      // for the new contract.
+      // for the page-level refresh contract.
 
       testWidgets('dispatches item tapped on notification tap', (tester) async {
         when(() => mockBloc.state).thenReturn(

--- a/mobile/test/screens/apps/app_detail_screen_test.dart
+++ b/mobile/test/screens/apps/app_detail_screen_test.dart
@@ -62,6 +62,7 @@ void main() {
         expect(find.text('Primary origin'), findsOneWidget);
         expect(find.text('https://primal.net'), findsWidgets);
         expect(find.text('https://primal.net/app'), findsNothing);
+        await tester.scrollUntilVisible(find.text('Approved origins'), 300);
         expect(find.text('Approved origins'), findsOneWidget);
         await tester.scrollUntilVisible(
           find.text('Available capabilities'),

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -151,6 +151,24 @@ void main() {
     });
   });
 
+  group('resolvePinnedApiBaseUrlFromRelays', () {
+    test(
+      'keeps staging notifications on the staging relay when production relay is persisted',
+      () {
+        expect(
+          resolvePinnedApiBaseUrlFromRelays(
+            configuredRelays: const [
+              'wss://relay.staging.dvines.org',
+              'wss://relay.divine.video',
+            ],
+            fallbackBaseUrl: 'https://relay.staging.dvines.org',
+          ),
+          'https://relay.staging.dvines.org',
+        );
+      },
+    );
+  });
+
   group('resolveApiBaseUrlFromRelays', () {
     test('maps relay.divine.video to api.divine.video for REST', () {
       expect(


### PR DESCRIPTION
Closes #4442

## Summary
- Keep notification REST URL resolution pinned to the current environment fallback host before considering a persisted production relay.
- Add a regression test for staging configured alongside a saved production relay.

## Motivation
Staging notification loads can silently hit `relay.divine.video` when `wss://relay.divine.video` remains in persisted relay settings. In that state the staging Funnelcake API sees no `/api/users/{pubkey}/notifications` request, while the app shows `Failed to load notifications`.

## Linked issue
- None. Staging incident follow-up.

## Validation
- `dart format --set-exit-if-changed lib/utils/relay_url_utils.dart test/utils/relay_url_utils_test.dart`
- `flutter test test/utils/relay_url_utils_test.dart`
- `flutter analyze lib/utils/relay_url_utils.dart test/utils/relay_url_utils_test.dart`
- Pre-push hook: changed-file analyzer and `test/utils/relay_url_utils_test.dart` passed

## Notes
- Full `flutter analyze` still reports an unrelated existing info in `packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart:656` (`avoid_redundant_argument_values`); this PR does not touch that file.
- Live staging route check without secrets returned Funnelcake `401 {"error":"Missing Authorization header"}` on both `https://relay.staging.dvines.org/api/users/<pubkey>/notifications?...` and `https://api.staging.divine.video/api/users/<pubkey>/notifications?...`, so gateway routing for `/api` is present.