### PR TITLE
fix(media): guard malformed thumbnail URLs

### DIFF
--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -39,6 +39,9 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
       error.contains('Connection closed while receiving data') &&
       hasRecoverableMediaHost;
 
+  final isMissingHttpHost =
+      library == 'dart:_http' && error.contains('No host specified in URI');
+
   final isInvalidImageData =
       error.contains('Invalid image data') &&
       (library == 'dart:ui' ||
@@ -48,6 +51,7 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   if (isImage404 ||
       isMediaHostLookup ||
       isInterruptedMediaDownload ||
+      isMissingHttpHost ||
       isInvalidImageData) {
     return _recoverableMediaLoadReason;
   }

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -263,14 +263,18 @@ class VideoEvent {
                 dimensions ??= value;
               case 'thumb':
                 // Thumbnail URL
-                thumbnailUrl ??= value;
+                if (value.isNotEmpty && _isValidVideoUrl(value)) {
+                  thumbnailUrl ??= value;
+                }
               case 'image':
                 // NIP-92 uses 'image' for thumbnail in imeta
-                thumbnailUrl ??= value;
-                developer.log(
-                  '✅ Set thumbnailUrl from imeta image tag: $value',
-                  name: 'VideoEvent',
-                );
+                if (value.isNotEmpty && _isValidVideoUrl(value)) {
+                  thumbnailUrl ??= value;
+                  developer.log(
+                    '✅ Set thumbnailUrl from imeta image tag: $value',
+                    name: 'VideoEvent',
+                  );
+                }
               case 'blurhash':
                 // Blurhash for progressive loading
                 blurhash ??= value;
@@ -297,7 +301,9 @@ class VideoEvent {
           fileSize = int.tryParse(tagValue);
         case 'thumb':
           // Thumbnail URL - prefer static thumbnails for grid display
-          thumbnailUrl = tagValue as String?;
+          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+            thumbnailUrl = tagValue;
+          }
         case 'preview':
           // Animated GIF preview - store separately, don't use as main
           // thumbnail. GIFs auto-play and would make the grid look chaotic.
@@ -312,7 +318,9 @@ class VideoEvent {
           }
         case 'image':
           // Alternative to 'thumb' tag - some clients use 'image' instead
-          thumbnailUrl ??= tagValue as String?;
+          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+            thumbnailUrl ??= tagValue;
+          }
         case 'd':
           // Replaceable event ID - original vine ID
           vineId = tagValue as String?;

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -367,6 +367,7 @@ class VideoEvent {
               );
             } else if (type == 'thumbnail' &&
                 url.isNotEmpty &&
+                _isValidVideoUrl(url) &&
                 !url.contains('picsum.photos')) {
               thumbnailUrl ??= url;
               developer.log(

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -285,6 +285,41 @@ void main() {
       // Assert
       expect(videoEvent.videoUrl, isNull);
     });
+
+    test('should ignore invalid thumbnail URLs from typed r tags', () {
+      final nostrEvent = Event(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+          ['r', 'https:///missing-host.jpg', 'thumbnail'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.videoUrl, equals('https://example.com/video.mp4'));
+      expect(videoEvent.thumbnailUrl, isNull);
+    });
+
+    test('should accept valid thumbnail URLs from typed r tags', () {
+      final nostrEvent = Event(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+          ['r', 'https://example.com/thumb.jpg', 'thumbnail'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.thumbnailUrl, equals('https://example.com/thumb.jpg'));
+    });
   });
 
   group('VideoEvent collaborator parsing', () {

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -304,6 +304,64 @@ void main() {
       expect(videoEvent.thumbnailUrl, isNull);
     });
 
+    test('should ignore invalid thumbnail URLs from top-level tags', () {
+      final invalidThumbnailTags = [
+        ['thumb', 'https:///missing-host.jpg'],
+        ['image', 'https:///missing-host.jpg'],
+      ];
+
+      for (final thumbnailTag in invalidThumbnailTags) {
+        final nostrEvent = Event(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+            thumbnailTag,
+          ],
+          'Test video',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(
+          videoEvent.thumbnailUrl,
+          isNull,
+          reason: 'Expected ${thumbnailTag.first} to reject malformed URLs',
+        );
+      }
+    });
+
+    test('should ignore invalid thumbnail URLs from imeta tags', () {
+      final invalidImetaTags = [
+        [
+          'imeta',
+          'thumb https:///missing-host.jpg',
+        ],
+        [
+          'imeta',
+          'image https:///missing-host.jpg',
+        ],
+      ];
+
+      for (final imetaTag in invalidImetaTags) {
+        final nostrEvent = Event(
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+            imetaTag,
+          ],
+          'Test video',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(videoEvent.thumbnailUrl, isNull);
+      }
+    });
+
     test('should accept valid thumbnail URLs from typed r tags', () {
       final nostrEvent = Event(
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -61,6 +61,18 @@ void main() {
       );
     });
 
+    test('classifies dart:_http missing-host URI failures as recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: ArgumentError('No host specified in URI https:///thumb.jpg'),
+        library: 'dart:_http',
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable media load failure',
+      );
+    });
+
     test('does not classify unrelated gesture errors as recoverable', () {
       final details = FlutterErrorDetails(
         exception: Exception('GoError: There is nothing to pop.'),


### PR DESCRIPTION
## Summary
- validate typed r-tag thumbnail URLs with the existing video URL guard before storing them
- classify dart:_http missing-host URI failures as recoverable media load failures
- remove a redundant default video-player argument so analyze stays clean

Fixes #4391

## Verification
- flutter test test/src/video_event_parsing_test.dart (from mobile/packages/models)
- flutter test test/utils/recoverable_flutter_error_test.dart (from mobile)
- flutter analyze (from mobile)
- pre-push hook analyzer + changed-file tests