### PR TITLE
fix(notifications): prefer named actors in grouped rows

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -22,6 +22,12 @@ const _maxCommentLength = 50;
 /// Maximum number of actor avatars shown in a grouped notification.
 const _maxGroupActors = 3;
 
+final RegExp _hexIdentifierPattern = RegExp(r'^[0-9a-fA-F]{32,}$');
+final RegExp _npubIdentifierPattern = RegExp(
+  r'^npub1[023456789acdefghjklmnpqrstuvwxyz]+$',
+  caseSensitive: false,
+);
+
 /// Repository for fetching, enriching, grouping, and managing
 /// notifications.
 ///
@@ -637,7 +643,11 @@ class NotificationRepository {
     for (final entry in groups.entries) {
       final group = entry.value
         ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-      final actors = group
+      final actorNotifications = _orderVideoGroupActorNotifications(
+        group,
+        profiles,
+      );
+      final actors = actorNotifications
           .take(_maxGroupActors)
           .map((n) => _buildActor(n.sourcePubkey, profiles))
           .toList();
@@ -661,7 +671,7 @@ class NotificationRepository {
       // no body text. Reuses the same length-cap as actor-anchored
       // comments / replies for layout safety.
       final commentTextForRow = entry.key.kind == NotificationKind.comment
-          ? _truncateComment(group.first.content, entry.key.kind)
+          ? _truncateComment(actorNotifications.first.content, entry.key.kind)
           : null;
       result.add(
         VideoNotification(
@@ -895,9 +905,74 @@ class NotificationRepository {
     final profile = profiles[pubkey];
     return ActorInfo(
       pubkey: pubkey,
-      displayName: profile?.bestDisplayName ?? 'Unknown user',
+      displayName: _displayNameForActor(pubkey, profile),
       pictureUrl: profile?.picture,
     );
+  }
+
+  /// Orders grouped video notifications with a named profile in the lead
+  /// actor position.
+  List<RelayNotification> _orderVideoGroupActorNotifications(
+    List<RelayNotification> group,
+    Map<String, UserProfile> profiles,
+  ) {
+    RelayNotification? lead;
+    for (final n in group) {
+      if (_hasExplicitActorName(n.sourcePubkey, profiles)) {
+        lead = n;
+        break;
+      }
+    }
+
+    final ordered = lead == null
+        ? group
+        : <RelayNotification>[
+            lead,
+            ...group.where((n) => !identical(n, lead)),
+          ];
+    return ordered;
+  }
+
+  static bool _hasExplicitActorName(
+    String pubkey,
+    Map<String, UserProfile> profiles,
+  ) => _explicitActorName(pubkey, profiles[pubkey]) != null;
+
+  static String _displayNameForActor(String pubkey, UserProfile? profile) {
+    final explicit = _explicitActorName(pubkey, profile);
+    if (explicit != null) return explicit;
+
+    final fallback = profile?.bestDisplayName;
+    if (_isUsableActorName(fallback, pubkey)) return fallback!.trim();
+
+    return UserProfile.defaultDisplayNameFor(pubkey);
+  }
+
+  static String? _explicitActorName(String pubkey, UserProfile? profile) {
+    if (profile == null) return null;
+
+    final displayName = profile.displayName;
+    if (_isUsableActorName(displayName, pubkey)) {
+      return displayName!.trim();
+    }
+
+    final name = profile.name;
+    if (_isUsableActorName(name, pubkey)) return name!.trim();
+
+    return null;
+  }
+
+  static bool _isUsableActorName(String? value, String pubkey) {
+    final name = value?.trim();
+    if (name == null || name.isEmpty) return false;
+
+    final lower = name.toLowerCase();
+    if (lower == 'unknown' || lower == 'unknown user') return false;
+    if (name == pubkey) return false;
+    if (_hexIdentifierPattern.hasMatch(name)) return false;
+    if (_npubIdentifierPattern.hasMatch(name)) return false;
+
+    return true;
   }
 
   /// Maps a relay notification type string + source kind to

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -15,6 +15,7 @@ import 'package:profile_repository/profile_repository.dart';
 // Hide rxdart's `NotificationKind` (a stream-event enum) to avoid clashing
 // with the domain `NotificationKind` from `models`.
 import 'package:rxdart/rxdart.dart' hide NotificationKind;
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Maximum length for comment preview text before truncation.
 const _maxCommentLength = 50;
@@ -290,13 +291,13 @@ class NotificationRepository {
   /// `videoEventId` and `type`, returns a new list with that row replaced
   /// by the merged group; otherwise returns null.
   ///
-  /// Merge semantics (mirror the pre-snapshot bloc handler): prepend the
-  /// new actor onto the existing actors capped at [_maxGroupActors],
-  /// increment `totalCount`, flip `isRead` to false, bump `timestamp` to
-  /// the incoming arrival, and union the underlying `sourceEventIds` so
-  /// the merged row carries every Nostr event it represents. The row
-  /// stays at its existing index — no re-sort, so the visible list
-  /// doesn't jump.
+  /// Merge semantics (mirror the pre-snapshot bloc handler): add the
+  /// incoming actor, reapply the grouped-row actor ordering, increment
+  /// `totalCount`, flip `isRead` to false, bump `timestamp` to the
+  /// incoming arrival, and union the underlying `sourceEventIds` so the
+  /// merged row carries every Nostr event it represents. The row stays
+  /// at its existing index — no re-sort, so the visible list doesn't
+  /// jump.
   static List<NotificationItem>? _mergeIntoExistingVideoGroup(
     List<NotificationItem> items,
     VideoNotification incoming,
@@ -308,10 +309,11 @@ class NotificationRepository {
           existing is VideoNotification &&
           existing.videoEventId == incoming.videoEventId &&
           existing.type == incoming.type) {
-        final mergedActors = [
-          incoming.actors.first,
-          ...existing.actors,
-        ].take(_maxGroupActors).toList();
+        final incomingActor = incoming.actors.first;
+        final mergedActors = _orderVideoGroupActors([
+          incomingActor,
+          ...existing.actors.where((a) => a.pubkey != incomingActor.pubkey),
+        ]).take(_maxGroupActors).toList();
         final mergedSourceEventIds = <String>{
           ...existing.sourceEventIds,
           ...incoming.sourceEventIds,
@@ -436,10 +438,9 @@ class NotificationRepository {
   ///   `totalCount >= actors.length` invariant always holds even in the
   ///   defensive edge case where both sides had empty `sourceEventIds`
   ///   (server response missing `source_event_id`).
-  /// - `actors` = existing actors first, then non-duplicate incoming
-  ///   actors (matched by pubkey), capped at [_maxGroupActors].
-  ///   "Existing first" matches production semantics: pagination walks
-  ///   backward in time, so existing.actors carry the newer createdAts.
+  /// - `actors` = the union of existing + incoming actors, then
+  ///   re-ordered to keep an explicitly named actor in front and capped
+  ///   at [_maxGroupActors].
   /// - `isRead` = `existing.isRead && incoming.isRead` (either side
   ///   being unread keeps the row unread).
   /// - `timestamp` = `max(existing.timestamp, incoming.timestamp)`.
@@ -448,11 +449,8 @@ class NotificationRepository {
   ///   `_nonEmpty(...) ?? _nonEmpty(...)` pattern).
   /// - `commentText` for comment-kind rows: pick from the side with the
   ///   larger `timestamp`, falling back to the other side only when the
-  ///   newer side has no text. Mirrors `_groupVideoAnchored`'s
-  ///   newest-wins (sort desc by `createdAt`, take `group.first.content`)
-  ///   and the `timestamp = max(...)` rule above, so the bold first-actor
-  ///   quote stays the latest comment even though REST pagination walks
-  ///   backward in time.
+  ///   newer side has no text. Mirrors the long-standing pagination
+  ///   merge contract even after lead-actor reordering.
   static VideoNotification _mergeAppendedVideoGroup(
     VideoNotification existing,
     VideoNotification incoming,
@@ -461,12 +459,12 @@ class NotificationRepository {
       ...existing.sourceEventIds,
       ...incoming.sourceEventIds,
     }.toList();
-    final mergedActors = [
+    final mergedActors = _orderVideoGroupActors([
       ...existing.actors,
       ...incoming.actors.where(
         (a) => !existing.actors.any((e) => e.pubkey == a.pubkey),
       ),
-    ].take(_maxGroupActors).toList();
+    ]).take(_maxGroupActors).toList();
     final existingIsNewer = !existing.timestamp.isBefore(incoming.timestamp);
     final mergedTimestamp = existingIsNewer
         ? existing.timestamp
@@ -647,10 +645,12 @@ class NotificationRepository {
         group,
         profiles,
       );
-      final actors = actorNotifications
-          .take(_maxGroupActors)
-          .map((n) => _buildActor(n.sourcePubkey, profiles))
-          .toList();
+      final actors = _orderVideoGroupActors(
+        actorNotifications
+            .take(_maxGroupActors)
+            .map((n) => _buildActor(n.sourcePubkey, profiles))
+            .toList(),
+      );
       final video = videosById[entry.key.eventId];
       final dTag = group
           .map((n) => n.referencedDTag)
@@ -665,11 +665,11 @@ class NotificationRepository {
       final titleFromNotif = group
           .map((n) => n.referencedVideoTitle)
           .firstWhere((t) => t != null && t.isNotEmpty, orElse: () => null);
-      // Carry the most-recent comment text (the same payload the bold
-      // first-actor span shows) so the row can quote it under the message
-      // text. Only meaningful for `comment` kind — likes and reposts have
-      // no body text. Reuses the same length-cap as actor-anchored
-      // comments / replies for layout safety.
+      // Carry the lead actor's comment text so the quoted body stays in
+      // sync with the bold first-actor span after named-actor reordering.
+      // Only meaningful for `comment` kind — likes and reposts have no
+      // body text. Reuses the same length-cap as actor-anchored comments
+      // / replies for layout safety.
       final commentTextForRow = entry.key.kind == NotificationKind.comment
           ? _truncateComment(actorNotifications.first.content, entry.key.kind)
           : null;
@@ -926,10 +926,7 @@ class NotificationRepository {
 
     final ordered = lead == null
         ? group
-        : <RelayNotification>[
-            lead,
-            ...group.where((n) => !identical(n, lead)),
-          ];
+        : <RelayNotification>[lead, ...group.where((n) => !identical(n, lead))];
     return ordered;
   }
 
@@ -953,13 +950,33 @@ class NotificationRepository {
 
     final displayName = profile.displayName;
     if (_isUsableActorName(displayName, pubkey)) {
-      return displayName!.trim();
+      return stripZalgo(displayName!).trim();
     }
 
     final name = profile.name;
-    if (_isUsableActorName(name, pubkey)) return name!.trim();
+    if (_isUsableActorName(name, pubkey)) return stripZalgo(name!).trim();
 
     return null;
+  }
+
+  static List<ActorInfo> _orderVideoGroupActors(List<ActorInfo> actors) {
+    ActorInfo? lead;
+    for (final actor in actors) {
+      if (_hasPreferredLeadActorName(actor.displayName, actor.pubkey)) {
+        lead = actor;
+        break;
+      }
+    }
+
+    if (lead == null) return actors;
+    return [lead, ...actors.where((actor) => actor.pubkey != lead!.pubkey)];
+  }
+
+  static bool _hasPreferredLeadActorName(String displayName, String pubkey) {
+    if (!_isUsableActorName(displayName, pubkey)) {
+      return false;
+    }
+    return displayName.trim() != UserProfile.defaultDisplayNameFor(pubkey);
   }
 
   static bool _isUsableActorName(String? value, String pubkey) {

--- a/mobile/packages/notification_repository/pubspec.yaml
+++ b/mobile/packages/notification_repository/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   nostr_client:
   profile_repository:
   rxdart: ^0.28.0
+  text_sanitizer:
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -267,17 +267,23 @@ void main() {
         expect(item.videoTitle, equals('Hello'));
       });
 
-      test('falls back to "Unknown user" for missing profiles', () async {
-        stubNotifications([makeNotification(sourcePubkey: 'unknown_pub')]);
-        stubProfiles({});
+      test(
+        'falls back to a generated display name for missing profiles',
+        () async {
+          stubNotifications([makeNotification(sourcePubkey: 'unknown_pub')]);
+          stubProfiles({});
 
-        final page = await repository.getNotifications();
+          final page = await repository.getNotifications();
 
-        expect(page.items, hasLength(1));
-        final item = page.items.first as VideoNotification;
-        expect(item.actors.first.displayName, equals('Unknown user'));
-        expect(item.actors.first.pictureUrl, isNull);
-      });
+          expect(page.items, hasLength(1));
+          final item = page.items.first as VideoNotification;
+          expect(
+            item.actors.first.displayName,
+            equals(UserProfile.defaultDisplayNameFor('unknown_pub')),
+          );
+          expect(item.actors.first.pictureUrl, isNull);
+        },
+      );
 
       test('rethrows on API error after logging', () async {
         when(
@@ -491,6 +497,45 @@ void main() {
         // Newest first — pub_0 had the latest createdAt.
         expect(item.actors.first.displayName, equals('Actor0'));
         expect(item.videoEventId, equals('video_x'));
+      });
+
+      test('grouped video notifications lead with a named actor', () async {
+        const hashPubkey =
+            '2949ede154d1f121402761cbd73f2b8c490b5041cdd85c9908c5322f1a2fe3f6';
+        stubNotifications([
+          makeNotification(
+            id: 'l1',
+            sourcePubkey: hashPubkey,
+            referencedEventId: 'video_x',
+            createdAt: DateTime(2025, 1, 5),
+          ),
+          makeNotification(
+            id: 'l2',
+            sourcePubkey: 'pub_named',
+            referencedEventId: 'video_x',
+            createdAt: DateTime(2025, 1, 4),
+          ),
+          makeNotification(
+            id: 'l3',
+            sourcePubkey: 'pub_missing',
+            referencedEventId: 'video_x',
+            createdAt: DateTime(2025, 1, 3),
+          ),
+        ]);
+        stubProfiles({
+          hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
+          'pub_named': makeProfile(
+            'pub_named',
+            displayName: 'Sally Strawberry',
+          ),
+        });
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.totalCount, equals(3));
+        expect(item.actors.first.pubkey, equals('pub_named'));
+        expect(item.actors.first.displayName, equals('Sally Strawberry'));
       });
 
       test('grouped video notifications build addressable id from '

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -138,6 +138,7 @@ void main() {
   UserProfile makeProfile(
     String pubkey, {
     String? displayName,
+    String? name,
     String? picture,
   }) {
     return UserProfile(
@@ -146,6 +147,7 @@ void main() {
       createdAt: DateTime(2024),
       eventId: 'evt_$pubkey',
       displayName: displayName,
+      name: name,
       picture: picture,
     );
   }
@@ -284,6 +286,21 @@ void main() {
           expect(item.actors.first.pictureUrl, isNull);
         },
       );
+
+      test('sanitizes explicit display names before rendering', () async {
+        stubNotifications([makeNotification(sourcePubkey: 'zalgo_pub')]);
+        stubProfiles({
+          'zalgo_pub': makeProfile(
+            'zalgo_pub',
+            displayName: 'A\u0300\u0301\u0302',
+          ),
+        });
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.actors.first.displayName, equals('A\u0300\u0301'));
+      });
 
       test('rethrows on API error after logging', () async {
         when(
@@ -851,10 +868,7 @@ void main() {
           final page = await repository.getNotifications();
           final item = page.items.single as ActorNotification;
           expect(item.type, equals(NotificationKind.likeComment));
-          expect(
-            item.videoAddressableId,
-            equals('34236:$userPubkey:vine-abc'),
-          );
+          expect(item.videoAddressableId, equals('34236:$userPubkey:vine-abc'));
         },
       );
 
@@ -1563,45 +1577,36 @@ void main() {
         expect(actor.targetEventId, equals('comment_evt_id'));
       });
 
-      test(
-        'enrichOne: likeComment carries videoAddressableId when '
-        'referencedDTag is set',
-        () async {
-          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+      test('enrichOne: likeComment carries videoAddressableId when '
+          'referencedDTag is set', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
-          final result = await repository.enrichOne(
-            raw(
-              referencedEventId: 'comment_evt_id',
-              isReferencedVideo: false,
-              referencedDTag: 'vine-xyz',
-            ),
-          );
+        final result = await repository.enrichOne(
+          raw(
+            referencedEventId: 'comment_evt_id',
+            isReferencedVideo: false,
+            referencedDTag: 'vine-xyz',
+          ),
+        );
 
-          expect(result, isA<ActorNotification>());
-          final actor = result! as ActorNotification;
-          expect(actor.type, equals(NotificationKind.likeComment));
-          expect(
-            actor.videoAddressableId,
-            equals('34236:$userPubkey:vine-xyz'),
-          );
-        },
-      );
+        expect(result, isA<ActorNotification>());
+        final actor = result! as ActorNotification;
+        expect(actor.type, equals(NotificationKind.likeComment));
+        expect(actor.videoAddressableId, equals('34236:$userPubkey:vine-xyz'));
+      });
 
-      test(
-        'enrichOne: likeComment videoAddressableId is null when '
-        'referencedDTag is absent',
-        () async {
-          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+      test('enrichOne: likeComment videoAddressableId is null when '
+          'referencedDTag is absent', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
-          final result = await repository.enrichOne(
-            raw(referencedEventId: 'comment_evt_id', isReferencedVideo: false),
-          );
+        final result = await repository.enrichOne(
+          raw(referencedEventId: 'comment_evt_id', isReferencedVideo: false),
+        );
 
-          expect(result, isA<ActorNotification>());
-          final actor = result! as ActorNotification;
-          expect(actor.videoAddressableId, isNull);
-        },
-      );
+        expect(result, isA<ActorNotification>());
+        final actor = result! as ActorNotification;
+        expect(actor.videoAddressableId, isNull);
+      });
     });
 
     group('reactive snapshot', () {
@@ -1795,67 +1800,64 @@ void main() {
         expect(afterItems, equals(beforeItems));
       });
 
-      test(
-        'acceptRealtime by-id guard fires when existing row has empty '
-        'sourceEventIds',
-        () async {
-          // Pins the by-id dedupe gate that survives below the
-          // `_snapshotContainsSourceEventId` checks. The gate fires when
-          // the incoming raw's `id` is not represented in any existing
-          // row's `sourceEventIds` (so the cross-path checks can't see
-          // it), but its `id` literally matches an item already in the
-          // snapshot. If a future refactor deletes the by-id gate,
-          // empty-sourceEventIds duplicates would inflate the snapshot
-          // and this test will fail.
-          stubProfiles({
-            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
-          });
-          stubNotifications([]);
-          await repository.refresh();
+      test('acceptRealtime by-id guard fires when existing row has empty '
+          'sourceEventIds', () async {
+        // Pins the by-id dedupe gate that survives below the
+        // `_snapshotContainsSourceEventId` checks. The gate fires when
+        // the incoming raw's `id` is not represented in any existing
+        // row's `sourceEventIds` (so the cross-path checks can't see
+        // it), but its `id` literally matches an item already in the
+        // snapshot. If a future refactor deletes the by-id gate,
+        // empty-sourceEventIds duplicates would inflate the snapshot
+        // and this test will fail.
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+        stubNotifications([]);
+        await repository.refresh();
 
-          // First WS arrival with empty sourceEventId — the resulting
-          // row has `sourceEventIds = []`, so the cross-path checks
-          // can't see it on the second arrival.
-          await repository.acceptRealtime(
-            makeNotification(
-              id: 'evt1',
-              sourceEventId: '',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              isReferencedVideo: false,
-            ),
-          );
+        // First WS arrival with empty sourceEventId — the resulting
+        // row has `sourceEventIds = []`, so the cross-path checks
+        // can't see it on the second arrival.
+        await repository.acceptRealtime(
+          makeNotification(
+            id: 'evt1',
+            sourceEventId: '',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            isReferencedVideo: false,
+          ),
+        );
 
-          final firstItems = (await repository.watchSnapshot().first).items;
-          expect(firstItems, hasLength(1));
-          expect(firstItems.single.id, equals('evt1'));
-          expect(firstItems.single.sourceEventIds, isEmpty);
+        final firstItems = (await repository.watchSnapshot().first).items;
+        expect(firstItems, hasLength(1));
+        expect(firstItems.single.id, equals('evt1'));
+        expect(firstItems.single.sourceEventIds, isEmpty);
 
-          // Same raw again — only the by-id gate can dedupe this.
-          await repository.acceptRealtime(
-            makeNotification(
-              id: 'evt1',
-              sourceEventId: '',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              isReferencedVideo: false,
-            ),
-          );
+        // Same raw again — only the by-id gate can dedupe this.
+        await repository.acceptRealtime(
+          makeNotification(
+            id: 'evt1',
+            sourceEventId: '',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            isReferencedVideo: false,
+          ),
+        );
 
-          final afterItems = (await repository.watchSnapshot().first).items;
-          expect(
-            afterItems,
-            hasLength(1),
-            reason:
-                'Duplicate WS arrival with empty sourceEventId must '
-                'be deduped by the by-id gate; the sourceEventIds-based '
-                'cross-path check cannot see an existing row with empty '
-                'sourceEventIds.',
-          );
-        },
-      );
+        final afterItems = (await repository.watchSnapshot().first).items;
+        expect(
+          afterItems,
+          hasLength(1),
+          reason:
+              'Duplicate WS arrival with empty sourceEventId must '
+              'be deduped by the by-id gate; the sourceEventIds-based '
+              'cross-path check cannot see an existing row with empty '
+              'sourceEventIds.',
+        );
+      });
 
       test(
         'acceptRealtime dedupes WS arrivals against snapshot sourceEventIds',
@@ -1934,59 +1936,56 @@ void main() {
         expect(items.single.sourceEventIds, equals(<String>['nostr-event-1']));
       });
 
-      test(
-        'acceptRealtime rechecks the snapshot after enrichment before '
-        'writing',
-        () async {
-          final profilesCompleter = Completer<Map<String, UserProfile>>();
-          when(
-            () => profileRepository.fetchBatchProfiles(
-              pubkeys: any(named: 'pubkeys'),
-            ),
-          ).thenAnswer((_) => profilesCompleter.future);
+      test('acceptRealtime rechecks the snapshot after enrichment before '
+          'writing', () async {
+        final profilesCompleter = Completer<Map<String, UserProfile>>();
+        when(
+          () => profileRepository.fetchBatchProfiles(
+            pubkeys: any(named: 'pubkeys'),
+          ),
+        ).thenAnswer((_) => profilesCompleter.future);
 
-          final realtimeFuture = repository.acceptRealtime(
-            makeNotification(
-              id: 'nostr-event-1',
-              sourceEventId: 'nostr-event-1',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              isReferencedVideo: false,
-            ),
-          );
+        final realtimeFuture = repository.acceptRealtime(
+          makeNotification(
+            id: 'nostr-event-1',
+            sourceEventId: 'nostr-event-1',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            isReferencedVideo: false,
+          ),
+        );
 
-          stubProfiles({
-            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
-          });
-          stubNotifications([
-            makeNotification(
-              id: 'server-uuid-1',
-              sourceEventId: 'nostr-event-1',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              isReferencedVideo: false,
-            ),
-          ], unreadCount: 1);
-          await repository.refresh();
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+        stubNotifications([
+          makeNotification(
+            id: 'server-uuid-1',
+            sourceEventId: 'nostr-event-1',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            isReferencedVideo: false,
+          ),
+        ], unreadCount: 1);
+        await repository.refresh();
 
-          profilesCompleter.complete({
-            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
-          });
-          await realtimeFuture;
+        profilesCompleter.complete({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+        await realtimeFuture;
 
-          final items = (await repository.watchSnapshot().first).items;
-          expect(
-            items,
-            hasLength(1),
-            reason:
-                'The post-await snapshot check must see the refreshed REST '
-                'row and avoid prepending a stale duplicate.',
-          );
-          expect(items.single.id, equals('server-uuid-1'));
-        },
-      );
+        final items = (await repository.watchSnapshot().first).items;
+        expect(
+          items,
+          hasLength(1),
+          reason:
+              'The post-await snapshot check must see the refreshed REST '
+              'row and avoid prepending a stale duplicate.',
+        );
+        expect(items.single.id, equals('server-uuid-1'));
+      });
 
       test('acceptRealtime merges a second actor into an existing '
           '$VideoNotification group (same videoEventId + type)', () async {
@@ -2038,6 +2037,48 @@ void main() {
         // watchUnreadCount reflects the un-read flip.
         expect(await repository.watchUnreadCount().first, equals(1));
       });
+
+      test(
+        'acceptRealtime keeps a named actor in front when a fallback actor '
+        'arrives later',
+        () async {
+          const hashPubkey =
+              '2949ede154d1f121402761cbd73f2b8c490b5041'
+              'cdd85c9908c5322f1a2fe3f6';
+          stubProfiles({
+            'pubkey_sally': makeProfile(
+              'pubkey_sally',
+              displayName: 'Sally Strawberry',
+            ),
+            hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
+          });
+          stubNotifications([
+            makeNotification(
+              id: 'named-first',
+              sourcePubkey: 'pubkey_sally',
+              referencedEventId: 'video_named',
+              createdAt: DateTime(2025, 3),
+            ),
+          ], unreadCount: 1);
+          await repository.refresh();
+
+          await repository.acceptRealtime(
+            makeNotification(
+              id: 'fallback-second',
+              sourcePubkey: hashPubkey,
+              referencedEventId: 'video_named',
+              createdAt: DateTime(2025, 4),
+            ),
+          );
+
+          final merged =
+              (await repository.watchSnapshot().first).items.single
+                  as VideoNotification;
+          expect(merged.totalCount, equals(2));
+          expect(merged.actors.first.pubkey, equals('pubkey_sally'));
+          expect(merged.actors.first.displayName, equals('Sally Strawberry'));
+        },
+      );
 
       test(
         'acceptRealtime caps merged actors at the group display limit',
@@ -2497,6 +2538,56 @@ void main() {
           reason: 'timestamp must be the max of the two sides.',
         );
       });
+
+      test(
+        'pagination merge keeps the named actor in front when the existing '
+        'row is unnamed',
+        () async {
+          const hashPubkey =
+              '2949ede154d1f121402761cbd73f2b8c490b5041'
+              'cdd85c9908c5322f1a2fe3f6';
+          stubProfiles({
+            hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
+            'pub_named': makeProfile(
+              'pub_named',
+              displayName: 'Sally Strawberry',
+            ),
+          });
+          stubNotifications(
+            [
+              makeNotification(
+                id: 'server-uuid-unnamed',
+                sourceEventId: 'nostr-unnamed',
+                sourcePubkey: hashPubkey,
+                referencedEventId: 'video_named',
+                createdAt: DateTime(2025, 6),
+              ),
+            ],
+            nextCursor: 'cursor_after_first',
+            hasMore: true,
+          );
+          await repository.refresh();
+
+          stubNotifications([
+            makeNotification(
+              id: 'server-uuid-named',
+              sourceEventId: 'nostr-named',
+              sourcePubkey: 'pub_named',
+              referencedEventId: 'video_named',
+              createdAt: DateTime(2025, 4),
+            ),
+          ]);
+
+          await repository.getNotifications();
+
+          final merged =
+              (await repository.watchSnapshot().first).items.single
+                  as VideoNotification;
+          expect(merged.totalCount, equals(2));
+          expect(merged.actors.first.pubkey, equals('pub_named'));
+          expect(merged.actors.first.displayName, equals('Sally Strawberry'));
+        },
+      );
 
       test("comment-kind merge keeps the newer side's commentText "
           '(REST page newer than WS) — symmetric direction', () async {


### PR DESCRIPTION
Closes #4453

## Summary
- prefer an explicitly named actor as the lead for grouped video notification rows
- replace Unknown user/hash-like actor names with the existing generated display-name fallback
- add regression coverage for grouped notifications where the newest actor has a hash-like display name

## Verification
- flutter test test/src/notification_repository_test.dart (from mobile/packages/notification_repository)
- flutter analyze (from mobile/packages/notification_repository)
- pre-push hook: changed-file analyzer + notification_repository_test.dart

Note: full mobile/flutter analyze currently reports an unrelated existing info in packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart:656.
