### PR TITLE
fix(notifications): handle staging comment payloads

### DIFF
--- a/mobile/docs/ANALYTICS_INTEGRATION.md
+++ b/mobile/docs/ANALYTICS_INTEGRATION.md
@@ -23,9 +23,9 @@ When analytics is enabled, the following metrics will be tracked:
 
 ### DiVine FunnelCake Relay
 
-- **Base URL**: `https://relay.staging.dvines.org`
-- **Swagger Docs**: https://relay.staging.dvines.org/swagger-ui/
-- **OpenAPI Spec**: https://relay.staging.dvines.org/openapi.json
+- **Base URL**: `https://relay.staging.divine.video`
+- **Swagger Docs**: https://relay.staging.divine.video/swagger-ui/
+- **OpenAPI Spec**: https://relay.staging.divine.video/openapi.json
 
 ### Available Endpoints (Read-Only)
 

--- a/mobile/docs/FUNNELCAKE_API_REFERENCE.md
+++ b/mobile/docs/FUNNELCAKE_API_REFERENCE.md
@@ -134,7 +134,7 @@ Host resolution for notifications must use this order:
 2. Pinned production relay host (`relay.divine.video`), for production installs that have it configured.
 3. Current environment fallback relay host.
 
-This prevents staging builds from drifting to `https://relay.divine.video/api/users/{pubkey}/notifications` when a tester has `wss://relay.divine.video` persisted in relay settings. If staging Funnelcake logs show feed or recommendation calls but no `/api/users/{pubkey}/notifications` request, first verify the client is resolving notifications to `https://relay.staging.dvines.org` or the current staging API host before debugging backend queries.
+This prevents staging builds from drifting to `https://relay.divine.video/api/users/{pubkey}/notifications` when a tester has `wss://relay.divine.video` persisted in relay settings. If staging Funnelcake logs show feed or recommendation calls but no `/api/users/{pubkey}/notifications` request, first verify the client is resolving notifications to `https://relay.staging.divine.video` or the current staging API host before debugging backend queries.
 
 Unauthenticated route probes should return Funnelcake `401` with `Missing Authorization header`. A 401 proves the gateway path reaches Funnelcake; it does not prove the app signed the right URL.
 

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -66,7 +66,7 @@ class EnvironmentConfig {
       case AppEnvironment.poc:
         return 'wss://relay.poc.dvines.org';
       case AppEnvironment.staging:
-        return 'wss://relay.staging.dvines.org';
+        return 'wss://relay.staging.divine.video';
       case AppEnvironment.test:
         return 'wss://relay.test.dvines.org';
       case AppEnvironment.local:

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -40,7 +40,7 @@ class DivineBlocObserver extends BlocObserver {
     super.onError(bloc, error, stackTrace);
     final runtimeType = bloc.runtimeType;
     Log.error(
-      'Bloc error: $runtimeType',
+      'Bloc error: $runtimeType: $error',
       name: 'BlocObserver',
       error: error,
       stackTrace: stackTrace,

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -18,6 +18,8 @@ class RelayNotification {
     this.referencedVideoTitle,
     this.referencedVideoThumbnail,
     this.referencedDTag,
+    this.rootEventId,
+    this.targetCommentId,
   });
 
   /// Parses a notification payload from the FunnelCake API.
@@ -62,6 +64,8 @@ class RelayNotification {
           ? rawThumbnail
           : null,
       referencedDTag: (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
+      rootEventId: _nonEmpty(json['root_event_id'] as String?),
+      targetCommentId: _nonEmpty(json['target_comment_id'] as String?),
     );
   }
 
@@ -114,6 +118,22 @@ class RelayNotification {
   /// coordinate (`34236:pubkey:d-tag`) which is stable across metadata edits.
   final String? referencedDTag;
 
+  /// Root video event ID included by Funnelcake for NIP-22 comment
+  /// notifications.
+  ///
+  /// Some staging payloads report a kind 1111 comment as
+  /// `notification_type: mention` with an empty `referenced_event_id`, but
+  /// still include `root_event_id`. Keeping this field lets app layers anchor
+  /// the notification directly to the video instead of resolving the comment
+  /// event through a relay round-trip.
+  final String? rootEventId;
+
+  /// Comment event ID included by Funnelcake for NIP-22 comment notifications.
+  final String? targetCommentId;
+
   /// Stable dedup key -- falls back to sourceEventId if id is empty.
   String get dedupeKey => id.isNotEmpty ? id : sourceEventId;
+
+  static String? _nonEmpty(String? value) =>
+      value == null || value.isEmpty ? null : value;
 }

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
@@ -321,6 +321,31 @@ void main() {
         );
       });
 
+      test('includes response body details on server error', () async {
+        when(
+          () => mockHttpClient.get(
+            any(),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            '{"error":"notifications table unavailable"}',
+            500,
+          ),
+        );
+
+        expect(
+          () => client.getNotifications(pubkey: testPubkey),
+          throwsA(
+            isA<FunnelcakeApiException>().having(
+              (e) => e.toString(),
+              'toString',
+              contains('notifications table unavailable'),
+            ),
+          ),
+        );
+      });
+
       test('throws FunnelcakeTimeoutException on timeout', () async {
         when(
           () => mockHttpClient.get(

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -333,6 +333,55 @@ void main() {
           ),
         );
       });
+
+      test(
+        'parses staging NIP-22 comment anchor fields',
+        () {
+          final json = {
+            'id': '',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 1111,
+            'referenced_event_id': '',
+            'notification_type': 'mention',
+            'created_at': 1712345678,
+            'read': false,
+            'content': 'Fake staging comment from Codex',
+            'referenced_event_title': 'Codex staging comment notification test',
+            'target_comment_id': '11223344' * 8,
+            'root_event_id': '55667788' * 8,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(notification.referencedEventId, equals(''));
+          expect(notification.rootEventId, equals('55667788' * 8));
+          expect(notification.targetCommentId, equals('11223344' * 8));
+          expect(
+            notification.referencedVideoTitle,
+            equals('Codex staging comment notification test'),
+          );
+        },
+      );
+
+      test('treats empty root_event_id and target_comment_id as null', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 1111,
+          'notification_type': 'mention',
+          'created_at': 1712345678,
+          'read': false,
+          'root_event_id': '',
+          'target_comment_id': '',
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.rootEventId, isNull);
+        expect(notification.targetCommentId, isNull);
+      });
     });
 
     group('dedupeKey', () {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1028,7 +1028,8 @@ class NotificationRepository {
           ? NotificationKind.like
           : NotificationKind.likeComment;
     }
-    if (n.sourceKind == 1111 &&
+    if (n.notificationType != 'reply' &&
+        n.sourceKind == 1111 &&
         n.rootEventId != null &&
         n.rootEventId!.isNotEmpty) {
       return NotificationKind.comment;

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -646,7 +646,7 @@ class NotificationRepository {
     for (final n in raw) {
       final kind = _mapNotificationKind(n);
       if (!isVideoAnchored(kind)) continue;
-      final eventId = n.referencedEventId;
+      final eventId = _videoAnchorEventId(kind, n);
       if (eventId == null || eventId.isEmpty) continue;
       final key = _VideoGroupKey(eventId, kind);
       (groups[key] ??= []).add(n);
@@ -767,7 +767,7 @@ class NotificationRepository {
   /// missing a `referencedEventId`).
   Future<NotificationItem?> enrichOne(RelayNotification raw) async {
     final kind = _mapNotificationKind(raw);
-    final referenced = raw.referencedEventId;
+    final referenced = _videoAnchorEventId(kind, raw);
     final isVideoAnchored =
         kind == NotificationKind.like ||
         kind == NotificationKind.comment ||
@@ -1028,6 +1028,11 @@ class NotificationRepository {
           ? NotificationKind.like
           : NotificationKind.likeComment;
     }
+    if (n.sourceKind == 1111 &&
+        n.rootEventId != null &&
+        n.rootEventId!.isNotEmpty) {
+      return NotificationKind.comment;
+    }
     return switch (n.notificationType) {
       'reply' =>
         n.isReferencedVideo ? NotificationKind.comment : NotificationKind.reply,
@@ -1040,6 +1045,23 @@ class NotificationRepository {
       _ when n.sourceKind == 1 => NotificationKind.comment,
       _ => NotificationKind.system,
     };
+  }
+
+  /// Returns the video event ID a video-anchored notification should group by.
+  ///
+  /// New staging Funnelcake payloads for NIP-22 comments can omit
+  /// `referenced_event_id` while including `root_event_id`. For comments, the
+  /// root ID is the video we want to open and group on.
+  static String? _videoAnchorEventId(
+    NotificationKind kind,
+    RelayNotification n,
+  ) {
+    if (kind == NotificationKind.comment &&
+        n.rootEventId != null &&
+        n.rootEventId!.isNotEmpty) {
+      return n.rootEventId;
+    }
+    return n.referencedEventId;
   }
 
   /// Truncates comment text to [_maxCommentLength] characters.

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -83,6 +83,8 @@ void main() {
     bool read = false,
     String? referencedEventId = 'video_default',
     String? referencedDTag,
+    String? rootEventId,
+    String? targetCommentId,
     String? content,
     bool isReferencedVideo = true,
   }) {
@@ -96,6 +98,8 @@ void main() {
       read: read,
       referencedEventId: referencedEventId,
       referencedDTag: referencedDTag,
+      rootEventId: rootEventId,
+      targetCommentId: targetCommentId,
       content: content,
       isReferencedVideo: isReferencedVideo,
     );
@@ -1104,6 +1108,40 @@ void main() {
           final item = page.items.single as ActorNotification;
           expect(item.type, equals(NotificationKind.mention));
           expect(item.targetEventId, equals('mention_evt_id'));
+        },
+      );
+
+      test(
+        'kind 1111 staging mention with rootEventId maps to video comment',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: '',
+              sourceEventId: 'comment_evt_id',
+              sourceKind: 1111,
+              notificationType: 'mention',
+              referencedEventId: '',
+              rootEventId: 'root_video_evt_id',
+              targetCommentId: 'comment_evt_id',
+              content: 'Fake staging comment from Codex',
+              isReferencedVideo: false,
+            ),
+          ]);
+          stubProfiles({
+            'pubkey_alice': makeProfile(
+              'pubkey_alice',
+              displayName: 'Alice',
+            ),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.id, equals('comment_evt_id'));
+          expect(item.type, equals(NotificationKind.comment));
+          expect(item.videoEventId, equals('root_video_evt_id'));
+          expect(item.commentText, equals('Fake staging comment from Codex'));
+          expect(item.sourceEventIds, equals(['comment_evt_id']));
         },
       );
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1145,6 +1145,40 @@ void main() {
         },
       );
 
+      test(
+        'kind 1111 reply with rootEventId stays reply and keeps actor anchor',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: '',
+              sourceEventId: 'reply_evt_id',
+              sourceKind: 1111,
+              notificationType: 'reply',
+              referencedEventId: '',
+              rootEventId: 'root_video_evt_id',
+              targetCommentId: 'parent_comment_evt_id',
+              content: 'Nested reply from staging payload',
+              isReferencedVideo: false,
+            ),
+          ]);
+          stubProfiles({
+            'pubkey_alice': makeProfile(
+              'pubkey_alice',
+              displayName: 'Alice',
+            ),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as ActorNotification;
+          expect(item.id, equals('reply_evt_id'));
+          expect(item.type, equals(NotificationKind.reply));
+          expect(item.targetEventId, equals('reply_evt_id'));
+          expect(item.commentText, equals('Nested reply from staging payload'));
+          expect(item.sourceEventIds, equals(['reply_evt_id']));
+        },
+      );
+
       test('follow maps to follow ($ActorNotification)', () async {
         stubNotifications([
           makeNotification(

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       test('staging returns staging relay', () {
         const config = EnvironmentConfig(environment: AppEnvironment.staging);
-        expect(config.relayUrl, 'wss://relay.staging.dvines.org');
+        expect(config.relayUrl, 'wss://relay.staging.divine.video');
       });
 
       test('test returns test relay', () {
@@ -54,7 +54,7 @@ void main() {
 
       test('staging derives from relay URL', () {
         const config = EnvironmentConfig(environment: AppEnvironment.staging);
-        expect(config.apiBaseUrl, 'https://relay.staging.dvines.org');
+        expect(config.apiBaseUrl, 'https://relay.staging.divine.video');
       });
 
       test('test derives from relay URL', () {

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -8,6 +8,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/observability/divine_bloc_observer.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockCrashReportingService extends Mock
     implements CrashReportingService {}
@@ -27,7 +28,8 @@ void main() {
     late _MockCrashReportingService mockCrash;
     late DivineBlocObserver observer;
 
-    setUp(() {
+    setUp(() async {
+      await LogCaptureService().clearAllLogs();
       mockCrash = _MockCrashReportingService();
       when(
         () => mockCrash.recordError(
@@ -88,6 +90,26 @@ void main() {
           any<StackTrace?>(),
           reason: any(named: 'reason'),
         ),
+      );
+    });
+
+    test('includes the error string in the visible log message', () async {
+      final cubit = _CountCubit();
+      addTearDown(cubit.close);
+
+      observer.onError(
+        cubit,
+        Exception('staging notifications 500'),
+        StackTrace.current,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      final logs = LogCaptureService().getRecentLogs();
+      expect(logs.last.message, contains('Bloc error: _CountCubit'));
+      expect(
+        logs.last.message,
+        contains('Exception: staging notifications 500'),
       );
     });
 

--- a/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
+++ b/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
@@ -365,7 +365,7 @@ void main() {
     test(
       'uses injected primaryRelayUrl in r tag and target relay list (#3183)',
       () async {
-        const stagingRelayUrl = 'wss://relay.staging.dvines.org';
+        const stagingRelayUrl = 'wss://relay.staging.divine.video';
 
         final discovery = _ControllableRelayDiscoveryService(
           outcome: () => RelayDiscoveryResult.failure('No relay list found'),

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -639,7 +639,7 @@ void main() {
     });
 
     test('publishes report to the configured moderation relay', () async {
-      const customRelay = 'wss://relay.staging.dvines.org';
+      const customRelay = 'wss://relay.staging.divine.video';
       SharedPreferences.setMockInitialValues({});
       final testPrefs = await SharedPreferences.getInstance();
       final stagingService = ContentReportingService(

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -144,9 +144,9 @@ void main() {
       expect(
         resolvePinnedApiBaseUrlFromRelays(
           configuredRelays: const ['wss://relay.damus.io'],
-          fallbackBaseUrl: 'https://relay.staging.dvines.org',
+          fallbackBaseUrl: 'https://relay.staging.divine.video',
         ),
-        'https://relay.staging.dvines.org',
+        'https://relay.staging.divine.video',
       );
     });
   });
@@ -158,12 +158,12 @@ void main() {
         expect(
           resolvePinnedApiBaseUrlFromRelays(
             configuredRelays: const [
-              'wss://relay.staging.dvines.org',
+              'wss://relay.staging.divine.video',
               'wss://relay.divine.video',
             ],
-            fallbackBaseUrl: 'https://relay.staging.dvines.org',
+            fallbackBaseUrl: 'https://relay.staging.divine.video',
           ),
-          'https://relay.staging.dvines.org',
+          'https://relay.staging.divine.video',
         );
       },
     );
@@ -183,10 +183,10 @@ void main() {
     test('uses the first configured non-divine relay when needed', () {
       expect(
         resolveApiBaseUrlFromRelays(
-          configuredRelays: const ['wss://relay.staging.dvines.org'],
-          fallbackBaseUrl: 'https://relay.staging.dvines.org',
+          configuredRelays: const ['wss://relay.staging.divine.video'],
+          fallbackBaseUrl: 'https://relay.staging.divine.video',
         ),
-        'https://relay.staging.dvines.org',
+        'https://relay.staging.divine.video',
       );
     });
   });


### PR DESCRIPTION
Closes #4450

## Summary
- Point staging relay/API resolution at `relay.staging.divine.video`.
- Preserve Funnelcake notification response details in logs and exceptions for easier debugging.
- Parse `root_event_id` / `target_comment_id` and map staging kind 1111 comment payloads back to video comment notifications.

## Staging evidence
- Published throwaway staging kind 3 follow, kind 34236 video, kind 7 reaction, and kind 1111 comment events.
- Verified NIP-98 authenticated notification GETs against `https://relay.staging.divine.video/api/users/<pubkey>/notifications`.
- Observed kind 1111 comments returned as `notification_type: mention` with empty `referenced_event_id` and populated `root_event_id`; this PR handles that shape directly.

## Test Plan
- `flutter test test/src/models/relay_notification_test.dart test/src/funnelcake_api_client_notification_test.dart` from `mobile/packages/funnelcake_api_client`
- `flutter test test/src/notification_repository_test.dart` from `mobile/packages/notification_repository`
- `flutter analyze packages/funnelcake_api_client/lib/src/models/relay_notification.dart packages/funnelcake_api_client/test/src/models/relay_notification_test.dart packages/notification_repository/lib/src/notification_repository.dart packages/notification_repository/test/src/notification_repository_test.dart lib/models/environment_config.dart lib/observability/divine_bloc_observer.dart test/models/environment_config_test.dart test/observability/divine_bloc_observer_test.dart test/utils/relay_url_utils_test.dart` from `mobile`
- Pre-push hook analyzer and changed-file tests passed