### PR TITLE
fix(notifications): refresh auth and stable cursors

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -244,32 +244,34 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     // Resolve the navigation target.
     //
     // The stable-ID path (videoAddressableId set) and the raw-event-id
-    // fallback are synchronous — no await before navigation.
-    // The resolver path (comment/mention without addressable ID) requires
-    // one relay round-trip; we await only that before opening the screen,
-    // then hand the video fetch off as a stream so the screen opens
-    // immediately showing its own loading indicator.
-    String routeId;
+    // fallback are synchronous. The comment/reply fallback path may require
+    // one relay round-trip to walk E/e tags, but that work belongs inside the
+    // opened screen's loading stream rather than blocking the route push.
+    Future<String?> routeIdFuture;
     if (videoAddressableId != null && videoAddressableId.isNotEmpty) {
       // Stable path: addressable ID works even after a metadata update.
-      routeId = videoAddressableId;
+      routeIdFuture = Future.value(videoAddressableId);
     } else if (shouldAutoOpenComments) {
       // Comment/mention path: walk E/e tags to find the root video event ID.
-      final resolved = await NotificationTargetResolver(
+      routeIdFuture = NotificationTargetResolver(
         videoEventService: videoEventService,
         nostrService: ref.read(nostrServiceProvider),
       ).resolveVideoEventIdFromNotificationTarget(videoEventId);
 
-      if (!context.mounted) return false;
-
-      if (resolved == null) {
-        // Resolution failed — caller decides the fallback (e.g. profile).
-        return false;
+      if (notificationKind == NotificationKind.mention) {
+        // Mentions can legitimately have no video context. Preserve the
+        // profile fallback by resolving before pushing only for that kind.
+        final resolved = await routeIdFuture;
+        if (!context.mounted) return false;
+        if (resolved == null) {
+          // Resolution failed — caller decides the fallback (e.g. profile).
+          return false;
+        }
+        routeIdFuture = Future.value(resolved);
       }
-      routeId = resolved;
     } else {
       // Fallback: no addressable ID available, use raw event ID.
-      routeId = videoEventId;
+      routeIdFuture = Future.value(videoEventId);
     }
 
     // Capture l10n and scaffold messenger before the async gap; they remain
@@ -277,40 +279,10 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     final l10n = context.l10n;
     final scaffoldMessenger = ScaffoldMessenger.of(context);
 
-    // Fetch the video concurrently. The stream is consumed by the opened
-    // screen's BLoC — we never pop here to avoid touching the wrong route
-    // if the user navigated away before the fetch resolved.
-    final videoFuture = videosRepository
-        .fetchVideoWithStatsForRouteId(routeId)
-        .then((video) {
-          if (video == null) {
-            scaffoldMessenger.showSnackBar(
-              SnackBar(
-                content: Text(l10n.notificationsVideoNotFound),
-                duration: const Duration(seconds: 2),
-              ),
-            );
-            return <VideoEvent>[];
-          }
-          if (videoEventService.shouldHideVideo(video)) {
-            scaffoldMessenger.showSnackBar(
-              SnackBar(
-                content: Text(l10n.notificationsVideoUnavailable),
-                duration: const Duration(seconds: 2),
-              ),
-            );
-            return <VideoEvent>[];
-          }
-          return [video];
-        })
-        .onError<Object>((e, stackTrace) {
-          Log.error(
-            'Failed to fetch video for notification',
-            name: 'NotificationsView',
-            category: LogCategory.ui,
-            error: e,
-            stackTrace: stackTrace,
-          );
+    Future<List<VideoEvent>> loadVideo() async {
+      try {
+        final routeId = await routeIdFuture;
+        if (routeId == null || routeId.isEmpty) {
           scaffoldMessenger.showSnackBar(
             SnackBar(
               content: Text(l10n.notificationsVideoNotFound),
@@ -318,7 +290,52 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             ),
           );
           return <VideoEvent>[];
-        });
+        }
+
+        final video = await videosRepository.fetchVideoWithStatsForRouteId(
+          routeId,
+        );
+        if (video == null) {
+          scaffoldMessenger.showSnackBar(
+            SnackBar(
+              content: Text(l10n.notificationsVideoNotFound),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+          return <VideoEvent>[];
+        }
+        if (videoEventService.shouldHideVideo(video)) {
+          scaffoldMessenger.showSnackBar(
+            SnackBar(
+              content: Text(l10n.notificationsVideoUnavailable),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+          return <VideoEvent>[];
+        }
+        return [video];
+      } catch (e, stackTrace) {
+        Log.error(
+          'Failed to fetch video for notification',
+          name: 'NotificationsView',
+          category: LogCategory.ui,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.notificationsVideoNotFound),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+        return <VideoEvent>[];
+      }
+    }
+
+    // Fetch the video concurrently. The stream is consumed by the opened
+    // screen's BLoC — we never pop here to avoid touching the wrong route
+    // if the user navigated away before the fetch resolved.
+    final videoFuture = loadVideo();
 
     if (!context.mounted) return false;
 

--- a/mobile/lib/services/nip98_auth_service.dart
+++ b/mobile/lib/services/nip98_auth_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -48,7 +49,7 @@ class Nip98Token {
   final DateTime expiresAt;
 
   /// Check if the token is expired
-  bool get isExpired => DateTime.now().isAfter(expiresAt);
+  bool get isExpired => clock.now().isAfter(expiresAt);
 
   /// Get the authorization header value
   String get authorizationHeader => 'Nostr $token';
@@ -72,7 +73,7 @@ class Nip98AuthService {
 
   // Token cache to avoid repeated signing for identical requests
   final Map<String, Nip98Token> _tokenCache = {};
-  static const Duration _tokenValidityDuration = Duration(minutes: 10);
+  static const Duration _tokenValidityDuration = Duration(seconds: 45);
   static const Duration _cacheCleanupInterval = Duration(minutes: 15);
 
   Timer? _cleanupTimer;
@@ -134,7 +135,7 @@ class Nip98AuthService {
       final eventJson = jsonEncode(authEvent.toJson());
       final token = base64Encode(utf8.encode(eventJson));
 
-      final now = DateTime.now();
+      final now = clock.now();
       final nip98Token = Nip98Token(
         token: token,
         signedEvent: authEvent,
@@ -174,7 +175,7 @@ class Nip98AuthService {
     String? payload,
   }) async {
     try {
-      final now = DateTime.now();
+      final now = clock.now();
       final timestamp = (now.millisecondsSinceEpoch / 1000).round();
 
       // Create tags according to NIP-98
@@ -297,7 +298,7 @@ class Nip98AuthService {
         return false;
       }
 
-      final now = (DateTime.now().millisecondsSinceEpoch / 1000).round();
+      final now = (clock.now().millisecondsSinceEpoch / 1000).round();
       final timeDiff = (now - tagTimestamp).abs();
       if (timeDiff > 60) {
         // 60 seconds
@@ -373,7 +374,7 @@ class Nip98AuthService {
       'expired_tokens': expiredTokens,
       'is_authenticated': _authService.isAuthenticated,
       'cleanup_interval_minutes': _cacheCleanupInterval.inMinutes,
-      'token_validity_minutes': _tokenValidityDuration.inMinutes,
+      'token_validity_seconds': _tokenValidityDuration.inSeconds,
     };
   }
 

--- a/mobile/lib/services/nip98_auth_service.dart
+++ b/mobile/lib/services/nip98_auth_service.dart
@@ -73,6 +73,7 @@ class Nip98AuthService {
 
   // Token cache to avoid repeated signing for identical requests
   final Map<String, Nip98Token> _tokenCache = {};
+  // Funnelcake rejects NIP-98 auth events older than 60s, so keep a buffer.
   static const Duration _tokenValidityDuration = Duration(seconds: 45);
   static const Duration _cacheCleanupInterval = Duration(minutes: 15);
 

--- a/mobile/lib/services/notification_target_resolver.dart
+++ b/mobile/lib/services/notification_target_resolver.dart
@@ -29,7 +29,15 @@ class NotificationTargetResolver {
       return targetId;
     }
 
-    // NIP-22: uppercase E tag = root scope, always points to root video
+    // NIP-22: uppercase A tag = root addressable scope. Prefer this when
+    // available because it remains valid across NIP-33 video replacements.
+    for (final tag in event.tags) {
+      if (tag.length >= 2 && tag[0] == 'A' && _isVideoAddressableId(tag[1])) {
+        return tag[1];
+      }
+    }
+
+    // NIP-22: uppercase E tag = root scope, points to root video event.
     for (final tag in event.tags) {
       if (tag.length >= 2 && tag[0] == 'E' && tag[1].isNotEmpty) {
         return tag[1];
@@ -58,5 +66,13 @@ class NotificationTargetResolver {
     }
 
     return replyId ?? firstEtagId;
+  }
+
+  bool _isVideoAddressableId(String value) {
+    final parts = value.split(':');
+    if (parts.length < 3) return false;
+
+    final kind = int.tryParse(parts.first);
+    return kind != null && NIP71VideoKinds.isAcceptableVideoKind(kind);
   }
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/exceptions.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/exceptions.dart
@@ -34,6 +34,8 @@ class FunnelcakeApiException extends FunnelcakeException {
     required String message,
     required this.statusCode,
     this.url,
+    this.responseBody,
+    this.diagnosticHeaders = const {},
   }) : super(message);
 
   /// The HTTP status code returned by the server.
@@ -42,8 +44,50 @@ class FunnelcakeApiException extends FunnelcakeException {
   /// The URL that was requested (if available).
   final String? url;
 
+  /// Raw response body returned by the server, when available.
+  final String? responseBody;
+
+  /// Low-cardinality response headers useful for correlating client logs with
+  /// edge/backend logs. Does not include request headers or auth material.
+  final Map<String, String> diagnosticHeaders;
+
+  /// Best available request/correlation id returned by the server or edge.
+  String? get requestId =>
+      diagnosticHeaders['x-request-id'] ??
+      diagnosticHeaders['x-correlation-id'] ??
+      diagnosticHeaders['traceparent'];
+
   @override
-  String toString() => 'FunnelcakeApiException: $message (status: $statusCode)';
+  String toString() {
+    final details = <String>['status: $statusCode'];
+    final requestUrl = url;
+    if (requestUrl != null && requestUrl.isNotEmpty) {
+      details.add('url: $requestUrl');
+    }
+
+    final id = requestId;
+    if (id != null && id.isNotEmpty) {
+      details.add('requestId: $id');
+    }
+
+    final cfRay = diagnosticHeaders['cf-ray'];
+    if (cfRay != null && cfRay.isNotEmpty) {
+      details.add('cf-ray: $cfRay');
+    }
+
+    final body = responseBody;
+    if (body != null && body.isNotEmpty) {
+      details.add('body: ${_truncateDiagnosticValue(body)}');
+    }
+
+    return 'FunnelcakeApiException: $message (${details.join(', ')})';
+  }
+}
+
+String _truncateDiagnosticValue(String value) {
+  const maxLength = 1000;
+  if (value.length <= maxLength) return value;
+  return '${value.substring(0, maxLength)}...';
 }
 
 /// Exception thrown when a resource is not found (HTTP 404).

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -167,6 +167,7 @@ class FunnelcakeApiClient {
     required String pubkey,
     int limit = 50,
     String? cursor,
+    String? cursorId,
   }) {
     // Server timestamps are Unix seconds, not milliseconds.
     final effectiveBefore =
@@ -174,6 +175,7 @@ class FunnelcakeApiClient {
     final queryParams = <String, String>{
       'limit': '$limit',
       'before': effectiveBefore,
+      'before_id': ?cursorId,
     };
 
     return Uri.parse(
@@ -2250,8 +2252,9 @@ class FunnelcakeApiClient {
   /// Fetches notifications for a user from the relay REST API.
   ///
   /// Uses NIP-98 authentication. The [cursor] parameter enables pagination
-  /// via the `before` query param. The [authHeaders] parameter allows the
-  /// caller to provide pre-built NIP-98 auth headers.
+  /// via the `before` query param and optional `before_id` tiebreaker.
+  /// The [authHeaders] parameter allows the caller to provide pre-built
+  /// NIP-98 auth headers.
   ///
   /// Throws:
   /// - [FunnelcakeNotConfiguredException] if the API is not configured.
@@ -2262,6 +2265,7 @@ class FunnelcakeApiClient {
     required String pubkey,
     int limit = 50,
     String? cursor,
+    String? cursorId,
     Uri? requestUri,
     Map<String, String>? authHeaders,
   }) async {
@@ -2271,7 +2275,12 @@ class FunnelcakeApiClient {
 
     final url =
         requestUri ??
-        notificationsUri(pubkey: pubkey, limit: limit, cursor: cursor);
+        notificationsUri(
+          pubkey: pubkey,
+          limit: limit,
+          cursor: cursor,
+          cursorId: cursorId,
+        );
 
     try {
       final response = await _httpClient

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -105,6 +105,23 @@ class FunnelcakeApiClient {
         .timeout(_timeout);
   }
 
+  Map<String, String> _diagnosticHeaders(http.Response response) {
+    const headerNames = <String>[
+      'x-request-id',
+      'x-correlation-id',
+      'traceparent',
+      'cf-ray',
+      'x-amzn-trace-id',
+      'server-timing',
+    ];
+
+    return {
+      for (final name in headerNames)
+        if (response.headers[name]?.isNotEmpty ?? false)
+          name: response.headers[name]!,
+    };
+  }
+
   Map<String, String> _videoQueryParameters(Map<String, String> params) {
     return <String, String>{
       ...params,
@@ -2302,6 +2319,8 @@ class FunnelcakeApiClient {
           message: 'Failed to fetch notifications',
           statusCode: response.statusCode,
           url: url.toString(),
+          responseBody: response.body,
+          diagnosticHeaders: _diagnosticHeaders(response),
         );
       }
     } on TimeoutException {

--- a/mobile/packages/funnelcake_api_client/lib/src/models/notification_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/notification_response.dart
@@ -8,6 +8,7 @@ class NotificationResponse {
     required this.unreadCount,
     required this.hasMore,
     this.nextCursor,
+    this.nextCursorId,
   });
 
   /// Parses the REST response body into a typed notification payload.
@@ -21,6 +22,7 @@ class NotificationResponse {
           .toList(),
       unreadCount: json['unread_count'] as int? ?? 0,
       nextCursor: json['next_cursor'] as String?,
+      nextCursorId: json['next_cursor_id'] as String?,
       hasMore: json['has_more'] as bool? ?? false,
     );
   }
@@ -33,6 +35,9 @@ class NotificationResponse {
 
   /// Cursor for fetching the next page when available.
   final String? nextCursor;
+
+  /// Cursor tiebreaker for fetching the next page when available.
+  final String? nextCursorId;
 
   /// Whether more notifications are available beyond this page.
   final bool hasMore;

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
@@ -22,6 +22,8 @@ void main() {
     const baseUrl = 'https://api.example.com';
     const testPubkey =
         'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+    const stableCursorId =
+        '1122334411223344112233441122334411223344112233441122334411223344';
 
     setUp(() {
       mockHttpClient = _MockHttpClient();
@@ -107,6 +109,43 @@ void main() {
         ).captured;
         final url = captured.first as Uri;
         expect(url.queryParameters['before'], equals('cursor_abc'));
+      });
+
+      test('passes cursorId as before_id parameter', () async {
+        when(
+          () => mockHttpClient.get(
+            any(),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'notifications': <Map<String, dynamic>>[],
+              'unread_count': 0,
+              'has_more': false,
+            }),
+            200,
+          ),
+        );
+
+        await client.getNotifications(
+          pubkey: testPubkey,
+          cursor: '1700000000',
+          cursorId: stableCursorId,
+        );
+
+        final captured = verify(
+          () => mockHttpClient.get(
+            captureAny(),
+            headers: any(named: 'headers'),
+          ),
+        ).captured;
+        final url = captured.first as Uri;
+        expect(url.queryParameters['before'], equals('1700000000'));
+        expect(
+          url.queryParameters['before_id'],
+          equals(stableCursorId),
+        );
       });
 
       test('passes authHeaders when provided', () async {
@@ -581,6 +620,20 @@ void main() {
         );
 
         expect(uri.queryParameters['before'], equals('1700000000'));
+      });
+
+      test('includes before_id when cursorId is provided', () {
+        final uri = client.notificationsUri(
+          pubkey: testPubkey,
+          cursor: '1700000000',
+          cursorId: stableCursorId,
+        );
+
+        expect(uri.queryParameters['before'], equals('1700000000'));
+        expect(
+          uri.queryParameters['before_id'],
+          equals(stableCursorId),
+        );
       });
     });
   });

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
@@ -259,17 +259,64 @@ void main() {
             headers: any(named: 'headers'),
           ),
         ).thenAnswer(
-          (_) async => http.Response('Internal error', 500),
+          (_) async => http.Response(
+            '{"error":"Internal server error"}',
+            500,
+            headers: {
+              'x-request-id': 'req-123',
+              'cf-ray': 'ray-456',
+            },
+          ),
         );
 
         expect(
-          () => client.getNotifications(pubkey: testPubkey),
+          () => client.getNotifications(
+            pubkey: testPubkey,
+            cursor: '1778198474',
+            cursorId: stableCursorId,
+          ),
           throwsA(
-            isA<FunnelcakeApiException>().having(
-              (e) => e.statusCode,
-              'statusCode',
-              equals(500),
-            ),
+            isA<FunnelcakeApiException>()
+                .having(
+                  (e) => e.statusCode,
+                  'statusCode',
+                  equals(500),
+                )
+                .having(
+                  (e) => e.url,
+                  'url',
+                  allOf(
+                    contains('before=1778198474'),
+                    contains('before_id=$stableCursorId'),
+                  ),
+                )
+                .having(
+                  (e) => e.responseBody,
+                  'responseBody',
+                  equals('{"error":"Internal server error"}'),
+                )
+                .having(
+                  (e) => e.requestId,
+                  'requestId',
+                  equals('req-123'),
+                )
+                .having(
+                  (e) => e.diagnosticHeaders,
+                  'diagnosticHeaders',
+                  containsPair('cf-ray', 'ray-456'),
+                )
+                .having(
+                  (e) => e.toString(),
+                  'toString',
+                  allOf(
+                    contains('status: 500'),
+                    contains('before=1778198474'),
+                    contains('before_id=$stableCursorId'),
+                    contains('requestId: req-123'),
+                    contains('cf-ray: ray-456'),
+                    contains('body: {"error":"Internal server error"}'),
+                  ),
+                ),
           ),
         );
       });

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -5217,7 +5217,10 @@ void main() {
       expect(exception.url, equals('https://example.com'));
       expect(
         exception.toString(),
-        equals('FunnelcakeApiException: Test error (status: 500)'),
+        equals(
+          'FunnelcakeApiException: Test error '
+          '(status: 500, url: https://example.com)',
+        ),
       );
     });
 

--- a/mobile/packages/funnelcake_api_client/test/src/models/notification_response_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/notification_response_test.dart
@@ -18,6 +18,7 @@ void main() {
         ],
         'unread_count': 5,
         'next_cursor': 'cursor_abc',
+        'next_cursor_id': '11223344' * 8,
         'has_more': true,
       };
 
@@ -26,6 +27,7 @@ void main() {
       expect(response.notifications, hasLength(1));
       expect(response.unreadCount, equals(5));
       expect(response.nextCursor, equals('cursor_abc'));
+      expect(response.nextCursorId, equals('11223344' * 8));
       expect(response.hasMore, isTrue);
     });
 
@@ -41,6 +43,7 @@ void main() {
       expect(response.notifications, isEmpty);
       expect(response.unreadCount, equals(0));
       expect(response.nextCursor, isNull);
+      expect(response.nextCursorId, isNull);
       expect(response.hasMore, isFalse);
     });
 
@@ -50,6 +53,7 @@ void main() {
       expect(response.notifications, isEmpty);
       expect(response.unreadCount, equals(0));
       expect(response.nextCursor, isNull);
+      expect(response.nextCursorId, isNull);
       expect(response.hasMore, isFalse);
     });
   });

--- a/mobile/packages/notification_repository/lib/src/notification_page.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_page.dart
@@ -11,6 +11,7 @@ class NotificationPage extends Equatable {
     required this.items,
     required this.unreadCount,
     this.nextCursor,
+    this.nextCursorId,
     this.hasMore = false,
   });
 
@@ -26,6 +27,9 @@ class NotificationPage extends Equatable {
   /// Cursor for fetching the next page, if available.
   final String? nextCursor;
 
+  /// Cursor tiebreaker for fetching the next page, if available.
+  final String? nextCursorId;
+
   /// Whether more pages are available.
   final bool hasMore;
 
@@ -34,16 +38,24 @@ class NotificationPage extends Equatable {
     List<NotificationItem>? items,
     int? unreadCount,
     String? nextCursor,
+    String? nextCursorId,
     bool? hasMore,
   }) {
     return NotificationPage(
       items: items ?? this.items,
       unreadCount: unreadCount ?? this.unreadCount,
       nextCursor: nextCursor ?? this.nextCursor,
+      nextCursorId: nextCursorId ?? this.nextCursorId,
       hasMore: hasMore ?? this.hasMore,
     );
   }
 
   @override
-  List<Object?> get props => [items, unreadCount, nextCursor, hasMore];
+  List<Object?> get props => [
+    items,
+    unreadCount,
+    nextCursor,
+    nextCursorId,
+    hasMore,
+  ];
 }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -120,7 +120,9 @@ class NotificationRepository {
   }) async {
     try {
       final effectiveCursor = cursor ?? _lastCursor;
-      final effectiveCursorId = cursorId ?? _lastCursorId;
+      final effectiveCursorId = cursor != null
+          ? cursorId
+          : cursorId ?? _lastCursorId;
       final requestUrl = _funnelcakeApiClient
           .notificationsUri(
             pubkey: _userPubkey,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -68,6 +68,7 @@ class NotificationRepository {
 
   /// Last cursor returned by the API, used for pagination.
   String? _lastCursor;
+  String? _lastCursorId;
 
   /// Reactive snapshot of the enriched, grouped notification feed.
   ///
@@ -113,11 +114,19 @@ class NotificationRepository {
   /// after structured logging, so callers can drive a failure UI. The
   /// snapshot is left at its prior value on throw — the [BehaviorSubject]
   /// preserves it for downstream consumers.
-  Future<NotificationPage> getNotifications({String? cursor}) async {
+  Future<NotificationPage> getNotifications({
+    String? cursor,
+    String? cursorId,
+  }) async {
     try {
       final effectiveCursor = cursor ?? _lastCursor;
+      final effectiveCursorId = cursorId ?? _lastCursorId;
       final requestUrl = _funnelcakeApiClient
-          .notificationsUri(pubkey: _userPubkey, cursor: effectiveCursor)
+          .notificationsUri(
+            pubkey: _userPubkey,
+            cursor: effectiveCursor,
+            cursorId: effectiveCursorId,
+          )
           .toString();
 
       final authHeaders = _authHeadersProvider != null
@@ -127,11 +136,13 @@ class NotificationRepository {
       final response = await _funnelcakeApiClient.getNotifications(
         pubkey: _userPubkey,
         cursor: effectiveCursor,
+        cursorId: effectiveCursorId,
         requestUri: Uri.parse(requestUrl),
         authHeaders: authHeaders,
       );
 
       _lastCursor = response.nextCursor;
+      _lastCursorId = response.nextCursorId;
 
       final items = await _enrichAndGroup(response.notifications);
 
@@ -139,6 +150,7 @@ class NotificationRepository {
         items: items,
         unreadCount: response.unreadCount,
         nextCursor: response.nextCursor,
+        nextCursorId: response.nextCursorId,
         hasMore: response.hasMore,
       );
       _emitSnapshotForPage(page, isFirstPage: effectiveCursor == null);
@@ -157,6 +169,7 @@ class NotificationRepository {
   /// Refreshes notifications from the beginning (no cursor).
   Future<NotificationPage> refresh() {
     _lastCursor = null;
+    _lastCursorId = null;
     return getNotifications();
   }
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -279,6 +279,43 @@ void main() {
         },
       );
 
+      test(
+        'explicit cursor override does not leak stored cursor id',
+        () async {
+          var signedUrl = '';
+          repository = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+            authHeadersProvider: (url, method) async {
+              signedUrl = url;
+              return {'Authorization': 'Nostr test-token'};
+            },
+          );
+          stubNotifications(
+            [],
+            nextCursor: '1700000000',
+            nextCursorId: stableCursorId,
+            hasMore: true,
+          );
+          stubProfiles({});
+
+          await repository.getNotifications();
+          stubNotifications([], nextCursor: 'manual_next');
+
+          await repository.getNotifications(cursor: 'manual_cursor');
+
+          expect(
+            signedUrl,
+            equals(
+              'https://api.example.com/api/users/$userPubkey/notifications'
+              '?limit=50&before=manual_cursor',
+            ),
+          );
+        },
+      );
+
       test('one like becomes a $VideoNotification with totalCount 1', () async {
         stubNotifications([
           makeNotification(

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -25,6 +25,8 @@ void main() {
   late NotificationRepository repository;
 
   const userPubkey = 'user1234567890abcdef';
+  const stableCursorId =
+      '1122334411223344112233441122334411223344112233441122334411223344';
 
   setUp(() {
     funnelcakeApiClient = _MockFunnelcakeApiClient();
@@ -35,21 +37,23 @@ void main() {
         pubkey: any(named: 'pubkey'),
         limit: any(named: 'limit'),
         cursor: any(named: 'cursor'),
+        cursorId: any(named: 'cursorId'),
       ),
     ).thenAnswer((invocation) {
       final pubkey = invocation.namedArguments[#pubkey] as String;
       final limit = invocation.namedArguments[#limit] as int? ?? 50;
       final cursor = invocation.namedArguments[#cursor] as String?;
+      final cursorId = invocation.namedArguments[#cursorId] as String?;
       final effectiveBefore =
           cursor ?? DateTime.now().millisecondsSinceEpoch.toString();
+      final queryParameters = <String, String>{
+        'limit': '$limit',
+        'before': effectiveBefore,
+        'before_id': ?cursorId,
+      };
       return Uri.parse(
         'https://api.example.com/api/users/$pubkey/notifications',
-      ).replace(
-        queryParameters: <String, String>{
-          'limit': '$limit',
-          'before': effectiveBefore,
-        },
-      );
+      ).replace(queryParameters: queryParameters);
     });
     // Default: getVideoStats throws (no metadata fetched). Tests that need a
     // thumbnail override this stub explicitly.
@@ -109,11 +113,13 @@ void main() {
     int unreadCount = 0,
     bool hasMore = false,
     String? nextCursor,
+    String? nextCursorId,
   }) {
     when(
       () => funnelcakeApiClient.getNotifications(
         pubkey: any(named: 'pubkey'),
         cursor: any(named: 'cursor'),
+        cursorId: any(named: 'cursorId'),
         requestUri: any(named: 'requestUri'),
         authHeaders: any(named: 'authHeaders'),
         limit: any(named: 'limit'),
@@ -124,6 +130,7 @@ void main() {
         unreadCount: unreadCount,
         hasMore: hasMore,
         nextCursor: nextCursor,
+        nextCursorId: nextCursorId,
       ),
     );
   }
@@ -233,6 +240,44 @@ void main() {
           ),
         );
       });
+
+      test(
+        'signs the full paginated notifications URL with cursor id',
+        () async {
+          var signedUrl = '';
+          repository = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+            authHeadersProvider: (url, method) async {
+              signedUrl = url;
+              return {'Authorization': 'Nostr test-token'};
+            },
+          );
+          stubNotifications(
+            [],
+            nextCursor: '1700000000',
+            nextCursorId: stableCursorId,
+            hasMore: true,
+          );
+          stubProfiles({});
+
+          await repository.getNotifications();
+          stubNotifications([], nextCursor: '1699999999');
+
+          await repository.getNotifications();
+
+          expect(
+            signedUrl,
+            equals(
+              'https://api.example.com/api/users/$userPubkey/notifications'
+              '?limit=50&before=1700000000'
+              '&before_id=$stableCursorId',
+            ),
+          );
+        },
+      );
 
       test('one like becomes a $VideoNotification with totalCount 1', () async {
         stubNotifications([

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -3,6 +3,8 @@
 
 // ignore_for_file: prefer_const_constructors
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -470,6 +472,86 @@ void main() {
           ).called(1);
           expect(capturedArgs, hasLength(1));
           expect(capturedArgs.single.autoOpenComments, isTrue);
+        },
+      );
+
+      testWidgets(
+        'reply tap pushes video route before resolver completes',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const parentCommentId = 'slow_parent_comment_id';
+          const rootVideoEventId = 'slow_reply_root_video';
+          final resolvedVideo = _video(rootVideoEventId);
+          final resolverCompleter = Completer<Event?>();
+
+          when(
+            () => videoService.getVideoById(parentCommentId),
+          ).thenReturn(null);
+          when(
+            () => nostrClient.fetchEventById(parentCommentId),
+          ).thenAnswer((_) => resolverCompleter.future);
+          when(
+            () => videosRepository.fetchVideoWithStatsForRouteId(
+              rootVideoEventId,
+            ),
+          ).thenAnswer((_) async => resolvedVideo);
+          when(
+            () => videoService.shouldHideVideo(resolvedVideo),
+          ).thenReturn(false);
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'slow-reply',
+                  type: NotificationKind.reply,
+                  actor: ActorInfo(pubkey: 'replier', displayName: 'Bob'),
+                  timestamp: DateTime(2026),
+                  targetEventId: parentCommentId,
+                ),
+              ],
+            ),
+          );
+
+          final capturedArgs = await _pumpRoutedView(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pump();
+
+          expect(capturedArgs, hasLength(1));
+          expect(capturedArgs.single.autoOpenComments, isTrue);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+
+          final event = Event(
+            'a' * 64,
+            1111,
+            const [
+              ['E', rootVideoEventId],
+            ],
+            'parent comment text',
+            createdAt: 1700000000,
+          );
+          event.id = parentCommentId;
+          resolverCompleter.complete(event);
+
+          final videos = await capturedArgs.single.videosStream.first;
+          expect(videos.single.id, resolvedVideo.id);
+          verify(
+            () => videosRepository.fetchVideoWithStatsForRouteId(
+              rootVideoEventId,
+            ),
+          ).called(1);
         },
       );
 

--- a/mobile/test/services/nip98_auth_service_test.dart
+++ b/mobile/test/services/nip98_auth_service_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_sdk/event.dart';
@@ -343,6 +344,54 @@ void main() {
           ),
         ).called(2);
       });
+
+      test(
+        'does not reuse cached token after NIP-98 freshness window',
+        () async {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+
+          var callCount = 0;
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((invocation) async {
+            callCount++;
+            final tags =
+                invocation.namedArguments[#tags] as List<List<String>>? ?? [];
+            return _createMockEvent(tags: tags, idSuffix: callCount.toString());
+          });
+
+          var now = DateTime.now();
+          await withClock(Clock(() => now), () async {
+            final token1 = await service.createAuthToken(
+              url: 'https://relay.example.com/api/endpoint?cursor=first',
+              method: HttpMethod.get,
+            );
+
+            now = now.add(const Duration(seconds: 61));
+
+            final token2 = await service.createAuthToken(
+              url: 'https://relay.example.com/api/endpoint?cursor=first',
+              method: HttpMethod.get,
+            );
+
+            expect(token1, isNotNull);
+            expect(token2, isNotNull);
+            expect(token1!.token, isNot(equals(token2!.token)));
+          });
+
+          verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).called(2);
+        },
+      );
     });
 
     group('payload hashing', () {

--- a/mobile/test/services/notification_target_resolver_test.dart
+++ b/mobile/test/services/notification_target_resolver_test.dart
@@ -82,6 +82,33 @@ void main() {
     );
 
     test(
+      'prefers NIP-22 uppercase A root route over uppercase E event id',
+      () async {
+        const rootAddressableId =
+            '34236:'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            ':vine-stable-id';
+        const rootVideoId = 'root_video_nip22';
+
+        when(
+          () => videoEventService.getVideoById('comment_with_a'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('comment_with_a')).thenAnswer(
+          (_) async => Event('b' * 64, 1111, const [
+            ['A', rootAddressableId, ''],
+            ['E', rootVideoId, '', 'video_author_pubkey_hex'],
+            ['K', '34236'],
+          ], 'reply with stable root route'),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget('comment_with_a');
+
+        expect(resolved, equals(rootAddressableId));
+      },
+    );
+
+    test(
       'resolves root video from NIP-22 uppercase E tag on top-level comment',
       () async {
         const rootVideoId = 'root_video_toplevel';


### PR DESCRIPTION
Closes #4452

## Summary
- Shorten NIP-98 auth token caching to stay inside Funnelcake's 60s freshness window and make token time checks clock-driven for regression coverage.
- Add mobile support for Funnelcake notification stable cursor pairs: parse next_cursor_id and send before_id on subsequent pages.
- Speed comment/reply notification taps by pushing the fullscreen route before the relay resolver completes, while the opened screen loads the target video.
- Prefer NIP-22 uppercase A root addressable tags in the notification resolver, so comment notifications can fetch stable NIP-33 video routes instead of stale event IDs when available.
- Preserve Liz's cursor override fix so explicit cursor overrides do not accidentally reuse a stored before_id.
- Add Funnelcake notification fetch diagnostics: failed fetch exceptions now include request URL/cursor params, response body, and correlation headers such as x-request-id/traceparent/cf-ray when present.
- Remove a redundant infinite_video_feed default argument that blocked full analyzer.

## Context
- Related backend PR: divinevideo/divine-funnelcake#400
- Fixes the notification pagination path reusing a cached NIP-98 event after Funnelcake rejects events older than 60s.
- The slow comment tap log showed route navigation waiting on resolver work before /pooled-video-feed appeared; the UI now navigates immediately for reply/comment-like targets and keeps mention profile fallback behavior unchanged.
- A bare `500 {"error":"Internal server error"}` from notifications is not enough to debug backend failures; the next client log will include the exact signed request URL and any edge/backend correlation headers available on the response.

## Validation
- flutter test test/services/notification_target_resolver_test.dart test/notifications/view/notifications_view_test.dart
- flutter analyze lib/services/notification_target_resolver.dart lib/notifications/view/notifications_view.dart test/services/notification_target_resolver_test.dart test/notifications/view/notifications_view_test.dart
- flutter test test/services/nip98_auth_service_test.dart packages/funnelcake_api_client/test/src/models/notification_response_test.dart packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart packages/notification_repository/test/src/notification_repository_test.dart
- flutter test packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
- flutter test packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart --plain-name "FunnelcakeApiException includes status code"
- flutter analyze packages/funnelcake_api_client/lib/src/exceptions.dart packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
- flutter test packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
- flutter analyze
- pre-push hook: analyzer + changed-file tests
