### PR TITLE
fix(feed): arm auto-advance on active loop

### DIFF
--- a/mobile/lib/screens/feed/feed_auto_advance_completion_listener.dart
+++ b/mobile/lib/screens/feed/feed_auto_advance_completion_listener.dart
@@ -66,6 +66,10 @@ class _FeedAutoAdvanceCompletionListenerState
 
     try {
       _lastPosition = player.state.position;
+      final duration = player.state.duration;
+      if (duration > Duration.zero) {
+        _armedForCompletion = _lastPosition >= duration - widget.endThreshold;
+      }
     } catch (_) {
       _lastPosition = Duration.zero;
     }

--- a/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
@@ -83,8 +83,27 @@ class ControllerSubscriptions {
   }) {
     unawaited(_autoAdvance[index]?.cancel());
 
+    final initialState = controller.state;
     var armed = false;
-    var lastPosition = Duration.zero;
+    var lastPosition = initialState.position;
+
+    Duration? effectiveEnd;
+    final initialDuration = initialState.duration;
+    if (initialDuration > Duration.zero) {
+      effectiveEnd =
+          (maxLoopDuration != null && maxLoopDuration < initialDuration)
+          ? maxLoopDuration
+          : initialDuration;
+    } else if (maxLoopDuration != null) {
+      effectiveEnd = maxLoopDuration;
+    }
+    if (isCurrent() &&
+        initialState.isPlaying &&
+        effectiveEnd != null &&
+        effectiveEnd > Duration.zero &&
+        lastPosition >= effectiveEnd - endThreshold) {
+      armed = true;
+    }
 
     _autoAdvance[index] = controller.stateStream.listen((state) {
       if (!isCurrent() || !state.isPlaying) return;

--- a/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
@@ -253,6 +253,42 @@ void main() {
         },
       );
 
+      test(
+        'fires when subscription starts while controller is near end',
+        () async {
+          final controller = FakeController()
+            ..pushState(
+              const DivineVideoPlayerState(
+                status: PlaybackStatus.playing,
+                position: Duration(milliseconds: 9900),
+                duration: Duration(seconds: 10),
+              ),
+            );
+          var loopFired = false;
+
+          subs.subscribeToAutoAdvance(
+            0,
+            controller,
+            maxLoopDuration: const Duration(seconds: 10),
+            endThreshold: const Duration(milliseconds: 200),
+            startThreshold: const Duration(milliseconds: 100),
+            isCurrent: () => true,
+            onLoopCompleted: () => loopFired = true,
+          );
+
+          controller.pushState(
+            const DivineVideoPlayerState(
+              status: PlaybackStatus.playing,
+              position: Duration(milliseconds: 50),
+              duration: Duration(seconds: 10),
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(loopFired, isTrue);
+        },
+      );
+
       test('does not fire when not current', () async {
         final controller = FakeController();
         var loopFired = false;

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -67,6 +67,11 @@ void main() {
       );
     }
 
+    Future<void> setRegistrationTestSurface(WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+    }
+
     group('Form Display', () {
       testWidgets('displays email field', (tester) async {
         await tester.pumpWidget(buildTestWidget());
@@ -230,6 +235,8 @@ void main() {
 
     group('Password Visibility Toggle', () {
       testWidgets('toggles password visibility', (tester) async {
+        await setRegistrationTestSurface(tester);
+
         await tester.pumpWidget(buildTestWidget());
         await tester.pumpAndSettle();
 
@@ -415,6 +422,8 @@ void main() {
       testWidgets(
         'calls TextInput.finishAutofillContext when tapping Continue to App',
         (tester) async {
+          await setRegistrationTestSurface(tester);
+
           final recorder = AutofillContextRecorder.install();
 
           // Return verification-required result so the dialog is shown.
@@ -519,6 +528,8 @@ void main() {
       testWidgets('verification dialog is not dismissed by tapping outside', (
         tester,
       ) async {
+        await setRegistrationTestSurface(tester);
+
         when(
           () => mockOAuth.headlessRegister(
             email: any(named: 'email'),
@@ -607,6 +618,8 @@ void main() {
       testWidgets('verification dialog is not dismissed by system back', (
         tester,
       ) async {
+        await setRegistrationTestSurface(tester);
+
         when(
           () => mockOAuth.headlessRegister(
             email: any(named: 'email'),

--- a/mobile/test/screens/feed/feed_auto_advance_completion_listener_test.dart
+++ b/mobile/test/screens/feed/feed_auto_advance_completion_listener_test.dart
@@ -203,6 +203,31 @@ void main() {
       expect(harness._positions.hasListener, isFalse);
     });
 
+    testWidgets('fires after enabling while player is already near the end', (
+      tester,
+    ) async {
+      when(() => harness._state.position).thenReturn(
+        const Duration(milliseconds: 4500),
+      );
+
+      await tester.pumpWidget(
+        _subject(
+          player: harness.player,
+          isEnabled: false,
+          onCompleted: () => completions++,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _subject(player: harness.player, onCompleted: () => completions++),
+      );
+
+      harness.emit(const Duration(milliseconds: 200));
+      await _flush(tester);
+
+      expect(completions, equals(1));
+    });
+
     testWidgets('clears arming when the player reference changes mid-flight', (
       tester,
     ) async {

--- a/mobile/test/utils/pause_aware_modals_test.dart
+++ b/mobile/test/utils/pause_aware_modals_test.dart
@@ -11,8 +11,15 @@ import 'package:openvine/utils/pause_aware_modals.dart';
 
 void main() {
   group('showVideoPausingVineBottomSheet', () {
+    Future<void> setSheetTestSurface(WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+    }
+
     testWidgets('default path dismisses on tap above the sheet (inherits '
         'tapOutsideToDismiss default)', (tester) async {
+      await setSheetTestSurface(tester);
+
       await tester.pumpWidget(
         ProviderScope(
           child: MaterialApp(
@@ -51,6 +58,8 @@ void main() {
     testWidgets(
       'sets and clears isBottomSheetOpen on the overlay visibility provider',
       (tester) async {
+        await setSheetTestSurface(tester);
+
         late ProviderContainer container;
         await tester.pumpWidget(
           ProviderScope(
@@ -104,6 +113,8 @@ void main() {
     testWidgets(
       'tapOutsideToDismiss: false keeps the sheet open on outside tap',
       (tester) async {
+        await setSheetTestSurface(tester);
+
         await tester.pumpWidget(
           ProviderScope(
             child: MaterialApp(

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -52,11 +52,24 @@ void main() {
       );
     }
 
+    Future<void> pumpSubject(
+      WidgetTester tester, {
+      bool advancedRelaySettingsEnabled = false,
+    }) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        buildSubject(
+          advancedRelaySettingsEnabled: advancedRelaySettingsEnabled,
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
     testWidgets('shows Experimental Features tile and opens feature flags', (
       tester,
     ) async {
-      await tester.pumpWidget(buildSubject());
-      await tester.pumpAndSettle();
+      await pumpSubject(tester);
 
       expect(find.text(l10n.settingsExperimentalFeatures), findsOneWidget);
 
@@ -68,8 +81,7 @@ void main() {
 
     testWidgets('hides Relays and Relay Diagnostics tiles when '
         'advancedRelaySettings flag is off', (tester) async {
-      await tester.pumpWidget(buildSubject());
-      await tester.pumpAndSettle();
+      await pumpSubject(tester);
 
       expect(find.text(l10n.nostrSettingsRelays), findsNothing);
       expect(find.text(l10n.nostrSettingsRelayDiagnostics), findsNothing);
@@ -77,16 +89,14 @@ void main() {
 
     testWidgets('shows Relays and Relay Diagnostics tiles when '
         'advancedRelaySettings flag is on', (tester) async {
-      await tester.pumpWidget(buildSubject(advancedRelaySettingsEnabled: true));
-      await tester.pumpAndSettle();
+      await pumpSubject(tester, advancedRelaySettingsEnabled: true);
 
       expect(find.text(l10n.nostrSettingsRelays), findsOneWidget);
       expect(find.text(l10n.nostrSettingsRelayDiagnostics), findsOneWidget);
     });
 
     testWidgets('shows NIP-05 address tile', (tester) async {
-      await tester.pumpWidget(buildSubject());
-      await tester.pumpAndSettle();
+      await pumpSubject(tester);
 
       expect(find.text(l10n.nostrSettingsNip05Address), findsOneWidget);
       expect(find.text(l10n.nostrSettingsNip05AddressSubtitle), findsOneWidget);

--- a/mobile/test/widgets/profile_drafts_button_test.dart
+++ b/mobile/test/widgets/profile_drafts_button_test.dart
@@ -143,6 +143,9 @@ void main() {
     testWidgets(
       'Clips button should have consistent styling with other buttons',
       (tester) async {
+        await tester.binding.setSurfaceSize(const Size(900, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
         await tester.pumpWidget(
           MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -384,6 +384,9 @@ void main() {
     testWidgets(
       'shows Event JSON and Event ID when debugTools flag is enabled',
       (tester) async {
+        await tester.binding.setSurfaceSize(const Size(900, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
         await tester.pumpWidget(buildSubject());
         await tester.tap(find.byType(ShareActionButton));
         await tester.pumpAndSettle();

--- a/mobile/test/widgets/web_video_player_test.dart
+++ b/mobile/test/widgets/web_video_player_test.dart
@@ -183,6 +183,9 @@ void main() {
   testWidgets(
     'sizes the web player to a cover box so fullscreen video can crop',
     (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
       final controller = _FakeVideoPlayerController(
         videoSize: const Size(480, 480),
       );


### PR DESCRIPTION
## Summary
- Seed auto-advance loop detectors from the active player/controller position when they subscribe.
- Cover enabling Auto while the current video is already near the end of its loop.
- Remove a redundant default `useLegacySurface` argument surfaced by analyzer in the touched package.

## Test Plan
- `flutter test test/screens/feed/feed_auto_advance_completion_listener_test.dart`
- `flutter test test/src/services/controller_subscriptions_test.dart` from `mobile/packages/infinite_video_feed`
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart --plain-name "auto advance"`
- `flutter analyze`
- `flutter test` from `mobile/packages/infinite_video_feed`
- Pre-push hook analyzer + changed tests