### PR TITLE
fix(feed): normalize invalid engagement counts

### DIFF
--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -652,34 +652,48 @@ class _VideosGrid extends ConsumerWidget {
 
   Widget _buildEmptyState(BuildContext context) {
     final l10n = context.l10n;
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(
-            Icons.videocam_off_outlined,
-            size: 64,
-            color: VineTheme.lightText,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            l10n.soundNoVideosYet,
-            style: const TextStyle(
-              color: VineTheme.whiteText,
-              fontSize: 18,
-              fontWeight: FontWeight.w500,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.videocam_off_outlined,
+                      size: 64,
+                      color: VineTheme.lightText,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      l10n.soundNoVideosYet,
+                      style: const TextStyle(
+                        color: VineTheme.whiteText,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      l10n.soundBeFirstToUse,
+                      style: const TextStyle(
+                        color: VineTheme.onSurfaceMuted,
+                        fontSize: 14,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
             ),
           ),
-          const SizedBox(height: 8),
-          Text(
-            l10n.soundBeFirstToUse,
-            style: const TextStyle(
-              color: VineTheme.onSurfaceMuted,
-              fontSize: 14,
-            ),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -689,51 +703,64 @@ class _VideosGrid extends ConsumerWidget {
     VoidCallback onRetry,
   ) {
     final l10n = context.l10n;
-    return Center(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.error_outline, size: 64, color: VineTheme.likeRed),
-            const SizedBox(height: 16),
-            Text(
-              l10n.soundFailedToLoadVideos,
-              style: const TextStyle(
-                color: VineTheme.whiteText,
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              error.toString(),
-              style: const TextStyle(
-                color: VineTheme.onSurfaceMuted,
-                fontSize: 12,
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 3,
-              overflow: TextOverflow.ellipsis,
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: onRetry,
-              icon: const Icon(Icons.refresh),
-              label: Text(l10n.soundRetry),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: VineTheme.vineGreen,
-                foregroundColor: VineTheme.backgroundColor,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 24,
-                  vertical: 12,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      size: 64,
+                      color: VineTheme.likeRed,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      l10n.soundFailedToLoadVideos,
+                      style: const TextStyle(
+                        color: VineTheme.whiteText,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      error.toString(),
+                      style: const TextStyle(
+                        color: VineTheme.onSurfaceMuted,
+                        fontSize: 12,
+                      ),
+                      textAlign: TextAlign.center,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton.icon(
+                      onPressed: onRetry,
+                      icon: const Icon(Icons.refresh),
+                      label: Text(l10n.soundRetry),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: VineTheme.vineGreen,
+                        foregroundColor: VineTheme.backgroundColor,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 24,
+                          vertical: 12,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
+++ b/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:models/src/engagement_count_parser.dart';
 
 /// Engagement stats for a single video from a bulk stats response.
 ///
@@ -24,7 +25,7 @@ class BulkVideoStatsEntry {
     return BulkVideoStatsEntry(
       eventId: (json['event_id'] ?? json['id'] ?? '').toString(),
       reactions:
-          _findIntDeep(json, {
+          _findEngagementCountDeep(json, {
             'reactions',
             'likes',
             'like_count',
@@ -32,10 +33,19 @@ class BulkVideoStatsEntry {
           }) ??
           0,
       comments:
-          _findIntDeep(json, {'comments', 'comment_count', 'total_comments'}) ??
+          _findEngagementCountDeep(json, {
+            'comments',
+            'comment_count',
+            'total_comments',
+          }) ??
           0,
       reposts:
-          _findIntDeep(json, {'reposts', 'repost_count', 'total_reposts'}) ?? 0,
+          _findEngagementCountDeep(json, {
+            'reposts',
+            'repost_count',
+            'total_reposts',
+          }) ??
+          0,
       loops: _findIntDeep(json, {
         'loops',
         'loop_count',
@@ -118,6 +128,29 @@ int? _findIntDeep(dynamic source, Set<String> targetKeys) {
   } else if (source is List) {
     for (final value in source) {
       final result = _findIntDeep(value, targetKeys);
+      if (result != null) return result;
+    }
+  }
+  return null;
+}
+
+/// Recursively searches a JSON structure for engagement keys and normalizes
+/// invalid counters to zero.
+int? _findEngagementCountDeep(dynamic source, Set<String> targetKeys) {
+  if (source is Map) {
+    for (final entry in source.entries) {
+      final key = entry.key.toString().toLowerCase();
+      if (targetKeys.contains(key)) {
+        return parseEngagementCount(entry.value);
+      }
+    }
+    for (final value in source.values) {
+      final result = _findEngagementCountDeep(value, targetKeys);
+      if (result != null) return result;
+    }
+  } else if (source is List) {
+    for (final value in source) {
+      final result = _findEngagementCountDeep(value, targetKeys);
       if (result != null) return result;
     }
   }

--- a/mobile/packages/models/lib/src/engagement_count_parser.dart
+++ b/mobile/packages/models/lib/src/engagement_count_parser.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Shared parsing for video engagement counters from API/Nostr data.
+// ABOUTME: Keeps absent or sentinel count values from surfacing in the UI.
+
+const _invalidEngagementCountStrings = {
+  // Common max-int sentinels/underflow values that mean "no count" in
+  // upstream analytics stores, not real human engagement.
+  '2147483647',
+  '4294967295',
+  '9223372036854775807',
+  '18446744073709551615',
+};
+
+/// Parses an engagement counter and returns a display-safe non-negative value.
+///
+/// Engagement counts are user-visible numbers. Negative values and known
+/// max-int sentinel values are treated as absent and normalized to zero.
+int parseEngagementCount(dynamic value) {
+  final parsed = _parseCount(value);
+  if (parsed == null || parsed < 0) return 0;
+  return parsed;
+}
+
+int? _parseCount(dynamic value) {
+  if (value is int) {
+    return _invalidEngagementCountStrings.contains(value.toString())
+        ? null
+        : value;
+  }
+  if (value is double) {
+    if (!value.isFinite) return null;
+    final parsed = value.toInt();
+    return _invalidEngagementCountStrings.contains(parsed.toString())
+        ? null
+        : parsed;
+  }
+  if (value is String) {
+    final normalized = value.replaceAll(',', '').trim();
+    if (normalized.isEmpty) return null;
+    if (_invalidEngagementCountStrings.contains(normalized)) return null;
+    final asInt = int.tryParse(normalized);
+    if (asInt != null) return asInt;
+    final asDouble = double.tryParse(normalized);
+    if (asDouble == null || !asDouble.isFinite) return null;
+    return asDouble.toInt();
+  }
+  return null;
+}

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -3,6 +3,7 @@
 // ABOUTME: ClickHouse-backed analytics API.
 
 import 'package:meta/meta.dart';
+import 'package:models/src/engagement_count_parser.dart';
 import 'package:models/src/video_event.dart';
 
 /// Video with engagement metrics from Funnelcake API.
@@ -369,9 +370,9 @@ class VideoStats {
       authorAvatar: authorAvatar,
       blurhash: blurhash,
       dimensions: dimensions,
-      reactions: _parseInt(reactions),
-      comments: _parseInt(comments),
-      reposts: _parseInt(reposts),
+      reactions: parseEngagementCount(reactions),
+      comments: parseEngagementCount(comments),
+      reposts: parseEngagementCount(reposts),
       engagementScore: _parseInt(
         statsData['engagement_score'] ?? json['engagement_score'],
       ),

--- a/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
+++ b/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
@@ -132,6 +132,21 @@ void main() {
         expect(entry.loops, equals(100));
       });
 
+      test('normalizes invalid engagement counters to zero', () {
+        final entry = BulkVideoStatsEntry.fromJson(const {
+          'event_id': 'test',
+          'stats': {
+            'reactions': -1,
+            'comments': '9223372036854775807',
+            'reposts': '18446744073709551615',
+          },
+        });
+
+        expect(entry.reactions, equals(0));
+        expect(entry.comments, equals(0));
+        expect(entry.reposts, equals(0));
+      });
+
       test('defaults to 0 when no matching key found', () {
         final entry = BulkVideoStatsEntry.fromJson(const {
           'event_id': 'test',

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -123,6 +123,29 @@ void main() {
         expect(stats.trendingScore, equals(0.75));
       });
 
+      test('normalizes invalid engagement counters to zero', () {
+        final stats = VideoStats.fromJson(const {
+          'id': 'test-id',
+          'pubkey': 'test-pubkey',
+          'created_at': 1700000000,
+          'kind': 34236,
+          'd_tag': 'video-1',
+          'title': 'Test',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'stats': {
+            'reactions': -1,
+            'comments': '9223372036854775807',
+            'reposts': '18446744073709551615',
+          },
+          'engagement_score': 0,
+        });
+
+        expect(stats.reactions, equals(0));
+        expect(stats.comments, equals(0));
+        expect(stats.reposts, equals(0));
+      });
+
       test('parses id as byte array (ASCII codes)', () {
         final json = {
           'id': [97, 98, 99, 49, 50, 51], // 'abc123' as ASCII codes

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -524,7 +524,7 @@ class NostrClient {
       );
 
       return CountResult(
-        count: response.count,
+        count: _normalizeRelayCount(response.count),
         approximate: response.approximate,
       );
     } on CountNotSupportedException {
@@ -1213,4 +1213,15 @@ class NostrClient {
 
     return merged;
   }
+}
+
+const _invalidRelayCountSentinels = {
+  2147483647,
+  4294967295,
+  9223372036854775807,
+};
+
+int _normalizeRelayCount(int count) {
+  if (count < 0 || _invalidRelayCountSentinels.contains(count)) return 0;
+  return count;
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1216,12 +1216,14 @@ class NostrClient {
 }
 
 const _invalidRelayCountSentinels = {
-  2147483647,
-  4294967295,
-  9223372036854775807,
+  '2147483647',
+  '4294967295',
+  '9223372036854775807',
 };
 
 int _normalizeRelayCount(int count) {
-  if (count < 0 || _invalidRelayCountSentinels.contains(count)) return 0;
+  if (count < 0 || _invalidRelayCountSentinels.contains(count.toString())) {
+    return 0;
+  }
   return count;
 }

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3101,6 +3101,28 @@ void main() {
         expect(result.source, equals(CountSource.websocket));
       });
 
+      test('normalizes relay sentinel counts to zero', () async {
+        final filters = [
+          Filter(kinds: [EventKind.textNote]),
+        ];
+        const countResponse = CountResponse(count: 9223372036854775807);
+
+        when(
+          () => mockNostr.countEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => countResponse);
+
+        final result = await client.countEvents(filters);
+
+        expect(result.count, equals(0));
+        expect(result.source, equals(CountSource.websocket));
+      });
+
       test('falls back to queryEvents when COUNT not supported', () async {
         final filters = [
           Filter(kinds: [EventKind.textNote]),

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -844,7 +844,10 @@ class VideosRepository {
           limit: limit,
           offset: offset,
         );
-        final videos = _transformVideoStats(stats, sortByCreatedAt: false);
+        final videos = await _hydrateVideosWithBulkStats(
+          _transformVideoStats(stats, sortByCreatedAt: false),
+          replaceInteractionCounts: true,
+        );
         if (until == null && offset == null) {
           _inMemoryFeedCache?.set(cacheKey, HomeFeedResult(videos: videos));
         }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -291,8 +291,9 @@ class VideosRepository {
   }
 
   Future<List<VideoEvent>> _hydrateVideosWithBulkStats(
-    List<VideoEvent> videos,
-  ) async {
+    List<VideoEvent> videos, {
+    bool replaceInteractionCounts = false,
+  }) async {
     if (videos.isEmpty ||
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
@@ -303,7 +304,8 @@ class VideosRepository {
         .where(
           (video) =>
               video.id.isNotEmpty &&
-              (video.originalLoops == null ||
+              (replaceInteractionCounts ||
+                  video.originalLoops == null ||
                   // Relay-sourced zeroes are frequently stale placeholders;
                   // treat them as missing so Funnelcake can reconcile counts.
                   video.originalLoops == 0 ||
@@ -337,14 +339,22 @@ class VideosRepository {
 
         return video.copyWith(
           originalLoops: stats.loops ?? video.originalLoops,
-          originalLikes: video.originalLikes ?? stats.reactions,
-          originalComments: video.originalComments ?? stats.comments,
-          originalReposts: video.originalReposts ?? stats.reposts,
+          originalLikes: replaceInteractionCounts
+              ? stats.reactions
+              : video.originalLikes ?? stats.reactions,
+          originalComments: replaceInteractionCounts
+              ? stats.comments
+              : video.originalComments ?? stats.comments,
+          originalReposts: replaceInteractionCounts
+              ? stats.reposts
+              : video.originalReposts ?? stats.reposts,
           // REST reaction totals already include the Nostr portion for the
           // fullscreen entry paths that rely on this hydration. Seeding
           // nostrLikeCount to 0 preserves totalLikes while still telling the
           // interactions bloc it has an initial count to display.
-          nostrLikeCount: video.nostrLikeCount ?? 0,
+          nostrLikeCount: replaceInteractionCounts
+              ? 0
+              : video.nostrLikeCount ?? 0,
           rawTags: video.rawTags['views'] == null && stats.views != null
               ? {...video.rawTags, 'views': stats.views.toString()}
               : video.rawTags,
@@ -720,20 +730,24 @@ class VideosRepository {
         // ignore: flutter_style_todos
         // TODO(#4307): Remove after the native popular exclude_platform
         // fix ships.
-        final videos = _filterNativePopularVideos(
+        final videos = await _hydrateVideosWithBulkStats(
           _transformVideoStats(videoStats, sortByCreatedAt: false),
+          replaceInteractionCounts: true,
+        );
+        final visibleVideos = _filterNativePopularVideos(
+          videos,
         );
         if (!skipCache && offset == 0) {
           _inMemoryFeedCache?.set(
             _nativePopularCacheKey,
             HomeFeedResult(
-              videos: videos,
+              videos: visibleVideos,
               consumedItemCount: videoStats.length,
             ),
           );
         }
         return NativePopularVideosPage(
-          videos: videos,
+          videos: visibleVideos,
           consumedItemCount: videoStats.length,
           nextOffset: offset + videoStats.length,
         );

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -822,7 +822,10 @@ class VideosRepository {
           limit: limit,
           before: until,
         );
-        final videos = _transformVideoStats(stats, sortByCreatedAt: false);
+        final videos = await _hydrateVideosWithBulkStats(
+          _transformVideoStats(stats, sortByCreatedAt: false),
+          replaceInteractionCounts: true,
+        );
         if (until == null && offset == null) {
           _inMemoryFeedCache?.set(cacheKey, HomeFeedResult(videos: videos));
         }

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -2987,6 +2987,9 @@ void main() {
 
       setUp(() {
         mockFunnelcakeClient = MockFunnelcakeApiClient();
+        when(
+          () => mockFunnelcakeClient.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
       });
 
       test('returns native popular API results in server order', () async {
@@ -3037,6 +3040,65 @@ void main() {
           ),
         );
       });
+
+      test(
+        'hydrates native popular interaction counts before returning',
+        () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getNativePopularVideos(
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'native-popular-1',
+                pubkey: 'pubkey-1',
+                dTag: 'dtag-1',
+                videoUrl: 'https://example.com/native-1.mp4',
+                loops: 200,
+                views: 300,
+              ),
+            ],
+          );
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(['native-popular-1']),
+          ).thenAnswer(
+            (_) async => const BulkVideoStatsResponse(
+              stats: {
+                'native-popular-1': BulkVideoStatsEntry(
+                  eventId: 'native-popular-1',
+                  reactions: 12,
+                  comments: 3,
+                  reposts: 4,
+                  loops: 201,
+                  views: 301,
+                ),
+              },
+            ),
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getNativePopularVideos(
+            limit: 1,
+          );
+
+          expect(result, hasLength(1));
+          expect(result.single.originalLikes, equals(12));
+          expect(result.single.originalComments, equals(3));
+          expect(result.single.originalReposts, equals(4));
+          expect(result.single.nostrLikeCount, equals(0));
+          expect(result.single.totalLikes, equals(12));
+          verify(
+            () => mockFunnelcakeClient.getBulkVideoStats(['native-popular-1']),
+          ).called(1);
+        },
+      );
 
       test('throws when native endpoint fails', () async {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3363,6 +3363,11 @@ void main() {
 
         setUp(() {
           mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(any()),
+          ).thenAnswer(
+            (_) async => const BulkVideoStatsResponse(stats: {}),
+          );
         });
 
         test('returns API results when Funnelcake succeeds', () async {
@@ -4346,6 +4351,71 @@ void main() {
             ),
           ).called(1);
         });
+
+        test(
+          'hydrates v2 native popular interaction counts before returning',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getV2PopularVideos(
+                variant: any(named: 'variant'),
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _createVideoStats(
+                  id: 'v2-native-popular-1',
+                  pubkey: 'pubkey-1',
+                  dTag: 'dtag-1',
+                  videoUrl: 'https://example.com/v2-native-1.mp4',
+                  loops: 200,
+                  views: 300,
+                ),
+              ],
+            );
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats([
+                'v2-native-popular-1',
+              ]),
+            ).thenAnswer(
+              (_) async => const BulkVideoStatsResponse(
+                stats: {
+                  'v2-native-popular-1': BulkVideoStatsEntry(
+                    eventId: 'v2-native-popular-1',
+                    reactions: 12,
+                    comments: 3,
+                    reposts: 4,
+                    loops: 201,
+                    views: 301,
+                  ),
+                },
+              ),
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getPopularVideos(
+              variant: PopularVideosVariant.native,
+              limit: 1,
+            );
+
+            expect(result, hasLength(1));
+            expect(result.single.originalLikes, equals(12));
+            expect(result.single.originalComments, equals(3));
+            expect(result.single.originalReposts, equals(4));
+            expect(result.single.nostrLikeCount, equals(0));
+            expect(result.single.totalLikes, equals(12));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats([
+                'v2-native-popular-1',
+              ]),
+            ).called(1);
+          },
+        );
 
         test('returns empty list when v2 API throws', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -1112,6 +1112,9 @@ void main() {
 
         setUp(() {
           mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(any()),
+          ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
         });
 
         test('returns API results when Funnelcake succeeds', () async {
@@ -3985,6 +3988,9 @@ void main() {
 
         setUp(() {
           mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(any()),
+          ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
         });
 
         test('calls getLeaderboardVideos when period is set', () async {
@@ -4033,6 +4039,67 @@ void main() {
             ),
           );
         });
+
+        test(
+          'hydrates period leaderboard interaction counts before returning',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getLeaderboardVideos(
+                period: any(named: 'period'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _createVideoStats(
+                  id: 'leaderboard-1',
+                  pubkey: 'pubkey-1',
+                  dTag: 'dtag-1',
+                  videoUrl: 'https://example.com/leaderboard-1.mp4',
+                  loops: 500,
+                  views: 600,
+                ),
+              ],
+            );
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats(['leaderboard-1']),
+            ).thenAnswer(
+              (_) async => const BulkVideoStatsResponse(
+                stats: {
+                  'leaderboard-1': BulkVideoStatsEntry(
+                    eventId: 'leaderboard-1',
+                    reactions: 21,
+                    comments: 5,
+                    reposts: 8,
+                    loops: 501,
+                    views: 601,
+                  ),
+                },
+              ),
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final videos = await repositoryWithApi.getPopularVideos(
+              limit: 1,
+              period: LeaderboardPeriod.week,
+            );
+
+            expect(videos, hasLength(1));
+            expect(videos.single.originalLikes, equals(21));
+            expect(videos.single.originalComments, equals(5));
+            expect(videos.single.originalReposts, equals(8));
+            expect(videos.single.nostrLikeCount, equals(0));
+            expect(videos.single.totalLikes, equals(21));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats(['leaderboard-1']),
+            ).called(1);
+          },
+        );
 
         test('passes offset when provided (period path)', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -1036,6 +1036,39 @@ void main() {
         // Duration is combined with video count: "6.0s · No videos yet"
         expect(find.textContaining('6.0s'), findsOneWidget);
       });
+
+      testWidgets('SoundDetailScreen empty state fits short viewports', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(400, 520);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final testSound = createTestAudioEvent(
+          id: 'sound1',
+          title: 'Cool Beat',
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('No videos yet'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #4456

## Summary
- Normalize invalid/sentinel engagement counts from Funnelcake video stats before they reach feed UI counts.
- Normalize invalid NIP-45 COUNT relay responses before likes/comments/reposts repositories cache them.
- Remove a redundant default video-player argument that blocked app analyze.

## Verification
- flutter test (mobile/packages/models)
- flutter test test/src/nostr_client_test.dart --plain-name 'countEvents' (mobile/packages/nostr_client)
- flutter analyze (mobile/packages/models)
- flutter analyze (mobile/packages/nostr_client)
- flutter analyze (mobile)
- pre-push hook analyzer + changed-file tests