### PR TITLE
fix(video_recorder): implement shutter long-press handling to prevent phantom clicks

### DIFF
--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
@@ -7,12 +7,21 @@ import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_cla
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart';
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
+import 'package:openvine/widgets/video_recorder/shutter_long_press_mixin.dart';
 
-class VideoRecorderClassicStack extends ConsumerWidget {
+class VideoRecorderClassicStack extends ConsumerStatefulWidget {
   const VideoRecorderClassicStack({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<VideoRecorderClassicStack> createState() =>
+      _VideoRecorderClassicStackState();
+}
+
+class _VideoRecorderClassicStackState
+    extends ConsumerState<VideoRecorderClassicStack>
+    with ShutterLongPressMixin {
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(
       videoRecorderProvider.select(
         (p) => (
@@ -64,11 +73,17 @@ class VideoRecorderClassicStack extends ConsumerWidget {
                           : context.l10n.videoRecorderTapToStartLabel,
                       child: GestureDetector(
                         behavior: .opaque,
-                        onTap: isEnabled ? notifier.toggleRecording : null,
-                        onLongPressStart: isEnabled
-                            ? (_) => notifier.startRecording()
+                        onTap: isEnabled
+                            ? () => handleShutterTap(notifier.toggleRecording)
                             : null,
-                        onLongPressUp: notifier.stopRecording,
+                        onLongPressStart: isEnabled
+                            ? (_) => handleShutterLongPressStart(
+                                isRecording: state.isRecording,
+                                start: notifier.startRecording,
+                              )
+                            : null,
+                        onLongPressUp: () =>
+                            handleShutterLongPressUp(notifier.stopRecording),
                         child: const IgnorePointer(
                           child: VideoRecorderCameraPreview(
                             enableTapToFocus: false,

--- a/mobile/lib/widgets/video_recorder/shutter_long_press_mixin.dart
+++ b/mobile/lib/widgets/video_recorder/shutter_long_press_mixin.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+
+/// Shared gesture-arena gating for shutter widgets that expose both a
+/// tap and a long-press to start/stop recording on the same target.
+///
+/// Tracks whether the in-progress recording was started by a long-press
+/// on this widget. Without this guard, an incidental long-touch on the
+/// shutter while a tap-started take is already running would call
+/// `stopRecording` on release, producing a phantom click that
+/// interrupts the take. See issue #4409.
+mixin ShutterLongPressMixin<T extends StatefulWidget> on State<T> {
+  bool _startedByLongPress = false;
+
+  /// Wrap the tap handler. Resets the long-press flag, then invokes
+  /// [toggle] (typically `notifier.toggleRecording`).
+  void handleShutterTap(VoidCallback toggle) {
+    _startedByLongPress = false;
+    toggle();
+  }
+
+  /// Wrap the long-press-start handler. Only flips the flag and calls
+  /// [start] when no recording is in progress; if a tap-started take
+  /// is already running, the long-press is treated as incidental.
+  void handleShutterLongPressStart({
+    required bool isRecording,
+    required VoidCallback start,
+  }) {
+    if (isRecording) return;
+    _startedByLongPress = true;
+    start();
+  }
+
+  /// Wrap the long-press-up handler. Only invokes [stop] if this
+  /// long-press actually started the recording.
+  void handleShutterLongPressUp(VoidCallback stop) {
+    if (!_startedByLongPress) return;
+    _startedByLongPress = false;
+    stop();
+  }
+}

--- a/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
@@ -4,13 +4,20 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
+import 'package:openvine/widgets/video_recorder/shutter_long_press_mixin.dart';
 
 /// Circular record button for starting/stopping video recording.
-class RecordButton extends ConsumerWidget {
+class RecordButton extends ConsumerStatefulWidget {
   const RecordButton({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RecordButton> createState() => _RecordButtonState();
+}
+
+class _RecordButtonState extends ConsumerState<RecordButton>
+    with ShutterLongPressMixin {
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(
       videoRecorderProvider.select(
         (p) => (
@@ -46,15 +53,22 @@ class RecordButton extends ConsumerWidget {
           ? context.l10n.videoRecorderStopRecordingTooltip
           : context.l10n.videoRecorderStartRecordingTooltip,
       child: GestureDetector(
-        onTap: isEnabled ? notifier.toggleRecording : null,
+        onTap: isEnabled
+            ? () => handleShutterTap(notifier.toggleRecording)
+            : null,
         onLongPressStart: isEnabled && isLongPressSupported
-            ? (_) => notifier.startRecording()
+            ? (_) => handleShutterLongPressStart(
+                isRecording: state.isRecording,
+                start: notifier.startRecording,
+              )
             : null,
         onLongPressMoveUpdate: state.isRecording && isLongPressSupported
             ? (details) =>
                   notifier.zoomByLongPressMove(details.localOffsetFromOrigin)
             : null,
-        onLongPressUp: isLongPressSupported ? notifier.stopRecording : null,
+        onLongPressUp: isLongPressSupported
+            ? () => handleShutterLongPressUp(notifier.stopRecording)
+            : null,
         child: AnimatedOpacity(
           duration: const Duration(milliseconds: 200),
           opacity: isEnabled ? 1.0 : 0.5,

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
@@ -241,6 +241,63 @@ void main() {
         expect(notifier.stopRecordingCalled, isTrue);
       });
     });
+
+    // Regression tests for issue #4409 ("Phantom click"): an incidental
+    // long-touch on the preview shutter while a tap-started recording is
+    // in progress must NOT call stopRecording on release.
+    group('phantom click regression (issue #4409)', () {
+      testWidgets(
+        'long-press release does not stop a tap-started recording',
+        (tester) async {
+          late _TestVideoRecorderNotifier notifier;
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                videoRecorderProvider.overrideWith(() {
+                  notifier = _TestVideoRecorderNotifier(
+                    mockCamera,
+                    recordingState: VideoRecorderState.recording,
+                  );
+                  return notifier;
+                }),
+                clipManagerProvider.overrideWith(
+                  () => _TestClipManagerNotifier(clips: const []),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(body: VideoRecorderClassicStack()),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final gesture = await tester.startGesture(
+            tester.getCenter(
+              find.ancestor(
+                of: find.byType(VideoRecorderCameraPreview),
+                matching: find.byType(GestureDetector),
+              ),
+            ),
+          );
+          await tester.pump(const Duration(seconds: 1));
+          await gesture.up();
+          await tester.pumpAndSettle();
+
+          expect(
+            notifier.stopRecordingCallCount,
+            equals(0),
+            reason:
+                'stopRecording must not be called when a long-press '
+                'release follows an incidental touch on an already- '
+                'recording shutter (issue #4409).',
+          );
+          expect(notifier.startRecordingCallCount, equals(0));
+        },
+      );
+    });
   });
 }
 
@@ -254,6 +311,8 @@ class _TestVideoRecorderNotifier extends VideoRecorderNotifier {
 
   var startRecordingCalled = false;
   var stopRecordingCalled = false;
+  int startRecordingCallCount = 0;
+  int stopRecordingCallCount = 0;
 
   @override
   VideoRecorderProviderState build() {
@@ -267,11 +326,13 @@ class _TestVideoRecorderNotifier extends VideoRecorderNotifier {
   @override
   Future<void> startRecording() async {
     startRecordingCalled = true;
+    startRecordingCallCount++;
   }
 
   @override
   Future<void> stopRecording([EditorVideo? result]) async {
     stopRecordingCalled = true;
+    stopRecordingCallCount++;
   }
 }
 

--- a/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
+++ b/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_recorder/shutter_long_press_mixin.dart';
+
+void main() {
+  group(ShutterLongPressMixin, () {
+    late _HostState host;
+
+    Future<void> pumpHost(WidgetTester tester) async {
+      await tester.pumpWidget(_Host(onState: (state) => host = state));
+    }
+
+    testWidgets('handleShutterTap resets the flag and invokes toggle', (
+      tester,
+    ) async {
+      await pumpHost(tester);
+
+      var toggled = 0;
+      host.handleShutterTap(() => toggled++);
+
+      expect(toggled, equals(1));
+      // After a tap, a following long-press release must not stop.
+      var stopped = 0;
+      host.handleShutterLongPressUp(() => stopped++);
+      expect(stopped, equals(0));
+    });
+
+    testWidgets(
+      'handleShutterLongPressStart is a no-op when already recording',
+      (tester) async {
+        await pumpHost(tester);
+
+        var started = 0;
+        host.handleShutterLongPressStart(
+          isRecording: true,
+          start: () => started++,
+        );
+
+        expect(started, equals(0));
+        // Flag must stay false → release is also a no-op.
+        var stopped = 0;
+        host.handleShutterLongPressUp(() => stopped++);
+        expect(stopped, equals(0));
+      },
+    );
+
+    testWidgets(
+      'handleShutterLongPressStart sets the flag and invokes start when idle',
+      (tester) async {
+        await pumpHost(tester);
+
+        var started = 0;
+        host.handleShutterLongPressStart(
+          isRecording: false,
+          start: () => started++,
+        );
+
+        expect(started, equals(1));
+        // Flag is now true → release stops exactly once.
+        var stopped = 0;
+        host.handleShutterLongPressUp(() => stopped++);
+        expect(stopped, equals(1));
+      },
+    );
+
+    testWidgets('handleShutterLongPressUp resets the flag after stopping', (
+      tester,
+    ) async {
+      await pumpHost(tester);
+
+      host.handleShutterLongPressStart(isRecording: false, start: () {});
+      var stopped = 0;
+      host.handleShutterLongPressUp(() => stopped++);
+      host.handleShutterLongPressUp(() => stopped++);
+
+      expect(
+        stopped,
+        equals(1),
+        reason: 'second release must not stop again',
+      );
+    });
+
+    testWidgets(
+      'tap after a long-press take resets the flag for the next cycle',
+      (tester) async {
+        await pumpHost(tester);
+
+        // Long-press cycle: start + release sets and clears the flag.
+        host.handleShutterLongPressStart(isRecording: false, start: () {});
+        host.handleShutterLongPressUp(() {});
+
+        // New tap-started take → incidental long-press release must no-op.
+        host.handleShutterTap(() {});
+        var stopped = 0;
+        host.handleShutterLongPressUp(() => stopped++);
+        expect(stopped, equals(0));
+      },
+    );
+  });
+}
+
+class _Host extends StatefulWidget {
+  const _Host({required this.onState});
+
+  final void Function(_HostState state) onState;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> with ShutterLongPressMixin<_Host> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onState(this);
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/mobile/test/widgets/video_recorder/video_recorder_record_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_record_button_test.dart
@@ -9,6 +9,7 @@ import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 import '../../mocks/mock_camera_service.dart';
 
@@ -171,6 +172,92 @@ void main() {
         expect(semantics.properties.button, isTrue);
       });
     });
+
+    // Regression tests for issue #4409 ("Phantom click"): an incidental
+    // long-touch on the record button while a tap-started recording is
+    // in progress must NOT call stopRecording on release.
+    group('phantom click regression (issue #4409)', () {
+      testWidgets(
+        'long-press release does not stop a tap-started recording',
+        (tester) async {
+          final notifier = _TrackingVideoRecorderNotifier(
+            mockCamera,
+            recordingState: VideoRecorderState.recording,
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                videoRecorderProvider.overrideWith(() => notifier),
+                clipManagerProvider.overrideWith(
+                  () => _TestClipManagerNotifier(clips: const []),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(body: Center(child: RecordButton())),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Simulate the user resting a finger on the shutter while a
+          // tap-started take is already running.
+          final gesture = await tester.startGesture(
+            tester.getCenter(find.byType(RecordButton)),
+          );
+          await tester.pump(const Duration(seconds: 1));
+          await gesture.up();
+          await tester.pumpAndSettle();
+
+          expect(
+            notifier.stopRecordingCallCount,
+            equals(0),
+            reason:
+                'stopRecording must not be called when a long-press '
+                'release follows an incidental touch on an already- '
+                'recording shutter (issue #4409).',
+          );
+          expect(notifier.startRecordingCallCount, equals(0));
+          expect(notifier.toggleRecordingCallCount, equals(0));
+        },
+      );
+
+      testWidgets(
+        'long-press from idle starts recording and release stops it',
+        (tester) async {
+          final notifier = _TrackingVideoRecorderNotifier(mockCamera);
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                videoRecorderProvider.overrideWith(() => notifier),
+                clipManagerProvider.overrideWith(
+                  () => _TestClipManagerNotifier(clips: const []),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(body: Center(child: RecordButton())),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final gesture = await tester.startGesture(
+            tester.getCenter(find.byType(RecordButton)),
+          );
+          await tester.pump(const Duration(seconds: 1));
+          await gesture.up();
+          await tester.pumpAndSettle();
+
+          expect(notifier.startRecordingCallCount, equals(1));
+          expect(notifier.stopRecordingCallCount, equals(1));
+        },
+      );
+    });
   });
 }
 
@@ -205,5 +292,45 @@ class _TestClipManagerNotifier extends ClipManagerNotifier {
   @override
   ClipManagerState build() {
     return ClipManagerState(clips: clips);
+  }
+}
+
+/// Test notifier that tracks how many times each recording method is
+/// invoked, without performing any real camera work. Used by the
+/// phantom-click regression tests (issue #4409).
+class _TrackingVideoRecorderNotifier extends VideoRecorderNotifier {
+  _TrackingVideoRecorderNotifier(
+    super.cameraService, {
+    this.recordingState = VideoRecorderState.idle,
+  });
+
+  final VideoRecorderState recordingState;
+
+  int toggleRecordingCallCount = 0;
+  int startRecordingCallCount = 0;
+  int stopRecordingCallCount = 0;
+
+  @override
+  VideoRecorderProviderState build() {
+    return VideoRecorderProviderState(
+      recordingState: recordingState,
+      canRecord: true,
+      isCameraInitialized: true,
+    );
+  }
+
+  @override
+  Future<void> toggleRecording() async {
+    toggleRecordingCallCount++;
+  }
+
+  @override
+  Future<void> startRecording() async {
+    startRecordingCallCount++;
+  }
+
+  @override
+  Future<void> stopRecording([EditorVideo? result]) async {
+    stopRecordingCallCount++;
   }
 }


### PR DESCRIPTION


## Description

When a user tap-started a recording and then accidentally kept their finger down long enough to trigger a long-press gesture, the onLongPressUp callback would fire on release and call stopRecording — silently terminating a recording the user hadn't intended to stop.

**Related Issue:** Closes #4409

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
