### PR TITLE
revert: "fix(android): default useLegacySurface to true to close FlutterJNI renderer race (#3416)"

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -59,18 +59,17 @@ internal class DivineVideoPlayerInstance(
     //
     // Two backends are supported and selected per player at
     // [enableTextureOutput] time:
-    //  * [TextureRegistry.SurfaceTextureEntry] (default): single-buffer
-    //    SurfaceTexture owned by the player for its full lifetime. No
-    //    surface-recreate callback, but no `ImageReader` either — immune
-    //    to the cross-decoder ghost-frame issue and to the #3416
-    //    `FlutterJNI`-detached `scheduleFrame()` race on engine teardown.
-    //  * [TextureRegistry.SurfaceProducer]: Android 14+ ImageReader
+    //  * [TextureRegistry.SurfaceProducer] (default): Android 14+ ImageReader
     //    backend. Forwards Surface destroy/recreate events via the
     //    [TextureRegistry.SurfaceProducer.Callback] callback so playback can
     //    survive OEM compositor events (Vivo/Android 16, permission dialogs).
     //    Has a small (3–4) hardcoded buffer pool which can leak a stale
     //    frame across decoder format reprobes — visible as a 1-frame ghost
     //    when many players coexist (the feed). See #3416 / feed flicker.
+    //  * [TextureRegistry.SurfaceTextureEntry] (legacy): single-buffer
+    //    SurfaceTexture. No surface-recreate callback, but no shared pool
+    //    either, so it is immune to the cross-decoder ghost-frame issue.
+    //    Used by callers that render many players at once (the feed).
     //
     // Exactly one of these is non-null after [enableTextureOutput].
     private var surfaceProducer: TextureRegistry.SurfaceProducer? = null
@@ -180,26 +179,21 @@ internal class DivineVideoPlayerInstance(
      * Must be called before any clips are loaded. Returns the texture
      * ID that Dart should pass to the `Texture` widget.
      *
-     * When [useLegacySurface] is `true` (default) this uses the legacy
-     * [TextureRegistry.SurfaceTextureEntry]. Its surface is owned by
-     * the player for its full lifetime, with no `ImageReader` callback
-     * that can fire on a detached `FlutterJNI` during engine teardown
-     * (#3416). It does not deliver surface-recreate callbacks, so it
-     * cannot transparently survive an OEM compositor event — accepted
-     * trade-off given the codebase's chosen safety posture.
+     * When [useLegacySurface] is `false` (default) this uses
+     * [TextureRegistry.SurfaceProducer] so Android can notify us when
+     * the underlying surface is destroyed and recreated (permission
+     * dialogs, OEM compositor events on Vivo/Android 16).
      *
-     * When [useLegacySurface] is `false` this uses
-     * [TextureRegistry.SurfaceProducer] which adds Android 14+
-     * surface destroy/recreate callbacks (permission dialogs,
-     * Vivo/Android 16 compositor events), at the cost of the
-     * residual #3416 race window between
-     * `ImageReaderSurfaceProducer.onImage` and `FlutterJNI` detach.
-     * No callsite currently opts in — tests pass `false` explicitly
-     * to exercise the `SurfaceProducer.Callback` contract.
+     * When [useLegacySurface] is `true` this uses the legacy
+     * [TextureRegistry.SurfaceTextureEntry] which does not deliver
+     * surface-recreate callbacks but is immune to the SurfaceProducer
+     * ImageReader-pool ghost-frame issue. Use this for screens that
+     * render many players at once (the feed) where a sibling decoder's
+     * release can leak a stale frame onto a peer's surface.
      */
     fun enableTextureOutput(
         registry: TextureRegistry,
-        useLegacySurface: Boolean = true,
+        useLegacySurface: Boolean = false,
     ): Long {
         if (useLegacySurface) {
             val entry = registry.createSurfaceTexture()

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -132,7 +132,7 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
                 val useTexture = call.argument<Boolean>("useTexture") ?: false
                 if (useTexture) {
                     val useLegacySurface =
-                        call.argument<Boolean>("useLegacySurface") ?: true
+                        call.argument<Boolean>("useLegacySurface") ?: false
                     val textureId = instance.enableTextureOutput(
                         binding.textureRegistry,
                         useLegacySurface = useLegacySurface,

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -1,7 +1,6 @@
 package com.divinevideo.divine_video_player
 
 import android.content.Context
-import android.graphics.SurfaceTexture
 import android.os.Handler
 import android.view.Surface
 import androidx.media3.common.PlaybackException
@@ -15,13 +14,10 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.runs
 import io.mockk.slot
-import io.mockk.unmockkConstructor
 import io.mockk.verify
 import io.mockk.verifyOrder
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -44,8 +40,6 @@ class DivineVideoPlayerInstanceTest {
     private lateinit var mockRegistry: TextureRegistry
     private lateinit var mockProducer: TextureRegistry.SurfaceProducer
     private lateinit var mockSurface: Surface
-    private lateinit var mockTextureEntry: TextureRegistry.SurfaceTextureEntry
-    private lateinit var mockSurfaceTexture: SurfaceTexture
     private lateinit var instance: DivineVideoPlayerInstance
 
     @Before
@@ -58,14 +52,9 @@ class DivineVideoPlayerInstanceTest {
         mockRegistry = mockk(relaxed = true)
         mockProducer = mockk(relaxed = true)
         mockSurface = mockk(relaxed = true)
-        mockTextureEntry = mockk(relaxed = true)
-        mockSurfaceTexture = mockk(relaxed = true)
 
         every { mockRegistry.createSurfaceProducer() } returns mockProducer
         every { mockProducer.id() } returns 42L
-        every { mockRegistry.createSurfaceTexture() } returns mockTextureEntry
-        every { mockTextureEntry.surfaceTexture() } returns mockSurfaceTexture
-        every { mockTextureEntry.id() } returns 99L
 
         instance = DivineVideoPlayerInstance(
             messenger = messenger,
@@ -148,7 +137,7 @@ class DivineVideoPlayerInstanceTest {
     fun `onSurfaceAvailable attaches surface to player and clears needsSurface`() {
         // Start with a null surface so enableTextureOutput leaves needsSurface = true.
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
+        instance.enableTextureOutput(mockRegistry)
 
         // Surface becomes available; simulate the callback firing with the real surface.
         every { mockProducer.surface } returns mockSurface
@@ -169,7 +158,7 @@ class DivineVideoPlayerInstanceTest {
     fun `onSurfaceAvailable leaves needsSurface true when player has not been created`() {
         // Surface is null at enableTextureOutput time → needsSurface = true.
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
+        instance.enableTextureOutput(mockRegistry)
 
         // Surface now available, but player still null.
         every { mockProducer.surface } returns mockSurface
@@ -187,7 +176,7 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `onSurfaceCleanup detaches surface from player and raises needsSurface`() {
         every { mockProducer.surface } returns mockSurface
-        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
+        instance.enableTextureOutput(mockRegistry)
         materializePlayer()
 
         instance.onSurfaceCleanup()
@@ -201,7 +190,7 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `onSurfaceCleanup raises needsSurface even when player is null`() {
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
+        instance.enableTextureOutput(mockRegistry)
         // Player never materialised — setVideoSurface(null) is a no-op via ?.
 
         instance.onSurfaceCleanup()
@@ -211,46 +200,6 @@ class DivineVideoPlayerInstanceTest {
         materializePlayer()
         // ensurePlayer() must attach because needsSurface was left true.
         verify { mockPlayer.setVideoSurface(mockSurface) }
-    }
-
-    // -- legacy SurfaceTextureEntry backend --
-
-    @Test
-    fun `enableTextureOutput default uses createSurfaceTexture, not createSurfaceProducer`() {
-        // Production hits this path via the Dart-side default (useLegacySurface = true)
-        // and the MethodChannel fallback. Kotlin's default is aligned to true so a
-        // direct call with no argument exercises the same path.
-        //
-        // Surface(SurfaceTexture) is an Android framework constructor that throws
-        // "Stub!" on the unit-test JVM unless intercepted; mockkConstructor returns
-        // a relaxed Surface mock instead.
-        mockkConstructor(Surface::class)
-        try {
-            val textureId = instance.enableTextureOutput(mockRegistry)
-
-            verify(exactly = 1) { mockRegistry.createSurfaceTexture() }
-            verify(exactly = 0) { mockRegistry.createSurfaceProducer() }
-            verify(exactly = 1) { mockTextureEntry.surfaceTexture() }
-            assertEquals(99L, textureId)
-        } finally {
-            unmockkConstructor(Surface::class)
-        }
-    }
-
-    @Test
-    fun `legacy backend attaches surface eagerly to materialized player`() {
-        mockkConstructor(Surface::class)
-        try {
-            instance.enableTextureOutput(mockRegistry)
-            materializePlayer()
-
-            // Legacy surface is owned for the player's lifetime; ensurePlayer must
-            // attach it eagerly (no waiting for an onSurfaceAvailable callback that
-            // the SurfaceTextureEntry backend never fires).
-            verify { mockPlayer.setVideoSurface(any<Surface>()) }
-        } finally {
-            unmockkConstructor(Surface::class)
-        }
     }
 
     // -- onMediaItemTransition detach/reattach --
@@ -265,7 +214,7 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `MEDIA_ITEM_TRANSITION_REASON_AUTO forces surface detach then reattach`() {
         every { mockProducer.surface } returns mockSurface
-        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
+        instance.enableTextureOutput(mockRegistry)
         val listener = capturePlayerListener()
 
         listener.onMediaItemTransition(null, Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
@@ -280,7 +229,7 @@ class DivineVideoPlayerInstanceTest {
     fun `MEDIA_ITEM_TRANSITION_REASON_AUTO is skipped when surface is not yet attached`() {
         // Surface null during enableTextureOutput → needsSurface = true.
         every { mockProducer.surface } returns null
-        instance.enableTextureOutput(mockRegistry, useLegacySurface = false)
+        instance.enableTextureOutput(mockRegistry)
         every { mockProducer.surface } returns mockSurface
         val listener = capturePlayerListener()
         // ensurePlayer attached the surface (needsSurface = false). Force the flag

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -1,6 +1,7 @@
 package com.divinevideo.divine_video_player
 
 import android.content.Context
+import android.graphics.SurfaceTexture
 import android.os.Handler
 import android.view.Surface
 import androidx.media3.common.PlaybackException
@@ -14,10 +15,13 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import io.mockk.verify
 import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -40,6 +44,8 @@ class DivineVideoPlayerInstanceTest {
     private lateinit var mockRegistry: TextureRegistry
     private lateinit var mockProducer: TextureRegistry.SurfaceProducer
     private lateinit var mockSurface: Surface
+    private lateinit var mockTextureEntry: TextureRegistry.SurfaceTextureEntry
+    private lateinit var mockSurfaceTexture: SurfaceTexture
     private lateinit var instance: DivineVideoPlayerInstance
 
     @Before
@@ -52,9 +58,14 @@ class DivineVideoPlayerInstanceTest {
         mockRegistry = mockk(relaxed = true)
         mockProducer = mockk(relaxed = true)
         mockSurface = mockk(relaxed = true)
+        mockTextureEntry = mockk(relaxed = true)
+        mockSurfaceTexture = mockk(relaxed = true)
 
         every { mockRegistry.createSurfaceProducer() } returns mockProducer
         every { mockProducer.id() } returns 42L
+        every { mockRegistry.createSurfaceTexture() } returns mockTextureEntry
+        every { mockTextureEntry.surfaceTexture() } returns mockSurfaceTexture
+        every { mockTextureEntry.id() } returns 99L
 
         instance = DivineVideoPlayerInstance(
             messenger = messenger,
@@ -200,6 +211,24 @@ class DivineVideoPlayerInstanceTest {
         materializePlayer()
         // ensurePlayer() must attach because needsSurface was left true.
         verify { mockPlayer.setVideoSurface(mockSurface) }
+    }
+
+    @Test
+    fun `enableTextureOutput true uses createSurfaceTexture not createSurfaceProducer`() {
+        mockkConstructor(Surface::class)
+        try {
+            val textureId = instance.enableTextureOutput(
+                mockRegistry,
+                useLegacySurface = true,
+            )
+
+            verify(exactly = 1) { mockRegistry.createSurfaceTexture() }
+            verify(exactly = 0) { mockRegistry.createSurfaceProducer() }
+            verify(exactly = 1) { mockTextureEntry.surfaceTexture() }
+            assertEquals(99L, textureId)
+        } finally {
+            unmockkConstructor(Surface::class)
+        }
     }
 
     // -- onMediaItemTransition detach/reattach --

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -31,24 +31,19 @@ class DivineVideoPlayerController {
   /// separate `CALayer`s that bypass Flutter's rendering pipeline.
   /// Defaults to `false` (platform view).
   ///
-  /// When [useLegacySurface] is `true` (default) AND [useTexture] is
-  /// `true`, the Android side allocates a legacy `SurfaceTextureEntry`
-  /// for texture output. Legacy is the safe default — its surface is
-  /// owned by the player for its full lifetime, so there is no
-  /// `ImageReader` callback that can fire on a detached `FlutterJNI`
-  /// during engine teardown (#3416).
-  ///
-  /// Pass `false` to opt into `SurfaceProducer` instead.
-  /// `SurfaceProducer` adds Android 14+ surface destroy/recreate
-  /// callbacks (useful when a permission dialog or OEM compositor
-  /// event — e.g. Vivo/Android 16 — temporarily destroys the
-  /// surface), at the cost of a residual race window between the
-  /// SDK-internal `ImageReaderSurfaceProducer.onImage` callback and
-  /// `FlutterJNI` detach. Only opt in when the recreate callback is
-  /// actually needed. No effect on iOS/macOS.
+  /// When [useLegacySurface] is `true` AND [useTexture] is `true`, the
+  /// Android side allocates a legacy `SurfaceTextureEntry` instead of
+  /// the default `SurfaceProducer`. The legacy backend has no
+  /// surface-recreate callback (so it can't transparently survive
+  /// permission dialogs / OEM compositor events), but it has no shared
+  /// `ImageReader` buffer pool either — which makes it immune to the
+  /// 1-frame ghost frame that surfaces when many `SurfaceProducer`-backed
+  /// players coexist and a sibling decoder is released (the feed flicker).
+  /// Use it for screens that render many players at once. No effect on
+  /// iOS/macOS. Defaults to `false`.
   DivineVideoPlayerController({
     this.useTexture = false,
-    this.useLegacySurface = true,
+    this.useLegacySurface = false,
   });
 
   /// Whether this player renders via a Flutter texture instead of a

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -176,12 +176,9 @@ void main() {
       });
 
       test(
-        'passes explicit useLegacySurface false through create',
+        'passes default useLegacySurface false through create',
         () async {
-          controller = DivineVideoPlayerController(
-            useTexture: true,
-            useLegacySurface: false,
-          );
+          controller = DivineVideoPlayerController(useTexture: true);
 
           await initController();
 

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -175,36 +175,6 @@ void main() {
         );
       });
 
-      test(
-        'defaults useLegacySurface to true when useTexture is true',
-        () async {
-          controller = DivineVideoPlayerController(useTexture: true);
-
-          await controller.initialize();
-
-          expect(globalCalls, hasLength(1));
-          expect(
-            globalCalls.first.arguments,
-            containsPair('useLegacySurface', isTrue),
-          );
-        },
-      );
-
-      test('passes explicit useLegacySurface false through create', () async {
-        controller = DivineVideoPlayerController(
-          useTexture: true,
-          useLegacySurface: false,
-        );
-
-        await controller.initialize();
-
-        expect(globalCalls, hasLength(1));
-        expect(
-          globalCalls.first.arguments,
-          containsPair('useLegacySurface', isFalse),
-        );
-      });
-
       test('throws StateError if called twice', () async {
         await initController();
 

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -175,6 +175,42 @@ void main() {
         );
       });
 
+      test(
+        'passes explicit useLegacySurface false through create',
+        () async {
+          controller = DivineVideoPlayerController(
+            useTexture: true,
+            useLegacySurface: false,
+          );
+
+          await initController();
+
+          expect(globalCalls, hasLength(1));
+          expect(
+            globalCalls.first.arguments,
+            containsPair('useLegacySurface', isFalse),
+          );
+        },
+      );
+
+      test(
+        'passes explicit useLegacySurface true through create',
+        () async {
+          controller = DivineVideoPlayerController(
+            useTexture: true,
+            useLegacySurface: true,
+          );
+
+          await initController();
+
+          expect(globalCalls, hasLength(1));
+          expect(
+            globalCalls.first.arguments,
+            containsPair('useLegacySurface', isTrue),
+          );
+        },
+      );
+
       test('throws StateError if called twice', () async {
         await initController();
 

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -651,7 +651,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     // Trade-off: no surface-recreate callback (e.g. permission dialogs);
     // acceptable for the feed because the screen is always foregrounded
     // while videos are playing. No effect on iOS/macOS.
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      useLegacySurface: true,
+    );
     _controllers[index] = controller;
 
     bool ownsInit() {


### PR DESCRIPTION
Closes #4459

Reverts divinevideo/divine-mobile#4404

This PR changes the default value for **every** `DivineVideoPlayer` back to the old Android legacy surface. We already know that the old surface causes issues in the video editor, which is exactly why we moved away from it before. We only need the old surface in the feed for now, because otherwise there is flickering between video players until the Flutter team fixes that issue.

Switching every video player back to the legacy surface just reintroduces problems we already fixed.

@realmeylisdev I tested this on my Samsung Galaxy and I was not able to reproduce the issue before or after this change. Were you able to reproduce it on a real device and verify that this actually fixes it? 
Because I’m pretty sure this would not solve the issue at all, especially since we never shipped the new surface to production users yet so the fix undo something which users never had in the play-store version. That would mean somebody internally must have experienced this issue that we see it in Crashlytics.
