### PR TITLE
fix(web): use optimized video playback URLs

### DIFF
--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -366,13 +366,14 @@ class WebVideoFeedState extends State<WebVideoFeed> {
           return const ColoredBox(color: VineTheme.backgroundColor);
         }
 
+        final playbackUrl = video.getOptimalVideoUrlForPlatform() ?? videoUrl;
         final playerKey = _getPlayerKey(index);
 
         return _WebVideoFeedItem(
           video: video,
           index: index,
           isActive: isActive,
-          videoUrl: videoUrl,
+          videoUrl: playbackUrl,
           playerKey: playerKey,
           headers: widget.headers,
           controllerFactory: widget.controllerFactory,

--- a/mobile/test/widgets/web_video_feed_test.dart
+++ b/mobile/test/widgets/web_video_feed_test.dart
@@ -161,7 +161,7 @@ VideoEvent _makeDivineVideo() {
     createdAt: 1700000000,
     content: 'Divine video',
     timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
-    videoUrl: 'https://media.divine.video/$hash/720p.mp4',
+    videoUrl: 'https://media.divine.video/$hash',
   );
 }
 
@@ -417,11 +417,14 @@ void main() {
   });
 
   testWidgets(
-    'forwards HLS fallback URLs for Divine media to the auth player',
+    'uses optimized playback and HLS fallback URLs for Divine media',
     (tester) async {
       Future<String?> provider(String url, String method) async {
         return 'Nostr test-header';
       }
+
+      const hash =
+          'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
 
       await tester.pumpWidget(
         MaterialApp(
@@ -436,6 +439,7 @@ void main() {
       await tester.pump();
 
       final player = tester.widget<WebVideoPlayer>(find.byType(WebVideoPlayer));
+      expect(player.url, equals('https://media.divine.video/$hash/720p.mp4'));
       expect(player.hlsFallbackUrl, isNotNull);
       expect(player.hlsFallbackUrl, contains('/hls/'));
       expect(player.hlsFallbackUrl, endsWith('.m3u8'));


### PR DESCRIPTION
Closes #4462

## Summary
- route web feed playback through VideoEvent.getOptimalVideoUrlForPlatform()
- keep HLS fallback wiring intact for the auth web player
- add a regression assertion for bare Divine media hash URLs

## Verification
- flutter test test/widgets/web_video_feed_test.dart
- flutter analyze lib/widgets/web_video_feed.dart test/widgets/web_video_feed_test.dart
- flutter build web --release --tree-shake-icons --optimization-level=4 --pwa-strategy=none --dart-define=BACKEND_URL=https://api.openvine.co --dart-define=ENVIRONMENT=production --dart-define=GH_ACTIONS_PR_PREVIEW=true --no-source-maps