### PR TITLE
fix(inbox): sanitize unpaired UTF-16 surrogates in DM bubbles

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -80,7 +80,13 @@ class MessageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final videoMatch = divineVideoUrlRegex.firstMatch(message);
+    // NIP-17 rumor bodies (and any sender-controlled text reaching the
+    // app via JSON `\uXXXX` escapes) can carry unpaired UTF-16
+    // surrogates that crash Flutter's text renderer. Sanitize once at
+    // the top so every downstream substring / split / Text widget sees
+    // well-formed input.
+    final safeMessage = StringUtils.sanitizeUtf16(message);
+    final videoMatch = divineVideoUrlRegex.firstMatch(safeMessage);
     final videoStableId = videoMatch?.group(1);
 
     // Slice the message body around the video URL.
@@ -100,10 +106,10 @@ class MessageBubble extends StatelessWidget {
     final String? personalMessage;
     final String? textAfterUrl;
     if (videoMatch != null) {
-      final after = message.substring(videoMatch.end).trim();
+      final after = safeMessage.substring(videoMatch.end).trim();
       textAfterUrl = after.isEmpty ? null : after;
 
-      final beforeLines = message
+      final beforeLines = safeMessage
           .substring(0, videoMatch.start)
           .split('\n')
           .map((line) => line.trim())
@@ -211,7 +217,7 @@ class MessageBubble extends StatelessWidget {
                         ),
                       ),
                   ] else
-                    _MessageText(message: message, isSent: isSent),
+                    _MessageText(message: safeMessage, isSent: isSent),
                 ],
               ),
             ),
@@ -346,10 +352,7 @@ class _MessageText extends StatelessWidget {
 /// and renders state via [BlocBuilder]. Falls back to a tappable link when
 /// the video cannot be resolved.
 class _VideoLinkPreview extends ConsumerWidget {
-  const _VideoLinkPreview({
-    required this.videoStableId,
-    required this.isSent,
-  });
+  const _VideoLinkPreview({required this.videoStableId, required this.isSent});
 
   final String videoStableId;
   final bool isSent;

--- a/mobile/lib/utils/string_utils.dart
+++ b/mobile/lib/utils/string_utils.dart
@@ -41,4 +41,36 @@ class StringUtils {
   /// locale-aware number formatting across the app.
   static String formatCompactNumber(int number, {String? locale}) =>
       CountFormatter.formatCompact(number, locale: locale);
+
+  /// Strip unpaired UTF-16 surrogate code units from [input].
+  ///
+  /// Flutter's text rendering asserts that strings are well-formed UTF-16.
+  /// Sender-controlled content reaching the app via JSON `\uXXXX` escapes
+  /// (notably NIP-17 DM rumor bodies after `jsonDecode`) can carry
+  /// unpaired surrogates that survive transport and crash the renderer
+  /// with `Invalid argument(s): string is not well-formed UTF-16`. Apply
+  /// this at render boundaries that display untrusted text.
+  ///
+  /// Returns [input] unchanged when it is already well-formed.
+  static String sanitizeUtf16(String input) {
+    final units = input.codeUnits;
+    final out = <int>[];
+    for (var i = 0; i < units.length; i++) {
+      final unit = units[i];
+      if (unit >= 0xD800 && unit <= 0xDBFF) {
+        final next = i + 1 < units.length ? units[i + 1] : 0;
+        if (next >= 0xDC00 && next <= 0xDFFF) {
+          out
+            ..add(unit)
+            ..add(next);
+          i++;
+        }
+      } else if (unit >= 0xDC00 && unit <= 0xDFFF) {
+        continue;
+      } else {
+        out.add(unit);
+      }
+    }
+    return out.length == units.length ? input : String.fromCharCodes(out);
+  }
 }

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -202,6 +202,34 @@ void main() {
 
         expect(align.alignment, equals(AlignmentDirectional.centerStart));
       });
+
+      testWidgets(
+        'renders without crashing when message contains an unpaired '
+        'UTF-16 surrogate',
+        (tester) async {
+          // Sender-controlled NIP-17 rumor bodies can deliver malformed
+          // UTF-16 via JSON \uXXXX escapes; the renderer asserts on
+          // well-formed UTF-16, so MessageBubble must sanitize before
+          // painting. See https://github.com/divinevideo/divine-mobile/issues/4463.
+          final malformed = 'before${String.fromCharCode(0xD83D)}after';
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: MessageBubble(
+                  message: malformed,
+                  timestamp: '2:30 PM',
+                  isSent: true,
+                ),
+              ),
+            ),
+          );
+
+          expect(tester.takeException(), isNull);
+          expect(find.text('beforeafter'), findsOneWidget);
+        },
+      );
     });
 
     group('URL linkification', () {

--- a/mobile/test/utils/string_utils_test.dart
+++ b/mobile/test/utils/string_utils_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/string_utils.dart';
+
+void main() {
+  group(StringUtils, () {
+    group('sanitizeUtf16', () {
+      test('returns identical instance when input is plain ASCII', () {
+        const input = 'hello world';
+        expect(identical(StringUtils.sanitizeUtf16(input), input), isTrue);
+      });
+
+      test('returns identical instance when input is empty', () {
+        const input = '';
+        expect(identical(StringUtils.sanitizeUtf16(input), input), isTrue);
+      });
+
+      test('preserves a well-formed surrogate pair (emoji)', () {
+        // U+1F600 GRINNING FACE = D83D DE00
+        const input = 'hi 😀';
+        final result = StringUtils.sanitizeUtf16(input);
+        expect(result, equals(input));
+        expect(result.runes.last, equals(0x1F600));
+      });
+
+      test('drops an unpaired high surrogate', () {
+        final input = 'a${String.fromCharCode(0xD83D)}b';
+        expect(StringUtils.sanitizeUtf16(input), equals('ab'));
+      });
+
+      test('drops an unpaired low surrogate', () {
+        final input = 'a${String.fromCharCode(0xDE00)}b';
+        expect(StringUtils.sanitizeUtf16(input), equals('ab'));
+      });
+
+      test('drops a trailing unpaired high surrogate', () {
+        final input = 'trail${String.fromCharCode(0xD83D)}';
+        expect(StringUtils.sanitizeUtf16(input), equals('trail'));
+      });
+
+      test('drops a high surrogate followed by a non-surrogate', () {
+        final input = '${String.fromCharCode(0xD83D)}x';
+        expect(StringUtils.sanitizeUtf16(input), equals('x'));
+      });
+
+      test('preserves adjacent valid pairs separated by an unpaired one', () {
+        final input = '😀${String.fromCharCode(0xD83D)}😀';
+        final result = StringUtils.sanitizeUtf16(input);
+        expect(result, equals('😀😀'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `StringUtils.sanitizeUtf16` — strips unpaired UTF-16 surrogate code units, returns the same instance when input is already well-formed
- Applies it once at the top of `MessageBubble.build` so substring/split and the downstream `Text` widget all see clean input
- New unit tests for the sanitizer and a widget test asserting `MessageBubble` doesn't crash on an unpaired surrogate

## Why

NIP-17 rumor bodies and other sender-controlled text reach the app via JSON `\uXXXX` escapes that can carry unpaired surrogates. Strict UTF-8 in the local nip44 path catches byte-level malformations, but JSON-decoded escape sequences slip through. Flutter's text renderer asserts well-formed UTF-16 and crashes with `Invalid argument(s): string is not well-formed UTF-16`, taking out the open conversation. Surfaced in production logs after PR #4451 made the inbox usable on staging.

Closes #4463.

## Test plan

- [x] `flutter test test/utils/string_utils_test.dart` — 8 sanitizer cases (ASCII identity, empty identity, emoji preserved, unpaired high/low/trailing dropped, valid pairs around unpaired)
- [x] `flutter test test/screens/inbox/conversation/widgets/message_bubble_test.dart` — 29 cases incl. new surrogate-doesn't-crash assertion
- [x] `flutter analyze` clean on the three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)