### PR TITLE
feat(feed): prefetch 10 from end + show loading pill at last video

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2262,6 +2262,10 @@
   "feedExploreVideos": "Explore Videos",
   "feedExternalVideoSlow": "External video loading slowly",
   "feedSkip": "Skip",
+  "feedLoadingMore": "Loading more videos…",
+  "@feedLoadingMore": {
+    "description": "Shown in a small pill at the bottom of the fullscreen video feed while the next page of videos is being fetched."
+  },
   "uploadWaitingToUpload": "Waiting to upload",
   "uploadUploadingVideo": "Uploading video",
   "uploadProcessingVideo": "Processing video",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7238,6 +7238,12 @@ abstract class AppLocalizations {
   /// **'Skip'**
   String get feedSkip;
 
+  /// Shown in a small pill at the bottom of the fullscreen video feed while the next page of videos is being fetched.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading more videos…'**
+  String get feedLoadingMore;
+
   /// No description provided for @uploadWaitingToUpload.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4043,6 +4043,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get feedSkip => 'ዝለል';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'ለመስቀል በመጠበቅ ላይ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4089,6 +4089,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get feedSkip => 'تخطي';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'في انتظار الرفع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4177,6 +4177,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get feedSkip => 'Пропускане';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Чака качване';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4182,6 +4182,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get feedSkip => 'Überspringen';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Warten auf Upload';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4132,6 +4132,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get feedSkip => 'Skip';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Waiting to upload';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4178,6 +4178,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get feedSkip => 'Saltar';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Esperando para subir';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4190,6 +4190,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get feedSkip => 'Laktawan';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Naghihintay i-upload';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4194,6 +4194,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get feedSkip => 'Passer';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'En attente d\'envoi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4103,6 +4103,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get feedSkip => 'Lewati';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Menunggu unggah';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4176,6 +4176,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get feedSkip => 'Salta';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'In attesa di caricamento';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3934,6 +3934,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get feedSkip => 'スキップ';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'アップロード待ち';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3949,6 +3949,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get feedSkip => '건너뛰기';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => '업로드 대기 중';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4147,6 +4147,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get feedSkip => 'Overslaan';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Wachten om te uploaden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4239,6 +4239,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get feedSkip => 'Pomiń';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Czekam na przesłanie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4157,6 +4157,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get feedSkip => 'Pular';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Aguardando envio';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4255,6 +4255,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get feedSkip => 'Sari peste';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Se așteaptă încărcarea';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4129,6 +4129,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get feedSkip => 'Hoppa över';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Väntar på att laddas upp';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4113,6 +4113,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get feedSkip => 'Atla';
 
   @override
+  String get feedLoadingMore => 'Loading more videos…';
+
+  @override
   String get uploadWaitingToUpload => 'Yüklemek için bekleniyor';
 
   @override

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -550,12 +550,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   }
 
   void _onNearEnd(FullscreenFeedState state, int index) {
-    if (!state.canLoadMore) {
-      return;
-    }
-
-    final isAtEnd = index >= state.videos.length - 1;
-    if (isAtEnd) {
+    if (state.canLoadMore) {
       _triggerLoadMore();
     }
   }
@@ -872,163 +867,176 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       // shares its hex (`#00150D`) with the comment
                       // bar's [VineTheme.surfaceBackground], so the
                       // rounded cutouts seam continuously into the bar.
-                      child: VideoTapShield(
-                        child: _MaybeRoundFeedBottom(
-                          roundCorners: showCommentBar,
-                          child:
-                              InfiniteVideoFeed.isSupported &&
-                                  ref.watch(
-                                    isFeatureEnabledProvider(
-                                      .nativeFeedPlayer,
-                                    ),
-                                  )
-                              ? FeedVideos(
-                                  key: _feedVideosKey,
-                                  videos: state.videos,
-                                  contextTitle: widget.contextTitle,
-                                  currentIndex: state.currentIndex,
-                                  shouldPortraitExpand: false,
-                                  hasMore: state.canLoadMore,
-                                  isLoadingMore: state.isLoadingMore,
-                                  onActiveVideoChanged: (video, index) {
-                                    _resumeAutoAdvanceAfterSwipe();
-                                    FeedPerformanceTracker()
-                                        .startVideoSwipeTracking(
-                                          video.id,
-                                        );
-                                    context.read<FullscreenFeedBloc>().add(
-                                      FullscreenFeedIndexChanged(index),
-                                    );
-                                    widget.onPageChanged?.call(index);
-                                  },
-                                  onNearEnd: () {
-                                    if (state.canLoadMore) {
-                                      _triggerLoadMore();
-                                    }
-                                  },
-                                )
-                              : kIsWeb
-                              ? WebVideoFeed(
-                                  key: _webFeedKey,
-                                  videos: state.videos
-                                      .where((v) => v.videoUrl != null)
-                                      .toList(),
-                                  initialIndex: state.currentIndex,
-                                  controllerFactory:
-                                      widget.webControllerFactory ??
-                                      defaultWebVideoPlayerControllerFactory,
-                                  authHeaderProvider: webAuthHeaderProvider,
-                                  initialVolume: context
-                                      .read<VideoVolumeCubit>()
-                                      .state
-                                      .volume,
-                                  onActiveVideoChanged: (video, index) {
-                                    _pagePosition.value = index.toDouble();
-                                    _resumeAutoAdvanceAfterSwipe();
-                                    FeedPerformanceTracker()
-                                        .startVideoSwipeTracking(
-                                          video.id,
-                                        );
-                                    context.read<FullscreenFeedBloc>().add(
-                                      FullscreenFeedIndexChanged(index),
-                                    );
-                                    widget.onPageChanged?.call(index);
-                                  },
-                                  onCompleted: (_) =>
-                                      _handleAutoAdvanceCompleted(),
-                                  onErrored: _handleWebPlayerErrored,
-                                  onRequiresAuth: _handleWebPlayerRequiresAuth,
-                                  onNearEnd: (index) =>
-                                      _onNearEnd(state, index),
-                                  itemBuilder:
-                                      (
-                                        context,
-                                        video,
-                                        index, {
-                                        required isActive,
-                                        controller,
-                                      }) {
-                                        return _WebFullscreenItem(
-                                          video: video,
-                                          isActive: isActive,
-                                          isOwnVideo:
-                                              currentUserPubkey == video.pubkey,
-                                          controller: controller,
-                                          contextTitle: widget.contextTitle,
-                                          onInteracted: _suppressAutoAdvance,
-                                        );
-                                      },
-                                )
-                              : PooledVideoFeed(
-                                  key: _feedKey,
-                                  videos: state.pooledVideos,
-                                  controller: _controller,
-                                  initialIndex: state.currentIndex,
-                                  onActiveVideoChanged: (video, index) {
-                                    _resumeAutoAdvanceAfterSwipe();
-                                    FeedPerformanceTracker()
-                                        .startVideoSwipeTracking(
-                                          video.id,
-                                        );
-                                    context.read<FullscreenFeedBloc>().add(
-                                      FullscreenFeedIndexChanged(index),
-                                    );
-                                    widget.onPageChanged?.call(index);
-                                  },
-                                  onNearEnd: (index) =>
-                                      _onNearEnd(state, index),
-                                  nearEndThreshold: 0,
-                                  onScrollOffsetChanged: (page) =>
-                                      _pagePosition.value = page,
-                                  maxLoopDuration:
-                                      VideoEditorConstants.maxDuration,
-                                  itemBuilder: (context, video, index, {required isActive}) {
-                                    if (state.videos.isEmpty) {
-                                      debugPrint(
-                                        'FullscreenFeed: itemBuilder called with empty '
-                                        'state.videos! index=$index, '
-                                        'video.id=${video.id}',
-                                      );
-                                      return const ColoredBox(
-                                        color: VineTheme.backgroundColor,
-                                      );
-                                    }
-                                    final originalEvent = state.videos.firstWhere(
-                                      (v) => v.id == video.id,
-                                      orElse: () {
-                                        final clamped = index.clamp(
-                                          0,
-                                          state.videos.length - 1,
-                                        );
-                                        debugPrint(
-                                          'FullscreenFeed: video ID lookup miss! '
-                                          'video.id=${video.id}, index=$index, '
-                                          'clamped=$clamped, '
-                                          'state.videos.length='
-                                          '${state.videos.length}, '
-                                          'pooledVideos.length='
-                                          '${state.pooledVideos.length}',
-                                        );
-                                        return state.videos[clamped];
-                                      },
-                                    );
-                                    return _PooledFullscreenItem(
-                                      video: originalEvent,
-                                      index: index,
-                                      isActive: isActive,
-                                      pagePosition: _pagePosition,
+                      child: Stack(
+                        children: [
+                          VideoTapShield(
+                            child: _MaybeRoundFeedBottom(
+                              roundCorners: showCommentBar,
+                              child:
+                                  InfiniteVideoFeed.isSupported &&
+                                      ref.watch(
+                                        isFeatureEnabledProvider(
+                                          .nativeFeedPlayer,
+                                        ),
+                                      )
+                                  ? FeedVideos(
+                                      key: _feedVideosKey,
+                                      videos: state.videos,
                                       contextTitle: widget.contextTitle,
-                                      trafficSource: widget.trafficSource,
-                                      sourceDetail: widget.sourceDetail,
-                                      isOwnVideo: isOwnVideo,
-                                      isAutoAdvanceActive: effectiveAutoActive,
-                                      onInteracted: _suppressAutoAdvance,
-                                      onAutoAdvanceCompleted:
-                                          _handleAutoAdvanceCompleted,
-                                    );
-                                  },
-                                ),
-                        ),
+                                      currentIndex: state.currentIndex,
+                                      shouldPortraitExpand: false,
+                                      hasMore: state.canLoadMore,
+                                      isLoadingMore: state.isLoadingMore,
+                                      onActiveVideoChanged: (video, index) {
+                                        _resumeAutoAdvanceAfterSwipe();
+                                        FeedPerformanceTracker()
+                                            .startVideoSwipeTracking(video.id);
+                                        context.read<FullscreenFeedBloc>().add(
+                                          FullscreenFeedIndexChanged(index),
+                                        );
+                                        widget.onPageChanged?.call(index);
+                                      },
+                                      onNearEnd: () {
+                                        if (state.canLoadMore) {
+                                          _triggerLoadMore();
+                                        }
+                                      },
+                                    )
+                                  : kIsWeb
+                                  ? WebVideoFeed(
+                                      key: _webFeedKey,
+                                      videos: state.videos
+                                          .where((v) => v.videoUrl != null)
+                                          .toList(),
+                                      initialIndex: state.currentIndex,
+                                      controllerFactory:
+                                          widget.webControllerFactory ??
+                                          defaultWebVideoPlayerControllerFactory,
+                                      authHeaderProvider: webAuthHeaderProvider,
+                                      initialVolume: context
+                                          .read<VideoVolumeCubit>()
+                                          .state
+                                          .volume,
+                                      onActiveVideoChanged: (video, index) {
+                                        _pagePosition.value = index.toDouble();
+                                        _resumeAutoAdvanceAfterSwipe();
+                                        FeedPerformanceTracker()
+                                            .startVideoSwipeTracking(video.id);
+                                        context.read<FullscreenFeedBloc>().add(
+                                          FullscreenFeedIndexChanged(index),
+                                        );
+                                        widget.onPageChanged?.call(index);
+                                      },
+                                      onCompleted: (_) =>
+                                          _handleAutoAdvanceCompleted(),
+                                      onErrored: _handleWebPlayerErrored,
+                                      onRequiresAuth:
+                                          _handleWebPlayerRequiresAuth,
+                                      onNearEnd: (index) =>
+                                          _onNearEnd(state, index),
+                                      nearEndThreshold: 10,
+                                      itemBuilder:
+                                          (
+                                            context,
+                                            video,
+                                            index, {
+                                            required isActive,
+                                            controller,
+                                          }) {
+                                            return _WebFullscreenItem(
+                                              video: video,
+                                              isActive: isActive,
+                                              isOwnVideo:
+                                                  currentUserPubkey ==
+                                                  video.pubkey,
+                                              controller: controller,
+                                              contextTitle: widget.contextTitle,
+                                              onInteracted:
+                                                  _suppressAutoAdvance,
+                                            );
+                                          },
+                                    )
+                                  : PooledVideoFeed(
+                                      key: _feedKey,
+                                      videos: state.pooledVideos,
+                                      controller: _controller,
+                                      initialIndex: state.currentIndex,
+                                      onActiveVideoChanged: (video, index) {
+                                        _resumeAutoAdvanceAfterSwipe();
+                                        FeedPerformanceTracker()
+                                            .startVideoSwipeTracking(video.id);
+                                        context.read<FullscreenFeedBloc>().add(
+                                          FullscreenFeedIndexChanged(index),
+                                        );
+                                        widget.onPageChanged?.call(index);
+                                      },
+                                      onNearEnd: (index) =>
+                                          _onNearEnd(state, index),
+                                      nearEndThreshold: 10,
+                                      onScrollOffsetChanged: (page) =>
+                                          _pagePosition.value = page,
+                                      maxLoopDuration:
+                                          VideoEditorConstants.maxDuration,
+                                      itemBuilder: (context, video, index, {required isActive}) {
+                                        if (state.videos.isEmpty) {
+                                          debugPrint(
+                                            'FullscreenFeed: itemBuilder called with empty '
+                                            'state.videos! index=$index, '
+                                            'video.id=${video.id}',
+                                          );
+                                          return const ColoredBox(
+                                            color: VineTheme.backgroundColor,
+                                          );
+                                        }
+                                        final originalEvent = state.videos.firstWhere(
+                                          (v) => v.id == video.id,
+                                          orElse: () {
+                                            final clamped = index.clamp(
+                                              0,
+                                              state.videos.length - 1,
+                                            );
+                                            debugPrint(
+                                              'FullscreenFeed: video ID lookup miss! '
+                                              'video.id=${video.id}, index=$index, '
+                                              'clamped=$clamped, '
+                                              'state.videos.length='
+                                              '${state.videos.length}, '
+                                              'pooledVideos.length='
+                                              '${state.pooledVideos.length}',
+                                            );
+                                            return state.videos[clamped];
+                                          },
+                                        );
+                                        return _PooledFullscreenItem(
+                                          video: originalEvent,
+                                          index: index,
+                                          isActive: isActive,
+                                          pagePosition: _pagePosition,
+                                          contextTitle: widget.contextTitle,
+                                          trafficSource: widget.trafficSource,
+                                          sourceDetail: widget.sourceDetail,
+                                          isOwnVideo: isOwnVideo,
+                                          isAutoAdvanceActive:
+                                              effectiveAutoActive,
+                                          onInteracted: _suppressAutoAdvance,
+                                          onAutoAdvanceCompleted:
+                                              _handleAutoAdvanceCompleted,
+                                        );
+                                      },
+                                    ),
+                            ),
+                          ),
+                          Positioned(
+                            left: 0,
+                            right: 0,
+                            bottom: 16,
+                            child: LoadingMorePill(
+                              isVisible:
+                                  state.isLoadingMore &&
+                                  state.currentIndex >= state.videos.length - 1,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                     if (showCommentBar) const InlineCommentComposerBar(),
@@ -1394,9 +1402,7 @@ class _PooledFullscreenItemContentState
             // cover the screen entirely and would never reveal the
             // backdrop, so we skip it for them.
             if (showBlurBackdrop)
-              Positioned.fill(
-                child: _BlurredVideoBackdrop(url: thumbnailUrl),
-              ),
+              Positioned.fill(child: _BlurredVideoBackdrop(url: thumbnailUrl)),
             PooledVideoPlayer(
               index: widget.index,
               isActive: widget.isActive,
@@ -1675,9 +1681,7 @@ class _FittedVideoPlayer extends StatelessWidget {
       builder: (context, rect, _) {
         final detected = _detectPortrait(rect, fallback: isPortrait);
         final boxFit = detected ? BoxFit.cover : BoxFit.contain;
-        final alignment = fullscreenVideoMediaAlignment(
-          isPortrait: detected,
-        );
+        final alignment = fullscreenVideoMediaAlignment(isPortrait: detected);
         // Do not set filterQuality to high — on Android the bicubic
         // interpolation causes visible blur on the Texture widget
         // when the video resolution doesn't match the display size
@@ -1703,10 +1707,7 @@ class _FittedVideoPlayer extends StatelessWidget {
 }
 
 class _VideoLoadingPlaceholder extends StatelessWidget {
-  const _VideoLoadingPlaceholder({
-    this.thumbnailUrl,
-    this.isPortrait = true,
-  });
+  const _VideoLoadingPlaceholder({this.thumbnailUrl, this.isPortrait = true});
 
   final String? thumbnailUrl;
   final bool isPortrait;
@@ -1819,6 +1820,54 @@ class _MaybeRoundFeedBottom extends StatelessWidget {
     return NavRoundedShell(
       innerColor: VineTheme.surfaceContainerHigh,
       child: child,
+    );
+  }
+}
+
+/// Bottom-center pill shown while the fullscreen feed is fetching the
+/// next page of videos and the user is already on the last item.
+/// Hidden (with a short fade) otherwise so it doesn't sit on top of
+/// the video chrome during normal scrolling.
+@visibleForTesting
+class LoadingMorePill extends StatelessWidget {
+  @visibleForTesting
+  const LoadingMorePill({required this.isVisible, super.key});
+
+  final bool isVisible;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 200),
+        opacity: isVisible ? 1 : 0,
+        child: Center(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: VineTheme.surfaceBackground.withValues(alpha: 0.85),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 10,
+                children: [
+                  const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: BrandedLoadingIndicator(size: 16),
+                  ),
+                  Text(
+                    context.l10n.feedLoadingMore,
+                    style: VineTheme.bodyMediumFont(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -441,6 +441,10 @@ const _knownUntranslatedDebt = {
   'videoOverlayCommentBarSendLabel',
   'videoOverlayCommentPostedSnackbar',
   'videoOverlayCommentPostFailedSnackbar',
+  // Added by the end-of-feed loading pill on the fullscreen video feed.
+  // Translators will pick this up in a follow-up pass; until then non-English
+  // locales fall back to the English source.
+  'feedLoadingMore',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -855,6 +855,185 @@ void main() {
       });
 
       testWidgets(
+        'dispatches FullscreenFeedLoadMoreRequested for prefetch indices '
+        'before the last item (not only at the end)',
+        (tester) async {
+          // Regression: _onNearEnd previously gated on isAtEnd, defeating
+          // the underlying widget's nearEndThreshold so the next page only
+          // loaded when the user reached the very last video. The wrapper
+          // must now trust the threshold and dispatch on any prefetch call
+          // when canLoadMore is true.
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                canLoadMore: true,
+              ),
+            ),
+          );
+
+          final pooledVideoFeed = tester.widget<PooledVideoFeed>(
+            find.byType(PooledVideoFeed),
+          );
+
+          pooledVideoFeed.onNearEnd?.call(0);
+
+          verify(
+            () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'does not dispatch FullscreenFeedLoadMoreRequested when '
+        'canLoadMore is false',
+        (tester) async {
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
+            ),
+          );
+
+          final pooledVideoFeed = tester.widget<PooledVideoFeed>(
+            find.byType(PooledVideoFeed),
+          );
+
+          pooledVideoFeed.onNearEnd?.call(2);
+
+          verifyNever(
+            () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
+          );
+        },
+      );
+
+      testWidgets('passes nearEndThreshold of 10 to PooledVideoFeed', (
+        tester,
+      ) async {
+        final videos = createTestVideos();
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
+              canLoadMore: true,
+            ),
+          ),
+        );
+
+        final pooledVideoFeed = tester.widget<PooledVideoFeed>(
+          find.byType(PooledVideoFeed),
+        );
+
+        expect(pooledVideoFeed.nearEndThreshold, equals(10));
+      });
+
+      testWidgets(
+        'shows LoadingMorePill (visible) on last video while loading more',
+        (tester) async {
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                currentIndex: videos.length - 1,
+                isLoadingMore: true,
+                canLoadMore: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          final pill = tester.widget<LoadingMorePill>(
+            find.byType(LoadingMorePill),
+          );
+          expect(pill.isVisible, isTrue);
+        },
+      );
+
+      testWidgets(
+        'hides LoadingMorePill when isLoadingMore is false',
+        (tester) async {
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                currentIndex: videos.length - 1,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          final pill = tester.widget<LoadingMorePill>(
+            find.byType(LoadingMorePill),
+          );
+          expect(pill.isVisible, isFalse);
+        },
+      );
+
+      testWidgets(
+        'hides LoadingMorePill when not on the last video',
+        (tester) async {
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                isLoadingMore: true,
+                canLoadMore: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          final pill = tester.widget<LoadingMorePill>(
+            find.byType(LoadingMorePill),
+          );
+          expect(pill.isVisible, isFalse);
+        },
+      );
+
+      testWidgets(
+        'LoadingMorePill renders localized feedLoadingMore copy when visible',
+        (tester) async {
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+                currentIndex: videos.length - 1,
+                isLoadingMore: true,
+                canLoadMore: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          final loadingMoreText = lookupAppLocalizations(
+            const Locale('en'),
+          ).feedLoadingMore;
+          expect(find.text(loadingMoreText), findsOneWidget);
+        },
+      );
+
+      testWidgets(
         'navigator.maybePop fires when status becomes emptyAfterRemoval',
         (tester) async {
           // Capture pops via a NavigatorObserver. The widget tree puts


### PR DESCRIPTION
Closes #4469

## Summary

The fullscreen "New Videos" feed only loaded more videos when the user reached the very last item, so swiping forward could stall on a black page while the next page fetched.

Root cause in `pooled_fullscreen_video_feed_screen.dart`:
- `_onNearEnd` (line 557) gated with `isAtEnd = index >= state.videos.length - 1`, which defeated whatever threshold the underlying feed widget used.
- `PooledVideoFeed` was wired with `nearEndThreshold: 0` (line 902) — explicit "only at the end" behavior.
- The `WebVideoFeed` path inherited the same `_onNearEnd` gate even though its package default threshold is 3.

Changes:
- Drop the `isAtEnd` gate in `_onNearEnd` — just trust the widget's threshold and dispatch when `canLoadMore` is true.
- Set `nearEndThreshold: 10` on both `PooledVideoFeed` and `WebVideoFeed` (native `FeedVideos` already defaults to 10 via `InfiniteVideoFeed`).
- Add a low-profile "Loading more videos…" pill that fades in at the bottom-center when `isLoadingMore` is true and the user is on the last visible video, so prefetch lag is no longer invisible.
- l10n: add `feedLoadingMore` to `app_en.arb`, add to the ARB-consistency allowlist, regenerate locales.

The home feed (`video_feed_page.dart`) was unaffected — it already trusted each widget's threshold and only checked `state.hasMore`.

## Test plan

- [x] `flutter analyze lib test integration_test` — no issues
- [x] `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — 37 pass / 4 skipped (pre-existing)
- [x] `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart` — pass (web-only skipped on host)
- [x] `flutter test test/l10n/arb_consistency_test.dart` — pass
- [x] Added regression coverage:
  - dispatches `LoadMoreRequested` for prefetch indices before the last item
  - does NOT dispatch when `canLoadMore` is false
  - `PooledVideoFeed.nearEndThreshold == 10`
  - `LoadingMorePill` visible when on last + isLoadingMore
  - hidden when not loading, and when not on last
  - renders localized `feedLoadingMore` copy
- [ ] Smoke-test on device: swipe through the New Videos fullscreen feed, confirm next page arrives before reaching the last item; on slow network, confirm the pill appears on the last video and fades out when more arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)