### PR TITLE
fix(notifications): preserve cached feed and grouped reads

### DIFF
--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -17,6 +17,7 @@ class ActorNotification extends NotificationItem {
     super.isRead,
     super.targetEventId,
     super.sourceEventIds,
+    super.notificationIds,
     this.commentText,
     this.isFollowingBack = false,
     this.videoAddressableId,
@@ -60,6 +61,7 @@ class ActorNotification extends NotificationItem {
     bool? isFollowingBack,
     String? targetEventId,
     List<String>? sourceEventIds,
+    List<String>? notificationIds,
     String? videoAddressableId,
   }) {
     return ActorNotification(
@@ -72,6 +74,7 @@ class ActorNotification extends NotificationItem {
       isFollowingBack: isFollowingBack ?? this.isFollowingBack,
       targetEventId: targetEventId ?? this.targetEventId,
       sourceEventIds: sourceEventIds ?? this.sourceEventIds,
+      notificationIds: notificationIds ?? this.notificationIds,
       videoAddressableId: videoAddressableId ?? this.videoAddressableId,
     );
   }
@@ -87,6 +90,7 @@ class ActorNotification extends NotificationItem {
     isFollowingBack,
     targetEventId,
     sourceEventIds,
+    notificationIds,
     videoAddressableId,
   ];
 }

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -40,6 +40,7 @@ sealed class NotificationItem extends Equatable {
     this.isRead = false,
     this.targetEventId,
     this.sourceEventIds = const [],
+    this.notificationIds = const [],
   });
 
   final String id;
@@ -60,4 +61,11 @@ sealed class NotificationItem extends Equatable {
   /// notifications this is the union of all underlying likes/comments/
   /// reposts contributing to the row.
   final List<String> sourceEventIds;
+
+  /// Raw relay notification ids represented by this rendered row.
+  ///
+  /// Grouped rows can stand in for multiple server notifications. Mark-read
+  /// writes must send every underlying raw id or a later refresh can
+  /// resurrect unread state for the same visible row.
+  final List<String> notificationIds;
 }

--- a/mobile/packages/models/lib/src/video_notification.dart
+++ b/mobile/packages/models/lib/src/video_notification.dart
@@ -20,6 +20,7 @@ class VideoNotification extends NotificationItem {
     required super.timestamp,
     super.isRead,
     super.sourceEventIds,
+    super.notificationIds,
     this.videoThumbnailUrl,
     this.videoTitle,
     this.videoAddressableId,
@@ -85,6 +86,7 @@ class VideoNotification extends NotificationItem {
     bool? isRead,
     String? commentText,
     List<String>? sourceEventIds,
+    List<String>? notificationIds,
   }) {
     return VideoNotification(
       id: id ?? this.id,
@@ -99,6 +101,7 @@ class VideoNotification extends NotificationItem {
       isRead: isRead ?? this.isRead,
       commentText: commentText ?? this.commentText,
       sourceEventIds: sourceEventIds ?? this.sourceEventIds,
+      notificationIds: notificationIds ?? this.notificationIds,
     );
   }
 
@@ -116,5 +119,6 @@ class VideoNotification extends NotificationItem {
     isRead,
     commentText,
     sourceEventIds,
+    notificationIds,
   ];
 }

--- a/mobile/packages/models/test/src/actor_notification_test.dart
+++ b/mobile/packages/models/test/src/actor_notification_test.dart
@@ -256,5 +256,52 @@ void main() {
         expect(a, isNot(equals(b)));
       });
     });
+
+    group('notificationIds', () {
+      test('defaults to const [] when not provided', () {
+        final notification = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.follow,
+          actor: actor,
+          timestamp: timestamp,
+        );
+
+        expect(notification.notificationIds, isEmpty);
+      });
+
+      test('round-trips through copyWith', () {
+        final original = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.follow,
+          actor: actor,
+          timestamp: timestamp,
+        );
+
+        final updated = original.copyWith(
+          notificationIds: const ['notif-follow-1'],
+        );
+
+        expect(updated.notificationIds, equals(<String>['notif-follow-1']));
+      });
+
+      test('two otherwise-equal items differ by notificationIds', () {
+        final a = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.follow,
+          actor: actor,
+          timestamp: timestamp,
+          notificationIds: const ['notif-a'],
+        );
+        final b = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.follow,
+          actor: actor,
+          timestamp: timestamp,
+          notificationIds: const ['notif-b'],
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+    });
   });
 }

--- a/mobile/packages/models/test/src/video_notification_test.dart
+++ b/mobile/packages/models/test/src/video_notification_test.dart
@@ -227,5 +227,60 @@ void main() {
         expect(a, isNot(equals(b)));
       });
     });
+
+    group('notificationIds', () {
+      test('defaults to const [] when not provided', () {
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.like,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+        );
+
+        expect(notification.notificationIds, isEmpty);
+      });
+
+      test('round-trips through copyWith', () {
+        final original = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.like,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+        );
+
+        final updated = original.copyWith(
+          notificationIds: const ['notif-a', 'notif-b'],
+        );
+
+        expect(updated.notificationIds, equals(<String>['notif-a', 'notif-b']));
+      });
+
+      test('two otherwise-equal items differ by notificationIds', () {
+        final a = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.like,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          notificationIds: const ['notif-a'],
+        );
+        final b = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.like,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          notificationIds: const ['notif-b'],
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+    });
   });
 }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -361,10 +361,7 @@ class NotificationRepository {
       row.timestamp * 1000,
       isUtc: true,
     ).toLocal();
-    final actor = ActorInfo(
-      pubkey: row.fromPubkey,
-      displayName: 'Loading…',
-    );
+    final actor = ActorInfo(pubkey: row.fromPubkey, displayName: 'Loading…');
 
     // Video-anchored kinds — reconstruct VideoNotification using the cached
     // targetEventId (which `_itemToCacheRow` writes as videoEventId).
@@ -381,11 +378,12 @@ class NotificationRepository {
         timestamp: timestamp,
         isRead: row.isRead,
         commentText: videoKind == NotificationKind.comment ? row.content : null,
+        notificationIds: row.id.isNotEmpty ? [row.id] : const [],
         // sourceEventIds intentionally empty — the cache stores only the
-        // dedupeKey (`id`) and the videoEventId (`targetEventId`), not the
-        // underlying Nostr source event id. First-page REST emission
-        // replaces the placeholder, so the union-by-sourceEventId merge in
-        // _emitSnapshotForPage doesn't need a value here.
+        // persisted row id and the videoEventId (`targetEventId`), not the
+        // underlying Nostr source event id set. First-page REST emission
+        // replaces the placeholder, so the union-by-sourceEventId merge path
+        // doesn't need a value here.
       );
     }
 
@@ -399,6 +397,7 @@ class NotificationRepository {
       isRead: row.isRead,
       commentText: row.content,
       targetEventId: row.targetEventId,
+      notificationIds: row.id.isNotEmpty ? [row.id] : const [],
     );
   }
 
@@ -517,6 +516,7 @@ class NotificationRepository {
     final idSet = ids.toSet();
     final before = _snapshot.value;
     _snapshot.add(before.copyWith(items: _flipIsRead(before.items, idSet)));
+    final notificationIds = _expandServerNotificationIds(before.items, idSet);
 
     try {
       final authHeaders = _authHeadersProvider != null
@@ -528,11 +528,11 @@ class NotificationRepository {
 
       await _funnelcakeApiClient.markNotificationsRead(
         pubkey: _userPubkey,
-        notificationIds: ids,
+        notificationIds: notificationIds,
         authHeaders: authHeaders,
       );
 
-      for (final id in ids) {
+      for (final id in notificationIds) {
         await _notificationsDao.markAsRead(id);
       }
     } catch (_) {
@@ -662,6 +662,10 @@ class NotificationRepository {
           ...existing.sourceEventIds,
           ...incoming.sourceEventIds,
         }.toList();
+        final mergedNotificationIds = <String>{
+          ...existing.notificationIds,
+          ...incoming.notificationIds,
+        }.toList();
         result.add(
           existing.copyWith(
             actors: mergedActors,
@@ -669,6 +673,7 @@ class NotificationRepository {
             isRead: false,
             timestamp: incoming.timestamp,
             sourceEventIds: mergedSourceEventIds,
+            notificationIds: mergedNotificationIds,
           ),
         );
         merged = true;
@@ -803,6 +808,10 @@ class NotificationRepository {
       ...existing.sourceEventIds,
       ...incoming.sourceEventIds,
     }.toList();
+    final unionNotificationIds = <String>{
+      ...existing.notificationIds,
+      ...incoming.notificationIds,
+    }.toList();
     final mergedActors = _orderVideoGroupActors([
       ...existing.actors,
       ...incoming.actors.where(
@@ -823,6 +832,7 @@ class NotificationRepository {
         : mergedActors.length;
     return existing.copyWith(
       sourceEventIds: unionIds,
+      notificationIds: unionNotificationIds,
       actors: mergedActors,
       totalCount: mergedTotalCount,
       isRead: existing.isRead && incoming.isRead,
@@ -845,12 +855,48 @@ class NotificationRepository {
     Set<String> ids,
   ) {
     return items.map((n) {
-      if (!ids.contains(n.id) || n.isRead) return n;
+      if (!_matchesMarkReadId(n, ids) || n.isRead) return n;
       return switch (n) {
         VideoNotification() => n.copyWith(isRead: true),
         ActorNotification() => n.copyWith(isRead: true),
       };
     }).toList();
+  }
+
+  /// Expands display-row ids to all raw server notification ids represented by
+  /// those rows. Unknown ids pass through so callers can still mark a raw id
+  /// that is not present in the current snapshot.
+  static List<String> _expandServerNotificationIds(
+    List<NotificationItem> items,
+    Set<String> ids,
+  ) {
+    final expanded = <String>{};
+    final matchedInputIds = <String>{};
+
+    for (final item in items) {
+      if (!_matchesMarkReadId(item, ids)) continue;
+
+      matchedInputIds
+        ..add(item.id)
+        ..addAll(item.notificationIds.where(ids.contains));
+
+      final rawIds = item.notificationIds.isNotEmpty
+          ? item.notificationIds
+          : [item.id];
+      expanded.addAll(rawIds.where((id) => id.isNotEmpty));
+    }
+
+    for (final id in ids) {
+      if (id.isNotEmpty && !matchedInputIds.contains(id)) {
+        expanded.add(id);
+      }
+    }
+
+    return expanded.toList();
+  }
+
+  static bool _matchesMarkReadId(NotificationItem item, Set<String> ids) {
+    return ids.contains(item.id) || item.notificationIds.any(ids.contains);
   }
 
   /// Returns [items] with every item flipped to `isRead: true`.
@@ -1035,6 +1081,10 @@ class NotificationRepository {
               .map((n) => n.sourceEventId)
               .where((s) => s.isNotEmpty)
               .toList(),
+          notificationIds: group
+              .map((n) => n.dedupeKey)
+              .where((s) => s.isNotEmpty)
+              .toList(),
         ),
       );
     }
@@ -1081,6 +1131,7 @@ class NotificationRepository {
           sourceEventIds: n.sourceEventId.isNotEmpty
               ? [n.sourceEventId]
               : const [],
+          notificationIds: n.dedupeKey.isNotEmpty ? [n.dedupeKey] : const [],
           videoAddressableId: _actorVideoAddressableId(mapped, n),
         ),
       );
@@ -1137,6 +1188,7 @@ class NotificationRepository {
         sourceEventIds: raw.sourceEventId.isNotEmpty
             ? [raw.sourceEventId]
             : const [],
+        notificationIds: raw.dedupeKey.isNotEmpty ? [raw.dedupeKey] : const [],
       );
     }
 
@@ -1159,6 +1211,7 @@ class NotificationRepository {
       sourceEventIds: raw.sourceEventId.isNotEmpty
           ? [raw.sourceEventId]
           : const [],
+      notificationIds: raw.dedupeKey.isNotEmpty ? [raw.dedupeKey] : const [],
       videoAddressableId: _actorVideoAddressableId(mapped, raw),
     );
   }

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -70,9 +70,7 @@ void main() {
     when(
       () => notificationsDao.getAllNotifications(limit: any(named: 'limit')),
     ).thenAnswer((_) async => <NotificationRow>[]);
-    when(
-      () => notificationsDao.replaceAll(any()),
-    ).thenAnswer((_) async {});
+    when(() => notificationsDao.replaceAll(any())).thenAnswer((_) async {});
     repository = NotificationRepository(
       funnelcakeApiClient: funnelcakeApiClient,
       profileRepository: profileRepository,
@@ -297,42 +295,39 @@ void main() {
         },
       );
 
-      test(
-        'explicit cursor override does not leak stored cursor id',
-        () async {
-          var signedUrl = '';
-          repository = NotificationRepository(
-            funnelcakeApiClient: funnelcakeApiClient,
-            profileRepository: profileRepository,
-            notificationsDao: notificationsDao,
-            userPubkey: userPubkey,
-            authHeadersProvider: (url, method) async {
-              signedUrl = url;
-              return {'Authorization': 'Nostr test-token'};
-            },
-          );
-          stubNotifications(
-            [],
-            nextCursor: '1700000000',
-            nextCursorId: stableCursorId,
-            hasMore: true,
-          );
-          stubProfiles({});
+      test('explicit cursor override does not leak stored cursor id', () async {
+        var signedUrl = '';
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          authHeadersProvider: (url, method) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubNotifications(
+          [],
+          nextCursor: '1700000000',
+          nextCursorId: stableCursorId,
+          hasMore: true,
+        );
+        stubProfiles({});
 
-          await repository.getNotifications();
-          stubNotifications([], nextCursor: 'manual_next');
+        await repository.getNotifications();
+        stubNotifications([], nextCursor: 'manual_next');
 
-          await repository.getNotifications(cursor: 'manual_cursor');
+        await repository.getNotifications(cursor: 'manual_cursor');
 
-          expect(
-            signedUrl,
-            equals(
-              'https://api.example.com/api/users/$userPubkey/notifications'
-              '?limit=50&before=manual_cursor',
-            ),
-          );
-        },
-      );
+        expect(
+          signedUrl,
+          equals(
+            'https://api.example.com/api/users/$userPubkey/notifications'
+            '?limit=50&before=manual_cursor',
+          ),
+        );
+      });
 
       test('one like becomes a $VideoNotification with totalCount 1', () async {
         stubNotifications([
@@ -524,45 +519,42 @@ void main() {
         );
       });
 
-      test(
-        'retries first-page fetch on transient 5xx and succeeds on second '
-        'attempt',
-        () async {
-          stubProfiles({});
-          var calls = 0;
-          when(
-            () => funnelcakeApiClient.getNotifications(
-              pubkey: any(named: 'pubkey'),
-              cursor: any(named: 'cursor'),
-              requestUri: any(named: 'requestUri'),
-              authHeaders: any(named: 'authHeaders'),
-              limit: any(named: 'limit'),
-            ),
-          ).thenAnswer((_) async {
-            calls++;
-            if (calls == 1) {
-              throw const FunnelcakeApiException(
-                message: 'Internal server error',
-                statusCode: 500,
-                url: 'https://api.example.com/api/users/x/notifications',
-              );
-            }
-            return const NotificationResponse(
-              notifications: [],
-              unreadCount: 0,
-              hasMore: false,
+      test('retries first-page fetch on transient 5xx and succeeds on second '
+          'attempt', () async {
+        stubProfiles({});
+        var calls = 0;
+        when(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: any(named: 'pubkey'),
+            cursor: any(named: 'cursor'),
+            requestUri: any(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          if (calls == 1) {
+            throw const FunnelcakeApiException(
+              message: 'Internal server error',
+              statusCode: 500,
+              url: 'https://api.example.com/api/users/x/notifications',
             );
-          });
-
-          final page = await repository.getNotifications();
-          expect(page.items, isEmpty);
-          expect(calls, equals(2));
-          expect(
-            (await repository.watchSnapshot().first).lastRefreshError,
-            isFalse,
+          }
+          return const NotificationResponse(
+            notifications: [],
+            unreadCount: 0,
+            hasMore: false,
           );
-        },
-      );
+        });
+
+        final page = await repository.getNotifications();
+        expect(page.items, isEmpty);
+        expect(calls, equals(2));
+        expect(
+          (await repository.watchSnapshot().first).lastRefreshError,
+          isFalse,
+        );
+      });
 
       test(
         'does not retry first-page fetch on 4xx — surfaces error immediately',
@@ -1257,10 +1249,7 @@ void main() {
             ),
           ]);
           stubProfiles({
-            'pubkey_alice': makeProfile(
-              'pubkey_alice',
-              displayName: 'Alice',
-            ),
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
           });
 
           final page = await repository.getNotifications();
@@ -1291,10 +1280,7 @@ void main() {
             ),
           ]);
           stubProfiles({
-            'pubkey_alice': makeProfile(
-              'pubkey_alice',
-              displayName: 'Alice',
-            ),
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
           });
 
           final page = await repository.getNotifications();
@@ -1552,51 +1538,47 @@ void main() {
         },
       );
 
-      test(
-        'cached "comment" row becomes $VideoNotification placeholder '
-        'with commentText preserved',
-        () async {
-          when(
-            () => notificationsDao.getAllNotifications(
-              limit: any(named: 'limit'),
+      test('cached "comment" row becomes $VideoNotification placeholder '
+          'with commentText preserved', () async {
+        when(
+          () =>
+              notificationsDao.getAllNotifications(limit: any(named: 'limit')),
+        ).thenAnswer(
+          (_) async => [
+            NotificationRow(
+              id: 'cached_comment_1',
+              type: 'comment',
+              fromPubkey: 'actor_pub',
+              timestamp: 1700000000,
+              targetEventId: 'video_evt_2',
+              content: 'Nice clip!',
+              isRead: false,
+              cachedAt: DateTime(2026),
             ),
-          ).thenAnswer(
-            (_) async => [
-              NotificationRow(
-                id: 'cached_comment_1',
-                type: 'comment',
-                fromPubkey: 'actor_pub',
-                timestamp: 1700000000,
-                targetEventId: 'video_evt_2',
-                content: 'Nice clip!',
-                isRead: false,
-                cachedAt: DateTime(2026),
-              ),
-            ],
-          );
-          final hydrated = NotificationRepository(
-            funnelcakeApiClient: funnelcakeApiClient,
-            profileRepository: profileRepository,
-            notificationsDao: notificationsDao,
-            userPubkey: userPubkey,
-          );
-          addTearDown(hydrated.close);
+          ],
+        );
+        final hydrated = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+        );
+        addTearDown(hydrated.close);
 
-          await expectLater(
-            hydrated.watchSnapshot(),
-            emitsThrough(
-              predicate<NotificationPage>((p) {
-                if (p.items.length != 1) return false;
-                final item = p.items.first;
-                return item is VideoNotification &&
-                    item.type == NotificationKind.comment &&
-                    item.videoEventId == 'video_evt_2' &&
-                    item.commentText == 'Nice clip!';
-              }, 'placeholder is VideoNotification(comment) with content'),
-            ),
-          );
-        },
-      );
+        await expectLater(
+          hydrated.watchSnapshot(),
+          emitsThrough(
+            predicate<NotificationPage>((p) {
+              if (p.items.length != 1) return false;
+              final item = p.items.first;
+              return item is VideoNotification &&
+                  item.type == NotificationKind.comment &&
+                  item.videoEventId == 'video_evt_2' &&
+                  item.commentText == 'Nice clip!';
+            }, 'placeholder is VideoNotification(comment) with content'),
+          ),
+        );
+      });
 
       test(
         'cached "repost" row becomes $VideoNotification placeholder',
@@ -1781,6 +1763,65 @@ void main() {
           ),
         );
       });
+
+      test(
+        'expands a grouped row to every raw notification id before '
+        'marking read',
+        () async {
+          when(
+            () => funnelcakeApiClient.markNotificationsRead(
+              pubkey: any(named: 'pubkey'),
+              notificationIds: any(named: 'notificationIds'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          ).thenAnswer(
+            (_) async => const MarkReadResponse(success: true, markedCount: 2),
+          );
+          when(
+            () => notificationsDao.markAsRead(any()),
+          ).thenAnswer((_) async => true);
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+            'pubkey_bob': makeProfile('pubkey_bob', displayName: 'Bob'),
+          });
+          stubNotifications([
+            makeNotification(
+              id: 'older_server_notification',
+              sourceEventId: 'older_source_event',
+              createdAt: DateTime(2025),
+            ),
+            makeNotification(
+              id: 'newer_server_notification',
+              sourcePubkey: 'pubkey_bob',
+              sourceEventId: 'newer_source_event',
+              createdAt: DateTime(2025, 1, 2),
+            ),
+          ], unreadCount: 2);
+          await repository.refresh();
+
+          final groupedRow =
+              (await repository.watchSnapshot().first).items.first;
+
+          await repository.markAsRead([groupedRow.id]);
+
+          verify(
+            () => funnelcakeApiClient.markNotificationsRead(
+              pubkey: userPubkey,
+              notificationIds: [
+                'newer_server_notification',
+                'older_server_notification',
+              ],
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          ).called(1);
+          verify(
+            () => notificationsDao.markAsRead('newer_server_notification'),
+          ).called(1);
+          verify(
+            () => notificationsDao.markAsRead('older_server_notification'),
+          ).called(1);
+        },
+      );
 
       test(
         'rolls back the optimistic snapshot when authHeadersProvider throws',
@@ -2596,47 +2637,44 @@ void main() {
         expect(await repository.watchUnreadCount().first, equals(1));
       });
 
-      test(
-        'acceptRealtime keeps a named actor in front when a fallback actor '
-        'arrives later',
-        () async {
-          const hashPubkey =
-              '2949ede154d1f121402761cbd73f2b8c490b5041'
-              'cdd85c9908c5322f1a2fe3f6';
-          stubProfiles({
-            'pubkey_sally': makeProfile(
-              'pubkey_sally',
-              displayName: 'Sally Strawberry',
-            ),
-            hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
-          });
-          stubNotifications([
-            makeNotification(
-              id: 'named-first',
-              sourcePubkey: 'pubkey_sally',
-              referencedEventId: 'video_named',
-              createdAt: DateTime(2025, 3),
-            ),
-          ], unreadCount: 1);
-          await repository.refresh();
+      test('acceptRealtime keeps a named actor in front when a fallback actor '
+          'arrives later', () async {
+        const hashPubkey =
+            '2949ede154d1f121402761cbd73f2b8c490b5041'
+            'cdd85c9908c5322f1a2fe3f6';
+        stubProfiles({
+          'pubkey_sally': makeProfile(
+            'pubkey_sally',
+            displayName: 'Sally Strawberry',
+          ),
+          hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
+        });
+        stubNotifications([
+          makeNotification(
+            id: 'named-first',
+            sourcePubkey: 'pubkey_sally',
+            referencedEventId: 'video_named',
+            createdAt: DateTime(2025, 3),
+          ),
+        ], unreadCount: 1);
+        await repository.refresh();
 
-          await repository.acceptRealtime(
-            makeNotification(
-              id: 'fallback-second',
-              sourcePubkey: hashPubkey,
-              referencedEventId: 'video_named',
-              createdAt: DateTime(2025, 4),
-            ),
-          );
+        await repository.acceptRealtime(
+          makeNotification(
+            id: 'fallback-second',
+            sourcePubkey: hashPubkey,
+            referencedEventId: 'video_named',
+            createdAt: DateTime(2025, 4),
+          ),
+        );
 
-          final merged =
-              (await repository.watchSnapshot().first).items.single
-                  as VideoNotification;
-          expect(merged.totalCount, equals(2));
-          expect(merged.actors.first.pubkey, equals('pubkey_sally'));
-          expect(merged.actors.first.displayName, equals('Sally Strawberry'));
-        },
-      );
+        final merged =
+            (await repository.watchSnapshot().first).items.single
+                as VideoNotification;
+        expect(merged.totalCount, equals(2));
+        expect(merged.actors.first.pubkey, equals('pubkey_sally'));
+        expect(merged.actors.first.displayName, equals('Sally Strawberry'));
+      });
 
       test(
         'acceptRealtime caps merged actors at the group display limit',
@@ -3097,55 +3135,52 @@ void main() {
         );
       });
 
-      test(
-        'pagination merge keeps the named actor in front when the existing '
-        'row is unnamed',
-        () async {
-          const hashPubkey =
-              '2949ede154d1f121402761cbd73f2b8c490b5041'
-              'cdd85c9908c5322f1a2fe3f6';
-          stubProfiles({
-            hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
-            'pub_named': makeProfile(
-              'pub_named',
-              displayName: 'Sally Strawberry',
-            ),
-          });
-          stubNotifications(
-            [
-              makeNotification(
-                id: 'server-uuid-unnamed',
-                sourceEventId: 'nostr-unnamed',
-                sourcePubkey: hashPubkey,
-                referencedEventId: 'video_named',
-                createdAt: DateTime(2025, 6),
-              ),
-            ],
-            nextCursor: 'cursor_after_first',
-            hasMore: true,
-          );
-          await repository.refresh();
-
-          stubNotifications([
+      test('pagination merge keeps the named actor in front when the existing '
+          'row is unnamed', () async {
+        const hashPubkey =
+            '2949ede154d1f121402761cbd73f2b8c490b5041'
+            'cdd85c9908c5322f1a2fe3f6';
+        stubProfiles({
+          hashPubkey: makeProfile(hashPubkey, displayName: hashPubkey),
+          'pub_named': makeProfile(
+            'pub_named',
+            displayName: 'Sally Strawberry',
+          ),
+        });
+        stubNotifications(
+          [
             makeNotification(
-              id: 'server-uuid-named',
-              sourceEventId: 'nostr-named',
-              sourcePubkey: 'pub_named',
+              id: 'server-uuid-unnamed',
+              sourceEventId: 'nostr-unnamed',
+              sourcePubkey: hashPubkey,
               referencedEventId: 'video_named',
-              createdAt: DateTime(2025, 4),
+              createdAt: DateTime(2025, 6),
             ),
-          ]);
+          ],
+          nextCursor: 'cursor_after_first',
+          hasMore: true,
+        );
+        await repository.refresh();
 
-          await repository.getNotifications();
+        stubNotifications([
+          makeNotification(
+            id: 'server-uuid-named',
+            sourceEventId: 'nostr-named',
+            sourcePubkey: 'pub_named',
+            referencedEventId: 'video_named',
+            createdAt: DateTime(2025, 4),
+          ),
+        ]);
 
-          final merged =
-              (await repository.watchSnapshot().first).items.single
-                  as VideoNotification;
-          expect(merged.totalCount, equals(2));
-          expect(merged.actors.first.pubkey, equals('pub_named'));
-          expect(merged.actors.first.displayName, equals('Sally Strawberry'));
-        },
-      );
+        await repository.getNotifications();
+
+        final merged =
+            (await repository.watchSnapshot().first).items.single
+                as VideoNotification;
+        expect(merged.totalCount, equals(2));
+        expect(merged.actors.first.pubkey, equals('pub_named'));
+        expect(merged.actors.first.displayName, equals('Sally Strawberry'));
+      });
 
       test("comment-kind merge keeps the newer side's commentText "
           '(REST page newer than WS) — symmetric direction', () async {


### PR DESCRIPTION
Closes #4475

## Summary
- promote non-empty notification repository snapshots to loaded state
- avoid full-screen loading/failure when cached notifications are already visible
- carry raw server notification IDs through grouped notification rows so tapping a group marks every underlying notification read
- add bloc and repository coverage for stale refresh behavior and grouped mark-read expansion

## Verification
- flutter test test/notifications/bloc/notification_feed_bloc_test.dart
- flutter test (from mobile/packages/notification_repository)
- flutter analyze
- pre-push checks