### PR TITLE
fix(feed): use age-decayed popular feed

### DIFF
--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Popular Videos feed provider showing trending native videos.
-// ABOUTME: Uses VideosRepository's native Popular path for Explore pagination.
+// ABOUTME: Popular Videos feed provider showing age-decayed popular videos.
+// ABOUTME: Uses VideosRepository's v2 Popular path for Explore pagination.
 
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -25,8 +25,8 @@ final popularVideosVariantProvider = StateProvider<PopularVideosVariant>(
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
-/// Delegates video fetching to [VideosRepository.getNativePopularVideos], which
-/// uses the new divine video leaderboard.
+/// Delegates video fetching to [VideosRepository.getPopularVideos] with the
+/// selected native/classic variant.
 ///
 /// Rebuilds when:
 /// - Pull to refresh
@@ -34,7 +34,7 @@ final popularVideosVariantProvider = StateProvider<PopularVideosVariant>(
 /// - Content filter preferences change
 @Riverpod(keepAlive: true)
 class PopularVideosFeed extends _$PopularVideosFeed {
-  _PopularFeedCursor _cursor = const _NativePopularCursor(offset: 0);
+  _PopularFeedCursor _cursor = const _NativePopularCursor(until: null);
 
   @override
   Future<VideoFeedState> build() async {
@@ -131,12 +131,14 @@ class PopularVideosFeed extends _$PopularVideosFeed {
   }) async {
     final videosRepository = ref.read(videosRepositoryProvider);
     return switch (variant) {
-      PopularVideosVariant.native =>
-        videosRepository.getNativePopularVideosPage(
+      PopularVideosVariant.native => _buildPopularPage(
+        videos: await videosRepository.getPopularVideos(
           limit: AppConstants.paginationBatchSize,
+          variant: variant,
           skipCache: skipCache,
         ),
-      PopularVideosVariant.classic => _buildClassicPage(
+      ),
+      PopularVideosVariant.classic => _buildPopularPage(
         videos: await videosRepository.getPopularVideos(
           limit: AppConstants.paginationBatchSize,
           variant: variant,
@@ -224,12 +226,14 @@ class PopularVideosFeed extends _$PopularVideosFeed {
   Future<NativePopularVideosPage> _fetchNextPage() async {
     final videosRepository = ref.read(videosRepositoryProvider);
     return switch (_cursor) {
-      _NativePopularCursor(:final offset) =>
-        videosRepository.getNativePopularVideosPage(
+      _NativePopularCursor(:final until) => _buildPopularPage(
+        videos: await videosRepository.getPopularVideos(
           limit: AppConstants.paginationBatchSize,
-          offset: offset,
+          until: until,
+          variant: PopularVideosVariant.native,
         ),
-      _ClassicPopularCursor(:final until) => _buildClassicPage(
+      ),
+      _ClassicPopularCursor(:final until) => _buildPopularPage(
         videos: await videosRepository.getPopularVideos(
           limit: AppConstants.paginationBatchSize,
           until: until,
@@ -279,7 +283,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
 
   _PopularFeedCursor _initialCursorFor(PopularVideosVariant variant) {
     return switch (variant) {
-      PopularVideosVariant.native => const _NativePopularCursor(offset: 0),
+      PopularVideosVariant.native => const _NativePopularCursor(until: null),
       PopularVideosVariant.classic => const _ClassicPopularCursor(until: null),
     };
   }
@@ -290,7 +294,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
   ) {
     return switch (variant) {
       PopularVideosVariant.native => _NativePopularCursor(
-        offset: page.nextOffset ?? page.videos.length,
+        until: page.videos.isEmpty ? null : getOldestTimestamp(page.videos),
       ),
       PopularVideosVariant.classic => _ClassicPopularCursor(
         until: page.videos.isEmpty ? null : getOldestTimestamp(page.videos),
@@ -298,7 +302,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
     };
   }
 
-  NativePopularVideosPage _buildClassicPage({
+  NativePopularVideosPage _buildPopularPage({
     required List<VideoEvent> videos,
   }) {
     return NativePopularVideosPage(
@@ -356,9 +360,9 @@ sealed class _PopularFeedCursor {
 }
 
 class _NativePopularCursor extends _PopularFeedCursor {
-  const _NativePopularCursor({required this.offset});
+  const _NativePopularCursor({required this.until});
 
-  final int offset;
+  final int? until;
 }
 
 class _ClassicPopularCursor extends _PopularFeedCursor {

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -10,8 +10,8 @@ part of 'popular_videos_feed_provider.dart';
 // ignore_for_file: type=lint, type=warning
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
-/// Delegates video fetching to [VideosRepository.getNativePopularVideos], which
-/// uses the new divine video leaderboard.
+/// Delegates video fetching to [VideosRepository.getPopularVideos] with the
+/// selected native/classic variant.
 ///
 /// Rebuilds when:
 /// - Pull to refresh
@@ -23,8 +23,8 @@ const popularVideosFeedProvider = PopularVideosFeedProvider._();
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
-/// Delegates video fetching to [VideosRepository.getNativePopularVideos], which
-/// uses the new divine video leaderboard.
+/// Delegates video fetching to [VideosRepository.getPopularVideos] with the
+/// selected native/classic variant.
 ///
 /// Rebuilds when:
 /// - Pull to refresh
@@ -34,8 +34,8 @@ final class PopularVideosFeedProvider
     extends $AsyncNotifierProvider<PopularVideosFeed, VideoFeedState> {
   /// Popular Videos feed provider - shows trending videos by recent engagement.
   ///
-  /// Delegates video fetching to [VideosRepository.getNativePopularVideos], which
-  /// uses the new divine video leaderboard.
+  /// Delegates video fetching to [VideosRepository.getPopularVideos] with the
+  /// selected native/classic variant.
   ///
   /// Rebuilds when:
   /// - Pull to refresh
@@ -60,12 +60,12 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'1aee71b4befef9549e64cabe481975e432f338d8';
+String _$popularVideosFeedHash() => r'899d23a6fde684b906af0337d293809cac63f7fa';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
-/// Delegates video fetching to [VideosRepository.getNativePopularVideos], which
-/// uses the new divine video leaderboard.
+/// Delegates video fetching to [VideosRepository.getPopularVideos] with the
+/// selected native/classic variant.
 ///
 /// Rebuilds when:
 /// - Pull to refresh

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -494,7 +494,7 @@ class FunnelcakeApiClient {
   /// imports.
   ///
   /// Native mode maps to `sort=popular&period=now&exclude_platform=vine`;
-  /// classic mode maps to `sort=popular&period=week&platform=vine`.
+  /// classic mode maps to `sort=popular&period=month&platform=vine`.
   Future<List<VideoStats>> getV2PopularVideos({
     required PopularVideosVariant variant,
     int limit = 50,
@@ -506,7 +506,7 @@ class FunnelcakeApiClient {
 
     final queryParams = _videoQueryParameters({
       'sort': 'popular',
-      'period': variant == PopularVideosVariant.classic ? 'week' : 'now',
+      'period': variant == PopularVideosVariant.classic ? 'month' : 'now',
       'limit': limit.toString(),
     });
     if (variant == PopularVideosVariant.classic) {

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -2784,7 +2784,7 @@ void main() {
 
     group('getV2PopularVideos', () {
       test(
-        'classic mode requests weekly popular imported Vine videos',
+        'classic mode requests monthly popular imported Vine videos',
         () async {
           when(
             () => mockHttpClient.get(any(), headers: any(named: 'headers')),
@@ -2804,7 +2804,7 @@ void main() {
                   as Uri;
           expect(uri.path, equals('/api/v2/videos'));
           expect(uri.queryParameters['sort'], equals('popular'));
-          expect(uri.queryParameters['period'], equals('week'));
+          expect(uri.queryParameters['period'], equals('month'));
           expect(uri.queryParameters['platform'], equals('vine'));
           expect(uri.queryParameters.containsKey('exclude_platform'), isFalse);
         },

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -274,13 +274,17 @@ void main() {
       () async {
         final initialVideos = [_video('popular-initial')];
         final refreshedVideos = [_video('popular-refreshed')];
-        final refreshCompleter = Completer<NativePopularVideosPage>();
+        final refreshCompleter = Completer<List<VideoEvent>>();
         var requestCount = 0;
 
         when(
-          () => mockVideosRepository.getNativePopularVideosPage(
+          () => mockVideosRepository.getPopularVideos(
             limit: any(named: 'limit'),
+            until: any(named: 'until'),
             offset: any(named: 'offset'),
+            period: any(named: 'period'),
+            variant: any(named: 'variant'),
+            fetchMultiplier: any(named: 'fetchMultiplier'),
             skipCache: any(named: 'skipCache'),
           ),
         ).thenAnswer((invocation) {
@@ -288,7 +292,7 @@ void main() {
           final skipCache = invocation.namedArguments[#skipCache] as bool?;
           if (requestCount == 1) {
             expect(skipCache, isNot(true));
-            return Future.value(_nativePage(initialVideos));
+            return Future.value(initialVideos);
           }
           expect(skipCache, isTrue);
           return refreshCompleter.future;
@@ -333,7 +337,7 @@ void main() {
         ]);
         expect(refreshingState.isRefreshing, isTrue);
 
-        refreshCompleter.complete(_nativePage(refreshedVideos));
+        refreshCompleter.complete(refreshedVideos);
         await refreshFuture;
 
         final finalState = container.read(popularVideosFeedProvider).value;
@@ -343,13 +347,59 @@ void main() {
         ]);
         expect(finalState.isRefreshing, isFalse);
         verify(
-          () => mockVideosRepository.getNativePopularVideosPage(
+          () => mockVideosRepository.getPopularVideos(
             limit: AppConstants.paginationBatchSize,
+            variant: PopularVideosVariant.native,
             skipCache: true,
           ),
         ).called(1);
       },
     );
+
+    test('popular videos native source uses age-decayed v2 popular', () async {
+      when(
+        () => mockVideosRepository.getPopularVideos(
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+          offset: any(named: 'offset'),
+          period: any(named: 'period'),
+          variant: any(named: 'variant'),
+          fetchMultiplier: any(named: 'fetchMultiplier'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer((_) async => [_video('popular-age-decayed')]);
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          appReadyProvider.overrideWithValue(true),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          contentBlocklistRepositoryProvider.overrideWithValue(
+            mockBlocklistRepository,
+          ),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+          nostrServiceProvider.overrideWithValue(mockNostrClient),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(popularVideosFeedProvider.future);
+
+      expect(state.videos.map((video) => video.id), ['popular-age-decayed']);
+      verify(
+        () => mockVideosRepository.getPopularVideos(
+          limit: AppConstants.paginationBatchSize,
+          variant: PopularVideosVariant.native,
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockVideosRepository.getNativePopularVideosPage(
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      );
+    });
 
     test(
       'popular videos preserves existing videos when refresh fails',
@@ -358,19 +408,23 @@ void main() {
         var requestCount = 0;
 
         when(
-          () => mockVideosRepository.getNativePopularVideosPage(
+          () => mockVideosRepository.getPopularVideos(
             limit: any(named: 'limit'),
+            until: any(named: 'until'),
             offset: any(named: 'offset'),
+            period: any(named: 'period'),
+            variant: any(named: 'variant'),
+            fetchMultiplier: any(named: 'fetchMultiplier'),
             skipCache: any(named: 'skipCache'),
           ),
         ).thenAnswer((invocation) {
           requestCount += 1;
           final skipCache = invocation.namedArguments[#skipCache] as bool?;
           if (requestCount == 1) {
-            return Future.value(_nativePage(initialVideos));
+            return Future.value(initialVideos);
           }
           expect(skipCache, isTrue);
-          throw StateError('native refresh failed');
+          throw StateError('age-decayed refresh failed');
         });
 
         final container = ProviderContainer(
@@ -408,48 +462,49 @@ void main() {
           'popular-initial',
         ]);
         expect(finalState.isRefreshing, isFalse);
-        expect(finalState.error, contains('native refresh failed'));
+        expect(finalState.error, contains('age-decayed refresh failed'));
       },
     );
 
     test(
-      'popular videos load more uses raw offset and filters duplicates',
+      'popular videos load more uses timestamp cursor and filters duplicates',
       () async {
         final initialRawVideos = [
           _video('popular-initial'),
           for (var i = 1; i < AppConstants.paginationBatchSize; i++)
-            _vineArchiveVideo('popular-vine-$i'),
+            _vineArchiveVideo(
+              'popular-vine-$i',
+              createdAt: 1_742_169_600 - i,
+            ),
         ];
         final loadMoreRawVideos = [
           _video('popular-initial'),
           _video('popular-more'),
         ];
-        final requestedOffsets = <int>[];
+        const oldestInitialCursor =
+            1_742_169_600 - (AppConstants.paginationBatchSize - 1);
+        final requestedCursors = <int?>[];
 
         when(
-          () => mockVideosRepository.getNativePopularVideosPage(
+          () => mockVideosRepository.getPopularVideos(
             limit: any(named: 'limit'),
+            until: any(named: 'until'),
             offset: any(named: 'offset'),
+            period: any(named: 'period'),
+            variant: any(named: 'variant'),
+            fetchMultiplier: any(named: 'fetchMultiplier'),
             skipCache: any(named: 'skipCache'),
           ),
         ).thenAnswer((invocation) async {
-          final offset = invocation.namedArguments[#offset] as int? ?? 0;
-          requestedOffsets.add(offset);
-          if (offset == 0) {
-            return _nativePage(
-              initialRawVideos,
-              consumedItemCount: initialRawVideos.length,
-              nextOffset: initialRawVideos.length,
-            );
+          final until = invocation.namedArguments[#until] as int?;
+          requestedCursors.add(until);
+          if (until == null) {
+            return initialRawVideos;
           }
-          if (offset == initialRawVideos.length) {
-            return _nativePage(
-              loadMoreRawVideos,
-              consumedItemCount: 3,
-              nextOffset: offset + 3,
-            );
+          if (until == oldestInitialCursor) {
+            return loadMoreRawVideos;
           }
-          throw StateError('unexpected offset $offset');
+          throw StateError('unexpected cursor $until');
         });
 
         final container = ProviderContainer(
@@ -490,18 +545,22 @@ void main() {
         ]);
         expect(finalState.hasMoreContent, isFalse);
         expect(finalState.isLoadingMore, isFalse);
-        expect(requestedOffsets, [0, initialRawVideos.length]);
+        expect(requestedCursors, [null, oldestInitialCursor]);
       },
     );
 
-    test('popular videos does not fall back to legacy popular', () async {
+    test('popular videos does not fall back to native leaderboard', () async {
       when(
-        () => mockVideosRepository.getNativePopularVideosPage(
+        () => mockVideosRepository.getPopularVideos(
           limit: any(named: 'limit'),
+          until: any(named: 'until'),
           offset: any(named: 'offset'),
+          period: any(named: 'period'),
+          variant: any(named: 'variant'),
+          fetchMultiplier: any(named: 'fetchMultiplier'),
           skipCache: any(named: 'skipCache'),
         ),
-      ).thenThrow(StateError('native popular unavailable'));
+      ).thenThrow(StateError('age-decayed popular unavailable'));
 
       final container = ProviderContainer(
         overrides: [
@@ -521,11 +580,12 @@ void main() {
 
       expect(state.videos, isEmpty);
       expect(state.hasMoreContent, isFalse);
-      expect(state.error, contains('native popular unavailable'));
+      expect(state.error, contains('age-decayed popular unavailable'));
       verifyNever(
-        () => mockVideosRepository.getPopularVideos(
+        () => mockVideosRepository.getNativePopularVideosPage(
           limit: any(named: 'limit'),
-          until: any(named: 'until'),
+          offset: any(named: 'offset'),
+          skipCache: any(named: 'skipCache'),
         ),
       );
     });
@@ -706,18 +766,6 @@ void main() {
   });
 }
 
-NativePopularVideosPage _nativePage(
-  List<VideoEvent> videos, {
-  int? consumedItemCount,
-  int? nextOffset,
-}) {
-  return NativePopularVideosPage(
-    videos: videos,
-    consumedItemCount: consumedItemCount ?? videos.length,
-    nextOffset: nextOffset ?? consumedItemCount ?? videos.length,
-  );
-}
-
 WatchingVideosResponse _watchingResponse(
   List<String> ids, {
   int? nextCursor,
@@ -753,9 +801,10 @@ VideoEvent _video(
   );
 }
 
-VideoEvent _vineArchiveVideo(String id) {
+VideoEvent _vineArchiveVideo(String id, {int createdAt = 1_742_169_600}) {
   return _video(
     id,
+    createdAt: createdAt,
     rawTags: const {
       'd': 'seed',
       'x': '1',


### PR DESCRIPTION
Closes #4474

## Summary
- Route the native Popular tab through VideosRepository.getPopularVideos with the native variant instead of the leaderboard page API
- Use the v2 popular timestamp cursor for native Popular pagination
- Widen Classic Popular from the weekly v2 window to monthly so archived Vines have more ranking signal
- Update provider/API-client tests to prove the native path avoids leaderboard and Classic requests month

## Resulting requests
Native Popular now uses:
`GET /api/v2/videos?sort=popular&period=now&exclude_platform=vine&limit=<limit>&before=<oldest-created-at>`

Classic Popular now uses:
`GET /api/v2/videos?sort=popular&period=month&platform=vine&limit=<limit>&before=<oldest-created-at>`

## Verification
- `flutter test packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart`
- `flutter test test/providers/explore_feed_refresh_retention_test.dart`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- pre-push checks: analyzer, generated files, changed tests
- GitHub checks: Mobile CI, Tests, Analyze, Format, Generated Files, VGV Tag Gate, Build Flutter Web Preview