### PR TITLE
fix(video-interactions): keep carried like count when relay returns 0 after edit

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -176,9 +176,23 @@ class VideoInteractionsBloc
         repostCountFuture,
       ]);
 
-      final likeCount = results[0];
+      final fetchedLikeCount = results[0];
       final commentCount = results[1];
       final repostCount = results[2];
+
+      // For addressable videos, treat a relay-fetched 0 as "no fresh info"
+      // when we already have a non-zero pre-fetch count. After a metadata
+      // edit the new event_id has no #e reactions yet, and the #a COUNT on
+      // the divine relay for kind 7 is unreliable — letting that 0 stomp
+      // the carried-forward nostrLikeCount (or Vine originalLikes portion)
+      // surfaces as #4432 ("likes went to zero after editing"). Mirrors the
+      // skip-zero guard in VideoEventService._executeLikeCountBatchFetch.
+      final likeCount =
+          (_addressableId != null &&
+              fetchedLikeCount == 0 &&
+              (preFetchLikeCount ?? 0) > 0)
+          ? preFetchLikeCount!
+          : fetchedLikeCount;
 
       emit(
         state.copyWith(

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -222,6 +222,96 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // Regression for #4432: after a metadata edit the new event_id has
+        // no #e reactions yet, and the divine relay's #a COUNT for kind 7
+        // can transiently return 0. _mergeUpdatedVideo carries
+        // nostrLikeCount forward into the per-video bloc seed, so a
+        // relay-fetched 0 here must not stomp it for addressable videos.
+        // Mirrors the skip-zero guard in
+        // VideoEventService._executeLikeCountBatchFetch.
+        'does not overwrite a seeded non-zero likeCount with a relay 0 for '
+        'addressable videos (regression for #4432)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 0);
+        },
+        build: () => createBloc(
+          addressableId: testAddressableId,
+          initialLikeCount: 5,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 5,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 5, // Preserved — relay 0 did not stomp the seed.
+            repostCount: 0,
+            commentCount: 0,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // Companion to the addressable case above: for non-addressable
+        // videos (kind 22) the event_id never changes, so a relay 0 is
+        // authoritative and must still overwrite a stale seed. This pins
+        // the PR #4253 contract — relay is the source of truth — for the
+        // case where the #4432 guard does not apply.
+        'still overwrites a seeded likeCount with a relay 0 for '
+        'non-addressable videos (preserves #4253 contract)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(testEventId),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockCommentsRepository.getCommentsCount(testEventId),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockRepostsRepository.getRepostCountByEventId(testEventId),
+          ).thenAnswer((_) async => 0);
+        },
+        build: () => createBloc(initialLikeCount: 5),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 5,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 0, // Relay 0 wins — no addressable id to gate on.
+            repostCount: 0,
+            commentCount: 0,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
         'emits [loading, success] when video is not liked',
         setUp: () {
           when(


### PR DESCRIPTION
## Description

After a user edits a video, the new Nostr event has a fresh `event_id` but reuses the `d` tag. `VideoEventService._mergeUpdatedVideo` already carries `nostrLikeCount` forward into the merged video (#4150), and `VideoMetadataUpdateService` preserves the Vine-imported `['likes', 'N']` engagement tags. The carry survives until a per-video `VideoInteractionsBloc` is freshly created (profile re-entry, fullscreen open, home-feed scroll-back after disposal).

At that point `_onFetchRequested` runs `LikesRepository.getLikeCount(_eventId, addressableId: _addressableId)`. The relay query for `Filter(kinds:[7], e:[new_event_id])` returns 0 (no reactions yet on the new id). The companion `Filter(kinds:[7], a:[address])` query — meant to recover the carry — in practice returns 0 too on `relay.divine.video` (NIP-45 COUNT for `#a` on kind 7 is unreliable; some non-Divine reactions are tagged only with `#e`). `max(0, 0) = 0` then unconditionally overwrites the carried `state.likeCount`. For Vine-imported videos the Vine portion is lost too, because the bloc's `state.likeCount` is treated everywhere as the displayed total.

The batch path (`VideoEventService._executeLikeCountBatchFetch`) has the symmetric `if (likeCount == 0) continue;` guard since #4150, exactly for this reason. The singular `_onFetchRequested` path was missing it after #4253 removed the `state.likeCount != null` short-circuit.

This PR mirrors the guard, gated on `_addressableId != null` so:
- Addressable kind 34236 (Divine's only published kind) — the edit-regression scenario — is fixed.
- Non-addressable kind 22 (other clients' videos in feeds) still honors a relay 0 as authoritative, preserving #4253's "relay wins over stale REST seed" contract.

A second test pins that non-addressable contract so a future cleanup can't widen the guard without noticing.

**Related Issue:** Closes #4432

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- \`flutter test test/blocs/video_interactions/video_interactions_bloc_test.dart\` — 49/49 pass, including 2 new regression tests
- \`flutter test test/services/video_event_service_replaceable_test.dart test/services/video_metadata_update_service_test.dart\` — 21/21 pass (carry-forward + edit-publish paths still green)
- \`flutter analyze lib test integration_test\` — No issues

## Manual test plan

- [ ] Edit a video that has ≥1 like → open the edited video from profile grid → count does not drop to 0
- [ ] Edit a Vine-imported video with `originalLikes` > 0 and 0 Nostr reactions → count remains at `originalLikes`
- [ ] Tap a like notification → open the video → count still updates to the fresh relay value when relay returns higher (preserves #4253)

## Follow-ups (separate PRs)

- Relay-side: investigate NIP-45 COUNT on `Filter(kinds:[7], a:[…])` indexing on `relay.divine.video`.
- Mobile: extend the same guard to `CommentsRepository.getCommentsCount` and `RepostsRepository.getRepostCount` post-edit (touched by the same bloc).
- Mobile: thread `originalLikes` into `VideoInteractionsBloc` so the displayed `state.likeCount` is the true total (Vine + Nostr) end-to-end, not just the Nostr portion. Not blocking this fix; the gated skip-zero already prevents the user-visible regression.
- May or may not also close sibling reports in the engagement-reset cluster (#4403, #4384). Flagging here, not claiming closure.