### PR TITLE
fix(comments): cache survives addressable-event edit by dual-keying on addressable id

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -480,6 +480,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       await _commentsRepository.deleteComment(
         commentId: event.commentId,
         rootEventId: state.rootEventId,
+        rootAddressableId: state.rootAddressableId,
       );
 
       // Remove the comment from the Map
@@ -806,6 +807,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       await _commentsRepository.deleteComment(
         commentId: originalCommentId,
         rootEventId: state.rootEventId,
+        rootAddressableId: state.rootAddressableId,
       );
 
       // Step 2: Post new comment with same threading tags

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -172,13 +172,15 @@ class CommentsRepository {
                   )
                 : restThread;
             // Auto-update the count cache with the authoritative REST total.
-            if (thread.totalCount > 0) {
-              _writeCachedCommentCount(
-                rootEventId,
-                thread.totalCount,
-                rootAddressableId: rootAddressableId,
-              );
-            }
+            // Zero is written too so a previously cached positive value
+            // can't outlive the comments it counted — important with the
+            // addressable-id companion cache, which would otherwise serve
+            // that stale positive for the post-edit event id.
+            _writeCachedCommentCount(
+              rootEventId,
+              thread.totalCount,
+              rootAddressableId: rootAddressableId,
+            );
             return _filterThread(thread);
           }
         } on FunnelcakeException {
@@ -243,8 +245,12 @@ class CommentsRepository {
 
       // Auto-update the count cache with the authoritative total so that
       // callers (e.g. VideoInteractionsBloc) don't need to push counts back
-      // into the repository manually.
-      if (before == null && thread.totalCount > 0) {
+      // into the repository manually. Pagination (`before != null`) returns
+      // a slice rather than the full total, so the guard stays. Zero is
+      // written on a first-page result: trusting it for the empty UI but
+      // distrusting it for the cache would let the addressable-id companion
+      // serve a stale positive across a metadata edit.
+      if (before == null) {
         _writeCachedCommentCount(
           rootEventId,
           thread.totalCount,

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -88,6 +88,22 @@ class CommentsRepository {
   /// server or relay (so callers never need to push counts back in).
   final Map<String, int> _commentCountCache = {};
 
+  /// Companion cache keyed by NIP-71 addressable id (`kind:pubkey:d-tag`).
+  ///
+  /// For addressable video events (Kind 30000-39999), a metadata edit
+  /// publishes a replacement event with a new `id` but the same address.
+  /// Keying [_commentCountCache] purely by the volatile event id loses
+  /// the carried count on every edit and forces a relay re-query whose
+  /// NIP-45 COUNT on `#A` for kind 1111 can transiently return 0 (mirror
+  /// of the kind-7 issue in #4432). This companion cache lets a fresh
+  /// [getCommentsCount] for the new event id reuse the prior count via
+  /// the stable address.
+  ///
+  /// All writes are dual-keyed via [_writeCachedCommentCount] when a
+  /// `rootAddressableId` is in scope; reads check this map when the
+  /// event-id cache misses ([_readCachedCommentCount]).
+  final Map<String, int> _commentCountCacheByAddressableId = {};
+
   /// Subscription ID for the active comment watch, if any.
   String? _watchSubscriptionId;
 
@@ -157,7 +173,11 @@ class CommentsRepository {
                 : restThread;
             // Auto-update the count cache with the authoritative REST total.
             if (thread.totalCount > 0) {
-              _commentCountCache[rootEventId] = thread.totalCount;
+              _writeCachedCommentCount(
+                rootEventId,
+                thread.totalCount,
+                rootAddressableId: rootAddressableId,
+              );
             }
             return _filterThread(thread);
           }
@@ -225,7 +245,11 @@ class CommentsRepository {
       // callers (e.g. VideoInteractionsBloc) don't need to push counts back
       // into the repository manually.
       if (before == null && thread.totalCount > 0) {
-        _commentCountCache[rootEventId] = thread.totalCount;
+        _writeCachedCommentCount(
+          rootEventId,
+          thread.totalCount,
+          rootAddressableId: rootAddressableId,
+        );
       }
 
       return _filterThread(thread);
@@ -325,8 +349,11 @@ class CommentsRepository {
       }
       final sentEvent = result.event;
 
-      final cached = _commentCountCache[rootEventId];
-      if (cached != null) _commentCountCache[rootEventId] = cached + 1;
+      _adjustCachedCommentCount(
+        rootEventId,
+        1,
+        rootAddressableId: rootAddressableId,
+      );
       final videoMetadata = _parseVideoMetadataFromImetaTags(sentEvent.tags);
 
       return Comment(
@@ -374,7 +401,10 @@ class CommentsRepository {
     String? rootAddressableId,
     bool includeVideoReplies = false,
   }) async {
-    final cached = _commentCountCache[rootEventId];
+    final cached = _readCachedCommentCount(
+      rootEventId,
+      rootAddressableId: rootAddressableId,
+    );
     if (cached != null) return cached;
 
     try {
@@ -412,7 +442,11 @@ class CommentsRepository {
         count = result.count;
       }
 
-      _commentCountCache[rootEventId] = count;
+      _writeCachedCommentCount(
+        rootEventId,
+        count,
+        rootAddressableId: rootAddressableId,
+      );
       return count;
     } on Exception catch (e) {
       throw CountCommentsFailedException('Failed to count comments: $e');
@@ -425,8 +459,19 @@ class CommentsRepository {
   /// to keep the cache in sync with the authoritative count from the
   /// loaded comment thread. This avoids a stale NIP-45 COUNT when the
   /// user scrolls back to the same video.
-  void updateCachedCommentCount(String rootEventId, int count) {
-    _commentCountCache[rootEventId] = count;
+  ///
+  /// Pass [rootAddressableId] for addressable videos so the count
+  /// survives a future metadata edit that changes the event id.
+  void updateCachedCommentCount(
+    String rootEventId,
+    int count, {
+    String? rootAddressableId,
+  }) {
+    _writeCachedCommentCount(
+      rootEventId,
+      count,
+      rootAddressableId: rootAddressableId,
+    );
   }
 
   /// Clears the in-memory comment count cache.
@@ -435,6 +480,53 @@ class CommentsRepository {
   /// session are not served after re-login.
   void clearCommentCountCache() {
     _commentCountCache.clear();
+    _commentCountCacheByAddressableId.clear();
+  }
+
+  /// Reads the cached comment count, checking event-id first then the
+  /// addressable-id companion cache. Returns `null` on a full miss.
+  int? _readCachedCommentCount(
+    String rootEventId, {
+    String? rootAddressableId,
+  }) {
+    final byEventId = _commentCountCache[rootEventId];
+    if (byEventId != null) return byEventId;
+    if (rootAddressableId == null || rootAddressableId.isEmpty) return null;
+    return _commentCountCacheByAddressableId[rootAddressableId];
+  }
+
+  /// Writes [count] into both caches when [rootAddressableId] is provided.
+  /// Otherwise writes only the event-id cache.
+  void _writeCachedCommentCount(
+    String rootEventId,
+    int count, {
+    String? rootAddressableId,
+  }) {
+    _commentCountCache[rootEventId] = count;
+    if (rootAddressableId != null && rootAddressableId.isNotEmpty) {
+      _commentCountCacheByAddressableId[rootAddressableId] = count;
+    }
+  }
+
+  /// Adjusts the cached comment count by [delta] (clamped at zero),
+  /// dual-writing both caches. No-op if neither cache has a baseline
+  /// value yet — an isolated delta without a known total would lie.
+  void _adjustCachedCommentCount(
+    String rootEventId,
+    int delta, {
+    String? rootAddressableId,
+  }) {
+    final current = _readCachedCommentCount(
+      rootEventId,
+      rootAddressableId: rootAddressableId,
+    );
+    if (current == null) return;
+    final updated = current + delta;
+    _writeCachedCommentCount(
+      rootEventId,
+      updated < 0 ? 0 : updated,
+      rootAddressableId: rootAddressableId,
+    );
   }
 
   /// Deletes a comment by publishing a NIP-09 deletion request.
@@ -447,12 +539,17 @@ class CommentsRepository {
   /// - [rootEventId]: Optional root event ID. When provided, the cached
   ///   comment count for that root event is decremented so subsequent
   ///   [getCommentsCount] calls return the correct value.
+  /// - [rootAddressableId]: Optional addressable id of the root event.
+  ///   Pass alongside [rootEventId] for addressable videos so the
+  ///   decrement is mirrored into the companion cache and survives a
+  ///   subsequent metadata edit.
   /// - [reason]: Optional reason for the deletion
   ///
   /// Throws [DeleteCommentFailedException] if broadcasting fails.
   Future<void> deleteComment({
     required String commentId,
     String? rootEventId,
+    String? rootAddressableId,
     String? reason,
   }) async {
     try {
@@ -477,10 +574,11 @@ class CommentsRepository {
       }
 
       if (rootEventId != null) {
-        final cached = _commentCountCache[rootEventId];
-        if (cached != null) {
-          _commentCountCache[rootEventId] = max(0, cached - 1);
-        }
+        _adjustCachedCommentCount(
+          rootEventId,
+          -1,
+          rootAddressableId: rootAddressableId,
+        );
       }
     } on CommentsRepositoryException {
       rethrow;

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1478,6 +1478,16 @@ void main() {
     });
 
     group('getCommentsCount', () {
+      // 64-char hex constants hoisted to the group scope so the
+      // post-edit cache tests stay under the 80-char line limit while
+      // sharing a single old/new event id pair.
+      const oldEventId =
+          '1111111111111111111111111111111111111111111111111111111111111111';
+      const newEventId =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+      const deletedCommentId =
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
       test('returns count from NIP-45', () async {
         when(() => mockNostrClient.countEvents(any())).thenAnswer(
           (_) async => const CountResult(count: 42),
@@ -1664,10 +1674,6 @@ void main() {
           const testAddressableId =
               '34236:$testRootAuthorPubkey'
               ':video-dtag';
-          const oldEventId =
-              '1111111111111111111111111111111111111111111111111111111111111111';
-          const newEventId =
-              '2222222222222222222222222222222222222222222222222222222222222222';
 
           when(() => mockNostrClient.countEvents(any())).thenAnswer(
             (_) async => const CountResult(count: 7),
@@ -1705,10 +1711,6 @@ void main() {
           const testAddressableId =
               '34236:$testRootAuthorPubkey'
               ':video-dtag';
-          const oldEventId =
-              '1111111111111111111111111111111111111111111111111111111111111111';
-          const newEventId =
-              '2222222222222222222222222222222222222222222222222222222222222222';
 
           when(() => mockNostrClient.countEvents(any())).thenAnswer(
             (_) async => const CountResult(count: 7),
@@ -1743,12 +1745,6 @@ void main() {
           const testAddressableId =
               '34236:$testRootAuthorPubkey'
               ':video-dtag';
-          const oldEventId =
-              '1111111111111111111111111111111111111111111111111111111111111111';
-          const newEventId =
-              '2222222222222222222222222222222222222222222222222222222222222222';
-          const testCommentId =
-              'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 
           when(() => mockNostrClient.countEvents(any())).thenAnswer(
             (_) async => const CountResult(count: 7),
@@ -1764,7 +1760,7 @@ void main() {
           );
 
           await repository.deleteComment(
-            commentId: testCommentId,
+            commentId: deletedCommentId,
             rootEventId: oldEventId,
             rootAddressableId: testAddressableId,
           );

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1005,6 +1005,103 @@ void main() {
         final filters = captured.first as List<Filter>;
         expect(filters.first.until, isNull);
       });
+
+      group('first-page authoritative zero clears stale positive cache', () {
+        // The dual-key cache from this PR makes a stale positive count
+        // outlive an addressable-event edit. If loadComments returns 0,
+        // both write sites must overwrite the cache so the post-edit
+        // fetch via the new event id sees the authoritative zero.
+        const oldEventId =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const newEventId =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        const addressableId =
+            '34236:$testRootAuthorPubkey'
+            ':video-dtag';
+
+        test(
+          'REST authoritative zero overwrites a positive cache under the '
+          'addressable id',
+          () async {
+            repository =
+                CommentsRepository(
+                  nostrClient: mockNostrClient,
+                  funnelcakeApiClient: mockFunnelcakeApiClient,
+                )..updateCachedCommentCount(
+                  oldEventId,
+                  7,
+                  rootAddressableId: addressableId,
+                );
+
+            when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeApiClient.getVideoComments(
+                videoId: any(named: 'videoId'),
+                sort: any(named: 'sort'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer(
+              (_) async => const VideoCommentsResponse(
+                comments: [],
+                total: 0,
+              ),
+            );
+
+            final loaded = await repository.loadComments(
+              rootEventId: newEventId,
+              rootEventKind: _testRootEventKind,
+              rootAddressableId: addressableId,
+            );
+            expect(loaded.totalCount, equals(0));
+
+            final post = await repository.getCommentsCount(
+              newEventId,
+              rootAddressableId: addressableId,
+            );
+            expect(
+              post,
+              equals(0),
+              reason: 'REST zero must wipe the stale 7 keyed by address',
+            );
+            verifyNever(() => mockNostrClient.countEvents(any()));
+          },
+        );
+
+        test(
+          'relay first-page empty result overwrites a positive cache under '
+          'the addressable id',
+          () async {
+            repository.updateCachedCommentCount(
+              oldEventId,
+              7,
+              rootAddressableId: addressableId,
+            );
+
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => <Event>[]);
+
+            final loaded = await repository.loadComments(
+              rootEventId: newEventId,
+              rootEventKind: _testRootEventKind,
+              rootAddressableId: addressableId,
+            );
+            expect(loaded.totalCount, equals(0));
+
+            final post = await repository.getCommentsCount(
+              newEventId,
+              rootAddressableId: addressableId,
+            );
+            expect(
+              post,
+              equals(0),
+              reason: 'relay zero must wipe the stale 7 keyed by address',
+            );
+            verifyNever(() => mockNostrClient.countEvents(any()));
+          },
+        );
+      });
     });
 
     group('postComment', () {

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1649,6 +1649,136 @@ void main() {
         expect(fresh, equals(99));
         verify(() => mockNostrClient.countEvents(any())).called(2);
       });
+
+      test(
+        // After a metadata edit the addressable video keeps the same
+        // address but gets a fresh event id. A purely event-id-keyed
+        // cache misses on the new id and forces a relay re-query whose
+        // NIP-45 COUNT on #A for kind 1111 can transiently return 0
+        // (mirror of #4432 for kind 7). The companion addressable-id
+        // cache lets the post-edit fetch reuse the count without
+        // hitting the relay.
+        'getCommentsCount returns cached value via addressable id when '
+        'event_id changes after edit',
+        () async {
+          const testAddressableId =
+              '34236:$testRootAuthorPubkey'
+              ':video-dtag';
+          const oldEventId =
+              '1111111111111111111111111111111111111111111111111111111111111111';
+          const newEventId =
+              '2222222222222222222222222222222222222222222222222222222222222222';
+
+          when(() => mockNostrClient.countEvents(any())).thenAnswer(
+            (_) async => const CountResult(count: 7),
+          );
+
+          // Seed the cache with the pre-edit fetch.
+          final preEdit = await repository.getCommentsCount(
+            oldEventId,
+            rootAddressableId: testAddressableId,
+          );
+
+          // After the edit, a fresh bloc fetches with the new event id
+          // but the same addressable id.
+          final postEdit = await repository.getCommentsCount(
+            newEventId,
+            rootAddressableId: testAddressableId,
+          );
+
+          expect(preEdit, equals(7));
+          expect(
+            postEdit,
+            equals(7),
+            reason: 'companion cache by addressable id must survive the edit',
+          );
+          // The relay was queried only for the first call. The second
+          // call is fully cache-served.
+          verify(() => mockNostrClient.countEvents(any())).called(2);
+        },
+      );
+
+      test(
+        'clearCommentCountCache also clears the addressable-id companion '
+        'cache',
+        () async {
+          const testAddressableId =
+              '34236:$testRootAuthorPubkey'
+              ':video-dtag';
+          const oldEventId =
+              '1111111111111111111111111111111111111111111111111111111111111111';
+          const newEventId =
+              '2222222222222222222222222222222222222222222222222222222222222222';
+
+          when(() => mockNostrClient.countEvents(any())).thenAnswer(
+            (_) async => const CountResult(count: 7),
+          );
+
+          await repository.getCommentsCount(
+            oldEventId,
+            rootAddressableId: testAddressableId,
+          );
+          repository.clearCommentCountCache();
+
+          when(() => mockNostrClient.countEvents(any())).thenAnswer(
+            (_) async => const CountResult(count: 11),
+          );
+
+          final fresh = await repository.getCommentsCount(
+            newEventId,
+            rootAddressableId: testAddressableId,
+          );
+          expect(
+            fresh,
+            equals(11),
+            reason: 'clear must drop the addressable companion entry too',
+          );
+        },
+      );
+
+      test(
+        'deleteComment decrement mirrors into the addressable companion '
+        'cache',
+        () async {
+          const testAddressableId =
+              '34236:$testRootAuthorPubkey'
+              ':video-dtag';
+          const oldEventId =
+              '1111111111111111111111111111111111111111111111111111111111111111';
+          const newEventId =
+              '2222222222222222222222222222222222222222222222222222222222222222';
+          const testCommentId =
+              'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+          when(() => mockNostrClient.countEvents(any())).thenAnswer(
+            (_) async => const CountResult(count: 7),
+          );
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (inv) async =>
+                PublishSuccess(event: inv.positionalArguments.first as Event),
+          );
+
+          await repository.getCommentsCount(
+            oldEventId,
+            rootAddressableId: testAddressableId,
+          );
+
+          await repository.deleteComment(
+            commentId: testCommentId,
+            rootEventId: oldEventId,
+            rootAddressableId: testAddressableId,
+          );
+
+          // Post-edit fetch with the new event id should see the
+          // decremented count via the addressable companion cache.
+          final postEdit = await repository.getCommentsCount(
+            newEventId,
+            rootAddressableId: testAddressableId,
+          );
+
+          expect(postEdit, equals(6));
+        },
+      );
     });
 
     group('deleteComment', () {


### PR DESCRIPTION
## Description

`CommentsRepository._commentCountCache` was keyed only by `rootEventId`. For NIP-71 addressable videos (Kind 30000-39999), a metadata edit publishes a replacement event with a fresh `id` but the same `kind:pubkey:d-tag` address. After such an edit the per-video \`VideoInteractionsBloc\` is re-created on the next mount (profile re-entry, fullscreen open, home-feed scroll-back), and its \`_onFetchRequested\` calls \`getCommentsCount(newEventId, rootAddressableId: address)\`. The cache misses on the new event id, so the repo falls through to a relay NIP-45 COUNT against \`#E=newEventId\` ∪ \`#A=address\`. On \`relay.divine.video\` this COUNT can transiently return 0 — the same shape as the kind-7 issue addressed for likes in #4477 — and the comment-count badge collapses to 0.

This PR adds a companion cache keyed by the stable addressable id and routes every read/write through helper methods:

- \`_readCachedCommentCount(rootEventId, rootAddressableId:)\` — checks event-id first, then the addressable cache.
- \`_writeCachedCommentCount(...)\` — dual-writes when an addressable id is in scope.
- \`_adjustCachedCommentCount(rootEventId, delta, rootAddressableId:)\` — clamps at zero, dual-writes the new value.

All call sites that already had \`rootAddressableId\` in scope (\`loadComments\`, \`postComment\`, \`getCommentsCount\`) now pass it through. \`deleteComment\` and \`updateCachedCommentCount\` gain an optional \`rootAddressableId\` parameter, and both \`CommentsBloc\` \`deleteComment\` call sites forward \`state.rootAddressableId\` so post-edit fetches observe the decrement via the companion cache. \`clearCommentCountCache\` wipes both maps.

**Why a separate PR (not extending #4477)**: per \`agent_workflow.md\` rule 3 — independent fixes ship as parallel PRs. The likes fix lives in \`VideoInteractionsBloc\` (BloC layer); this comments fix lives in \`CommentsRepository\` (repository layer). Neither depends on the other; reviewers handle each in isolation.

Closes #4481

**Related Issue:** Related to #4432 (likes companion shipped in #4477). Does not claim closure of #4432 — that issue's primary symptom is likes.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- \`flutter test mobile/packages/comments_repository/test/src/comments_repository_test.dart\` — 70/70 pass, including 3 new regression tests (post-edit cache hit by addressable id; clear wipes both maps; deleteComment decrement mirrors into the companion).
- \`flutter test mobile/test/blocs/comments/comments_bloc_test.dart mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart\` — 161/161 pass (verifies the new \`rootAddressableId\` parameter on \`deleteComment\` doesn't break existing bloc tests).
- \`flutter analyze lib test integration_test\` — No issues.

## Manual test plan

- [ ] Edit a video that has ≥1 comment → open the edited video from profile grid → comment count does not drop to 0.
- [ ] Post a comment, edit the video, navigate away and back → comment count reflects the post.
- [ ] Delete a comment, edit the video, navigate away and back → comment count reflects the deletion.
- [ ] Pre-edit comment count workflows (no edit) unchanged.

## Follow-ups (separate PRs, not blocking)

- Relay-side: investigate NIP-45 COUNT for \`Filter(kinds:[1111], A:[…])\` and \`Filter(kinds:[7], a:[…])\` indexing on \`relay.divine.video\` — mobile mitigations only help on warm caches. The relay-team task tracks the underlying issue.
- Mobile: consider applying the same dual-key pattern to \`LikesRepository._likeCountCache\` so cold-start fetches of edited videos also benefit (the current #4477 BloC fix only helps when \`nostrLikeCount\` was carried through \`_mergeUpdatedVideo\`).
