### PR TITLE
fix(library): close clip preview after delete confirmation

### DIFF
--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -156,7 +156,14 @@ class ClipLibraryService {
 
     // Fetch clip before deleting so we can clean up files
     final clip = await getClipById(id);
-    if (clip == null) return;
+    if (clip == null) {
+      Log.info(
+        '🗑️ Clip already deleted, skipping: $id',
+        name: 'ClipLibraryService',
+        category: LogCategory.video,
+      );
+      return;
+    }
 
     // Delete from DB, then clean up files
     await _clipsDao.deleteClip(id);

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -154,7 +154,7 @@ class ClipsTab extends StatelessWidget {
     BuildContext context,
     DivineVideoClip clip,
   ) async {
-    await VineBottomSheetPrompt.show<void>(
+    final confirmed = await VineBottomSheetPrompt.show<bool>(
       context: context,
       sticker: .alert,
       title: context.l10n.libraryDeleteClipTitle,
@@ -162,12 +162,17 @@ class ClipsTab extends StatelessWidget {
       additionalText: context.l10n.libraryDeleteClipsWarning,
       primaryButtonText: context.l10n.libraryDeleteConfirm,
       secondaryButtonText: context.l10n.commonCancel,
-      onPrimaryPressed: () {
-        Navigator.pop(context);
-        context.read<ClipsLibraryBloc>().add(ClipsLibraryDeleteClip(clip));
-      },
-      onSecondaryPressed: context.pop,
+      onPrimaryPressed: () => Navigator.of(context).pop(true),
+      onSecondaryPressed: () => Navigator.of(context).pop(false),
     );
+
+    if (confirmed != true) return;
+    if (!context.mounted) return;
+
+    context.read<ClipsLibraryBloc>().add(ClipsLibraryDeleteClip(clip));
+    // Close the underlying VideoClipPreview so the user returns to the
+    // library, which already reflects the deletion via the BLoC reload.
+    Navigator.of(context).pop();
   }
 }
 

--- a/mobile/test/widgets/library/clips_tab_test.dart
+++ b/mobile/test/widgets/library/clips_tab_test.dart
@@ -3,8 +3,11 @@
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
@@ -13,8 +16,11 @@ import 'package:openvine/l10n/generated/app_localizations_en.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/library/clips_tab.dart';
 import 'package:openvine/widgets/library/empty_library_state.dart';
+import 'package:openvine/widgets/video_clip/video_clip_preview.dart';
 import 'package:openvine/widgets/video_clip/video_clip_thumbnail_card.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../../helpers/go_router.dart';
 
 class _MockClipsLibraryBloc
     extends MockBloc<ClipsLibraryEvent, ClipsLibraryState>
@@ -143,6 +149,82 @@ void main() {
           () => mockBloc.add(ClipsLibraryToggleSelection(clip1)),
         ).called(1);
       });
+
+      testWidgets(
+        'long-press → trash → confirm closes preview and dispatches delete',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final messenger =
+              TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+          messenger.setMockMethodCallHandler(
+            const MethodChannel('divine_video_player'),
+            (call) async {
+              if (call.method == 'create') {
+                return <String, Object?>{'textureId': 1};
+              }
+              return null;
+            },
+          );
+          messenger.setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            (call) async => null,
+          );
+
+          final mockGoRouter = MockGoRouter();
+          when(() => mockGoRouter.pop<Object?>(any())).thenReturn(null);
+          when(mockGoRouter.canPop).thenReturn(true);
+
+          when(() => mockBloc.state).thenReturn(
+            ClipsLibraryState(
+              status: ClipsLibraryStatus.loaded,
+              clips: [clip1],
+            ),
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              child: MockGoRouterProvider(
+                goRouter: mockGoRouter,
+                child: buildWidget(),
+              ),
+            ),
+          );
+
+          // Long-press opens the VideoClipPreview overlay; tapping
+          // (default selectionEnabled=true) would only toggle selection.
+          // pumpAndSettle never settles here because the preview shows a
+          // CircularProgressIndicator while the player initializes.
+          await tester.longPress(find.byType(VideoClipThumbnailCard).first);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(find.byType(VideoClipPreview), findsOneWidget);
+
+          await tester.tap(
+            find.byWidgetPredicate(
+              (w) => w is DivineIcon && w.icon == DivineIconName.trash,
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+
+          await tester.tap(find.text(en.libraryDeleteConfirm));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(find.byType(VideoClipPreview), findsNothing);
+          verify(() => mockBloc.add(ClipsLibraryDeleteClip(clip1))).called(1);
+
+          messenger.setMockMethodCallHandler(
+            const MethodChannel('divine_video_player'),
+            null,
+          );
+          messenger.setMockMethodCallHandler(
+            const MethodChannel('divine_video_player/player_0'),
+            null,
+          );
+        },
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Close the `VideoClipPreview` overlay automatically when the user confirms a clip delete, so the deletion has visible feedback instead of silently leaving the user on a stale preview.
- Make the bottom sheet return a `bool` result rather than dispatching the delete event from inside its callback — pairs the dispatch and the preview pop atomically.
- Log redundant `deleteClip` calls so the silent no-op path is greppable in future bug reports.
- Add a regression-guard widget test: opening preview → tapping trash → confirming dispatches `ClipsLibraryDeleteClip` and removes `VideoClipPreview` from the tree.

Closes #4482.

## Root cause

`mobile/lib/widgets/library/clips_tab.dart` → `_confirmDeleteClip` was calling `Navigator.pop(context)` to close only the bottom sheet, then dispatching `ClipsLibraryDeleteClip`. The enclosing `VideoClipPreview` `PageRouteBuilder` was never popped, so users saw no visual change after confirming and would tap **Delete** again — the second tap silently short-circuited at `ClipLibraryService.deleteClip` → `if (clip == null) return;` (DB row was already removed on the first tap, so `getClipById` returned null).

The `FileCleanupService` "🔗 File still referenced, skipping delete" path is intentional and stays unchanged — clips recorded in the same session share a source `VID_*.mp4`, and keeping that file alive until the last sibling is gone is the correct behavior.

## Test plan

- [x] `flutter analyze lib/widgets/library/clips_tab.dart lib/services/clip_library_service.dart test/widgets/library/clips_tab_test.dart` — clean.
- [x] `flutter test test/widgets/library/clips_tab_test.dart test/widgets/video_clip/video_clip_preview_test.dart test/blocs/clips_library/ test/services/clip_library_service_test.dart` — 82 / 82 pass, including the new regression test.
- [ ] Manual smoke: library → tap clip → tap trash → confirm. Preview closes, snackbar "1 clip deleted", clip gone from the grid.
- [ ] Manual smoke: repeat for a clip whose source video is shared with another clip — same behavior, file silently preserved on disk.

## Risk

3 files touched (1 widget, 1 service log line, 1 new test). No BLoC contract change, no state shape change, no l10n string additions, no changes to `FileCleanupService` reference-counting semantics.