### PR TITLE
feat(divine_video_player): add Linux playback backend

### DIFF
--- a/mobile/packages/divine_video_player/README.md
+++ b/mobile/packages/divine_video_player/README.md
@@ -6,7 +6,7 @@ Seamless multi-clip video player using native platform APIs.
 
 - Seamless playback across multiple video clips with no delay
 - Continuous timeline with global position tracking
-- Native implementations: Media3/ExoPlayer (Android), AVFoundation (iOS/macOS)
+- Native implementations: Media3/ExoPlayer (Android), AVFoundation (iOS/macOS), media_kit/mpv (Linux)
 - Preloading and buffering handled natively
 - Looping, clip jumping, and playback speed control
 - Multi-track audio overlays synced to the video timeline
@@ -141,3 +141,22 @@ enabled and falls back to the platform view otherwise.
 - Android: API 28+
 - iOS: 16.0+
 - macOS: 13.0+
+- Linux: `libmpv` is bundled through `media_kit_libs_video`; install the
+  system packages `libfontconfig1` and `libass9` if your distro does not
+  already provide them.
+
+## Linux Backend Notes
+
+Linux uses a Dart backend built on `media_kit` rather than the package's
+platform-channel plugin path. That keeps the public `DivineVideoPlayer`
+API consistent without introducing a separate C++ Linux plugin to maintain.
+
+The Linux backend supports:
+
+- HLS and MP4 playback
+- Multi-clip timelines using `media_kit` playlists with per-clip `start` and `end`
+- Play, pause, seek, loop, buffer, volume, speed, and disposal
+
+The Linux backend does not yet support overlay audio tracks via
+`setAudioTracks`. Callers that need mixed timeline audio should continue to
+use the existing mobile/macOS native backends.

--- a/mobile/packages/divine_video_player/lib/divine_video_player.dart
+++ b/mobile/packages/divine_video_player/lib/divine_video_player.dart
@@ -1,6 +1,7 @@
 export 'src/audio_track.dart';
 export 'src/divine_video_player_controller.dart';
 export 'src/divine_video_player_widget.dart';
+export 'src/linux/divine_video_player_linux_plugin.dart';
 export 'src/player_error_code.dart';
 export 'src/video_clip.dart';
 export 'src/video_player_state.dart';

--- a/mobile/packages/divine_video_player/lib/divine_video_player.dart
+++ b/mobile/packages/divine_video_player/lib/divine_video_player.dart
@@ -1,7 +1,6 @@
 export 'src/audio_track.dart';
 export 'src/divine_video_player_controller.dart';
 export 'src/divine_video_player_widget.dart';
-export 'src/linux/divine_video_player_linux_plugin.dart';
 export 'src/player_error_code.dart';
 export 'src/video_clip.dart';
 export 'src/video_player_state.dart';

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -60,6 +60,7 @@ class DivineVideoPlayerController {
   static const _globalChannel = MethodChannel('divine_video_player');
 
   /// Factory used to create the Linux backend implementation.
+  @visibleForTesting
   static LinuxVideoPlayerBackendFactory linuxBackendFactory =
       MediaKitLinuxVideoPlayerBackend.new;
 

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -97,7 +97,12 @@ class DivineVideoPlayerController {
   /// process-level state across hot restarts, so old ExoPlayer /
   /// AVPlayer instances and their timers survive unless explicitly
   /// released.
+  ///
+  /// No-op on web and Linux where no native channel is registered.
   static Future<void> disposeAll() {
+    if (kIsWeb || defaultTargetPlatform == TargetPlatform.linux) {
+      return Future.value();
+    }
     return _globalChannel.invokeMethod<void>('disposeAll');
   }
 
@@ -122,6 +127,9 @@ class DivineVideoPlayerController {
   static Future<void> configureCache({
     int maxSizeBytes = kDefaultCacheMaxSizeBytes,
   }) {
+    if (kIsWeb || defaultTargetPlatform == TargetPlatform.linux) {
+      return Future.value();
+    }
     return _globalChannel.invokeMethod<void>('configureCache', {
       'maxSizeBytes': maxSizeBytes,
     });

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -317,9 +317,9 @@ class DivineVideoPlayerController {
   Future<void> setVolume(double volume) async {
     _ensureInitialized();
     final vol = volume.clamp(0.0, 1.0);
+    if (_isLinuxBackend) return _linuxBackend!.setVolume(vol);
     _state = _state.copyWith(volume: vol);
     _stateController.add(_state);
-    if (_isLinuxBackend) return _linuxBackend!.setVolume(vol);
     await _methodChannel.invokeMethod<void>('setVolume', {'volume': vol});
   }
 

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
 import 'package:divine_video_player/src/audio_track.dart';
+import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
 import 'package:divine_video_player/src/video_clip.dart';
 import 'package:divine_video_player/src/video_player_state.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -56,6 +58,14 @@ class DivineVideoPlayerController {
   final bool useLegacySurface;
 
   static const _globalChannel = MethodChannel('divine_video_player');
+
+  /// Factory used to create the Linux backend implementation.
+  static LinuxVideoPlayerBackendFactory linuxBackendFactory =
+      MediaKitLinuxVideoPlayerBackend.new;
+
+  /// Test hook that forces Linux backend selection regardless of platform.
+  @visibleForTesting
+  static bool? debugForceLinuxBackend;
 
   /// Seeded from the current time so that IDs are unique across hot
   /// restarts. Without this, Dart's static reset would reuse id 0
@@ -111,10 +121,9 @@ class DivineVideoPlayerController {
   static Future<void> configureCache({
     int maxSizeBytes = kDefaultCacheMaxSizeBytes,
   }) {
-    return _globalChannel.invokeMethod<void>(
-      'configureCache',
-      {'maxSizeBytes': maxSizeBytes},
-    );
+    return _globalChannel.invokeMethod<void>('configureCache', {
+      'maxSizeBytes': maxSizeBytes,
+    });
   }
 
   /// Pre-loads video metadata and initial buffer data into the native
@@ -131,15 +140,15 @@ class DivineVideoPlayerController {
   /// ]);
   /// ```
   static Future<void> preload(List<VideoClip> clips) {
-    return _globalChannel.invokeMethod<void>(
-      'preload',
-      {'clips': clips.map((c) => c.toMap()).toList()},
-    );
+    return _globalChannel.invokeMethod<void>('preload', {
+      'clips': clips.map((c) => c.toMap()).toList(),
+    });
   }
 
   late final int _playerId;
   late final MethodChannel _methodChannel;
   late final EventChannel _eventChannel;
+  LinuxVideoPlayerBackend? _linuxBackend;
 
   final _stateController = StreamController<DivineVideoPlayerState>.broadcast();
 
@@ -148,6 +157,7 @@ class DivineVideoPlayerController {
   var _state = const DivineVideoPlayerState();
   var _initialized = false;
   var _disposed = false;
+  var _isLinuxBackend = false;
   var _firstFrameCompleter = Completer<bool>();
 
   /// The texture ID returned by the native side when [useTexture] is
@@ -159,6 +169,9 @@ class DivineVideoPlayerController {
   /// Only non-null after [initialize] completes when [useTexture] is
   /// `true`.
   int? get textureId => _textureId;
+
+  /// Whether this controller instance is backed by the Linux Dart backend.
+  bool get usesLinuxBackend => _isLinuxBackend;
 
   /// The current player state.
   DivineVideoPlayerState get state => _state;
@@ -195,27 +208,36 @@ class DivineVideoPlayerController {
     }
 
     _playerId = _nextId++;
-    _methodChannel = MethodChannel('divine_video_player/player_$_playerId');
-    _eventChannel = EventChannel(
-      'divine_video_player/player_$_playerId/events',
-    );
+    _isLinuxBackend = debugForceLinuxBackend ?? _usesLinuxBackend;
+    if (_isLinuxBackend) {
+      _linuxBackend = linuxBackendFactory();
+      await _linuxBackend!.initialize(
+        onStateChanged: _handleLinuxState,
+        onError: _handleEventError,
+      );
+    } else {
+      _methodChannel = MethodChannel('divine_video_player/player_$_playerId');
+      _eventChannel = EventChannel(
+        'divine_video_player/player_$_playerId/events',
+      );
 
-    final result = await _globalChannel.invokeMethod<Map<Object?, Object?>>(
-      'create',
-      {
-        'id': _playerId,
-        'useTexture': useTexture,
-        'useLegacySurface': useLegacySurface,
-      },
-    );
-    if (useTexture && result != null) {
-      _textureId = result['textureId'] as int?;
+      final result = await _globalChannel.invokeMethod<Map<Object?, Object?>>(
+        'create',
+        {
+          'id': _playerId,
+          'useTexture': useTexture,
+          'useLegacySurface': useLegacySurface,
+        },
+      );
+      if (useTexture && result != null) {
+        _textureId = result['textureId'] as int?;
+      }
+
+      _eventSubscription = _eventChannel.receiveBroadcastStream().listen(
+        _handleEvent,
+        onError: _handleEventError,
+      );
     }
-
-    _eventSubscription = _eventChannel.receiveBroadcastStream().listen(
-      _handleEvent,
-      onError: _handleEventError,
-    );
 
     _initialized = true;
   }
@@ -245,25 +267,28 @@ class DivineVideoPlayerController {
     if (_firstFrameCompleter.isCompleted) {
       _firstFrameCompleter = Completer<bool>();
     }
-    await _methodChannel.invokeMethod<void>(
-      'setClips',
-      {
-        'clips': clips.map((c) => c.toMap()).toList(),
-        if (startPosition != null && startPosition > Duration.zero)
-          'startPositionMs': startPosition.inMilliseconds,
-      },
-    );
+    if (_isLinuxBackend) {
+      await _linuxBackend!.setClips(clips, startPosition: startPosition);
+      return;
+    }
+    await _methodChannel.invokeMethod<void>('setClips', {
+      'clips': clips.map((c) => c.toMap()).toList(),
+      if (startPosition != null && startPosition > Duration.zero)
+        'startPositionMs': startPosition.inMilliseconds,
+    });
   }
 
   /// Starts or resumes playback.
   Future<void> play() async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.play();
     await _methodChannel.invokeMethod<void>('play');
   }
 
   /// Pauses playback.
   Future<void> pause() async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.pause();
     await _methodChannel.invokeMethod<void>('pause');
   }
 
@@ -274,12 +299,14 @@ class DivineVideoPlayerController {
   /// be reused by calling [setSource] or [setClips] again.
   Future<void> stop() async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.stop();
     await _methodChannel.invokeMethod<void>('stop');
   }
 
   /// Seeks to [position] on the global timeline.
   Future<void> seekTo(Duration position) async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.seekTo(position);
     await _methodChannel.invokeMethod<void>('seekTo', {
       'positionMs': position.inMilliseconds,
     });
@@ -291,18 +318,17 @@ class DivineVideoPlayerController {
     final vol = volume.clamp(0.0, 1.0);
     _state = _state.copyWith(volume: vol);
     _stateController.add(_state);
-    await _methodChannel.invokeMethod<void>('setVolume', {
-      'volume': vol,
-    });
+    if (_isLinuxBackend) return _linuxBackend!.setVolume(vol);
+    await _methodChannel.invokeMethod<void>('setVolume', {'volume': vol});
   }
 
   /// Sets the playback speed multiplier.
   Future<void> setPlaybackSpeed(double speed) async {
     _ensureInitialized();
-    await _methodChannel.invokeMethod<void>(
-      'setPlaybackSpeed',
-      {'speed': speed},
-    );
+    if (_isLinuxBackend) return _linuxBackend!.setPlaybackSpeed(speed);
+    await _methodChannel.invokeMethod<void>('setPlaybackSpeed', {
+      'speed': speed,
+    });
   }
 
   /// Enables or disables looping.
@@ -311,12 +337,14 @@ class DivineVideoPlayerController {
   /// clips finish.
   Future<void> setLooping({required bool looping}) async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.setLooping(looping: looping);
     await _methodChannel.invokeMethod<void>('setLooping', {'looping': looping});
   }
 
   /// Jumps playback to the start of the clip at [index].
   Future<void> jumpToClip(int index) async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.jumpToClip(index);
     await _methodChannel.invokeMethod<void>('jumpToClip', {'index': index});
   }
 
@@ -328,15 +356,16 @@ class DivineVideoPlayerController {
   /// Replaces any previously set audio tracks.
   Future<void> setAudioTracks(List<AudioTrack> tracks) async {
     _ensureInitialized();
-    await _methodChannel.invokeMethod<void>(
-      'setAudioTracks',
-      {'tracks': tracks.map((t) => t.toMap()).toList()},
-    );
+    if (_isLinuxBackend) return _linuxBackend!.setAudioTracks(tracks);
+    await _methodChannel.invokeMethod<void>('setAudioTracks', {
+      'tracks': tracks.map((t) => t.toMap()).toList(),
+    });
   }
 
   /// Removes all overlay audio tracks.
   Future<void> removeAllAudioTracks() async {
     _ensureInitialized();
+    if (_isLinuxBackend) return _linuxBackend!.removeAllAudioTracks();
     await _methodChannel.invokeMethod<void>('removeAllAudioTracks');
   }
 
@@ -346,6 +375,9 @@ class DivineVideoPlayerController {
   /// Has no effect if [index] is out of range.
   Future<void> setAudioTrackVolume(int index, double volume) async {
     _ensureInitialized();
+    if (_isLinuxBackend) {
+      return _linuxBackend!.setAudioTrackVolume(index, volume);
+    }
     await _methodChannel.invokeMethod<void>('setAudioTrackVolume', {
       'index': index,
       'volume': volume.clamp(0.0, 1.0),
@@ -366,7 +398,9 @@ class DivineVideoPlayerController {
     _eventSubscription = null;
 
     await Future.wait<void>([
-      if (_initialized)
+      if (_initialized && _isLinuxBackend)
+        _linuxBackend!.dispose()
+      else if (_initialized)
         _globalChannel.invokeMethod<void>('dispose', {'id': _playerId}),
       _stateController.close(),
     ]);
@@ -398,10 +432,32 @@ class DivineVideoPlayerController {
     }
   }
 
+  void _handleLinuxState(DivineVideoPlayerState state) {
+    _state = state;
+    if (_state.isFirstFrameRendered && !_firstFrameCompleter.isCompleted) {
+      _firstFrameCompleter.complete(true);
+    }
+    if (!_stateController.isClosed) {
+      _stateController.add(_state);
+    }
+  }
+
   void _handleEventError(Object error) {
     _state = _state.copyWith(status: PlaybackStatus.error);
     if (!_stateController.isClosed) {
       _stateController.add(_state);
     }
+  }
+
+  bool get _usesLinuxBackend =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.linux;
+
+  /// Builds the Linux video surface for this controller instance.
+  @internal
+  Widget buildLinuxView() {
+    if (!_isLinuxBackend || _linuxBackend == null) {
+      throw StateError('Linux view is not available.');
+    }
+    return _linuxBackend!.buildView();
   }
 }

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_widget.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_widget.dart
@@ -64,7 +64,6 @@ class DivineVideoPlayer extends StatelessWidget {
           creationParams: creationParams,
           creationParamsCodec: const StandardMessageCodec(),
         ),
-        TargetPlatform.linux => ctrl.buildLinuxView(),
         TargetPlatform.macOS => AppKitView(
           viewType: ctrl.viewType,
           creationParams: creationParams,

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_widget.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_widget.dart
@@ -42,7 +42,9 @@ class DivineVideoPlayer extends StatelessWidget {
     final ctrl = controller!;
 
     final Widget surface;
-    if (ctrl.useTexture && ctrl.textureId != null) {
+    if (ctrl.usesLinuxBackend) {
+      surface = ctrl.buildLinuxView();
+    } else if (ctrl.useTexture && ctrl.textureId != null) {
       // SurfaceProducer does not forward ExoPlayer's GL transform matrix
       // (NATIVE_WINDOW_TRANSFORM_HINT) to Flutter, unlike the legacy
       // SurfaceTextureEntry which encoded rotation implicitly. The native
@@ -62,14 +64,13 @@ class DivineVideoPlayer extends StatelessWidget {
           creationParams: creationParams,
           creationParamsCodec: const StandardMessageCodec(),
         ),
+        TargetPlatform.linux => ctrl.buildLinuxView(),
         TargetPlatform.macOS => AppKitView(
           viewType: ctrl.viewType,
           creationParams: creationParams,
           creationParamsCodec: const StandardMessageCodec(),
         ),
-        _ => const Center(
-          child: Text('Platform not supported'),
-        ),
+        _ => const Center(child: Text('Platform not supported')),
       };
     }
 
@@ -81,10 +82,7 @@ class DivineVideoPlayer extends StatelessWidget {
       fit: .expand,
       children: [
         surface,
-        _PlaceholderOverlay(
-          controller: ctrl,
-          placeholder: placeholder!,
-        ),
+        _PlaceholderOverlay(controller: ctrl, placeholder: placeholder!),
       ],
     );
   }

--- a/mobile/packages/divine_video_player/lib/src/linux/divine_video_player_linux_plugin.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/divine_video_player_linux_plugin.dart
@@ -1,0 +1,7 @@
+/// Registers the Linux implementation for the Flutter plugin toolchain.
+///
+/// The actual playback logic lives in Dart, so registration is a no-op.
+base class DivineVideoPlayerLinuxPlugin {
+  /// Registers the Linux plugin implementation.
+  static void registerWith() {}
+}

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -65,19 +65,39 @@ abstract interface class LinuxVideoPlayerBackend {
 /// Linux backend powered by `media_kit` and mpv.
 class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   /// Creates a Linux backend instance.
-  MediaKitLinuxVideoPlayerBackend();
+  MediaKitLinuxVideoPlayerBackend({
+    void Function()? mediaKitInitializer,
+    Player Function()? playerFactory,
+    Object Function(Player player)? videoControllerFactory,
+    Future<void> Function(Object controller)? videoControllerReady,
+    Widget Function(Object controller)? videoViewBuilder,
+    Future<Duration> Function(String uri)? durationProbe,
+  }) : _mediaKitInitializer = mediaKitInitializer ?? MediaKit.ensureInitialized,
+       _playerFactory = playerFactory ?? Player.new,
+       _videoControllerFactory =
+           videoControllerFactory ?? _defaultVideoControllerFactory,
+       _videoControllerReady =
+           videoControllerReady ?? _defaultVideoControllerReady,
+       _videoViewBuilder = videoViewBuilder ?? _defaultVideoViewBuilder,
+       _durationProbe = durationProbe;
 
   static bool _mediaKitInitialized = false;
 
-  /// Ensures `media_kit` is initialized exactly once per process.
-  static void ensureInitialized() {
-    if (_mediaKitInitialized) return;
-    MediaKit.ensureInitialized();
-    _mediaKitInitialized = true;
+  final void Function() _mediaKitInitializer;
+  final Player Function() _playerFactory;
+  final Object Function(Player player) _videoControllerFactory;
+  final Future<void> Function(Object controller) _videoControllerReady;
+  final Widget Function(Object controller) _videoViewBuilder;
+  final Future<Duration> Function(String uri)? _durationProbe;
+
+  /// Resets the one-time media_kit initialization latch for tests.
+  @visibleForTesting
+  static void resetInitializationForTesting() {
+    _mediaKitInitialized = false;
   }
 
   late final Player _player;
-  late final media_kit.VideoController _videoController;
+  late final Object _videoController;
   final _subscriptions = <StreamSubscription<dynamic>>[];
   final _clips = <VideoClip>[];
   final _clipDurations = <Duration>[];
@@ -98,16 +118,16 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
     required void Function(DivineVideoPlayerState state) onStateChanged,
     required void Function(Object error) onError,
   }) async {
-    ensureInitialized();
+    _ensureMediaKitInitialized();
     _onStateChanged = onStateChanged;
     _onError = onError;
-    _player = Player();
-    _videoController = media_kit.VideoController(_player);
+    _player = _playerFactory();
+    _videoController = _videoControllerFactory(_player);
     _listenToPlayer();
     _initialized = true;
 
     unawaited(
-      _videoController.waitUntilFirstFrameRendered.then((_) {
+      _videoControllerReady(_videoController).then((_) {
         _emitState(_state.copyWith(isFirstFrameRendered: true));
       }, onError: onError),
     );
@@ -241,39 +261,28 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   }
 
   @override
-  Future<void> setAudioTracks(List<divine.AudioTrack> tracks) {
-    throw UnsupportedError(
-      'Linux backend does not support overlay audio tracks yet.',
-    );
-  }
+  Future<void> setAudioTracks(List<divine.AudioTrack> tracks) async {}
 
   @override
   Future<void> removeAllAudioTracks() async {}
 
   @override
-  Future<void> setAudioTrackVolume(int index, double volume) {
-    throw UnsupportedError(
-      'Linux backend does not support overlay audio tracks yet.',
-    );
-  }
+  Future<void> setAudioTrackVolume(int index, double volume) async {}
 
   @override
   Widget buildView() {
     _ensureReady();
-    return media_kit.Video(
-      controller: _videoController,
-      controls: null,
-    );
+    return _videoViewBuilder(_videoController);
   }
 
   @override
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
-    await Future.wait<void>([
-      for (final subscription in _subscriptions) subscription.cancel(),
-      _player.dispose(),
-    ]);
+    for (final subscription in _subscriptions) {
+      await subscription.cancel();
+    }
+    await _player.dispose();
   }
 
   void _listenToPlayer() {
@@ -329,18 +338,32 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
     final durations = <Duration>[];
     for (final clip in clips) {
       if (clip.end != null) {
+        if (clip.end! < clip.start) {
+          throw ArgumentError.value(
+            clip.end,
+            'clip.end',
+            'must be greater than or equal to clip.start',
+          );
+        }
         durations.add(clip.end! - clip.start);
         continue;
       }
 
-      final sourceDuration = await _probeDuration(clip.uri);
+      final sourceDuration = await (_durationProbe ?? _probeDuration)(clip.uri);
+      if (clip.start > sourceDuration) {
+        throw ArgumentError.value(
+          clip.start,
+          'clip.start',
+          'must be less than or equal to the source duration',
+        );
+      }
       durations.add(sourceDuration - clip.start);
     }
     return durations;
   }
 
   Future<Duration> _probeDuration(String uri) async {
-    final probe = Player();
+    final probe = _playerFactory();
     try {
       await probe.open(Media(uri), play: false);
       final duration = await probe.stream.duration.firstWhere(
@@ -351,6 +374,17 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
       await probe.dispose();
     }
   }
+
+  static Object _defaultVideoControllerFactory(Player player) =>
+      media_kit.VideoController(player);
+
+  static Future<void> _defaultVideoControllerReady(Object controller) =>
+      (controller as media_kit.VideoController).waitUntilFirstFrameRendered;
+
+  static Widget _defaultVideoViewBuilder(Object controller) => media_kit.Video(
+    controller: controller as media_kit.VideoController,
+    controls: null,
+  );
 
   void _rebuildClipOffsets() {
     _clipOffsets
@@ -449,15 +483,23 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   }
 
   void _emitState(DivineVideoPlayerState newState) {
+    if (_disposed) return;
     _state = newState;
     _onStateChanged?.call(newState);
   }
 
   void _handleError(Object error) {
+    if (_disposed) return;
     _emitState(
       _state.copyWith(status: PlaybackStatus.error, errorMessage: '$error'),
     );
     _onError?.call(error);
+  }
+
+  void _ensureMediaKitInitialized() {
+    if (_mediaKitInitialized) return;
+    _mediaKitInitializer();
+    _mediaKitInitialized = true;
   }
 
   void _ensureReady() {

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -1,0 +1,471 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:divine_video_player/src/audio_track.dart' as divine;
+import 'package:divine_video_player/src/video_clip.dart';
+import 'package:divine_video_player/src/video_player_state.dart';
+import 'package:flutter/widgets.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart' as media_kit;
+
+/// Creates a Linux video backend implementation.
+typedef LinuxVideoPlayerBackendFactory = LinuxVideoPlayerBackend Function();
+
+/// Linux-specific playback backend used by the public controller.
+abstract interface class LinuxVideoPlayerBackend {
+  /// Initializes the backend and starts emitting state changes.
+  Future<void> initialize({
+    required void Function(DivineVideoPlayerState state) onStateChanged,
+    required void Function(Object error) onError,
+  });
+
+  /// Loads one or more clips into the backend player.
+  Future<void> setClips(List<VideoClip> clips, {Duration? startPosition});
+
+  /// Starts or resumes playback.
+  Future<void> play();
+
+  /// Pauses playback.
+  Future<void> pause();
+
+  /// Stops playback and unloads media.
+  Future<void> stop();
+
+  /// Seeks to a position on the global timeline.
+  Future<void> seekTo(Duration position);
+
+  /// Sets the player volume.
+  Future<void> setVolume(double volume);
+
+  /// Sets the playback speed multiplier.
+  Future<void> setPlaybackSpeed(double speed);
+
+  /// Enables or disables looping.
+  Future<void> setLooping({required bool looping});
+
+  /// Jumps to a clip index within the current timeline.
+  Future<void> jumpToClip(int index);
+
+  /// Replaces the active overlay audio tracks.
+  Future<void> setAudioTracks(List<divine.AudioTrack> tracks);
+
+  /// Removes all overlay audio tracks.
+  Future<void> removeAllAudioTracks();
+
+  /// Sets the volume of a single overlay audio track.
+  Future<void> setAudioTrackVolume(int index, double volume);
+
+  /// Builds the platform-specific render widget.
+  Widget buildView();
+
+  /// Disposes the backend and releases native resources.
+  Future<void> dispose();
+}
+
+/// Linux backend powered by `media_kit` and mpv.
+class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
+  /// Creates a Linux backend instance.
+  MediaKitLinuxVideoPlayerBackend();
+
+  static bool _mediaKitInitialized = false;
+
+  /// Ensures `media_kit` is initialized exactly once per process.
+  static void ensureInitialized() {
+    if (_mediaKitInitialized) return;
+    MediaKit.ensureInitialized();
+    _mediaKitInitialized = true;
+  }
+
+  late final Player _player;
+  late final media_kit.VideoController _videoController;
+  final _subscriptions = <StreamSubscription<dynamic>>[];
+  final _clips = <VideoClip>[];
+  final _clipDurations = <Duration>[];
+  final _clipOffsets = <Duration>[];
+
+  void Function(DivineVideoPlayerState state)? _onStateChanged;
+  void Function(Object error)? _onError;
+
+  DivineVideoPlayerState _state = const DivineVideoPlayerState();
+  bool _initialized = false;
+  bool _disposed = false;
+  bool _isLooping = false;
+  bool _hasLoadedMedia = false;
+  int _currentClipIndex = 0;
+
+  @override
+  Future<void> initialize({
+    required void Function(DivineVideoPlayerState state) onStateChanged,
+    required void Function(Object error) onError,
+  }) async {
+    ensureInitialized();
+    _onStateChanged = onStateChanged;
+    _onError = onError;
+    _player = Player();
+    _videoController = media_kit.VideoController(_player);
+    _listenToPlayer();
+    _initialized = true;
+
+    unawaited(
+      _videoController.waitUntilFirstFrameRendered.then((_) {
+        _emitState(_state.copyWith(isFirstFrameRendered: true));
+      }, onError: onError),
+    );
+  }
+
+  @override
+  Future<void> setClips(
+    List<VideoClip> clips, {
+    Duration? startPosition,
+  }) async {
+    _ensureReady();
+    _clips
+      ..clear()
+      ..addAll(clips);
+
+    final boundedDurations = await _resolveClipDurations(clips);
+    _clipDurations
+      ..clear()
+      ..addAll(boundedDurations);
+    _rebuildClipOffsets();
+
+    final playlist = Playlist([
+      for (final clip in clips)
+        Media(clip.uri, start: clip.start, end: clip.end),
+    ]);
+
+    _hasLoadedMedia = true;
+    _currentClipIndex = 0;
+    _emitState(
+      _state.copyWith(
+        status: PlaybackStatus.buffering,
+        clipCount: clips.length,
+        currentClipIndex: 0,
+        duration: _totalDuration,
+        position: Duration.zero,
+        bufferedPosition: Duration.zero,
+        isFirstFrameRendered: false,
+        clearError: true,
+      ),
+    );
+
+    await _player.open(playlist, play: false);
+    await _player.setPlaylistMode(
+      _isLooping ? PlaylistMode.loop : PlaylistMode.none,
+    );
+
+    final seekPosition = startPosition ?? Duration.zero;
+    if (seekPosition > Duration.zero) {
+      await seekTo(seekPosition);
+    } else {
+      _refreshState();
+    }
+  }
+
+  @override
+  Future<void> play() async {
+    _ensureReady();
+    await _player.play();
+    _refreshState();
+  }
+
+  @override
+  Future<void> pause() async {
+    _ensureReady();
+    await _player.pause();
+    _refreshState();
+  }
+
+  @override
+  Future<void> stop() async {
+    _ensureReady();
+    await _player.stop();
+    _hasLoadedMedia = false;
+    _clips.clear();
+    _clipDurations.clear();
+    _clipOffsets.clear();
+    _currentClipIndex = 0;
+    _emitState(const DivineVideoPlayerState());
+  }
+
+  @override
+  Future<void> seekTo(Duration position) async {
+    _ensureReady();
+    if (_clips.isEmpty) return;
+
+    final clamped = _clampGlobalPosition(position);
+    final targetIndex = _clipIndexForPosition(clamped);
+    final clipOffset = _clipOffsets[targetIndex];
+    final clip = _clips[targetIndex];
+    final localOffset = clamped - clipOffset;
+    final sourcePosition = clip.start + localOffset;
+
+    if (_currentClipIndex != targetIndex) {
+      await _player.jump(targetIndex);
+    }
+    await _player.seek(sourcePosition);
+    _refreshState();
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {
+    _ensureReady();
+    await _player.setVolume(volume * 100);
+    _emitState(_state.copyWith(volume: volume));
+  }
+
+  @override
+  Future<void> setPlaybackSpeed(double speed) async {
+    _ensureReady();
+    await _player.setRate(speed);
+    _emitState(_state.copyWith(playbackSpeed: speed));
+  }
+
+  @override
+  Future<void> setLooping({required bool looping}) async {
+    _ensureReady();
+    _isLooping = looping;
+    await _player.setPlaylistMode(
+      looping ? PlaylistMode.loop : PlaylistMode.none,
+    );
+    _emitState(_state.copyWith(isLooping: looping));
+  }
+
+  @override
+  Future<void> jumpToClip(int index) async {
+    _ensureReady();
+    if (index < 0 || index >= _clips.length) return;
+    await _player.jump(index);
+    await _player.seek(_clips[index].start);
+    _refreshState();
+  }
+
+  @override
+  Future<void> setAudioTracks(List<divine.AudioTrack> tracks) {
+    throw UnsupportedError(
+      'Linux backend does not support overlay audio tracks yet.',
+    );
+  }
+
+  @override
+  Future<void> removeAllAudioTracks() async {}
+
+  @override
+  Future<void> setAudioTrackVolume(int index, double volume) {
+    throw UnsupportedError(
+      'Linux backend does not support overlay audio tracks yet.',
+    );
+  }
+
+  @override
+  Widget buildView() {
+    _ensureReady();
+    return media_kit.Video(
+      controller: _videoController,
+      controls: null,
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await Future.wait<void>([
+      for (final subscription in _subscriptions) subscription.cancel(),
+      _player.dispose(),
+    ]);
+  }
+
+  void _listenToPlayer() {
+    _subscriptions.addAll([
+      _player.stream.playing.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.position.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.duration.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.buffer.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.buffering.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.playlist.listen((playlist) {
+        _currentClipIndex = playlist.index.clamp(
+          0,
+          math.max(_clips.length - 1, 0),
+        );
+        _refreshState();
+      }, onError: _handleError),
+      _player.stream.completed.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.volume.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.rate.listen((_) => _refreshState(), onError: _handleError),
+      _player.stream.width.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+      _player.stream.height.listen(
+        (_) => _refreshState(),
+        onError: _handleError,
+      ),
+    ]);
+  }
+
+  Future<List<Duration>> _resolveClipDurations(List<VideoClip> clips) async {
+    final durations = <Duration>[];
+    for (final clip in clips) {
+      if (clip.end != null) {
+        durations.add(clip.end! - clip.start);
+        continue;
+      }
+
+      final sourceDuration = await _probeDuration(clip.uri);
+      durations.add(sourceDuration - clip.start);
+    }
+    return durations;
+  }
+
+  Future<Duration> _probeDuration(String uri) async {
+    final probe = Player();
+    try {
+      await probe.open(Media(uri), play: false);
+      final duration = await probe.stream.duration.firstWhere(
+        (value) => value > Duration.zero,
+      );
+      return duration;
+    } finally {
+      await probe.dispose();
+    }
+  }
+
+  void _rebuildClipOffsets() {
+    _clipOffsets
+      ..clear()
+      ..addAll([
+        Duration.zero,
+        for (var i = 1; i < _clipDurations.length; i++)
+          _clipDurations.take(i).fold(Duration.zero, (a, b) => a + b),
+      ]);
+  }
+
+  Duration get _totalDuration =>
+      _clipDurations.fold(Duration.zero, (a, b) => a + b);
+
+  Duration _clampGlobalPosition(Duration position) {
+    if (_clipDurations.isEmpty) return Duration.zero;
+    if (position <= Duration.zero) return Duration.zero;
+    if (position >= _totalDuration) return _totalDuration;
+    return position;
+  }
+
+  int _clipIndexForPosition(Duration position) {
+    for (var i = 0; i < _clipOffsets.length; i++) {
+      final start = _clipOffsets[i];
+      final end = start + _clipDurations[i];
+      if (position < end || i == _clipOffsets.length - 1) {
+        return i;
+      }
+    }
+    return 0;
+  }
+
+  void _refreshState() {
+    if (!_initialized || _disposed) return;
+
+    final playerState = _player.state;
+    final hasClips = _clips.isNotEmpty;
+    final currentIndex = hasClips
+        ? _currentClipIndex.clamp(0, _clips.length - 1)
+        : 0;
+    final currentClip = hasClips ? _clips[currentIndex] : null;
+    final currentOffset = hasClips ? _clipOffsets[currentIndex] : Duration.zero;
+    final currentDuration = hasClips
+        ? _clipDurations[currentIndex]
+        : Duration.zero;
+
+    final localPosition = currentClip == null
+        ? Duration.zero
+        : _clampDuration(
+            playerState.position - currentClip.start,
+            max: currentDuration,
+          );
+    final localBuffer = currentClip == null
+        ? Duration.zero
+        : _clampDuration(
+            playerState.buffer - currentClip.start,
+            max: currentDuration,
+          );
+
+    final status = switch ((
+      hasClips,
+      playerState.completed,
+      playerState.buffering,
+      playerState.playing,
+    )) {
+      (false, _, _, _) => PlaybackStatus.idle,
+      (_, true, _, _) when !_isLooping => PlaybackStatus.completed,
+      (_, _, true, _) => PlaybackStatus.buffering,
+      (_, _, _, true) => PlaybackStatus.playing,
+      _ when _hasLoadedMedia => PlaybackStatus.ready,
+      _ => PlaybackStatus.idle,
+    };
+
+    _emitState(
+      _state.copyWith(
+        status: status,
+        position: currentOffset + localPosition,
+        duration: _totalDuration,
+        bufferedPosition: currentOffset + localBuffer,
+        currentClipIndex: currentIndex,
+        clipCount: _clips.length,
+        isLooping: _isLooping,
+        volume: playerState.volume / 100,
+        playbackSpeed: playerState.rate,
+        videoWidth: playerState.width ?? 0,
+        videoHeight: playerState.height ?? 0,
+        clearError: status != PlaybackStatus.error,
+      ),
+    );
+  }
+
+  Duration _clampDuration(Duration value, {required Duration max}) {
+    if (value <= Duration.zero) return Duration.zero;
+    if (value >= max) return max;
+    return value;
+  }
+
+  void _emitState(DivineVideoPlayerState newState) {
+    _state = newState;
+    _onStateChanged?.call(newState);
+  }
+
+  void _handleError(Object error) {
+    _emitState(
+      _state.copyWith(status: PlaybackStatus.error, errorMessage: '$error'),
+    );
+    _onError?.call(error);
+  }
+
+  void _ensureReady() {
+    if (!_initialized) {
+      throw StateError('Linux backend is not initialized.');
+    }
+    if (_disposed) {
+      throw StateError('Linux backend has been disposed.');
+    }
+  }
+}

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:math' as math;
 
 import 'package:divine_video_player/src/audio_track.dart' as divine;
@@ -81,6 +82,8 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
        _videoViewBuilder = videoViewBuilder ?? _defaultVideoViewBuilder,
        _durationProbe = durationProbe;
 
+  // media_kit native initialization is process-global, so this latch must
+  // survive hot restart. Tests reset it explicitly via the visible hook.
   static bool _mediaKitInitialized = false;
 
   final void Function() _mediaKitInitializer;
@@ -111,6 +114,7 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   bool _disposed = false;
   bool _isLooping = false;
   bool _hasLoadedMedia = false;
+  bool _didLogUnsupportedAudioTrackWarning = false;
   int _currentClipIndex = 0;
 
   @override
@@ -261,13 +265,18 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   }
 
   @override
-  Future<void> setAudioTracks(List<divine.AudioTrack> tracks) async {}
+  Future<void> setAudioTracks(List<divine.AudioTrack> tracks) async {
+    if (tracks.isEmpty) return;
+    _logUnsupportedAudioTrackOperation();
+  }
 
   @override
   Future<void> removeAllAudioTracks() async {}
 
   @override
-  Future<void> setAudioTrackVolume(int index, double volume) async {}
+  Future<void> setAudioTrackVolume(int index, double volume) async {
+    _logUnsupportedAudioTrackOperation();
+  }
 
   @override
   Widget buildView() {
@@ -366,9 +375,15 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
     final probe = _playerFactory();
     try {
       await probe.open(Media(uri), play: false);
-      final duration = await probe.stream.duration.firstWhere(
-        (value) => value > Duration.zero,
-      );
+      final duration = await probe.stream.duration
+          .firstWhere(
+            (value) => value > Duration.zero,
+          )
+          .timeout(
+            const Duration(seconds: 10),
+            onTimeout: () =>
+                throw TimeoutException('Could not probe duration for $uri'),
+          );
       return duration;
     } finally {
       await probe.dispose();
@@ -392,13 +407,12 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   // coverage:ignore-end
 
   void _rebuildClipOffsets() {
-    _clipOffsets
-      ..clear()
-      ..addAll([
-        Duration.zero,
-        for (var i = 1; i < _clipDurations.length; i++)
-          _clipDurations.take(i).fold(Duration.zero, (a, b) => a + b),
-      ]);
+    _clipOffsets.clear();
+    var offset = Duration.zero;
+    for (final duration in _clipDurations) {
+      _clipOffsets.add(offset);
+      offset += duration;
+    }
   }
 
   Duration get _totalDuration =>
@@ -499,6 +513,15 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
       _state.copyWith(status: PlaybackStatus.error, errorMessage: '$error'),
     );
     _onError?.call(error);
+  }
+
+  void _logUnsupportedAudioTrackOperation() {
+    if (_didLogUnsupportedAudioTrackWarning) return;
+    _didLogUnsupportedAudioTrackWarning = true;
+    developer.log(
+      'Overlay audio tracks are not supported on the Linux backend yet.',
+      name: 'divine_video_player',
+    );
   }
 
   void _ensureMediaKitInitialized() {

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer' as developer;
+import 'dart:io' show Platform;
 import 'dart:math' as math;
 
 import 'package:divine_video_player/src/audio_track.dart' as divine;
@@ -394,16 +395,56 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   // Default seams that bind to real media_kit native objects. They cannot
   // run in a headless unit test (no native media_kit backend), which is why
   // they are injectable — tests substitute fakes via the constructor.
-  static Object _defaultVideoControllerFactory(Player player) =>
-      media_kit.VideoController(player);
+  //
+  // Environment escape hatch: setting `DIVINE_LINUX_NO_VIDEO_OUTPUT=1` skips
+  // VideoController construction entirely. mpv's GL render-context setup
+  // segfaults natively on virtual GPUs (QEMU virtio-gpu, some headless CI
+  // runners) the moment it touches Flutter's EGL config — a native crash that
+  // cannot be caught from Dart. With the flag set, audio still plays via the
+  // mpv `Player`, and `buildView()` returns an empty placeholder so the
+  // thumbnail behind it stays visible.
+  static const _disableVideoOutputEnvVar = 'DIVINE_LINUX_NO_VIDEO_OUTPUT';
 
-  static Future<void> _defaultVideoControllerReady(Object controller) =>
-      (controller as media_kit.VideoController).waitUntilFirstFrameRendered;
+  static bool get _videoOutputDisabled {
+    final value = Platform.environment[_disableVideoOutputEnvVar];
+    if (value == null) return false;
+    final normalized = value.trim().toLowerCase();
+    return normalized == '1' || normalized == 'true' || normalized == 'yes';
+  }
 
-  static Widget _defaultVideoViewBuilder(Object controller) => media_kit.Video(
-    controller: controller as media_kit.VideoController,
-    controls: null,
-  );
+  static Object _defaultVideoControllerFactory(Player player) {
+    if (_videoOutputDisabled) {
+      developer.log(
+        'DIVINE_LINUX_NO_VIDEO_OUTPUT is set — skipping VideoController. '
+        'Audio will play but video frames will not render.',
+        name: 'divine_video_player',
+      );
+      return const _DisabledVideoController();
+    }
+    // Hardware-accelerated EGL rendering crashes on virtual GPUs (QEMU,
+    // VirtualBox). Software rendering is reliable across all Linux setups.
+    return media_kit.VideoController(
+      player,
+      configuration: const media_kit.VideoControllerConfiguration(
+        enableHardwareAcceleration: false,
+      ),
+    );
+  }
+
+  static Future<void> _defaultVideoControllerReady(Object controller) {
+    if (controller is _DisabledVideoController) return Future.value();
+    return (controller as media_kit.VideoController).waitUntilFirstFrameRendered;
+  }
+
+  static Widget _defaultVideoViewBuilder(Object controller) {
+    if (controller is _DisabledVideoController) {
+      return const SizedBox.expand();
+    }
+    return media_kit.Video(
+      controller: controller as media_kit.VideoController,
+      controls: null,
+    );
+  }
   // coverage:ignore-end
 
   void _rebuildClipOffsets() {
@@ -538,4 +579,11 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
       throw StateError('Linux backend has been disposed.');
     }
   }
+}
+
+/// Sentinel marker used in place of a real `VideoController` when video
+/// output is disabled via `DIVINE_LINUX_NO_VIDEO_OUTPUT`. Lets the rest of
+/// the backend stay non-nullable while skipping native GL setup.
+class _DisabledVideoController {
+  const _DisabledVideoController();
 }

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -375,6 +375,10 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
     }
   }
 
+  // coverage:ignore-start
+  // Default seams that bind to real media_kit native objects. They cannot
+  // run in a headless unit test (no native media_kit backend), which is why
+  // they are injectable — tests substitute fakes via the constructor.
   static Object _defaultVideoControllerFactory(Player player) =>
       media_kit.VideoController(player);
 
@@ -385,6 +389,7 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
     controller: controller as media_kit.VideoController,
     controls: null,
   );
+  // coverage:ignore-end
 
   void _rebuildClipOffsets() {
     _clipOffsets

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -271,7 +271,9 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
   }
 
   @override
-  Future<void> removeAllAudioTracks() async {}
+  Future<void> removeAllAudioTracks() async {
+    _logUnsupportedAudioTrackOperation();
+  }
 
   @override
   Future<void> setAudioTrackVolume(int index, double volume) async {

--- a/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
+++ b/mobile/packages/divine_video_player/lib/src/linux/linux_video_player_backend.dart
@@ -435,7 +435,8 @@ class MediaKitLinuxVideoPlayerBackend implements LinuxVideoPlayerBackend {
 
   static Future<void> _defaultVideoControllerReady(Object controller) {
     if (controller is _DisabledVideoController) return Future.value();
-    return (controller as media_kit.VideoController).waitUntilFirstFrameRendered;
+    return (controller as media_kit.VideoController)
+        .waitUntilFirstFrameRendered;
   }
 
   static Widget _defaultVideoViewBuilder(Object controller) {

--- a/mobile/packages/divine_video_player/pubspec.yaml
+++ b/mobile/packages/divine_video_player/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   path_provider: ^2.1.5
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   path_provider_platform_interface: ^2.1.2

--- a/mobile/packages/divine_video_player/pubspec.yaml
+++ b/mobile/packages/divine_video_player/pubspec.yaml
@@ -14,6 +14,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  media_kit: ^1.2.6
+  media_kit_libs_video: ^1.0.7
+  media_kit_video:
+    git:
+      url: https://github.com/divinevideo/media-kit
+      ref: fix/texture-rotation
+      path: media_kit_video
   path_provider: ^2.1.5
 
 dev_dependencies:
@@ -33,3 +40,5 @@ flutter:
         pluginClass: DivineVideoPlayerPlugin
       macos:
         pluginClass: DivineVideoPlayerPlugin
+      linux:
+        dartPluginClass: DivineVideoPlayerLinuxPlugin

--- a/mobile/packages/divine_video_player/pubspec.yaml
+++ b/mobile/packages/divine_video_player/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   media_kit_video:
     git:
       url: https://github.com/divinevideo/media-kit
-      ref: fix/texture-rotation
+      ref: 6b718491261e40ddebf1fe9b880b3d5d30205ee0
       path: media_kit_video
   path_provider: ^2.1.5
 

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -17,6 +19,9 @@ void main() {
 
   setUp(() {
     DivineVideoPlayerController.resetIdCounterForTesting();
+    DivineVideoPlayerController.debugForceLinuxBackend = null;
+    DivineVideoPlayerController.linuxBackendFactory =
+        MediaKitLinuxVideoPlayerBackend.new;
     globalCalls = <MethodCall>[];
     playerCalls = <MethodCall>[];
     eventController = StreamController<Map<Object?, Object?>>.broadcast();
@@ -24,6 +29,9 @@ void main() {
   });
 
   tearDown(() async {
+    DivineVideoPlayerController.debugForceLinuxBackend = null;
+    DivineVideoPlayerController.linuxBackendFactory =
+        MediaKitLinuxVideoPlayerBackend.new;
     await eventController.close();
   });
 
@@ -256,6 +264,24 @@ void main() {
 
         expect(controller.textureId, equals(42));
       });
+
+      test('buildLinuxView throws when Linux backend is unavailable', () async {
+        await initController();
+
+        expect(controller.buildLinuxView, throwsStateError);
+      });
+
+      test('uses the Linux backend when forced for testing', () async {
+        final fakeLinuxBackend = _ControllerFakeLinuxBackend();
+        DivineVideoPlayerController.debugForceLinuxBackend = true;
+        DivineVideoPlayerController.linuxBackendFactory = () =>
+            fakeLinuxBackend;
+
+        await controller.initialize();
+
+        expect(controller.usesLinuxBackend, isTrue);
+        expect(fakeLinuxBackend.initializeCalls, 1);
+      });
     });
 
     group('playback methods', () {
@@ -434,6 +460,26 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         expect(completed, isFalse);
       });
+
+      test('setClips delegates to the Linux backend when active', () async {
+        final fakeLinuxBackend = _ControllerFakeLinuxBackend();
+        controller = DivineVideoPlayerController();
+        DivineVideoPlayerController.debugForceLinuxBackend = true;
+        DivineVideoPlayerController.linuxBackendFactory = () =>
+            fakeLinuxBackend;
+
+        await controller.initialize();
+        await controller.setClips(
+          const [VideoClip(uri: '/linux.mp4')],
+          startPosition: const Duration(seconds: 4),
+        );
+
+        expect(fakeLinuxBackend.lastClips, hasLength(1));
+        expect(
+          fakeLinuxBackend.lastStartPosition,
+          const Duration(seconds: 4),
+        );
+      });
     });
 
     group('audio tracks', () {
@@ -500,6 +546,23 @@ void main() {
           containsPair('volume', 1.0),
         );
       });
+
+      test(
+        'setAudioTrackVolume delegates to the Linux backend when active',
+        () async {
+          final fakeLinuxBackend = _ControllerFakeLinuxBackend();
+          controller = DivineVideoPlayerController();
+          DivineVideoPlayerController.debugForceLinuxBackend = true;
+          DivineVideoPlayerController.linuxBackendFactory = () =>
+              fakeLinuxBackend;
+
+          await controller.initialize();
+          await controller.setAudioTrackVolume(2, 1.5);
+
+          expect(fakeLinuxBackend.lastAudioTrackIndex, 2);
+          expect(fakeLinuxBackend.lastAudioTrackVolume, 1.5);
+        },
+      );
     });
 
     group('event handling', () {
@@ -668,6 +731,18 @@ void main() {
         expect(() => controller.play(), throwsStateError);
         expect(() => controller.pause(), throwsStateError);
       });
+
+      test('disposes the Linux backend when active', () async {
+        final fakeLinuxBackend = _ControllerFakeLinuxBackend();
+        DivineVideoPlayerController.debugForceLinuxBackend = true;
+        DivineVideoPlayerController.linuxBackendFactory = () =>
+            fakeLinuxBackend;
+
+        await controller.initialize();
+        await controller.dispose();
+
+        expect(fakeLinuxBackend.disposeCalls, 1);
+      });
     });
 
     group('static methods', () {
@@ -771,4 +846,74 @@ class _TestStreamHandler extends MockStreamHandler {
     unawaited(_subscription?.cancel());
     _subscription = null;
   }
+}
+
+class _ControllerFakeLinuxBackend implements LinuxVideoPlayerBackend {
+  int initializeCalls = 0;
+  int disposeCalls = 0;
+  List<VideoClip>? lastClips;
+  Duration? lastStartPosition;
+  int? lastAudioTrackIndex;
+  double? lastAudioTrackVolume;
+
+  @override
+  Widget buildView() => const SizedBox.shrink();
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+  }
+
+  @override
+  Future<void> initialize({
+    required void Function(DivineVideoPlayerState state) onStateChanged,
+    required void Function(Object error) onError,
+  }) async {
+    initializeCalls++;
+  }
+
+  @override
+  Future<void> jumpToClip(int index) async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> play() async {}
+
+  @override
+  Future<void> removeAllAudioTracks() async {}
+
+  @override
+  Future<void> seekTo(Duration position) async {}
+
+  @override
+  Future<void> setAudioTrackVolume(int index, double volume) async {
+    lastAudioTrackIndex = index;
+    lastAudioTrackVolume = volume;
+  }
+
+  @override
+  Future<void> setAudioTracks(List<AudioTrack> tracks) async {}
+
+  @override
+  Future<void> setClips(
+    List<VideoClip> clips, {
+    Duration? startPosition,
+  }) async {
+    lastClips = clips;
+    lastStartPosition = startPosition;
+  }
+
+  @override
+  Future<void> setLooping({required bool looping}) async {}
+
+  @override
+  Future<void> setPlaybackSpeed(double speed) async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> stop() async {}
 }

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -843,6 +844,44 @@ void main() {
 
         expect(globalCalls, hasLength(1));
         expect(globalCalls.first.method, equals('disposeAll'));
+      });
+
+      test('disposeAll is a no-op on Linux', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        addTearDown(
+          () => debugDefaultTargetPlatformOverride = null,
+        );
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player'),
+              (call) async {
+                globalCalls.add(call);
+                return null;
+              },
+            );
+
+        await DivineVideoPlayerController.disposeAll();
+
+        expect(globalCalls, isEmpty);
+      });
+
+      test('configureCache is a no-op on Linux', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        addTearDown(
+          () => debugDefaultTargetPlatformOverride = null,
+        );
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player'),
+              (call) async {
+                globalCalls.add(call);
+                return null;
+              },
+            );
+
+        await DivineVideoPlayerController.configureCache();
+
+        expect(globalCalls, isEmpty);
       });
     });
   });

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -351,6 +351,28 @@ void main() {
         );
       });
 
+      test(
+        'setVolume on Linux emits exactly one backend-driven update',
+        () async {
+          final fakeLinuxBackend = _ControllerFakeLinuxBackend();
+          final states = <DivineVideoPlayerState>[];
+          controller = DivineVideoPlayerController();
+          DivineVideoPlayerController.debugForceLinuxBackend = true;
+          DivineVideoPlayerController.linuxBackendFactory = () =>
+              fakeLinuxBackend;
+
+          await controller.initialize();
+          controller.stateStream.listen(states.add);
+
+          await controller.setVolume(0.5);
+
+          expect(fakeLinuxBackend.lastVolume, 0.5);
+          expect(controller.state.volume, 0.5);
+          expect(states, hasLength(1));
+          expect(states.single.volume, 0.5);
+        },
+      );
+
       test('setPlaybackSpeed sends speed', () async {
         await controller.setPlaybackSpeed(2);
 
@@ -855,6 +877,8 @@ class _ControllerFakeLinuxBackend implements LinuxVideoPlayerBackend {
   Duration? lastStartPosition;
   int? lastAudioTrackIndex;
   double? lastAudioTrackVolume;
+  double? lastVolume;
+  late void Function(DivineVideoPlayerState state) _onStateChanged;
 
   @override
   Widget buildView() => const SizedBox.shrink();
@@ -870,6 +894,7 @@ class _ControllerFakeLinuxBackend implements LinuxVideoPlayerBackend {
     required void Function(Object error) onError,
   }) async {
     initializeCalls++;
+    _onStateChanged = onStateChanged;
   }
 
   @override
@@ -912,7 +937,15 @@ class _ControllerFakeLinuxBackend implements LinuxVideoPlayerBackend {
   Future<void> setPlaybackSpeed(double speed) async {}
 
   @override
-  Future<void> setVolume(double volume) async {}
+  Future<void> setVolume(double volume) async {
+    lastVolume = volume;
+    _onStateChanged(
+      DivineVideoPlayerState(
+        status: PlaybackStatus.ready,
+        volume: volume,
+      ),
+    );
+  }
 
   @override
   Future<void> stop() async {}

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_widget_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -11,6 +12,8 @@ void main() {
 
   setUp(() async {
     DivineVideoPlayerController.resetIdCounterForTesting();
+    DivineVideoPlayerController.debugForceLinuxBackend = null;
+    DivineVideoPlayerController.linuxBackendFactory = _FakeLinuxBackend.new;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
           const MethodChannel('divine_video_player'),
@@ -27,19 +30,41 @@ void main() {
         );
   });
 
+  tearDown(() {
+    DivineVideoPlayerController.debugForceLinuxBackend = null;
+    DivineVideoPlayerController.linuxBackendFactory =
+        MediaKitLinuxVideoPlayerBackend.new;
+    _FakeLinuxBackend.instance = null;
+  });
+
+  Future<DivineVideoPlayerController> initLinuxController({
+    bool firstFrameRendered = false,
+  }) async {
+    DivineVideoPlayerController.debugForceLinuxBackend = true;
+    final linuxController = DivineVideoPlayerController();
+    await linuxController.initialize();
+    _FakeLinuxBackend.instance!.emitState(
+      DivineVideoPlayerState(
+        status: PlaybackStatus.ready,
+        clipCount: 1,
+        isFirstFrameRendered: firstFrameRendered,
+      ),
+    );
+    return linuxController;
+  }
+
   group(DivineVideoPlayer, () {
-    testWidgets('renders Text for unsupported platform', (tester) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    testWidgets('renders Linux backend view on Linux', (tester) async {
+      final linuxController = await initLinuxController();
 
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: DivineVideoPlayer(controller: controller),
+          child: DivineVideoPlayer(controller: linuxController),
         ),
       );
 
-      expect(find.text('Platform not supported'), findsOneWidget);
-      debugDefaultTargetPlatformOverride = null;
+      expect(find.text('Linux player view'), findsOneWidget);
     });
 
     testWidgets('renders Text for unsupported fuchsia', (tester) async {
@@ -230,29 +255,28 @@ void main() {
     testWidgets('does not render Stack when placeholder is null', (
       tester,
     ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      final linuxController = await initLinuxController();
 
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: DivineVideoPlayer(controller: controller),
+          child: DivineVideoPlayer(controller: linuxController),
         ),
       );
 
       expect(find.byType(Stack), findsNothing);
-      debugDefaultTargetPlatformOverride = null;
     });
 
     testWidgets('renders placeholder over surface before first frame', (
       tester,
     ) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      final linuxController = await initLinuxController();
 
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: DivineVideoPlayer(
-            controller: controller,
+            controller: linuxController,
             placeholder: const Text('Loading...'),
           ),
         ),
@@ -260,31 +284,12 @@ void main() {
 
       expect(find.byType(Stack), findsOneWidget);
       expect(find.text('Loading...'), findsOneWidget);
-      debugDefaultTargetPlatformOverride = null;
     });
 
     testWidgets('hides placeholder after first frame rendered', (tester) async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
-
-      // Set up a mock stream handler that emits firstFrameRendered=true,
-      // then create a fresh controller so its initialize() subscribes to
-      // that stream.
-      final nextId = DivineVideoPlayerController.nextId;
-
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            MethodChannel('divine_video_player/player_$nextId'),
-            (call) async => null,
-          );
-
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockStreamHandler(
-            EventChannel('divine_video_player/player_$nextId/events'),
-            _FirstFrameStreamHandler(),
-          );
-
-      final freshController = DivineVideoPlayerController();
-      await freshController.initialize();
+      final freshController = await initLinuxController(
+        firstFrameRendered: true,
+      );
 
       await tester.pumpWidget(
         Directionality(
@@ -300,9 +305,73 @@ void main() {
       await tester.pump();
 
       expect(find.text('Loading...'), findsNothing);
-      debugDefaultTargetPlatformOverride = null;
     });
   });
+}
+
+class _FakeLinuxBackend implements LinuxVideoPlayerBackend {
+  _FakeLinuxBackend() {
+    instance = this;
+  }
+
+  static _FakeLinuxBackend? instance;
+
+  late void Function(DivineVideoPlayerState state) _onStateChanged;
+
+  @override
+  Future<void> initialize({
+    required void Function(DivineVideoPlayerState state) onStateChanged,
+    required void Function(Object error) onError,
+  }) async {
+    _onStateChanged = onStateChanged;
+  }
+
+  void emitState(DivineVideoPlayerState state) => _onStateChanged(state);
+
+  @override
+  Widget buildView() => const Text('Linux player view');
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> jumpToClip(int index) async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> play() async {}
+
+  @override
+  Future<void> removeAllAudioTracks() async {}
+
+  @override
+  Future<void> seekTo(Duration position) async {}
+
+  @override
+  Future<void> setAudioTrackVolume(int index, double volume) async {}
+
+  @override
+  Future<void> setAudioTracks(List<AudioTrack> tracks) async {}
+
+  @override
+  Future<void> setClips(
+    List<VideoClip> clips, {
+    Duration? startPosition,
+  }) async {}
+
+  @override
+  Future<void> setLooping({required bool looping}) async {}
+
+  @override
+  Future<void> setPlaybackSpeed(double speed) async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> stop() async {}
 }
 
 class _FirstFrameStreamHandler extends MockStreamHandler {

--- a/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
+++ b/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
@@ -3,9 +3,10 @@ import 'dart:async';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:divine_video_player/src/linux/divine_video_player_linux_plugin.dart';
 import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:media_kit/media_kit.dart';
+import 'package:media_kit/media_kit.dart' hide AudioTrack;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -157,6 +158,35 @@ void main() {
       );
     });
 
+    test('times out when the default duration probe never resolves', () async {
+      final mainPlayer = _FakePlatformPlayer();
+      final probePlayer = _FakePlatformPlayer();
+      final players = <_FakePlatformPlayer>[mainPlayer, probePlayer];
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: players.removeAt(0)),
+        videoControllerFactory: (_) => _FakeVideoController(),
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const SizedBox.shrink(),
+      );
+
+      await backend.initialize(onStateChanged: (_) {}, onError: (_) {});
+
+      Object? error;
+      fakeAsync((async) {
+        backend
+            .setClips([const VideoClip(uri: 'file:///clip.mp4')])
+            .catchError((Object caughtError) => error = caughtError);
+
+        async.elapse(const Duration(seconds: 11));
+        async.flushMicrotasks();
+      });
+
+      expect(error, isA<TimeoutException>());
+      expect(probePlayer.lastOpenedMedia?.uri, endsWith('clip.mp4'));
+    });
+
     test(
       'playback controls and state refresh update the emitted state',
       () async {
@@ -282,6 +312,9 @@ void main() {
 
       await backend.initialize(onStateChanged: (_) {}, onError: (_) {});
 
+      await backend.setAudioTracks(const [
+        AudioTrack(uri: 'file:///overlay.mp3'),
+      ]);
       await backend.setAudioTracks(const []);
       await backend.removeAllAudioTracks();
       await backend.setAudioTrackVolume(0, 0.5);

--- a/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
+++ b/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
@@ -1,0 +1,528 @@
+import 'dart:async';
+
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(MediaKitLinuxVideoPlayerBackend.resetInitializationForTesting);
+  tearDown(MediaKitLinuxVideoPlayerBackend.resetInitializationForTesting);
+
+  group(MediaKitLinuxVideoPlayerBackend, () {
+    test('only invokes the media kit initializer once per process', () async {
+      var calls = 0;
+
+      Future<void> initializeBackend() async {
+        final backend = MediaKitLinuxVideoPlayerBackend(
+          mediaKitInitializer: () => calls++,
+          playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),
+          videoControllerFactory: (_) => _FakeVideoController(),
+          videoControllerReady: (controller) =>
+              (controller as _FakeVideoController).ready.future,
+          videoViewBuilder: (_) => const SizedBox.shrink(),
+        );
+        await backend.initialize(onStateChanged: (_) {}, onError: (_) {});
+      }
+
+      await initializeBackend();
+      await initializeBackend();
+
+      expect(calls, 1);
+    });
+
+    test('buildView and playback methods require initialization', () {
+      final backend = MediaKitLinuxVideoPlayerBackend();
+
+      expect(backend.buildView, throwsStateError);
+      expect(backend.play, throwsStateError);
+      expect(backend.pause, throwsStateError);
+      expect(backend.stop, throwsStateError);
+      expect(() => backend.seekTo(Duration.zero), throwsStateError);
+      expect(() => backend.setVolume(1), throwsStateError);
+      expect(() => backend.setPlaybackSpeed(1), throwsStateError);
+      expect(() => backend.setLooping(looping: true), throwsStateError);
+      expect(() => backend.jumpToClip(0), throwsStateError);
+    });
+
+    test('initialize wires first-frame callback and buildView', () async {
+      final fakeVideoController = _FakeVideoController();
+      final emittedStates = <DivineVideoPlayerState>[];
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),
+        videoControllerFactory: (_) => fakeVideoController,
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const Text('Linux view'),
+      );
+
+      await backend.initialize(
+        onStateChanged: emittedStates.add,
+        onError: (_) {},
+      );
+
+      expect(backend.buildView(), isA<Text>());
+
+      fakeVideoController.ready.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emittedStates.last.isFirstFrameRendered, isTrue);
+    });
+
+    test(
+      'setClips uses the default duration probe and supports seeks',
+      () async {
+        final mainPlayer = _FakePlatformPlayer();
+        final probePlayer = _FakePlatformPlayer(probeDuration: 9.seconds);
+        final players = <_FakePlatformPlayer>[mainPlayer, probePlayer];
+        final emittedStates = <DivineVideoPlayerState>[];
+        final backend = MediaKitLinuxVideoPlayerBackend(
+          mediaKitInitializer: _noop,
+          playerFactory: () => Player(platformPlayer: players.removeAt(0)),
+          videoControllerFactory: (_) => _FakeVideoController(),
+          videoControllerReady: (controller) =>
+              (controller as _FakeVideoController).ready.future,
+          videoViewBuilder: (_) => const SizedBox.shrink(),
+        );
+
+        await backend.initialize(
+          onStateChanged: emittedStates.add,
+          onError: (_) {},
+        );
+
+        await backend.setClips([
+          VideoClip(uri: 'file:///clip-1.mp4', end: 5.seconds),
+          VideoClip(uri: 'file:///clip-2.mp4', start: 2.seconds),
+        ], startPosition: 6.seconds);
+
+        expect(mainPlayer.lastOpenedPlaylist?.medias, hasLength(2));
+        expect(mainPlayer.lastJumpIndex, 1);
+        expect(mainPlayer.lastSeekPosition, 3.seconds);
+        expect(emittedStates.first.status, PlaybackStatus.buffering);
+        expect(emittedStates.last.duration, 12.seconds);
+        expect(probePlayer.lastOpenedMedia?.uri, endsWith('clip-2.mp4'));
+      },
+    );
+
+    test('rejects clips with end before start', () async {
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),
+        videoControllerFactory: (_) => _FakeVideoController(),
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const SizedBox.shrink(),
+      );
+
+      await backend.initialize(onStateChanged: (_) {}, onError: (_) {});
+
+      await expectLater(
+        () => backend.setClips([
+          const VideoClip(
+            uri: 'file:///clip.mp4',
+            start: Duration(seconds: 4),
+            end: Duration(seconds: 2),
+          ),
+        ]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects clips whose start exceeds source duration', () async {
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),
+        videoControllerFactory: (_) => _FakeVideoController(),
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const SizedBox.shrink(),
+        durationProbe: (_) async => 3.seconds,
+      );
+
+      await backend.initialize(onStateChanged: (_) {}, onError: (_) {});
+
+      await expectLater(
+        () => backend.setClips([
+          const VideoClip(
+            uri: 'file:///clip.mp4',
+            start: Duration(seconds: 4),
+          ),
+        ]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+      'playback controls and state refresh update the emitted state',
+      () async {
+        final fakePlayer = _FakePlatformPlayer();
+        final emittedStates = <DivineVideoPlayerState>[];
+        final errors = <Object>[];
+        final backend = MediaKitLinuxVideoPlayerBackend(
+          mediaKitInitializer: _noop,
+          playerFactory: () => Player(platformPlayer: fakePlayer),
+          videoControllerFactory: (_) => _FakeVideoController(),
+          videoControllerReady: (controller) =>
+              (controller as _FakeVideoController).ready.future,
+          videoViewBuilder: (_) => const SizedBox.shrink(),
+          durationProbe: (_) async => 7.seconds,
+        );
+
+        await backend.initialize(
+          onStateChanged: emittedStates.add,
+          onError: errors.add,
+        );
+        await backend.setClips([
+          VideoClip(uri: 'file:///clip-1.mp4', end: 4.seconds),
+          const VideoClip(uri: 'file:///clip-2.mp4'),
+        ]);
+
+        fakePlayer.emitState(
+          fakePlayer.state.copyWith(
+            position: 2.seconds,
+            buffer: 3.seconds,
+            width: 1920,
+            height: 1080,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        await backend.play();
+        await backend.pause();
+        fakePlayer.emitState(
+          fakePlayer.state.copyWith(buffering: false, playing: false),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await backend.setVolume(0.25);
+        await backend.setPlaybackSpeed(1.5);
+        await backend.setLooping(looping: true);
+        await backend.jumpToClip(1);
+        await backend.jumpToClip(5);
+        await backend.seekTo(5.seconds);
+
+        fakePlayer
+          ..emitPlaylistIndex(1)
+          ..emitState(
+            fakePlayer.state.copyWith(
+              playing: true,
+              position: 5.seconds,
+              buffer: 6.seconds,
+              volume: 25,
+              rate: 1.5,
+              width: 1280,
+              height: 720,
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        fakePlayer.emitState(
+          fakePlayer.state.copyWith(buffering: true, playing: false),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        await backend.setLooping(looping: false);
+        fakePlayer.emitState(
+          fakePlayer.state.copyWith(
+            buffering: false,
+            completed: true,
+            playing: false,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        fakePlayer.emitPositionError('position stream failed');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(fakePlayer.playCalls, 1);
+        expect(fakePlayer.pauseCalls, 1);
+        expect(fakePlayer.lastVolume, 25);
+        expect(fakePlayer.lastRate, 1.5);
+        expect(fakePlayer.lastPlaylistMode, PlaylistMode.none);
+        expect(fakePlayer.lastJumpIndex, 1);
+        expect(fakePlayer.lastSeekPosition, 1.seconds);
+        expect(
+          emittedStates.any((state) => state.status == PlaybackStatus.playing),
+          isTrue,
+        );
+        expect(
+          emittedStates.any(
+            (state) => state.status == PlaybackStatus.buffering,
+          ),
+          isTrue,
+        );
+        expect(
+          emittedStates.any((state) => state.status == PlaybackStatus.ready),
+          isTrue,
+        );
+        expect(
+          emittedStates.any(
+            (state) => state.status == PlaybackStatus.completed,
+          ),
+          isTrue,
+        );
+        expect(emittedStates.last.status, PlaybackStatus.error);
+        expect(errors, contains('position stream failed'));
+      },
+    );
+
+    test('audio track methods are safe no-ops on Linux', () async {
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),
+        videoControllerFactory: (_) => _FakeVideoController(),
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const SizedBox.shrink(),
+      );
+
+      await backend.initialize(onStateChanged: (_) {}, onError: (_) {});
+
+      await backend.setAudioTracks(const []);
+      await backend.removeAllAudioTracks();
+      await backend.setAudioTrackVolume(0, 0.5);
+    });
+
+    test('dispose cancels listeners before player teardown', () async {
+      final fakePlayer = _FakePlatformPlayer(emitErrorOnDispose: true);
+      final emittedStates = <DivineVideoPlayerState>[];
+      final errors = <Object>[];
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: fakePlayer),
+        videoControllerFactory: (_) => _FakeVideoController(),
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const SizedBox.shrink(),
+        durationProbe: (_) async => 4.seconds,
+      );
+
+      await backend.initialize(
+        onStateChanged: emittedStates.add,
+        onError: errors.add,
+      );
+      await backend.setClips([const VideoClip(uri: 'file:///clip.mp4')]);
+      final emittedBeforeDispose = emittedStates.length;
+
+      await backend.dispose();
+      await backend.dispose();
+
+      expect(fakePlayer.disposeCalls, 1);
+      expect(emittedStates, hasLength(emittedBeforeDispose));
+      expect(errors, isEmpty);
+      expect(backend.play, throwsStateError);
+    });
+
+    test(
+      'dispose ignores first-frame callbacks that complete afterward',
+      () async {
+        final fakeVideoController = _FakeVideoController();
+        final emittedStates = <DivineVideoPlayerState>[];
+        final backend = MediaKitLinuxVideoPlayerBackend(
+          mediaKitInitializer: _noop,
+          playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),
+          videoControllerFactory: (_) => fakeVideoController,
+          videoControllerReady: (controller) =>
+              (controller as _FakeVideoController).ready.future,
+          videoViewBuilder: (_) => const SizedBox.shrink(),
+        );
+
+        await backend.initialize(
+          onStateChanged: emittedStates.add,
+          onError: (_) {},
+        );
+        await backend.dispose();
+
+        fakeVideoController.ready.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emittedStates, isEmpty);
+      },
+    );
+
+    test('stop resets state and dispose is idempotent', () async {
+      final fakePlayer = _FakePlatformPlayer();
+      final emittedStates = <DivineVideoPlayerState>[];
+      final backend = MediaKitLinuxVideoPlayerBackend(
+        mediaKitInitializer: _noop,
+        playerFactory: () => Player(platformPlayer: fakePlayer),
+        videoControllerFactory: (_) => _FakeVideoController(),
+        videoControllerReady: (controller) =>
+            (controller as _FakeVideoController).ready.future,
+        videoViewBuilder: (_) => const SizedBox.shrink(),
+        durationProbe: (_) async => 4.seconds,
+      );
+
+      await backend.initialize(
+        onStateChanged: emittedStates.add,
+        onError: (_) {},
+      );
+      await backend.setClips([const VideoClip(uri: 'file:///clip.mp4')]);
+
+      await backend.stop();
+
+      expect(emittedStates.last, const DivineVideoPlayerState());
+      expect(fakePlayer.stopCalls, 1);
+
+      await backend.dispose();
+      await backend.dispose();
+
+      expect(fakePlayer.disposeCalls, 1);
+      expect(backend.play, throwsStateError);
+    });
+  });
+
+  test(
+    'linux plugin registration is a no-op',
+    () => expect(DivineVideoPlayerLinuxPlugin.registerWith, returnsNormally),
+  );
+}
+
+class _FakeVideoController {
+  final ready = Completer<void>();
+}
+
+class _FakePlatformPlayer extends PlatformPlayer {
+  _FakePlatformPlayer({this.probeDuration, this.emitErrorOnDispose = false})
+    : super(configuration: const PlayerConfiguration());
+
+  final Duration? probeDuration;
+  final bool emitErrorOnDispose;
+
+  Playlist? lastOpenedPlaylist;
+  Media? lastOpenedMedia;
+  PlaylistMode? lastPlaylistMode;
+  Duration? lastSeekPosition;
+  double? lastVolume;
+  double? lastRate;
+  int? lastJumpIndex;
+  int playCalls = 0;
+  int pauseCalls = 0;
+  int stopCalls = 0;
+  int disposeCalls = 0;
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+    if (emitErrorOnDispose) {
+      positionController.addError('dispose error');
+    }
+    await super.dispose();
+  }
+
+  @override
+  Future<void> jump(int index) async {
+    lastJumpIndex = index;
+  }
+
+  @override
+  Future<void> open(Playable playable, {bool play = true}) async {
+    if (playable is Playlist) {
+      lastOpenedPlaylist = playable;
+      state = state.copyWith(
+        playlist: playable,
+        completed: false,
+        playing: play,
+      );
+      playlistController.add(playable);
+      return;
+    }
+
+    if (playable is Media) {
+      lastOpenedMedia = playable;
+      if (probeDuration != null) {
+        state = state.copyWith(duration: probeDuration);
+        unawaited(
+          Future<void>.delayed(
+            Duration.zero,
+            () => durationController.add(probeDuration!),
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCalls++;
+    state = state.copyWith(playing: false);
+    playingController.add(false);
+  }
+
+  @override
+  Future<void> play() async {
+    playCalls++;
+    state = state.copyWith(playing: true);
+    playingController.add(true);
+  }
+
+  void emitPlaylistIndex(int index) {
+    final playlist = (lastOpenedPlaylist ?? const Playlist([])).copyWith(
+      index: index,
+    );
+    state = state.copyWith(playlist: playlist);
+    playlistController.add(playlist);
+  }
+
+  void emitState(PlayerState nextState) {
+    state = nextState;
+    positionController.add(nextState.position);
+    durationController.add(nextState.duration);
+    bufferController.add(nextState.buffer);
+    bufferingController.add(nextState.buffering);
+    completedController.add(nextState.completed);
+    playingController.add(nextState.playing);
+    volumeController.add(nextState.volume);
+    rateController.add(nextState.rate);
+    widthController.add(nextState.width);
+    heightController.add(nextState.height);
+  }
+
+  void emitPositionError(String error) {
+    positionController.addError(error);
+  }
+
+  @override
+  Future<void> seek(Duration duration) async {
+    lastSeekPosition = duration;
+    state = state.copyWith(position: duration);
+    positionController.add(duration);
+  }
+
+  @override
+  Future<void> setPlaylistMode(PlaylistMode playlistMode) async {
+    lastPlaylistMode = playlistMode;
+    state = state.copyWith(playlistMode: playlistMode);
+    playlistModeController.add(playlistMode);
+  }
+
+  @override
+  Future<void> setRate(double rate) async {
+    lastRate = rate;
+    state = state.copyWith(rate: rate);
+    rateController.add(rate);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {
+    lastVolume = volume;
+    state = state.copyWith(volume: volume);
+    volumeController.add(volume);
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    state = const PlayerState();
+    positionController.add(Duration.zero);
+  }
+}
+
+extension on int {
+  Duration get seconds => Duration(seconds: this);
+}
+
+void _noop() {}

--- a/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
+++ b/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
@@ -303,7 +303,7 @@ void main() {
       },
     );
 
-    test('audio track methods are safe no-ops on Linux', () async {
+    test('audio track methods warn once and do not throw on Linux', () async {
       final backend = MediaKitLinuxVideoPlayerBackend(
         mediaKitInitializer: _noop,
         playerFactory: () => Player(platformPlayer: _FakePlatformPlayer()),

--- a/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
+++ b/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
@@ -175,12 +175,15 @@ void main() {
 
       Object? error;
       fakeAsync((async) {
-        backend
-            .setClips([const VideoClip(uri: 'file:///clip.mp4')])
-            .catchError((Object caughtError) => error = caughtError);
+        unawaited(
+          backend
+              .setClips([const VideoClip(uri: 'file:///clip.mp4')])
+              .catchError((Object caughtError) => error = caughtError),
+        );
 
-        async.elapse(const Duration(seconds: 11));
-        async.flushMicrotasks();
+        async
+          ..elapse(const Duration(seconds: 11))
+          ..flushMicrotasks();
       });
 
       expect(error, isA<TimeoutException>());

--- a/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
+++ b/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
-import 'package:divine_video_player/src/linux/divine_video_player_linux_plugin.dart';
 import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter/widgets.dart';

--- a/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
+++ b/mobile/packages/divine_video_player/test/src/linux_video_player_backend_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:divine_video_player/src/linux/divine_video_player_linux_plugin.dart';
 import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -60,7 +60,11 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// all other desktop platforms.
   static bool get isSupported =>
       _isSupportedOverrideForTesting ??
-      (!kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS));
+      (!kIsWeb &&
+          (Platform.isAndroid ||
+              Platform.isIOS ||
+              Platform.isMacOS ||
+              Platform.isLinux));
 
   static bool? _isSupportedOverrideForTesting;
 

--- a/mobile/packages/pooled_video_player/pubspec.yaml
+++ b/mobile/packages/pooled_video_player/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   media_kit_video:
     git:
       url: https://github.com/divinevideo/media-kit
-      ref: fix/texture-rotation
+      ref: 6b718491261e40ddebf1fe9b880b3d5d30205ee0
       path: media_kit_video
 
 dev_dependencies:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1503,7 +1503,7 @@ packages:
     dependency: "direct main"
     description:
       path: media_kit_video
-      ref: "fix/texture-rotation"
+      ref: "6b718491261e40ddebf1fe9b880b3d5d30205ee0"
       resolved-ref: "6b718491261e40ddebf1fe9b880b3d5d30205ee0"
       url: "https://github.com/divinevideo/media-kit"
     source: git

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -296,7 +296,7 @@ dependencies:
   media_kit_video:
     git:
       url: https://github.com/divinevideo/media-kit
-      ref: fix/texture-rotation
+      ref: 6b718491261e40ddebf1fe9b880b3d5d30205ee0
       path: media_kit_video
   stream_transform: ^2.1.1
   flutter_staggered_grid_view: ^0.7.0


### PR DESCRIPTION
## Summary
- add a Linux backend for divine_video_player using media_kit/mpv
- route the controller and widget through the Dart backend on Linux while leaving Android, iOS, and macOS unchanged
- update package docs and widget tests for Linux behavior

## Testing
- flutter test from mobile/packages/divine_video_player
- flutter analyze from mobile/packages/divine_video_player
- flutter analyze lib test integration_test from mobile

Closes #4465