### PR TITLE
test(collabs): pin creator-removal invariant + document #4201 closeout

### DIFF
--- a/docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md
+++ b/docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md
@@ -10,6 +10,39 @@
 
 ---
 
+## Mobile-Side Status (2026-05-17)
+
+The mobile-side chunks of this plan have shipped under coordination epic
+`#4201` (week of 2026-05-09 → 2026-05-17). Authoritative state derives from
+the Funnelcake read model once it ships; until then, mobile uses the
+in-process pipeline described below.
+
+**Shipped on mobile:**
+
+- **Kind choice + constant** (`KIND_COLLAB_RESPONSE = 34238`): `mobile/lib/constants/collaboration_event_kinds.dart`.
+- **Acceptance publish path** (Chunk 4 Task 10): `mobile/lib/services/collaborator_response_service.dart` — landed via `#3373` / `#4045`.
+- **Invite parser + local state store** (Chunk 3 Tasks 7–9): `collaborator_invite_parser.dart`, `collaborator_invite_state_store.dart`.
+- **Invite card + conversation wiring** (Chunk 4 Task 11): `collaborator_invite_card.dart`, `collaborator_invite_actions_cubit.dart`; updated for video preview by `#4378`.
+- **Message-request preview** (Chunk 4 Task 12): `request_preview_page.dart` / `request_preview_view.dart`.
+- **Post-publish invite delivery + retry** (Chunk 5 Tasks 13–14): `video_publish_service.dart`, `share_video_menu.dart`.
+- **Funnelcake confirmed-collab client** (Chunk 6 Task 15): `mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart` (`getCollabVideos` → `/api/users/{pubkey}/collabs`).
+- **Profile collabs BLoC + grid** (Chunk 6 Task 16): `profile_collab_videos_bloc.dart`, `profile_collabs_grid.dart`.
+- **Raw `p`-tag feed expansion neutralized** (Chunk 6 Task 17 partial): `mobile/lib/services/video_event_service.dart` no-ops the legacy expansion path with a comment pointing back to this plan.
+- **Read consumer for acceptance** (closeout of `#4192` via `#4256`): new `mobile/packages/collaborator_repository` provides `CollaboratorConfirmationRepository` + `CollaboratorVisibility` + `VideoCollaboratorStatusCubit`. Pending vs confirmed render correctly on the inviter's own video and the recipient's own avatar.
+- **Self-acceptance publish path closed** (`#3559` / `#3566`): sender-side Accept/Ignore is removed; cubit asserts + early-returns when `currentUser == creator`. Mobile-side audit for `#3664` closed on 2026-04-29.
+- **p-tag construction centralized** (`#3704` via `#4326`, `#4383`): single helper for the 4-element collaborator p-tag.
+- **Profile enrichment race fixed** (`#3705` via `#4261`): targeted reconciliation prevents the duplicate-video flash on collab accept via Connect.
+
+**Funnelcake-side gates (still required for full plan completion):**
+
+- Chunk 1 Tasks 1–3 — `video_collaborators_current_data` + `video_feed_edges_current_data` read models.
+- Chunk 2 Tasks 4–6 — confirmed-only `/api/users/{pubkey}/collabs`, feed-edge-based following feed, Gorse feedback exclusion.
+- `#3664` — backend filter against self-acceptance events + historical row cleanup.
+
+Until the Funnelcake gates close, third-party viewers of any video still see all tagged collaborators including pending ones, and the following feed does not include videos from videos the user follows via a collaborator edge. Both gaps are documented in `mobile/packages/collaborator_repository/lib/src/collaborator_confirmation_repository.dart` and `mobile/lib/services/video_event_service.dart`.
+
+---
+
 ## Scope Check
 
 This is a two-repo feature. Execute it as two focused PRs, in this order:

--- a/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart
@@ -166,6 +166,76 @@ void main() {
     });
 
     test(
+      'creator removal wins: re-watch with empty taggedPubkeys excludes '
+      'previously-confirmed collaborators',
+      () async {
+        // Spec invariant from
+        // docs/superpowers/plans/2026-04-25-collab-full-lifecycle.md:
+        // "Creator removal always wins. If the latest creator-authored video
+        // event no longer has the collaborator role `p` tag, Funnelcake must
+        // remove the pending/confirmed edge even if an old acceptance event
+        // still exists."
+        //
+        // Mobile-side analogue: even though `_relayAccepted` retains the
+        // historical acceptance, a re-watch driven by the latest creator-
+        // authored event with an empty (or shrunk) `taggedPubkeys` must
+        // produce a snapshot that does not surface the removed collaborator.
+        final repo = CollaboratorConfirmationRepository(
+          nostrClient: nostrClient,
+          localStateReader: _StaticLocalStateReader(const {}),
+          currentUserPubkey: _creatorPubkey,
+        );
+
+        // Initial state: B is tagged and has accepted.
+        final emissions = <VideoCollaboratorStatus>[];
+        final sub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const [_collaboratorPubkey],
+            )
+            .listen(emissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+        relayController.add(_acceptanceEvent(pubkey: _collaboratorPubkey));
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          emissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.confirmed),
+        );
+
+        await sub.cancel();
+        repo.release(_videoAddress);
+
+        // Simulate the creator editing the video and removing B. A fresh
+        // watcher arrives with the new (empty) tagged list.
+        final reEmissions = <VideoCollaboratorStatus>[];
+        final reSub = repo
+            .watch(
+              _videoAddress,
+              creatorPubkey: _creatorPubkey,
+              taggedPubkeys: const <String>[],
+            )
+            .listen(reEmissions.add);
+
+        await Future<void>.delayed(Duration.zero);
+
+        // B was previously confirmed. The new snapshot must not surface them.
+        expect(reEmissions.last.statusByPubkey, isEmpty);
+        expect(
+          reEmissions.last.statusFor(_collaboratorPubkey),
+          equals(CollaboratorStatus.pending),
+          reason:
+              'statusFor falls back to pending for unknown pubkeys; the key '
+              'guarantee is that B is no longer in statusByPubkey.',
+        );
+
+        await reSub.cancel();
+        repo.release(_videoAddress);
+      },
+    );
+
+    test(
       'rejects events whose only address tag is `d` (NIP-33 self-id)',
       () async {
         // Defense in depth: even if a relay misbehaves and delivers an event


### PR DESCRIPTION
Closes #4201

## Summary

- Pins the spec invariant **creator removal always wins** as a regression test in `collaborator_confirmation_repository_test.dart` — previously uncovered.
- Documents the mobile-side closeout of epic #4201 directly in the two-repo lifecycle plan so the funnelcake-side team has a single doc for the handoff state.
- No production code changes. All mobile-side lifecycle code shipped in earlier PRs this week (#4256, #4261, #4326, #4378, #4383).

## Why

After tracing every render surface, repository path, and read consumer that touches the collaborator pipeline, the only meaningful regression guard missing was the creator-removal invariant. The current code is correct because `_snapshot` iterates `taggedPubkeys` (the fresh list from the latest creator-authored video event), not `_relayAccepted` — but no test pinned that behavior. A future refactor that "optimized" the snapshot to iterate accepted-set first would silently regress the spec.

The lifecycle plan checkboxes were never ticked as mobile chunks landed across the week. Adding an explicit "Mobile-Side Status (2026-05-17)" header gives the funnelcake-side team (the remaining work) a single doc to read for handoff state, including which gaps are still backend-blocked.

## What does NOT change

- No `mobile/lib/*` production code touched.
- No public APIs, models, or BLoCs changed.
- Existing 11 tests in `collaborator_confirmation_repository_test.dart` still green; only one new test added.

## Closeout map for #4201

| Child issue | State | Closing PR |
|--|--|--|
| #4192 accept/ignore no-op | CLOSED | #4256 (2026-05-11) |
| #3705 transient duplicate | CLOSED | #4261 (2026-05-11) |
| #3704 p-tag refactor | CLOSED | #4326 (2026-05-13) + #4383 |
| #3664 backend audit | OPEN | Funnelcake-side, mobile audit closed 2026-04-29 |

## Test plan

- [x] `cd mobile/packages/collaborator_repository && flutter test --no-pub test/src/collaborator_confirmation_repository_test.dart` — 11/11 passing including new "creator removal wins" test
- [x] `cd mobile && flutter analyze packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart` — clean
- [x] `cd mobile && dart format --output=none --set-exit-if-changed packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart` — no diff
- [ ] CI green before requesting review

## Out of scope (verified deferral; documented in updated lifecycle plan)

- Funnelcake `video_collaborators_current_data` read model
- Funnelcake `video_feed_edges_current_data` read model
- Mobile-side switch to confirmed feed edges (gated on the above)
- Third-party rendering of pending vs confirmed (same gate)
- #3664 backend self-acceptance filter + historical-row audit
- Public decline signal (v2)

## Related

- Parent epic: #4201
- Mobile-side audit of #3664 closed 2026-04-29 (comment on #3664)