### PR TITLE
fix(sound-detail): scrollable error state + provider overrides in test

### DIFF
--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -690,9 +690,10 @@ class _VideosGrid extends ConsumerWidget {
   ) {
     final l10n = context.l10n;
     return Center(
-      child: Padding(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(32),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Icon(Icons.error_outline, size: 64, color: VineTheme.likeRed),

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -1120,5 +1120,52 @@ void main() {
         verify(() => mockGoRouter.pop<Object?>()).called(1);
       });
     });
+
+    group('Error State Layout', () {
+      testWidgets(
+        'videos error state stays scrollable when the grid slot is short',
+        (tester) async {
+          // Reproduces the seed-1263147621 CI flake: when shuffled tests
+          // race the un-mocked sounds repository into an error before
+          // pumpAndSettle finishes, the screen rendered _buildErrorState
+          // and its Column overflowed the _VideosGrid slot by 15px (slot
+          // height was 222px in the failing run), throwing a RenderFlex
+          // exception that the framework promoted to a TestFailure
+          // across unrelated tests in the same VGV-optimized isolate.
+          // Shrink the surface enough to reproduce that short slot and
+          // verify no layout exception leaks out.
+          await tester.binding.setSurfaceSize(const Size(360, 480));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+
+          final testSound = createTestAudioEvent(id: 'sound1');
+
+          await tester.pumpWidget(
+            createTestWidget(
+              child: SoundDetailScreen(sound: testSound),
+              overrides: [
+                soundUsageCountProvider(
+                  testSound.id,
+                ).overrideWith((ref) => Future.value(0)),
+                videosUsingSoundProvider(testSound.id).overrideWith(
+                  (ref) => Future<List<String>>.error(
+                    Exception('forced error for layout regression test'),
+                  ),
+                ),
+                audioPlaybackServiceProvider.overrideWithValue(
+                  mockAudioService,
+                ),
+              ],
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          // The error body must actually be on screen (no fallback path).
+          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+          // No layout exception should have been thrown while building.
+          expect(tester.takeException(), isNull);
+        },
+      );
+    });
   });
 }

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -1010,7 +1010,22 @@ void main() {
         );
 
         await tester.pumpWidget(
-          createTestWidget(child: SoundDetailScreen(sound: testSound)),
+          createTestWidget(
+            child: SoundDetailScreen(sound: testSound),
+            overrides: [
+              // Mock the videos + usage providers so the un-mocked
+              // soundsRepository fetch can't race into the error state and
+              // tip the framework with a RenderFlex overflow under shuffled
+              // VGV-optimized seeds.
+              soundUsageCountProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(0)),
+              videosUsingSoundProvider(
+                testSound.id,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
         );
 
         await tester.pumpAndSettle();


### PR DESCRIPTION
## Description

CI was flaking on `main` because the `SoundsScreen Detail Navigation › SoundDetailScreen displays sound information` test (`mobile/test/screens/sounds_screen_test.dart:1004`) pumped `SoundDetailScreen` with **no provider overrides**. Under `very_good test --optimization --test-randomize-ordering-seed random`, the un-mocked `videosUsingSoundProvider` and `soundUsageCountProvider` raced the shared `soundsRepositoryProvider`. When earlier tests in the shuffled order poisoned the relay cache, the future resolved to an error before `pumpAndSettle` returned, and the screen rendered `_buildErrorState`. That widget's `Center → Padding(32) → Column` overflowed the 222px `_VideosGrid` slot by 15px and the framework promoted the `RenderFlex` exception to a `TestFailure` — which, in the worst seed, cascaded into 274 failures across 132 unrelated files in the same isolate.

Three back-to-back CI runs on `59f605e6` made the seed-dependency unambiguous:

| Attempt | Seed | Result |
|---|---|---|
| 1 | `2736348722` | `-274` failures (132 files) |
| 2 | `1263147621` | `-1` (this test, `sound_detail_screen.dart:695` overflow) |
| 3 | `3960218568` | `+8912` all green |

Each individual failing test passes in isolation, ruling out a product regression.

### Fix

1. `mobile/lib/screens/sound_detail_screen.dart` — wrap `_buildErrorState` in a `SingleChildScrollView` and shrink its `Column` to `MainAxisSize.min` so the layout tolerates narrow heights (real production bug too, not just a CI symptom — small-phone users in the error path would have seen yellow-and-black overflow stripes).
2. `mobile/test/screens/sounds_screen_test.dart` — mock `videosUsingSoundProvider`, `soundUsageCountProvider`, and `audioPlaybackServiceProvider` in the failing test, matching the pattern already established in `sound_detail_screen_test.dart`.
3. `mobile/test/screens/sound_detail_screen_test.dart` — add a regression test that forces the error path under a surface size reproducing the failing 222px slot; verified the test fails without the production fix and passes with it.

**Related Issue:** Closes #4489 · Relates to #4337

## Out of Scope

- The broader test-pollution audit (other widgets that overflow under shared `--optimization` isolation) and any decision around `--test-randomize-ordering-seed`. Belongs to #4337.

## Verification

- `dart format` clean (no changes needed).
- `flutter analyze lib test integration_test` → `No issues found!`.
- `flutter test test/screens/sound_detail_screen_test.dart test/screens/sounds_screen_test.dart` → `+58 ~2: All tests passed!`.
- Stashed the production fix and reran the new regression test → it correctly **fails** with `RenderFlex overflowed by 15 pixels on the bottom`. Restored the fix → green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)