### PR TITLE
fix(feed): preserve nested engagement count fallback

### DIFF
--- a/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
+++ b/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
@@ -141,7 +141,8 @@ int? _findEngagementCountDeep(dynamic source, Set<String> targetKeys) {
     for (final entry in source.entries) {
       final key = entry.key.toString().toLowerCase();
       if (targetKeys.contains(key)) {
-        return parseEngagementCount(entry.value);
+        final parsed = tryParseEngagementCount(entry.value);
+        if (parsed != null) return parsed;
       }
     }
     for (final value in source.values) {

--- a/mobile/packages/models/lib/src/engagement_count_parser.dart
+++ b/mobile/packages/models/lib/src/engagement_count_parser.dart
@@ -15,8 +15,18 @@ const _invalidEngagementCountStrings = {
 /// Engagement counts are user-visible numbers. Negative values and known
 /// max-int sentinel values are treated as absent and normalized to zero.
 int parseEngagementCount(dynamic value) {
+  final parsed = tryParseEngagementCount(value);
+  if (parsed == null) return 0;
+  return parsed;
+}
+
+/// Parses an engagement counter and preserves missing/unparseable values.
+///
+/// This is used by fallback search paths that need to keep looking when a
+/// matching field is present but does not contain a usable count.
+int? tryParseEngagementCount(dynamic value) {
   final parsed = _parseCount(value);
-  if (parsed == null || parsed < 0) return 0;
+  if (parsed == null || parsed < 0) return null;
   return parsed;
 }
 

--- a/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
+++ b/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
@@ -120,11 +120,7 @@ void main() {
       test('handles nested stats', () {
         final entry = BulkVideoStatsEntry.fromJson(const {
           'event_id': 'test',
-          'stats': {
-            'reactions': 10,
-            'comments': 5,
-            'loops': 100,
-          },
+          'stats': {'reactions': 10, 'comments': 5, 'loops': 100},
         });
 
         expect(entry.reactions, equals(10));
@@ -151,18 +147,24 @@ void main() {
         final entry = BulkVideoStatsEntry.fromJson(const {
           'event_id': 'test',
           'comments': '',
-          'stats': {
-            'comments': 5,
-          },
+          'stats': {'comments': 5},
         });
 
         expect(entry.comments, equals(5));
       });
 
-      test('defaults to 0 when no matching key found', () {
+      test('top-level zero wins over nested non-zero engagement counts', () {
         final entry = BulkVideoStatsEntry.fromJson(const {
           'event_id': 'test',
+          'comments': 0,
+          'stats': {'comments': 5},
         });
+
+        expect(entry.comments, equals(0));
+      });
+
+      test('defaults to 0 when no matching key found', () {
+        final entry = BulkVideoStatsEntry.fromJson(const {'event_id': 'test'});
 
         expect(entry.reactions, equals(0));
         expect(entry.comments, equals(0));
@@ -172,9 +174,7 @@ void main() {
       });
 
       test('handles empty JSON', () {
-        final entry = BulkVideoStatsEntry.fromJson(
-          const <String, dynamic>{},
-        );
+        final entry = BulkVideoStatsEntry.fromJson(const <String, dynamic>{});
 
         expect(entry.eventId, isEmpty);
         expect(entry.reactions, equals(0));

--- a/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
+++ b/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
@@ -147,6 +147,18 @@ void main() {
         expect(entry.reposts, equals(0));
       });
 
+      test('falls through invalid top-level engagement counters', () {
+        final entry = BulkVideoStatsEntry.fromJson(const {
+          'event_id': 'test',
+          'comments': '',
+          'stats': {
+            'comments': 5,
+          },
+        });
+
+        expect(entry.comments, equals(5));
+      });
+
       test('defaults to 0 when no matching key found', () {
         final entry = BulkVideoStatsEntry.fromJson(const {
           'event_id': 'test',

--- a/mobile/packages/models/test/src/engagement_count_parser_test.dart
+++ b/mobile/packages/models/test/src/engagement_count_parser_test.dart
@@ -1,0 +1,39 @@
+import 'package:models/src/engagement_count_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('tryParseEngagementCount', () {
+    test('returns null for unusable values', () {
+      expect(tryParseEngagementCount(null), isNull);
+      expect(tryParseEngagementCount(''), isNull);
+      expect(tryParseEngagementCount('   '), isNull);
+      expect(tryParseEngagementCount(-1), isNull);
+      expect(tryParseEngagementCount('2147483647'), isNull);
+      expect(tryParseEngagementCount('9223372036854775807'), isNull);
+      expect(tryParseEngagementCount('18446744073709551615'), isNull);
+    });
+
+    test('returns parsed non-negative counts', () {
+      expect(tryParseEngagementCount(0), equals(0));
+      expect(tryParseEngagementCount('0'), equals(0));
+      expect(tryParseEngagementCount('1,000'), equals(1000));
+      expect(tryParseEngagementCount('42.9'), equals(42));
+      expect(tryParseEngagementCount(7.8), equals(7));
+    });
+  });
+
+  group('parseEngagementCount', () {
+    test('normalizes unusable values to zero', () {
+      expect(parseEngagementCount(null), equals(0));
+      expect(parseEngagementCount(''), equals(0));
+      expect(parseEngagementCount(-1), equals(0));
+      expect(parseEngagementCount('4294967295'), equals(0));
+    });
+
+    test('preserves parsed non-negative counts', () {
+      expect(parseEngagementCount('0'), equals(0));
+      expect(parseEngagementCount('1,000'), equals(1000));
+      expect(parseEngagementCount('42.9'), equals(42));
+    });
+  });
+}


### PR DESCRIPTION
Closes #4496

## Summary
- preserve nested bulk-stats fallback when a top-level engagement field is present but invalid
- keep UI normalization behavior for real engagement values while allowing deep search to continue on missing or unusable values
- add a regression test for invalid top-level counts with valid nested stats

## Context
- follow-up to merged PR #4455
- fixes the remaining bulk-stats parsing regression on main where invalid top-level engagement values could mask valid nested stats

## Verification
- flutter test test/src/bulk_video_stats_entry_test.dart test/src/video_stats_test.dart (mobile/packages/models)
- pre-push hook analyzer + changed-file tests