### PR TITLE
feat(tags-picker): support pasting multiple tags as comma/space-separated list

### DIFF
--- a/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
@@ -1,0 +1,174 @@
+// ABOUTME: BLoC for the video metadata tags picker sheet.
+// ABOUTME: Sanitizes / dedups committed tags and searches suggestions.
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hashtag_repository/hashtag_repository.dart';
+import 'package:openvine/constants/search_constants.dart';
+
+part 'tags_picker_event.dart';
+part 'tags_picker_state.dart';
+
+/// Allowed characters in a hashtag — everything else is stripped on commit.
+final _sanitizePattern = RegExp('[^a-zA-Z0-9]');
+
+/// Matches one or more consecutive tag separators (space or comma). Used
+/// both for detecting whether the input contains a separator and for
+/// splitting it into tokens.
+final _separatorPattern = RegExp('[ ,]+');
+
+/// Result of parsing a tag-input text change into committable tokens
+/// plus a remainder that should stay in the text field.
+class TagsPickerInputParseResult {
+  /// Creates a parse result.
+  const TagsPickerInputParseResult({
+    required this.completed,
+    required this.remainder,
+  });
+
+  /// Tokens that are ready to be added to the selected tags.
+  final List<String> completed;
+
+  /// Trailing partial token that should remain in the text field.
+  final String remainder;
+}
+
+/// Pure parser that decides which tokens are completed and which is a
+/// remainder partial token, based on the new and previous text.
+///
+/// A "paste" is detected when [text] grew by more than one character vs
+/// [previousText]; in that case the trailing token is also committed
+/// (so pasting `"foo, bar, baz"` adds all three).
+///
+/// This is the parsing rule for the tags picker text field. The widget
+/// is only responsible for forwarding the result to the controller and
+/// dispatching the bloc events.
+TagsPickerInputParseResult parseTagsPickerInput({
+  required String text,
+  required String previousText,
+}) {
+  if (!text.contains(_separatorPattern)) {
+    return TagsPickerInputParseResult(
+      completed: const [],
+      remainder: text,
+    );
+  }
+  final parts = text.split(_separatorPattern);
+  final isPaste = text.length - previousText.length > 1;
+  if (isPaste) {
+    return TagsPickerInputParseResult(
+      completed: parts.where((p) => p.isNotEmpty).toList(),
+      remainder: '',
+    );
+  }
+  return TagsPickerInputParseResult(
+    completed: parts
+        .sublist(0, parts.length - 1)
+        .where((p) => p.isNotEmpty)
+        .toList(),
+    remainder: parts.last,
+  );
+}
+
+/// BLoC that owns the state of the tags picker sheet.
+///
+/// Responsibilities:
+///   * sanitize and deduplicate tokens before adding them to [TagsPickerState.selectedTags]
+///   * debounce-restart hashtag search requests against [HashtagRepository]
+///   * filter the resulting suggestions against already-selected tags
+class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
+  TagsPickerBloc({
+    required HashtagRepository hashtagRepository,
+    required Set<String> initialTags,
+  }) : _hashtagRepository = hashtagRepository,
+       super(TagsPickerState(selectedTags: Set.of(initialTags))) {
+    on<TagsPickerTagsAdded>(_onTagsAdded);
+    on<TagsPickerTagRemoved>(_onTagRemoved);
+    on<TagsPickerQueryChanged>(
+      _onQueryChanged,
+      transformer: debounceRestartable(),
+    );
+  }
+
+  final HashtagRepository _hashtagRepository;
+
+  void _onTagsAdded(
+    TagsPickerTagsAdded event,
+    Emitter<TagsPickerState> emit,
+  ) {
+    final updated = Set<String>.of(state.selectedTags);
+    var changed = false;
+    for (final raw in event.rawTokens) {
+      final tag = raw.replaceAll(_sanitizePattern, '');
+      if (tag.isEmpty) continue;
+      final exists = updated.any(
+        (t) => t.toLowerCase() == tag.toLowerCase(),
+      );
+      if (exists) continue;
+      updated.add(tag);
+      changed = true;
+    }
+    if (!changed) return;
+    emit(
+      state.copyWith(
+        selectedTags: updated,
+        suggestions: _filterSuggestions(state.suggestions, updated),
+      ),
+    );
+  }
+
+  void _onTagRemoved(
+    TagsPickerTagRemoved event,
+    Emitter<TagsPickerState> emit,
+  ) {
+    if (!state.selectedTags.contains(event.tag)) return;
+    final updated = Set<String>.of(state.selectedTags)..remove(event.tag);
+    emit(state.copyWith(selectedTags: updated));
+  }
+
+  Future<void> _onQueryChanged(
+    TagsPickerQueryChanged event,
+    Emitter<TagsPickerState> emit,
+  ) async {
+    final query = event.query.trim();
+    if (query.isEmpty) {
+      emit(
+        state.copyWith(
+          status: TagsPickerStatus.initial,
+          query: '',
+          suggestions: const [],
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: TagsPickerStatus.searching,
+        query: query,
+      ),
+    );
+
+    // HashtagRepository.searchHashtags is documented as never-throws and
+    // falls back to an empty list on any upstream failure, so we don't need
+    // a try/catch or a separate failure status here.
+    final results = await _hashtagRepository.searchHashtags(query: query);
+    emit(
+      state.copyWith(
+        status: TagsPickerStatus.success,
+        suggestions: _filterSuggestions(results, state.selectedTags),
+      ),
+    );
+  }
+
+  static List<String> _filterSuggestions(
+    List<String> suggestions,
+    Set<String> selected,
+  ) {
+    if (suggestions.isEmpty) return suggestions;
+    final lowerSelected = selected.map((t) => t.toLowerCase()).toSet();
+    return suggestions
+        .where((s) => !lowerSelected.contains(s.toLowerCase()))
+        .toList();
+  }
+}

--- a/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
@@ -54,6 +54,11 @@ TagsPickerInputParseResult parseTagsPickerInput({
     );
   }
   final parts = text.split(_separatorPattern);
+  // Heuristic: input that grew by >1 character in a single notifier tick
+  // is treated as a paste. Safe today because the field filters to
+  // [a-zA-Z0-9 ,] — if the allow-list is widened, autocorrect / IME
+  // (e.g. CJK composition, swipe-to-type, `omw` → `on my way`) may land
+  // here and unexpectedly commit a token.
   final isPaste = text.length - previousText.length > 1;
   if (isPaste) {
     return TagsPickerInputParseResult(

--- a/mobile/lib/blocs/tags_picker/tags_picker_event.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_event.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Events for [TagsPickerBloc].
+
+part of 'tags_picker_bloc.dart';
+
+/// Base class for tags picker events.
+sealed class TagsPickerEvent extends Equatable {
+  const TagsPickerEvent();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// One or more raw tokens were committed by the user (separator typed, paste,
+/// submit, or suggestion tap). The bloc is responsible for sanitizing and
+/// deduplicating before adding them to the selected set.
+final class TagsPickerTagsAdded extends TagsPickerEvent {
+  const TagsPickerTagsAdded(this.rawTokens);
+
+  final Iterable<String> rawTokens;
+
+  @override
+  List<Object?> get props => [rawTokens.toList()];
+}
+
+/// User removed a previously selected tag.
+final class TagsPickerTagRemoved extends TagsPickerEvent {
+  const TagsPickerTagRemoved(this.tag);
+
+  final String tag;
+
+  @override
+  List<Object?> get props => [tag];
+}
+
+/// The current (uncommitted) query in the search field changed.
+final class TagsPickerQueryChanged extends TagsPickerEvent {
+  const TagsPickerQueryChanged(this.query);
+
+  final String query;
+
+  @override
+  List<Object?> get props => [query];
+}

--- a/mobile/lib/blocs/tags_picker/tags_picker_event.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_event.dart
@@ -16,10 +16,10 @@ sealed class TagsPickerEvent extends Equatable {
 final class TagsPickerTagsAdded extends TagsPickerEvent {
   const TagsPickerTagsAdded(this.rawTokens);
 
-  final Iterable<String> rawTokens;
+  final List<String> rawTokens;
 
   @override
-  List<Object?> get props => [rawTokens.toList()];
+  List<Object?> get props => [rawTokens];
 }
 
 /// User removed a previously selected tag.

--- a/mobile/lib/blocs/tags_picker/tags_picker_state.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_state.dart
@@ -1,0 +1,68 @@
+// ABOUTME: State for [TagsPickerBloc].
+
+part of 'tags_picker_bloc.dart';
+
+/// Status of the tags picker search lifecycle.
+enum TagsPickerStatus {
+  /// No query is active; suggestions are empty.
+  initial,
+
+  /// A debounced search is in flight.
+  searching,
+
+  /// Search completed; [TagsPickerState.suggestions] is populated (possibly
+  /// empty if the repository found no matches or fell back silently).
+  success,
+}
+
+/// State for the tags picker sheet.
+final class TagsPickerState extends Equatable {
+  const TagsPickerState({
+    this.selectedTags = const <String>{},
+    this.query = '',
+    this.suggestions = const <String>[],
+    this.status = TagsPickerStatus.initial,
+  });
+
+  /// Tags the user has committed in this session.
+  final Set<String> selectedTags;
+
+  /// Current (trimmed) query driving the suggestion list.
+  final String query;
+
+  /// Suggestions returned by [HashtagRepository], minus anything that has
+  /// already been selected.
+  final List<String> suggestions;
+
+  /// Lifecycle of the suggestion search.
+  final TagsPickerStatus status;
+
+  /// The sanitized query — i.e. what would be added if the user committed it.
+  String get sanitizedQuery => query.replaceAll(_sanitizePattern, '');
+
+  /// Whether the sanitized query is non-empty and not already selected
+  /// (case-insensitive).
+  bool get canAddQuery {
+    final s = sanitizedQuery;
+    if (s.isEmpty) return false;
+    final lower = s.toLowerCase();
+    return !selectedTags.any((t) => t.toLowerCase() == lower);
+  }
+
+  TagsPickerState copyWith({
+    Set<String>? selectedTags,
+    String? query,
+    List<String>? suggestions,
+    TagsPickerStatus? status,
+  }) {
+    return TagsPickerState(
+      selectedTags: selectedTags ?? this.selectedTags,
+      query: query ?? this.query,
+      suggestions: suggestions ?? this.suggestions,
+      status: status ?? this.status,
+    );
+  }
+
+  @override
+  List<Object?> get props => [selectedTags, query, suggestions, status];
+}

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -1,14 +1,13 @@
 // ABOUTME: Bottom-sheet widget for searching and managing video hashtags
 // ABOUTME: Matches the UserPickerSheet pattern: rounded search field + list rows
 
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:hashtag_repository/hashtag_repository.dart';
+import 'package:openvine/blocs/tags_picker/tags_picker_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -74,7 +73,7 @@ class VideoMetadataTagsSelector extends ConsumerWidget {
 
 // ─── Sheet ─────────────────────────────────────────────────────────────────
 
-class _TagsPickerSheet extends ConsumerStatefulWidget {
+class _TagsPickerSheet extends ConsumerWidget {
   const _TagsPickerSheet({
     required this.initialTags,
     this.scrollController,
@@ -84,83 +83,89 @@ class _TagsPickerSheet extends ConsumerStatefulWidget {
   final ScrollController? scrollController;
 
   @override
-  ConsumerState<_TagsPickerSheet> createState() => _TagsPickerSheetState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Watch the repo so the bloc is recreated if Riverpod ever rebuilds the
+    // provider (auth flip, account switch). See state_management.md →
+    // "Bridging Riverpod-provided dependencies into BlocProvider".
+    final hashtagRepository = ref.watch(hashtagRepositoryProvider);
+    return BlocProvider<TagsPickerBloc>(
+      key: ValueKey(hashtagRepository),
+      create: (_) => TagsPickerBloc(
+        hashtagRepository: hashtagRepository,
+        initialTags: initialTags,
+      ),
+      child: _TagsPickerView(scrollController: scrollController),
+    );
+  }
 }
 
-class _TagsPickerSheetState extends ConsumerState<_TagsPickerSheet> {
-  late Set<String> _tags;
-  late final HashtagRepository _hashtagRepository;
+class _TagsPickerView extends StatefulWidget {
+  const _TagsPickerView({this.scrollController});
+
+  final ScrollController? scrollController;
+
+  @override
+  State<_TagsPickerView> createState() => _TagsPickerViewState();
+}
+
+class _TagsPickerViewState extends State<_TagsPickerView> {
   final _searchController = TextEditingController();
-  String _query = '';
-  List<String> _suggestions = [];
-  Timer? _debounceTimer;
-  bool _isLoading = false;
+  String _previousText = '';
 
   @override
   void initState() {
     super.initState();
-    _tags = Set.of(widget.initialTags);
-    _hashtagRepository = ref.read(hashtagRepositoryProvider);
     _searchController.addListener(_onSearchChanged);
   }
 
   @override
   void dispose() {
-    _debounceTimer?.cancel();
     _searchController.dispose();
     super.dispose();
   }
 
   void _onSearchChanged() {
-    final query = _searchController.text.trim();
-    setState(() => _query = query);
-    _debounceTimer?.cancel();
-    if (query.isEmpty) {
-      setState(() {
-        _suggestions = [];
-        _isLoading = false;
-      });
+    final text = _searchController.text;
+    final previous = _previousText;
+
+    final parsed = parseTagsPickerInput(
+      text: text,
+      previousText: previous,
+    );
+
+    // No separator → just forward the raw text as a search query.
+    if (parsed.completed.isEmpty) {
+      _previousText = text;
+      context.read<TagsPickerBloc>().add(TagsPickerQueryChanged(text));
       return;
     }
-    _debounceTimer = Timer(const Duration(milliseconds: 350), () async {
-      if (!mounted) return;
-      setState(() => _isLoading = true);
-      final results = await _hashtagRepository.searchHashtags(query: query);
-      if (!mounted) return;
-      setState(() {
-        _isLoading = false;
-        _suggestions = results
-            .where(
-              (t) => !_tags.any((a) => a.toLowerCase() == t.toLowerCase()),
-            )
-            .toList();
-      });
-    });
+
+    context.read<TagsPickerBloc>().add(TagsPickerTagsAdded(parsed.completed));
+    _previousText = parsed.remainder;
+    _searchController.value = TextEditingValue(
+      text: parsed.remainder,
+      selection: TextSelection.collapsed(offset: parsed.remainder.length),
+    );
+    // Listener re-fires with the cleaned text and emits the query event.
   }
 
   void _addTag(String raw) {
-    final tag = raw.replaceAll(RegExp('[^a-zA-Z0-9]'), '');
-    if (tag.isEmpty) return;
-    setState(() {
-      _tags.add(tag);
-      _suggestions.removeWhere((s) => s.toLowerCase() == tag.toLowerCase());
-    });
+    context.read<TagsPickerBloc>().add(TagsPickerTagsAdded([raw]));
+    // Clear the field so the next suggestion tap / submit starts fresh.
+    if (_searchController.text.isNotEmpty) {
+      _previousText = '';
+      _searchController.clear();
+    }
   }
 
-  void _removeTag(String tag) => setState(() => _tags.remove(tag));
-
-  bool get _canAddQuery {
-    if (_query.isEmpty) return false;
-    final sanitized = _query.replaceAll(RegExp('[^a-zA-Z0-9]'), '');
-    if (sanitized.isEmpty) return false;
-    return !_tags.any((t) => t.toLowerCase() == sanitized.toLowerCase());
+  void _removeTag(String tag) {
+    context.read<TagsPickerBloc>().add(TagsPickerTagRemoved(tag));
   }
 
   static const _searchInputBorderRadius = 20.0;
 
   @override
   Widget build(BuildContext context) {
-    final sanitizedQuery = _query.replaceAll(RegExp('[^a-zA-Z0-9]'), '');
     final hintText = context.l10n.videoMetadataTagsPickerSearchHint;
 
     return Column(
@@ -181,7 +186,8 @@ class _TagsPickerSheetState extends ConsumerState<_TagsPickerSheet> {
           trailingAction: DivineIconButton(
             icon: .check,
             size: .small,
-            onPressed: () => context.pop(_tags),
+            onPressed: () =>
+                context.pop(context.read<TagsPickerBloc>().state.selectedTags),
           ),
         ),
 
@@ -202,7 +208,7 @@ class _TagsPickerSheetState extends ConsumerState<_TagsPickerSheet> {
               autocorrect: false,
               enableSuggestions: false,
               inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9]')),
+                FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9 ,]')),
               ],
               onSubmitted: _addTag,
               cursorColor: VineTheme.vineGreen,
@@ -239,55 +245,72 @@ class _TagsPickerSheetState extends ConsumerState<_TagsPickerSheet> {
           ),
         ),
 
-        AnimatedSize(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          alignment: Alignment.topCenter,
-          child: _tags.isNotEmpty
-              ? ConstrainedBox(
-                  constraints: const BoxConstraints(maxHeight: 128),
-                  child: SingleChildScrollView(
-                    padding: const .only(bottom: 16),
-                    child: _SelectedTagsChipRow(
-                      tags: _tags.toList()..sort(),
-                      onRemove: _removeTag,
-                    ),
+        BlocSelector<TagsPickerBloc, TagsPickerState, Set<String>>(
+          selector: (s) => s.selectedTags,
+          builder: (context, selectedTags) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.topCenter,
+                  child: selectedTags.isNotEmpty
+                      ? ConstrainedBox(
+                          constraints: const BoxConstraints(maxHeight: 128),
+                          child: SingleChildScrollView(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: _SelectedTagsChipRow(
+                              tags: selectedTags.toList()..sort(),
+                              onRemove: _removeTag,
+                            ),
+                          ),
+                        )
+                      : const SizedBox.shrink(),
+                ),
+                if (selectedTags.isNotEmpty)
+                  const Divider(
+                    height: 1,
+                    thickness: 1,
+                    color: VineTheme.outlineDisabled,
                   ),
-                )
-              : const SizedBox.shrink(),
+              ],
+            );
+          },
         ),
-        if (_tags.isNotEmpty)
-          const Divider(
-            height: 1,
-            thickness: 1,
-            color: VineTheme.outlineDisabled,
-          )
-        else if (_query.isEmpty)
-          const _EmptyState(),
 
-        AnimatedOpacity(
-          opacity: _isLoading ? 1.0 : 0.0,
-          duration: const Duration(milliseconds: 200),
-          child: const LinearProgressIndicator(
-            backgroundColor: Colors.transparent,
-            color: VineTheme.primary,
-            minHeight: 2,
-          ),
+        BlocSelector<TagsPickerBloc, TagsPickerState, bool>(
+          selector: (s) => s.status == TagsPickerStatus.searching,
+          builder: (context, isLoading) {
+            return AnimatedOpacity(
+              opacity: isLoading ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: const LinearProgressIndicator(
+                backgroundColor: Colors.transparent,
+                color: VineTheme.primary,
+                minHeight: 2,
+              ),
+            );
+          },
         ),
 
         Expanded(
-          child: Builder(
-            builder: (context) {
-              final resultTags = [
-                if (_canAddQuery) sanitizedQuery,
-                ..._suggestions.where(
-                  (s) => s.toLowerCase() != sanitizedQuery.toLowerCase(),
-                ),
-              ];
-
-              if (_query.isEmpty) {
+          child: BlocBuilder<TagsPickerBloc, TagsPickerState>(
+            builder: (context, state) {
+              if (state.query.isEmpty) {
+                if (state.selectedTags.isEmpty) {
+                  return const _EmptyState();
+                }
                 return const SizedBox.shrink();
               }
+
+              final sanitized = state.sanitizedQuery;
+              final resultTags = [
+                if (state.canAddQuery) sanitized,
+                ...state.suggestions.where(
+                  (s) => s.toLowerCase() != sanitized.toLowerCase(),
+                ),
+              ];
 
               if (resultTags.isEmpty) {
                 return Padding(

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -133,8 +133,20 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
       previousText: previous,
     );
 
-    // No separator → just forward the raw text as a search query.
+    // No committable tokens. Two sub-cases:
+    //   1. No separator at all (typical typing) — forward as search query.
+    //   2. Separator(s) but only empty tokens (e.g. ' ' or ',,,') — clear
+    //      the field so we don't leave separator junk visible underneath
+    //      an empty-state pane.
     if (parsed.completed.isEmpty) {
+      if (parsed.remainder != text) {
+        _previousText = parsed.remainder;
+        _searchController.value = TextEditingValue(
+          text: parsed.remainder,
+          selection: TextSelection.collapsed(offset: parsed.remainder.length),
+        );
+        return;
+      }
       _previousText = text;
       context.read<TagsPickerBloc>().add(TagsPickerQueryChanged(text));
       return;
@@ -146,7 +158,10 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
       text: parsed.remainder,
       selection: TextSelection.collapsed(offset: parsed.remainder.length),
     );
-    // Listener re-fires with the cleaned text and emits the query event.
+    // Listener re-fires with the cleaned text. The cleaned text never
+    // contains a separator, so the re-entry hits the `completed.isEmpty`
+    // branch above and dispatches at most one `TagsPickerQueryChanged` —
+    // no unbounded recursion.
   }
 
   void _addTag(String raw) {
@@ -186,8 +201,11 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
           trailingAction: DivineIconButton(
             icon: .check,
             size: .small,
-            onPressed: () =>
-                context.pop(context.read<TagsPickerBloc>().state.selectedTags),
+            onPressed: () => context.pop(
+              Set<String>.unmodifiable(
+                context.read<TagsPickerBloc>().state.selectedTags,
+              ),
+            ),
           ),
         ),
 

--- a/mobile/test/blocs/tags_picker/tags_picker_bloc_test.dart
+++ b/mobile/test/blocs/tags_picker/tags_picker_bloc_test.dart
@@ -236,5 +236,34 @@ void main() {
       expect(r.completed, ['foo']);
       expect(r.remainder, 'bar');
     });
+
+    test('typed branch filters empty tokens from consecutive separators', () {
+      // User typed a second comma — `foo,,` produces ['foo', '', ''] which
+      // must collapse to just the leading token, with an empty remainder.
+      final r = parseTagsPickerInput(text: 'foo,,', previousText: 'foo,');
+      expect(r.completed, ['foo']);
+      expect(r.remainder, '');
+    });
+
+    test('paste with mixed separators (comma + space) commits all tokens', () {
+      final r = parseTagsPickerInput(
+        text: 'foo, bar,baz qux',
+        previousText: '',
+      );
+      expect(r.completed, ['foo', 'bar', 'baz', 'qux']);
+      expect(r.remainder, '');
+    });
+
+    test('parser is sanitize-agnostic — passes tokens through verbatim', () {
+      // Sanitization is the bloc's job (TagsPickerTagsAdded). The parser
+      // must not silently drop tokens that contain non-alphanumeric chars,
+      // otherwise the bloc never sees them and can't normalize them.
+      final r = parseTagsPickerInput(
+        text: '#foo, #bar',
+        previousText: '',
+      );
+      expect(r.completed, ['#foo', '#bar']);
+      expect(r.remainder, '');
+    });
   });
 }

--- a/mobile/test/blocs/tags_picker/tags_picker_bloc_test.dart
+++ b/mobile/test/blocs/tags_picker/tags_picker_bloc_test.dart
@@ -1,0 +1,240 @@
+// ABOUTME: Tests for TagsPickerBloc — sanitize/dedup/search behavior.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hashtag_repository/hashtag_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/tags_picker/tags_picker_bloc.dart';
+
+class _MockHashtagRepository extends Mock implements HashtagRepository {}
+
+void main() {
+  group(TagsPickerBloc, () {
+    late _MockHashtagRepository repo;
+
+    setUp(() {
+      repo = _MockHashtagRepository();
+      when(
+        () => repo.searchHashtags(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => []);
+    });
+
+    TagsPickerBloc createBloc({Set<String> initial = const <String>{}}) =>
+        TagsPickerBloc(hashtagRepository: repo, initialTags: initial);
+
+    test('initial state contains the initialTags and is idle', () {
+      final bloc = createBloc(initial: {'foo', 'bar'});
+      expect(bloc.state.selectedTags, {'foo', 'bar'});
+      expect(bloc.state.status, TagsPickerStatus.initial);
+      expect(bloc.state.query, isEmpty);
+      expect(bloc.state.suggestions, isEmpty);
+      bloc.close();
+    });
+
+    group('TagsPickerTagsAdded', () {
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'sanitizes tokens (strips non-alphanumeric)',
+        build: createBloc,
+        act: (b) => b.add(const TagsPickerTagsAdded(['#foo!', 'bar-baz'])),
+        expect: () => [
+          isA<TagsPickerState>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'foo', 'barbaz'},
+          ),
+        ],
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'is case-insensitive deduping against existing tags',
+        build: () => createBloc(initial: {'Foo'}),
+        act: (b) => b.add(const TagsPickerTagsAdded(['FOO', 'bar'])),
+        expect: () => [
+          isA<TagsPickerState>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Foo', 'bar'},
+          ),
+        ],
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'emits nothing when all tokens are empty or duplicates',
+        build: () => createBloc(initial: {'foo'}),
+        act: (b) => b.add(const TagsPickerTagsAdded(['', '   ', 'foo'])),
+        expect: () => const <TagsPickerState>[],
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'commits all tokens from a pasted batch',
+        build: createBloc,
+        act: (b) => b.add(const TagsPickerTagsAdded(['foo', 'bar', 'baz'])),
+        expect: () => [
+          isA<TagsPickerState>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'foo', 'bar', 'baz'},
+          ),
+        ],
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'filters suggestions against newly-added tags',
+        build: createBloc,
+        seed: () => const TagsPickerState(
+          query: 'foo',
+          suggestions: ['foo', 'foobar', 'other'],
+          status: TagsPickerStatus.success,
+        ),
+        act: (b) => b.add(const TagsPickerTagsAdded(['foo'])),
+        expect: () => [
+          isA<TagsPickerState>()
+              .having((s) => s.selectedTags, 'selectedTags', {'foo'})
+              .having((s) => s.suggestions, 'suggestions', ['foobar', 'other']),
+        ],
+      );
+    });
+
+    group('TagsPickerTagRemoved', () {
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'removes a previously selected tag',
+        build: () => createBloc(initial: {'foo', 'bar'}),
+        act: (b) => b.add(const TagsPickerTagRemoved('foo')),
+        expect: () => [
+          isA<TagsPickerState>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'bar'},
+          ),
+        ],
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'is a no-op for an unknown tag',
+        build: () => createBloc(initial: {'foo'}),
+        act: (b) => b.add(const TagsPickerTagRemoved('xxx')),
+        expect: () => const <TagsPickerState>[],
+      );
+    });
+
+    group('TagsPickerQueryChanged', () {
+      // Matches searchDebounceDuration (300ms) plus buffer.
+      const debounce = Duration(milliseconds: 400);
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'emits [searching, success] with filtered suggestions',
+        setUp: () {
+          when(
+            () => repo.searchHashtags(query: 'mus'),
+          ).thenAnswer((_) async => ['music', 'musician']);
+        },
+        build: () => createBloc(initial: {'Music'}),
+        act: (b) => b.add(const TagsPickerQueryChanged('mus')),
+        wait: debounce,
+        expect: () => [
+          isA<TagsPickerState>()
+              .having((s) => s.status, 'status', TagsPickerStatus.searching)
+              .having((s) => s.query, 'query', 'mus'),
+          isA<TagsPickerState>()
+              .having((s) => s.status, 'status', TagsPickerStatus.success)
+              .having((s) => s.suggestions, 'suggestions', ['musician']),
+        ],
+        verify: (_) {
+          verify(() => repo.searchHashtags(query: 'mus')).called(1);
+        },
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'resets to initial when query is whitespace',
+        build: createBloc,
+        seed: () => const TagsPickerState(
+          query: 'old',
+          suggestions: ['old'],
+          status: TagsPickerStatus.success,
+        ),
+        act: (b) => b.add(const TagsPickerQueryChanged('   ')),
+        wait: debounce,
+        expect: () => [
+          const TagsPickerState(),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => repo.searchHashtags(query: any(named: 'query')),
+          );
+        },
+      );
+    });
+
+    group('canAddQuery', () {
+      test('false when sanitized query is empty', () {
+        const state = TagsPickerState(query: '  ###  ');
+        expect(state.canAddQuery, isFalse);
+      });
+
+      test('false when query already in selectedTags (case-insensitive)', () {
+        const state = TagsPickerState(
+          query: 'FOO',
+          selectedTags: {'foo'},
+        );
+        expect(state.canAddQuery, isFalse);
+      });
+
+      test('true when sanitized query is new', () {
+        const state = TagsPickerState(query: 'foo!');
+        expect(state.canAddQuery, isTrue);
+        expect(state.sanitizedQuery, 'foo');
+      });
+    });
+  });
+
+  group('parseTagsPickerInput', () {
+    test('no separator → empty completed and full remainder', () {
+      final r = parseTagsPickerInput(text: 'foo', previousText: 'fo');
+      expect(r.completed, isEmpty);
+      expect(r.remainder, 'foo');
+    });
+
+    test(
+      'typed trailing separator commits leading token, keeps empty rest',
+      () {
+        final r = parseTagsPickerInput(text: 'foo ', previousText: 'foo');
+        expect(r.completed, ['foo']);
+        expect(r.remainder, '');
+      },
+    );
+
+    test('typed token after separator keeps it as remainder', () {
+      final r = parseTagsPickerInput(text: 'foo bar', previousText: 'foo ba');
+      expect(r.completed, ['foo']);
+      expect(r.remainder, 'bar');
+    });
+
+    test('paste of multiple tokens commits all (no remainder kept)', () {
+      final r = parseTagsPickerInput(
+        text: 'foo, bar, baz',
+        previousText: '',
+      );
+      expect(r.completed, ['foo', 'bar', 'baz']);
+      expect(r.remainder, '');
+    });
+
+    test('paste with trailing separator still commits all tokens', () {
+      final r = parseTagsPickerInput(
+        text: 'foo bar baz ',
+        previousText: '',
+      );
+      expect(r.completed, ['foo', 'bar', 'baz']);
+      expect(r.remainder, '');
+    });
+
+    test('comma-only separator works the same as space', () {
+      final r = parseTagsPickerInput(text: 'foo,bar', previousText: 'foo,ba');
+      expect(r.completed, ['foo']);
+      expect(r.remainder, 'bar');
+    });
+  });
+}

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -2,26 +2,35 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hashtag_repository/hashtag_repository.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/widgets/video_metadata/video_metadata_selection_tile.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_tags_selector.dart';
 
 void main() {
+  late _MockHashtagRepository hashtagRepository;
+
+  setUp(() {
+    hashtagRepository = _MockHashtagRepository();
+    when(
+      () => hashtagRepository.searchHashtags(
+        query: any(named: 'query'),
+        limit: any(named: 'limit'),
+        offset: any(named: 'offset'),
+      ),
+    ).thenAnswer((_) async => const []);
+  });
+
   group(VideoMetadataTagsSelector, () {
     testWidgets('renders tags label when no tags selected', (tester) async {
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            videoEditorProvider.overrideWith(
-              () => _MockVideoEditorNotifier(VideoEditorProviderState()),
-            ),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: VideoMetadataTagsSelector()),
-          ),
+        _buildTestApp(
+          hashtagRepository: hashtagRepository,
+          videoEditorState: VideoEditorProviderState(),
         ),
       );
 
@@ -35,23 +44,68 @@ void main() {
       );
 
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            videoEditorProvider.overrideWith(
-              () => _MockVideoEditorNotifier(state),
-            ),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: VideoMetadataTagsSelector()),
-          ),
+        _buildTestApp(
+          hashtagRepository: hashtagRepository,
+          videoEditorState: state,
         ),
       );
 
       expect(find.text('flutter, dart'), findsOneWidget);
     });
+
+    testWidgets(
+      'pasting multiple tags adds chips and clears the field',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildTestApp(
+            hashtagRepository: hashtagRepository,
+            videoEditorState: VideoEditorProviderState(),
+          ),
+        );
+
+        await tester.tap(
+          find.byType(VideoMetadataSelectionTile),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final searchField = find.byType(TextField).last;
+        expect(searchField, findsOneWidget);
+
+        await tester.enterText(searchField, 'foo, bar');
+        await tester.pump();
+
+        expect(find.text('foo'), findsOneWidget);
+        expect(find.text('bar'), findsOneWidget);
+        expect(
+          tester.widget<TextField>(searchField).controller?.text,
+          isEmpty,
+        );
+
+        await tester.pump(const Duration(milliseconds: 400));
+      },
+    );
   });
+}
+
+Widget _buildTestApp({
+  required HashtagRepository hashtagRepository,
+  required VideoEditorProviderState videoEditorState,
+}) {
+  return ProviderScope(
+    overrides: [
+      hashtagRepositoryProvider.overrideWithValue(hashtagRepository),
+      videoEditorProvider.overrideWith(
+        () => _MockVideoEditorNotifier(videoEditorState),
+      ),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: VideoMetadataTagsSelector()),
+    ),
+  );
 }
 
 class _MockVideoEditorNotifier extends VideoEditorNotifier {
@@ -69,3 +123,5 @@ class _MockVideoEditorNotifier extends VideoEditorNotifier {
     }
   }
 }
+
+class _MockHashtagRepository extends Mock implements HashtagRepository {}


### PR DESCRIPTION

## Description

Users can now paste or type `foo, bar baz` into the tag search field and all tokens are committed at once instead of having to add them one by one.

**Changes**
- parseTagsPickerInput detects separator characters (, / space) and splits input into multiple completed tags in a single pass
- Parser filters empty tokens, so trailing separators produce no ghost entries
- Consolidated duplicate regex patterns into a single _separatorPattern
- Removed dead TagsPickerStatus.failure branch — HashtagRepository.searchHashtags is documented as never-throws
- Simplified _onSearchChanged to write _previousText exactly once per code path


This was requested on Discord [here](https://discord.com/channels/1470168817589158040/1470256031434149953/1505580994579791962)

Closes #4498


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore