### PR TITLE
feat(chat): dismiss keyboard on scroll and pointer-down

### DIFF
--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -129,57 +129,73 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         listener: _onSendOutcome,
         child: Column(
           children: [
-            ConversationAppBar(
-              displayName: displayName,
-              handle: handle,
-              onBack: () => context.pop(),
-              onTitleTap: otherPubkey.isNotEmpty
-                  ? () => context.push(
-                      '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
-                    )
-                  : null,
-              onOptions: () => _onOptions(otherPubkey, displayName),
-            ),
+            // Wrap the AppBar + messages region in a Listener so any
+            // tap above the input bar — back button, title, options,
+            // dead space in the messages area, a MessageBubble —
+            // dismisses the keyboard before any navigation or sheet
+            // animation begins. The `_SendBar` is intentionally
+            // OUTSIDE this Listener: wrapping the input would
+            // `unfocus` on pointer-down and race with the TextField's
+            // own focus request, producing a re-focus flicker on
+            // every input tap.
+            //
+            // `Listener` catches pointer-downs without entering the
+            // gesture arena, so descendant tap/long-press recognizers
+            // (MessageBubble.onLongPress, ConversationAppBar's three
+            // buttons) still resolve normally afterwards. Matches the
+            // pattern shipped in `comments_list.dart`.
             Expanded(
-              // Force the messages card to fill the available width
-              // regardless of its content. Without this, the empty /
-              // loading state's SingleChildScrollView shrink-wraps the
-              // ClipRRect down to the EmptyConversation column's
-              // intrinsic width and the surface card renders as a
-              // narrow strip; the ListView (with messages) is fine on
-              // its own.
-              child: SizedBox(
-                width: double.infinity,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(32),
-                  child: ColoredBox(
-                    color: VineTheme.surfaceContainerHigh,
-                    // Any pointer interaction with the messages area
-                    // dismisses the keyboard so the user can read
-                    // history unobstructed — matches `comments_list`
-                    // (TikTok/Reels behavior). `Listener` catches
-                    // pointer-downs without entering the gesture arena,
-                    // so bubble long-press and list scroll still resolve
-                    // normally. The ListView's `onDrag` below is
-                    // complementary defense in depth for scrolls that
-                    // begin slightly outside the wrapped area.
-                    child: Listener(
-                      behavior: HitTestBehavior.translucent,
-                      onPointerDown: (_) =>
-                          FocusManager.instance.primaryFocus?.unfocus(),
-                      child: _ConversationContent(
-                        currentPubkey: currentPubkey,
-                        otherPubkey: otherPubkey,
-                        displayName: displayName,
-                        imageUrl: profile?.picture,
-                        nip05: profile?.shortDisplayNip05,
-                        onViewProfile: () {
-                          final npub = NostrKeyUtils.encodePubKey(otherPubkey);
-                          context.push('${OtherProfileScreen.path}/$npub');
-                        },
+              child: Listener(
+                behavior: HitTestBehavior.translucent,
+                onPointerDown: (_) =>
+                    FocusManager.instance.primaryFocus?.unfocus(),
+                child: Column(
+                  children: [
+                    ConversationAppBar(
+                      displayName: displayName,
+                      handle: handle,
+                      onBack: () => context.pop(),
+                      onTitleTap: otherPubkey.isNotEmpty
+                          ? () => context.push(
+                              '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
+                            )
+                          : null,
+                      onOptions: () => _onOptions(otherPubkey, displayName),
+                    ),
+                    Expanded(
+                      // Force the messages card to fill the available width
+                      // regardless of its content. Without this, the empty /
+                      // loading state's SingleChildScrollView shrink-wraps the
+                      // ClipRRect down to the EmptyConversation column's
+                      // intrinsic width and the surface card renders as a
+                      // narrow strip; the ListView (with messages) is fine on
+                      // its own.
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(32),
+                          child: ColoredBox(
+                            color: VineTheme.surfaceContainerHigh,
+                            child: _ConversationContent(
+                              currentPubkey: currentPubkey,
+                              otherPubkey: otherPubkey,
+                              displayName: displayName,
+                              imageUrl: profile?.picture,
+                              nip05: profile?.shortDisplayNip05,
+                              onViewProfile: () {
+                                final npub = NostrKeyUtils.encodePubKey(
+                                  otherPubkey,
+                                );
+                                context.push(
+                                  '${OtherProfileScreen.path}/$npub',
+                                );
+                              },
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                  ],
                 ),
               ),
             ),

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -154,12 +154,19 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                   borderRadius: BorderRadius.circular(32),
                   child: ColoredBox(
                     color: VineTheme.surfaceContainerHigh,
-                    // Tap anywhere in the messages area to dismiss the
-                    // keyboard. Translucent hit behavior keeps bubble
-                    // long-press and list-scroll gestures intact.
-                    child: GestureDetector(
+                    // Any pointer interaction with the messages area
+                    // dismisses the keyboard so the user can read
+                    // history unobstructed — matches `comments_list`
+                    // (TikTok/Reels behavior). `Listener` catches
+                    // pointer-downs without entering the gesture arena,
+                    // so bubble long-press and list scroll still resolve
+                    // normally. The ListView's `onDrag` below is
+                    // complementary defense in depth for scrolls that
+                    // begin slightly outside the wrapped area.
+                    child: Listener(
                       behavior: HitTestBehavior.translucent,
-                      onTap: () => FocusScope.of(context).unfocus(),
+                      onPointerDown: (_) =>
+                          FocusManager.instance.primaryFocus?.unfocus(),
                       child: _ConversationContent(
                         currentPubkey: currentPubkey,
                         otherPubkey: otherPubkey,
@@ -374,6 +381,7 @@ class _MessageList extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView.builder(
       reverse: true,
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       // bottom: 8 stacks with the newest bubble's own 8 px bottom padding
       // for a 16 px gap to the scroll-view edge.
       padding: const EdgeInsets.only(top: 8, bottom: 8),

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1084,5 +1084,72 @@ void main() {
         },
       );
     });
+
+    // Keyboard-dismissal contract: any pointer-down in the messages
+    // area or a real finger-drag on the message list dismisses the
+    // soft keyboard so the user can read history unobstructed. The
+    // Listener-on-pointer-down handles the tap/long-press case;
+    // ScrollViewKeyboardDismissBehavior.onDrag handles the scroll
+    // case (gated internally on ScrollUpdateNotification.dragDetails
+    // != null, so programmatic scrolls do NOT dismiss — which is the
+    // intentional contract for any future auto-scroll-on-new-message
+    // behavior).
+    group('keyboard dismissal', () {
+      Future<void> pumpWithMessage(WidgetTester tester) async {
+        final message = DmMessage(
+          id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          conversationId:
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+          senderPubkey: otherPubkey,
+          content: 'Hello there!',
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          giftWrapId:
+              'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [message],
+            ),
+          ),
+        );
+        await tester.pump();
+      }
+
+      testWidgets(
+        'dismisses keyboard when the message list is dragged',
+        (tester) async {
+          await pumpWithMessage(tester);
+          await tester.showKeyboard(find.byType(TextField));
+          expect(tester.testTextInput.isVisible, isTrue);
+
+          // `tester.drag` synthesizes a real pointer drag, producing
+          // a ScrollUpdateNotification with non-null dragDetails —
+          // the same code path as a real finger. controller.jumpTo
+          // would NOT trigger dismissal (no drag details).
+          await tester.drag(find.byType(ListView), const Offset(0, 200));
+          await tester.pump();
+
+          expect(tester.testTextInput.isVisible, isFalse);
+        },
+      );
+
+      testWidgets(
+        'dismisses keyboard on pointer-down inside the messages area '
+        '(regression guard for the Listener swap)',
+        (tester) async {
+          await pumpWithMessage(tester);
+          await tester.showKeyboard(find.byType(TextField));
+          expect(tester.testTextInput.isVisible, isTrue);
+
+          await tester.tapAt(tester.getCenter(find.byType(MessageBubble)));
+          await tester.pump();
+
+          expect(tester.testTextInput.isVisible, isFalse);
+        },
+      );
+    });
   });
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -1150,6 +1150,46 @@ void main() {
           expect(tester.testTextInput.isVisible, isFalse);
         },
       );
+
+      // Pins the second half of the GestureDetector → Listener swap
+      // contract: dismissal on pointer-down must NOT eat the
+      // descendant long-press recognizer on `MessageBubble`. A bare
+      // `GestureDetector(onTap:)` competes in the gesture arena and
+      // can swallow tap/long-press on descendants; `Listener` does
+      // not. The earlier "renders MessageBubble" test only proves the
+      // bubble renders — this test proves the full chain
+      // Listener (conversation_view) → MessageBubble → onLongPress
+      // → MessageActionsSheet.show is intact after the swap.
+      testWidgets(
+        'long-pressing a $MessageBubble still surfaces '
+        '$MessageActionsSheet',
+        (tester) async {
+          await pumpWithMessage(tester);
+
+          // Mirror `message_bubble_test.dart`: long-press the bubble
+          // by its rendered text. `find.byType(MessageBubble)` aims
+          // at the widget's geometric center, which sits over the
+          // padding/Semantics node above the bubble's inner
+          // GestureDetector and misses the hit-test (Flutter warns
+          // "warnIfMissed" in that case).
+          await tester.longPress(find.text('Hello there!'));
+          await tester.pumpAndSettle();
+
+          // The sheet's localized action labels are the cheapest
+          // proof the modal actually mounted — asserting on the
+          // sheet widget class would also work but couples to its
+          // current implementation (VineBottomSheetActionMenu).
+          expect(find.text(l10n.dmMessageActionCopyText), findsOneWidget);
+          // `pumpWithMessage` constructs a received message
+          // (senderPubkey = otherPubkey), so the sheet must offer
+          // Report (received-only) and not Delete (sent-only).
+          expect(find.text(l10n.dmMessageActionReport), findsOneWidget);
+          expect(
+            find.text(l10n.dmMessageActionDeleteForEveryone),
+            findsNothing,
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #4500

## Steps to reproduce (before this PR)

1. Open a direct-message thread (Inbox tab → tap any conversation).
2. Tap the message input — the soft keyboard slides up.
3. Drag the message history upward to read older messages.
4. **Observed bug**: the keyboard stays open, covering the bottom half of the history. The only ways to dismiss are (a) tap dead space inside the messages area, or (b) tap the system back gesture / Done key.

## Expected (after this PR)

- Step 3 → keyboard dismisses the moment the drag begins (matches Telegram / iMessage / Signal / WhatsApp behaviour for the majority case).
- Existing tap-to-dismiss still works on dead space inside the messages area.
- Tapping a `MessageBubble` (short tap) also dismisses the keyboard, while long-press still surfaces `MessageActionsSheet` — the previous `GestureDetector(onTap:)` did not dismiss on a tap that landed on a bubble; the new `Listener(onPointerDown:)` does, without breaking the long-press.

## Summary

Match modern chat-app UX (Telegram / iMessage / Signal): a finger drag on the DM message history dismisses the soft keyboard so the user can read older messages unobstructed. Previously, only an explicit tap inside the messages area dismissed it; scrolling kept the keyboard up.

The fix mirrors the in-repo pattern already shipped at `mobile/lib/screens/comments/widgets/comments_list.dart` (added in the TikTok/Reels-style comments refresh): a `Listener` on pointer-down for the tap/long-press case plus `ScrollViewKeyboardDismissBehavior.onDrag` on the `ListView` for the drag case. Two surfaces, one pattern.

## Why this shape (not the one-line diff)

A single `keyboardDismissBehavior: onDrag` would have shipped the drag UX. But the existing `GestureDetector(onTap: unfocus)` at `conversation_view.dart:160` was the older / inferior shape for tap-dismissal:

- `GestureDetector(onTap:)` participates in the gesture arena and can contend with descendant tap/long-press recognizers.
- `Listener(onPointerDown:)` dispatches pointer events alongside recognition, so descendants always win cleanly — and it also fires on long-press start, matching the "any interaction dismisses the keyboard" intent the `comments_list` rationale describes.

Swapping to `Listener` brings chat in line with the comments precedent and is strictly better for the existing tap case too, for ~5 lines of extra diff.

## Contract pinned by tests

`ScrollViewKeyboardDismissBehavior.onDrag` is internally gated on `ScrollUpdateNotification.dragDetails != null`, so it fires only for real pointer drags — any future auto-scroll on incoming messages deliberately will NOT dismiss the keyboard. The new widget test uses `tester.drag` (which synthesizes a real pointer drag with non-null `dragDetails`), so it exercises the exact code path a finger would.

## Test plan

- [x] `flutter analyze lib/screens/inbox/conversation test/screens/inbox/conversation` — clean.
- [x] `flutter test test/screens/inbox/conversation/conversation_view_test.dart` — 23/23 pass, including 2 new keyboard-dismissal tests.
- [x] Local smoke-test by author on device (per request before opening for review).
- [ ] Reviewer manual QA (iOS or Android, doesn't matter — pattern is platform-agnostic):
  - [ ] Open a DM, tap input → keyboard appears.
  - [ ] Drag the message list upward → keyboard dismisses smoothly. Input bar stays pinned.
  - [ ] Tap dead space inside the messages area → keyboard dismisses.
  - [ ] Tap a `MessageBubble` → keyboard dismisses AND long-press still surfaces `MessageActionsSheet`.
  - [ ] Send a message → text field clears, keyboard stays open (existing behavior, regression check).

## Out of scope (intentionally)

- No `FocusNode` added to `MessageInputBar` — no UI consumer needs `focusNode.hasFocus` (unlike `CommentInput`, which surfaces a "hide keyboard" button keyed on focus).
- No `ScrollController` added to the chat `ListView` — no other caller would use it.
- No app-wide `MaterialApp.scrollBehavior` override — `comments_list` chose per-list, so chat matches; a global change would silently affect every scrollable in the app with no test coverage on those surfaces.