### PR TITLE
feat(sounds): wire sound-bot library into manifest

### DIFF
--- a/mobile/assets/sounds/sounds_manifest.json
+++ b/mobile/assets/sounds/sounds_manifest.json
@@ -474,6 +474,396 @@
       "license": "Public Domain",
       "sourceUrl": "https://www.youtube.com/shorts/kcEM8xNVyiU",
       "tags": ["default", "short", "road", "new zealand", "travel"]
+    },
+    {
+      "id": "soundbot_you_call_that_an_insult_ahh_metroman_mem_dtarzl",
+      "title": "\"You call that an insult?\"",
+      "assetPath": "assets/sounds/sound-bot/you_call_that_an_insult_ahh_metroman_mem_17_TARzlg.mp3",
+      "durationMs": 7767,
+      "artist": "Quirky Things",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=mDK2DTARzlg"
+    },
+    {
+      "id": "soundbot_60_seconds_of_classic_vines_2_dwrspa",
+      "title": "60 Seconds of Classic Vines #2",
+      "assetPath": "assets/sounds/sound-bot/60_seconds_of_classic_vines_2_01_wRsPAk.mp3",
+      "durationMs": 45685,
+      "artist": "Throwback To Vine",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=EHpzdwRsPAk"
+    },
+    {
+      "id": "soundbot_90s_really_was_a_vibe_t4dfjv",
+      "title": "90s Really Was a Vibe",
+      "assetPath": "assets/sounds/sound-bot/90s_really_was_a_vibe_01_4dfjvA.mp3",
+      "durationMs": 42214,
+      "artist": "Jewel",
+      "tags": ["soundbot", "viral", "video-audio", "vibe", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=pj-et4dfjvA"
+    },
+    {
+      "id": "soundbot_pranking_my_detention_teacher_with_auugh_z_gvk2",
+      "title": "AUUGHHH Teacher Prank",
+      "assetPath": "assets/sounds/sound-bot/pranking_my_detention_teacher_with_auugh_11_-GVk2I.mp3",
+      "durationMs": 4516,
+      "artist": "Arsenic Productions",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=ozXhZ-GVk2I"
+    },
+    {
+      "id": "soundbot_funny_sound_of_buffalo_sound_buffalo_ani_gflfgn",
+      "title": "Buffalo Sound",
+      "assetPath": "assets/sounds/sound-bot/funny_sound_of_buffalo_sound_buffalo_ani_10_FLfgnI.mp3",
+      "durationMs": 4795,
+      "artist": "Village guy",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=Rp9uGFLfgnI"
+    },
+    {
+      "id": "soundbot_chinese_gong_meme_sound_effect_memeeffec__znmm3",
+      "title": "Chinese Gong Meme Sound Effect",
+      "assetPath": "assets/sounds/sound-bot/chinese_gong_meme_sound_effect_memeeffec_13_znMM3Q.mp3",
+      "durationMs": 4226,
+      "artist": "Meme Template And Sound",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=Hx5D_znMM3Q"
+    },
+    {
+      "id": "soundbot_classic_vine_from_2016_asmpvi",
+      "title": "Classic Vine From 2016",
+      "assetPath": "assets/sounds/sound-bot/classic_vine_from_2016_01_SmpvIw.mp3",
+      "durationMs": 9033,
+      "artist": "Onevilage",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=8wWEaSmpvIw"
+    },
+    {
+      "id": "soundbot_do_it_for_the_vine_tsnkyy",
+      "title": "Do It For The Vine",
+      "assetPath": "assets/sounds/sound-bot/do_it_for_the_vine_01_snkYYM.mp3",
+      "durationMs": 6502,
+      "artist": "Fun Master",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=24FaTsnkYYM"
+    },
+    {
+      "id": "soundbot_doesnt_make_it_any_better_bro_shorts_she_a8akfx",
+      "title": "Doesn't Make It Any Better Bro",
+      "assetPath": "assets/sounds/sound-bot/doesnt_make_it_any_better_bro_shorts_she_14_8Akfxo.mp3",
+      "durationMs": 9253,
+      "artist": "repilus",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=8W7RA8Akfxo"
+    },
+    {
+      "id": "soundbot_don_t_look_at_audio_memes_funny_shorts_g_pomb2c",
+      "title": "Don't Look At Audio",
+      "assetPath": "assets/sounds/sound-bot/don_t_look_at_audio_memes_funny_shorts_g_02_Omb2C0.mp3",
+      "durationMs": 4934,
+      "artist": "Vikifer",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "music", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=6Vj-pOmb2C0"
+    },
+    {
+      "id": "soundbot_dublagem_kyvb7k",
+      "title": "Dublagem",
+      "assetPath": "assets/sounds/sound-bot/dublagem_01_yVB7Kw.mp3",
+      "durationMs": 4435,
+      "artist": "Purrfect Meow",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=Z4iPKyVB7Kw"
+    },
+    {
+      "id": "soundbot_they_say_when_you_hit_your_30s_you_need__tdgeeq",
+      "title": "Find Your Hobby",
+      "assetPath": "assets/sounds/sound-bot/they_say_when_you_hit_your_30s_you_need__01_dGEeQs.mp3",
+      "durationMs": 22549,
+      "artist": "BrickPadawan",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=IhV7tdGEeQs"
+    },
+    {
+      "id": "soundbot_fresh_avocado_vine_8a48o1",
+      "title": "Fresh Avocado Vine",
+      "assetPath": "assets/sounds/sound-bot/fresh_avocado_vine_04_a48o1E.mp3",
+      "durationMs": 6513,
+      "artist": "MemeHubbard",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=bE4C8a48o1E"
+    },
+    {
+      "id": "soundbot_funny_laugh_sound_effect_hd_hghils",
+      "title": "Funny Laugh Sound Effect",
+      "assetPath": "assets/sounds/sound-bot/funny_laugh_sound_effect_hd_19_GHiLSo.mp3",
+      "durationMs": 6676,
+      "artist": "Gaming Sounds",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=ng0ShGHiLSo"
+    },
+    {
+      "id": "soundbot_funny_sound_effects_lough_shorts_funny_c_zkw6oh",
+      "title": "Funny Laugh Sound Effect Short",
+      "assetPath": "assets/sounds/sound-bot/funny_sound_effects_lough_shorts_funny_c_08_kw6oHw.mp3",
+      "durationMs": 4656,
+      "artist": "ALL ROUNDER 410",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=NaUMzkw6oHw"
+    },
+    {
+      "id": "soundbot_green_alien_cat_talk_meaning_greenalien__0qcbdt",
+      "title": "Green Alien Cat Talk",
+      "assetPath": "assets/sounds/sound-bot/green_alien_cat_talk_meaning_greenalien__12_QCbdtA.mp3",
+      "durationMs": 4551,
+      "artist": "just HERMANTO",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=N2Oz0QCbdtA"
+    },
+    {
+      "id": "soundbot_hahaha_i_do_that_vine_i181co",
+      "title": "Hahaha I Do That",
+      "assetPath": "assets/sounds/sound-bot/hahaha_i_do_that_vine_03_181COA.mp3",
+      "durationMs": 5573,
+      "artist": "MoistCrow:)",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=vqE6I181COA"
+    },
+    {
+      "id": "soundbot_i_don_t_wanna_do_the_work_today_qqvzq9",
+      "title": "I Don't Wanna Do The Work Today",
+      "assetPath": "assets/sounds/sound-bot/i_don_t_wanna_do_the_work_today_01_qvZQ9o.mp3",
+      "durationMs": 24764,
+      "artist": "Mommy And Athena",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=ZzihqqvZQ9o"
+    },
+    {
+      "id": "soundbot_if_your_name_is_junior_vine_xovhum",
+      "title": "If Your Name Is Junior",
+      "assetPath": "assets/sounds/sound-bot/if_your_name_is_junior_vine_01_oVHUmM.mp3",
+      "durationMs": 6420,
+      "artist": "ethan",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=g_KlxoVHUmM"
+    },
+    {
+      "id": "soundbot_odetari_hd_odecore_odetarigetsomesleep_a_u09_08",
+      "title": "Odetari Gets Some Sleep",
+      "assetPath": "assets/sounds/sound-bot/odetari_hd_odecore_odetarigetsomesleep_a_03_09_08w.mp3",
+      "durationMs": 5979,
+      "artist": "Odetari",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=BfQyu09_08w"
+    },
+    {
+      "id": "soundbot_of_course_she_was_and_still_she_is_hwbrha",
+      "title": "Of Course She Was",
+      "assetPath": "assets/sounds/sound-bot/of_course_she_was_and_still_she_is_01_WBrHAw.mp3",
+      "durationMs": 3971,
+      "artist": "Celevoq",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=FSmEhWBrHAw"
+    },
+    {
+      "id": "soundbot_in_2018_bus_drivers_in_okayama_japan_wen_hrsvgn",
+      "title": "Okayama Bus Strike",
+      "assetPath": "assets/sounds/sound-bot/in_2018_bus_drivers_in_okayama_japan_wen_01_RSVGNM.mp3",
+      "durationMs": 3053,
+      "artist": "islamic123",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=OWt4HRSVGNM"
+    },
+    {
+      "id": "soundbot_oye_wapas_rakh_use_kabir_singh_dilogue_m_uubb2k",
+      "title": "Oye Wapas Rakh Use",
+      "assetPath": "assets/sounds/sound-bot/oye_wapas_rakh_use_kabir_singh_dilogue_m_16_UBB2ks.mp3",
+      "durationMs": 4052,
+      "artist": "Vision clips",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=80K_UUBB2ks"
+    },
+    {
+      "id": "soundbot_popstar_shi_r6x25a",
+      "title": "POPSTAR SHI",
+      "assetPath": "assets/sounds/sound-bot/popstar_shi_01_6X25Ak.mp3",
+      "durationMs": 13584,
+      "artist": "BIG SIS",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=q18lR6X25Ak"
+    },
+    {
+      "id": "soundbot_risking_its_life_for_a_squishmallow_04_gpwzq8",
+      "title": "Risking Its Life For A Squishmallow 1",
+      "assetPath": "assets/sounds/sound-bot/risking_its_life_for_a_squishmallow_04_pwZq8s.mp3",
+      "durationMs": 5155,
+      "artist": "The McFive Circus",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=Nb6xGpwZq8s"
+    },
+    {
+      "id": "soundbot_risking_its_life_for_a_squishmallow_gpwzq8",
+      "title": "Risking Its Life For A Squishmallow 2",
+      "assetPath": "assets/sounds/sound-bot/risking_its_life_for_a_squishmallow_10_pwZq8s.mp3",
+      "durationMs": 5143,
+      "artist": "The McFive Circus",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=Nb6xGpwZq8s"
+    },
+    {
+      "id": "soundbot_sad_violin_sound_effect_cg01_x",
+      "title": "Sad Violin Sound Effect",
+      "assetPath": "assets/sounds/sound-bot/sad_violin_sound_effect_09_g01-XI.mp3",
+      "durationMs": 4609,
+      "artist": "Sound Meme",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "sad", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=TVRpcg01-XI"
+    },
+    {
+      "id": "soundbot_sad_violin_sound_effect_hd_shorts_sounde_mxo_y4",
+      "title": "Sad Violin Sound Effect HD",
+      "assetPath": "assets/sounds/sound-bot/sad_violin_sound_effect_hd_shorts_sounde_15_xO-y4s.mp3",
+      "durationMs": 4807,
+      "artist": "Meme Sound Effects",
+      "tags": ["soundbot", "viral", "video-audio", "meme", "sad", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=A0pYMxO-y4s"
+    },
+    {
+      "id": "soundbot_school_bro_friends_guys_nmjfi0",
+      "title": "School Bro Friends Guys",
+      "assetPath": "assets/sounds/sound-bot/school_bro_friends_guys_01_MJFi0Q.mp3",
+      "durationMs": 16173,
+      "artist": "hugostroy044",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=OM2VnMJFi0Q"
+    },
+    {
+      "id": "soundbot_spirits_by_the_strumbellas_shorts_07_qfpaua",
+      "title": "Spirits By The Strumbellas 1",
+      "assetPath": "assets/sounds/sound-bot/spirits_by_the_strumbellas_shorts_07_FPAuaE.mp3",
+      "durationMs": 5875,
+      "artist": "The Regan Bros",
+      "tags": ["soundbot", "viral", "video-audio", "music", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=pDtbqFPAuaE"
+    },
+    {
+      "id": "soundbot_spirits_by_the_strumbellas_shorts_qfpaua",
+      "title": "Spirits By The Strumbellas 2",
+      "assetPath": "assets/sounds/sound-bot/spirits_by_the_strumbellas_shorts_16_FPAuaE.mp3",
+      "durationMs": 5875,
+      "artist": "The Regan Bros",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=pDtbqFPAuaE"
+    },
+    {
+      "id": "soundbot_this_song_is_a_vibe_agree_adventure_trav_0jfc4r",
+      "title": "This Song Is a Vibe",
+      "assetPath": "assets/sounds/sound-bot/this_song_is_a_vibe_agree_adventure_trav_14_jfc4R4.mp3",
+      "durationMs": 4609,
+      "artist": "TravelSunlit",
+      "tags": ["soundbot", "viral", "video-audio", "travel", "vibe", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=L43i0jfc4R4"
+    },
+    {
+      "id": "soundbot_timelapse_start_to_finish_alone_build_lo_lh21af",
+      "title": "Timelapse Log Cabin",
+      "assetPath": "assets/sounds/sound-bot/timelapse_start_to_finish_alone_build_lo_01_h21aFc.mp3",
+      "durationMs": 4523,
+      "artist": "Katariya News",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=nPrvLh21aFc"
+    },
+    {
+      "id": "soundbot_this_edit_is_so_addicting_tudum_2023_sho_hd_2fv",
+      "title": "Tudum 2023 Edit",
+      "assetPath": "assets/sounds/sound-bot/this_edit_is_so_addicting_tudum_2023_sho_05_d-2FVA.mp3",
+      "durationMs": 9985,
+      "artist": "aedevii",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=xLKUhd-2FVA"
+    },
+    {
+      "id": "soundbot_use_headphones_png_for_reels_shorts_vira_06_iatr9t",
+      "title": "Use Headphones 1",
+      "assetPath": "assets/sounds/sound-bot/use_headphones_png_for_reels_shorts_vira_06_aTR9TI.mp3",
+      "durationMs": 4574,
+      "artist": "Umair broken",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=lxPAIaTR9TI"
+    },
+    {
+      "id": "soundbot_use_headphones_png_for_reels_shorts_vira_iatr9t",
+      "title": "Use Headphones 2",
+      "assetPath": "assets/sounds/sound-bot/use_headphones_png_for_reels_shorts_vira_15_aTR9TI.mp3",
+      "durationMs": 4574,
+      "artist": "Umair broken",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=lxPAIaTR9TI"
+    },
+    {
+      "id": "soundbot_vine_rather_be_xbfm_b",
+      "title": "Vine / Rather Be",
+      "assetPath": "assets/sounds/sound-bot/vine_rather_be_01_bFM_Bk.mp3",
+      "durationMs": 6943,
+      "artist": "Charts One",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=dA7lXbFM_Bk"
+    },
+    {
+      "id": "soundbot_pov_people_trying_to_make_a_viral_sound__cqynws",
+      "title": "Viral Sound POV",
+      "assetPath": "assets/sounds/sound-bot/pov_people_trying_to_make_a_viral_sound__05_qYnwSw.mp3",
+      "durationMs": 5898,
+      "artist": "Avery_H",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=C0fTCqYnwSw"
+    },
+    {
+      "id": "soundbot_what_you_gonna_do_vine_kxji0j",
+      "title": "What You Gonna Do",
+      "assetPath": "assets/sounds/sound-bot/what_you_gonna_do_vine_05_xJi0Jw.mp3",
+      "durationMs": 6478,
+      "artist": "Fat Asshole",
+      "tags": ["soundbot", "viral", "video-audio", "dialogue"],
+      "license": "unknown",
+      "sourceUrl": "https://www.youtube.com/watch?v=FTfakxJi0Jw"
     }
   ]
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -368,6 +368,7 @@ flutter:
   assets:
     - assets/videos/
     - assets/sounds/
+    - assets/sounds/sound-bot/
     - assets/categories/
     - assets/top_1000_hashtags.json
     - assets/fonts/

--- a/mobile/test/services/sound_library_service_test.dart
+++ b/mobile/test/services/sound_library_service_test.dart
@@ -80,6 +80,38 @@ void main() {
       expect(sound.duration.inMilliseconds, equals(6269));
     });
 
+    test(
+      'real manifest includes sound-bot clips with bundled assets',
+      () async {
+        final manifestFile = File('assets/sounds/sounds_manifest.json');
+        final pubspecFile = File('pubspec.yaml');
+        final sounds = SoundLibraryService.parseManifest(
+          await manifestFile.readAsString(),
+        );
+
+        final soundBotSounds = sounds
+            .where((sound) => sound.id.startsWith('soundbot_'))
+            .toList();
+
+        expect(soundBotSounds, hasLength(39));
+
+        for (final sound in soundBotSounds) {
+          expect(
+            File(sound.assetPath).existsSync(),
+            isTrue,
+            reason: '${sound.id} should reference a bundled sound asset',
+          );
+          expect(sound.tags, contains('soundbot'));
+          expect(sound.duration.inMilliseconds, greaterThan(0));
+        }
+
+        expect(
+          await pubspecFile.readAsString(),
+          contains('- assets/sounds/sound-bot/'),
+        );
+      },
+    );
+
     test('searchSounds filters by query', () {
       final sounds = [
         VineSound(


### PR DESCRIPTION
Closes #4502

## Summary
- Adds manifest entries for the 39 bundled sound-bot MP3 assets already present under assets/sounds/sound-bot/.
- Adds the nested sound-bot asset directory to Flutter asset bundling.
- Covers the real manifest with a test that verifies sound-bot entries, asset files, tags, durations, and pubspec wiring.

## Test Plan
- flutter test test/services/sound_library_service_test.dart
- flutter analyze
- pre-push hook: analyzer + test/services/sound_library_service_test.dart