### PR TITLE
fix(infinite-feed): resolve issue on ios that loading-indicator always showed up

### DIFF
--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -595,6 +595,20 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     guard let self else { return }
                     self.nudgeOutputQueue()
                     self.textureOutput?.forceRefresh(for: time)
+                    // `step(byCount:)` enqueues into the player's
+                    // internal pipeline and the resulting frame is not
+                    // available on `copyPixelBuffer` until the next
+                    // runloop iteration. Defer the synchronous pull
+                    // attempt one tick so it has a chance to succeed —
+                    // and only flip `firstFrameRendered` (via
+                    // `deliverFrame`→`onFirstFrame`) when a real
+                    // `CVPixelBuffer` is actually in the texture.
+                    // Otherwise Flutter would hide the loader over an
+                    // empty texture and render one frame of black
+                    // before the display-link path catches up.
+                    DispatchQueue.main.async { [weak self] in
+                        self?.textureOutput?.tryPullFrameNow(at: time)
+                    }
                 }
             }
             return
@@ -619,6 +633,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                         guard let self else { return }
                         self.nudgeOutputQueue()
                         self.textureOutput?.forceRefresh(for: time)
+                        // See sibling branch above: defer the pull one
+                        // runloop tick so `step(byCount:)` has produced
+                        // a frame, and only mark the controller as
+                        // ready when a real `CVPixelBuffer` lands in
+                        // the Flutter texture.
+                        DispatchQueue.main.async { [weak self] in
+                            self?.textureOutput?.tryPullFrameNow(at: time)
+                        }
                     }
                 }
             }
@@ -832,8 +854,17 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     func getPlayer() -> AVPlayer? { player }
 
-    /// Called by the platform view when `AVPlayerLayer.isReadyForDisplay`
-    /// becomes `true`.
+    /// Marks the controller as having produced its first renderable
+    /// frame. Called by the platform view path when
+    /// `AVPlayerLayer.isReadyForDisplay` flips to `true`, and by the
+    /// texture path's `VideoTextureOutput.onFirstFrame` callback when
+    /// a real `CVPixelBuffer` has actually been delivered to the
+    /// Flutter texture (either via `tryPullFrameNow` from
+    /// `safePreroll` for prefetched items, or via the
+    /// `CADisplayLink` poll once playback begins). Flipping this flag
+    /// hides the loader overlay in Flutter, so it must only happen
+    /// after the texture has a buffer — otherwise the texture renders
+    /// one frame of black before the next display-link tick.
     func setFirstFrameRendered() {
         guard !firstFrameRendered else { return }
         firstFrameRendered = true

--- a/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
@@ -161,6 +161,31 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         videoOutput?.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
 
+    /// Synchronously attempts to pull a frame at `time` and push it into
+    /// the Flutter texture. Returns `true` if a real `CVPixelBuffer` was
+    /// delivered (which fires `onFirstFrame` on the first successful
+    /// call). Used by `safePreroll` to flip
+    /// `DivineVideoPlayerInstance.firstFrameRendered` only when the
+    /// texture actually has a buffer — otherwise Flutter would render
+    /// the texture's initial empty state (black) until the async
+    /// display-link path delivers one.
+    @discardableResult
+    func tryPullFrameNow(at time: CMTime) -> Bool {
+        guard let output = videoOutput else { return false }
+        guard let pixelBuffer = output.copyPixelBuffer(
+            forItemTime: time,
+            itemTimeForDisplay: nil
+        ) else {
+            return false
+        }
+        pendingSeekTime = .invalid
+        forceRefreshDeadline = 0
+        forceWindowFailCount = 0
+        mediaDataRearmCount = 0
+        deliverFrame(pixelBuffer)
+        return true
+    }
+
     // MARK: - AVPlayerItemOutputPullDelegate
 
     /// Called after a seek flushes the output queue.

--- a/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
@@ -164,7 +164,8 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Synchronously attempts to pull a frame at `time` and push it into
     /// the Flutter texture. Returns `true` if a real `CVPixelBuffer` was
     /// delivered (which fires `onFirstFrame` on the first successful
-    /// call). Used by `safePreroll` to flip
+    /// call) and resets the output's retry/refresh bookkeeping like a
+    /// regular delivery would. Used by `safePreroll` to flip
     /// `DivineVideoPlayerInstance.firstFrameRendered` only when the
     /// texture actually has a buffer — otherwise Flutter would render
     /// the texture's initial empty state (black) until the async

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -508,6 +508,20 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     guard let self else { return }
                     self.nudgeOutputQueue()
                     self.textureOutput?.forceRefresh(for: time)
+                    // `step(byCount:)` enqueues into the player's
+                    // internal pipeline and the resulting frame is not
+                    // available on `copyPixelBuffer` until the next
+                    // runloop iteration. Defer the synchronous pull
+                    // attempt one tick so it has a chance to succeed —
+                    // and only flip `firstFrameRendered` (via
+                    // `deliverFrame`→`onFirstFrame`) when a real
+                    // `CVPixelBuffer` is actually in the texture.
+                    // Otherwise Flutter would hide the loader over an
+                    // empty texture and render one frame of black
+                    // before the polling path catches up.
+                    DispatchQueue.main.async { [weak self] in
+                        self?.textureOutput?.tryPullFrameNow(at: time)
+                    }
                 }
             }
             return
@@ -532,6 +546,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                         guard let self else { return }
                         self.nudgeOutputQueue()
                         self.textureOutput?.forceRefresh(for: time)
+                        // See sibling branch above: defer the pull one
+                        // runloop tick so `step(byCount:)` has produced
+                        // a frame, and only mark the controller as
+                        // ready when a real `CVPixelBuffer` lands in
+                        // the Flutter texture.
+                        DispatchQueue.main.async { [weak self] in
+                            self?.textureOutput?.tryPullFrameNow(at: time)
+                        }
                     }
                 }
             }

--- a/mobile/packages/divine_video_player/macos/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/VideoTextureOutput.swift
@@ -123,6 +123,32 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         videoOutput?.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
 
+    /// Synchronously attempts to pull a frame at `time` and push it into
+    /// the Flutter texture. Returns `true` if a real `CVPixelBuffer` was
+    /// delivered (which fires `onFirstFrame` on the first successful
+    /// call) and resets the output's retry/refresh bookkeeping like a
+    /// regular delivery would. Used by `safePreroll` to flip
+    /// `DivineVideoPlayerInstance.firstFrameRendered` only when the
+    /// texture actually has a buffer — otherwise Flutter would render
+    /// the texture's initial empty state (black) until the async
+    /// polling path delivers one.
+    @discardableResult
+    func tryPullFrameNow(at time: CMTime) -> Bool {
+        guard let output = videoOutput else { return false }
+        guard let pixelBuffer = output.copyPixelBuffer(
+            forItemTime: time,
+            itemTimeForDisplay: nil
+        ) else {
+            return false
+        }
+        pendingSeekTime = .invalid
+        forceRefreshDeadline = 0
+        forceWindowFailCount = 0
+        mediaDataRearmCount = 0
+        deliverFrame(pixelBuffer)
+        return true
+    }
+
     // MARK: - AVPlayerItemOutputPullDelegate
 
     /// Called after a seek flushes the output queue.

--- a/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
@@ -2,15 +2,16 @@ import 'dart:async';
 
 import 'package:divine_video_player/divine_video_player.dart';
 
-/// Bundles the four state-stream subscriptions the feed maintains per
+/// Bundles the state-stream subscriptions the feed maintains per
 /// active player controller (errors, loop enforcement, auto-advance loop
-/// detection, dimensions).
+/// detection, dimensions, first-frame).
 ///
 /// Each `subscribeTo*` call cancels any prior subscription of the same
-/// kind for that index. [unsubscribe] cancels all four for one index;
+/// kind for that index. [unsubscribe] cancels all of them for one index;
 /// [disposeAll] cancels every subscription.
 class ControllerSubscriptions {
   final _dimensions = <int, StreamSubscription<DivineVideoPlayerState>>{};
+  final _firstFrame = <int, StreamSubscription<DivineVideoPlayerState>>{};
   final _errors = <int, StreamSubscription<DivineVideoPlayerState>>{};
   final _loop = <int, StreamSubscription<DivineVideoPlayerState>>{};
   final _autoAdvance = <int, StreamSubscription<DivineVideoPlayerState>>{};
@@ -162,9 +163,39 @@ class ControllerSubscriptions {
     });
   }
 
+  /// Subscribes to the first-frame transition and auto-cancels itself
+  /// once `state.isFirstFrameRendered` flips to `true`. Calls
+  /// [onFirstFrame] exactly once.
+  ///
+  /// If the controller already reports a rendered first frame on
+  /// subscribe (e.g. a reused controller whose surface is warm),
+  /// [onFirstFrame] fires synchronously and no stream subscription is
+  /// created. This is what guarantees the loader overlay drops on the
+  /// same frame as the swipe when iOS has the texture ready ahead of
+  /// time.
+  void subscribeToFirstFrame(
+    int index,
+    DivineVideoPlayerController controller, {
+    required void Function() onFirstFrame,
+  }) {
+    if (controller.state.isFirstFrameRendered) {
+      onFirstFrame();
+      return;
+    }
+
+    unawaited(_firstFrame[index]?.cancel());
+    _firstFrame[index] = controller.stateStream.listen((state) {
+      if (state.isFirstFrameRendered) {
+        unawaited(_firstFrame.remove(index)?.cancel());
+        onFirstFrame();
+      }
+    });
+  }
+
   /// Cancels all four subscriptions for [index].
   void unsubscribe(int index) {
     unawaited(_dimensions.remove(index)?.cancel());
+    unawaited(_firstFrame.remove(index)?.cancel());
     unawaited(_errors.remove(index)?.cancel());
     unawaited(_loop.remove(index)?.cancel());
     unawaited(_autoAdvance.remove(index)?.cancel());
@@ -176,6 +207,10 @@ class ControllerSubscriptions {
       unawaited(s.cancel());
     }
     _dimensions.clear();
+    for (final s in _firstFrame.values) {
+      unawaited(s.cancel());
+    }
+    _firstFrame.clear();
     for (final s in _errors.values) {
       unawaited(s.cancel());
     }

--- a/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/controller_subscriptions.dart
@@ -192,7 +192,7 @@ class ControllerSubscriptions {
     });
   }
 
-  /// Cancels all four subscriptions for [index].
+  /// Cancels every subscription for [index].
   void unsubscribe(int index) {
     unawaited(_dimensions.remove(index)?.cancel());
     unawaited(_firstFrame.remove(index)?.cancel());

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -935,6 +935,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   void _attachSubscriptions(int index, DivineVideoPlayerController controller) {
     _subscriptions
       ..subscribeToDimensions(index, controller, onDimensionsReady: _rebuild)
+      ..subscribeToFirstFrame(index, controller, onFirstFrame: _rebuild)
       ..subscribeToPlaybackErrors(
         index,
         controller,

--- a/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
@@ -402,6 +402,95 @@ void main() {
     });
 
     // ------------------------------------------------------------------
+    group('subscribeToFirstFrame', () {
+      test('fires onFirstFrame when first-frame flag flips to true', () async {
+        final controller = FakeController();
+        var fired = false;
+
+        subs.subscribeToFirstFrame(
+          0,
+          controller,
+          onFirstFrame: () => fired = true,
+        );
+
+        controller.pushState(
+          const DivineVideoPlayerState(isFirstFrameRendered: true),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(fired, isTrue);
+      });
+
+      test(
+        'fires onFirstFrame synchronously when already rendered',
+        () async {
+          final controller = FakeController()
+            ..pushState(
+              const DivineVideoPlayerState(isFirstFrameRendered: true),
+            );
+          var count = 0;
+
+          subs.subscribeToFirstFrame(
+            0,
+            controller,
+            onFirstFrame: () => count++,
+          );
+
+          // Synchronous fire — no async gap needed.
+          expect(count, equals(1));
+
+          // Further state pushes must not re-fire (no subscription was
+          // created).
+          controller.pushState(
+            const DivineVideoPlayerState(isFirstFrameRendered: true),
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(count, equals(1));
+        },
+      );
+
+      test('fires only once even on further state updates', () async {
+        final controller = FakeController();
+        var count = 0;
+
+        subs.subscribeToFirstFrame(
+          0,
+          controller,
+          onFirstFrame: () => count++,
+        );
+
+        controller.pushState(
+          const DivineVideoPlayerState(isFirstFrameRendered: true),
+        );
+        await Future<void>.delayed(Duration.zero);
+        controller.pushState(
+          const DivineVideoPlayerState(isFirstFrameRendered: true),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(count, equals(1));
+      });
+
+      test('does not fire while first-frame flag is still false', () async {
+        final controller = FakeController();
+        var fired = false;
+
+        subs.subscribeToFirstFrame(
+          0,
+          controller,
+          onFirstFrame: () => fired = true,
+        );
+
+        controller.pushState(
+          const DivineVideoPlayerState(videoWidth: 1920, videoHeight: 1080),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(fired, isFalse);
+      });
+    });
+
+    // ------------------------------------------------------------------
     group('unsubscribe', () {
       test('cancels subscriptions for a specific index', () async {
         final controller = FakeController();

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -344,6 +344,105 @@ void main() {
         );
       });
 
+      testWidgets(
+        'hides loading when first frame becomes rendered after init',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          const globalChannel = MethodChannel('divine_video_player');
+          const playerChannel = MethodChannel('divine_video_player/player_0');
+          const eventChannelName = 'divine_video_player/player_0/events';
+          const methodCodec = StandardMethodCodec();
+
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            globalChannel,
+            (call) async {
+              if (call.method == 'create') return <Object?, Object?>{};
+              return null;
+            },
+          );
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            playerChannel,
+            (_) async => null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+            eventChannelName,
+            (message) async {
+              final call = methodCodec.decodeMethodCall(message);
+              if (call.method == 'listen') {
+                scheduleMicrotask(() async {
+                  await tester.binding.defaultBinaryMessenger
+                      .handlePlatformMessage(
+                        eventChannelName,
+                        methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
+                          'status': 'ready',
+                          'videoWidth': 1280,
+                          'videoHeight': 720,
+                          'isFirstFrameRendered': false,
+                        }),
+                        (_) {},
+                      );
+                });
+              }
+              return methodCodec.encodeSuccessEnvelope(null);
+            },
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('first_frame_transition')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                loadingBuilder: (_, _, {required isSquare}) =>
+                    const Text('loading'),
+                videoBuilder: (_, _, _) => const Text('video'),
+              ),
+            ),
+          );
+
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('loading'), findsOneWidget);
+          expect(find.text('video'), findsOneWidget);
+
+          scheduleMicrotask(() async {
+            await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+              eventChannelName,
+              methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
+                'status': 'ready',
+                'videoWidth': 1280,
+                'videoHeight': 720,
+                'isFirstFrameRendered': true,
+              }),
+              (_) {},
+            );
+          });
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('loading'), findsNothing);
+          expect(find.text('video'), findsOneWidget);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pumpAndSettle();
+
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            globalChannel,
+            null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            playerChannel,
+            null,
+          );
+          tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+            eventChannelName,
+            null,
+          );
+        },
+      );
+
       testWidgets('renders default VideoItemWidget when video size is ready', (
         tester,
       ) async {


### PR DESCRIPTION
Closes #4519

## Description

On iOS the infinite video feed kept showing the loading indicator after videos had loaded because `firstFrameRendered` was set `true` too early — before the Flutter texture actually contained a frame.

**Root cause:** `safePreroll` in `DivineVideoPlayerInstance.swift` marked the first frame as rendered as soon as the preroll callback fired, without verifying that the texture was actually filled. On iOS the display-link pipeline delivers the first frame with a slight delay, so Flutter briefly rendered the texture's empty (black) initial state while `firstFrameRendered` was already `true`, keeping the loading indicator visible indefinitely.

**Fix:**
- Added `tryPullFrameNow(at:)` to `VideoTextureOutput`: synchronously pulls a `CVPixelBuffer` right after preroll and pushes it into the Flutter texture, firing `onFirstFrame` on success.
- `DivineVideoPlayerInstance.safePreroll` now uses this synchronous pull; `firstFrameRendered` is only set `true` when a real buffer was delivered.
- `ControllerSubscriptions` exposes `subscribeToFirstFrame(...)` on the Dart side so the feed hides the loading indicator only after the first real frame.


**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore