### PR TITLE
fix(feed): refresh following feed when follow repo initializes late

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -154,12 +154,22 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       }
     }
 
-    // Subscribe to following list changes (skip first replay — the initial
-    // load already handled the current state, and the follow repo's
-    // force-emit for empty lists will arrive as emission #2).
+    // Subscribe to following list changes.
+    //
+    // If the follow repository was already initialized when we ran the
+    // initial load, skip the first replay — that load already used
+    // up-to-date data and we don't want a redundant second network call.
+    //
+    // If it was NOT yet initialized (the common cold-start race condition),
+    // skip nothing — the first real emission arrives when initialize()
+    // completes and serves as a corrective refresh.  This fixes the bug
+    // where Following and For You show identical content because the
+    // Funnelcake /feed endpoint returned stale/popular-fallback content
+    // before the server-side follow-graph index was confirmed ready.
+    final wasInitialized = _followRepository.isInitialized;
     unawaited(
       emit.onEach<List<String>>(
-        _followRepository.followingStream.skip(1),
+        _followRepository.followingStream.skip(wasInitialized ? 1 : 0),
         onData: (pubkeys) => add(VideoFeedFollowingListChanged(pubkeys)),
       ),
     );

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -104,10 +104,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// attempted first (fast path).
   ///
   /// After the initial load, subscribes to [FollowRepository.followingStream]
-  /// (skipping the first replay) so only runtime follow/unfollow changes
-  /// trigger a refresh — avoiding a redundant second API call on startup.
-  /// The "no follows" CTA is handled by [_onFollowingListChanged] when the
-  /// follow repo's force-emit for empty lists arrives as emission #2.
+  /// and ignores only the first replay when it exactly matches the follow
+  /// list already used for that load. This avoids a redundant second API
+  /// call on startup while still allowing late [FollowRepository.initialize]
+  /// completions to trigger a corrective refresh or "no follows" CTA.
   ///
   /// Also subscribes to [CuratedListRepository.subscribedListsStream]
   /// (skipping the first replay) so curated list changes refresh the feed.
@@ -133,6 +133,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
     _feedTracker?.startFeedLoad(mode.name);
 
+    final initialFollowingPubkeys = List<String>.unmodifiable(
+      _followRepository.followingPubkeys,
+    );
+
     await _loadVideos(mode, emit);
 
     // After the initial load, check for the "no follows" CTA. Needed for
@@ -156,21 +160,28 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
     // Subscribe to following list changes.
     //
-    // If the follow repository was already initialized when we ran the
-    // initial load, skip the first replay — that load already used
-    // up-to-date data and we don't want a redundant second network call.
+    // The first replay can mean one of two things:
+    // - the initial load already used this exact follow list and a refresh
+    //   would be redundant
+    // - initialize() completed after the first load and this replay is the
+    //   corrective signal that the feed should refresh or show the CTA
     //
-    // If it was NOT yet initialized (the common cold-start race condition),
-    // skip nothing — the first real emission arrives when initialize()
-    // completes and serves as a corrective refresh.  This fixes the bug
-    // where Following and For You show identical content because the
-    // Funnelcake /feed endpoint returned stale/popular-fallback content
-    // before the server-side follow-graph index was confirmed ready.
-    final wasInitialized = _followRepository.isInitialized;
+    // Distinguish those cases by comparing the first replay with the list
+    // used for the initial fetch instead of relying on isInitialized.
+    var isFirstFollowingEmission = true;
     unawaited(
       emit.onEach<List<String>>(
-        _followRepository.followingStream.skip(wasInitialized ? 1 : 0),
-        onData: (pubkeys) => add(VideoFeedFollowingListChanged(pubkeys)),
+        _followRepository.followingStream,
+        onData: (pubkeys) {
+          if (isFirstFollowingEmission) {
+            isFirstFollowingEmission = false;
+            if (_listsEqual(pubkeys, initialFollowingPubkeys)) {
+              return;
+            }
+          }
+
+          add(VideoFeedFollowingListChanged(pubkeys));
+        },
       ),
     );
 
@@ -204,6 +215,16 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     );
 
     await _loadVideos(event.mode, emit);
+  }
+
+  bool _listsEqual(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+
+    return true;
   }
 
   /// Handle load more request (pagination).

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -57,6 +57,10 @@ void main() {
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => followingController.stream);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+      // Default: repo already initialized — preserves existing test behaviour
+      // (skip(1) path).  Override to false in tests that exercise the
+      // cold-start race condition (skip(0) path).
+      when(() => mockFollowRepository.isInitialized).thenReturn(true);
 
       when(
         () => mockCuratedListRepository.subscribedListsStream,
@@ -515,6 +519,95 @@ void main() {
               skipCache: any(named: 'skipCache'),
             ),
           ).called(1);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'refreshes following feed when follow repo initializes after initial load',
+        // Regression test for: Following and For You show identical content
+        // when the Funnelcake /feed endpoint returns stale/popular-fallback
+        // content because FollowRepository.initialize() has not finished yet.
+        //
+        // Before the fix: .skip(1) always dropped the first followingStream
+        // emission, so no corrective refresh ever fired.
+        //
+        // After the fix: .skip(0) when isInitialized==false at _onStarted time
+        // means the post-initialize() emission triggers _onFollowingListChanged,
+        // which does a skipCache refresh with the real follow list.
+        setUp: () {
+          final popularVideos = createTestVideos(5, idPrefix: 'popular');
+          final followingVideos = createTestVideos(5, idPrefix: 'following');
+
+          // Simulate: repo NOT yet initialized when VideoFeedStarted fires.
+          when(() => mockFollowRepository.isInitialized).thenReturn(false);
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+
+          // Both calls (initial load + corrective refresh) share the same
+          // signature; distinguish by call order via a counter.
+          var callCount = 0;
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            return callCount == 1
+                ? HomeFeedResult(videos: popularVideos)
+                : HomeFeedResult(videos: followingVideos);
+          });
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+          // Wait for the initial load to complete.
+          await Future<void>.delayed(Duration.zero);
+          // Simulate FollowRepository.initialize() completing and emitting
+          // the real follow list.  With isInitialized==false the BLoC uses
+          // .skip(0), so this first emission is NOT dropped.
+          followingController.add(['author1', 'author2']);
+          // Wait for _onFollowingListChanged to finish the corrective refresh.
+          await Future<void>.delayed(Duration.zero);
+        },
+        expect: () => [
+          // 1. Loading state
+          const VideoFeedState(mode: FeedMode.following),
+          // 2. Initial load succeeds with popular/fallback content
+          isA<VideoFeedState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'videos count', 5)
+              .having(
+                (s) => s.videos.first.id,
+                'first video id',
+                startsWith('popular'),
+              ),
+          // 3. Silent refresh replaces with real following content
+          isA<VideoFeedState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'videos count', 5)
+              .having(
+                (s) => s.videos.first.id,
+                'first video id',
+                startsWith('following'),
+              ),
+        ],
+        verify: (_) {
+          // getHomeFeedVideos must be called twice: once for the initial load
+          // (empty authors) and once for the corrective refresh (real authors).
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).called(2);
         },
       );
     });

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -57,10 +58,6 @@ void main() {
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => followingController.stream);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-      // Default: repo already initialized — preserves existing test behaviour
-      // (skip(1) path).  Override to false in tests that exercise the
-      // cold-start race condition (skip(0) path).
-      when(() => mockFollowRepository.isInitialized).thenReturn(true);
 
       when(
         () => mockCuratedListRepository.subscribedListsStream,
@@ -522,24 +519,23 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'refreshes following feed when follow repo initializes after initial load',
         // Regression test for: Following and For You show identical content
         // when the Funnelcake /feed endpoint returns stale/popular-fallback
         // content because FollowRepository.initialize() has not finished yet.
         //
-        // Before the fix: .skip(1) always dropped the first followingStream
-        // emission, so no corrective refresh ever fired.
+        // Before the fix: the first followingStream replay was always ignored,
+        // so no corrective refresh ever fired.
         //
-        // After the fix: .skip(0) when isInitialized==false at _onStarted time
-        // means the post-initialize() emission triggers _onFollowingListChanged,
-        // which does a skipCache refresh with the real follow list.
+        // After the fix: the first replay is processed when it differs from
+        // the follow list used for the initial fetch, so the post-initialize()
+        // emission triggers _onFollowingListChanged and does a skipCache
+        // refresh with the real follow list.
         setUp: () {
           final popularVideos = createTestVideos(5, idPrefix: 'popular');
           final followingVideos = createTestVideos(5, idPrefix: 'following');
 
-          // Simulate: repo NOT yet initialized when VideoFeedStarted fires.
-          when(() => mockFollowRepository.isInitialized).thenReturn(false);
           when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
 
           // Both calls (initial load + corrective refresh) share the same
@@ -567,17 +563,17 @@ void main() {
           // Wait for the initial load to complete.
           await Future<void>.delayed(Duration.zero);
           // Simulate FollowRepository.initialize() completing and emitting
-          // the real follow list.  With isInitialized==false the BLoC uses
-          // .skip(0), so this first emission is NOT dropped.
+          // the real follow list. Because this first replay differs from the
+          // list used for the initial fetch, it is NOT ignored.
           followingController.add(['author1', 'author2']);
           // Wait for _onFollowingListChanged to finish the corrective refresh.
           await Future<void>.delayed(Duration.zero);
         },
         expect: () => [
           // 1. Loading state
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // 2. Initial load succeeds with popular/fallback content
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', 5)
               .having(
@@ -586,7 +582,7 @@ void main() {
                 startsWith('popular'),
               ),
           // 3. Silent refresh replaces with real following content
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', 5)
               .having(
@@ -608,6 +604,65 @@ void main() {
               skipCache: any(named: 'skipCache'),
             ),
           ).called(2);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'does not refresh twice when cached follows replay before initialize finishes',
+        setUp: () {
+          final replayingFollowing = BehaviorSubject<List<String>>.seeded([
+            'author1',
+            'author2',
+          ]);
+          addTearDown(replayingFollowing.close);
+
+          final followingVideos = createTestVideos(5, idPrefix: 'following');
+
+          when(
+            () => mockFollowRepository.followingStream,
+          ).thenAnswer((_) => replayingFollowing.stream);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(['author1', 'author2']);
+
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: followingVideos));
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+          await Future<void>.delayed(Duration.zero);
+        },
+        expect: () => [
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'videos count', 5)
+              .having(
+                (s) => s.videos.first.id,
+                'first video id',
+                startsWith('following'),
+              ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: ['author1', 'author2'],
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).called(1);
         },
       );
     });
@@ -2194,9 +2249,7 @@ void main() {
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer(
-            (_) async => HomeFeedResult(videos: recommendedVideos),
-          );
+          ).thenAnswer((_) async => HomeFeedResult(videos: recommendedVideos));
         },
         build: createBlocWithCache,
         act: (bloc) => bloc.add(const VideoFeedStarted()),


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
On cold start, VideoFeedBloc._onStarted unconditionally used .skip(1) on followingStream, dropping the first emission even when FollowRepository hadn't finished initialize() yet. If the Funnelcake /feed endpoint returned stale or popular-fallback content (because the server's follow-graph index wasn't ready), no corrective refresh ever fired and the Following feed showed the same content as For You.

Fix: capture isInitialized before subscribing and use .skip(0) when the repo was not yet initialized. The first post-initialize() emission then reaches _onFollowingListChanged, which performs a skipCache refresh with the real follow list.

When the repo was already initialized at startup time the existing .skip(1) behaviour is preserved to avoid a redundant second API call.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4324 

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
