### PR TITLE
refactor(video-feed): rename BLoC's VideoFeedState to VideoFeedBlocState

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -34,7 +34,7 @@ const _feedModeKey = 'selected_feed_mode';
 /// - Pagination via cursor-based loading
 /// - Following list changes for home feed
 /// - Pull-to-refresh functionality
-class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
+class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   VideoFeedBloc({
     required VideosRepository videosRepository,
     required FollowRepository followRepository,
@@ -58,7 +58,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
        _autoRefreshMinInterval = autoRefreshMinInterval,
        _feedTracker = feedTracker,
        _homeFeedCache = homeFeedCache ?? const HomeFeedCache(),
-       super(const VideoFeedState()) {
+       super(const VideoFeedBlocState()) {
     on<VideoFeedStarted>(_onStarted);
     on<VideoFeedModeChanged>(_onModeChanged);
     on<VideoFeedLoadMoreRequested>(
@@ -119,7 +119,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// restored. Otherwise [event.mode] is used.
   Future<void> _onStarted(
     VideoFeedStarted event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     final savedModeName = _sharedPreferences?.getString(_feedModeKey);
     final mode = savedModeName != null
@@ -174,7 +174,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// Handle mode changed event.
   Future<void> _onModeChanged(
     VideoFeedModeChanged event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     // Skip if already on this mode
     if (state.mode == event.mode && state.status == VideoFeedStatus.success) {
@@ -199,7 +199,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// Handle load more request (pagination).
   Future<void> _onLoadMoreRequested(
     VideoFeedLoadMoreRequested event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     // Skip if not in success state, already loading more, or no more content
     if (state.status != VideoFeedStatus.success ||
@@ -280,7 +280,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// Handle refresh request.
   Future<void> _onRefreshRequested(
     VideoFeedRefreshRequested event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     emit(
       state.copyWith(
@@ -302,7 +302,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   ///   [_autoRefreshMinInterval])
   Future<void> _onAutoRefreshRequested(
     VideoFeedAutoRefreshRequested event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     if (state.mode != FeedMode.following) return;
 
@@ -336,7 +336,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   ///   flash).
   Future<void> _onFollowingListChanged(
     VideoFeedFollowingListChanged event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     if (state.mode != FeedMode.following) return;
     if (state.status == VideoFeedStatus.loading) return;
@@ -366,7 +366,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// feed has already been loaded (avoids double-loading on startup).
   Future<void> _onCuratedListsChanged(
     VideoFeedCuratedListsChanged event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     if (state.mode != FeedMode.following) return;
     if (state.status == VideoFeedStatus.loading) return;
@@ -390,7 +390,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// filters the current videos against the full blocklist in-memory.
   void _onBlocklistChanged(
     VideoFeedBlocklistChanged event,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) {
     final pubkey = event.blockedPubkey;
     if (pubkey != null) {
@@ -427,7 +427,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// the `noFollowedUsers` CTA or refresh the feed.
   Future<void> _loadVideos(
     FeedMode mode,
-    Emitter<VideoFeedState> emit, {
+    Emitter<VideoFeedBlocState> emit, {
     bool skipCache = false,
   }) async {
     // Serve cached home feed on first load for instant startup.
@@ -562,7 +562,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   /// after videos are already emitted.
   Future<void> _fetchCreatorProfiles(
     List<VideoEvent> videos,
-    Emitter<VideoFeedState> emit,
+    Emitter<VideoFeedBlocState> emit,
   ) async {
     if (_profileRepository == null || videos.isEmpty) return;
 

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -45,8 +45,8 @@ enum VideoFeedError {
 /// - [hasMore]: Whether more videos can be loaded
 /// - [isLoadingMore]: Whether pagination is in progress
 /// - [error]: Any error that occurred
-final class VideoFeedState extends Equatable {
-  const VideoFeedState({
+final class VideoFeedBlocState extends Equatable {
+  const VideoFeedBlocState({
     this.status = VideoFeedStatus.loading,
     this.videos = const [],
     this.mode = FeedMode.forYou,
@@ -105,7 +105,7 @@ final class VideoFeedState extends Equatable {
   bool get isEmpty => status == VideoFeedStatus.success && videos.isEmpty;
 
   /// Create a copy with updated values.
-  VideoFeedState copyWith({
+  VideoFeedBlocState copyWith({
     VideoFeedStatus? status,
     List<VideoEvent>? videos,
     FeedMode? mode,
@@ -117,7 +117,7 @@ final class VideoFeedState extends Equatable {
     Set<String>? listOnlyVideoIds,
     Map<String, UserProfile>? creatorProfiles,
   }) {
-    return VideoFeedState(
+    return VideoFeedBlocState(
       status: status ?? this.status,
       videos: videos ?? this.videos,
       mode: mode ?? this.mode,

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -53,7 +53,7 @@ class FeedModeSwitch extends StatelessWidget {
                 ? _FeedModeContent(
                     label: _labelForMode(FeedMode.forYou, context.l10n),
                   )
-                : BlocBuilder<VideoFeedBloc, VideoFeedState>(
+                : BlocBuilder<VideoFeedBloc, VideoFeedBlocState>(
                     buildWhen: (prev, curr) => prev.mode != curr.mode,
                     builder: (context, state) => _FeedModeContent(
                       onTap: () =>

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -256,7 +256,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     unawaited(feedState.animateToPage(targetIndex));
   }
 
-  FeedAutoAdvanceSnapshot _autoAdvanceSnapshot(VideoFeedState state) {
+  FeedAutoAdvanceSnapshot _autoAdvanceSnapshot(VideoFeedBlocState state) {
     return FeedAutoAdvanceSnapshot(
       currentIndex: _currentFeedIndex(),
       itemCount: state.videos.length,
@@ -293,7 +293,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     );
   }
 
-  void _continuePendingAutoAdvance(VideoFeedState state) {
+  void _continuePendingAutoAdvance(VideoFeedBlocState state) {
     continueFeedAutoAdvanceAfterPagination(
       cubit: _autoAdvanceCubit,
       snapshot: _autoAdvanceSnapshot(state),
@@ -305,7 +305,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   ///
   /// Called from [didChangeDependencies] for eager setup and from
   /// [BlocListener] when videos arrive asynchronously.
-  void handleVideoController([VideoFeedState? state]) {
+  void handleVideoController([VideoFeedBlocState? state]) {
     if (kIsWeb) return; // Skip media_kit controller on web
     if (!ownsController) return;
     if (InfiniteVideoFeed.isSupported &&
@@ -364,7 +364,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   }
 
   /// Handles new videos from pagination by adding them to the controller.
-  void handleVideosChanged(VideoFeedState state) {
+  void handleVideosChanged(VideoFeedBlocState state) {
     if (!ownsController) return;
 
     final pooledVideos = state.videos.toPooledVideoItems();
@@ -525,7 +525,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
             ),
             // Reset controller when mode changes so a fresh one is
             // created for the new feed.
-            BlocListener<VideoFeedBloc, VideoFeedState>(
+            BlocListener<VideoFeedBloc, VideoFeedBlocState>(
               listenWhen: (previous, current) => previous.mode != current.mode,
               listener: (_, state) {
                 _pagePosition.value = 0;
@@ -534,7 +534,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
               },
             ),
             // Initialize controller when videos first become available
-            BlocListener<VideoFeedBloc, VideoFeedState>(
+            BlocListener<VideoFeedBloc, VideoFeedBlocState>(
               listenWhen: (previous, current) =>
                   !previous.isLoaded &&
                   current.isLoaded &&
@@ -548,12 +548,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
               },
             ),
             // Handle new videos from pagination
-            BlocListener<VideoFeedBloc, VideoFeedState>(
+            BlocListener<VideoFeedBloc, VideoFeedBlocState>(
               listenWhen: (previous, current) =>
                   previous.videos.length != current.videos.length,
               listener: (_, state) => handleVideosChanged(state),
             ),
-            BlocListener<VideoFeedBloc, VideoFeedState>(
+            BlocListener<VideoFeedBloc, VideoFeedBlocState>(
               listenWhen: (previous, current) =>
                   previous.videos.length != current.videos.length ||
                   previous.hasMore != current.hasMore ||
@@ -561,7 +561,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
               listener: (_, state) => _continuePendingAutoAdvance(state),
             ),
           ],
-          child: BlocBuilder<VideoFeedBloc, VideoFeedState>(
+          child: BlocBuilder<VideoFeedBloc, VideoFeedBlocState>(
             builder: (context, state) {
               // Loading state (including initial state before first load)
               if (state.isLoading) {
@@ -872,7 +872,7 @@ class _FeedErrorWidget extends StatelessWidget {
 class FeedEmptyWidget extends StatelessWidget {
   const FeedEmptyWidget({required this.state, super.key});
 
-  final VideoFeedState state;
+  final VideoFeedBlocState state;
 
   @override
   Widget build(BuildContext context) {
@@ -912,7 +912,7 @@ class FeedEmptyWidget extends StatelessWidget {
     );
   }
 
-  String _getEmptyMessage(BuildContext context, VideoFeedState state) {
+  String _getEmptyMessage(BuildContext context, VideoFeedBlocState state) {
     if ((state.mode == FeedMode.following || state.mode == FeedMode.forYou) &&
         state.error == VideoFeedError.noFollowedUsers) {
       return context.l10n.feedNoFollowedUsers;

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -128,24 +128,26 @@ void main() {
       bloc.close();
     });
 
-    group('VideoFeedState', () {
+    group('VideoFeedBlocState', () {
       test('isLoaded returns true when status is success', () {
-        const initialState = VideoFeedState();
-        const successState = VideoFeedState(status: VideoFeedStatus.success);
+        const initialState = VideoFeedBlocState();
+        const successState = VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+        );
 
         expect(initialState.isLoaded, isFalse);
         expect(successState.isLoaded, isTrue);
       });
 
       test('isLoading returns true when status is loading', () {
-        const initialState = VideoFeedState();
+        const initialState = VideoFeedBlocState();
 
         expect(initialState.isLoading, isTrue);
       });
 
       test('isEmpty returns true when success with no videos', () {
-        const emptyState = VideoFeedState(status: VideoFeedStatus.success);
-        final loadedState = VideoFeedState(
+        const emptyState = VideoFeedBlocState(status: VideoFeedStatus.success);
+        final loadedState = VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: [createTestVideo('v1')],
         );
@@ -155,7 +157,7 @@ void main() {
       });
 
       test('copyWith creates copy with updated values', () {
-        const state = VideoFeedState();
+        const state = VideoFeedBlocState();
 
         final updated = state.copyWith(
           status: VideoFeedStatus.success,
@@ -167,7 +169,7 @@ void main() {
       });
 
       test('copyWith preserves values when not specified', () {
-        const state = VideoFeedState(
+        const state = VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.latest,
         );
@@ -179,7 +181,7 @@ void main() {
       });
 
       test('copyWith clearError removes error', () {
-        const state = VideoFeedState(error: VideoFeedError.loadFailed);
+        const state = VideoFeedBlocState(error: VideoFeedError.loadFailed);
 
         final updated = state.copyWith(clearError: true);
 
@@ -188,7 +190,7 @@ void main() {
     });
 
     group('VideoFeedStarted', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'emits [loading, success] when home feed loads successfully',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -210,8 +212,8 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
               .having((s) => s.mode, 'mode', FeedMode.following)
@@ -219,7 +221,7 @@ void main() {
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'emits [loading, success] with latest mode when specified',
         setUp: () {
           final videos = createTestVideos(5);
@@ -235,14 +237,14 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.latest)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.latest),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.latest),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.mode, 'mode', FeedMode.latest),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'loads recommendations when forYou mode is specified',
         setUp: () {
           final videos = createTestVideos(5);
@@ -261,8 +263,8 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
-          const VideoFeedState(),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.mode, 'mode', FeedMode.forYou),
         ],
@@ -288,7 +290,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'restores saved mode from SharedPreferences before loading',
         setUp: () async {
           final videos = createTestVideos(5);
@@ -323,14 +325,14 @@ void main() {
         build: () => savedModeBloc,
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.latest),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.latest),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.mode, 'mode', FeedMode.latest),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'emits noFollowedUsers when following list is empty on startup',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
@@ -349,15 +351,15 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // _loadVideos emits success with empty videos
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.following,
             hasMore: false,
           ),
           // _onStarted detects empty follows → noFollowedUsers CTA
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.following,
             hasMore: false,
@@ -366,7 +368,7 @@ void main() {
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does not emit noFollowedUsers for forYou when following list is empty',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
@@ -382,15 +384,15 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
-          const VideoFeedState(),
-          const VideoFeedState(
+          const VideoFeedBlocState(),
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             hasMore: false,
           ),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'emits [loading, failure] when repository throws',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
@@ -409,8 +411,8 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          const VideoFeedState(
+          const VideoFeedBlocState(mode: FeedMode.following),
+          const VideoFeedBlocState(
             status: VideoFeedStatus.failure,
             mode: FeedMode.following,
             error: VideoFeedError.loadFailed,
@@ -418,7 +420,7 @@ void main() {
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'keeps hasMore true when fewer than page size returned',
         setUp: () {
           final videos = createTestVideos(3); // Less than 5 (page size)
@@ -439,15 +441,15 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', 3)
               .having((s) => s.hasMore, 'hasMore', true),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'sets hasMore to false when empty list returned',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
@@ -466,15 +468,15 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos, 'videos', isEmpty)
               .having((s) => s.hasMore, 'hasMore', false),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does not await initialized before calling repository',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -518,7 +520,7 @@ void main() {
     });
 
     group('VideoFeedModeChanged', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'clears videos and loads new mode',
         setUp: () {
           final latestVideos = createTestVideos(5);
@@ -532,31 +534,31 @@ void main() {
           ).thenAnswer((_) async => latestVideos);
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(3),
         ),
         act: (bloc) => bloc.add(const VideoFeedModeChanged(FeedMode.latest)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.latest),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.latest),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.mode, 'mode', FeedMode.latest)
               .having((s) => s.videos.length, 'videos count', 5),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when already on the same mode with success state',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.latest,
           videos: createTestVideos(5),
         ),
         act: (bloc) => bloc.add(const VideoFeedModeChanged(FeedMode.latest)),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
         verify: (_) {
           verifyNever(
             () => mockVideosRepository.getNewVideos(
@@ -570,7 +572,7 @@ void main() {
     });
 
     group('VideoFeedLoadMoreRequested', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'uses recommendations pagination path for forYou mode',
         setUp: () {
           final moreVideos = createTestVideos(
@@ -589,18 +591,18 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: moreVideos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videos.length, 'videos count', pageSize + 2)
               .having((s) => s.hasMore, 'hasMore', true),
@@ -626,7 +628,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'appends new videos to existing list',
         setUp: () {
           // Use different ID prefix to ensure unique videos
@@ -649,19 +651,19 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: moreVideos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videos.length, 'videos count', pageSize * 2)
               .having((s) => s.hasMore, 'hasMore', true),
@@ -680,47 +682,47 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when not in success state',
         build: createBloc,
-        seed: () => const VideoFeedState(),
+        seed: () => const VideoFeedBlocState(),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when already loading more',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: createTestVideos(5),
           isLoadingMore: true,
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when hasMore is false',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: createTestVideos(5),
           hasMore: false,
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when videos list is empty',
         build: createBloc,
-        seed: () => const VideoFeedState(status: VideoFeedStatus.success),
+        seed: () => const VideoFeedBlocState(status: VideoFeedStatus.success),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'keeps hasMore true when fewer than page size returned from load more',
         setUp: () {
           // Return fewer videos than page size with unique IDs.
@@ -745,26 +747,26 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: moreVideos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videos.length, 'videos count', pageSize + 2)
               .having((s) => s.hasMore, 'hasMore', true),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'sets hasMore to false when empty list returned from load more',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
@@ -780,26 +782,26 @@ void main() {
           ).thenAnswer((_) async => const HomeFeedResult(videos: []));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videos.length, 'videos count', pageSize)
               .having((s) => s.hasMore, 'hasMore', false),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'drops concurrent requests via droppable transformer',
         setUp: () {
           final moreVideos = createTestVideos(
@@ -825,7 +827,7 @@ void main() {
           });
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
@@ -853,7 +855,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'deduplicates overlapping videos from Funnelcake and Nostr',
         setUp: () {
           // Return videos that partially overlap with existing ones.
@@ -880,7 +882,7 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: overlappingVideos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(
@@ -891,12 +893,12 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               // 3 existing + 3 new = 6 (2 duplicates removed)
               .having((s) => s.videos.length, 'videos count', 6)
@@ -904,7 +906,7 @@ void main() {
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'resets isLoadingMore on error',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
@@ -920,19 +922,19 @@ void main() {
           ).thenThrow(Exception('Network error'));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(5),
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videos.length, 'videos count', 5),
         ],
@@ -940,7 +942,7 @@ void main() {
     });
 
     group('VideoFeedRefreshRequested', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'clears videos and reloads from beginning',
         setUp: () {
           final freshVideos = createTestVideos(pageSize);
@@ -958,7 +960,7 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: freshVideos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(10), // Previous videos
@@ -966,8 +968,8 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoFeedRefreshRequested()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
               .having((s) => s.hasMore, 'hasMore', true),
@@ -987,7 +989,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'clears error on refresh',
         setUp: () {
           final videos = createTestVideos(5);
@@ -1005,15 +1007,15 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: videos));
         },
         build: createBloc,
-        seed: () => const VideoFeedState(
+        seed: () => const VideoFeedBlocState(
           status: VideoFeedStatus.failure,
           mode: FeedMode.following,
           error: VideoFeedError.loadFailed,
         ),
         act: (bloc) => bloc.add(const VideoFeedRefreshRequested()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.error, 'error', isNull),
         ],
@@ -1021,7 +1023,7 @@ void main() {
     });
 
     group('VideoFeedAutoRefreshRequested', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'refreshes when on home mode and data is stale',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1044,44 +1046,44 @@ void main() {
           curatedListRepository: mockCuratedListRepository,
           autoRefreshMinInterval: Duration.zero,
         ),
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(3),
         ),
         act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when mode is not home',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.latest,
           videos: createTestVideos(5),
         ),
         act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when mode is forYou',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: createTestVideos(5),
         ),
         act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when data is fresh '
         '(last refresh within auto-refresh interval)',
         setUp: () {
@@ -1106,7 +1108,7 @@ void main() {
           // Large interval so data is always considered fresh
           autoRefreshMinInterval: const Duration(hours: 1),
         ),
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(pageSize),
@@ -1120,10 +1122,10 @@ void main() {
           bloc.add(const VideoFeedAutoRefreshRequested());
         },
         skip: 2, // Skip the loading + success from VideoFeedStarted
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'refreshes when auto-refresh interval has elapsed',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1146,7 +1148,7 @@ void main() {
           curatedListRepository: mockCuratedListRepository,
           autoRefreshMinInterval: Duration.zero,
         ),
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: createTestVideos(pageSize),
         ),
@@ -1160,14 +1162,14 @@ void main() {
         },
         skip: 2, // Skip the loading + success from VideoFeedStarted
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'refreshes when _lastRefreshedAt is null '
         '(feed never loaded successfully)',
         setUp: () {
@@ -1186,15 +1188,15 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: videos));
         },
         build: createBloc,
-        seed: () => const VideoFeedState(
+        seed: () => const VideoFeedBlocState(
           status: VideoFeedStatus.failure,
           mode: FeedMode.following,
           error: VideoFeedError.loadFailed,
         ),
         act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize),
         ],
@@ -1202,7 +1204,7 @@ void main() {
     });
 
     group('VideoFeedFollowingListChanged', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'silently refreshes home feed on follow list change',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1222,7 +1224,7 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: videos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(3),
@@ -1231,36 +1233,36 @@ void main() {
             bloc.add(const VideoFeedFollowingListChanged(['new-author'])),
         expect: () => [
           // No loading state — silent refresh replaces in-place
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
               .having((s) => s.mode, 'mode', FeedMode.following),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when mode is not home',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.latest,
           videos: createTestVideos(5),
         ),
         act: (bloc) =>
             bloc.add(const VideoFeedFollowingListChanged(['new-author'])),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when feed is still loading',
         build: createBloc,
-        seed: () => const VideoFeedState(mode: FeedMode.following),
+        seed: () => const VideoFeedBlocState(mode: FeedMode.following),
         act: (bloc) =>
             bloc.add(const VideoFeedFollowingListChanged(['new-author'])),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'transitions from noFollowedUsers to loaded feed',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1280,7 +1282,7 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: videos));
         },
         build: createBloc,
-        seed: () => const VideoFeedState(
+        seed: () => const VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           hasMore: false,
@@ -1290,14 +1292,14 @@ void main() {
             bloc.add(const VideoFeedFollowingListChanged(['first-follow'])),
         expect: () => [
           // No loading state — silent refresh replaces in-place
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
               .having((s) => s.error, 'error', isNull),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'skips initial follow list replay to avoid redundant API call',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1325,7 +1327,7 @@ void main() {
           followingController.add(['author']);
         },
         skip: 2, // Skip loading + success from VideoFeedStarted
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
         verify: (_) {
           // Called only once — the replay is skipped, no redundant call
           verify(
@@ -1341,7 +1343,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'silently refreshes on second follow list emission after feed '
         'is empty (Funnelcake failed)',
         setUp: () {
@@ -1382,7 +1384,7 @@ void main() {
         skip: 2, // Skip loading + success(empty) from VideoFeedStarted
         expect: () => [
           // No loading state — silent refresh replaces in-place
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize),
         ],
@@ -1401,7 +1403,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'silently refreshes on runtime follow list changes '
         '(skips initial replay)',
         setUp: () {
@@ -1433,7 +1435,7 @@ void main() {
         },
         skip: 2, // Skip loading + success from VideoFeedStarted
         // No state changes — same videos returned, Equatable deduplicates
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
         verify: (_) {
           // Called 2 times: initial + runtime (replay is skipped)
           verify(
@@ -1451,7 +1453,7 @@ void main() {
     });
 
     group('VideoFeedCuratedListsChanged', () {
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'refreshes home feed when curated lists change',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1471,42 +1473,42 @@ void main() {
           ).thenAnswer((_) async => HomeFeedResult(videos: videos));
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(3),
         ),
         act: (bloc) => bloc.add(const VideoFeedCuratedListsChanged()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
               .having((s) => s.mode, 'mode', FeedMode.following),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when mode is not home',
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.latest,
           videos: createTestVideos(5),
         ),
         act: (bloc) => bloc.add(const VideoFeedCuratedListsChanged()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does nothing when feed is still loading',
         build: createBloc,
-        seed: () => const VideoFeedState(mode: FeedMode.following),
+        seed: () => const VideoFeedBlocState(mode: FeedMode.following),
         act: (bloc) => bloc.add(const VideoFeedCuratedListsChanged()),
-        expect: () => <VideoFeedState>[],
+        expect: () => <VideoFeedBlocState>[],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'subscribes to subscribedListsStream via emit.onEach on startup',
         setUp: () {
           final videos = createTestVideos(pageSize);
@@ -1538,14 +1540,14 @@ void main() {
         },
         skip: 2, // Skip loading + success from VideoFeedStarted
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'emits state with videoListSources and listOnlyVideoIds '
         'from HomeFeedResult',
         setUp: () {
@@ -1574,15 +1576,15 @@ void main() {
           );
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(3),
         ),
         act: (bloc) => bloc.add(const VideoFeedCuratedListsChanged()),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videoListSources, 'videoListSources', {
                 'video-0': {'list-1'},
@@ -1593,7 +1595,7 @@ void main() {
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'merges attribution metadata on load more',
         setUp: () {
           final moreVideos = createTestVideos(
@@ -1623,7 +1625,7 @@ void main() {
           );
         },
         build: createBloc,
-        seed: () => VideoFeedState(
+        seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.following,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
@@ -1634,12 +1636,12 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             true,
           ),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videoListSources, 'videoListSources', {
                 'existing-0': {'list-1'},
@@ -1678,7 +1680,7 @@ void main() {
         feedTracker: mockTracker,
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'calls startFeedLoad on VideoFeedStarted',
         setUp: () {
           final videos = createTestVideos(3);
@@ -1702,7 +1704,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'calls markFirstVideosReceived and markFeedDisplayed on success',
         setUp: () {
           final videos = createTestVideos(3);
@@ -1729,7 +1731,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'calls trackFeedError on failure',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
@@ -1760,7 +1762,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'uses correct feed type for latest mode',
         setUp: () {
           final videos = createTestVideos(3);
@@ -1837,7 +1839,7 @@ void main() {
         homeFeedCache: mockCache,
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'emits cached videos then fresh videos on cold start',
         setUp: () {
           final cachedVideos = createTestVideos(2, idPrefix: 'cached');
@@ -1869,14 +1871,14 @@ void main() {
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
           // 1. Loading state from _onStarted
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // 2. Cached videos served immediately
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'cached count', 2)
               .having((s) => s.videos[0].id, 'first cached id', 'cached-0'),
           // 3. Fresh videos replace cached
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'fresh count', 3)
               .having((s) => s.videos[0].id, 'first fresh id', 'fresh-0'),
@@ -1886,7 +1888,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'skips cache when no SharedPreferences provided',
         setUp: () {
           final videos = createTestVideos(3);
@@ -1912,8 +1914,8 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'count', 3),
         ],
@@ -1922,7 +1924,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'skips cache when cache returns null',
         setUp: () {
           final videos = createTestVideos(3);
@@ -1949,14 +1951,14 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'count', 3),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'writes raw response body to cache after fresh fetch',
         setUp: () {
           final videos = createTestVideos(3);
@@ -1990,7 +1992,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'writes forYou raw response body to Home tab cache after fresh fetch',
         setUp: () {
           final videos = createTestVideos(3);
@@ -2023,7 +2025,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does not write cache when rawResponseBody is null',
         setUp: () {
           final videos = createTestVideos(3);
@@ -2048,7 +2050,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does not serve cache on non-home mode',
         setUp: () {
           final videos = createTestVideos(3);
@@ -2064,8 +2066,12 @@ void main() {
         build: createBlocWithCache,
         act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.latest)),
         expect: () => [
-          isA<VideoFeedState>().having((s) => s.mode, 'mode', FeedMode.latest),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>().having(
+            (s) => s.mode,
+            'mode',
+            FeedMode.latest,
+          ),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'count', 3),
         ],
@@ -2074,7 +2080,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'serves cached Home tab data before fresh forYou recommendations',
         setUp: () {
           final cachedVideos = createTestVideos(2, idPrefix: 'cached');
@@ -2102,12 +2108,12 @@ void main() {
         build: createBlocWithCache,
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
-          const VideoFeedState(),
-          isA<VideoFeedState>()
+          const VideoFeedBlocState(),
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'cached count', 2)
               .having((s) => s.videos.first.id, 'first cached id', 'cached-0'),
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'recommended count', 3)
               .having(
@@ -2121,7 +2127,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'keeps cached data visible when network fails',
         setUp: () {
           final cachedVideos = createTestVideos(2, idPrefix: 'cached');
@@ -2146,16 +2152,16 @@ void main() {
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
           // 1. Loading state
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // 2. Cached videos served
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'cached count', 2),
           // No failure state emitted because cached data is displayed
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'serves cache only once per bloc instance',
         setUp: () {
           final cachedVideos = createTestVideos(2, idPrefix: 'cached');
@@ -2192,7 +2198,7 @@ void main() {
         },
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'filters cached videos through '
         'VideosRepository.applyContentPreferences before emitting them',
         setUp: () {
@@ -2247,9 +2253,9 @@ void main() {
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
           // 1. Loading state from _onStarted
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // 2. Cached emission: hidden filtered out via applyContentPreferences
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'cached count', 1)
               .having(
@@ -2259,7 +2265,7 @@ void main() {
               ),
           // 3. Fresh fetch result replaces cached state (unfiltered on the
           //    fresh path — only the cache path is under test here).
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'fresh count', 2),
         ],
@@ -2314,7 +2320,7 @@ void main() {
         createdAt: DateTime(2024),
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'fetches creator profiles when videos load',
         setUp: () {
           final baseTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -2361,20 +2367,20 @@ void main() {
           ).called(1);
         },
         expect: () => [
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // Videos loaded (no profiles yet)
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos, 'videos', hasLength(2))
               .having((s) => s.creatorProfiles, 'profiles', isEmpty),
           // Profiles fetched
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.creatorProfiles, 'profiles', hasLength(2)),
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'fetches only new profiles on pagination',
         setUp: () {
           final baseTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -2439,29 +2445,29 @@ void main() {
         },
         expect: () => [
           // Loading
-          const VideoFeedState(mode: FeedMode.following),
+          const VideoFeedBlocState(mode: FeedMode.following),
           // Initial videos loaded
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos, 'videos', hasLength(1)),
           // Profiles for initial videos
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.creatorProfiles,
             'profiles after initial',
             hasLength(1),
           ),
           // Pagination loading
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.isLoadingMore,
             'isLoadingMore',
             isTrue,
           ),
           // Pagination complete
-          isA<VideoFeedState>()
+          isA<VideoFeedBlocState>()
               .having((s) => s.videos, 'videos', hasLength(3))
               .having((s) => s.isLoadingMore, 'isLoadingMore', isFalse),
           // Profiles for new creators
-          isA<VideoFeedState>().having(
+          isA<VideoFeedBlocState>().having(
             (s) => s.creatorProfiles,
             'profiles after pagination',
             hasLength(3),
@@ -2469,7 +2475,7 @@ void main() {
         ],
       );
 
-      blocTest<VideoFeedBloc, VideoFeedState>(
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'does not re-fetch existing profiles on pagination',
         setUp: () {
           final baseTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -12,7 +12,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 
-class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedState>
+class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedBlocState>
     implements VideoFeedBloc {}
 
 void main() {
@@ -55,7 +55,7 @@ void main() {
     group('Feed Mode Labels', () {
       testWidgets('displays "New" label for latest mode', (tester) async {
         when(() => mockBloc.state).thenReturn(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.latest,
           ),
@@ -70,7 +70,7 @@ void main() {
       ) async {
         when(
           () => mockBloc.state,
-        ).thenReturn(const VideoFeedState(status: VideoFeedStatus.success));
+        ).thenReturn(const VideoFeedBlocState(status: VideoFeedStatus.success));
         await tester.pumpWidget(createTestWidget());
 
         expect(find.text(l10n.feedModeForYou), findsOneWidget);
@@ -80,7 +80,7 @@ void main() {
     group('Tap Interaction', () {
       testWidgets('opens VineBottomSheet on tap', (tester) async {
         when(() => mockBloc.state).thenReturn(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.latest,
           ),
@@ -97,7 +97,7 @@ void main() {
         tester,
       ) async {
         when(() => mockBloc.state).thenReturn(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.latest,
           ),
@@ -120,7 +120,7 @@ void main() {
       ) async {
         when(
           () => mockBloc.state,
-        ).thenReturn(const VideoFeedState(status: VideoFeedStatus.success));
+        ).thenReturn(const VideoFeedBlocState(status: VideoFeedStatus.success));
         await tester.pumpWidget(createTestWidget());
 
         await tester.tap(find.text(l10n.feedModeForYou));
@@ -138,7 +138,7 @@ void main() {
         tester,
       ) async {
         when(() => mockBloc.state).thenReturn(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.latest,
           ),
@@ -166,7 +166,7 @@ void main() {
         'opens bottom sheet when caret icon is tapped (not the text label)',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
-            const VideoFeedState(
+            const VideoFeedBlocState(
               status: VideoFeedStatus.success,
             ),
           );
@@ -198,7 +198,7 @@ void main() {
           // The 12 px Row spacing gap has no child widget drawn in it;
           // HitTestBehavior.opaque ensures it still registers taps.
           when(() => mockBloc.state).thenReturn(
-            const VideoFeedState(
+            const VideoFeedBlocState(
               status: VideoFeedStatus.success,
             ),
           );
@@ -250,7 +250,7 @@ void main() {
         'Semantics widget carries button=true and the current mode label',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
-            const VideoFeedState(
+            const VideoFeedBlocState(
               status: VideoFeedStatus.success,
               mode: FeedMode.latest,
             ),
@@ -275,12 +275,12 @@ void main() {
           whenListen(
             mockBloc,
             Stream.fromIterable([
-              const VideoFeedState(
+              const VideoFeedBlocState(
                 status: VideoFeedStatus.success,
                 mode: FeedMode.following,
               ),
             ]),
-            initialState: const VideoFeedState(
+            initialState: const VideoFeedBlocState(
               status: VideoFeedStatus.success,
               mode: FeedMode.latest,
             ),
@@ -305,7 +305,7 @@ void main() {
         'opens bottom sheet when the Semantics button area is tapped',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
-            const VideoFeedState(
+            const VideoFeedBlocState(
               status: VideoFeedStatus.success,
               mode: FeedMode.latest,
             ),
@@ -336,9 +336,9 @@ void main() {
       whenListen(
         mockBloc,
         Stream.fromIterable([
-          const VideoFeedState(status: VideoFeedStatus.success),
+          const VideoFeedBlocState(status: VideoFeedStatus.success),
         ]),
-        initialState: const VideoFeedState(
+        initialState: const VideoFeedBlocState(
           status: VideoFeedStatus.success,
           mode: FeedMode.latest,
         ),

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -32,7 +32,7 @@ import 'package:pooled_video_player/pooled_video_player.dart';
 import '../../helpers/test_provider_overrides.dart';
 import '../../test_data/video_test_data.dart';
 
-class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedState>
+class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedBlocState>
     implements VideoFeedBloc {}
 
 class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
@@ -69,7 +69,7 @@ _MockPlayer _stubPlayer(
   return player;
 }
 
-Widget _buildEmptyFeedSubject(VideoFeedState state) {
+Widget _buildEmptyFeedSubject(VideoFeedBlocState state) {
   return MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
@@ -94,7 +94,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         _buildEmptyFeedSubject(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             error: VideoFeedError.noFollowedUsers,
           ),
@@ -117,7 +117,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         _buildEmptyFeedSubject(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.following,
             error: VideoFeedError.noFollowedUsers,
@@ -139,7 +139,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         _buildEmptyFeedSubject(
-          const VideoFeedState(status: VideoFeedStatus.success),
+          const VideoFeedBlocState(status: VideoFeedStatus.success),
         ),
       );
 
@@ -159,7 +159,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         _buildEmptyFeedSubject(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.following,
           ),
@@ -181,7 +181,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         _buildEmptyFeedSubject(
-          const VideoFeedState(
+          const VideoFeedBlocState(
             status: VideoFeedStatus.success,
             mode: FeedMode.latest,
           ),
@@ -223,12 +223,12 @@ void main() {
     });
 
     Widget buildSubject({
-      VideoFeedState? state,
+      VideoFeedBlocState? state,
       List<dynamic>? additionalOverrides,
     }) {
       when(
         () => videoFeedBloc.state,
-      ).thenReturn(state ?? const VideoFeedState());
+      ).thenReturn(state ?? const VideoFeedBlocState());
 
       return testMaterialApp(
         additionalOverrides: [
@@ -374,10 +374,10 @@ void main() {
       // Start with loading state
       whenListen(
         videoFeedBloc,
-        Stream<VideoFeedState>.fromIterable([
-          const VideoFeedState(status: VideoFeedStatus.success),
+        Stream<VideoFeedBlocState>.fromIterable([
+          const VideoFeedBlocState(status: VideoFeedStatus.success),
         ]),
-        initialState: const VideoFeedState(),
+        initialState: const VideoFeedBlocState(),
       );
 
       await tester.pumpWidget(buildSubject());
@@ -436,7 +436,7 @@ void main() {
     });
 
     Widget buildSubject() {
-      when(() => videoFeedBloc.state).thenReturn(const VideoFeedState());
+      when(() => videoFeedBloc.state).thenReturn(const VideoFeedBlocState());
 
       return testMaterialApp(
         additionalOverrides: [
@@ -458,7 +458,7 @@ void main() {
     }
 
     Widget buildSubjectWithInitialLocation(String location) {
-      when(() => videoFeedBloc.state).thenReturn(const VideoFeedState());
+      when(() => videoFeedBloc.state).thenReturn(const VideoFeedBlocState());
 
       return testMaterialApp(
         additionalOverrides: [
@@ -503,7 +503,7 @@ void main() {
 
         container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
 
-        when(() => videoFeedBloc.state).thenReturn(const VideoFeedState());
+        when(() => videoFeedBloc.state).thenReturn(const VideoFeedBlocState());
 
         await tester.pumpWidget(
           UncontrolledProviderScope(
@@ -711,7 +711,7 @@ void main() {
       registerFallbackValue(const VideoFeedRefreshRequested());
     });
 
-    Widget buildSubject(VideoFeedState state) {
+    Widget buildSubject(VideoFeedBlocState state) {
       when(() => videoFeedBloc.state).thenReturn(state);
 
       return testMaterialApp(
@@ -749,7 +749,7 @@ void main() {
       'renders native pooled feed with a GlobalKey for programmatic control',
       (tester) async {
         final testVideo = createTestVideoEvent();
-        final state = VideoFeedState(
+        final state = VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: [testVideo],
         );
@@ -770,7 +770,7 @@ void main() {
     testWidgets('wraps the loaded feed in a RefreshIndicator that dispatches '
         'VideoFeedRefreshRequested on pull', (tester) async {
       final testVideo = createTestVideoEvent();
-      final state = VideoFeedState(
+      final state = VideoFeedBlocState(
         status: VideoFeedStatus.success,
         videos: [testVideo],
       );
@@ -800,7 +800,7 @@ void main() {
       'overscroll the RefreshIndicator listens for',
       (tester) async {
         final testVideo = createTestVideoEvent();
-        final state = VideoFeedState(
+        final state = VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: [testVideo],
         );
@@ -846,7 +846,10 @@ void main() {
       InfiniteVideoFeed.debugIsSupportedOverride = false;
     });
 
-    Widget buildSubject(VideoFeedState state, {bool nativeFeedEnabled = true}) {
+    Widget buildSubject(
+      VideoFeedBlocState state, {
+      bool nativeFeedEnabled = true,
+    }) {
       when(() => videoFeedBloc.state).thenReturn(state);
 
       return testMaterialApp(
@@ -874,7 +877,7 @@ void main() {
     testWidgets('renders FeedVideos + InfiniteVideoFeed when supported', (
       tester,
     ) async {
-      final state = VideoFeedState(
+      final state = VideoFeedBlocState(
         status: VideoFeedStatus.success,
         videos: [createTestVideoEvent()],
       );
@@ -891,7 +894,7 @@ void main() {
     testWidgets(
       'renders PooledVideoFeed when supported but flag is off',
       (tester) async {
-        final state = VideoFeedState(
+        final state = VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: [createTestVideoEvent()],
         );
@@ -989,7 +992,7 @@ void main() {
       ];
     }
 
-    Widget buildSubject(VideoFeedState state, {int currentIndex = 0}) {
+    Widget buildSubject(VideoFeedBlocState state, {int currentIndex = 0}) {
       when(() => videoFeedBloc.state).thenReturn(state);
       final pooledVideos = state.videos
           .map((video) => VideoItem(id: video.id, url: video.videoUrl!))
@@ -1027,7 +1030,7 @@ void main() {
 
       await tester.pumpWidget(
         buildSubject(
-          VideoFeedState(status: VideoFeedStatus.success, videos: videos),
+          VideoFeedBlocState(status: VideoFeedStatus.success, videos: videos),
         ),
       );
       await tester.pump();
@@ -1050,7 +1053,7 @@ void main() {
 
       await tester.pumpWidget(
         buildSubject(
-          VideoFeedState(status: VideoFeedStatus.success, videos: videos),
+          VideoFeedBlocState(status: VideoFeedStatus.success, videos: videos),
         ),
       );
       await tester.pump();
@@ -1078,7 +1081,7 @@ void main() {
 
       await tester.pumpWidget(
         buildSubject(
-          VideoFeedState(status: VideoFeedStatus.success, videos: videos),
+          VideoFeedBlocState(status: VideoFeedStatus.success, videos: videos),
         ),
       );
       await tester.pump();

--- a/mobile/test/screens/feed/video_feed_page_web_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_web_test.dart
@@ -16,7 +16,7 @@ import '../../helpers/test_provider_overrides.dart';
 import '../../helpers/web_video_player_test_doubles.dart';
 import '../../test_data/video_test_data.dart';
 
-class MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedState>
+class MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedBlocState>
     implements VideoFeedBloc {}
 
 void main() {
@@ -50,7 +50,7 @@ void main() {
             'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3',
         videoUrl: 'https://example.com/video1.mp4',
       );
-      final state = VideoFeedState(
+      final state = VideoFeedBlocState(
         status: VideoFeedStatus.success,
         videos: [video],
       );


### PR DESCRIPTION
## Summary

Closes #3597. Part of #4339 Wave 1 (parallel-safe quick wins).

Two classes named `VideoFeedState` lived in different paths and were easy to confuse:
- `lib/state/video_feed_state.dart` — Freezed sealed class, consumed by Riverpod providers
- `lib/blocs/video_feed/video_feed_state.dart` — Equatable class, consumed by `VideoFeedBloc`

Renamed the BLoC-internal class to `VideoFeedBlocState`. The Riverpod class keeps its name.

## Scope

Word-boundary rename across 8 files (2 BLoC, 2 lib screens, 4 tests). `PooledVideoFeedState`, `WebVideoFeedState`, and `VideoFeedStatus` are untouched (verified by post-rename grep).

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `flutter test test/blocs/video_feed test/screens/feed` — 222 passed, 7 pre-existing skips
- [x] `dart format` applied