### PR TITLE
refactor(providers): split Nostr Apps providers out of app_providers.dart

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -26,11 +26,9 @@ import 'package:http/http.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
-import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:nostr_client/nostr_client.dart'
     show NostrClient, RelayConnectionStatus, RelayState;
 import 'package:nostr_key_manager/nostr_key_manager.dart';
-import 'package:openvine/config/app_config.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -130,6 +128,7 @@ import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
+export 'nostr_apps_providers.dart';
 export 'preferences_providers.dart';
 
 part 'app_providers.g.dart';
@@ -152,24 +151,6 @@ BlockedVideoFilter _createBlockedAuthorFilter(Ref ref) {
 
   return createBlocklistFilter(blocklistRepository);
 }
-
-final nostrAppDirectoryServiceProvider = Provider<NostrAppDirectoryService>((
-  ref,
-) {
-  final prefs = ref.watch(sharedPreferencesProvider);
-  final client = Client();
-  ref.onDispose(client.close);
-  return NostrAppDirectoryService(
-    sharedPreferences: prefs,
-    client: client,
-    baseUrl: AppConfig.appsDirectoryBaseUrl,
-  );
-});
-
-final nostrAppGrantStoreProvider = Provider<NostrAppGrantStore>((ref) {
-  final prefs = ref.watch(sharedPreferencesProvider);
-  return NostrAppGrantStore(sharedPreferences: prefs);
-});
 
 final firebaseMessagingProvider = Provider<FirebaseMessaging>(
   (ref) => FirebaseMessaging.instance,
@@ -410,47 +391,6 @@ final notificationPreferencesStoreProvider =
         openBox: HiveNotificationPreferencesStore.openBox,
       );
     });
-
-final nostrAppBridgePolicyProvider = Provider<NostrAppBridgePolicy>((ref) {
-  final authService = ref.watch(authServiceProvider);
-  final grantStore = ref.watch(nostrAppGrantStoreProvider);
-  return NostrAppBridgePolicy(
-    grantStore: grantStore,
-    currentUserPubkey: authService.currentPublicKeyHex,
-  );
-});
-
-final nostrAppAuditServiceProvider = Provider<NostrAppAuditService>((ref) {
-  final nip98AuthService = ref.watch(nip98AuthServiceProvider);
-  final client = Client();
-  ref.onDispose(client.close);
-  return NostrAppAuditService(
-    workerBaseUri: Uri.parse(AppConfig.appsDirectoryBaseUrl),
-    authTokenProvider:
-        ({required url, required method, required payload}) async {
-          final token = await nip98AuthService.createAuthToken(
-            url: url,
-            method: HttpMethod.post,
-            payload: payload,
-          );
-          if (token == null) return null;
-          return AuditAuthToken(authorizationHeader: token.authorizationHeader);
-        },
-    httpClient: client,
-  );
-});
-
-final nostrAppBridgeServiceProvider = Provider<NostrAppBridgeService>((ref) {
-  final authService = ref.watch(authServiceProvider);
-  final policy = ref.watch(nostrAppBridgePolicyProvider);
-  final auditService = ref.watch(nostrAppAuditServiceProvider);
-  return NostrAppBridgeService(
-    authProvider: _AuthServiceBridgeAdapter(authService),
-    policy: policy,
-    signerFactory: () => authService.requireIdentity,
-    auditService: auditService,
-  );
-});
 
 final badgeRepositoryProvider = Provider<BadgeRepository>((ref) {
   final authService = ref.watch(authServiceProvider);
@@ -2791,39 +2731,6 @@ RepostsRepository repostsRepository(Ref ref) {
   ref.onDispose(repository.dispose);
 
   return repository;
-}
-
-/// Adapts the app-level [AuthService] to the package-level
-/// [BridgeAuthProvider] interface.
-class _AuthServiceBridgeAdapter implements BridgeAuthProvider {
-  const _AuthServiceBridgeAdapter(this._authService);
-
-  final AuthService _authService;
-
-  @override
-  String? get currentPublicKeyHex => _authService.currentPublicKeyHex;
-
-  @override
-  List<BridgeRelay> get userRelays => _authService.userRelays
-      .map((r) => BridgeRelay(url: r.url, read: r.read, write: r.write))
-      .toList();
-
-  @override
-  Future<BridgeSignedEvent?> createAndSignEvent({
-    required int kind,
-    required String content,
-    required List<List<String>> tags,
-    int? createdAt,
-  }) async {
-    final event = await _authService.createAndSignEvent(
-      kind: kind,
-      content: content,
-      tags: tags,
-      createdAt: createdAt,
-    );
-    if (event == null) return null;
-    return BridgeSignedEvent(json: event.toJson());
-  }
 }
 
 /// Adapts the app-level [AuthService] to the package-level

--- a/mobile/lib/providers/nostr_apps_providers.dart
+++ b/mobile/lib/providers/nostr_apps_providers.dart
@@ -1,0 +1,103 @@
+// ABOUTME: Nostr Apps Riverpod providers split from app_providers.dart
+// ABOUTME: Owns the apps-directory client, grant store, audit, bridge policy/service
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart';
+import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
+import 'package:openvine/config/app_config.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:openvine/services/nip98_auth_service.dart';
+
+final nostrAppDirectoryServiceProvider = Provider<NostrAppDirectoryService>((
+  ref,
+) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  final client = Client();
+  ref.onDispose(client.close);
+  return NostrAppDirectoryService(
+    sharedPreferences: prefs,
+    client: client,
+    baseUrl: AppConfig.appsDirectoryBaseUrl,
+  );
+});
+
+final nostrAppGrantStoreProvider = Provider<NostrAppGrantStore>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return NostrAppGrantStore(sharedPreferences: prefs);
+});
+
+final nostrAppBridgePolicyProvider = Provider<NostrAppBridgePolicy>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  final grantStore = ref.watch(nostrAppGrantStoreProvider);
+  return NostrAppBridgePolicy(
+    grantStore: grantStore,
+    currentUserPubkey: authService.currentPublicKeyHex,
+  );
+});
+
+final nostrAppAuditServiceProvider = Provider<NostrAppAuditService>((ref) {
+  final nip98AuthService = ref.watch(nip98AuthServiceProvider);
+  final client = Client();
+  ref.onDispose(client.close);
+  return NostrAppAuditService(
+    workerBaseUri: Uri.parse(AppConfig.appsDirectoryBaseUrl),
+    authTokenProvider:
+        ({required url, required method, required payload}) async {
+          final token = await nip98AuthService.createAuthToken(
+            url: url,
+            method: HttpMethod.post,
+            payload: payload,
+          );
+          if (token == null) return null;
+          return AuditAuthToken(authorizationHeader: token.authorizationHeader);
+        },
+    httpClient: client,
+  );
+});
+
+final nostrAppBridgeServiceProvider = Provider<NostrAppBridgeService>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  final policy = ref.watch(nostrAppBridgePolicyProvider);
+  final auditService = ref.watch(nostrAppAuditServiceProvider);
+  return NostrAppBridgeService(
+    authProvider: _AuthServiceBridgeAdapter(authService),
+    policy: policy,
+    signerFactory: () => authService.requireIdentity,
+    auditService: auditService,
+  );
+});
+
+/// Adapts the app-level [AuthService] to the package-level
+/// [BridgeAuthProvider] interface.
+class _AuthServiceBridgeAdapter implements BridgeAuthProvider {
+  const _AuthServiceBridgeAdapter(this._authService);
+
+  final AuthService _authService;
+
+  @override
+  String? get currentPublicKeyHex => _authService.currentPublicKeyHex;
+
+  @override
+  List<BridgeRelay> get userRelays => _authService.userRelays
+      .map((r) => BridgeRelay(url: r.url, read: r.read, write: r.write))
+      .toList();
+
+  @override
+  Future<BridgeSignedEvent?> createAndSignEvent({
+    required int kind,
+    required String content,
+    required List<List<String>> tags,
+    int? createdAt,
+  }) async {
+    final event = await _authService.createAndSignEvent(
+      kind: kind,
+      content: content,
+      tags: tags,
+      createdAt: createdAt,
+    );
+    if (event == null) return null;
+    return BridgeSignedEvent(json: event.toJson());
+  }
+}


### PR DESCRIPTION
## Summary

Second batch of #4506 (app_providers.dart decomposition). Refs #4339 Wave 2.

Moves the Nostr Apps cluster — five providers and their private `_AuthServiceBridgeAdapter` — out of `app_providers.dart` into a new `lib/providers/nostr_apps_providers.dart`:

- `nostrAppDirectoryServiceProvider`
- `nostrAppGrantStoreProvider`
- `nostrAppBridgePolicyProvider`
- `nostrAppAuditServiceProvider`
- `nostrAppBridgeServiceProvider`
- `_AuthServiceBridgeAdapter` (private to the new file; only the bridge service provider uses it)

## Migration pattern

`app_providers.dart` re-exports the new file:

\`\`\`dart
export 'nostr_apps_providers.dart';
\`\`\`

Unlike batch 1, the matching `import` is on the **other** side — `nostr_apps_providers.dart` imports `app_providers.dart` to reach `authServiceProvider` and `nip98AuthServiceProvider`, which still live there (until batches 7 and 5 respectively). `app_providers.dart` needs no import of the new file back, because no remaining provider in it consumes the Nostr Apps cluster. The seven existing consumer sites (`apps_directory_screen.dart`, `app_detail_screen.dart`, `nostr_app_sandbox_screen.dart`, `resolved_sandbox_route_screen.dart`, and three matching test files) keep their existing `import 'package:openvine/providers/app_providers.dart'` unchanged.

## Scope

- Removed now-unused imports from `app_providers.dart`: `package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart` and `package:openvine/config/app_config.dart`.
- No `@Riverpod` annotations in this batch — codegen output unchanged (only `Provider<X>(...)` style declarations).
- Net `app_providers.dart` shrinkage: ~96 LoC (2,918 → ~2,825 after both batches land).

## Test plan

- [x] `dart run build_runner build --delete-conflicting-outputs` — no `.g.dart` drift
- [x] `flutter analyze lib test integration_test` — clean
- [x] `flutter test test/screens/apps test/router/apps_sandbox_route_test.dart` — 44 passed
- [x] `dart format` applied

## Next batches

3. Permissions/Geo/Gallery · 4. Notifications · 5. Relay & Connection · 6. Content Moderation · 7. Auth & Identity · 8. Video & Feed · 9. Upload/Media + remainder