### PR TITLE
fix(linux): ensure linux apps can startup

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -180,6 +180,17 @@ Future<void> configureVideoPlayerCacheForStartup({
   await configureCache();
 }
 
+@visibleForTesting
+Future<void> disposeVideoPlayersForStartup({
+  required bool skip,
+  required Future<void> Function() disposeAll,
+}) async {
+  if (skip) {
+    return;
+  }
+  await disposeAll();
+}
+
 Future<void> _runTimedStartupTask({
   required String phaseName,
   required String initializationStep,
@@ -609,10 +620,10 @@ Future<void> _startOpenVineApp() async {
   // Dispose any zombie native players from a previous Dart VM
   // (e.g. hot restart). Must happen after configureCache so the
   // global method channel is already registered.
-  // No-op on Linux/web — handled internally by the package.
-  if (!kIsWeb) {
-    await DivineVideoPlayerController.disposeAll();
-  }
+  await disposeVideoPlayersForStartup(
+    skip: !hasNativeVideoPlayer,
+    disposeAll: DivineVideoPlayerController.disposeAll,
+  );
 
   StartupPerformanceService.instance.completePhase('bindings');
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -90,6 +90,7 @@ import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
+import 'package:openvine/utils/platform_support.dart';
 import 'package:openvine/utils/recoverable_flutter_error.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:openvine/widgets/app_lifecycle_handler.dart';
@@ -170,10 +171,10 @@ bool handleKnownFrameworkError(
 
 @visibleForTesting
 Future<void> configureVideoPlayerCacheForStartup({
-  required bool isWeb,
+  required bool skip,
   required Future<void> Function() configureCache,
 }) async {
-  if (isWeb) {
+  if (skip) {
     return;
   }
   await configureCache();
@@ -498,60 +499,64 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
     optional: true,
   );
 
-  coordinator.registerService(
-    name: 'PushNotifications',
-    phase: StartupPhase.deferred,
-    initialize: () async {
-      FirebaseMessaging.onBackgroundMessage(
-        _firebaseMessagingBackgroundHandler,
-      );
+  // firebase_messaging only supports Android, iOS, and macOS.
+  // firebase_options.dart throws UnsupportedError for Linux/Windows.
+  if (isFirebaseSupported && !kIsWeb) {
+    coordinator.registerService(
+      name: 'PushNotifications',
+      phase: StartupPhase.deferred,
+      initialize: () async {
+        FirebaseMessaging.onBackgroundMessage(
+          _firebaseMessagingBackgroundHandler,
+        );
 
-      // Check if app was launched from a push notification tap (cold start)
-      final initialMessage = await FirebaseMessaging.instance
-          .getInitialMessage();
-      if (initialMessage != null) {
-        final parsed = _parseFcmPayload(initialMessage.data);
-        if (parsed != null) {
-          Log.info(
-            'App launched from push notification, '
-            'target: ${parsed.referencedEventId} '
-            '(type: ${parsed.notificationType})',
-            name: 'main',
-            category: LogCategory.system,
-          );
-          unawaited(
-            _resolveAndPushNotificationDeepLink(
-              referencedEventId: parsed.referencedEventId,
-              notificationType: parsed.notificationType,
-              container: container,
-            ),
-          );
+        // Check if app was launched from a push notification tap (cold start)
+        final initialMessage = await FirebaseMessaging.instance
+            .getInitialMessage();
+        if (initialMessage != null) {
+          final parsed = _parseFcmPayload(initialMessage.data);
+          if (parsed != null) {
+            Log.info(
+              'App launched from push notification, '
+              'target: ${parsed.referencedEventId} '
+              '(type: ${parsed.notificationType})',
+              name: 'main',
+              category: LogCategory.system,
+            );
+            unawaited(
+              _resolveAndPushNotificationDeepLink(
+                referencedEventId: parsed.referencedEventId,
+                notificationType: parsed.notificationType,
+                container: container,
+              ),
+            );
+          }
         }
-      }
 
-      // Handle taps on notifications while app is in background
-      FirebaseMessaging.onMessageOpenedApp.listen((message) {
-        final parsed = _parseFcmPayload(message.data);
-        if (parsed != null) {
-          Log.info(
-            'Push notification tapped (background), '
-            'target: ${parsed.referencedEventId} '
-            '(type: ${parsed.notificationType})',
-            name: 'main',
-            category: LogCategory.system,
-          );
-          unawaited(
-            _resolveAndPushNotificationDeepLink(
-              referencedEventId: parsed.referencedEventId,
-              notificationType: parsed.notificationType,
-              container: container,
-            ),
-          );
-        }
-      });
-    },
-    optional: true,
-  );
+        // Handle taps on notifications while app is in background
+        FirebaseMessaging.onMessageOpenedApp.listen((message) {
+          final parsed = _parseFcmPayload(message.data);
+          if (parsed != null) {
+            Log.info(
+              'Push notification tapped (background), '
+              'target: ${parsed.referencedEventId} '
+              '(type: ${parsed.notificationType})',
+              name: 'main',
+              category: LogCategory.system,
+            );
+            unawaited(
+              _resolveAndPushNotificationDeepLink(
+                referencedEventId: parsed.referencedEventId,
+                notificationType: parsed.notificationType,
+                container: container,
+              ),
+            );
+          }
+        });
+      },
+      optional: true,
+    );
+  }
 
   return coordinator;
 }
@@ -594,20 +599,17 @@ Future<void> _startOpenVineApp() async {
   // in web/index.html (already added).
 
   // Configure the native video player disk cache (500 MB, LRU eviction).
-  // divine_video_player only ships android/ios/macos plugin platforms, so
-  // invoking configureCache() on web throws MissingPluginException. That
-  // exception gets swallowed by the runZonedGuarded + CrashReportingService
-  // chain below (Firebase Crashlytics has no web impl), and runApp() is
-  // never reached — the HTML loading spinner stays up forever with no JS
-  // errors. Skip the call on web to unblock startup.
+  // Skip on web/Linux/Windows — divine_video_player has no native plugin
+  // on those targets and `configureCache` is a bare method-channel call.
   await configureVideoPlayerCacheForStartup(
-    isWeb: kIsWeb,
+    skip: !hasNativeVideoPlayer,
     configureCache: DivineVideoPlayerController.configureCache,
   );
 
   // Dispose any zombie native players from a previous Dart VM
   // (e.g. hot restart). Must happen after configureCache so the
   // global method channel is already registered.
+  // No-op on Linux/web — handled internally by the package.
   if (!kIsWeb) {
     await DivineVideoPlayerController.disposeAll();
   }

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -16,6 +16,7 @@ import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/services/notification_service_enhanced.dart';
 import 'package:openvine/services/push_notification_service.dart';
 import 'package:openvine/services/push_notification_session_coordinator.dart';
+import 'package:openvine/utils/platform_support.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -45,6 +46,11 @@ final notificationPreferencesStoreProvider =
 final pushNotificationServiceProvider = Provider<PushNotificationService?>((
   ref,
 ) {
+  // Firebase Messaging only supports Android, iOS, macOS, and web.
+  if (!isFirebaseSupported) {
+    return null;
+  }
+
   final readiness = ref.watch(nostrSessionProvider);
   if (!readiness.isReadyForActiveClient || readiness.client == null) {
     return null;
@@ -226,6 +232,11 @@ final notificationPreferencesServiceProvider =
 /// outgoing-session cleanup runs before signers and callbacks are cleared.
 @Riverpod(keepAlive: true)
 void pushNotificationSync(Ref ref) {
+  // Firebase Messaging only supports Android, iOS, macOS, and web.
+  if (!isFirebaseSupported) {
+    return;
+  }
+
   final authService = ref.watch(authServiceProvider);
   ref.watch(notificationPreferencesDirtySyncBridgeProvider);
 

--- a/mobile/lib/providers/notifications_providers.g.dart
+++ b/mobile/lib/providers/notifications_providers.g.dart
@@ -65,7 +65,7 @@ final class PushNotificationSyncProvider
 }
 
 String _$pushNotificationSyncHash() =>
-    r'6febd49e08c766ed1885edc6d4e7a49182497a30';
+    r'bd7c6af23335a355541b7086d8afedf15743369b';
 
 /// Enhanced notification service with Nostr integration (lazy loaded)
 

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -7,6 +7,7 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:openvine/firebase_options.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
+import 'package:openvine/utils/platform_support.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Crash reporting service for production error tracking
@@ -22,6 +23,13 @@ class CrashReportingService {
   /// Initialize crash reporting (Firebase Crashlytics)
   Future<void> initialize() async {
     if (_initialized) return;
+
+    // Firebase only supports Android, iOS, macOS, and web.
+    // DefaultFirebaseOptions.currentPlatform throws UnsupportedError for
+    // Linux and Windows — skip initialization on those platforms.
+    if (!isFirebaseSupported) {
+      return;
+    }
 
     try {
       // Initialize Firebase with platform-specific options

--- a/mobile/lib/utils/platform_support.dart
+++ b/mobile/lib/utils/platform_support.dart
@@ -20,10 +20,8 @@ bool get isFirebaseSupported =>
 /// Whether the `divine_video_player` plugin has a native implementation on
 /// the current platform.
 ///
-/// The plugin only ships native code for Android, iOS, and macOS. On web,
-/// Linux, and Windows the underlying method channel throws
-/// `MissingPluginException` for `configureCache`, `disposeAll`, etc., so
-/// callers must skip the call entirely.
+/// The plugin only ships native code for Android, iOS, and macOS, so callers
+/// must skip native-only startup work on web, Linux, and Windows.
 bool get hasNativeVideoPlayer =>
     !kIsWeb &&
     defaultTargetPlatform != TargetPlatform.linux &&

--- a/mobile/lib/utils/platform_support.dart
+++ b/mobile/lib/utils/platform_support.dart
@@ -1,0 +1,30 @@
+// ABOUTME: Web-safe platform support checks that avoid `dart:io`.
+// ABOUTME: Use these helpers from code that is compiled for web as well.
+
+import 'package:flutter/foundation.dart';
+
+/// Whether Firebase (and Firebase-dependent services like Crashlytics and
+/// Firebase Messaging) is supported on the current platform.
+///
+/// Firebase supports Android, iOS, macOS, and web. It does NOT support
+/// Linux or Windows — `DefaultFirebaseOptions.currentPlatform` throws
+/// `UnsupportedError` on those platforms.
+///
+/// Uses [defaultTargetPlatform] instead of `dart:io`'s `Platform` so the
+/// check is safe on web builds.
+bool get isFirebaseSupported =>
+    kIsWeb ||
+    (defaultTargetPlatform != TargetPlatform.linux &&
+        defaultTargetPlatform != TargetPlatform.windows);
+
+/// Whether the `divine_video_player` plugin has a native implementation on
+/// the current platform.
+///
+/// The plugin only ships native code for Android, iOS, and macOS. On web,
+/// Linux, and Windows the underlying method channel throws
+/// `MissingPluginException` for `configureCache`, `disposeAll`, etc., so
+/// callers must skip the call entirely.
+bool get hasNativeVideoPlayer =>
+    !kIsWeb &&
+    defaultTargetPlatform != TargetPlatform.linux &&
+    defaultTargetPlatform != TargetPlatform.windows;

--- a/mobile/overrides/cryptography_flutter-2.3.2/linux/CMakeLists.txt
+++ b/mobile/overrides/cryptography_flutter-2.3.2/linux/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10)
+set(PROJECT_NAME "cryptography_flutter")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+set(PLUGIN_NAME "cryptography_flutter_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "cryptography_flutter_plugin.cc"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+set(cryptography_flutter_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/mobile/overrides/cryptography_flutter-2.3.2/linux/cryptography_flutter_plugin.cc
+++ b/mobile/overrides/cryptography_flutter-2.3.2/linux/cryptography_flutter_plugin.cc
@@ -1,0 +1,65 @@
+#include "include/cryptography_flutter/cryptography_flutter_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+
+// Stub Linux implementation of the cryptography_flutter plugin.
+//
+// The upstream package (2.3.2) only ships native code for Android, iOS, and
+// macOS. We register the method channel here and respond `NotImplemented`
+// to every call so the Dart side of `package:cryptography_flutter` falls
+// back to its pure-Dart implementation via `package:cryptography`.
+//
+// Without this stub the engine logs "No implementation found for method ..."
+// noise on Linux desktop startup. Replace with a real backend once the
+// upstream package adds Linux support.
+
+#define CRYPTOGRAPHY_FLUTTER_PLUGIN(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), cryptography_flutter_plugin_get_type(), \
+                              CryptographyFlutterPlugin))
+
+struct _CryptographyFlutterPlugin {
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE(CryptographyFlutterPlugin, cryptography_flutter_plugin, g_object_get_type())
+
+static void cryptography_flutter_plugin_handle_method_call(
+    CryptographyFlutterPlugin* self,
+    FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+  response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  CryptographyFlutterPlugin* plugin = CRYPTOGRAPHY_FLUTTER_PLUGIN(user_data);
+  cryptography_flutter_plugin_handle_method_call(plugin, method_call);
+}
+
+void cryptography_flutter_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  CryptographyFlutterPlugin* plugin = CRYPTOGRAPHY_FLUTTER_PLUGIN(
+      g_object_new(cryptography_flutter_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            "cryptography_flutter",
+                            FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(channel, method_call_cb,
+                                            g_object_ref(plugin),
+                                            g_object_unref);
+
+  g_object_unref(plugin);
+}
+
+static void cryptography_flutter_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(cryptography_flutter_plugin_parent_class)->dispose(object);
+}
+
+static void cryptography_flutter_plugin_class_init(CryptographyFlutterPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = cryptography_flutter_plugin_dispose;
+}
+
+static void cryptography_flutter_plugin_init(CryptographyFlutterPlugin* self) {}

--- a/mobile/overrides/cryptography_flutter-2.3.2/linux/include/cryptography_flutter/cryptography_flutter_plugin.h
+++ b/mobile/overrides/cryptography_flutter-2.3.2/linux/include/cryptography_flutter/cryptography_flutter_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_CRYPTOGRAPHY_FLUTTER_PLUGIN_H_
+#define FLUTTER_PLUGIN_CRYPTOGRAPHY_FLUTTER_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _CryptographyFlutterPlugin CryptographyFlutterPlugin;
+typedef struct {
+  GObjectClass parent_class;
+} CryptographyFlutterPluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType cryptography_flutter_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void cryptography_flutter_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_CRYPTOGRAPHY_FLUTTER_PLUGIN_H_

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1872,10 +1872,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "9d914ec472119bc1a71b750d52ed3ce79169a27211f41fd7d6397693ecd4c466"
+      sha256: e16c1e67a2f9e7f91723764642f0dfb188a6ab4de1d3f98f2ec1ac699dd9ee9d
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.2"
+    version: "1.16.3"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -283,7 +283,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.16.2
+  pro_video_editor: ^1.16.3
   pro_image_editor: ^12.4.4
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/main_video_cache_startup_test.dart
+++ b/mobile/test/main_video_cache_startup_test.dart
@@ -3,11 +3,11 @@ import 'package:openvine/main.dart' as app;
 
 void main() {
   group('configureVideoPlayerCacheForStartup', () {
-    test('skips cache configuration on web', () async {
+    test('skips cache configuration when skip is true', () async {
       var invoked = false;
 
       await app.configureVideoPlayerCacheForStartup(
-        isWeb: true,
+        skip: true,
         configureCache: () async {
           invoked = true;
         },
@@ -16,11 +16,11 @@ void main() {
       expect(invoked, isFalse);
     });
 
-    test('configures cache on native platforms', () async {
+    test('configures cache when skip is false', () async {
       var invoked = false;
 
       await app.configureVideoPlayerCacheForStartup(
-        isWeb: false,
+        skip: false,
         configureCache: () async {
           invoked = true;
         },

--- a/mobile/test/main_video_cache_startup_test.dart
+++ b/mobile/test/main_video_cache_startup_test.dart
@@ -29,4 +29,32 @@ void main() {
       expect(invoked, isTrue);
     });
   });
+
+  group('disposeVideoPlayersForStartup', () {
+    test('skips disposal when skip is true', () async {
+      var invoked = false;
+
+      await app.disposeVideoPlayersForStartup(
+        skip: true,
+        disposeAll: () async {
+          invoked = true;
+        },
+      );
+
+      expect(invoked, isFalse);
+    });
+
+    test('disposes players when skip is false', () async {
+      var invoked = false;
+
+      await app.disposeVideoPlayersForStartup(
+        skip: false,
+        disposeAll: () async {
+          invoked = true;
+        },
+      );
+
+      expect(invoked, isTrue);
+    });
+  });
 }

--- a/mobile/test/utils/platform_support_test.dart
+++ b/mobile/test/utils/platform_support_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/platform_support.dart';
+
+void main() {
+  group('isFirebaseSupported', () {
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('is true on Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(isFirebaseSupported, isTrue);
+    });
+
+    test('is true on iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(isFirebaseSupported, isTrue);
+    });
+
+    test('is true on macOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      expect(isFirebaseSupported, isTrue);
+    });
+
+    test('is false on Linux', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      expect(isFirebaseSupported, isFalse);
+    });
+
+    test('is false on Windows', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      expect(isFirebaseSupported, isFalse);
+    });
+  });
+
+  group('hasNativeVideoPlayer', () {
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('is true on Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(hasNativeVideoPlayer, isTrue);
+    });
+
+    test('is true on iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(hasNativeVideoPlayer, isTrue);
+    });
+
+    test('is true on macOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      expect(hasNativeVideoPlayer, isTrue);
+    });
+
+    test('is false on Linux', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      expect(hasNativeVideoPlayer, isFalse);
+    });
+
+    test('is false on Windows', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      expect(hasNativeVideoPlayer, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #4529

## Description

The current Linux build no longer works, even though it has officially been supported since #1766 for [Flathub](https://flathub.org/en/about) users. This PR ensures that everything works correctly again for Linux builds.

Note the pro_video_editor was update to also support the linux build and `DivineVideoPlayerController.disposeAll` Linux guard is intentionally deferred — covered by #4487.


**Related Issue:** 

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore