### PR TITLE
fix(profile): add special checkmark pubkey

### DIFF
--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -10,9 +10,14 @@ const _specialProfileHosts = {
   'rabble.divine.video',
 };
 
+const _specialProfilePubkeys = {
+  'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
+};
+
 bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
   if (profile == null) return false;
-  return _matchesSpecialProfile(profile.nip05) ||
+  return _specialProfilePubkeys.contains(profile.pubkey.toLowerCase()) ||
+      _matchesSpecialProfile(profile.nip05) ||
       _matchesSpecialProfile(profile.displayNip05);
 }
 

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -10,10 +10,13 @@ import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/widgets/user_name.dart';
 
 void main() {
-  const pubkey =
+  const defaultPubkey =
       'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
-  Widget buildSubject({String nip05 = 'alice@example.com'}) {
+  Widget buildSubject({
+    String pubkey = defaultPubkey,
+    String nip05 = 'alice@example.com',
+  }) {
     return ProviderScope(
       overrides: [
         nip05VerificationProvider.overrideWith(
@@ -71,6 +74,19 @@ void main() {
 
   testWidgets('shows a checkmark for Rabble special profile', (tester) async {
     await tester.pumpWidget(buildSubject(nip05: '_@rabble.divine.video'));
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
+  testWidgets('shows a checkmark for special profile pubkey', (tester) async {
+    await tester.pumpWidget(
+      buildSubject(
+        pubkey:
+            'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
+      ),
+    );
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);


### PR DESCRIPTION
Closes #4538

## Summary
- add the supplied npub's decoded pubkey to the special profile checkmark allowlist
- keep the existing Rabble/Kirsten NIP-05 host exceptions intact
- add widget coverage that the special pubkey renders the checkmark

Decoded npub:
`aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4`

## Verification
- `flutter test test/widgets/user_name_nip05_test.dart`
- `flutter analyze lib/widgets/special_profile_checkmark.dart test/widgets/user_name_nip05_test.dart`
- pre-push hook: analyzer + `test/widgets/user_name_nip05_test.dart`