### PR TITLE
fix(infinite-feed): correct new video feed design with blurred backdrop

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -3,7 +3,6 @@
 // ABOUTME: Uses FullscreenFeedBloc for state management
 
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
@@ -41,6 +40,7 @@ import 'package:openvine/utils/scroll_driven_opacity.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
 import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
+import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
@@ -879,28 +879,37 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                                           .nativeFeedPlayer,
                                         ),
                                       )
-                                  ? FeedVideos(
-                                      key: _feedVideosKey,
-                                      videos: state.videos,
-                                      contextTitle: widget.contextTitle,
-                                      currentIndex: state.currentIndex,
-                                      shouldPortraitExpand: false,
-                                      hasMore: state.canLoadMore,
-                                      isLoadingMore: state.isLoadingMore,
-                                      onActiveVideoChanged: (video, index) {
-                                        _resumeAutoAdvanceAfterSwipe();
-                                        FeedPerformanceTracker()
-                                            .startVideoSwipeTracking(video.id);
-                                        context.read<FullscreenFeedBloc>().add(
-                                          FullscreenFeedIndexChanged(index),
-                                        );
-                                        widget.onPageChanged?.call(index);
-                                      },
-                                      onNearEnd: () {
-                                        if (state.canLoadMore) {
-                                          _triggerLoadMore();
-                                        }
-                                      },
+                                  ? MediaQuery.removePadding(
+                                      context: context,
+                                      removeBottom: true,
+                                      child: FeedVideos(
+                                        key: _feedVideosKey,
+                                        videos: state.videos,
+                                        contextTitle: widget.contextTitle,
+                                        currentIndex: state.currentIndex,
+                                        hasMore: state.canLoadMore,
+                                        isLoadingMore: state.isLoadingMore,
+                                        onActiveVideoChanged: (video, index) {
+                                          _resumeAutoAdvanceAfterSwipe();
+                                          FeedPerformanceTracker()
+                                              .startVideoSwipeTracking(
+                                                video.id,
+                                              );
+                                          context
+                                              .read<FullscreenFeedBloc>()
+                                              .add(
+                                                FullscreenFeedIndexChanged(
+                                                  index,
+                                                ),
+                                              );
+                                          widget.onPageChanged?.call(index);
+                                        },
+                                        onNearEnd: () {
+                                          if (state.canLoadMore) {
+                                            _triggerLoadMore();
+                                          }
+                                        },
+                                      ),
                                     )
                                   : kIsWeb
                                   ? WebVideoFeed(
@@ -1406,7 +1415,7 @@ class _PooledFullscreenItemContentState
             // cover the screen entirely and would never reveal the
             // backdrop, so we skip it for them.
             if (showBlurBackdrop)
-              Positioned.fill(child: _BlurredVideoBackdrop(url: thumbnailUrl)),
+              Positioned.fill(child: BlurredVideoBackdrop(url: thumbnailUrl)),
             PooledVideoPlayer(
               index: widget.index,
               isActive: widget.isActive,
@@ -1602,47 +1611,6 @@ class _PooledFullscreenItemContentState
               },
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Heavily-blurred copy of a video's poster thumbnail, stretched to
-/// `BoxFit.cover` the entire fullscreen area. Painted behind the video
-/// in `_PooledFullscreenItemContent` so contain-fit videos (1 × 1 /
-/// landscape) sit on a diffused colour cloud derived from their own
-/// first frame instead of a flat dark surface — matches the
-/// Instagram / TikTok "blurred poster" look.
-///
-/// Cost: one image decode + one GPU blur pass via [ImageFiltered].
-/// The decoded image lives in Flutter's image cache, so revisiting
-/// the same video re-uses it. No ongoing per-frame cost once the
-/// image is rasterised.
-class _BlurredVideoBackdrop extends StatelessWidget {
-  const _BlurredVideoBackdrop({required this.url});
-
-  final String url;
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRect(
-      // `ImageFiltered` applies the blur on the GPU side; `ClipRect`
-      // keeps the bleeding edge of the blur kernel from leaking
-      // outside the widget's box and over the surrounding chrome.
-      child: ImageFiltered(
-        imageFilter: ui.ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-        child: Image.network(
-          url,
-          fit: BoxFit.cover,
-          // 50 % opacity via [Image.opacity] (an animation) rather
-          // than an [Opacity] wrapper — the latter forces a full-
-          // screen save-layer, the former blends per-pixel during
-          // paint and is essentially free.
-          opacity: const AlwaysStoppedAnimation(0.5),
-          // Fall back to nothing on error — the parent
-          // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
-          errorBuilder: (_, _, _) => const SizedBox.shrink(),
         ),
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -1,4 +1,7 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/widgets.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Heavily-blurred copy of a video's poster thumbnail, stretched to
 /// `BoxFit.cover` the entire fullscreen area. Painted behind the video
@@ -8,9 +11,8 @@ import 'package:flutter/widgets.dart';
 /// Instagram / TikTok "blurred poster" look.
 ///
 /// Cost: one image decode + one GPU blur pass via [ImageFiltered].
-/// The decoded image lives in Flutter's image cache, so revisiting
-/// the same video re-uses it. No ongoing per-frame cost once the
-/// image is rasterised.
+/// [VineCachedImage] keeps poster fetches on the shared cache path, so
+/// revisiting the same video can reuse the cached thumbnail bytes.
 class BlurredVideoBackdrop extends StatelessWidget {
   /// Creates a blurred backdrop from the poster thumbnail at [url].
   ///
@@ -28,18 +30,15 @@ class BlurredVideoBackdrop extends StatelessWidget {
       // keeps the bleeding edge of the blur kernel from leaking
       // outside the widget's box and over the surrounding chrome.
       child: ImageFiltered(
-        imageFilter: .blur(sigmaX: 30, sigmaY: 30),
-        child: Image.network(
-          url,
-          fit: BoxFit.cover,
-          // 50 % opacity via [Image.opacity] (an animation) rather
-          // than an [Opacity] wrapper — the latter forces a full-
-          // screen save-layer, the former blends per-pixel during
-          // paint and is essentially free.
-          opacity: const AlwaysStoppedAnimation(0.5),
-          // Fall back to nothing on error — the parent
-          // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
-          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+        imageFilter: ui.ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+        child: Opacity(
+          opacity: 0.5,
+          child: VineCachedImage(
+            imageUrl: url,
+            // Fall back to nothing on error — the parent
+            // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
+            errorWidget: (_, _, _) => const SizedBox.shrink(),
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+/// Heavily-blurred copy of a video's poster thumbnail, stretched to
+/// `BoxFit.cover` the entire fullscreen area. Painted behind the video
+/// in `_PooledFullscreenItemContent` so contain-fit videos (1 × 1 /
+/// landscape) sit on a diffused colour cloud derived from their own
+/// first frame instead of a flat dark surface — matches the
+/// Instagram / TikTok "blurred poster" look.
+///
+/// Cost: one image decode + one GPU blur pass via [ImageFiltered].
+/// The decoded image lives in Flutter's image cache, so revisiting
+/// the same video re-uses it. No ongoing per-frame cost once the
+/// image is rasterised.
+class BlurredVideoBackdrop extends StatelessWidget {
+  /// Creates a blurred backdrop from the poster thumbnail at [url].
+  ///
+  /// [url] should be an HTTPS URL to a thumbnail/poster image.
+  /// If the image fails to load, the widget renders as empty
+  /// ([SizedBox.shrink]) and lets the parent background show through.
+  const BlurredVideoBackdrop({required this.url, super.key});
+
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      // `ImageFiltered` applies the blur on the GPU side; `ClipRect`
+      // keeps the bleeding edge of the blur kernel from leaking
+      // outside the widget's box and over the surrounding chrome.
+      child: ImageFiltered(
+        imageFilter: .blur(sigmaX: 30, sigmaY: 30),
+        child: Image.network(
+          url,
+          fit: BoxFit.cover,
+          // 50 % opacity via [Image.opacity] (an animation) rather
+          // than an [Opacity] wrapper — the latter forces a full-
+          // screen save-layer, the former blends per-pixel during
+          // paint and is essentially free.
+          opacity: const AlwaysStoppedAnimation(0.5),
+          // Fall back to nothing on error — the parent
+          // [ColoredBox(VineTheme.surfaceContainerHigh)] shows through.
+          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -25,6 +25,7 @@ import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
+import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
@@ -227,6 +228,26 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
         onVideoLoopCompleted: _handleAutoAdvanceCompleted,
         shouldPortraitExpand: widget.shouldPortraitExpand,
         maxLoopDuration: VideoEditorConstants.maxDuration,
+        videoBuilder: (context, child, index, controller) {
+          if (index < 0 || index >= widget.videos.length) {
+            return const SizedBox.shrink();
+          }
+          final video = widget.videos[index];
+
+          final thumbnailUrl = video.thumbnailUrl;
+          final showBlurBackdrop =
+              !video.isPortrait &&
+              thumbnailUrl != null &&
+              thumbnailUrl.isNotEmpty;
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              if (showBlurBackdrop)
+                Positioned.fill(child: BlurredVideoBackdrop(url: thumbnailUrl)),
+              child,
+            ],
+          );
+        },
         loadingBuilder: (context, index, {required bool isSquare}) {
           if (index < 0 || index >= widget.videos.length) {
             return const SizedBox.shrink();

--- a/mobile/packages/infinite_video_feed/lib/src/models/builders.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/models/builders.dart
@@ -27,6 +27,7 @@ typedef ErrorBuilder =
 typedef VideoBuilder =
     Widget Function(
       BuildContext context,
+      Widget child,
       int index,
       DivineVideoPlayerController? controller,
     );

--- a/mobile/packages/infinite_video_feed/lib/src/models/builders.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/models/builders.dart
@@ -22,8 +22,9 @@ typedef ErrorBuilder =
 
 /// Builder that wraps or replaces the default video player widget.
 ///
-/// Use this to inject metrics tracking, custom sizing, or other wrappers
-/// around the raw video surface.
+/// [child] is the default video item widget for the current feed item.
+/// Return it directly to keep the default player, or wrap/replace it to
+/// inject metrics tracking, custom sizing, or other feed-specific chrome.
 typedef VideoBuilder =
     Widget Function(
       BuildContext context,

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1112,6 +1112,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           controller,
           isActive: index == _currentIndex,
         );
+        final videoItem = VideoItemWidget(
+          controller: controller,
+          shouldPortraitExpand: widget.shouldPortraitExpand,
+        );
 
         final hasVideoSize =
             controller != null && controller.state.videoHeight != 0;
@@ -1132,18 +1136,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             if (!hasError && hasVideoSize)
               widget.videoBuilder?.call(
                     context,
-                    VideoItemWidget(
-                      controller: controller,
-                      shouldPortraitExpand: widget.shouldPortraitExpand,
-                    ),
+                    videoItem,
                     index,
                     controller,
                   ) ??
-                  VideoItemWidget(
-                    controller: controller,
-                    shouldPortraitExpand: widget.shouldPortraitExpand,
-                  ),
-
+                  videoItem,
             // Overlay layer — consumer-provided controls, progress, etc.
             ?overlay,
 

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -29,10 +29,10 @@ class InfiniteVideoFeed extends StatefulWidget {
   const InfiniteVideoFeed({
     required this.videos,
     required this.cache,
+    this.videoBuilder,
     this.urlResolver,
     this.loadingBuilder,
     this.errorBuilder,
-    this.videoBuilder,
     this.overlayBuilder,
     this.scrollPhysics,
     this.initialIndex = 0,
@@ -104,6 +104,8 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// When provided, called instead of the default [VideoItemWidget].
   /// Use this to inject metrics tracking, custom sizing, or other
   /// wrappers around the raw video surface.
+  ///
+  /// When `null`, the feed renders [VideoItemWidget] directly.
   final VideoBuilder? videoBuilder;
 
   /// Builder for the overlay layer rendered on top of the video.
@@ -1128,11 +1130,20 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
               ),
 
             if (!hasError && hasVideoSize)
-              widget.videoBuilder?.call(context, index, controller) ??
+              widget.videoBuilder?.call(
+                    context,
+                    VideoItemWidget(
+                      controller: controller,
+                      shouldPortraitExpand: widget.shouldPortraitExpand,
+                    ),
+                    index,
+                    controller,
+                  ) ??
                   VideoItemWidget(
                     controller: controller,
                     shouldPortraitExpand: widget.shouldPortraitExpand,
                   ),
+
             // Overlay layer — consumer-provided controls, progress, etc.
             ?overlay,
 

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -523,6 +523,87 @@ void main() {
         );
       });
 
+      testWidgets('passes default video item as child to videoBuilder', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        const globalChannel = MethodChannel('divine_video_player');
+        const playerChannel = MethodChannel('divine_video_player/player_0');
+        const eventChannelName = 'divine_video_player/player_0/events';
+        const methodCodec = StandardMethodCodec();
+        const wrapperKey = Key('video-builder-wrapper');
+
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          globalChannel,
+          (call) async {
+            if (call.method == 'create') return <Object?, Object?>{};
+            return null;
+          },
+        );
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          playerChannel,
+          (_) async => null,
+        );
+        tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+          eventChannelName,
+          (message) async {
+            final call = methodCodec.decodeMethodCall(message);
+            if (call.method == 'listen') {
+              scheduleMicrotask(() async {
+                await tester.binding.defaultBinaryMessenger
+                    .handlePlatformMessage(
+                      eventChannelName,
+                      methodCodec.encodeSuccessEnvelope(<Object?, Object?>{
+                        'status': 'ready',
+                        'videoWidth': 1280,
+                        'videoHeight': 720,
+                        'isFirstFrameRendered': true,
+                      }),
+                      (_) {},
+                    );
+              });
+            }
+            return methodCodec.encodeSuccessEnvelope(null);
+          },
+        );
+
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              videos: [_makeVideo('wrapped_video_builder')],
+              cache: cache,
+              prefetchCount: 0,
+              preloadGracePeriod: Duration.zero,
+              videoBuilder: (_, child, _, _) {
+                return KeyedSubtree(key: wrapperKey, child: child);
+              },
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byKey(wrapperKey), findsOneWidget);
+        expect(find.byType(VideoItemWidget), findsOneWidget);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          globalChannel,
+          null,
+        );
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          playerChannel,
+          null,
+        );
+        tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+          eventChannelName,
+          null,
+        );
+      });
+
       testWidgets('currentIndex returns 0 initially', (tester) async {
         final key = GlobalKey<InfiniteVideoFeedState>();
         final videos = List.generate(3, (i) => _makeVideo('v$i'));

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -316,7 +316,7 @@ void main() {
               preloadGracePeriod: Duration.zero,
               loadingBuilder: (_, _, {required isSquare}) =>
                   const Text('loading'),
-              videoBuilder: (_, _, _) => const Text('video'),
+              videoBuilder: (_, _, _, _) => const Text('video'),
             ),
           ),
         );

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -398,7 +398,9 @@ void main() {
                 preloadGracePeriod: Duration.zero,
                 loadingBuilder: (_, _, {required isSquare}) =>
                     const Text('loading'),
-                videoBuilder: (_, _, _) => const Text('video'),
+                videoBuilder: (_, _, _, _) {
+                  return const Text('video');
+                },
               ),
             ),
           );

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -316,7 +316,9 @@ void main() {
               preloadGracePeriod: Duration.zero,
               loadingBuilder: (_, _, {required isSquare}) =>
                   const Text('loading'),
-              videoBuilder: (_, _, _, _) => const Text('video'),
+              videoBuilder: (_, _, _, _) {
+                return const Text('video');
+              },
             ),
           ),
         );

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 void main() {
   group(BlurredVideoBackdrop, () {
@@ -24,31 +25,38 @@ void main() {
       expect(find.byType(ImageFiltered), findsOneWidget);
     });
 
-    testWidgets('passes url to network image provider', (tester) async {
+    testWidgets('passes url to $VineCachedImage', (tester) async {
       await tester.pumpWidget(buildWidget());
 
-      final image = tester.widget<Image>(find.byType(Image));
-      final provider = image.image as NetworkImage;
-      expect(provider.url, equals(testUrl));
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
+      expect(image.imageUrl, equals(testUrl));
     });
 
-    testWidgets('uses $BoxFit cover', (tester) async {
+    testWidgets('uses $BoxFit cover with half opacity', (tester) async {
       await tester.pumpWidget(buildWidget());
 
-      final image = tester.widget<Image>(find.byType(Image));
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
       expect(image.fit, equals(BoxFit.cover));
+      final opacity = tester.widget<Opacity>(find.byType(Opacity));
+      expect(opacity.opacity, equals(0.5));
     });
 
-    testWidgets('errorBuilder renders $SizedBox shrink when image fails', (
+    testWidgets('errorWidget renders $SizedBox shrink when image fails', (
       tester,
     ) async {
       await tester.pumpWidget(buildWidget());
 
-      final image = tester.widget<Image>(find.byType(Image));
-      final fallback = image.errorBuilder!(
-        tester.element(find.byType(Image)),
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
+      final fallback = image.errorWidget!(
+        tester.element(find.byType(VineCachedImage)),
+        'https://example.com/fallback.jpg',
         Exception('load error'),
-        StackTrace.current,
       );
 
       expect(fallback, isA<SizedBox>());

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
+
+void main() {
+  group(BlurredVideoBackdrop, () {
+    const testUrl = 'https://example.com/poster.jpg';
+
+    Widget buildWidget({String url = testUrl}) {
+      return WidgetsApp(
+        color: const Color(0xFF000000),
+        builder: (_, _) => SizedBox(
+          width: 400,
+          height: 800,
+          child: BlurredVideoBackdrop(url: url),
+        ),
+      );
+    }
+
+    testWidgets('renders $ClipRect wrapping $ImageFiltered', (tester) async {
+      await tester.pumpWidget(buildWidget());
+
+      expect(find.byType(ClipRect), findsOneWidget);
+      expect(find.byType(ImageFiltered), findsOneWidget);
+    });
+
+    testWidgets('passes url to network image provider', (tester) async {
+      await tester.pumpWidget(buildWidget());
+
+      final image = tester.widget<Image>(find.byType(Image));
+      final provider = image.image as NetworkImage;
+      expect(provider.url, equals(testUrl));
+    });
+
+    testWidgets('uses $BoxFit cover', (tester) async {
+      await tester.pumpWidget(buildWidget());
+
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.fit, equals(BoxFit.cover));
+    });
+
+    testWidgets('errorBuilder renders $SizedBox shrink when image fails', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+
+      final image = tester.widget<Image>(find.byType(Image));
+      final fallback = image.errorBuilder!(
+        tester.element(find.byType(Image)),
+        Exception('load error'),
+        StackTrace.current,
+      );
+
+      expect(fallback, isA<SizedBox>());
+      final box = fallback as SizedBox;
+      expect(box.width, equals(0));
+      expect(box.height, equals(0));
+    });
+  });
+}


### PR DESCRIPTION
Closes #4552

## Description

The feed design was recently updated with a blurred backdrop and new video expansion behavior. However, these changes were only applied to the old pooled video player implementation, which will soon be replaced by the native video player. This PR updates the new path as well to match the latest design.

**Related Issue:** 

 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore