### PR TITLE
refactor(async): use .timeout() in BackgroundActivityManager (#4517)

### DIFF
--- a/mobile/lib/services/background_activity_manager.dart
+++ b/mobile/lib/services/background_activity_manager.dart
@@ -17,10 +17,13 @@ class BackgroundActivityManager {
   bool _isInitialized = false;
   final List<BackgroundAwareService> _registeredServices = [];
 
-  // Max time we wait for a single service's onAppBackgrounded to settle
-  // before logging a warning and moving on. Bounded so a misbehaving
-  // service can't extend the immediate-background phase past iOS/Android
-  // watchdog limits.
+  // Defensive bound on how long the manager will await a single service's
+  // onAppBackgrounded notification before logging and moving on. The
+  // [BackgroundAwareService.onAppBackgrounded] interface is currently
+  // synchronous `void`, so the timeout does not fire for any in-tree
+  // implementation — it exists to protect the immediate-background phase
+  // from iOS/Android watchdog kills if the interface is ever widened to
+  // `FutureOr<void>` (or an impl starts blocking the microtask chain).
   static const Duration _suspendGracePeriod = Duration(seconds: 1);
 
   // Timers for delayed actions
@@ -168,18 +171,18 @@ class BackgroundActivityManager {
       category: LogCategory.system,
     );
 
-    // Process services async with timeout to prevent watchdog kills.
-    // Each service gets a 1-second grace period to suspend; if it exceeds
-    // that, log a warning and move on (the service call continues to run
-    // in the background — the timeout only bounds *our* wait).
+    // Fan out per-service notifications onto microtasks so a slow or
+    // misbehaving service cannot block the suspend pass. See the comment on
+    // [_suspendGracePeriod] for why the .timeout() bound exists despite
+    // never firing against the current sync `void` interface.
     for (final service in _registeredServices) {
       Future.microtask(() async {
         try {
           await Future(service.onAppBackgrounded).timeout(_suspendGracePeriod);
         } on TimeoutException {
           Log.warning(
-            'Service ${service.serviceName} exceeded $_suspendGracePeriod '
-            'suspend grace period',
+            'Service ${service.serviceName} exceeded '
+            '${_suspendGracePeriod.inSeconds}s suspend grace period',
             name: 'BackgroundActivityManager',
             category: LogCategory.system,
           );

--- a/mobile/lib/services/background_activity_manager.dart
+++ b/mobile/lib/services/background_activity_manager.dart
@@ -17,6 +17,12 @@ class BackgroundActivityManager {
   bool _isInitialized = false;
   final List<BackgroundAwareService> _registeredServices = [];
 
+  // Max time we wait for a single service's onAppBackgrounded to settle
+  // before logging a warning and moving on. Bounded so a misbehaving
+  // service can't extend the immediate-background phase past iOS/Android
+  // watchdog limits.
+  static const Duration _suspendGracePeriod = Duration(seconds: 1);
+
   // Timers for delayed actions
   Timer? _backgroundSuspensionTimer;
   Timer? _periodicCleanupTimer;
@@ -162,15 +168,21 @@ class BackgroundActivityManager {
       category: LogCategory.system,
     );
 
-    // Process services async with timeout to prevent watchdog kills
+    // Process services async with timeout to prevent watchdog kills.
+    // Each service gets a 1-second grace period to suspend; if it exceeds
+    // that, log a warning and move on (the service call continues to run
+    // in the background — the timeout only bounds *our* wait).
     for (final service in _registeredServices) {
       Future.microtask(() async {
         try {
-          // Give each service max 1 second to suspend
-          await Future.any([
-            Future(service.onAppBackgrounded),
-            Future.delayed(const Duration(seconds: 1)),
-          ]);
+          await Future(service.onAppBackgrounded).timeout(_suspendGracePeriod);
+        } on TimeoutException {
+          Log.warning(
+            'Service ${service.serviceName} exceeded $_suspendGracePeriod '
+            'suspend grace period',
+            name: 'BackgroundActivityManager',
+            category: LogCategory.system,
+          );
         } catch (e) {
           Log.error(
             'Error suspending service ${service.serviceName}: $e',

--- a/mobile/lib/services/background_activity_manager.dart
+++ b/mobile/lib/services/background_activity_manager.dart
@@ -107,8 +107,6 @@ class BackgroundActivityManager {
         _isAppInForeground = false;
         _onAppTerminating();
     }
-
-    if (wasInForeground != _isAppInForeground) {}
   }
 
   /// Handle app entering background

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -34,6 +34,30 @@ class TestBackgroundService implements BackgroundAwareService {
   }
 }
 
+/// Service whose [onAppBackgrounded] throws synchronously — used to assert
+/// the manager isolates failures and keeps processing remaining services.
+class _ThrowingBackgroundService implements BackgroundAwareService {
+  bool entered = false;
+
+  @override
+  String get serviceName => 'ThrowingService';
+
+  @override
+  void onAppBackgrounded() {
+    entered = true;
+    throw StateError('boom');
+  }
+
+  @override
+  void onExtendedBackground() {}
+
+  @override
+  void onAppResumed() {}
+
+  @override
+  void onPeriodicCleanup() {}
+}
+
 void main() {
   group('BackgroundActivityManager', () {
     late BackgroundActivityManager manager;
@@ -66,14 +90,38 @@ void main() {
       expect(manager.isAppInBackground, isTrue);
 
       // _performImmediateBackgroundActions wraps each service notification in
-      // Future.microtask(() async { await Future.any([Future(fn), ...]); }),
-      // so the notification chain is microtask → Timer(0) → completion. Drain
+      // `Future.microtask(() async { await Future(fn).timeout(...); })`, so
+      // the notification chain is microtask → Timer(0) → completion. Drain
       // the event queue deterministically instead of relying on a fixed
       // wall-clock delay, which is flaky under CI load.
       await pumpEventQueue();
 
       expect(testService.backgroundCalled, isTrue);
     });
+
+    test(
+      'isolates a throwing service so remaining services still get notified',
+      () async {
+        final throwing = _ThrowingBackgroundService();
+        manager.registerService(throwing);
+        manager.registerService(testService);
+        addTearDown(() {
+          manager.unregisterService(throwing);
+          manager.unregisterService(testService);
+        });
+
+        manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
+
+        // Same drain pattern as 'should register and notify services' —
+        // the per-service notification chain is microtask → completion.
+        await pumpEventQueue();
+
+        expect(throwing.entered, isTrue);
+        // The healthy service still received its notification despite the
+        // sibling service throwing inside the same suspend pass.
+        expect(testService.backgroundCalled, isTrue);
+      },
+    );
 
     test('should handle app resume', () async {
       manager.registerService(testService);

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -65,13 +65,14 @@ void main() {
 
     setUp(() async {
       manager = BackgroundActivityManager();
+      manager.dispose();
       testService = TestBackgroundService();
 
       // BackgroundActivityManager is a process-wide singleton. Tests in this
-      // file share the same instance and run in random order, so reset its
-      // state to foreground + drain any pending lifecycle notifications before
-      // each test. Otherwise a prior test that transitioned to background can
-      // cause "should provide status information" to observe stale state.
+      // file share the same instance and run in random order, so clear any
+      // prior registrations/timers, reset its state to foreground, and drain
+      // pending lifecycle notifications before each test. Otherwise a prior
+      // test can leak services or stale background state into the next case.
       manager.onAppLifecycleStateChanged(AppLifecycleState.resumed);
       await pumpEventQueue();
     });
@@ -83,6 +84,7 @@ void main() {
 
     test('should register and notify services', () async {
       manager.registerService(testService);
+      addTearDown(() => manager.unregisterService(testService));
 
       // Simulate app going to background
       manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
@@ -125,6 +127,7 @@ void main() {
 
     test('should handle app resume', () async {
       manager.registerService(testService);
+      addTearDown(() => manager.unregisterService(testService));
 
       // Go to background then resume
       manager.onAppLifecycleStateChanged(AppLifecycleState.paused);
@@ -153,6 +156,7 @@ void main() {
 
     test('should provide status information', () {
       manager.registerService(testService);
+      addTearDown(() => manager.unregisterService(testService));
 
       final status = manager.getStatus();
       expect(status['isAppInForeground'], isTrue);


### PR DESCRIPTION
Closes #4517

## Summary

First single-file slice of #4517's production `Future.delayed` cleanup.

Replaces the hand-rolled `Future.any([Future(fn), Future.delayed(...)])` timeout in `BackgroundActivityManager._performImmediateBackgroundActions` with the proper `.timeout()` API. **The change is API hygiene, not behavior** — see the "Honest accounting" section below for what does and doesn't change at runtime.

Also extracts the 1-second grace window into `_suspendGracePeriod` so the intent (and its current defensive-only status) is named at the field rather than implied at the call site.

## Diff shape

```dart
// Before
await Future.any([
  Future(service.onAppBackgrounded),
  Future.delayed(const Duration(seconds: 1)),
]);
// → silent timeout, no exception, no log

// After
await Future(service.onAppBackgrounded).timeout(_suspendGracePeriod);
// → explicit TimeoutException, caught + logged via Log.warning
```

## Honest accounting

`BackgroundAwareService.onAppBackgrounded` returns **`void`**, and the two in-tree implementations are purely synchronous:

- `AuthService.onAppBackgrounded`: `_bunkerSigner?.pause()` — sync, no `unawaited()`
- `AnalyticsService.onAppBackgrounded`: `_isInBackground = true` — sync, no `unawaited()`

This means **`Future(voidFn)` completes in one microtask in every case that exists today**, and `.timeout()` cannot fire. The original `Future.any` bound never fired either. The timeout wrapper is purely defensive against a future widening of the interface to `FutureOr<void>` (or a service that starts blocking the microtask chain).

I considered deleting the timeout wrapper entirely as dead-by-construction code (per "don't design for hypothetical future requirements"), but kept it because the file already structured this way and removing it is bigger than #4517's mandate. Happy to file a follow-up issue to simplify this once #4339 Wave 2 stabilizes if reviewer prefers.

The refactor's concrete benefits:
- Removes one `Future.delayed` call site (the #4517 mandate).
- Names `_suspendGracePeriod` as a constant with explicit defensive-only doc.
- If the interface is ever widened, the timeout starts producing `TimeoutException` with a distinct log line, rather than silently swallowing the bound.

## Tests

Updated `background_activity_manager_test.dart`:
- Refreshed the inline comment on `'should register and notify services'` to describe the new `.timeout()` chain shape (still microtask → completion).
- **Added regression test**: `'isolates a throwing service so remaining services still get notified'`. Pins the cross-service failure-isolation contract — a `_ThrowingBackgroundService` raises synchronously inside the same suspend pass as the healthy `TestBackgroundService`, and the test asserts the throw is caught while the sibling still gets notified.

Disclosure: this test passes against both the old `Future.any` code and the new `.timeout()` code — it pins a previously-untested invariant of the loop, not a new behavior introduced by this PR. Per #4517 acceptance, it is event-queue-drained (`pumpEventQueue`), not sleep-based.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `dart format` — clean
- [x] `flutter test test/services/background_activity_manager_test.dart` — **6 passed**

## Inventory delta against #4517

| Metric | Before | After |
|---|---:|---:|
| Files in `mobile/lib/` with `Future.delayed` | 18 | **17** |
| Call sites in `mobile/lib/` (per #4517 body) | 30 | **29** |

`grep -rln "Future\.delayed" mobile/lib --include="*.dart" | grep -v l10n/generated | wc -l` is the canonical CI guard mandated by #4517 acceptance criterion 3; that guard is not part of this PR.

## Reviewer

Per the established Wave 3 hygiene pattern (#4339), only @NotThatKindOfDrLiz added once CI returned green.