### PR TITLE
test(notifications): harden #4387 matrix with cubit + bloc convergence

### DIFF
--- a/mobile/test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart
+++ b/mobile/test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart
@@ -1,0 +1,150 @@
+// ABOUTME: Widget-level test for the badge cubit's auth-transition contract.
+// ABOUTME: Verifies that the BlocProvider/ValueKey wiring around the cubit
+// ABOUTME: discards the old subscription and re-subscribes when the Riverpod
+// ABOUTME: notificationRepositoryProvider flips identity (signed-out ->
+// ABOUTME: signed-in, account switch A->B).
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/notifications/providers/notification_repository_provider.dart';
+
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
+/// Override target — tests mutate this StateProvider to flip the
+/// repository that [notificationRepositoryProvider] returns.
+final _testRepoSelector = StateProvider<NotificationRepository?>(
+  (_) => null,
+);
+
+/// Probe widget mirroring `main.dart`'s wiring around the badge cubit:
+/// the [BlocProvider] is keyed on the identity of the repository, so
+/// the cubit is closed and recreated whenever the Riverpod provider
+/// hands over a new instance.
+class _BadgeProbe extends ConsumerWidget {
+  const _BadgeProbe();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BlocProvider(
+      key: ValueKey(
+        identityHashCode(ref.watch(notificationRepositoryProvider)),
+      ),
+      create: (_) => NotificationBadgeCubit(
+        repository: ref.read(notificationRepositoryProvider),
+      ),
+      child: BlocBuilder<NotificationBadgeCubit, int>(
+        builder: (context, count) => Text('count=$count'),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('NotificationBadgeCubit auth transition', () {
+    testWidgets(
+      'signed-out -> signed-in: badge resets at 0, then emits from the new '
+      "repository's stream",
+      (tester) async {
+        final controllerB = StreamController<int>.broadcast();
+        addTearDown(controllerB.close);
+        final repoB = _MockNotificationRepository();
+        when(repoB.watchUnreadCount).thenAnswer((_) => controllerB.stream);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              notificationRepositoryProvider.overrideWith(
+                (ref) => ref.watch(_testRepoSelector),
+              ),
+            ],
+            child: const MaterialApp(home: _BadgeProbe()),
+          ),
+        );
+
+        expect(find.text('count=0'), findsOneWidget);
+        verifyNever(repoB.watchUnreadCount);
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(_BadgeProbe)),
+        );
+        container.read(_testRepoSelector.notifier).state = repoB;
+        await tester.pumpAndSettle();
+
+        controllerB.add(5);
+        await tester.pumpAndSettle();
+
+        expect(find.text('count=5'), findsOneWidget);
+        verify(repoB.watchUnreadCount).called(1);
+      },
+    );
+
+    testWidgets(
+      'account switch A -> B: old subscription is cancelled and the new '
+      "cubit subscribes to B's stream",
+      (tester) async {
+        final controllerA = StreamController<int>.broadcast();
+        final controllerB = StreamController<int>.broadcast();
+        addTearDown(() async {
+          await controllerA.close();
+          await controllerB.close();
+        });
+
+        final repoA = _MockNotificationRepository();
+        final repoB = _MockNotificationRepository();
+        when(repoA.watchUnreadCount).thenAnswer((_) => controllerA.stream);
+        when(repoB.watchUnreadCount).thenAnswer((_) => controllerB.stream);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              _testRepoSelector.overrideWith((_) => repoA),
+              notificationRepositoryProvider.overrideWith(
+                (ref) => ref.watch(_testRepoSelector),
+              ),
+            ],
+            child: const MaterialApp(home: _BadgeProbe()),
+          ),
+        );
+
+        controllerA.add(3);
+        await tester.pumpAndSettle();
+        expect(find.text('count=3'), findsOneWidget);
+
+        // Swap repositories — Pattern A: in production this transitions
+        // through a null phase, but the BlocProvider's ValueKey keyed on
+        // identity is the contract this test pins. Any identity flip must
+        // close the prior cubit and create a fresh one against B.
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(_BadgeProbe)),
+        );
+        container.read(_testRepoSelector.notifier).state = repoB;
+        await tester.pumpAndSettle();
+
+        // Pre-emission default for the new cubit is 0 before B's stream
+        // pushes its first value.
+        expect(find.text('count=0'), findsOneWidget);
+
+        controllerB.add(7);
+        await tester.pumpAndSettle();
+        expect(find.text('count=7'), findsOneWidget);
+
+        // Late emission on A's stream must not reach the new cubit —
+        // proving the prior subscription was cancelled when the
+        // BlocProvider replaced the cubit instance.
+        controllerA.add(99);
+        await tester.pumpAndSettle();
+        expect(find.text('count=99'), findsNothing);
+        expect(find.text('count=7'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
+++ b/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
@@ -1,0 +1,198 @@
+// ABOUTME: Pins the "tap notification -> return -> badge converges"
+// ABOUTME: contract. Tap dispatches markAsRead through the bloc; the shared
+// ABOUTME: snapshot stream propagates the new unread count to both the feed
+// ABOUTME: bloc and the badge cubit so the bottom-nav badge stays in lock
+// ABOUTME: step with the per-row read state.
+
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:rxdart/rxdart.dart' hide NotificationKind;
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+/// Controllable fake that mirrors the real repository's shared-source-of-truth
+/// behaviour: a single [BehaviorSubject] feeds both [watchSnapshot] and
+/// [watchUnreadCount], and [markAsRead] re-emits with the targeted items
+/// flagged read so derived streams converge.
+class _FakeNotificationRepository extends Fake
+    implements NotificationRepository {
+  _FakeNotificationRepository(NotificationPage initial)
+    : _snapshot = BehaviorSubject<NotificationPage>.seeded(initial);
+
+  final BehaviorSubject<NotificationPage> _snapshot;
+
+  /// Notification IDs passed to the most recent [markAsRead] call.
+  List<String> lastMarkedRead = const [];
+
+  @override
+  Stream<NotificationPage> watchSnapshot() => _snapshot.stream;
+
+  @override
+  Stream<int> watchUnreadCount() => _snapshot.stream
+      .map((page) => page.items.where((n) => !n.isRead).length)
+      .distinct();
+
+  @override
+  Future<void> markAsRead(List<String> ids) async {
+    lastMarkedRead = ids;
+    final current = _snapshot.value;
+    final updated = current.items.map<NotificationItem>((item) {
+      if (!ids.contains(item.id)) return item;
+      return switch (item) {
+        VideoNotification(:final isRead) when isRead => item,
+        VideoNotification() => item.copyWith(isRead: true),
+        ActorNotification(:final isRead) when isRead => item,
+        ActorNotification() => item.copyWith(isRead: true),
+      };
+    }).toList();
+    _snapshot.add(current.copyWith(items: updated));
+  }
+
+  @override
+  Future<void> close() => _snapshot.close();
+}
+
+const _alicePubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _bobPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+VideoNotification _unreadLike(String id) {
+  return VideoNotification(
+    id: id,
+    type: NotificationKind.like,
+    videoEventId: 'video_$id',
+    actors: [ActorInfo(pubkey: _alicePubkey, displayName: 'Alice')],
+    totalCount: 1,
+    timestamp: DateTime(2026),
+  );
+}
+
+ActorNotification _unreadFollow(String id) {
+  return ActorNotification(
+    id: id,
+    type: NotificationKind.follow,
+    actor: ActorInfo(pubkey: _bobPubkey, displayName: 'Bob'),
+    timestamp: DateTime(2026),
+  );
+}
+
+void main() {
+  group('badge converges after tap -> read -> back', () {
+    late _FakeNotificationRepository repository;
+    late _MockFollowRepository followRepository;
+
+    setUp(() {
+      repository = _FakeNotificationRepository(
+        NotificationPage(
+          items: [_unreadLike('n1'), _unreadLike('n2'), _unreadFollow('n3')],
+          unreadCount: 3,
+        ),
+      );
+      followRepository = _MockFollowRepository();
+      when(() => followRepository.isFollowing(any())).thenReturn(false);
+    });
+
+    tearDown(() async {
+      await repository.close();
+    });
+
+    test(
+      'tapping one item drops both bloc-projected unread and badge by 1',
+      () async {
+        final bloc = NotificationFeedBloc(
+          notificationRepository: repository,
+          followRepository: followRepository,
+        );
+        addTearDown(bloc.close);
+        final badge = NotificationBadgeCubit(repository: repository);
+        addTearDown(badge.close);
+
+        // Wait for the initial snapshot to flow into both consumers.
+        await Future<void>.delayed(Duration.zero);
+        expect(badge.state, equals(3));
+        expect(bloc.state.notifications, hasLength(3));
+        expect(
+          bloc.state.notifications.where((n) => !n.isRead).length,
+          equals(3),
+        );
+
+        bloc.add(NotificationFeedItemTapped('n1'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repository.lastMarkedRead, equals(['n1']));
+        expect(badge.state, equals(2));
+        expect(
+          bloc.state.notifications.where((n) => !n.isRead).length,
+          equals(2),
+        );
+        // Row identity is preserved — same id, just flagged read.
+        expect(
+          bloc.state.notifications.singleWhere((n) => n.id == 'n1').isRead,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'tapping the already-read row leaves badge unchanged (no double-decrement)',
+      () async {
+        await repository.markAsRead(['n2']);
+
+        final bloc = NotificationFeedBloc(
+          notificationRepository: repository,
+          followRepository: followRepository,
+        );
+        addTearDown(bloc.close);
+        final badge = NotificationBadgeCubit(repository: repository);
+        addTearDown(badge.close);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(badge.state, equals(2));
+
+        bloc.add(NotificationFeedItemTapped('n2'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(badge.state, equals(2));
+      },
+    );
+
+    test(
+      'tapping every unread item converges badge to 0',
+      () async {
+        final bloc = NotificationFeedBloc(
+          notificationRepository: repository,
+          followRepository: followRepository,
+        );
+        addTearDown(bloc.close);
+        final badge = NotificationBadgeCubit(repository: repository);
+        addTearDown(badge.close);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(badge.state, equals(3));
+
+        bloc.add(NotificationFeedItemTapped('n1'));
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(NotificationFeedItemTapped('n2'));
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(NotificationFeedItemTapped('n3'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(badge.state, equals(0));
+        expect(
+          bloc.state.notifications.every((n) => n.isRead),
+          isTrue,
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
+++ b/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
@@ -4,8 +4,6 @@
 // ABOUTME: bloc and the badge cubit so the bottom-nav badge stays in lock
 // ABOUTME: step with the per-row read state.
 
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
-
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -30,8 +28,8 @@ class _FakeNotificationRepository extends Fake
 
   final BehaviorSubject<NotificationPage> _snapshot;
 
-  /// Notification IDs passed to the most recent [markAsRead] call.
-  List<String> lastMarkedRead = const [];
+  /// Notification ID batches passed to [markAsRead].
+  final List<List<String>> markedReadCalls = [];
 
   @override
   Stream<NotificationPage> watchSnapshot() => _snapshot.stream;
@@ -43,7 +41,7 @@ class _FakeNotificationRepository extends Fake
 
   @override
   Future<void> markAsRead(List<String> ids) async {
-    lastMarkedRead = ids;
+    markedReadCalls.add(List<String>.from(ids));
     final current = _snapshot.value;
     final updated = current.items.map<NotificationItem>((item) {
       if (!ids.contains(item.id)) return item;
@@ -71,7 +69,7 @@ VideoNotification _unreadLike(String id) {
     id: id,
     type: NotificationKind.like,
     videoEventId: 'video_$id',
-    actors: [ActorInfo(pubkey: _alicePubkey, displayName: 'Alice')],
+    actors: const [ActorInfo(pubkey: _alicePubkey, displayName: 'Alice')],
     totalCount: 1,
     timestamp: DateTime(2026),
   );
@@ -81,7 +79,7 @@ ActorNotification _unreadFollow(String id) {
   return ActorNotification(
     id: id,
     type: NotificationKind.follow,
-    actor: ActorInfo(pubkey: _bobPubkey, displayName: 'Bob'),
+    actor: const ActorInfo(pubkey: _bobPubkey, displayName: 'Bob'),
     timestamp: DateTime(2026),
   );
 }
@@ -126,10 +124,15 @@ void main() {
           equals(3),
         );
 
-        bloc.add(NotificationFeedItemTapped('n1'));
+        bloc.add(const NotificationFeedItemTapped('n1'));
         await Future<void>.delayed(Duration.zero);
 
-        expect(repository.lastMarkedRead, equals(['n1']));
+        expect(
+          repository.markedReadCalls,
+          equals([
+            ['n1'],
+          ]),
+        );
         expect(badge.state, equals(2));
         expect(
           bloc.state.notifications.where((n) => !n.isRead).length,
@@ -159,10 +162,17 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         expect(badge.state, equals(2));
 
-        bloc.add(NotificationFeedItemTapped('n2'));
+        bloc.add(const NotificationFeedItemTapped('n2'));
         await Future<void>.delayed(Duration.zero);
 
         expect(badge.state, equals(2));
+        expect(
+          repository.markedReadCalls,
+          equals([
+            ['n2'],
+            ['n2'],
+          ]),
+        );
       },
     );
 
@@ -180,14 +190,22 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         expect(badge.state, equals(3));
 
-        bloc.add(NotificationFeedItemTapped('n1'));
+        bloc.add(const NotificationFeedItemTapped('n1'));
         await Future<void>.delayed(Duration.zero);
-        bloc.add(NotificationFeedItemTapped('n2'));
+        bloc.add(const NotificationFeedItemTapped('n2'));
         await Future<void>.delayed(Duration.zero);
-        bloc.add(NotificationFeedItemTapped('n3'));
+        bloc.add(const NotificationFeedItemTapped('n3'));
         await Future<void>.delayed(Duration.zero);
 
         expect(badge.state, equals(0));
+        expect(
+          repository.markedReadCalls,
+          equals([
+            ['n1'],
+            ['n2'],
+            ['n3'],
+          ]),
+        );
         expect(
           bloc.state.notifications.every((n) => n.isRead),
           isTrue,


### PR DESCRIPTION
Closes #4387

## Summary
Closes the widget-level test gaps flagged in the #4387 regression sweep matrix that don't require real-device push delivery (gated on #4207).

**`notification_badge_cubit_auth_transition_test.dart`**
- Pins the `BlocProvider`/`ValueKey` wiring around the badge cubit: when `notificationRepositoryProvider` flips identity (signed-out → signed-in, account switch A→B), the cubit is closed and recreated against the new repository, late emissions on the prior stream cannot reach the new cubit, and the badge resets at 0 before B's stream pushes a value.

**`badge_converges_after_tap_read_back_test.dart`**
- Pins the "tap notification → mark-as-read → badge converges" contract. A shared `BehaviorSubject` feeds both `watchSnapshot` (bloc) and `watchUnreadCount` (cubit); tapping a row dispatches `markAsRead` through the bloc, the repository re-emits with the targeted item flagged read, and both consumers converge to the new unread count.
- Covers the no-double-decrement edge (tapping an already-read row leaves the badge unchanged) and the converges-to-zero terminal case.

Both tests run without any real-device or push infrastructure, so #4387's manual-QA surface shrinks to genuinely device-only items (cold-start FCM delivery, OS permission UX, 200% font visual pass).

Towards epic #4200 close-out.

## Test plan
- [x] `flutter test test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart test/notifications/badge_converges_after_tap_read_back_test.dart` — 5 tests pass.
- [x] `flutter test test/notifications/ test/blocs/notifications/ test/router/app_shell_notification_badge_test.dart` — 149 tests pass (no regressions on neighbours).
- [x] `flutter analyze lib test` — `No issues found!`.
- [x] No production code change; pure contract pinning.