### PR TITLE
fix(feed): restore restricted content overlay actions

### DIFF
--- a/mobile/lib/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart
+++ b/mobile/lib/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart
@@ -1,6 +1,6 @@
-// ABOUTME: Drives the deferred moderation-check gate during video loading.
-// ABOUTME: Starts a timer and emits restricted when the moderation API
-// ABOUTME: confirms the video is blocked, quarantined, or age-restricted.
+// ABOUTME: Drives the moderation-check gate during video loading.
+// ABOUTME: Emits restricted when the moderation API confirms the video is
+// ABOUTME: blocked, quarantined, or age-restricted.
 
 import 'dart:async';
 
@@ -8,19 +8,17 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/feed_loading_moderation/feed_loading_moderation_state.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 
-/// Performs a deferred moderation check during the video loading phase.
+/// Performs a moderation check during the video loading phase.
 ///
-/// After [checkDelay] (default 2 s), fetches the moderation status for the
-/// video's sha256. If the content is moderation-restricted (blocked,
-/// quarantined, or age-restricted), emits
+/// Fetches the moderation status for the video's sha256. If the content is
+/// moderation-restricted (blocked, quarantined, or age-restricted), emits
 /// [FeedLoadingModerationStatus.restricted]; otherwise the state remains
 /// [FeedLoadingModerationStatus.loading] for the lifetime of the cubit.
 ///
-/// Call [start] immediately after the cubit is constructed. The timer is
-/// cancelled automatically in [close].
+/// Call [start] immediately after the cubit is constructed.
 class FeedLoadingModerationCubit extends Cubit<FeedLoadingModerationState> {
   /// Creates the cubit and resolves the video's sha256 from [explicitSha256]
-  /// or [videoUrl]. No timer is started until [start] is called.
+  /// or [videoUrl]. No request is started until [start] is called.
   ///
   /// When [VideoModerationStatusService.shouldCheckModeration] returns
   /// `false` for [videoUrl], or when no sha256 can be resolved, [start]
@@ -30,9 +28,7 @@ class FeedLoadingModerationCubit extends Cubit<FeedLoadingModerationState> {
     required VideoModerationStatusService service,
     required String? explicitSha256,
     required String? videoUrl,
-    Duration checkDelay = const Duration(seconds: 2),
   }) : _service = service,
-       _checkDelay = checkDelay,
        _sha256 = VideoModerationStatusService.shouldCheckModeration(videoUrl)
            ? VideoModerationStatusService.resolveSha256(
                explicitSha256: explicitSha256,
@@ -42,21 +38,18 @@ class FeedLoadingModerationCubit extends Cubit<FeedLoadingModerationState> {
        super(const FeedLoadingModerationState());
 
   final VideoModerationStatusService _service;
-  final Duration _checkDelay;
 
   /// The resolved, normalised sha256 for this video, or `null` when the
   /// moderation check is not applicable.
   final String? _sha256;
 
-  Timer? _timer;
-
-  /// Starts the deferred moderation check.
+  /// Starts the moderation check.
   ///
   /// No-ops when there is no resolvable sha256 for this video.
   void start() {
     final sha256 = _sha256;
     if (sha256 == null) return;
-    _timer = Timer(_checkDelay, () => _checkModeration(sha256));
+    unawaited(_checkModeration(sha256));
   }
 
   Future<void> _checkModeration(String sha256) async {
@@ -70,11 +63,5 @@ class FeedLoadingModerationCubit extends Cubit<FeedLoadingModerationState> {
     } catch (e, stackTrace) {
       addError(e, stackTrace);
     }
-  }
-
-  @override
-  Future<void> close() {
-    _timer?.cancel();
-    return super.close();
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -13,6 +13,7 @@ import 'package:go_router/go_router.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart'
     show InfiniteVideoFeed, VideoErrorType;
 import 'package:models/models.dart';
+import 'package:openvine/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
@@ -34,6 +35,7 @@ import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/pooled_player_logger.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
@@ -1168,29 +1170,42 @@ class _WebFullscreenItem extends ConsumerWidget {
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
+    final moderationService = ref.watch(videoModerationStatusServiceProvider);
     final addressableId = video.addressableId;
 
-    return BlocProvider<VideoInteractionsBloc>(
-      key: videoInteractionsBlocKey(
-        likesRepository: likesRepository,
-        commentsRepository: commentsRepository,
-        repostsRepository: repostsRepository,
-        video: video,
-      ),
-      create: (_) =>
-          VideoInteractionsBloc(
-              eventId: video.id,
-              authorPubkey: video.pubkey,
-              likesRepository: likesRepository,
-              commentsRepository: commentsRepository,
-              repostsRepository: repostsRepository,
-              addressableId: addressableId,
-              initialLikeCount: video.nostrLikeCount != null
-                  ? video.totalLikes
-                  : null,
-            )
-            ..add(const VideoInteractionsSubscriptionRequested())
-            ..add(const VideoInteractionsFetchRequested()),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<FeedLoadingModerationCubit>(
+          key: ValueKey(moderationService),
+          create: (_) => FeedLoadingModerationCubit(
+            service: moderationService,
+            explicitSha256: video.sha256,
+            videoUrl: video.videoUrl,
+          )..start(),
+        ),
+        BlocProvider<VideoInteractionsBloc>(
+          key: videoInteractionsBlocKey(
+            likesRepository: likesRepository,
+            commentsRepository: commentsRepository,
+            repostsRepository: repostsRepository,
+            video: video,
+          ),
+          create: (_) =>
+              VideoInteractionsBloc(
+                  eventId: video.id,
+                  authorPubkey: video.pubkey,
+                  likesRepository: likesRepository,
+                  commentsRepository: commentsRepository,
+                  repostsRepository: repostsRepository,
+                  addressableId: addressableId,
+                  initialLikeCount: video.nostrLikeCount != null
+                      ? video.totalLikes
+                      : null,
+                )
+                ..add(const VideoInteractionsSubscriptionRequested())
+                ..add(const VideoInteractionsFetchRequested()),
+        ),
+      ],
       child: Stack(
         children: [
           VideoOverlayActions(
@@ -1253,7 +1268,30 @@ class _WebFullscreenItem extends ConsumerWidget {
               ),
             ),
           ),
+          _WebFullscreenLoadingModerationOverlay(video: video),
         ],
+      ),
+    );
+  }
+}
+
+class _WebFullscreenLoadingModerationOverlay extends StatelessWidget {
+  const _WebFullscreenLoadingModerationOverlay({required this.video});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context) {
+    final isRestricted = context.select(
+      (FeedLoadingModerationCubit cubit) => cubit.state.isRestricted,
+    );
+    if (!isRestricted) return const SizedBox.shrink();
+
+    return Positioned.fill(
+      child: PooledVideoErrorOverlay(
+        video: video,
+        onRetry: () {},
+        errorType: VideoErrorType.notFound,
       ),
     );
   }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1465,6 +1465,7 @@ class _PooledFullscreenItemContentState
                 return PooledVideoErrorOverlay(
                   video: video,
                   onRetry: onRetry,
+                  onVerifyAge: () => _verifyAgeForVideo(context, video),
                   errorType: feedErrorType,
                 );
               },

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1275,22 +1275,76 @@ class _WebFullscreenItem extends ConsumerWidget {
   }
 }
 
-class _WebFullscreenLoadingModerationOverlay extends StatelessWidget {
+class _WebFullscreenLoadingModerationOverlay extends ConsumerStatefulWidget {
   const _WebFullscreenLoadingModerationOverlay({required this.video});
 
   final VideoEvent video;
+
+  @override
+  ConsumerState<_WebFullscreenLoadingModerationOverlay> createState() =>
+      _WebFullscreenLoadingModerationOverlayState();
+}
+
+class _WebFullscreenLoadingModerationOverlayState
+    extends ConsumerState<_WebFullscreenLoadingModerationOverlay> {
+  bool _dismissedAfterVerify = false;
+
+  Future<void> _verifyAge() async {
+    final videoUrl = widget.video.videoUrl;
+    if (videoUrl == null || videoUrl.isEmpty) return;
+
+    final headers = await ref
+        .read(mediaAuthInterceptorProvider)
+        .handleUnauthorizedMedia(
+          context: context,
+          sha256Hash: VideoModerationStatusService.resolveSha256(
+            explicitSha256: widget.video.sha256,
+            videoUrl: videoUrl,
+          ),
+          url: videoUrl,
+          serverUrl: _extractServerUrl(videoUrl),
+          category: 'video',
+        );
+    if (headers == null || !mounted) return;
+
+    setState(() {
+      _dismissedAfterVerify = true;
+    });
+  }
+
+  String? _extractServerUrl(String videoUrl) {
+    try {
+      final uri = Uri.parse(videoUrl);
+      final portSuffix = uri.hasPort ? ':${uri.port}' : '';
+      return '${uri.scheme}://${uri.host}$portSuffix';
+    } catch (_) {
+      return null;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final isRestricted = context.select(
       (FeedLoadingModerationCubit cubit) => cubit.state.isRestricted,
     );
-    if (!isRestricted) return const SizedBox.shrink();
+    if (!isRestricted || _dismissedAfterVerify) return const SizedBox.shrink();
+
+    final sha256 = VideoModerationStatusService.resolveSha256(
+      explicitSha256: widget.video.sha256,
+      videoUrl: widget.video.videoUrl,
+    );
+    final moderationStatus = sha256 == null
+        ? null
+        : ref
+              .watch(videoModerationStatusProvider(sha256))
+              .whenOrNull(data: (status) => status);
+    final isAgeRestricted = moderationStatus?.ageRestricted ?? false;
 
     return Positioned.fill(
       child: PooledVideoErrorOverlay(
-        video: video,
+        video: widget.video,
         onRetry: () {},
+        onVerifyAge: isAgeRestricted ? _verifyAge : null,
         errorType: VideoErrorType.notFound,
       ),
     );

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -30,6 +30,7 @@ import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_error_listener.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
+import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/utils/pooled_player_logger.dart';
@@ -1264,10 +1265,18 @@ class _PooledVideoFeedItemContentState
             WidgetsBinding.instance.addPostFrameCallback((_) {
               cubit.report(video.id, playbackStatusFromError(feedErrorType));
             });
-            return PooledVideoErrorOverlay(
-              video: video,
-              onRetry: onRetry,
-              errorType: feedErrorType,
+            return Consumer(
+              builder: (context, ref, _) => PooledVideoErrorOverlay(
+                video: video,
+                onRetry: onRetry,
+                onVerifyAge: () => retryAgeRestrictedPooledVideo(
+                  context: context,
+                  ref: ref,
+                  video: video,
+                  index: widget.index,
+                ),
+                errorType: feedErrorType,
+              ),
             );
           },
           overlayBuilder: (context, videoController, player, feedController) =>

--- a/mobile/lib/services/video_moderation_status_service.dart
+++ b/mobile/lib/services/video_moderation_status_service.dart
@@ -147,17 +147,23 @@ class VideoModerationStatusService {
     http.Client? httpClient,
     List<Uri>? endpointBases,
     Duration? cacheTtl,
+    Duration? requestTimeout,
   }) : _httpClient = httpClient ?? http.Client(),
        _endpointBases =
            endpointBases ??
            const [
              'https://moderation-api.divine.video',
            ].map(Uri.parse).toList(),
-       _cacheTtl = cacheTtl ?? const Duration(minutes: 10);
+       _cacheTtl = cacheTtl ?? const Duration(minutes: 10),
+       _requestTimeout = requestTimeout ?? _defaultRequestTimeout;
+
+  static const _defaultRequestTimeout = Duration(seconds: 3);
+  static const _userAgent = 'DivineMobile/1.0';
 
   final http.Client _httpClient;
   final List<Uri> _endpointBases;
   final Duration _cacheTtl;
+  final Duration _requestTimeout;
 
   final Map<String, _CachedModerationStatus> _cache = {};
   final Map<String, Future<VideoModerationStatus?>> _inflight = {};
@@ -186,7 +192,12 @@ class VideoModerationStatusService {
     for (final base in _endpointBases) {
       final uri = base.resolve('/check-result/$sha256');
       try {
-        final response = await _httpClient.get(uri);
+        final response = await _httpClient
+            .get(
+              uri,
+              headers: const {'user-agent': _userAgent},
+            )
+            .timeout(_requestTimeout);
         if (response.statusCode != 200) {
           continue;
         }

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -289,6 +289,12 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           return PooledVideoErrorOverlay(
             video: video,
             onRetry: onRetry,
+            onVerifyAge: () => retryAgeRestrictedPooledVideo(
+              context: context,
+              ref: ref,
+              video: video,
+              index: index,
+            ),
             errorType: errorType,
             shouldPortraitExpand: widget.shouldPortraitExpand,
             isSquare: isSquare,
@@ -802,7 +808,7 @@ class _FeedLoadingOrRestrictedOverlay extends ConsumerWidget {
   }
 }
 
-class _FeedLoadingOrRestrictedOverlayView extends StatelessWidget {
+class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
   const _FeedLoadingOrRestrictedOverlayView({
     required this.video,
     required this.index,
@@ -818,7 +824,7 @@ class _FeedLoadingOrRestrictedOverlayView extends StatelessWidget {
   final bool shouldPortraitExpand;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final isRestricted = context.select(
       (FeedLoadingModerationCubit c) => c.state.isRestricted,
     );
@@ -828,6 +834,12 @@ class _FeedLoadingOrRestrictedOverlayView extends StatelessWidget {
         video: video,
         // Retry is hidden for moderation-restricted content.
         onRetry: () {},
+        onVerifyAge: () => retryAgeRestrictedPooledVideo(
+          context: context,
+          ref: ref,
+          video: video,
+          index: index,
+        ),
         errorType: VideoErrorType.notFound,
         shouldPortraitExpand: shouldPortraitExpand,
         isSquare: isSquare,

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -27,6 +27,7 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
     required this.video,
     required this.onRetry,
     required this.errorType,
+    this.onVerifyAge,
     this.shouldPortraitExpand = true,
     this.isSquare = false,
     super.key,
@@ -34,6 +35,7 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
 
   final VideoEvent video;
   final VoidCallback onRetry;
+  final VoidCallback? onVerifyAge;
   final VideoErrorType? errorType;
 
   /// Mirrors `InfiniteVideoFeed.shouldPortraitExpand`. When `false`, the
@@ -75,30 +77,49 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
     final moderationStatus = moderationAsync?.whenOrNull(
       data: (status) => status,
     );
+    final isModerationAgeRestricted =
+        shouldEnrichNotFoundWithModeration &&
+        moderationStatus != null &&
+        moderationStatus.ageRestricted;
     final isModerationRestricted =
         type == VideoErrorType.forbidden ||
         (shouldEnrichNotFoundWithModeration &&
             moderationStatus != null &&
             moderationStatus.isUnavailableDueToModeration);
+    final isAgeRestricted =
+        type == VideoErrorType.ageRestricted || isModerationAgeRestricted;
 
-    final DivineIconName icon = switch ((type, isModerationRestricted)) {
-      (VideoErrorType.ageRestricted, _) => DivineIconName.lockSimple,
-      (VideoErrorType.notFound, true) => DivineIconName.shieldCheck,
-      (VideoErrorType.notFound, false) => DivineIconName.warningCircle,
-      (_, true) => DivineIconName.shieldCheck,
+    final DivineIconName icon = switch ((
+      type,
+      isAgeRestricted,
+      isModerationRestricted,
+    )) {
+      (_, true, _) => DivineIconName.lockSimple,
+      (VideoErrorType.notFound, false, true) => DivineIconName.shieldCheck,
+      (VideoErrorType.notFound, false, false) => DivineIconName.warningCircle,
+      (_, false, true) => DivineIconName.shieldCheck,
       _ => DivineIconName.warningCircle,
     };
 
-    final message = switch ((type, isModerationRestricted)) {
-      (VideoErrorType.ageRestricted, _) => context.l10n.videoErrorAgeRestricted,
-      (VideoErrorType.notFound, true) =>
+    final message = switch ((type, isAgeRestricted, isModerationRestricted)) {
+      (_, true, _) => context.l10n.videoErrorAgeRestricted,
+      (VideoErrorType.notFound, false, true) =>
         context.l10n.videoErrorContentRestricted,
-      (VideoErrorType.notFound, false) => context.l10n.videoErrorNotFound,
-      (VideoErrorType.forbidden, _) => context.l10n.videoErrorContentRestricted,
-      (VideoErrorType.generic, _) => context.l10n.videoErrorPlayback,
+      (VideoErrorType.notFound, false, false) =>
+        context.l10n.videoErrorNotFound,
+      (VideoErrorType.forbidden, false, _) =>
+        context.l10n.videoErrorContentRestricted,
+      (VideoErrorType.ageRestricted, false, _) =>
+        context.l10n.videoErrorAgeRestricted,
+      (VideoErrorType.generic, false, _) => context.l10n.videoErrorPlayback,
     };
-
-    final showRetry = !isModerationRestricted;
+    final body = isAgeRestricted
+        ? context.l10n.videoErrorVerifyAgeBody
+        : isModerationRestricted
+        ? context.l10n.videoErrorContentRestrictedBody
+        : null;
+    final showVerifyAge = isAgeRestricted && onVerifyAge != null;
+    final showRetry = !isModerationRestricted && !showVerifyAge;
 
     return Stack(
       fit: StackFit.expand,
@@ -130,6 +151,22 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
                   style: VineTheme.bodyMediumFont(),
                   textAlign: TextAlign.center,
                 ),
+                if (body != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 32),
+                    child: Text(
+                      body,
+                      style: VineTheme.bodySmallFont(),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                if (showVerifyAge)
+                  DivineButton(
+                    label: context.l10n.videoErrorVerifyAgeButton,
+                    type: DivineButtonType.tertiary,
+                    size: DivineButtonSize.small,
+                    onPressed: onVerifyAge,
+                  ),
                 if (showRetry)
                   DivineButton(
                     label: context.l10n.videoErrorRetry,

--- a/mobile/test/blocs/feed_loading_moderation/feed_loading_moderation_cubit_test.dart
+++ b/mobile/test/blocs/feed_loading_moderation/feed_loading_moderation_cubit_test.dart
@@ -50,13 +50,11 @@ void main() {
   FeedLoadingModerationCubit buildCubit({
     String? explicitSha256,
     String? videoUrl,
-    Duration checkDelay = const Duration(seconds: 2),
   }) {
     return FeedLoadingModerationCubit(
       service: mockService,
       explicitSha256: explicitSha256,
       videoUrl: videoUrl,
-      checkDelay: checkDelay,
     );
   }
 
@@ -97,24 +95,8 @@ void main() {
         });
       });
 
-      test('does not emit restricted before the delay elapses', () {
-        when(
-          () => mockService.fetchStatus(sha256),
-        ).thenAnswer((_) async => blockedStatus);
-
-        fakeAsync((fake) {
-          final cubit = buildCubit(videoUrl: divineUrl);
-          cubit.start();
-          fake.elapse(const Duration(milliseconds: 1999));
-          fake.flushMicrotasks();
-          expect(cubit.state.isRestricted, isFalse);
-          cubit.close();
-          fake.flushMicrotasks();
-        });
-      });
-
       test(
-        'emits restricted after delay when service returns a blocked status',
+        'emits restricted immediately when service returns a blocked status',
         () {
           when(
             () => mockService.fetchStatus(sha256),
@@ -123,7 +105,6 @@ void main() {
           fakeAsync((fake) {
             final cubit = buildCubit(videoUrl: divineUrl);
             cubit.start();
-            fake.elapse(const Duration(seconds: 2));
             fake.flushMicrotasks();
             expect(cubit.state.isRestricted, isTrue);
             verify(() => mockService.fetchStatus(sha256)).called(1);
@@ -215,19 +196,6 @@ void main() {
       );
     });
 
-    group('close', () {
-      test('cancels the timer so fetchStatus is never called', () {
-        fakeAsync((fake) {
-          final cubit = buildCubit(videoUrl: divineUrl);
-          cubit.start();
-          cubit.close();
-          fake.elapse(const Duration(seconds: 3));
-          fake.flushMicrotasks();
-          verifyNever(() => mockService.fetchStatus(any()));
-        });
-      });
-    });
-
     group('error handling', () {
       blocTest<FeedLoadingModerationCubit, FeedLoadingModerationState>(
         'calls addError and stays loading when fetchStatus throws',
@@ -239,7 +207,6 @@ void main() {
             service: mockService,
             explicitSha256: sha256,
             videoUrl: divineUrl,
-            checkDelay: Duration.zero,
           );
         },
         act: (cubit) => cubit.start(),

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
@@ -10,8 +10,10 @@ import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
@@ -31,6 +33,25 @@ class _MockVideoModerationStatusService extends Mock
 
 class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
     implements VideoVolumeCubit {}
+
+class _FakeMediaAuthInterceptor implements MediaAuthInterceptor {
+  bool didHandleUnauthorizedMedia = false;
+
+  @override
+  bool get canCreateAuthHeaders => true;
+
+  @override
+  Future<Map<String, String>?> handleUnauthorizedMedia({
+    required BuildContext context,
+    String? sha256Hash,
+    String? url,
+    String? serverUrl,
+    String? category,
+  }) async {
+    didHandleUnauthorizedMedia = true;
+    return {'Authorization': 'Bearer test'};
+  }
+}
 
 const _testVideoId =
     'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
@@ -202,5 +223,77 @@ void main() {
         () => moderationService.fetchStatus(sha256),
       ).called(greaterThan(0));
     }, skip: !kIsWeb);
+
+    testWidgets(
+      'renders verify age action for age-restricted web loading overlay',
+      (tester) async {
+        const sha256 =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+        final video = createTestVideoEvent(
+          id: _testVideoId,
+          pubkey: _testPubkey,
+          sha256: sha256,
+          videoUrl: 'https://media.divine.video/$sha256',
+        );
+        final state = FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [video],
+        );
+        final moderationService = _MockVideoModerationStatusService();
+        final mediaAuthInterceptor = _FakeMediaAuthInterceptor();
+        when(() => mockBloc.state).thenReturn(state);
+        when(() => moderationService.fetchStatus(sha256)).thenAnswer(
+          (_) async => const VideoModerationStatus(
+            moderated: true,
+            blocked: false,
+            quarantined: false,
+            ageRestricted: true,
+            needsReview: false,
+            aiGenerated: false,
+          ),
+        );
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              videoModerationStatusServiceProvider.overrideWithValue(
+                moderationService,
+              ),
+              mediaAuthInterceptorProvider.overrideWith(
+                (ref) => mediaAuthInterceptor,
+              ),
+            ],
+            mockAuthService: mockAuthService,
+            mockProfileRepository: mockProfileRepository,
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<FullscreenFeedBloc>.value(value: mockBloc),
+                BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+                BlocProvider<VideoPlaybackStatusCubit>(
+                  create: (_) => VideoPlaybackStatusCubit(),
+                ),
+              ],
+              child: FullscreenFeedContent(
+                webControllerFactory: ({required url, required headers}) =>
+                    webController,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoErrorAgeRestricted), findsOneWidget);
+        expect(find.text(l10n.videoErrorVerifyAgeButton), findsOneWidget);
+
+        await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
+        await tester.pump();
+
+        expect(mediaAuthInterceptor.didHandleUnauthorizedMedia, isTrue);
+        expect(find.text(l10n.videoErrorAgeRestricted), findsNothing);
+      },
+      skip: !kIsWeb,
+    );
   });
 }

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
@@ -2,12 +2,17 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
-import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart'
@@ -21,6 +26,12 @@ class MockFullscreenFeedBloc
     extends MockBloc<FullscreenFeedEvent, FullscreenFeedState>
     implements FullscreenFeedBloc {}
 
+class _MockVideoModerationStatusService extends Mock
+    implements VideoModerationStatusService {}
+
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
+
 const _testVideoId =
     'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
 const _testPubkey =
@@ -31,6 +42,7 @@ void main() {
     late MockFullscreenFeedBloc mockBloc;
     late MockAuthService mockAuthService;
     late MockProfileRepository mockProfileRepository;
+    late _MockVideoVolumeCubit videoVolumeCubit;
     late StreamController<FullscreenFeedState> stateController;
     late video_platform.VideoPlayerPlatform originalPlatform;
     late FakeVideoPlayerController webController;
@@ -43,12 +55,14 @@ void main() {
       mockBloc = MockFullscreenFeedBloc();
       mockAuthService = createMockAuthService();
       mockProfileRepository = createMockProfileRepository();
+      videoVolumeCubit = _MockVideoVolumeCubit();
       stateController = StreamController<FullscreenFeedState>.broadcast();
       originalPlatform = video_platform.VideoPlayerPlatform.instance;
       video_platform.VideoPlayerPlatform.instance = FakeVideoPlayerPlatform();
       webController = FakeVideoPlayerController();
 
       when(() => mockBloc.stream).thenAnswer((_) => stateController.stream);
+      when(() => videoVolumeCubit.state).thenReturn(const VideoVolumeState());
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
     });
 
@@ -71,8 +85,14 @@ void main() {
         testMaterialApp(
           mockAuthService: mockAuthService,
           mockProfileRepository: mockProfileRepository,
-          home: BlocProvider<FullscreenFeedBloc>.value(
-            value: mockBloc,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<FullscreenFeedBloc>.value(value: mockBloc),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+            ],
             child: FullscreenFeedContent(
               webControllerFactory: ({required url, required headers}) =>
                   webController,
@@ -86,7 +106,7 @@ void main() {
       expect(find.byType(VideoOverlayActions), findsOneWidget);
     }, skip: !kIsWeb);
 
-    testWidgets('renders Auto action in the fullscreen web overlay', (
+    testWidgets('renders settings menu in the fullscreen web overlay', (
       tester,
     ) async {
       final video = createTestVideoEvent(id: _testVideoId, pubkey: _testPubkey);
@@ -100,8 +120,14 @@ void main() {
         testMaterialApp(
           mockAuthService: mockAuthService,
           mockProfileRepository: mockProfileRepository,
-          home: BlocProvider<FullscreenFeedBloc>.value(
-            value: mockBloc,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<FullscreenFeedBloc>.value(value: mockBloc),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+            ],
             child: FullscreenFeedContent(
               webControllerFactory: ({required url, required headers}) =>
                   webController,
@@ -111,7 +137,70 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.byType(AutoActionButton), findsOneWidget);
+      expect(find.byType(FeedSettingsMenu), findsOneWidget);
+    }, skip: !kIsWeb);
+
+    testWidgets('renders restricted content while web video is loading', (
+      tester,
+    ) async {
+      const sha256 =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final video = createTestVideoEvent(
+        id: _testVideoId,
+        pubkey: _testPubkey,
+        sha256: sha256,
+        videoUrl: 'https://media.divine.video/$sha256',
+      );
+      final state = FullscreenFeedState(
+        status: FullscreenFeedStatus.ready,
+        videos: [video],
+      );
+      final moderationService = _MockVideoModerationStatusService();
+      when(() => mockBloc.state).thenReturn(state);
+      when(() => moderationService.fetchStatus(sha256)).thenAnswer(
+        (_) async => const VideoModerationStatus(
+          moderated: true,
+          blocked: true,
+          quarantined: false,
+          ageRestricted: false,
+          needsReview: false,
+          aiGenerated: false,
+        ),
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          additionalOverrides: [
+            videoModerationStatusServiceProvider.overrideWithValue(
+              moderationService,
+            ),
+          ],
+          mockAuthService: mockAuthService,
+          mockProfileRepository: mockProfileRepository,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<FullscreenFeedBloc>.value(value: mockBloc),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+            ],
+            child: FullscreenFeedContent(
+              webControllerFactory: ({required url, required headers}) =>
+                  webController,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.videoErrorContentRestricted), findsOneWidget);
+      expect(find.text(l10n.videoErrorContentRestrictedBody), findsOneWidget);
+      verify(
+        () => moderationService.fetchStatus(sha256),
+      ).called(greaterThan(0));
     }, skip: !kIsWeb);
   });
 }

--- a/mobile/test/services/video_moderation_status_service_test.dart
+++ b/mobile/test/services/video_moderation_status_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -157,11 +158,17 @@ void main() {
     test('falls back when a moderation request times out', () async {
       const hash =
           'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+      final firstResponse = Completer<http.Response>();
+
+      addTearDown(() {
+        if (!firstResponse.isCompleted) {
+          firstResponse.complete(http.Response('late', 200));
+        }
+      });
 
       final client = MockClient((request) async {
         if (request.url.host == 'first.example') {
-          await Future<void>.delayed(const Duration(minutes: 1));
-          return http.Response('late', 200);
+          return firstResponse.future;
         }
 
         return http.Response(
@@ -194,6 +201,10 @@ void main() {
           ),
         ),
       );
+
+      if (!firstResponse.isCompleted) {
+        firstResponse.complete(http.Response('late', 200));
+      }
     });
 
     test('falls back across endpoints and caches result', () async {

--- a/mobile/test/services/video_moderation_status_service_test.dart
+++ b/mobile/test/services/video_moderation_status_service_test.dart
@@ -128,6 +128,74 @@ void main() {
       expect(requestedUri.path, '/check-result/$hash');
     });
 
+    test('sends a user agent with moderation requests', () async {
+      const hash =
+          'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+      late Map<String, String> requestHeaders;
+      final client = MockClient((request) async {
+        requestHeaders = request.headers;
+        return http.Response(
+          jsonEncode({
+            'moderated': true,
+            'blocked': false,
+            'age_restricted': false,
+            'needs_review': false,
+            'action': 'SAFE',
+          }),
+          200,
+        );
+      });
+
+      final service = VideoModerationStatusService(httpClient: client);
+
+      await service.fetchStatus(hash);
+
+      expect(requestHeaders['user-agent'], isNotEmpty);
+    });
+
+    test('falls back when a moderation request times out', () async {
+      const hash =
+          'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+      final client = MockClient((request) async {
+        if (request.url.host == 'first.example') {
+          await Future<void>.delayed(const Duration(minutes: 1));
+          return http.Response('late', 200);
+        }
+
+        return http.Response(
+          jsonEncode({
+            'moderated': true,
+            'blocked': true,
+            'age_restricted': false,
+            'needs_review': true,
+            'action': 'PERMANENT_BAN',
+          }),
+          200,
+        );
+      });
+      final service = VideoModerationStatusService(
+        httpClient: client,
+        endpointBases: [
+          Uri.parse('https://first.example'),
+          Uri.parse('https://second.example'),
+        ],
+        requestTimeout: const Duration(milliseconds: 10),
+      );
+
+      await expectLater(
+        service.fetchStatus(hash).timeout(const Duration(milliseconds: 100)),
+        completion(
+          isA<VideoModerationStatus>().having(
+            (status) => status.isUnavailableDueToModeration,
+            'isUnavailableDueToModeration',
+            isTrue,
+          ),
+        ),
+      );
+    });
+
     test('falls back across endpoints and caches result', () async {
       const hash =
           'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -23,6 +23,7 @@ void main() {
     late VideoEvent divineVideo;
     late VideoEvent thirdPartyVideo;
     late bool retryPressed;
+    late bool verifyAgePressed;
 
     // Valid 64-char hex sha256 for moderation status resolution.
     const testSha256 =
@@ -38,6 +39,7 @@ void main() {
         videoUrl: 'https://cdn.example.com/video.mp4',
       );
       retryPressed = false;
+      verifyAgePressed = false;
     });
 
     Widget buildWidget({VideoErrorType? errorType, VideoEvent? video}) {
@@ -65,6 +67,7 @@ void main() {
       required VideoErrorType? errorType,
       required VideoModerationStatus moderationStatus,
       VideoEvent? video,
+      VoidCallback? onVerifyAge,
     }) {
       return ProviderScope(
         overrides: [
@@ -79,6 +82,7 @@ void main() {
             body: PooledVideoErrorOverlay(
               video: video ?? divineVideo,
               onRetry: () => retryPressed = true,
+              onVerifyAge: onVerifyAge,
               errorType: errorType,
             ),
           ),
@@ -186,6 +190,39 @@ void main() {
 
           expect(_findDivineIcon(DivineIconName.shieldCheck), findsOneWidget);
           expect(find.text('Content restricted'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'shows age-gated explanation and verify action when moderation status is ageRestricted',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidgetWithModeration(
+              errorType: VideoErrorType.notFound,
+              moderationStatus: const VideoModerationStatus(
+                moderated: true,
+                blocked: false,
+                quarantined: false,
+                ageRestricted: true,
+                needsReview: false,
+                aiGenerated: false,
+              ),
+              onVerifyAge: () => verifyAgePressed = true,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('Age-restricted content'), findsOneWidget);
+          expect(
+            find.text('Verify your age to view this video.'),
+            findsOneWidget,
+          );
+          expect(find.text('Verify age'), findsOneWidget);
+          expect(find.text('Retry'), findsNothing);
+
+          await tester.tap(find.text('Verify age'));
+
+          expect(verifyAgePressed, isTrue);
         },
       );
 

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -24,6 +24,7 @@ void main() {
     late VideoEvent thirdPartyVideo;
     late bool retryPressed;
     late bool verifyAgePressed;
+    late AppLocalizations l10n;
 
     // Valid 64-char hex sha256 for moderation status resolution.
     const testSha256 =
@@ -40,6 +41,7 @@ void main() {
       );
       retryPressed = false;
       verifyAgePressed = false;
+      l10n = lookupAppLocalizations(const Locale('en'));
     });
 
     Widget buildWidget({VideoErrorType? errorType, VideoEvent? video}) {
@@ -98,7 +100,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(_findDivineIcon(DivineIconName.shieldCheck), findsOneWidget);
-        expect(find.text('Content restricted'), findsOneWidget);
+        expect(find.text(l10n.videoErrorContentRestricted), findsOneWidget);
       });
 
       testWidgets('does not show retry button', (tester) async {
@@ -107,7 +109,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Retry'), findsNothing);
+        expect(find.text(l10n.videoErrorRetry), findsNothing);
       });
     });
 
@@ -121,7 +123,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(_findDivineIcon(DivineIconName.lockSimple), findsOneWidget);
-        expect(find.text('Age-restricted content'), findsOneWidget);
+        expect(find.text(l10n.videoErrorAgeRestricted), findsOneWidget);
       });
 
       testWidgets('shows Retry button', (tester) async {
@@ -130,7 +132,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text(l10n.videoErrorRetry), findsOneWidget);
       });
     });
 
@@ -142,8 +144,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.text('Video not found'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text(l10n.videoErrorNotFound), findsOneWidget);
+        expect(find.text(l10n.videoErrorRetry), findsOneWidget);
       });
 
       testWidgets(
@@ -165,8 +167,8 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(_findDivineIcon(DivineIconName.shieldCheck), findsOneWidget);
-          expect(find.text('Content restricted'), findsOneWidget);
-          expect(find.text('Retry'), findsNothing);
+          expect(find.text(l10n.videoErrorContentRestricted), findsOneWidget);
+          expect(find.text(l10n.videoErrorRetry), findsNothing);
         },
       );
 
@@ -189,7 +191,7 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(_findDivineIcon(DivineIconName.shieldCheck), findsOneWidget);
-          expect(find.text('Content restricted'), findsOneWidget);
+          expect(find.text(l10n.videoErrorContentRestricted), findsOneWidget);
         },
       );
 
@@ -212,15 +214,12 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          expect(find.text('Age-restricted content'), findsOneWidget);
-          expect(
-            find.text('Verify your age to view this video.'),
-            findsOneWidget,
-          );
-          expect(find.text('Verify age'), findsOneWidget);
-          expect(find.text('Retry'), findsNothing);
+          expect(find.text(l10n.videoErrorAgeRestricted), findsOneWidget);
+          expect(find.text(l10n.videoErrorVerifyAgeBody), findsOneWidget);
+          expect(find.text(l10n.videoErrorVerifyAgeButton), findsOneWidget);
+          expect(find.text(l10n.videoErrorRetry), findsNothing);
 
-          await tester.tap(find.text('Verify age'));
+          await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
 
           expect(verifyAgePressed, isTrue);
         },
@@ -247,8 +246,8 @@ void main() {
 
         // Should show plain 404, not moderation-restricted.
         expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.text('Video not found'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text(l10n.videoErrorNotFound), findsOneWidget);
+        expect(find.text(l10n.videoErrorRetry), findsOneWidget);
       });
     });
 
@@ -263,8 +262,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.text('Video playback error'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text(l10n.videoErrorPlayback), findsOneWidget);
+        expect(find.text(l10n.videoErrorRetry), findsOneWidget);
       });
 
       testWidgets('shows generic error for null error type', (tester) async {
@@ -272,8 +271,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.text('Video playback error'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text(l10n.videoErrorPlayback), findsOneWidget);
+        expect(find.text(l10n.videoErrorRetry), findsOneWidget);
       });
 
       testWidgets(
@@ -295,8 +294,8 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(_findDivineIcon(DivineIconName.shieldCheck), findsOneWidget);
-          expect(find.text('Content restricted'), findsOneWidget);
-          expect(find.text('Retry'), findsNothing);
+          expect(find.text(l10n.videoErrorContentRestricted), findsOneWidget);
+          expect(find.text(l10n.videoErrorRetry), findsNothing);
         },
       );
     });
@@ -311,7 +310,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Retry'));
+        await tester.tap(find.text(l10n.videoErrorRetry));
         expect(retryPressed, isTrue);
       });
     });


### PR DESCRIPTION
Closes #4567

## Summary
- Restore explanatory copy in pooled restricted-content error overlays.
- Wire age-verification retry actions through feed, legacy pooled feed, and fullscreen pooled feed paths.
- Start SHA moderation status checks immediately during feed loading so known blocked media surfaces restricted UI before playback stall/failover paths.
- Harden moderation status lookups with a user agent and request timeout fallback.

## Test plan
- [x] dart format on changed files via pre-commit hook
- [x] Dart analyzer on changed files
- [x] Flutter widget tests: pooled_video_error_overlay_test.dart, feed_videos_test.dart, feed_video_overlay_test.dart, pooled_fullscreen_video_feed_screen_test.dart
- [x] Targeted analyzer: feed_loading_moderation_cubit.dart, video_moderation_status_service.dart, and related tests
- [x] Flutter tests: feed_loading_moderation_cubit_test.dart, video_moderation_status_service_test.dart, pooled_video_error_overlay_test.dart

🤖 Generated with [Claude Code](https://claude.com/claude-code)