### PR TITLE
fix(tags): reset search input when a suggestion is tapped

### DIFF
--- a/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
@@ -89,6 +89,7 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
        super(TagsPickerState(selectedTags: Set.of(initialTags))) {
     on<TagsPickerTagsAdded>(_onTagsAdded);
     on<TagsPickerTagRemoved>(_onTagRemoved);
+    on<TagsPickerSearchReset>(_onSearchReset);
     on<TagsPickerQueryChanged>(
       _onQueryChanged,
       transformer: debounceRestartable(),
@@ -129,6 +130,19 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
     if (!state.selectedTags.contains(event.tag)) return;
     final updated = Set<String>.of(state.selectedTags)..remove(event.tag);
     emit(state.copyWith(selectedTags: updated));
+  }
+
+  void _onSearchReset(
+    TagsPickerSearchReset event,
+    Emitter<TagsPickerState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        status: TagsPickerStatus.initial,
+        query: '',
+        suggestions: const [],
+      ),
+    );
   }
 
   Future<void> _onQueryChanged(

--- a/mobile/lib/blocs/tags_picker/tags_picker_event.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_event.dart
@@ -41,3 +41,12 @@ final class TagsPickerQueryChanged extends TagsPickerEvent {
   @override
   List<Object?> get props => [query];
 }
+
+/// The suggestion list was cleared synchronously (e.g. after a suggestion tap).
+///
+/// Unlike [TagsPickerQueryChanged], this event is not debounced — it resets
+/// [TagsPickerState.query] and [TagsPickerState.suggestions] immediately so
+/// stale results are never visible after the user commits a tag.
+final class TagsPickerSearchReset extends TagsPickerEvent {
+  const TagsPickerSearchReset();
+}

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -171,6 +171,12 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
   void _resetSearchInput() {
     _previousText = '';
+    // Synchronously clear the bloc's query/suggestions so stale results are
+    // never visible after a tag is committed. The controller clear below will
+    // also trigger _onSearchChanged which dispatches a debounced
+    // TagsPickerQueryChanged('') — that's fine, it will be a no-op once the
+    // query is already ''.
+    context.read<TagsPickerBloc>().add(const TagsPickerSearchReset());
     _searchController.value = const TextEditingValue();
   }
 

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -171,11 +171,7 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
   void _resetSearchInput() {
     _previousText = '';
-    if (_searchController.text.isNotEmpty) {
-      _searchController.value = const TextEditingValue();
-      return;
-    }
-    context.read<TagsPickerBloc>().add(const TagsPickerQueryChanged(''));
+    _searchController.value = const TextEditingValue();
   }
 
   void _removeTag(String tag) {

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -166,11 +166,16 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
   void _addTag(String raw) {
     context.read<TagsPickerBloc>().add(TagsPickerTagsAdded([raw]));
-    // Clear the field so the next suggestion tap / submit starts fresh.
+    _resetSearchInput();
+  }
+
+  void _resetSearchInput() {
+    _previousText = '';
     if (_searchController.text.isNotEmpty) {
-      _previousText = '';
-      _searchController.clear();
+      _searchController.value = const TextEditingValue();
+      return;
     }
+    context.read<TagsPickerBloc>().add(const TagsPickerQueryChanged(''));
   }
 
   void _removeTag(String tag) {

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -125,13 +125,19 @@ void main() {
 
         await tester.tap(musicSuggestion);
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 400));
 
+        // Immediate post-tap state: the synchronous TagsPickerSearchReset must
+        // have cleared the query and suggestions before the debounce fires.
         expect(
           tester.widget<TextField>(searchField).controller?.text,
           isEmpty,
         );
+        // No suggestion chip for the previous query ('mus') should be visible.
+        expect(find.text('mus'), findsNothing);
+        // Selected chip is present.
         expect(find.text('music'), findsOneWidget);
+
+        await tester.pump(const Duration(milliseconds: 400));
       },
     );
   });

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -86,6 +86,55 @@ void main() {
         await tester.pump(const Duration(milliseconds: 400));
       },
     );
+
+    testWidgets(
+      'tapping a suggestion clears the field and resets the search results',
+      (tester) async {
+        when(
+          () => hashtagRepository.searchHashtags(
+            query: 'mus',
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async => ['music']);
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            hashtagRepository: hashtagRepository,
+            videoEditorState: VideoEditorProviderState(),
+          ),
+        );
+
+        await tester.tap(
+          find.byType(VideoMetadataSelectionTile),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final searchField = find.byType(TextField).last;
+        expect(searchField, findsOneWidget);
+
+        await tester.enterText(searchField, 'mus');
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        final musicSuggestion = find.text('music');
+
+        expect(musicSuggestion, findsOneWidget);
+
+        await tester.tap(musicSuggestion);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(
+          tester.widget<TextField>(searchField).controller?.text,
+          isEmpty,
+        );
+        expect(musicSuggestion, findsOneWidget);
+        expect(find.text('music'), findsOneWidget);
+      },
+    );
   });
 }
 

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -131,7 +131,6 @@ void main() {
           tester.widget<TextField>(searchField).controller?.text,
           isEmpty,
         );
-        expect(musicSuggestion, findsOneWidget);
         expect(find.text('music'), findsOneWidget);
       },
     );


### PR DESCRIPTION
Closes #4570

## Description

This PR fixes the tags picker so selecting a suggested tag clears the search input and resets the search state immediately. That keeps stale suggestions from remaining visible after a tag is added and makes repeated tag selection feel consistent.

It also adds widget test coverage for the suggestion-tap flow, verifying that tapping a suggested tag clears the text field and updates the UI as expected.

**Related Issue:** 

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore