### PR TITLE
feat(notifications): mark all read on leave and fix mark-read sync

### DIFF
--- a/mobile/lib/notifications/providers/notification_repository_provider.dart
+++ b/mobile/lib/notifications/providers/notification_repository_provider.dart
@@ -46,7 +46,7 @@ final notificationRepositoryProvider = Provider<NotificationRepository?>((ref) {
     notificationsDao: db.notificationsDao,
     userPubkey: userPubkey,
     blockFilter: blocklistRepository.shouldFilterFromFeeds,
-    authHeadersProvider: (url, method) async {
+    authHeadersProvider: (url, method, {body}) async {
       final httpMethod = switch (method.toUpperCase()) {
         'POST' => HttpMethod.post,
         'PUT' => HttpMethod.put,
@@ -54,9 +54,13 @@ final notificationRepositoryProvider = Provider<NotificationRepository?>((ref) {
         'PATCH' => HttpMethod.patch,
         _ => HttpMethod.get,
       };
+      // Forward the request body so the NIP-98 `payload` tag hashes the
+      // bytes the request actually sends — without this the server 401s
+      // with `payload hash mismatch` and mark-read silently rolls back.
       final token = await nip98AuthService.createAuthToken(
         url: url,
         method: httpMethod,
+        payload: body,
       );
       if (token == null) return <String, String>{};
       return {'Authorization': token.authorizationHeader};

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -13,6 +13,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
+import 'package:openvine/notifications/widgets/mark_all_read_on_dispose.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/settings/invites_screen.dart';
 
@@ -45,7 +46,10 @@ class InboxNotificationsPage extends ConsumerWidget {
         notificationRepository: notificationRepository,
         followRepository: followRepository,
       )..add(const NotificationFeedStarted()),
-      child: const _InboxNotificationsScaffold(),
+      child: MarkAllReadOnDispose(
+        repository: notificationRepository,
+        child: const _InboxNotificationsScaffold(),
+      ),
     );
   }
 }

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -40,6 +40,12 @@ class InboxNotificationsPage extends ConsumerWidget {
     }
     final followRepository = ref.watch(followRepositoryProvider);
 
+    // Key on the watched dependency identities so the bloc rebuilds when
+    // either repository swaps (account switch, sign-out → sign-in, or
+    // provider invalidation). The upstream KeyedSubtree in `inbox_view.dart`
+    // already forces this subtree to remount on pubkey change today, but
+    // pinning the contract here keeps the page safe even if the inbox
+    // scaffold is restructured. See `.claude/rules/state_management.md`.
     return BlocProvider(
       key: ValueKey((notificationRepository, followRepository)),
       create: (_) => NotificationFeedBloc(

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -52,6 +52,14 @@ class NotificationsPage extends ConsumerWidget {
 
     final followRepository = ref.watch(followRepositoryProvider);
 
+    // Key on the watched dependency identities so the bloc rebuilds when
+    // either repository swaps (account switch, sign-out → sign-in, or
+    // provider invalidation). Without this the BlocProvider element
+    // persists across rebuilds and keeps the bloc bound to stale
+    // repositories, while any mark-on-leave wrapper inside the subtree
+    // would otherwise fire against whichever notification repository the
+    // rebuilt widget tree captured — i.e. the new user's notifications.
+    // See `.claude/rules/state_management.md`.
     return BlocProvider(
       key: ValueKey((notificationRepository, followRepository)),
       create: (_) => NotificationFeedBloc(

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
+import 'package:openvine/notifications/widgets/mark_all_read_on_dispose.dart';
 import 'package:openvine/providers/app_providers.dart';
 
 /// Top-level page for the notifications tab.
@@ -57,7 +58,10 @@ class NotificationsPage extends ConsumerWidget {
         notificationRepository: notificationRepository,
         followRepository: followRepository,
       )..add(const NotificationFeedStarted()),
-      child: const NotificationsView(),
+      child: MarkAllReadOnDispose(
+        repository: notificationRepository,
+        child: const NotificationsView(),
+      ),
     );
   }
 }

--- a/mobile/lib/notifications/widgets/mark_all_read_on_dispose.dart
+++ b/mobile/lib/notifications/widgets/mark_all_read_on_dispose.dart
@@ -37,6 +37,8 @@ class MarkAllReadOnDispose extends StatefulWidget {
 class _MarkAllReadOnDisposeState extends State<MarkAllReadOnDispose> {
   @override
   void dispose() {
+    // Call the repository directly here because it outlives the bloc teardown;
+    // dispatching a bloc event from dispose would race the bloc closing.
     unawaited(
       widget.repository.markAllAsRead().catchError((Object e, StackTrace s) {
         Log.warning(

--- a/mobile/lib/notifications/widgets/mark_all_read_on_dispose.dart
+++ b/mobile/lib/notifications/widgets/mark_all_read_on_dispose.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Stateful wrapper that calls NotificationRepository.markAllAsRead
+// ABOUTME: when its subtree is unmounted (user leaves the notifications view).
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Wraps a notifications subtree so that all currently-visible notifications
+/// are marked as read when the user leaves the screen.
+///
+/// The wrapper holds a reference to the [NotificationRepository] and fires
+/// `markAllAsRead()` once in [dispose]. The call is fire-and-forget — the
+/// repository optimistically flips the snapshot before awaiting the API,
+/// so the badge and feed reset to zero immediately and any rollback
+/// happens on the still-alive repository even after this widget is gone.
+class MarkAllReadOnDispose extends StatefulWidget {
+  /// Creates a [MarkAllReadOnDispose].
+  const MarkAllReadOnDispose({
+    required this.repository,
+    required this.child,
+    super.key,
+  });
+
+  /// The notification repository whose `markAllAsRead()` will be invoked
+  /// when this widget is disposed.
+  final NotificationRepository repository;
+
+  /// The subtree whose unmount triggers `markAllAsRead()`.
+  final Widget child;
+
+  @override
+  State<MarkAllReadOnDispose> createState() => _MarkAllReadOnDisposeState();
+}
+
+class _MarkAllReadOnDisposeState extends State<MarkAllReadOnDispose> {
+  @override
+  void dispose() {
+    unawaited(
+      widget.repository.markAllAsRead().catchError((Object e, StackTrace s) {
+        Log.warning(
+          'markAllAsRead on notifications leave failed: $e',
+          name: 'MarkAllReadOnDispose',
+          category: LogCategory.ui,
+        );
+      }),
+    );
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/mobile/lib/notifications/widgets/widgets.dart
+++ b/mobile/lib/notifications/widgets/widgets.dart
@@ -1,4 +1,5 @@
 export 'actor_notification_row.dart';
+export 'mark_all_read_on_dispose.dart';
 export 'notification_avatar_stack.dart';
 export 'notification_comment_quote.dart';
 export 'notification_empty_state.dart';

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -200,6 +200,29 @@ class FunnelcakeApiClient {
     ).replace(queryParameters: queryParams);
   }
 
+  /// Returns the full mark-notifications-read URI for the given user.
+  ///
+  /// Callers building NIP-98 auth headers must sign the same URL that the
+  /// HTTP request will use, including scheme + host. Use this helper to
+  /// avoid signing a path-only URL while the request goes out to a full
+  /// origin (the resulting `URL mismatch` 401 is the precise failure mode
+  /// PR #4034's rollback semantics treat as a hard failure).
+  Uri notificationsReadUri({required String pubkey}) =>
+      Uri.parse('$_baseUrl/api/users/$pubkey/notifications/read');
+
+  /// Builds the JSON body sent to [markNotificationsRead].
+  ///
+  /// Exposed so callers building NIP-98 auth headers can hash the exact
+  /// bytes that will land in the POST body — otherwise the auth event's
+  /// `payload` tag drifts from the request body and the server rejects
+  /// with `payload hash mismatch`.
+  ///
+  /// Passing `null` (or omitting [notificationIds]) marks all of the
+  /// user's unread notifications as read, per the funnelcake docs.
+  static String buildMarkNotificationsReadBody({
+    List<String>? notificationIds,
+  }) => jsonEncode({'notification_ids': ?notificationIds});
+
   /// Fetches videos by a specific author.
   ///
   /// [pubkey] is the author's public key (hex format).
@@ -2329,9 +2352,11 @@ class FunnelcakeApiClient {
       throw const FunnelcakeNotConfiguredException();
     }
 
-    final url = Uri.parse('$_baseUrl/api/users/$pubkey/notifications/read');
+    final url = notificationsReadUri(pubkey: pubkey);
 
-    final payload = jsonEncode({'notification_ids': ?notificationIds});
+    final payload = buildMarkNotificationsReadBody(
+      notificationIds: notificationIds,
+    );
 
     try {
       final response = await _httpClient

--- a/mobile/packages/funnelcake_api_client/lib/src/models/notification_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/notification_response.dart
@@ -53,11 +53,21 @@ class MarkReadResponse {
   });
 
   /// Parses the REST response body into a typed mark-read payload.
+  ///
+  /// The funnelcake server returns `{"marked_count": N, "marked_all": bool}`
+  /// on success and `{"error": "..."}` on soft-failure. The `success` field
+  /// that #4271 introduced was speculative — the real funnelcake response
+  /// never sends it, so defaulting to `false` made every successful 200
+  /// parse as a soft-failure (badge bounce-back from the repository
+  /// rollback). Accept the explicit `success` value when present (for
+  /// forward-compat with a server that adopts the field), otherwise derive
+  /// it from the absence of `error`.
   factory MarkReadResponse.fromJson(Map<String, dynamic> json) {
+    final error = json['error'] as String?;
     return MarkReadResponse(
-      success: json['success'] as bool? ?? false,
+      success: (json['success'] as bool?) ?? (error == null),
       markedCount: json['marked_count'] as int? ?? 0,
-      error: json['error'] as String?,
+      error: error,
     );
   }
 

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
@@ -431,7 +431,7 @@ void main() {
           ),
         ).thenAnswer(
           (_) async => http.Response(
-            jsonEncode({'success': true, 'marked_count': 5}),
+            jsonEncode({'marked_count': 5, 'marked_all': true}),
             200,
           ),
         );
@@ -463,7 +463,7 @@ void main() {
           ),
         ).thenAnswer(
           (_) async => http.Response(
-            jsonEncode({'success': true, 'marked_count': 0}),
+            jsonEncode({'marked_count': 0, 'marked_all': true}),
             200,
           ),
         );
@@ -493,7 +493,7 @@ void main() {
           ),
         ).thenAnswer(
           (_) async => http.Response(
-            jsonEncode({'success': true, 'marked_count': 2}),
+            jsonEncode({'marked_count': 2, 'marked_all': false}),
             200,
           ),
         );
@@ -588,25 +588,38 @@ void main() {
         );
       });
 
-      test('parses successful mark-read response', () async {
-        when(
-          () => mockHttpClient.post(
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => http.Response(
-            jsonEncode({'success': true, 'marked_count': 10}),
-            200,
-          ),
-        );
+      test(
+        'parses real funnelcake response shape (no `success` field) as '
+        'success',
+        () async {
+          // Per https://relay.divine.video/docs/llm-guide, the server
+          // returns {"marked_count": N, "marked_all": bool} on success and
+          // does NOT send a `success` field. PR #4271 introduced the
+          // soft-failure throw against a synthetic `success: true` field
+          // that never actually arrives — pre-PR this caused every
+          // mark-read call to throw and the repository to roll back the
+          // optimistic snapshot.
+          when(
+            () => mockHttpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => http.Response(
+              jsonEncode({'marked_count': 10, 'marked_all': true}),
+              200,
+            ),
+          );
 
-        final response = await client.markNotificationsRead(pubkey: testPubkey);
+          final response = await client.markNotificationsRead(
+            pubkey: testPubkey,
+          );
 
-        expect(response.success, isTrue);
-        expect(response.markedCount, equals(10));
-      });
+          expect(response.success, isTrue);
+          expect(response.markedCount, equals(10));
+        },
+      );
 
       test(
         'throws FunnelcakeApiException on 200 with success: false',

--- a/mobile/packages/funnelcake_api_client/test/src/models/notification_response_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/notification_response_test.dart
@@ -59,7 +59,7 @@ void main() {
   });
 
   group('MarkReadResponse', () {
-    test('parses success response', () {
+    test('honors explicit `success: true` when the server sends it', () {
       final json = {
         'success': true,
         'marked_count': 10,
@@ -72,7 +72,7 @@ void main() {
       expect(response.error, isNull);
     });
 
-    test('parses failure response with error', () {
+    test('honors explicit `success: false` when the server sends it', () {
       final json = {
         'success': false,
         'marked_count': 0,
@@ -86,10 +86,44 @@ void main() {
       expect(response.error, equals('unauthorized'));
     });
 
-    test('handles missing fields with defaults', () {
-      final response = MarkReadResponse.fromJson(<String, dynamic>{});
+    test(
+      'treats the real funnelcake response shape (no `success` field) as '
+      'success',
+      () {
+        // Per https://relay.divine.video/docs/llm-guide the server
+        // returns {"marked_count": N, "marked_all": bool} on success.
+        // There is no `success` field — PR #4271 assumed one and
+        // defaulted to `false`, which made every successful mark-read
+        // parse as a soft-failure and bounce the notifications badge
+        // back up via the repository's rollback path.
+        final json = {'marked_count': 5, 'marked_all': true};
+
+        final response = MarkReadResponse.fromJson(json);
+
+        expect(response.success, isTrue);
+        expect(response.markedCount, equals(5));
+        expect(response.error, isNull);
+      },
+    );
+
+    test('treats a body with an `error` field as failure', () {
+      // No `success` field but an `error` string → still a failure.
+      final json = {'error': 'token rejected'};
+
+      final response = MarkReadResponse.fromJson(json);
 
       expect(response.success, isFalse);
+      expect(response.markedCount, equals(0));
+      expect(response.error, equals('token rejected'));
+    });
+
+    test('treats an empty body as success (no error reported)', () {
+      // Degenerate empty body: server returned 200 with `{}`. Since
+      // there is no `error`, treat as success — the repository's
+      // optimistic flip already happened and no rollback is needed.
+      final response = MarkReadResponse.fromJson(<String, dynamic>{});
+
+      expect(response.success, isTrue);
       expect(response.markedCount, equals(0));
       expect(response.error, isNull);
     });

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -19,6 +19,21 @@ import 'package:rxdart/rxdart.dart' hide NotificationKind;
 import 'package:text_sanitizer/text_sanitizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Callback that returns NIP-98 auth headers for an outgoing request.
+///
+/// The repository invokes this with the **full** URL the request will use
+/// (scheme + host + path + query) and the HTTP method. For requests with
+/// a body, [body] is the exact byte-identical JSON the request will send
+/// so the implementation can compute the matching `payload` tag — passing
+/// an empty body for a POST/PUT/PATCH causes the server to 401 with
+/// `payload hash mismatch`.
+typedef AuthHeadersProvider =
+    Future<Map<String, String>> Function(
+      String url,
+      String method, {
+      String? body,
+    });
+
 /// Maximum length for comment preview text before truncation.
 const _maxCommentLength = 50;
 
@@ -77,8 +92,7 @@ class NotificationRepository {
     required NotificationsDao notificationsDao,
     required String userPubkey,
     BlockedNotificationFilter? blockFilter,
-    Future<Map<String, String>> Function(String url, String method)?
-    authHeadersProvider,
+    AuthHeadersProvider? authHeadersProvider,
     bool hydrateOnStart = true,
   }) : _funnelcakeApiClient = funnelcakeApiClient,
        _profileRepository = profileRepository,
@@ -96,8 +110,7 @@ class NotificationRepository {
   final NotificationsDao _notificationsDao;
   final String _userPubkey;
   final BlockedNotificationFilter? _blockFilter;
-  final Future<Map<String, String>> Function(String url, String method)?
-  _authHeadersProvider;
+  final AuthHeadersProvider? _authHeadersProvider;
 
   /// Last cursor returned by the API, used for pagination.
   String? _lastCursor;
@@ -523,11 +536,17 @@ class NotificationRepository {
     final notificationIds = _expandServerNotificationIds(before.items, idSet);
 
     try {
+      // Sign the exact URL + body the request will use, otherwise the
+      // funnelcake server 401s with `URL mismatch` / `payload hash
+      // mismatch` and the rollback bounces the badge back to N.
+      final url = _funnelcakeApiClient
+          .notificationsReadUri(pubkey: _userPubkey)
+          .toString();
+      final body = FunnelcakeApiClient.buildMarkNotificationsReadBody(
+        notificationIds: notificationIds,
+      );
       final authHeaders = _authHeadersProvider != null
-          ? await _authHeadersProvider(
-              '/api/users/$_userPubkey/notifications/read',
-              'POST',
-            )
+          ? await _authHeadersProvider(url, 'POST', body: body)
           : <String, String>{};
 
       await _funnelcakeApiClient.markNotificationsRead(
@@ -559,11 +578,12 @@ class NotificationRepository {
     _snapshot.add(before.copyWith(items: _flipAllRead(before.items)));
 
     try {
+      final url = _funnelcakeApiClient
+          .notificationsReadUri(pubkey: _userPubkey)
+          .toString();
+      final body = FunnelcakeApiClient.buildMarkNotificationsReadBody();
       final authHeaders = _authHeadersProvider != null
-          ? await _authHeadersProvider(
-              '/api/users/$_userPubkey/notifications/read',
-              'POST',
-            )
+          ? await _authHeadersProvider(url, 'POST', body: body)
           : <String, String>{};
 
       await _funnelcakeApiClient.markNotificationsRead(

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -74,6 +74,16 @@ void main() {
         'https://api.example.com/api/users/$pubkey/notifications',
       ).replace(queryParameters: queryParameters);
     });
+    when(
+      () => funnelcakeApiClient.notificationsReadUri(
+        pubkey: any(named: 'pubkey'),
+      ),
+    ).thenAnswer((invocation) {
+      final pubkey = invocation.namedArguments[#pubkey] as String;
+      return Uri.parse(
+        'https://api.example.com/api/users/$pubkey/notifications/read',
+      );
+    });
     // Default: getVideoStats throws (no metadata fetched). Tests that need a
     // thumbnail override this stub explicitly.
     when(
@@ -215,7 +225,7 @@ void main() {
           profileRepository: profileRepository,
           notificationsDao: notificationsDao,
           userPubkey: userPubkey,
-          authHeadersProvider: (url, method) async {
+          authHeadersProvider: (url, method, {body}) async {
             signedUrl = url;
             signedMethod = method;
             return {'Authorization': 'Nostr test-token'};
@@ -244,7 +254,7 @@ void main() {
           profileRepository: profileRepository,
           notificationsDao: notificationsDao,
           userPubkey: userPubkey,
-          authHeadersProvider: (url, method) async {
+          authHeadersProvider: (url, method, {body}) async {
             signedUrl = url;
             return {'Authorization': 'Nostr test-token'};
           },
@@ -275,7 +285,7 @@ void main() {
             profileRepository: profileRepository,
             notificationsDao: notificationsDao,
             userPubkey: userPubkey,
-            authHeadersProvider: (url, method) async {
+            authHeadersProvider: (url, method, {body}) async {
               signedUrl = url;
               return {'Authorization': 'Nostr test-token'};
             },
@@ -311,7 +321,7 @@ void main() {
           profileRepository: profileRepository,
           notificationsDao: notificationsDao,
           userPubkey: userPubkey,
-          authHeadersProvider: (url, method) async {
+          authHeadersProvider: (url, method, {body}) async {
             signedUrl = url;
             return {'Authorization': 'Nostr test-token'};
           },
@@ -636,7 +646,7 @@ void main() {
             profileRepository: profileRepository,
             notificationsDao: notificationsDao,
             userPubkey: userPubkey,
-            authHeadersProvider: (url, method) async {
+            authHeadersProvider: (url, method, {body}) async {
               signedUrl = url;
               return {'Authorization': 'Nostr test-token'};
             },
@@ -672,7 +682,7 @@ void main() {
             profileRepository: profileRepository,
             notificationsDao: notificationsDao,
             userPubkey: userPubkey,
-            authHeadersProvider: (url, method) async {
+            authHeadersProvider: (url, method, {body}) async {
               signedUrl = url;
               return {'Authorization': 'Nostr test-token'};
             },
@@ -1840,7 +1850,7 @@ void main() {
             profileRepository: profileRepository,
             notificationsDao: notificationsDao,
             userPubkey: userPubkey,
-            authHeadersProvider: (url, method) async {
+            authHeadersProvider: (url, method, {body}) async {
               if (method == 'POST') {
                 throw Exception('signer unavailable');
               }
@@ -1963,7 +1973,7 @@ void main() {
             profileRepository: profileRepository,
             notificationsDao: notificationsDao,
             userPubkey: userPubkey,
-            authHeadersProvider: (url, method) async {
+            authHeadersProvider: (url, method, {body}) async {
               if (method == 'POST') {
                 throw Exception('signer unavailable');
               }
@@ -2008,7 +2018,7 @@ void main() {
           profileRepository: profileRepository,
           notificationsDao: notificationsDao,
           userPubkey: userPubkey,
-          authHeadersProvider: (url, method) async => {
+          authHeadersProvider: (url, method, {body}) async => {
             'Authorization': 'Nostr abc123',
           },
         );
@@ -2028,6 +2038,135 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'markAllAsRead signs the full mark-read URL and empty body',
+        () async {
+          // NIP-98 requires the auth event's `u` tag to match the
+          // request URL exactly (scheme + host + path) and the
+          // `payload` tag to be sha256 of the actual body. Pinning the
+          // exact (url, body) tuple passed to the auth callback catches
+          // any future drift to a path-only URL or empty payload —
+          // both of which silently 401 the server and bounce the
+          // notifications badge back up via the repository rollback.
+          String? capturedUrl;
+          String? capturedMethod;
+          String? capturedBody;
+          when(
+            () => funnelcakeApiClient.notificationsReadUri(pubkey: userPubkey),
+          ).thenReturn(
+            Uri.parse(
+              'https://api.divine.video/api/users/$userPubkey/'
+              'notifications/read',
+            ),
+          );
+          when(
+            () => funnelcakeApiClient.markNotificationsRead(
+              pubkey: userPubkey,
+              notificationIds: any(named: 'notificationIds'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          ).thenAnswer(
+            (_) async => const MarkReadResponse(success: true, markedCount: 1),
+          );
+          when(
+            () => notificationsDao.markAllAsRead(),
+          ).thenAnswer((_) async => 1);
+
+          final authRepo = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+            authHeadersProvider: (url, method, {body}) async {
+              capturedUrl = url;
+              capturedMethod = method;
+              capturedBody = body;
+              return {'Authorization': 'Nostr signed-token'};
+            },
+          );
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+          });
+          stubNotifications([makeNotification()], unreadCount: 1);
+          await authRepo.refresh();
+
+          await authRepo.markAllAsRead();
+
+          expect(
+            capturedUrl,
+            equals(
+              'https://api.divine.video/api/users/$userPubkey/'
+              'notifications/read',
+            ),
+          );
+          expect(capturedMethod, equals('POST'));
+          // FunnelcakeApiClient.buildMarkNotificationsReadBody() with
+          // no ids should produce `{}` — the exact bytes the request
+          // body will carry.
+          expect(capturedBody, equals('{}'));
+        },
+      );
+
+      test(
+        'markAsRead signs the body that includes the notification IDs',
+        () async {
+          String? capturedBody;
+          when(
+            () => funnelcakeApiClient.notificationsReadUri(pubkey: userPubkey),
+          ).thenReturn(
+            Uri.parse(
+              'https://api.divine.video/api/users/$userPubkey/'
+              'notifications/read',
+            ),
+          );
+          when(
+            () => funnelcakeApiClient.markNotificationsRead(
+              pubkey: userPubkey,
+              notificationIds: any(named: 'notificationIds'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          ).thenAnswer(
+            (_) async => const MarkReadResponse(success: true, markedCount: 1),
+          );
+          when(
+            () => notificationsDao.markAsRead(any()),
+          ).thenAnswer((_) async => true);
+
+          final authRepo = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+            authHeadersProvider: (url, method, {body}) async {
+              capturedBody = body;
+              return {'Authorization': 'Nostr signed-token'};
+            },
+          );
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+          });
+          // Use a single notification whose id is both the row id and
+          // the expanded server notification id (the expansion in
+          // `_expandServerNotificationIds` falls back to the row id
+          // when the row carries no separate `notificationIds`).
+          stubNotifications([
+            makeNotification(id: 'server-notif-1', sourceEventId: 'evt-1'),
+          ], unreadCount: 1);
+          await authRepo.refresh();
+          final loadedId =
+              (await authRepo.watchSnapshot().first).items.first.id;
+
+          await authRepo.markAsRead([loadedId]);
+
+          // The expanded notification IDs end up in both the request
+          // body the client posts and the `payload` tag the NIP-98
+          // auth event signs — they must match byte-for-byte.
+          expect(capturedBody, isNotNull);
+          expect(capturedBody, contains('notification_ids'));
+          expect(capturedBody, contains('server-notif-1'));
+        },
+      );
     });
 
     group('sorting', () {

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -44,6 +44,9 @@ void main() {
       when(
         () => mockNotificationRepo.refresh(),
       ).thenAnswer((_) async => NotificationPage.empty);
+      when(
+        () => mockNotificationRepo.markAllAsRead(),
+      ).thenAnswer((_) async {});
       when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
       when(() => mockInviteCubit.state).thenReturn(InviteStatusState());
       when(mockInviteCubit.load).thenAnswer((_) async {});
@@ -73,6 +76,24 @@ void main() {
       verify(() => mockNotificationRepo.refresh()).called(1);
       verifyNever(() => mockNotificationRepo.markAllAsRead());
     });
+
+    testWidgets(
+      'marks all notifications read when the inbox page is unmounted',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+        verifyNever(() => mockNotificationRepo.markAllAsRead());
+
+        // Replace the subtree with an empty widget to trigger dispose.
+        // Mirrors the user toggling the Messages segment within InboxView
+        // (the notifications KeyedSubtree gets swapped out) or leaving
+        // the inbox tab entirely (ShellRoute unmounts the subtree).
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+
+        verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+      },
+    );
 
     testWidgets(
       'does not fan out refresh or mark-read across the five filter tabs',

--- a/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
+++ b/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
@@ -1,0 +1,318 @@
+// ABOUTME: Regression tests for the BlocProvider repo-swap pattern in
+// ABOUTME: NotificationsPage + InboxNotificationsPage — verifies that the
+// ABOUTME: NotificationFeedBloc is recreated when its Riverpod-provided
+// ABOUTME: repositories rebuild (auth flip / sign-out / account switch), so
+// ABOUTME: any mark-on-leave wrapper inside the subtree can never fire
+// ABOUTME: against the new user's repository while the old user was
+// ABOUTME: actually viewing.
+//
+// Mirrors `conversation_page_repo_swap_test.dart` and the four canonical
+// pooled-feed sites referenced in `.claude/rules/state_management.md`.
+// The production sites are
+// `mobile/lib/notifications/view/notifications_page.dart` and
+// `mobile/lib/notifications/view/inbox_notifications_page.dart`, each
+// carrying `BlocProvider<NotificationFeedBloc>(key: ValueKey(
+// notificationRepository, followRepository), …)`. Without the key,
+// the BlocProvider element persists across rebuilds and the bloc stays
+// bound to stale repositories — meanwhile `MarkAllReadOnDispose`
+// further down the subtree updates its `widget.repository` to whatever
+// the rebuilt widget tree captured (the new user's repository). When
+// the user later leaves the page, `dispose()` fires `markAllAsRead()`
+// against the new user's account, silently consuming notifications
+// they never saw.
+
+// ignore_for_file: prefer_const_constructors
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
+import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/notifications/providers/notification_repository_provider.dart';
+import 'package:openvine/notifications/view/inbox_notifications_page.dart';
+import 'package:openvine/notifications/view/notifications_page.dart';
+import 'package:openvine/notifications/view/notifications_view.dart';
+import 'package:openvine/providers/app_providers.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
+    implements InviteStatusCubit {}
+
+/// Toggle a `StateProvider<int>` to force `notificationRepositoryProvider`
+/// to rebuild and return a different mock — mirrors what happens in
+/// production when auth flips (the real provider rebuilds through the
+/// `profileRepositoryProvider`/`authServiceProvider` chain in
+/// `notification_repository_provider.dart`).
+final _notificationRepoSwap = StateProvider<int>((ref) => 0);
+final _followRepoSwap = StateProvider<int>((ref) => 0);
+
+void main() {
+  late _MockNotificationRepository mockRepoA;
+  late _MockNotificationRepository mockRepoB;
+  late _MockFollowRepository mockFollowRepoA;
+  late _MockFollowRepository mockFollowRepoB;
+  late _MockInviteStatusCubit mockInviteCubit;
+
+  setUp(() {
+    mockRepoA = _MockNotificationRepository();
+    mockRepoB = _MockNotificationRepository();
+    mockFollowRepoA = _MockFollowRepository();
+    mockFollowRepoB = _MockFollowRepository();
+    mockInviteCubit = _MockInviteStatusCubit();
+
+    for (final repo in [mockRepoA, mockRepoB]) {
+      when(
+        repo.watchSnapshot,
+      ).thenAnswer((_) => const Stream<NotificationPage>.empty());
+      when(repo.refresh).thenAnswer((_) async => NotificationPage.empty);
+    }
+    for (final repo in [mockFollowRepoA, mockFollowRepoB]) {
+      when(() => repo.isFollowing(any())).thenReturn(false);
+    }
+    when(() => mockInviteCubit.state).thenReturn(InviteStatusState());
+    when(mockInviteCubit.load).thenAnswer((_) async {});
+  });
+
+  group('NotificationsPage — BlocProvider repo-swap', () {
+    Widget buildSubject() {
+      return testMaterialApp(
+        additionalOverrides: [
+          notificationRepositoryProvider.overrideWith((ref) {
+            final v = ref.watch(_notificationRepoSwap);
+            return v == 0 ? mockRepoA : mockRepoB;
+          }),
+          followRepositoryProvider.overrideWith((ref) {
+            final v = ref.watch(_followRepoSwap);
+            return v == 0 ? mockFollowRepoA : mockFollowRepoB;
+          }),
+        ],
+        home: const NotificationsPage(),
+      );
+    }
+
+    testWidgets(
+      'recreates NotificationFeedBloc when notificationRepositoryProvider '
+      'rebuilds with a new repository instance',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        // Capture the bloc that was created when the page first built.
+        final viewContextBefore = tester.element(
+          find.byType(NotificationsView),
+        );
+        final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
+        expect(blocA.isClosed, isFalse, reason: 'initial bloc should be alive');
+        verify(() => mockRepoA.refresh()).called(1);
+        verifyNever(() => mockRepoB.refresh());
+
+        // Flip the toggle. notificationRepositoryProvider rebuilds,
+        // NotificationsPage's ref.watch fires, the ValueKey on the
+        // BlocProvider changes, the old element is torn down and a new
+        // bloc is constructed wrapping mockRepoB.
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(NotificationsPage)),
+        );
+        providerScope.read(_notificationRepoSwap.notifier).state = 1;
+        await tester.pumpAndSettle();
+
+        final viewContextAfter = tester.element(find.byType(NotificationsView));
+        final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
+
+        expect(
+          blocB,
+          isNot(same(blocA)),
+          reason:
+              'BlocProvider must create a new NotificationFeedBloc when '
+              'notificationRepository identity flips. Without the '
+              'ValueKey on the BlocProvider, the bloc would keep using '
+              'the stale repository, while MarkAllReadOnDispose further '
+              'down the subtree would update its widget.repository to '
+              'the new user — causing mark-all-read on the wrong user '
+              'when the user later leaves the page.',
+        );
+        verify(() => mockRepoB.refresh()).called(1);
+      },
+    );
+
+    testWidgets('recreates NotificationFeedBloc when followRepositoryProvider '
+        'rebuilds with a new repository instance', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final viewContextBefore = tester.element(find.byType(NotificationsView));
+      final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
+
+      final providerScope = ProviderScope.containerOf(
+        tester.element(find.byType(NotificationsPage)),
+      );
+      providerScope.read(_followRepoSwap.notifier).state = 1;
+      await tester.pumpAndSettle();
+
+      final viewContextAfter = tester.element(find.byType(NotificationsView));
+      final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
+
+      expect(
+        blocB,
+        isNot(same(blocA)),
+        reason:
+            'BlocProvider must also recreate the NotificationFeedBloc '
+            'when followRepository identity flips, because the bloc '
+            'captures both repositories. Narrowing the key to only '
+            'notificationRepository would preserve a stale '
+            'FollowRepository and drift the follow-back state logic.',
+      );
+      verify(() => mockRepoA.refresh()).called(2);
+    });
+
+    testWidgets('preserves the same NotificationFeedBloc when the repository '
+        'identity does not change across rebuilds', (tester) async {
+      await tester.pumpWidget(
+        testMaterialApp(
+          additionalOverrides: [
+            notificationRepositoryProvider.overrideWith((ref) {
+              ref.watch(_notificationRepoSwap);
+              return mockRepoA; // identity stays the same
+            }),
+            followRepositoryProvider.overrideWith((ref) {
+              ref.watch(_followRepoSwap);
+              return mockFollowRepoA; // identity stays the same
+            }),
+          ],
+          home: const NotificationsPage(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final blocA = BlocProvider.of<NotificationFeedBloc>(
+        tester.element(find.byType(NotificationsView)),
+      );
+
+      final providerScope = ProviderScope.containerOf(
+        tester.element(find.byType(NotificationsPage)),
+      );
+      providerScope.read(_notificationRepoSwap.notifier).state = 1;
+      await tester.pumpAndSettle();
+
+      final blocAfter = BlocProvider.of<NotificationFeedBloc>(
+        tester.element(find.byType(NotificationsView)),
+      );
+
+      expect(
+        blocAfter,
+        same(blocA),
+        reason:
+            'Identical repository identity should keep the same bloc '
+            '— the ValueKey prevents unnecessary churn on rebuilds.',
+      );
+      // Refresh should fire exactly once — the same bloc handled both
+      // pump cycles and NotificationFeedStarted is dispatched once.
+      verify(() => mockRepoA.refresh()).called(1);
+    });
+  });
+
+  group('InboxNotificationsPage — BlocProvider repo-swap', () {
+    Widget buildSubject() {
+      return testMaterialApp(
+        additionalOverrides: [
+          notificationRepositoryProvider.overrideWith((ref) {
+            final v = ref.watch(_notificationRepoSwap);
+            return v == 0 ? mockRepoA : mockRepoB;
+          }),
+          followRepositoryProvider.overrideWith((ref) {
+            final v = ref.watch(_followRepoSwap);
+            return v == 0 ? mockFollowRepoA : mockFollowRepoB;
+          }),
+        ],
+        home: BlocProvider<InviteStatusCubit>.value(
+          value: mockInviteCubit,
+          child: Scaffold(body: const InboxNotificationsPage()),
+        ),
+      );
+    }
+
+    testWidgets(
+      'recreates NotificationFeedBloc when notificationRepositoryProvider '
+      'rebuilds with a new repository instance',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        final viewContextBefore = tester.element(
+          find.byType(NotificationsView).first,
+        );
+        final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
+        expect(blocA.isClosed, isFalse);
+        verify(() => mockRepoA.refresh()).called(1);
+        verifyNever(() => mockRepoB.refresh());
+
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(InboxNotificationsPage)),
+        );
+        providerScope.read(_notificationRepoSwap.notifier).state = 1;
+        await tester.pumpAndSettle();
+
+        final viewContextAfter = tester.element(
+          find.byType(NotificationsView).first,
+        );
+        final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
+
+        expect(
+          blocB,
+          isNot(same(blocA)),
+          reason:
+              'The inbox-wrapped notifications page also needs the '
+              'ValueKey contract — the upstream KeyedSubtree in '
+              'inbox_view.dart provides one layer of protection today, '
+              'but if that wrapper is restructured the BlocProvider key '
+              'is what keeps the bloc/repository identity coupled.',
+        );
+        verify(() => mockRepoB.refresh()).called(1);
+      },
+    );
+
+    testWidgets('recreates NotificationFeedBloc when followRepositoryProvider '
+        'rebuilds with a new repository instance', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final viewContextBefore = tester.element(
+        find.byType(NotificationsView).first,
+      );
+      final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
+
+      final providerScope = ProviderScope.containerOf(
+        tester.element(find.byType(InboxNotificationsPage)),
+      );
+      providerScope.read(_followRepoSwap.notifier).state = 1;
+      await tester.pumpAndSettle();
+
+      final viewContextAfter = tester.element(
+        find.byType(NotificationsView).first,
+      );
+      final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
+
+      expect(
+        blocB,
+        isNot(same(blocA)),
+        reason:
+            'The inbox notifications page also captures both '
+            'repositories. Its key must track followRepository '
+            'identity too, not only notificationRepository.',
+      );
+      verify(() => mockRepoA.refresh()).called(2);
+    });
+  });
+}

--- a/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
+++ b/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
@@ -38,7 +38,6 @@ import 'package:openvine/notifications/providers/notification_repository_provide
 import 'package:openvine/notifications/view/inbox_notifications_page.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
-import 'package:openvine/providers/app_providers.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
@@ -56,20 +55,17 @@ class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
 /// `profileRepositoryProvider`/`authServiceProvider` chain in
 /// `notification_repository_provider.dart`).
 final _notificationRepoSwap = StateProvider<int>((ref) => 0);
-final _followRepoSwap = StateProvider<int>((ref) => 0);
 
 void main() {
   late _MockNotificationRepository mockRepoA;
   late _MockNotificationRepository mockRepoB;
-  late _MockFollowRepository mockFollowRepoA;
-  late _MockFollowRepository mockFollowRepoB;
+  late _MockFollowRepository mockFollowRepo;
   late _MockInviteStatusCubit mockInviteCubit;
 
   setUp(() {
     mockRepoA = _MockNotificationRepository();
     mockRepoB = _MockNotificationRepository();
-    mockFollowRepoA = _MockFollowRepository();
-    mockFollowRepoB = _MockFollowRepository();
+    mockFollowRepo = _MockFollowRepository();
     mockInviteCubit = _MockInviteStatusCubit();
 
     for (final repo in [mockRepoA, mockRepoB]) {
@@ -77,10 +73,9 @@ void main() {
         repo.watchSnapshot,
       ).thenAnswer((_) => const Stream<NotificationPage>.empty());
       when(repo.refresh).thenAnswer((_) async => NotificationPage.empty);
+      when(repo.markAllAsRead).thenAnswer((_) async {});
     }
-    for (final repo in [mockFollowRepoA, mockFollowRepoB]) {
-      when(() => repo.isFollowing(any())).thenReturn(false);
-    }
+    when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
     when(() => mockInviteCubit.state).thenReturn(InviteStatusState());
     when(mockInviteCubit.load).thenAnswer((_) async {});
   });
@@ -88,14 +83,11 @@ void main() {
   group('NotificationsPage — BlocProvider repo-swap', () {
     Widget buildSubject() {
       return testMaterialApp(
+        mockFollowRepository: mockFollowRepo,
         additionalOverrides: [
           notificationRepositoryProvider.overrideWith((ref) {
             final v = ref.watch(_notificationRepoSwap);
             return v == 0 ? mockRepoA : mockRepoB;
-          }),
-          followRepositoryProvider.overrideWith((ref) {
-            final v = ref.watch(_followRepoSwap);
-            return v == 0 ? mockFollowRepoA : mockFollowRepoB;
           }),
         ],
         home: const NotificationsPage(),
@@ -147,48 +139,15 @@ void main() {
       },
     );
 
-    testWidgets('recreates NotificationFeedBloc when followRepositoryProvider '
-        'rebuilds with a new repository instance', (tester) async {
-      await tester.pumpWidget(buildSubject());
-      await tester.pumpAndSettle();
-
-      final viewContextBefore = tester.element(find.byType(NotificationsView));
-      final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
-
-      final providerScope = ProviderScope.containerOf(
-        tester.element(find.byType(NotificationsPage)),
-      );
-      providerScope.read(_followRepoSwap.notifier).state = 1;
-      await tester.pumpAndSettle();
-
-      final viewContextAfter = tester.element(find.byType(NotificationsView));
-      final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
-
-      expect(
-        blocB,
-        isNot(same(blocA)),
-        reason:
-            'BlocProvider must also recreate the NotificationFeedBloc '
-            'when followRepository identity flips, because the bloc '
-            'captures both repositories. Narrowing the key to only '
-            'notificationRepository would preserve a stale '
-            'FollowRepository and drift the follow-back state logic.',
-      );
-      verify(() => mockRepoA.refresh()).called(2);
-    });
-
     testWidgets('preserves the same NotificationFeedBloc when the repository '
         'identity does not change across rebuilds', (tester) async {
       await tester.pumpWidget(
         testMaterialApp(
+          mockFollowRepository: mockFollowRepo,
           additionalOverrides: [
             notificationRepositoryProvider.overrideWith((ref) {
               ref.watch(_notificationRepoSwap);
               return mockRepoA; // identity stays the same
-            }),
-            followRepositoryProvider.overrideWith((ref) {
-              ref.watch(_followRepoSwap);
-              return mockFollowRepoA; // identity stays the same
             }),
           ],
           home: const NotificationsPage(),
@@ -226,14 +185,11 @@ void main() {
   group('InboxNotificationsPage — BlocProvider repo-swap', () {
     Widget buildSubject() {
       return testMaterialApp(
+        mockFollowRepository: mockFollowRepo,
         additionalOverrides: [
           notificationRepositoryProvider.overrideWith((ref) {
             final v = ref.watch(_notificationRepoSwap);
             return v == 0 ? mockRepoA : mockRepoB;
-          }),
-          followRepositoryProvider.overrideWith((ref) {
-            final v = ref.watch(_followRepoSwap);
-            return v == 0 ? mockFollowRepoA : mockFollowRepoB;
           }),
         ],
         home: BlocProvider<InviteStatusCubit>.value(
@@ -282,37 +238,5 @@ void main() {
         verify(() => mockRepoB.refresh()).called(1);
       },
     );
-
-    testWidgets('recreates NotificationFeedBloc when followRepositoryProvider '
-        'rebuilds with a new repository instance', (tester) async {
-      await tester.pumpWidget(buildSubject());
-      await tester.pumpAndSettle();
-
-      final viewContextBefore = tester.element(
-        find.byType(NotificationsView).first,
-      );
-      final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
-
-      final providerScope = ProviderScope.containerOf(
-        tester.element(find.byType(InboxNotificationsPage)),
-      );
-      providerScope.read(_followRepoSwap.notifier).state = 1;
-      await tester.pumpAndSettle();
-
-      final viewContextAfter = tester.element(
-        find.byType(NotificationsView).first,
-      );
-      final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
-
-      expect(
-        blocB,
-        isNot(same(blocA)),
-        reason:
-            'The inbox notifications page also captures both '
-            'repositories. Its key must track followRepository '
-            'identity too, not only notificationRepository.',
-      );
-      verify(() => mockRepoA.refresh()).called(2);
-    });
   });
 }

--- a/mobile/test/notifications/view/notifications_page_test.dart
+++ b/mobile/test/notifications/view/notifications_page_test.dart
@@ -62,6 +62,9 @@ void main() {
         when(
           () => mockNotificationRepo.refresh(),
         ).thenAnswer((_) async => NotificationPage.empty);
+        when(
+          () => mockNotificationRepo.markAllAsRead(),
+        ).thenAnswer((_) async {});
         when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
       });
 
@@ -92,6 +95,26 @@ void main() {
 
         verifyNever(() => mockNotificationRepo.markAllAsRead());
       });
+
+      testWidgets(
+        'marks all notifications read when the page is unmounted',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.pumpAndSettle();
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
+
+          // Replace the subtree with an empty widget to trigger dispose
+          // on the NotificationsPage (and the wrapping
+          // MarkAllReadOnDispose). This is the same lifecycle hook that
+          // fires when the user navigates to a different bottom-nav
+          // tab — the ShellRoute is not stateful, so leaving the
+          // notifications route unmounts the page.
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pumpAndSettle();
+
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        },
+      );
     });
   });
 }

--- a/mobile/test/notifications/widgets/mark_all_read_on_dispose_test.dart
+++ b/mobile/test/notifications/widgets/mark_all_read_on_dispose_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Tests for MarkAllReadOnDispose — verifies that the wrapper fires
+// ABOUTME: NotificationRepository.markAllAsRead exactly once when its
+// ABOUTME: subtree is unmounted, and swallows any failure from the call.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/notifications/widgets/mark_all_read_on_dispose.dart';
+
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
+void main() {
+  group(MarkAllReadOnDispose, () {
+    late _MockNotificationRepository repo;
+
+    setUp(() {
+      repo = _MockNotificationRepository();
+      when(() => repo.markAllAsRead()).thenAnswer((_) async {});
+    });
+
+    testWidgets('does not call markAllAsRead while mounted', (tester) async {
+      await tester.pumpWidget(
+        MarkAllReadOnDispose(
+          repository: repo,
+          child: const SizedBox.shrink(),
+        ),
+      );
+      await tester.pump();
+
+      verifyNever(() => repo.markAllAsRead());
+    });
+
+    testWidgets('calls markAllAsRead exactly once on unmount', (tester) async {
+      await tester.pumpWidget(
+        MarkAllReadOnDispose(
+          repository: repo,
+          child: const SizedBox.shrink(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      verify(() => repo.markAllAsRead()).called(1);
+    });
+
+    testWidgets('swallows errors from markAllAsRead', (tester) async {
+      when(
+        () => repo.markAllAsRead(),
+      ).thenAnswer((_) => Future<void>.error(StateError('offline')));
+
+      await tester.pumpWidget(
+        MarkAllReadOnDispose(
+          repository: repo,
+          child: const SizedBox.shrink(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      verify(() => repo.markAllAsRead()).called(1);
+      // No unhandled exception should escape — pumpAndSettle would have
+      // surfaced it via tester.takeException.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('renders the child while mounted', (tester) async {
+      const childKey = Key('mark-all-read-child');
+      await tester.pumpWidget(
+        MarkAllReadOnDispose(
+          repository: repo,
+          child: const SizedBox.shrink(key: childKey),
+        ),
+      );
+
+      expect(find.byKey(childKey), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- When the user opens notifications (either the standalone `/notifications` route or the Notifications segment inside the inbox) and then leaves, every visible notification is flipped to read and the badge collapses to 0.
- Fixes the mark-read server contract so the optimistic read-state change actually persists instead of rolling back because of NIP-98 URL/payload drift or the wrong success parsing.
- Restores the `BlocProvider` identity key contract on both notifications pages so auth/repository swaps cannot mark the wrong user's notifications read on dispose.

## Implementation

A small `MarkAllReadOnDispose` stateful wrapper fires `NotificationRepository.markAllAsRead()` once in `dispose()`. The repository already does the optimistic snapshot flip + server write + rollback on failure, so the badge cubit and feed bloc recover consistently if the API call fails.

The companion server-side fix does three things:
- forwards the exact full URL and JSON body into NIP-98 signing
- centralizes the mark-read URI and payload builders in `FunnelcakeApiClient`
- treats Funnelcake's real mark-read success shape (`marked_count` / `marked_all`) as success even when no synthetic `success` field is present

The Riverpod -> BLoC bridge fix keeps both notifications pages keyed on the watched repository identities and adds a repo-swap regression test so the mark-on-leave wrapper cannot ever dispose against a newly swapped-in account.

## Test plan

- [x] `flutter analyze --no-pub lib/notifications test/notifications`
- [x] `flutter test test/notifications/view/notifications_page_test.dart test/notifications/view/inbox_notifications_page_test.dart test/notifications/view/notification_pages_repo_swap_test.dart test/notifications/widgets/mark_all_read_on_dispose_test.dart`
- [x] `flutter test test/src/funnelcake_api_client_notification_test.dart test/src/models/notification_response_test.dart` from `mobile/packages/funnelcake_api_client`
- [x] `flutter test test/src/notification_repository_test.dart` from `mobile/packages/notification_repository`
- [x] Pre-push analyzer + changed-file test suite passed on the pushed head

## Notes

- The direct repository call from `MarkAllReadOnDispose.dispose()` is intentional because the repository outlives bloc teardown; dispatching a bloc event there would race bloc closure.
- The repo-swap test added here folds in the previously split identity-key follow-up so this PR is safe to land on its own.

🤖 Updated after review fixes
