### PR TITLE
fix(macos): use data protection keychain to stop repeated keychain prompts

### DIFF
--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -67,7 +67,6 @@ FlutterSecureStorage flutterSecureStorage(Ref ref) =>
         encryptedSharedPreferences: true,
         resetOnError: true,
       ),
-      mOptions: MacOsOptions(useDataProtectionKeyChain: false),
     );
 
 @Riverpod(keepAlive: true)

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -146,7 +146,7 @@ final class FlutterSecureStorageProvider
 }
 
 String _$flutterSecureStorageHash() =>
-    r'3e701848e4daaf6a76caf444539af06b4c9d4d9b';
+    r'983539a9d4eced8052f719fe7f4a011a3beb2c2a';
 
 @ProviderFor(secureKeycastStorage)
 const secureKeycastStorageProvider = SecureKeycastStorageProvider._();


### PR DESCRIPTION
Closes #4575

## Summary

- Removes the explicit `useDataProtectionKeyChain: false` override on `MacOsOptions` in `flutterSecureStorageProvider`. The flutter_secure_storage default is now `true`, which uses the modern data protection keychain.
- Items are scoped to the `keychain-access-groups` entitlement (already configured in `DebugProfile.entitlements` and `Release.entitlements` as `\$(AppIdentifierPrefix)\$(CFBundleIdentifier)`) instead of the binary's code signature. Rebuilds no longer trigger the "enter your login keychain password" prompt for every stored item on every fresh build.

## Why

Every `flutter run` / fresh macOS build produces a new code signature. The legacy login keychain scopes ACLs to that signature, so the user gets prompted once per stored item (auth token, nostr key, OAuth tokens, pubkey cache, …) on every rebuild. "Always Allow" only sticks for a single signature. The data protection keychain uses the `keychain-access-groups` entitlement instead, which is stable across signatures.

## Tradeoff

Existing macOS users have credentials in the legacy login keychain. After this change the app reads the data protection keychain and won't find them, so they'll need to sign in again on macOS. iOS, Android, and Linux are unaffected.

## Test plan

- [ ] Fresh `flutter run -d macos` no longer prompts for the login keychain password.
- [ ] Sign in, quit, rebuild, relaunch → still signed in, no keychain prompt.
- [ ] On the first run after the upgrade, the user is prompted to sign in again (expected — see Tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)