### PR TITLE
chore(deps): bump flutter_local_notifications v19 → v21 (#3642)

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -23,13 +23,13 @@ android {
     ndkVersion = "28.2.13676358"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
         isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -1,10 +1,12 @@
 import Flutter
 import UIKit
+import UserNotifications
 import AVFoundation
 import LibProofMode
 import ZendeskCoreSDK
 import SupportSDK
 import SupportProvidersSDK
+import flutter_local_notifications
 
 extension FlutterError: @retroactive Error {}
 
@@ -14,11 +16,17 @@ extension FlutterError: @retroactive Error {}
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   // UIScene lifecycle: Called when Flutter engine is ready
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    // Register plugins for any background notification action isolate.
+    FlutterLocalNotificationsPlugin.setPluginRegistrantCallback { registry in
+      GeneratedPluginRegistrant.register(with: registry)
+    }
+
     // Register plugins with the engine
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -122,7 +122,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     iOS: darwinInit,
     macOS: darwinInit,
   );
-  await plugin.initialize(initSettings);
+  await plugin.initialize(settings: initSettings);
 
   const androidDetails = AndroidNotificationDetails(
     'openvine_push',
@@ -137,10 +137,10 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   );
 
   await plugin.show(
-    DateTime.now().millisecondsSinceEpoch ~/ 1000,
-    title,
-    body,
-    details,
+    id: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    title: title,
+    body: body,
+    notificationDetails: details,
     payload: jsonEncode({
       'referencedEventId': data['referencedEventId'],
       // Normalise at the boundary: FCM wire key is 'type'; the internal

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -585,11 +585,11 @@ class NotificationService {
         linux: linuxDetails,
       );
 
-      // Show the notification
+      // Show the notification with unique ID from timestamp
+      final notificationId =
+          notification.timestamp.millisecondsSinceEpoch % 100000;
       await _flutterLocalNotificationsPlugin.show(
-        id:
-            notification.timestamp.millisecondsSinceEpoch %
-            100000, // Unique ID from timestamp
+        id: notificationId,
         title: title,
         body: body,
         notificationDetails: notificationDetails,

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -434,7 +434,7 @@ class NotificationService {
       );
 
       await _flutterLocalNotificationsPlugin.initialize(
-        initializationSettings,
+        settings: initializationSettings,
         onDidReceiveNotificationResponse: _onNotificationTapped,
       );
 
@@ -587,11 +587,12 @@ class NotificationService {
 
       // Show the notification
       await _flutterLocalNotificationsPlugin.show(
-        notification.timestamp.millisecondsSinceEpoch %
+        id:
+            notification.timestamp.millisecondsSinceEpoch %
             100000, // Unique ID from timestamp
-        title,
-        body,
-        notificationDetails,
+        title: title,
+        body: body,
+        notificationDetails: notificationDetails,
       );
 
       Log.debug(
@@ -708,10 +709,10 @@ class NotificationService {
       // Show the notification with unique ID from timestamp
       final notificationId = DateTime.now().millisecondsSinceEpoch % 100000;
       await _flutterLocalNotificationsPlugin.show(
-        notificationId,
-        title,
-        body,
-        notificationDetails,
+        id: notificationId,
+        title: title,
+        body: body,
+        notificationDetails: notificationDetails,
       );
 
       Log.debug(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -902,34 +902,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "11.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -2405,10 +2405,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -283,7 +283,7 @@ dependencies:
   # values-v31 styles) are hand-authored and should not be regenerated.
   # See #2749 and #2953 for context on the welcome-screen flash fix.
   flutter_native_splash: ^2.4.7
-  flutter_local_notifications: ^19.4.2
+  flutter_local_notifications: ^21.0.0
   package_info_plus: ^9.0.0
   uuid: ^4.5.1
   app_links: ^6.4.1


### PR DESCRIPTION
## Summary
- Bumps `flutter_local_notifications` from `^19.4.2` (resolved `19.5.0`) to `^21.0.0`, plus transitive bumps (`flutter_local_notifications_linux` 6→8, `_platform_interface` 9→11, `_windows` 1→3, `timezone` 0.10→0.11).
- v20 introduced named-only parameters on `initialize()` and `show()` — migrates 5 call sites accordingly.
- v21 only bumps minimum versions, all of which are already met (Flutter 3.41.9 ≥ 3.38.1, Dart 3.11 ≥ 3.10, iOS 16 ≥ 13, macOS 13 ≥ 10.15, Android minSdk 28 ≥ 24, compileSdk 36).

Closes #3642.

## Files touched
- `mobile/pubspec.yaml` — version constraint
- `mobile/pubspec.lock` — resolved versions
- `mobile/lib/main.dart` — `_firebaseMessagingBackgroundHandler` calls (`initialize`, `show`)
- `mobile/lib/services/notification_service.dart` — `_initializePlugin` (`initialize`), `sendLocal` (`show`), `_sendPlatformNotification` (`show`)

## Notes on what did *not* change
- `IOSFlutterLocalNotificationsPlugin.requestPermissions(alert:badge:sound:)` — unchanged in v21.
- `AndroidFlutterLocalNotificationsPlugin.requestNotificationsPermission()` — unchanged in v21.
- `resolvePlatformSpecificImplementation<…>()` — unchanged in v21.
- iOS `AppDelegate.swift` — already on UIScene lifecycle; `GeneratedPluginRegistrant.register(…)` is wired in `didInitializeImplicitFlutterEngine`; `FlutterAppDelegate` parent handles `UNUserNotificationCenterDelegate`. `setPluginRegistrantCallback` is only needed for OS-fired scheduled notifications, which this app does not use.
- `AndroidManifest.xml` — `POST_NOTIFICATIONS` already declared; FCM channel meta-data already present.
- Java compatibility — left at `VERSION_11`; debug APK builds clean against v21 (Gradle/AGP 8.9.1 + Kotlin 2.1).

## Test plan
- [x] `flutter analyze lib test integration_test` — no issues
- [x] `flutter test test/services/notification_service_test.dart test/services/notification_service_enhanced test/services/notification_helpers_test.dart test/services/notification_target_resolver_test.dart test/services/notification_preferences_service_test.dart` — 59 pass
- [x] `flutter test test/notifications test/widgets/notification_type_icon_test.dart test/widgets/notification_badge_test.dart` — 150 pass
- [x] `flutter test test/services/push_notification_service_test.dart test/router/app_shell_notification_badge_test.dart` — 29 pass
- [x] `flutter build apk --debug` — built successfully (~148s)
- [ ] Manual smoke: upload-complete notification on Android device
- [ ] Manual smoke: FCM push with `referencedEventId` triggers local notification + tap routes to video
- [ ] Manual smoke: permission deny path still gracefully falls back to in-app list
- [ ] iOS simulator debug build (deferred to CI / device)

## Out of scope
- No refactor of `sendLocal` / `_sendPlatformNotification` duplication — intentional and load-bearing per existing in-code comment.
- No Java VERSION_11 → 17 bump — debug APK builds clean against v21 with Java 11.
- No move to v22.0.0-dev preview.