### PR TITLE
fix(notifications): key BlocProvider on repository identity

### DIFF
--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -39,7 +39,14 @@ class InboxNotificationsPage extends ConsumerWidget {
     }
     final followRepository = ref.watch(followRepositoryProvider);
 
+    // Key on the repository identity so the bloc rebuilds when the
+    // underlying repository swaps (account switch, sign-out → sign-in).
+    // The upstream KeyedSubtree in `inbox_view.dart` already forces this
+    // subtree to remount on pubkey change today, but pinning the contract
+    // here keeps the page safe even if the inbox scaffold is restructured.
+    // See `.claude/rules/state_management.md`.
     return BlocProvider(
+      key: ValueKey(notificationRepository),
       create: (_) => NotificationFeedBloc(
         notificationRepository: notificationRepository,
         followRepository: followRepository,

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -51,7 +51,15 @@ class NotificationsPage extends ConsumerWidget {
 
     final followRepository = ref.watch(followRepositoryProvider);
 
+    // Key on the repository identity so the bloc rebuilds when the
+    // underlying repository swaps (account switch, sign-out → sign-in).
+    // Without this the BlocProvider element persists across rebuilds and
+    // keeps the bloc bound to the previous repository, while any
+    // mark-on-leave wrapper inside the subtree would otherwise fire
+    // against whichever repository the rebuilt widget tree captured —
+    // i.e. the new user's notifications. See `.claude/rules/state_management.md`.
     return BlocProvider(
+      key: ValueKey(notificationRepository),
       create: (_) => NotificationFeedBloc(
         notificationRepository: notificationRepository,
         followRepository: followRepository,

--- a/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
+++ b/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
@@ -1,0 +1,246 @@
+// ABOUTME: Regression tests for the BlocProvider repo-swap pattern in
+// ABOUTME: NotificationsPage + InboxNotificationsPage — verifies that the
+// ABOUTME: NotificationFeedBloc is recreated when notificationRepository
+// ABOUTME: Provider rebuilds (auth flip / sign-out / account switch), so
+// ABOUTME: any mark-on-leave wrapper inside the subtree can never fire
+// ABOUTME: against the new user's repository while the old user was
+// ABOUTME: actually viewing.
+//
+// Mirrors `conversation_page_repo_swap_test.dart` and the four canonical
+// pooled-feed sites referenced in `.claude/rules/state_management.md`.
+// The production sites are
+// `mobile/lib/notifications/view/notifications_page.dart` and
+// `mobile/lib/notifications/view/inbox_notifications_page.dart`, each
+// carrying `BlocProvider<NotificationFeedBloc>(key: ValueKey(
+// notificationRepository), …)`. Without the key, the BlocProvider
+// element persists across rebuilds and the bloc stays bound to the
+// previous repository — meanwhile `MarkAllReadOnDispose` further down
+// the subtree updates its `widget.repository` to whatever the rebuilt
+// widget tree captured (the new user's repository). When the user
+// later leaves the page, `dispose()` fires `markAllAsRead()` against
+// the new user's account, silently consuming notifications they never
+// saw.
+
+// ignore_for_file: prefer_const_constructors
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
+import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/notifications/providers/notification_repository_provider.dart';
+import 'package:openvine/notifications/view/inbox_notifications_page.dart';
+import 'package:openvine/notifications/view/notifications_page.dart';
+import 'package:openvine/notifications/view/notifications_view.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
+    implements InviteStatusCubit {}
+
+/// Toggle a `StateProvider<int>` to force `notificationRepositoryProvider`
+/// to rebuild and return a different mock — mirrors what happens in
+/// production when auth flips (the real provider rebuilds through the
+/// `profileRepositoryProvider`/`authServiceProvider` chain in
+/// `notification_repository_provider.dart`).
+final _notificationRepoSwap = StateProvider<int>((ref) => 0);
+
+void main() {
+  late _MockNotificationRepository mockRepoA;
+  late _MockNotificationRepository mockRepoB;
+  late _MockFollowRepository mockFollowRepo;
+  late _MockInviteStatusCubit mockInviteCubit;
+
+  setUp(() {
+    mockRepoA = _MockNotificationRepository();
+    mockRepoB = _MockNotificationRepository();
+    mockFollowRepo = _MockFollowRepository();
+    mockInviteCubit = _MockInviteStatusCubit();
+
+    for (final repo in [mockRepoA, mockRepoB]) {
+      when(
+        repo.watchSnapshot,
+      ).thenAnswer((_) => const Stream<NotificationPage>.empty());
+      when(repo.refresh).thenAnswer((_) async => NotificationPage.empty);
+    }
+    when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
+    when(() => mockInviteCubit.state).thenReturn(InviteStatusState());
+    when(mockInviteCubit.load).thenAnswer((_) async {});
+  });
+
+  group('NotificationsPage — BlocProvider repo-swap', () {
+    Widget buildSubject() {
+      return testMaterialApp(
+        mockFollowRepository: mockFollowRepo,
+        additionalOverrides: [
+          notificationRepositoryProvider.overrideWith((ref) {
+            final v = ref.watch(_notificationRepoSwap);
+            return v == 0 ? mockRepoA : mockRepoB;
+          }),
+        ],
+        home: const NotificationsPage(),
+      );
+    }
+
+    testWidgets(
+      'recreates NotificationFeedBloc when notificationRepositoryProvider '
+      'rebuilds with a new repository instance',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        // Capture the bloc that was created when the page first built.
+        final viewContextBefore = tester.element(
+          find.byType(NotificationsView),
+        );
+        final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
+        expect(blocA.isClosed, isFalse, reason: 'initial bloc should be alive');
+        verify(() => mockRepoA.refresh()).called(1);
+        verifyNever(() => mockRepoB.refresh());
+
+        // Flip the toggle. notificationRepositoryProvider rebuilds,
+        // NotificationsPage's ref.watch fires, the ValueKey on the
+        // BlocProvider changes, the old element is torn down and a new
+        // bloc is constructed wrapping mockRepoB.
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(NotificationsPage)),
+        );
+        providerScope.read(_notificationRepoSwap.notifier).state = 1;
+        await tester.pumpAndSettle();
+
+        final viewContextAfter = tester.element(
+          find.byType(NotificationsView),
+        );
+        final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
+
+        expect(
+          blocB,
+          isNot(same(blocA)),
+          reason:
+              'BlocProvider must create a new NotificationFeedBloc when '
+              'notificationRepository identity flips. Without the '
+              'ValueKey on the BlocProvider, the bloc would keep using '
+              'the stale repository, while MarkAllReadOnDispose further '
+              'down the subtree would update its widget.repository to '
+              'the new user — causing mark-all-read on the wrong user '
+              'when the user later leaves the page.',
+        );
+        verify(() => mockRepoB.refresh()).called(1);
+      },
+    );
+
+    testWidgets(
+      'preserves the same NotificationFeedBloc when the repository '
+      'identity does not change across rebuilds',
+      (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockFollowRepository: mockFollowRepo,
+            additionalOverrides: [
+              notificationRepositoryProvider.overrideWith((ref) {
+                ref.watch(_notificationRepoSwap);
+                return mockRepoA; // identity stays the same
+              }),
+            ],
+            home: const NotificationsPage(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final blocA = BlocProvider.of<NotificationFeedBloc>(
+          tester.element(find.byType(NotificationsView)),
+        );
+
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(NotificationsPage)),
+        );
+        providerScope.read(_notificationRepoSwap.notifier).state = 1;
+        await tester.pumpAndSettle();
+
+        final blocAfter = BlocProvider.of<NotificationFeedBloc>(
+          tester.element(find.byType(NotificationsView)),
+        );
+
+        expect(
+          blocAfter,
+          same(blocA),
+          reason:
+              'Identical repository identity should keep the same bloc '
+              '— the ValueKey prevents unnecessary churn on rebuilds.',
+        );
+        // Refresh should fire exactly once — the same bloc handled both
+        // pump cycles and NotificationFeedStarted is dispatched once.
+        verify(() => mockRepoA.refresh()).called(1);
+      },
+    );
+  });
+
+  group('InboxNotificationsPage — BlocProvider repo-swap', () {
+    Widget buildSubject() {
+      return testMaterialApp(
+        mockFollowRepository: mockFollowRepo,
+        additionalOverrides: [
+          notificationRepositoryProvider.overrideWith((ref) {
+            final v = ref.watch(_notificationRepoSwap);
+            return v == 0 ? mockRepoA : mockRepoB;
+          }),
+        ],
+        home: BlocProvider<InviteStatusCubit>.value(
+          value: mockInviteCubit,
+          child: Scaffold(body: const InboxNotificationsPage()),
+        ),
+      );
+    }
+
+    testWidgets(
+      'recreates NotificationFeedBloc when notificationRepositoryProvider '
+      'rebuilds with a new repository instance',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        final viewContextBefore = tester.element(
+          find.byType(NotificationsView).first,
+        );
+        final blocA = BlocProvider.of<NotificationFeedBloc>(viewContextBefore);
+        expect(blocA.isClosed, isFalse);
+        verify(() => mockRepoA.refresh()).called(1);
+        verifyNever(() => mockRepoB.refresh());
+
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(InboxNotificationsPage)),
+        );
+        providerScope.read(_notificationRepoSwap.notifier).state = 1;
+        await tester.pumpAndSettle();
+
+        final viewContextAfter = tester.element(
+          find.byType(NotificationsView).first,
+        );
+        final blocB = BlocProvider.of<NotificationFeedBloc>(viewContextAfter);
+
+        expect(
+          blocB,
+          isNot(same(blocA)),
+          reason:
+              'The inbox-wrapped notifications page also needs the '
+              'ValueKey contract — the upstream KeyedSubtree in '
+              'inbox_view.dart provides one layer of protection today, '
+              'but if that wrapper is restructured the BlocProvider key '
+              'is what keeps the bloc/repository identity coupled.',
+        );
+        verify(() => mockRepoB.refresh()).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #4585

## Summary

Both notifications pages were missing the `BlocProvider` identity key required by `.claude/rules/state_management.md`. The standalone `/notifications/:index` route is silently exposed to a mark-all-read-on-wrong-user bug once PR #4573's `MarkAllReadOnDispose` lands.

- `NotificationsPage` (standalone `/notifications/:index`) — no upstream key wrapper. `State<MarkAllReadOnDispose>` would persist across account switches, its `widget.repository` would update to the new user's repo via Flutter's normal widget update, and `dispose()` later would fire `markAllAsRead()` against the new user — silently consuming notifications they never saw.
- `InboxNotificationsPage` — works in practice because `inbox_view.dart:97-100` wraps it in `KeyedSubtree(key: ValueKey('notifications-$currentPubkey'))`, but the contract isn't pinned at the page itself. Adding the key here makes the page safe even if the inbox scaffold is restructured later.

Adds `key: ValueKey(notificationRepository)` on both `BlocProvider<NotificationFeedBloc>` sites and locks the contract with a repo-swap regression test that mirrors `conversation_page_repo_swap_test.dart` (the DM analogue of #3503).

## Why now

Found during a deep audit of the notifications surface ahead of closing epic #4200. PR #4573 is open and will introduce `MarkAllReadOnDispose` — this PR closes the latent failure mode before that change lands.

## Test plan

- [x] `flutter analyze lib/notifications/view/notifications_page.dart lib/notifications/view/inbox_notifications_page.dart test/notifications/view/notification_pages_repo_swap_test.dart` — clean
- [x] `flutter test test/notifications/view/notification_pages_repo_swap_test.dart` — 3/3 pass
- [x] `flutter test test/notifications/` — 140/140 pass (regression across the notification widget surface)

## Relates to

- Epic `#4200`
- Coordinates with open PR `#4573` (`MarkAllReadOnDispose`) — recommend landing this first