### PR TITLE
docs(error-handling): add per-layer failure contract and discoverability anchor

### DIFF
--- a/.claude/rules/error_handling.md
+++ b/.claude/rules/error_handling.md
@@ -119,6 +119,36 @@ void main() {
 
 ---
 
+## Per-layer failure contract
+
+The same failure travels four layers before a user sees it. Each layer
+has one job; mixing jobs is how silent failures and misleading
+dashboards get born.
+
+| Layer        | What it throws / returns                                                                                                                                                                                                                | What it does NOT do                                                                                              |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| Client       | Typed exception (`FooApiException`, `NetworkException`, etc.) with a `///` doc on every public method listing thrown types. No `false` / `null` "and also it failed" returns.                                                           | No knowledge of features, no fallback selection, no UI strings.                                                  |
+| Repository   | Either a typed exception (re-thrown / translated) **or** a sentinel value documented on the method (`Future<List<X>>` returning `[]` is valid only if the doc says so). Owns fallback composition between sources.                      | Never builds user-visible strings. Never decides what's "Reportable" — that's the BLoC's call.                   |
+| BLoC / Cubit | Catches typed exceptions, applies the [decision matrix](#decision-matrix), calls `addError(...)` (wrapping with `Reportable(...)` for YES cases), emits a *status enum* — never an error string, never an `Exception` field.            | Doesn't store error text. Doesn't `print`. Doesn't reach into UI.                                                |
+| UI           | Reads `state.status`, maps to `context.l10n.xxx`, renders. Wires snackbars, retry buttons, and recovery flows off the status enum.                                                                                                      | Doesn't read exception objects from state. Doesn't decide what's reportable. Doesn't call repositories directly. |
+
+If you find yourself adding a `String? errorMessage` to a state class,
+you've crossed two layers — undo it and lift the decision to whichever
+layer above is missing.
+
+The matrix that BLoCs apply in the third row above is in
+[Reportable errors and Crashlytics](#reportable-errors-and-crashlytics)
+immediately below.
+
+Adjacent rules this formalises into one table:
+
+- `state_management.md` → "State must NEVER contain error messages,
+  error strings, or exception objects."
+- `architecture.md` → "Fallback and composition logic belongs in the
+  repository."
+
+---
+
 ## Reportable errors and Crashlytics
 
 A project-wide `BlocObserver` (`DivineBlocObserver`) writes every Bloc/Cubit
@@ -217,6 +247,64 @@ supplementary triage text, not a dashboard branching key, so the
 typed-vs-string choice is a call-site discoverability decision rather
 than a dashboard-taxonomy decision.
 
+### Reporter port pattern (pure-Dart packages)
+
+Pure-Dart packages under `mobile/packages/` cannot import
+`package:openvine/observability/...` without inverting the layer
+boundary. The approved alternative is a **reporter-port typedef**
+injected as a nullable constructor parameter, wired in the app layer
+to `CrashReportingService.instance.recordError`.
+
+Shape (the canonical reference is `dm_repository` — see
+`mobile/packages/dm_repository/lib/src/dm_repository.dart` and
+`dm_repository_reportable_sites.dart`):
+
+```dart
+// In the package
+typedef PkgErrorReporter = void Function(
+  Object error,
+  StackTrace stackTrace, {
+  required String site,
+});
+
+class FooRepository {
+  FooRepository({PkgErrorReporter? errorReporter})
+      : _report = errorReporter;
+
+  final PkgErrorReporter? _report;
+
+  Future<void> doThing() async {
+    try {
+      // ...
+    } catch (e, st) {
+      _report?.call(
+        e,
+        st,
+        site: FooRepositoryReportableSites.doThing,
+      );
+      rethrow; // or translate to a typed exception
+    }
+  }
+}
+
+// In the app layer (provider wiring)
+FooRepository(
+  errorReporter: (e, st, {required String site}) {
+    CrashReportingService.instance.recordError(
+      e,
+      st,
+      reason: 'FooRepository.$site',
+    );
+  },
+);
+```
+
+This is the **only** approved Crashlytics surface for packages that
+can't depend on `openvine/observability` — do not introduce another.
+
+The package owns its `*ReportableSites` constants file (per the same
+naming rule as in [Naming `context` identifiers](#naming-context-identifiers)).
+
 ### PII
 
 `Reportable.toString()` strips Nostr `npub1…` and `nsec1…` identifiers
@@ -230,6 +318,12 @@ If you opt a project-owned exception in by `implements ReportableError`
 directly (skipping the `Reportable` wrapper), the marker bypasses the
 sanitizer. Make sure your `toString()` does not embed `npub` / `nsec`
 strings, or wrap the throw with `Reportable` at the boundary instead.
+
+**Required**: any new class that `implements ReportableError` directly
+must ship a unit test asserting its `toString()` is free of `npub1…`,
+`nsec1…`, and email-shaped identifiers. The wrapper's sanitizer is
+the safety net for `Reportable<T>` wraps only; direct implementers
+opt out of that net and must own the contract at the class level.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,7 @@ Rules:
   - [mobile/docs/NOSTR_VIDEO_EVENTS.md](mobile/docs/NOSTR_VIDEO_EVENTS.md)
   - [mobile/docs/DESIGN_SYSTEM_COMPONENTS.md](mobile/docs/DESIGN_SYSTEM_COMPONENTS.md)
   - [mobile/docs/GOLDEN_TESTING_GUIDE.md](mobile/docs/GOLDEN_TESTING_GUIDE.md)
+  - [mobile/docs/ERROR_HANDLING.md](mobile/docs/ERROR_HANDLING.md) (per-layer failure contract, Reportable matrix)
 
 ## Architecture Expectations
 

--- a/mobile/docs/ERROR_HANDLING.md
+++ b/mobile/docs/ERROR_HANDLING.md
@@ -20,27 +20,34 @@ the source of truth.
 ## Canonical examples (read before opening a sweep PR)
 
 - **BLoC multi-site pattern**:
-  `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart`
-  paired with `reportable_sites.dart` — multi-site files lift identifiers into
-  a `*ReportableSites` constants class.
+  [`video_interactions_bloc.dart`](../lib/blocs/video_interactions/video_interactions_bloc.dart)
+  paired with
+  [`reportable_sites.dart`](../lib/blocs/video_interactions/reportable_sites.dart)
+  — multi-site files lift identifiers into a `*ReportableSites` constants
+  class.
 - **Service-layer pattern**:
-  `mobile/lib/services/outgoing_dm_retry_service.dart` with its colocated
-  `outgoing_dm_retry_service_reportable_sites.dart`.
+  [`outgoing_dm_retry_service.dart`](../lib/services/outgoing_dm_retry_service.dart)
+  with its colocated
+  [`outgoing_dm_retry_service_reportable_sites.dart`](../lib/services/outgoing_dm_retry_service_reportable_sites.dart).
 - **Pure-Dart package (reporter port)**:
-  `mobile/packages/dm_repository/lib/src/dm_repository.dart` +
-  `dm_repository_reportable_sites.dart` — the only approved Crashlytics
-  surface for packages that can't depend on `openvine/observability`.
+  [`dm_repository.dart`](../packages/dm_repository/lib/src/dm_repository.dart)
+  +
+  [`dm_repository_reportable_sites.dart`](../packages/dm_repository/lib/src/dm_repository_reportable_sites.dart)
+  — the only approved Crashlytics surface for packages that can't depend on
+  `openvine/observability`.
 - **"Explicitly NOT Reportable" precedent**:
-  `mobile/lib/blocs/my_profile/my_profile_bloc.dart:184` — when the matrix says
-  NO, leave the raw `addError(e, st)` and add an inline comment citing the
-  matrix row.
+  [`my_profile_bloc.dart`](../lib/blocs/my_profile/my_profile_bloc.dart#L186)
+  — when the matrix says NO, leave the raw `addError(e, st)` and add an
+  inline comment citing the rule and decision.
 
 ## Foundation
 
-- `mobile/lib/observability/divine_bloc_observer.dart` — `Bloc.observer`;
+- [`divine_bloc_observer.dart`](../lib/observability/divine_bloc_observer.dart)
+  — `Bloc.observer`;
   forwards Bloc errors to Crashlytics, gated on `ReportableError`.
-- `mobile/lib/observability/reportable_error.dart` — the `ReportableError`
-  marker, the `Reportable<T>` wrapper, and `sanitizeForCrashReport` (strips
-  `npub1…` / `nsec1…` / email identifiers).
-- `mobile/lib/services/crash_reporting_service.dart` — Firebase Crashlytics
-  facade exposing `recordError`, `setCustomKey`, and breadcrumb `log`.
+- [`reportable_error.dart`](../lib/observability/reportable_error.dart) — the
+  `ReportableError` marker, the `Reportable<T>` wrapper, and
+  `sanitizeForCrashReport` (strips `npub1…` / `nsec1…` / email identifiers).
+- [`crash_reporting_service.dart`](../lib/services/crash_reporting_service.dart)
+  — Firebase Crashlytics facade exposing `recordError`, `setCustomKey`, and
+  breadcrumb `log`.

--- a/mobile/docs/ERROR_HANDLING.md
+++ b/mobile/docs/ERROR_HANDLING.md
@@ -1,0 +1,46 @@
+# Error Handling
+
+This file is the discoverability anchor for error-handling conventions in
+divine-mobile. The canonical rule lives at
+[`.claude/rules/error_handling.md`](../../.claude/rules/error_handling.md) and is
+the source of truth.
+
+## Three anchors to know
+
+- **[Per-layer failure contract](../../.claude/rules/error_handling.md#per-layer-failure-contract)** —
+  what each of Client / Repository / BLoC / UI throws, catches, surfaces, and
+  refuses to do. Read this first if you are designing a new feature.
+- **[Decision matrix](../../.claude/rules/error_handling.md#decision-matrix)** —
+  when an error is `Reportable` (forwarded to Crashlytics) and when it stays in
+  the local unified log only. Default is **not** reportable.
+- **[Migration recipe](../../.claude/rules/error_handling.md#migration-recipe)** —
+  how to wrap an inner error at the `addError` call site, plus the
+  `Reportable<T>` test-assertion gotcha when asserting in `blocTest`.
+
+## Canonical examples (read before opening a sweep PR)
+
+- **BLoC multi-site pattern**:
+  `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart`
+  paired with `reportable_sites.dart` — multi-site files lift identifiers into
+  a `*ReportableSites` constants class.
+- **Service-layer pattern**:
+  `mobile/lib/services/outgoing_dm_retry_service.dart` with its colocated
+  `outgoing_dm_retry_service_reportable_sites.dart`.
+- **Pure-Dart package (reporter port)**:
+  `mobile/packages/dm_repository/lib/src/dm_repository.dart` +
+  `dm_repository_reportable_sites.dart` — the only approved Crashlytics
+  surface for packages that can't depend on `openvine/observability`.
+- **"Explicitly NOT Reportable" precedent**:
+  `mobile/lib/blocs/my_profile/my_profile_bloc.dart:184` — when the matrix says
+  NO, leave the raw `addError(e, st)` and add an inline comment citing the
+  matrix row.
+
+## Foundation
+
+- `mobile/lib/observability/divine_bloc_observer.dart` — `Bloc.observer`;
+  forwards Bloc errors to Crashlytics, gated on `ReportableError`.
+- `mobile/lib/observability/reportable_error.dart` — the `ReportableError`
+  marker, the `Reportable<T>` wrapper, and `sanitizeForCrashReport` (strips
+  `npub1…` / `nsec1…` / email identifiers).
+- `mobile/lib/services/crash_reporting_service.dart` — Firebase Crashlytics
+  facade exposing `recordError`, `setCustomKey`, and breadcrumb `log`.


### PR DESCRIPTION
## Description

First PR under epic #4336 (reliability: standardize error handling, diagnostics, and failure contracts) — the **spec extension + discoverability** track. Zero behavioural change; pure docs.

Three edits:

1. **`.claude/rules/error_handling.md`** gains a new **Per-layer failure contract** section above the existing Reportable section. Single table that pins what each of Client / Repository / BLoC / UI is responsible for throwing, catching, surfacing, and explicitly *not* doing. Formalises language already scattered through `state_management.md` ("State must NEVER contain error messages") and `architecture.md` ("Fallback and composition logic belongs in the repository") without changing existing policy. Adds a **Reporter port pattern (pure-Dart packages)** sub-section in the Reportable section documenting the typedef-based approach used by `dm_repository` (PR #4402), so future package extractions cite a canonical reference instead of re-deriving the shape. Strengthens the PII contract: any new class that `implements ReportableError` directly must ship a `toString()` PII-free unit test, because direct implementers bypass the `Reportable<T>` sanitizer.

2. **`mobile/docs/ERROR_HANDLING.md`** (new) — discoverability anchor. ~35 lines linking to the rule file's three key anchors (per-layer contract, decision matrix, migration recipe) and listing the four canonical example sites (BLoC multi-site, service-layer, package reporter-port, "explicitly NOT Reportable" inline-comment precedent). Solves the "70+ docs in `mobile/docs/` and none is the canonical entry point" gap surfaced during the epic's investigation.

3. **`CONTRIBUTING.md`** — one line added to the "Where To Work" doc list pointing at the new file.

This PR unblocks the sweep PRs (C / C2 / D / E / G) that need a stable spec to cite. See `tasks/plan_4336.md` (local) for the full epic-level plan and §5 of that plan for the source table.

**Related Issue:** Relates to #4336. Adjacent open work that consumes this spec: #3758 (observer enrichment), #3343 (Firebase reconcile), #3588 / #3589 / #3591 (audit leaves), #4393 / #4394 / #4400 (high-priority Crashlytics hardening).

## Out of Scope

- Any code change. This is docs-only; subsequent sweep PRs apply the spec to call sites.
- New custom_lint rule to mechanically enforce "no error strings in state". Tracked as deferred PR L in the epic plan; will surface only if drift returns after audit leaves ship.
- `mobile/CONTRIBUTING.md` — does not exist; root `CONTRIBUTING.md` is the single contributor doc.

## Verification

- `flutter analyze lib test integration_test` from `mobile/`: **No issues found! (ran in 9.9s)**.
- Manual link check: every relative link in the new `mobile/docs/ERROR_HANDLING.md` resolves against the actual files (`.claude/rules/error_handling.md` sections + repo paths under `mobile/lib/` and `mobile/packages/`).
- Anchor IDs (`#per-layer-failure-contract`, `#decision-matrix`, `#migration-recipe`, `#naming-context-identifiers`) match GitHub's default heading-slug conventions and the slugs already used by intra-file links in the existing rule file.
- No ARB or `context.l10n` change → no `flutter test test/l10n/` needed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

## Reviewer

Per the epic subgroup, @NotThatKindOfDrLiz (DRI for #4336) is the natural reviewer; will add as reviewer when CI turns green.