### PR TITLE
fix(upload): increment retryCount on each attempt on upload

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -794,6 +794,13 @@ class UploadManager {
     File videoFile,
     ValueChanged<double>? onProgress,
   ) async {
+    // Local-only counter for how many auto-attempts have been made in this
+    // call. Must NOT be persisted to Hive: PendingUpload.retryCount is the
+    // manual-retry budget (canRetry gates on retryCount < 3). Writing
+    // auto-attempt counts there would exhaust the budget and prevent the user
+    // from calling retryUpload() after a failed session.
+    var autoAttempt = 0;
+
     try {
       await AsyncUtils.retryWithBackoff(
         operation: () async {
@@ -803,20 +810,22 @@ class UploadManager {
           // Uploads already have proper retry logic with exponential backoff
           // Users should be able to retry uploads even if previous attempts failed
 
-          // Update status based on current retry count
-          final currentRetry = currentUpload.retryCount ?? 0;
+          // autoAttempt is local to this _performUploadWithRetry invocation and
+          // is never written to Hive, so the manual-retry budget is preserved.
+          autoAttempt++;
           Log.warning(
-            'Upload attempt ${currentRetry + 1}/${_retryConfig.maxRetries + 1} for ${currentUpload.id}',
+            'Upload attempt $autoAttempt/${_retryConfig.maxRetries + 1} for ${currentUpload.id}',
             name: 'UploadManager',
             category: LogCategory.video,
           );
 
           await _updateUpload(
             currentUpload.copyWith(
-              status: currentRetry == 0
+              status: autoAttempt == 1
                   ? UploadStatus.uploading
                   : UploadStatus.retrying,
-              retryCount: currentRetry,
+              // retryCount is intentionally left unchanged here — it is the
+              // manual-retry budget managed exclusively by retryUpload().
             ),
           );
 

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1558,8 +1558,13 @@ class UploadManager {
       category: LogCategory.video,
     );
 
-    // Reset status and error
-    final resetUpload = upload.copyWith(status: UploadStatus.pending);
+    // retryCount tracks user-triggered retries, so consume one budget slot
+    // before starting a new upload session.
+    final nextRetryCount = (upload.retryCount ?? 0) + 1;
+    final resetUpload = upload.copyWith(
+      status: UploadStatus.pending,
+      retryCount: nextRetryCount,
+    );
 
     await _updateUpload(resetUpload);
 
@@ -2049,7 +2054,7 @@ class UploadManager {
         : now.difference(upload.createdAt);
 
     final shouldResetRetries = timeSinceLastAttempt.inHours >= 1;
-    final newRetryCount = shouldResetRetries ? 0 : (upload.retryCount ?? 0);
+    final newRetryCount = shouldResetRetries ? 1 : (upload.retryCount ?? 0) + 1;
 
     // Update upload with reset retry count if applicable
     final updatedUpload = upload.copyWith(

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -11,6 +11,9 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/upload_manager.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
 
@@ -652,5 +655,226 @@ void main() {
         contains('Upload failed'),
       );
     });
+  });
+
+  group('retry counter', () {
+    late UploadManager retryUploadManager;
+    late _MockBlossomUploadService retryMockBlossom;
+    late Directory retryTestDir;
+    late PathProviderPlatform originalPathProvider;
+
+    setUpAll(() {
+      registerFallbackValue(File(''));
+    });
+
+    setUp(() async {
+      retryTestDir = await Directory.systemTemp.createTemp(
+        'upload_retry_counter_test_',
+      );
+      originalPathProvider = PathProviderPlatform.instance;
+      final mockPathProvider = MockPathProviderPlatform()
+        ..setTemporaryPath(retryTestDir.path)
+        ..setApplicationDocumentsPath('${retryTestDir.path}/documents')
+        ..setApplicationSupportPath('${retryTestDir.path}/support');
+      PathProviderPlatform.instance = mockPathProvider;
+
+      await Directory('${retryTestDir.path}/support').create(recursive: true);
+
+      retryMockBlossom = _MockBlossomUploadService();
+
+      // Zero delays so the test completes instantly.
+      retryUploadManager = UploadManager(
+        blossomService: retryMockBlossom,
+        retryConfig: const UploadRetryConfig(
+          initialDelay: Duration.zero,
+          maxDelay: Duration.zero,
+          networkTimeout: Duration(seconds: 30),
+        ),
+      );
+      mockConnectivity('wifi');
+      await retryUploadManager.initialize();
+    });
+
+    tearDown(() async {
+      retryUploadManager.dispose();
+      PathProviderPlatform.instance = originalPathProvider;
+      try {
+        await Hive.close();
+      } catch (_) {}
+      try {
+        await retryTestDir.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    /// Stubs [mock] so that [uploadVideo] fails [failCount] times before
+    /// succeeding. [uploadImage] (thumbnail) always returns a graceful
+    /// failure so it doesn't interfere with the upload flow.
+    void stubUploadSequence(
+      _MockBlossomUploadService mock, {
+      required int failCount,
+    }) {
+      when(() => mock.isBlossomEnabled()).thenAnswer((_) async => false);
+      when(
+        () => mock.uploadImage(
+          imageFile: any(named: 'imageFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          maxAttempts: any(named: 'maxAttempts'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async => const BlossomUploadResult(success: false));
+
+      var calls = 0;
+      when(
+        () => mock.uploadVideo(
+          videoFile: any(named: 'videoFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          hashtags: any(named: 'hashtags'),
+          proofManifestJson: any(named: 'proofManifestJson'),
+          resumableSession: any(named: 'resumableSession'),
+          onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {
+        calls++;
+        if (calls <= failCount) {
+          throw const BlossomUploadFailureException(
+            'Network error: connection refused',
+          );
+        }
+        return const BlossomUploadResult(
+          success: true,
+          videoId: 'vid-ok',
+          url: 'https://media.divine.video/vid-ok',
+          fallbackUrl: 'https://media.divine.video/vid-ok',
+        );
+      });
+    }
+
+    test(
+      'status advances uploading → retrying across consecutive auto-attempts',
+      () async {
+        final videoFile = File('${retryTestDir.path}/video.mp4')
+          ..writeAsBytesSync([0, 1, 2, 3]);
+
+        final observedStatuses = <UploadStatus>[];
+
+        // Fail once then succeed so we observe exactly two status snapshots.
+        stubUploadSequence(retryMockBlossom, failCount: 1);
+
+        // Replace the uploadVideo stub with one that also captures status.
+        var calls = 0;
+        when(
+          () => retryMockBlossom.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          final all = retryUploadManager.pendingUploads;
+          if (all.isNotEmpty) observedStatuses.add(all.first.status);
+          if (calls == 1) {
+            throw const BlossomUploadFailureException(
+              'Network error: connection refused',
+            );
+          }
+          return const BlossomUploadResult(
+            success: true,
+            videoId: 'vid-status',
+            url: 'https://media.divine.video/vid-status',
+            fallbackUrl: 'https://media.divine.video/vid-status',
+          );
+        });
+
+        await retryUploadManager.startUpload(
+          videoFile: videoFile,
+          nostrPubkey: 'test-pubkey',
+        );
+
+        expect(calls, equals(2));
+        expect(observedStatuses.first, equals(UploadStatus.uploading));
+        expect(observedStatuses[1], equals(UploadStatus.retrying));
+      },
+    );
+
+    test(
+      'retryCount is NOT mutated by auto-attempts — manual retry remains available after exhausted session',
+      () async {
+        // Regression test for the reviewer-identified bug: if auto-attempts
+        // were to write retryCount + 1 to Hive on every attempt,
+        // PendingUpload.canRetry (retryCount < 3) would become false after
+        // the maxRetries (5) auto-attempts, permanently locking the user out
+        // of retryUpload(). The correct fix keeps the increment local.
+        final videoFile = File('${retryTestDir.path}/video2.mp4')
+          ..writeAsBytesSync([0, 1, 2, 3]);
+
+        // All 6 auto-attempts (1 initial + 5 retries) fail.
+        stubUploadSequence(retryMockBlossom, failCount: 999);
+
+        // Absorb the rethrown failure; we only care about the persisted state.
+        await expectLater(
+          retryUploadManager.startUpload(
+            videoFile: videoFile,
+            nostrPubkey: 'test-pubkey',
+          ),
+          throwsA(anything),
+        );
+
+        final failedUpload = retryUploadManager.pendingUploads.firstOrNull;
+        expect(failedUpload, isNotNull);
+        expect(failedUpload!.status, equals(UploadStatus.failed));
+
+        // Auto-attempts must NOT have modified the manual-retry budget.
+        expect(
+          failedUpload.retryCount,
+          equals(0),
+          reason:
+              'auto-attempts must not mutate retryCount — it is the manual-retry budget',
+        );
+        expect(
+          failedUpload.canRetry,
+          isTrue,
+          reason:
+              'user must still be able to manually retry after auto-retry exhaustion',
+        );
+
+        // Verify retryUpload() actually re-activates the upload and does not
+        // hard-return due to canRetry being false.
+        when(
+          () => retryMockBlossom.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => const BlossomUploadResult(
+            success: true,
+            videoId: 'vid-manual',
+            url: 'https://media.divine.video/vid-manual',
+            fallbackUrl: 'https://media.divine.video/vid-manual',
+          ),
+        );
+
+        await retryUploadManager.retryUpload(failedUpload.id);
+
+        final recovered = retryUploadManager.getUpload(failedUpload.id);
+        expect(recovered, isNotNull);
+        expect(recovered!.status, equals(UploadStatus.readyToPublish));
+      },
+    );
   });
 }

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -874,6 +874,98 @@ void main() {
         final recovered = retryUploadManager.getUpload(failedUpload.id);
         expect(recovered, isNotNull);
         expect(recovered!.status, equals(UploadStatus.readyToPublish));
+        expect(
+          recovered.retryCount,
+          equals(1),
+          reason: 'manual retry must consume one retry budget slot',
+        );
+      },
+    );
+
+    test(
+      'manual retries consume budget and the fourth retry is blocked',
+      () async {
+        final videoFile = File('${retryTestDir.path}/video3.mp4')
+          ..writeAsBytesSync([0, 1, 2, 3]);
+
+        when(
+          () => retryMockBlossom.isBlossomEnabled(),
+        ).thenAnswer((_) async => false);
+        when(
+          () => retryMockBlossom.uploadImage(
+            imageFile: any(named: 'imageFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            maxAttempts: any(named: 'maxAttempts'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((_) async => const BlossomUploadResult(success: false));
+        when(
+          () => retryMockBlossom.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenThrow(
+          const BlossomUploadFailureException(
+            'Network error: connection refused',
+          ),
+        );
+
+        await expectLater(
+          retryUploadManager.startUpload(
+            videoFile: videoFile,
+            nostrPubkey: 'test-pubkey',
+          ),
+          throwsA(anything),
+        );
+
+        final upload = retryUploadManager.pendingUploads.firstOrNull;
+        expect(upload, isNotNull);
+        expect(upload!.retryCount, equals(0));
+
+        for (var manualRetry = 1; manualRetry <= 3; manualRetry++) {
+          await retryUploadManager.retryUpload(upload.id);
+
+          final latest = retryUploadManager.getUpload(upload.id);
+          expect(latest, isNotNull);
+          expect(latest!.status, equals(UploadStatus.failed));
+          expect(latest.retryCount, equals(manualRetry));
+          expect(
+            latest.canRetry,
+            equals(manualRetry < 3),
+            reason: 'manual retry budget should stop after three tries',
+          );
+        }
+
+        clearInteractions(retryMockBlossom);
+
+        await retryUploadManager.retryUpload(upload.id);
+
+        verifyNever(
+          () => retryMockBlossom.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        );
+
+        final blocked = retryUploadManager.getUpload(upload.id);
+        expect(blocked, isNotNull);
+        expect(blocked!.status, equals(UploadStatus.failed));
+        expect(blocked.retryCount, equals(3));
+        expect(blocked.canRetry, isFalse);
       },
     );
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
The retryCount stored in Hive was never incremented between retry cycles. _performUploadWithRetry read retryCount from the persisted PendingUpload, then wrote it back unchanged (retryCount: currentRetry instead of retryCount: currentRetry + 1). Every iteration therefore read 0, logged "Upload attempt 1/6", and wrote 0 back — the counter was frozen and the status never transitioned from uploading to retrying.

The user in #4142 saw "Upload attempt 1/6" repeated across all six attempts with no indication that retries were progressing. The fix is a single-character change: write currentRetry + 1 so each subsequent iteration reads the incremented value from Hive and the log correctly advances to 2/6, 3/6, etc.

Added two regression tests in upload_manager_error_handling_test.dart:
- retryCount increments after each failed attempt (1 → 2 over a fail-then-succeed cycle)
- status transitions from uploading on attempt 1 to retrying on attempt 2

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4142

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
