### PR TITLE
refactor(state): define and enforce Riverpod/BLoC migration boundaries

### DIFF
--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -29,7 +29,7 @@ Copy the closest example when writing a new bridged screen:
 
 | Screen | File | Pattern |
 |--------|------|---------|
-| `NotificationsPage` | `mobile/lib/notifications/view/notifications_page.dart` | Nullable dep gate before creating `BlocProvider` |
+| `NotificationsPage` | `mobile/lib/notifications/view/notifications_page.dart` | Nullable dep gate before creating `BlocProvider`, re-keyed on watched repositories |
 | `AppsDirectoryScreen` | `mobile/lib/screens/apps/apps_directory_screen.dart` | `ref.read` stable service, no `ValueKey` needed |
 | `VideoEngagementListScreen` | `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` | `ref.watch` auth-sensitive repos + record `ValueKey` guard; view in separate file |
 

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -6,6 +6,35 @@
 >
 > **Existing code**: Riverpod is used for legacy code maintenance only
 
+## Ownership Boundary
+
+**Riverpod owns:** app-level DI, long-lived services/clients, infrastructure side-effects.  
+**BLoC/Cubit owns:** all feature UI state, all UI side effects, all loading/error/success states.
+
+## Allowed / Disallowed Patterns
+
+| Pattern | Verdict |
+|---------|---------|
+| `ConsumerWidget` outer Page + `BlocProvider` → `StatelessWidget` inner View | **Allowed** — canonical bridge; use `ref.watch` + `ValueKey` guard |
+| `ConsumerWidget` that only creates `BlocProvider` without reading any Riverpod dep | **Disallowed** — use plain `StatelessWidget` |
+| `ConsumerStatefulWidget` storing UI state in `_state` fields | **Disallowed** — extract to a `Cubit` |
+| New `@riverpod` / `StateProvider` for feature UI state | **Disallowed** — use BLoC/Cubit |
+| `*BridgeProvider` as infrastructure side-effect | **Allowed** — must have `// TODO(#issue):` removal comment |
+| `ref.read` capturing dep in `BlocProvider.create` without `ValueKey` guard | **Disallowed** — stale dep on auth flip |
+| `ref.watch` inside `BlocProvider.create` | **Disallowed** — `create` is called once; watch in `build`, pass via `ValueKey` |
+
+### Canonical template screens
+
+Copy the closest example when writing a new bridged screen:
+
+| Screen | File | Pattern |
+|--------|------|---------|
+| `NotificationsPage` | `mobile/lib/notifications/view/notifications_page.dart` | Nullable dep gate before creating `BlocProvider` |
+| `AppsDirectoryScreen` | `mobile/lib/screens/apps/apps_directory_screen.dart` | `ref.read` stable service, no `ValueKey` needed |
+| `VideoEngagementListScreen` | `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` | `ref.watch` auth-sensitive repos + record `ValueKey` guard; view in separate file |
+
+See `docs/BLOC_UI_MIGRATION_PRD.md` for the full rationale and bridge inventory.
+
 ---
 
 # BLoC (Primary - New Features)

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -40,7 +40,7 @@ jobs:
           bash scripts/check_native_transport_security.sh
       - name: 🪵 Verify no raw logging in production code
         run: bash scripts/check_raw_logging.sh
-      - name: 🚧 Verify Riverpod boundary (no @riverpod outside providers/services)
+      - name: 🚧 Verify Riverpod boundary (@riverpod / StateProvider locations)
         run: bash scripts/check_riverpod_boundary.sh
       - name: 🔨 Verify generated files are up-to-date
         run: |

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -40,6 +40,8 @@ jobs:
           bash scripts/check_native_transport_security.sh
       - name: 🪵 Verify no raw logging in production code
         run: bash scripts/check_raw_logging.sh
+      - name: 🚧 Verify Riverpod boundary (no @riverpod outside providers/services)
+        run: bash scripts/check_riverpod_boundary.sh
       - name: 🔨 Verify generated files are up-to-date
         run: |
           dart run build_runner build --delete-conflicting-outputs

--- a/docs/BLOC_UI_MIGRATION_PRD.md
+++ b/docs/BLOC_UI_MIGRATION_PRD.md
@@ -87,7 +87,7 @@ bridged screens. Do not invent a new pattern — pick the closest example below.
 
 | Screen | File | Pattern demonstrated |
 |--------|------|---------------------|
-| `NotificationsPage` | `mobile/lib/notifications/view/notifications_page.dart` | Nullable dep gate: returns loading widget until Riverpod dep is non-null, then creates `BlocProvider`. |
+| `NotificationsPage` | `mobile/lib/notifications/view/notifications_page.dart` | Nullable dep gate: returns loading widget until Riverpod dep is non-null, then creates `BlocProvider` re-keyed on the watched repositories. |
 | `AppsDirectoryScreen` | `mobile/lib/screens/apps/apps_directory_screen.dart` | `ref.read` on a stable service (no auth-flip risk); no `ValueKey` needed. |
 | `VideoEngagementListScreen` | `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` | `ref.watch` on auth-sensitive repos with a record `ValueKey` guard; view extracted to `video_engagement_list_view.dart`. |
 

--- a/docs/BLOC_UI_MIGRATION_PRD.md
+++ b/docs/BLOC_UI_MIGRATION_PRD.md
@@ -1,7 +1,7 @@
 # PRD: Incremental UI Migration from Riverpod to BLoC
 
 Status: Current
-Validated against: current mobile architecture direction on 2026-03-19.
+Validated against: current mobile architecture direction on 2026-05-20.
 
 ## Status
 - **Owner:** mobile team
@@ -24,15 +24,86 @@ Riverpod is not being removed everywhere immediately. Existing Riverpod code rem
 3. **Predictable rebuild control** with `BlocBuilder`, `BlocSelector`, and `context.select`.
 4. **Better phased migration ergonomics**: convert one feature/screen without a big-bang rewrite.
 
-## In-Progress PR Evidence
-- **#1908**: replace Riverpod profile providers with `ProfilesBloc` (Phase 6)  
-  https://github.com/divinevideo/divine-mobile/pull/1908
-- **#1894**: wire `MyProfileBloc` into main profile screen  
-  https://github.com/divinevideo/divine-mobile/pull/1894
-- **#1903**: retire `UserProfileService`; keep Riverpod bridge providers temporarily  
-  https://github.com/divinevideo/divine-mobile/pull/1903
-- **#1282 (merged)**: migrate username validation from Riverpod to BLoC  
-  https://github.com/divinevideo/divine-mobile/pull/1282
+## Completed Migration Evidence
+- **#1282 (merged):** migrate username validation from Riverpod to BLoC
+- **#1894 (merged 2026-03-09):** wire `MyProfileBloc` into main profile screen
+- **#1903 (merged 2026-03-10):** retire `UserProfileService`; migrate to Drift-backed `ProfileRepository`
+
+## Ownership Boundary (enforced by convention + code review)
+
+Riverpod **owns**:
+- App-level dependency injection (repositories, services, clients)
+- Long-lived infrastructure side-effects (relay sync, blocklist sync, push token sync)
+- DI bridges: `ConsumerWidget` pages that read Riverpod deps and hand them into `BlocProvider`
+
+BLoC/Cubit **owns**:
+- All feature UI state
+- All UI side effects (navigation triggers, snackbar signals, dialog sequencing)
+- All loading/error/success state managed by a screen or feature
+
+## Allowed / Disallowed Patterns
+
+| Pattern | Verdict | Notes |
+|---------|---------|-------|
+| `ConsumerWidget` outer Page + `BlocProvider` → `StatelessWidget` inner View | **Allowed** | Canonical bridge. Use `ref.watch` on deps + `ValueKey` guard (see below). |
+| `ConsumerWidget` that only creates a `BlocProvider` without reading any Riverpod dep | **Disallowed** | Use plain `StatelessWidget` instead — no Riverpod involvement needed. |
+| `ConsumerStatefulWidget` storing UI state in `_state` fields instead of a Cubit | **Disallowed** | Extract the state into a `Cubit`. The widget becomes a `ConsumerWidget` or `StatefulWidget`. |
+| New `@riverpod` / `StateProvider` for feature UI state | **Disallowed** | Use `BLoC`/`Cubit` for all new UI state. |
+| `*BridgeProvider` as infrastructure side-effect (relay sync, blocklist sync, etc.) | **Allowed with issue link** | Must have a `// TODO(#NNNN):` removal comment. See bridge inventory below. |
+| `ref.read` capturing a dep inside `BlocProvider.create` without a `ValueKey` guard | **Disallowed** | Stale dep on auth flip. Use `ref.watch` + `ValueKey((dep1, dep2, ...))` on the `BlocProvider`. |
+| `ref.watch` inside `BlocProvider.create` | **Disallowed** | `create` is called once; `ref.watch` has no effect there. Watch in `build`, pass via `ValueKey`. |
+
+### ValueKey guard — required pattern when bridging watched deps
+
+When a `BlocProvider` inside a `ConsumerWidget` captures Riverpod dependencies that can change
+(e.g. repository instances that are replaced on auth flip), always supply a `ValueKey` composed
+of all captured deps. Flutter will recreate the `BlocProvider` subtree when the key changes,
+giving the bloc fresh dependencies and resetting its state intentionally.
+
+```dart
+class MySomeScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repo = ref.watch(someRepositoryProvider);
+    return BlocProvider<SomeBloc>(
+      key: ValueKey(repo),                    // ← recreates bloc when repo identity changes
+      create: (_) => SomeBloc(repo: repo)..add(const SomeStarted()),
+      child: const _SomeView(),
+    );
+  }
+}
+```
+
+When multiple deps are captured, use a record:
+
+```dart
+key: ValueKey((likesRepo, repostsRepo, eventId, type)),
+```
+
+## Canonical Template Screens
+
+These three screens are the correct reference implementations to copy from when writing new
+bridged screens. Do not invent a new pattern — pick the closest example below.
+
+| Screen | File | Pattern demonstrated |
+|--------|------|---------------------|
+| `NotificationsPage` | `mobile/lib/notifications/view/notifications_page.dart` | Nullable dep gate: returns loading widget until Riverpod dep is non-null, then creates `BlocProvider`. |
+| `AppsDirectoryScreen` | `mobile/lib/screens/apps/apps_directory_screen.dart` | `ref.read` on a stable service (no auth-flip risk); no `ValueKey` needed. |
+| `VideoEngagementListScreen` | `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` | `ref.watch` on auth-sensitive repos with a record `ValueKey` guard; view extracted to `video_engagement_list_view.dart`. |
+
+## Current Bridge Inventory
+
+The following `*BridgeProvider`s are watched in `AppShell.build()` as infrastructure
+side-effects. They are **not** UI state — they are long-lived service wiring that has not yet
+been moved to a dedicated cubit/service lifecycle. Each is annotated with a removal criterion.
+Tracking issue: **#3339**.
+
+| Provider | Purpose | Removal criterion |
+|----------|---------|------------------|
+| `relayStatisticsBridgeProvider` | Records relay connection events for analytics | Remove when relay management moves to a dedicated cubit/service |
+| `relaySetChangeBridgeProvider` | Refreshes feeds when the relay set changes | Remove when feed refresh is driven by a relay event stream in a cubit |
+| `notificationPreferencesDirtySyncBridgeProvider` | Syncs notification preferences on auth change | Remove when `NotificationPreferencesCubit` owns this lifecycle |
+| `blocklistSyncBridgeProvider` | Syncs block/mute list after login | Remove when `BlocklistCubit` owns post-login sync |
 
 ## Migration Model
 ### Principles
@@ -108,12 +179,6 @@ This section is intentionally written as implementation guidance for both humans
 - Emitting many transient states that trigger full subtree rebuilds.
 - Mixing migration with unrelated refactors in the same PR.
 - Keeping temporary Riverpod bridges without TODO/issue linkage.
-
-## How current PRs demonstrate the model
-- **#1908** demonstrates app-level feature bloc migration (`ProfilesBloc`) and replacing bridge providers.
-- **#1894** demonstrates incremental cutover of a specific screen path (`MyProfileBloc` into profile UI).
-- **#1903** demonstrates transitional architecture: repository-first core with temporary compatibility bridges.
-- **#1282** demonstrates focused Riverpod→BLoC migration in a narrower domain (username validation).
 
 ## External references
 - VGV: Why we use flutter_bloc  

--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -20,7 +20,7 @@ The codebase remains hybrid during transition; Riverpod still exists in some leg
 
 | What you are building | Copy from |
 |-----------------------|-----------|
-| Screen that needs a repository from Riverpod | `NotificationsPage` — `mobile/lib/notifications/view/notifications_page.dart` |
+| Screen that needs a repository from Riverpod and must gate on nullable deps | `NotificationsPage` — `mobile/lib/notifications/view/notifications_page.dart` |
 | Screen using a stable service (no auth-flip risk) | `AppsDirectoryScreen` — `mobile/lib/screens/apps/apps_directory_screen.dart` |
 | Screen with auth-sensitive deps (needs `ValueKey` guard) | `VideoEngagementListScreen` — `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` |
 

--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -1,7 +1,7 @@
 # State Management (Current)
 
 Status: Current
-Validated against: current mobile architecture direction on 2026-03-19.
+Validated against: current mobile architecture direction on 2026-05-20.
 
 Single source of truth for current state-management direction:
 
@@ -12,10 +12,52 @@ Single source of truth for current state-management direction:
 Divine is in an incremental migration where **BLoC/Cubit is the default for UI state**.
 The codebase remains hybrid during transition; Riverpod still exists in some legacy/compatibility paths.
 
+## Quick Reference
+
+**The rule in one sentence:** Riverpod owns DI and long-lived services; BLoC/Cubit owns all feature UI state.
+
+**Canonical examples to copy from:**
+
+| What you are building | Copy from |
+|-----------------------|-----------|
+| Screen that needs a repository from Riverpod | `NotificationsPage` — `mobile/lib/notifications/view/notifications_page.dart` |
+| Screen using a stable service (no auth-flip risk) | `AppsDirectoryScreen` — `mobile/lib/screens/apps/apps_directory_screen.dart` |
+| Screen with auth-sensitive deps (needs `ValueKey` guard) | `VideoEngagementListScreen` — `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` |
+
+**The pattern in brief:**
+
+```dart
+// Outer Page: ConsumerWidget — reads Riverpod deps, creates BlocProvider
+class MyFeatureScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repo = ref.watch(myRepositoryProvider);
+    return BlocProvider<MyFeatureBloc>(
+      key: ValueKey(repo),
+      create: (_) => MyFeatureBloc(repo: repo)..add(const MyFeatureStarted()),
+      child: const MyFeatureView(),
+    );
+  }
+}
+
+// Inner View: StatelessWidget — consumes only BLoC, zero Riverpod
+class MyFeatureView extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<MyFeatureBloc, MyFeatureState>(
+      builder: (context, state) { ... },
+    );
+  }
+}
+```
+
+See `docs/BLOC_UI_MIGRATION_PRD.md` for the full Allowed/Disallowed pattern table, bridge inventory,
+and migration model.
+
 ## Why this file exists
 
 Older Riverpod migration docs were removed because they were stale and contradictory with current in-flight migration work.
 If you need implementation guidance, use:
 
 - `docs/FLUTTER.md` (engineering standards)
-- `docs/BLOC_UI_MIGRATION_PRD.md` (migration rationale, best practices, PR examples)
+- `docs/BLOC_UI_MIGRATION_PRD.md` (migration rationale, best practices, allowed/disallowed patterns)

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -40,6 +40,7 @@ class InboxNotificationsPage extends ConsumerWidget {
     final followRepository = ref.watch(followRepositoryProvider);
 
     return BlocProvider(
+      key: ValueKey((notificationRepository, followRepository)),
       create: (_) => NotificationFeedBloc(
         notificationRepository: notificationRepository,
         followRepository: followRepository,

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -52,6 +52,7 @@ class NotificationsPage extends ConsumerWidget {
     final followRepository = ref.watch(followRepositoryProvider);
 
     return BlocProvider(
+      key: ValueKey((notificationRepository, followRepository)),
       create: (_) => NotificationFeedBloc(
         notificationRepository: notificationRepository,
         followRepository: followRepository,

--- a/mobile/lib/providers/overlay_policy_provider.dart
+++ b/mobile/lib/providers/overlay_policy_provider.dart
@@ -1,0 +1,10 @@
+// ABOUTME: Riverpod provider for test-only overlay policy injection.
+// ABOUTME: Lives in lib/providers/ so overlay behavior overrides follow the
+// ABOUTME: same DI boundary as the rest of the Riverpod graph.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/ui/overlay_policy.dart';
+
+final overlayPolicyProvider = Provider<OverlayPolicy>(
+  (_) => OverlayPolicy.auto,
+);

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -201,20 +201,24 @@ class _AppShellState extends ConsumerState<AppShell> {
     // Initialize auto-cleanup provider to ensure only one video plays at a time
     ref.watch(videoControllerAutoCleanupProvider);
 
-    // Initialize relay statistics bridge to record connection events
+    // Transitional scaffold: records relay connection events for analytics.
+    // TODO(#3339): remove when relay management moves to a dedicated cubit/service.
     ref.watch(relayStatisticsBridgeProvider);
 
-    // Initialize relay set change bridge to refresh feeds when relays are added/removed
+    // Transitional scaffold: refreshes feeds when the relay set changes.
+    // TODO(#3339): remove when feed refresh is driven by a relay event stream in a cubit.
     ref.watch(relaySetChangeBridgeProvider);
 
     // Initialize Zendesk identity sync to keep user identity in sync with auth
     ref.watch(zendeskIdentitySyncProvider);
 
-    // Initialize push notification sync to register FCM token on auth
+    // Transitional scaffold: syncs notification preferences on auth change.
+    // TODO(#3339): remove when NotificationPreferencesCubit owns this lifecycle.
     ref.watch(notificationPreferencesDirtySyncBridgeProvider);
     ref.watch(pushNotificationSyncProvider);
 
-    // Start block/mute list sync once authenticated (handles post-reinstall login)
+    // Transitional scaffold: syncs block/mute list after login.
+    // TODO(#3339): remove when BlocklistCubit owns post-login sync.
     ref.watch(blocklistSyncBridgeProvider);
 
     // Watch page context to determine if back button should show and if on search route

--- a/mobile/lib/screens/video_engagement/video_engagement_list_screen.dart
+++ b/mobile/lib/screens/video_engagement/video_engagement_list_screen.dart
@@ -1,18 +1,28 @@
-// ABOUTME: Screen showing the list of users who liked or reposted a video.
-// ABOUTME: Reached when the video owner taps the Like or Repost button on
-// ABOUTME: their own video — replacing the toggle behavior with a list view.
+// ABOUTME: Page widget for the video engagement (likers/reposters) list.
+// ABOUTME: Bridges Riverpod-provided repositories into VideoEngagementBloc.
+// ABOUTME: This is the canonical ConsumerWidget Page + BlocProvider pattern —
+// ABOUTME: see docs/BLOC_UI_MIGRATION_PRD.md "Canonical Template Screens".
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/router/nav_extensions.dart';
-import 'package:openvine/widgets/user_profile_tile.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_view.dart';
 
 /// Page widget for the video engagement (likers / reposters) list.
+///
+/// This screen is the Page layer of the Page/View split:
+/// - [VideoEngagementListScreen] is a [ConsumerWidget] that reads Riverpod
+///   dependency providers and hands them into [VideoEngagementBloc] via
+///   [BlocProvider].
+/// - [VideoEngagementListView] (in `video_engagement_list_view.dart`) is the
+///   pure [StatelessWidget] View that consumes only [VideoEngagementBloc] state.
+///
+/// The [ValueKey] on [BlocProvider] is a record of all captured Riverpod deps
+/// plus the event-specific params. Flutter recreates the bloc subtree whenever
+/// any captured dependency changes (e.g. on auth flip / account switch),
+/// ensuring the bloc never holds a stale repository reference.
 class VideoEngagementListScreen extends ConsumerWidget {
   const VideoEngagementListScreen({
     required this.eventId,
@@ -57,141 +67,7 @@ class VideoEngagementListScreen extends ConsumerWidget {
         repostsRepository: repostsRepository,
         addressableId: addressableId,
       )..add(const VideoEngagementLoadRequested()),
-      child: const _VideoEngagementListView(),
-    );
-  }
-}
-
-class _VideoEngagementListView extends StatelessWidget {
-  const _VideoEngagementListView();
-
-  @override
-  Widget build(BuildContext context) {
-    final type = context.select(
-      (VideoEngagementBloc bloc) => bloc.state.type,
-    );
-    final title = switch (type) {
-      VideoEngagementType.likers => context.l10n.videoEngagementLikersTitle,
-      VideoEngagementType.reposters =>
-        context.l10n.videoEngagementRepostersTitle,
-    };
-
-    return Scaffold(
-      backgroundColor: VineTheme.surfaceBackground,
-      appBar: DiVineAppBar(
-        titleWidget: Text(title, style: VineTheme.titleMediumFont()),
-        showBackButton: true,
-        onBackPressed: () => Navigator.of(context).pop(),
-        backButtonSemanticLabel: context.l10n.commonBack,
-      ),
-      body: BlocBuilder<VideoEngagementBloc, VideoEngagementState>(
-        builder: (context, state) {
-          return switch (state.status) {
-            VideoEngagementStatus.initial ||
-            VideoEngagementStatus.loading => const Center(
-              child: CircularProgressIndicator(),
-            ),
-            VideoEngagementStatus.success when state.pubkeys.isEmpty =>
-              _EngagementEmptyState(type: state.type),
-            VideoEngagementStatus.success => _EngagementListBody(
-              pubkeys: state.pubkeys,
-            ),
-            VideoEngagementStatus.failure => const _EngagementErrorBody(),
-          };
-        },
-      ),
-    );
-  }
-}
-
-class _EngagementListBody extends StatelessWidget {
-  const _EngagementListBody({required this.pubkeys});
-
-  final List<String> pubkeys;
-
-  @override
-  Widget build(BuildContext context) {
-    return RefreshIndicator(
-      color: VineTheme.onPrimary,
-      backgroundColor: VineTheme.vineGreen,
-      onRefresh: () async {
-        context.read<VideoEngagementBloc>().add(
-          const VideoEngagementLoadRequested(),
-        );
-      },
-      child: ListView.builder(
-        itemCount: pubkeys.length,
-        itemBuilder: (context, index) {
-          final pubkey = pubkeys[index];
-          return UserProfileTile(
-            pubkey: pubkey,
-            onTap: () => context.pushOtherProfile(pubkey),
-            showFollowButton: false,
-            index: index,
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _EngagementEmptyState extends StatelessWidget {
-  const _EngagementEmptyState({required this.type});
-
-  final VideoEngagementType type;
-
-  @override
-  Widget build(BuildContext context) {
-    final message = switch (type) {
-      VideoEngagementType.likers => context.l10n.videoEngagementLikersEmpty,
-      VideoEngagementType.reposters =>
-        context.l10n.videoEngagementRepostersEmpty,
-    };
-    final icon = switch (type) {
-      VideoEngagementType.likers => Icons.favorite_border,
-      VideoEngagementType.reposters => Icons.repeat,
-    };
-
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(icon, size: 64, color: VineTheme.lightText),
-          const SizedBox(height: 16),
-          Text(
-            message,
-            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _EngagementErrorBody extends StatelessWidget {
-  const _EngagementErrorBody();
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
-          const SizedBox(height: 16),
-          Text(
-            context.l10n.videoEngagementLoadFailed,
-            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
-          ),
-          const SizedBox(height: 8),
-          TextButton(
-            onPressed: () => context.read<VideoEngagementBloc>().add(
-              const VideoEngagementLoadRequested(),
-            ),
-            child: Text(context.l10n.commonRetry),
-          ),
-        ],
-      ),
+      child: const VideoEngagementListView(),
     );
   }
 }

--- a/mobile/lib/screens/video_engagement/video_engagement_list_view.dart
+++ b/mobile/lib/screens/video_engagement/video_engagement_list_view.dart
@@ -1,0 +1,153 @@
+// ABOUTME: Pure StatelessWidget View for the video engagement (likers/reposters) list.
+// ABOUTME: Consumes VideoEngagementBloc via BlocBuilder — zero Riverpod dependency.
+// ABOUTME: Provided and owned by VideoEngagementListScreen (the Page layer).
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/router/nav_extensions.dart';
+import 'package:openvine/widgets/user_profile_tile.dart';
+
+/// Inner View for the video engagement list screen.
+///
+/// Pure [StatelessWidget] — reads state exclusively from [VideoEngagementBloc]
+/// via [BlocBuilder]/[context.select]. Has no Riverpod dependency.
+///
+/// See also: [VideoEngagementListScreen], which is the [ConsumerWidget] Page
+/// that wires Riverpod dependencies into [VideoEngagementBloc] and provides
+/// this view.
+class VideoEngagementListView extends StatelessWidget {
+  const VideoEngagementListView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final type = context.select(
+      (VideoEngagementBloc bloc) => bloc.state.type,
+    );
+    final title = switch (type) {
+      VideoEngagementType.likers => context.l10n.videoEngagementLikersTitle,
+      VideoEngagementType.reposters =>
+        context.l10n.videoEngagementRepostersTitle,
+    };
+
+    return Scaffold(
+      backgroundColor: VineTheme.surfaceBackground,
+      appBar: DiVineAppBar(
+        titleWidget: Text(title, style: VineTheme.titleMediumFont()),
+        showBackButton: true,
+        onBackPressed: () => Navigator.of(context).pop(),
+        backButtonSemanticLabel: context.l10n.commonBack,
+      ),
+      body: BlocBuilder<VideoEngagementBloc, VideoEngagementState>(
+        builder: (context, state) {
+          return switch (state.status) {
+            VideoEngagementStatus.initial ||
+            VideoEngagementStatus.loading => const Center(
+              child: CircularProgressIndicator(),
+            ),
+            VideoEngagementStatus.success when state.pubkeys.isEmpty =>
+              _EngagementEmptyState(type: state.type),
+            VideoEngagementStatus.success => _EngagementListBody(
+              pubkeys: state.pubkeys,
+            ),
+            VideoEngagementStatus.failure => const _EngagementErrorBody(),
+          };
+        },
+      ),
+    );
+  }
+}
+
+class _EngagementListBody extends StatelessWidget {
+  const _EngagementListBody({required this.pubkeys});
+
+  final List<String> pubkeys;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      color: VineTheme.onPrimary,
+      backgroundColor: VineTheme.vineGreen,
+      onRefresh: () async {
+        context.read<VideoEngagementBloc>().add(
+          const VideoEngagementLoadRequested(),
+        );
+      },
+      child: ListView.builder(
+        itemCount: pubkeys.length,
+        itemBuilder: (context, index) {
+          final pubkey = pubkeys[index];
+          return UserProfileTile(
+            pubkey: pubkey,
+            onTap: () => context.pushOtherProfile(pubkey),
+            showFollowButton: false,
+            index: index,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _EngagementEmptyState extends StatelessWidget {
+  const _EngagementEmptyState({required this.type});
+
+  final VideoEngagementType type;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = switch (type) {
+      VideoEngagementType.likers => context.l10n.videoEngagementLikersEmpty,
+      VideoEngagementType.reposters =>
+        context.l10n.videoEngagementRepostersEmpty,
+    };
+    final icon = switch (type) {
+      VideoEngagementType.likers => Icons.favorite_border,
+      VideoEngagementType.reposters => Icons.repeat,
+    };
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 64, color: VineTheme.lightText),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EngagementErrorBody extends StatelessWidget {
+  const _EngagementErrorBody();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const SizedBox(height: 16),
+          Text(
+            context.l10n.videoEngagementLoadFailed,
+            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () => context.read<VideoEngagementBloc>().add(
+              const VideoEngagementLoadRequested(),
+            ),
+            child: Text(context.l10n.commonRetry),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/ui/overlay_policy.dart
+++ b/mobile/lib/ui/overlay_policy.dart
@@ -1,10 +1,7 @@
 // ABOUTME: Injectable policy for controlling video overlay visibility in tests
 // ABOUTME: Allows tests to force overlays on/off while preserving production auto behavior
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+export 'package:openvine/providers/overlay_policy_provider.dart'
+    show overlayPolicyProvider;
 
 enum OverlayPolicy { auto, alwaysOn, alwaysOff }
-
-final overlayPolicyProvider = Provider<OverlayPolicy>(
-  (_) => OverlayPolicy.auto,
-);

--- a/mobile/scripts/check_riverpod_boundary.sh
+++ b/mobile/scripts/check_riverpod_boundary.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
-# Fails CI if a @riverpod annotation or StateProvider appears outside
-# mobile/lib/providers/, which is the only permitted home for Riverpod
-# providers in this codebase.
+# Fails CI if a new @riverpod annotation or StateProvider appears outside
+# the allowed provider directories.
 #
 # Rules enforced:
 #   • No @riverpod / @Riverpod( annotations in mobile/lib/ outside
-#     mobile/lib/providers/.
-#   • No StateProvider( calls in mobile/lib/ outside mobile/lib/providers/.
+#     the allowed provider directories.
+#   • No StateProvider( calls in mobile/lib/ outside the allowed provider
+#     directories.
 #
 # Background:
 #   Divine is mid-migration from Riverpod to BLoC/Cubit for UI state.
-#   The ownership boundary is: Riverpod owns DI and long-lived services
-#   (all in lib/providers/); BLoC/Cubit owns all feature UI state.
-#   Adding a new @riverpod provider for UI state inside lib/screens/ or
-#   lib/widgets/ silently extends the hybrid model instead of shrinking it.
-#   See docs/BLOC_UI_MIGRATION_PRD.md — "Allowed / Disallowed Patterns".
+#   The full ownership boundary is documented in docs/BLOC_UI_MIGRATION_PRD.md.
+#   This guard enforces the two highest-signal extension points for new
+#   Riverpod UI state: @riverpod annotations and StateProvider declarations.
 #
 # Allowed locations for @riverpod annotations (must be documented here if added):
 #   • mobile/lib/providers/ — primary home for app-wide DI providers.
@@ -50,7 +48,7 @@ GLOBAL_EXCLUDES=(
 )
 
 # ---------------------------------------------------------------------------
-# 1. No @riverpod annotation outside lib/providers/
+# 1. No @riverpod annotation outside allowed provider directories
 #    Catches both the shorthand @riverpod and the parameterised @Riverpod(...)
 #    forms produced by riverpod_annotation / riverpod_generator.
 # ---------------------------------------------------------------------------
@@ -64,13 +62,13 @@ RIVERPOD_ANNOTATION_VIOLATIONS=$(
 )
 
 if [[ -n "$RIVERPOD_ANNOTATION_VIOLATIONS" ]]; then
-  echo "FAIL [riverpod_boundary]: @riverpod annotation found outside lib/providers/ in:"
+  echo "FAIL [riverpod_boundary]: @riverpod annotation found outside allowed provider directories in:"
   echo "$RIVERPOD_ANNOTATION_VIOLATIONS" | sed 's/^/  /'
   fail=1
 fi
 
 # ---------------------------------------------------------------------------
-# 2. No StateProvider( outside lib/providers/
+# 2. No StateProvider( outside allowed provider directories
 #    StateProvider is the legacy Riverpod UI-state pattern explicitly listed
 #    as disallowed for new code in docs/BLOC_UI_MIGRATION_PRD.md.
 # ---------------------------------------------------------------------------
@@ -84,7 +82,7 @@ STATE_PROVIDER_VIOLATIONS=$(
 )
 
 if [[ -n "$STATE_PROVIDER_VIOLATIONS" ]]; then
-  echo "FAIL [riverpod_boundary]: StateProvider( found outside lib/providers/ in:"
+  echo "FAIL [riverpod_boundary]: StateProvider( found outside allowed provider directories in:"
   echo "$STATE_PROVIDER_VIOLATIONS" | sed 's/^/  /'
   fail=1
 fi
@@ -97,7 +95,8 @@ if [[ "$fail" -eq 0 ]]; then
   echo "OK: No Riverpod boundary violations found."
 else
   echo ""
-  echo "Riverpod providers must live in mobile/lib/providers/."
+  echo "New @riverpod annotations and StateProvider declarations must live in"
+  echo "mobile/lib/providers/, mobile/lib/*/providers/, or mobile/lib/services/."
   echo "For new UI state, use BLoC/Cubit instead of @riverpod or StateProvider."
   echo "See docs/BLOC_UI_MIGRATION_PRD.md — 'Allowed / Disallowed Patterns'."
   exit 1

--- a/mobile/scripts/check_riverpod_boundary.sh
+++ b/mobile/scripts/check_riverpod_boundary.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Fails CI if a @riverpod annotation or StateProvider appears outside
+# mobile/lib/providers/, which is the only permitted home for Riverpod
+# providers in this codebase.
+#
+# Rules enforced:
+#   • No @riverpod / @Riverpod( annotations in mobile/lib/ outside
+#     mobile/lib/providers/.
+#   • No StateProvider( calls in mobile/lib/ outside mobile/lib/providers/.
+#
+# Background:
+#   Divine is mid-migration from Riverpod to BLoC/Cubit for UI state.
+#   The ownership boundary is: Riverpod owns DI and long-lived services
+#   (all in lib/providers/); BLoC/Cubit owns all feature UI state.
+#   Adding a new @riverpod provider for UI state inside lib/screens/ or
+#   lib/widgets/ silently extends the hybrid model instead of shrinking it.
+#   See docs/BLOC_UI_MIGRATION_PRD.md — "Allowed / Disallowed Patterns".
+#
+# Allowed locations for @riverpod annotations (must be documented here if added):
+#   • mobile/lib/providers/ — primary home for app-wide DI providers.
+#   • mobile/lib/*/providers/ — feature-local provider directories (e.g.
+#     lib/features/feature_flags/providers/). Must contain only DI/service
+#     providers, never UI state.
+#   • mobile/lib/services/ — service classes that self-register as providers
+#     (e.g. OpenvineMediaCache). Must be infrastructure, not UI state.
+#   • *.g.dart, *.freezed.dart, *.mocks.dart — generated files (may contain
+#     provider references in generated glue code).
+#   • .dart_tool/ and build/ — build artifacts, never app code.
+#
+# Usage:
+#   bash mobile/scripts/check_riverpod_boundary.sh
+#   (run from the repository root or from mobile/)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail=0
+
+GLOBAL_EXCLUDES=(
+  -not -path "*/.dart_tool/*"
+  -not -path "*/build/*"
+  -not -name "*.g.dart"
+  -not -name "*.freezed.dart"
+  -not -name "*.mocks.dart"
+  -not -path "*/lib/providers/*"
+  -not -path "*/lib/services/*"
+  -not -path "*/providers/*"
+)
+
+# ---------------------------------------------------------------------------
+# 1. No @riverpod annotation outside lib/providers/
+#    Catches both the shorthand @riverpod and the parameterised @Riverpod(...)
+#    forms produced by riverpod_annotation / riverpod_generator.
+# ---------------------------------------------------------------------------
+
+RIVERPOD_ANNOTATION_VIOLATIONS=$(
+  find "$MOBILE_DIR/lib" \
+    "${GLOBAL_EXCLUDES[@]}" \
+    -name "*.dart" -print0 \
+  | xargs -0 grep -l -E "@riverpod|@Riverpod\(" 2>/dev/null \
+  || true
+)
+
+if [[ -n "$RIVERPOD_ANNOTATION_VIOLATIONS" ]]; then
+  echo "FAIL [riverpod_boundary]: @riverpod annotation found outside lib/providers/ in:"
+  echo "$RIVERPOD_ANNOTATION_VIOLATIONS" | sed 's/^/  /'
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. No StateProvider( outside lib/providers/
+#    StateProvider is the legacy Riverpod UI-state pattern explicitly listed
+#    as disallowed for new code in docs/BLOC_UI_MIGRATION_PRD.md.
+# ---------------------------------------------------------------------------
+
+STATE_PROVIDER_VIOLATIONS=$(
+  find "$MOBILE_DIR/lib" \
+    "${GLOBAL_EXCLUDES[@]}" \
+    -name "*.dart" -print0 \
+  | xargs -0 grep -l "StateProvider(" 2>/dev/null \
+  || true
+)
+
+if [[ -n "$STATE_PROVIDER_VIOLATIONS" ]]; then
+  echo "FAIL [riverpod_boundary]: StateProvider( found outside lib/providers/ in:"
+  echo "$STATE_PROVIDER_VIOLATIONS" | sed 's/^/  /'
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "OK: No Riverpod boundary violations found."
+else
+  echo ""
+  echo "Riverpod providers must live in mobile/lib/providers/."
+  echo "For new UI state, use BLoC/Cubit instead of @riverpod or StateProvider."
+  echo "See docs/BLOC_UI_MIGRATION_PRD.md — 'Allowed / Disallowed Patterns'."
+  exit 1
+fi

--- a/mobile/test/screens/video_engagement/video_engagement_list_screen_test.dart
+++ b/mobile/test/screens/video_engagement/video_engagement_list_screen_test.dart
@@ -1,0 +1,226 @@
+// ABOUTME: Widget tests for VideoEngagementListScreen — the canonical Page/View
+// ABOUTME: split template. Verifies that the ConsumerWidget Page correctly wires
+// ABOUTME: Riverpod-provided repositories into VideoEngagementBloc, and that the
+// ABOUTME: extracted VideoEngagementListView renders bloc state correctly.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
+import 'package:openvine/screens/video_engagement/video_engagement_list_view.dart';
+import 'package:reposts_repository/reposts_repository.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockLikesRepository extends Mock implements LikesRepository {}
+
+class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+void main() {
+  late _MockLikesRepository likesRepository;
+  late _MockRepostsRepository repostsRepository;
+
+  const testEventId =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const testPubkey1 =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const testPubkey2 =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+  setUp(() {
+    likesRepository = _MockLikesRepository();
+    repostsRepository = _MockRepostsRepository();
+  });
+
+  Widget buildSubject({
+    VideoEngagementType type = VideoEngagementType.likers,
+    String? addressableId,
+  }) {
+    return testMaterialApp(
+      additionalOverrides: [
+        likesRepositoryProvider.overrideWithValue(likesRepository),
+        repostsRepositoryProvider.overrideWithValue(repostsRepository),
+      ],
+      home: VideoEngagementListScreen(
+        eventId: testEventId,
+        type: type,
+        addressableId: addressableId,
+      ),
+    );
+  }
+
+  group('VideoEngagementListScreen (Page)', () {
+    testWidgets(
+      'renders VideoEngagementListView as its child',
+      (tester) async {
+        when(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).thenAnswer((_) async => const []);
+
+        await tester.pumpWidget(buildSubject());
+
+        expect(find.byType(VideoEngagementListView), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows a loading indicator while the bloc is fetching',
+      (tester) async {
+        // Completer that never completes — keeps bloc in loading state.
+        final completer = Completer<List<String>>();
+        when(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).thenAnswer((_) => completer.future);
+
+        await tester.pumpWidget(buildSubject());
+        // One pump: BlocProvider creates the bloc, dispatches
+        // VideoEngagementLoadRequested, bloc emits loading.
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // Clean up: complete the future to avoid pending-timer leak.
+        completer.complete([]);
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'shows a list when the bloc emits success with pubkeys',
+      (tester) async {
+        when(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).thenAnswer((_) async => const [testPubkey1, testPubkey2]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        // UserProfileTile renders one item per pubkey inside a ListView.
+        expect(find.byType(ListView), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows empty-state widget when success state has no pubkeys',
+      (tester) async {
+        when(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).thenAnswer((_) async => const []);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoEngagementLikersEmpty),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'shows likers title in app bar for VideoEngagementType.likers',
+      (tester) async {
+        when(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).thenAnswer((_) async => const []);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoEngagementLikersTitle), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows reposters title in app bar for VideoEngagementType.reposters',
+      (tester) async {
+        when(
+          () => repostsRepository.fetchEventReposters(eventId: testEventId),
+        ).thenAnswer((_) async => const []);
+
+        await tester.pumpWidget(
+          buildSubject(type: VideoEngagementType.reposters),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoEngagementRepostersTitle), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'dispatches VideoEngagementLoadRequested on construction',
+      (tester) async {
+        when(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).thenAnswer((_) async => const []);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        // The repo method being called proves the initial event was dispatched.
+        verify(
+          () => likesRepository.fetchEventLikers(eventId: testEventId),
+        ).called(1);
+      },
+    );
+  });
+
+  group('VideoEngagementListView (View)', () {
+    testWidgets(
+      'has no Riverpod dependency — can be rendered without ProviderScope',
+      (tester) async {
+        // Provide the bloc directly, with no ProviderScope wrapping the view.
+        // This proves VideoEngagementListView is a pure StatelessWidget
+        // with zero Riverpod dependency.
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: _BlocProviderWidget(
+              bloc: VideoEngagementBloc(
+                eventId: testEventId,
+                type: VideoEngagementType.likers,
+                likesRepository: likesRepository,
+                repostsRepository: repostsRepository,
+              ),
+              child: const VideoEngagementListView(),
+            ),
+          ),
+        );
+
+        // Initial state renders a loading indicator.
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// Tiny helper to provide a single bloc without ProviderScope.
+/// Keeps the "no Riverpod" test self-contained and makes the intent explicit.
+class _BlocProviderWidget extends StatelessWidget {
+  const _BlocProviderWidget({
+    required this.bloc,
+    required this.child,
+  });
+
+  final VideoEngagementBloc bloc;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<VideoEngagementBloc>.value(
+      value: bloc,
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Description

Defines and enforces the Riverpod/BLoC ownership boundary that was missing from the codebase. Previously, docs said BLoC/Cubit is the default for UI state but provided no concrete allowed/disallowed patterns, no bridge inventory, no enforcement mechanism, and no canonical example to copy from.

**Related Issue:** Closes #3339

---

### What changed

**Documentation**

- `docs/BLOC_UI_MIGRATION_PRD.md` — replaced stale PR evidence (#1908 closed, #1894/#1903 merged with dates); added Ownership Boundary section; added 7-row Allowed/Disallowed patterns table with `ValueKey` guard code example; added Canonical Template Screens table; added Current Bridge Inventory table with removal criteria for all four `*BridgeProvider`s; tracked to #3339
- `docs/STATE_MANAGEMENT.md` — added Quick Reference section with the one-sentence rule, canonical examples table, and copy-paste Page/View pattern
- `.claude/rules/state_management.md` — mirrored Allowed/Disallowed table and template screen references for agent-written code

**Template screen (Page/View split)**

- `mobile/lib/screens/video_engagement/video_engagement_list_view.dart` *(new)* — `VideoEngagementListView` extracted as a public `StatelessWidget` with zero Riverpod dependency
- `mobile/lib/screens/video_engagement/video_engagement_list_screen.dart` — ABOUTME updated to call out the canonical bridge pattern and reference the PRD; delegates to `VideoEngagementListView`

**Bridge TODO comments**

- `mobile/lib/router/app_shell.dart` — replaced vague comments on the four `*BridgeProvider` watches with `// TODO(#3339):` comments stating each bridge's purpose and concrete removal criterion

**CI enforcement**

- `mobile/scripts/check_riverpod_boundary.sh` *(new)* — fails CI if `@riverpod` or `StateProvider(` appears outside `providers/` or `services/` directories; prints violating files and links to the PRD; currently zero violations
- `.github/workflows/mobile_ci.yaml` — new step in the `generated-files` job wiring the guard into CI

**Tests**

- `mobile/test/screens/video_engagement/video_engagement_list_screen_test.dart` *(new)* — 8 widget tests: Page renders View, loading state, success with pubkeys, empty state, likers/reposters titles, initial event dispatch, and a dedicated `VideoEngagementListView` isolation test that renders the View without any `ProviderScope`

---

### Why VideoEngagementListScreen as the template

197 lines, already had a `StatelessWidget` inner view, uses `ref.watch` with a record `ValueKey` guard (the auth-flip-safe pattern). Zero logic changes — purely structural extraction and documentation. The three canonical examples now cover all common bridge variants:

| Screen | Pattern |
|--------|---------|
| `NotificationsPage` | Nullable dep gate before `BlocProvider` |
| `AppsDirectoryScreen` | `ref.read` stable service, no `ValueKey` needed |
| `VideoEngagementListScreen` | `ref.watch` auth-sensitive repos + record `ValueKey` guard |

---

### Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| AC1 | Architecture docs include concrete allowed/disallowed patterns | Met |
| AC2 | Bridge providers identified and linked to migration issues | Met |
| AC3 | One representative screen converted to Page/View split as template | Met |
| AC4 | Review/lint guidance prevents new long-lived Riverpod UI providers | Met (CI script) |
| AC5 | Docs reference current issue numbers, no stale migration claims | Met |

---

## Out of Scope

- Migrating `ExploreScreen` (1,276 lines, no existing cubit — needs its own issue)
- Migrating `AppShell` (bridge providers are infrastructure, not UI state)
- Re-enabling `riverpod_lint`/`custom_lint` — blocked by the rxdart `^0.28.0` pin, separate issue
- The ~50 remaining hybrid screens — each needs a focused PR

## Verification

```
bash mobile/scripts/check_riverpod_boundary.sh   # OK: No Riverpod boundary violations found.
flutter analyze lib test integration_test         # No issues in touched files
dart format --output=none --set-exit-if-changed   # 0 changed
flutter test test/screens/video_engagement/       # +8: All tests passed!
flutter test test/blocs/video_engagement/         # +8: All tests passed!
```

## Type of Change

- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation