### PR TITLE
fix(reporting): recover from Nostr client init race and surface errors inline

### DIFF
--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -155,9 +155,8 @@ class ContentReportingService {
   }) async {
     try {
       if (!_isInitialized) {
-        if (_nostrService.isInitialized) {
-          _isInitialized = true;
-        } else {
+        await initialize();
+        if (!_isInitialized) {
           return ReportResult.failure('Reporting service not initialized');
         }
       }

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -510,18 +510,6 @@ class ContentReportingService {
     return buffer.toString();
   }
 
-  /// Create metadata for report (for our internal tracking)
-  // ignore: unused_element
-  dynamic _createReportMetadata(String reportId, ContentFilterReason reason) {
-    // This would return proper NIP-94 metadata for the report
-    // For now, return a placeholder
-    return {
-      'reportId': reportId,
-      'reason': reason.name,
-      'timestamp': DateTime.now().toIso8601String(),
-    };
-  }
-
   /// Create Zendesk ticket for moderation tracking
   Future<void> _createZendeskTicket({
     required String reportId,

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -155,7 +155,11 @@ class ContentReportingService {
   }) async {
     try {
       if (!_isInitialized) {
-        return ReportResult.failure('Reporting service not initialized');
+        if (_nostrService.isInitialized) {
+          _isInitialized = true;
+        } else {
+          return ReportResult.failure('Reporting service not initialized');
+        }
       }
 
       if (!_authService.isAuthenticated) {

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -675,10 +675,14 @@ class ReportConfirmationDialog extends StatelessWidget {
       title: Row(
         spacing: 12,
         children: [
-          const Icon(Icons.check_circle, color: VineTheme.vineGreen, size: 28),
+          const DivineIcon(
+            icon: DivineIconName.checkCircle,
+            color: VineTheme.vineGreen,
+            size: 28,
+          ),
           Text(
             l10n.reportReceivedTitle,
-            style: const TextStyle(color: VineTheme.whiteText),
+            style: VineTheme.titleMediumFont(),
           ),
         ],
       ),
@@ -688,67 +692,68 @@ class ReportConfirmationDialog extends StatelessWidget {
         children: [
           Text(
             l10n.reportReceivedThankYou,
-            style: const TextStyle(color: VineTheme.whiteText, fontSize: 16),
+            style: VineTheme.bodyLargeFont(),
           ),
           const SizedBox(height: 16),
           Text(
             l10n.reportReceivedReviewNotice,
-            style: const TextStyle(
+            style: VineTheme.bodyMediumFont(
               color: VineTheme.secondaryText,
-              fontSize: 14,
             ),
           ),
           const SizedBox(height: 20),
-          InkWell(
-            onTap: () async {
-              final uri = Uri.parse('https://divine.video/safety');
-              if (await canLaunchUrl(uri)) {
-                await launchUrl(uri, mode: LaunchMode.externalApplication);
-              }
-            },
-            child: Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: VineTheme.backgroundColor,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: VineTheme.vineGreen),
-              ),
-              child: Row(
-                spacing: 8,
-                children: [
-                  const Icon(
-                    Icons.info_outline,
-                    color: VineTheme.vineGreen,
-                    size: 20,
-                  ),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          l10n.reportLearnMore,
-                          style: const TextStyle(
-                            color: VineTheme.whiteText,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        Text(
-                          l10n.reportSafetyUrl,
-                          style: const TextStyle(
-                            color: VineTheme.vineGreen,
-                            fontSize: 12,
-                          ),
-                        ),
-                      ],
+          Semantics(
+            button: true,
+            label: l10n.reportLearnMore,
+            child: InkWell(
+              onTap: () async {
+                final uri = Uri.parse('https://divine.video/safety');
+                if (await canLaunchUrl(uri)) {
+                  await launchUrl(
+                    uri,
+                    mode: LaunchMode.externalApplication,
+                  );
+                }
+              },
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: VineTheme.backgroundColor,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: VineTheme.vineGreen),
+                ),
+                child: Row(
+                  spacing: 8,
+                  children: [
+                    const DivineIcon(
+                      icon: DivineIconName.info,
+                      color: VineTheme.vineGreen,
+                      size: 20,
                     ),
-                  ),
-                  const Icon(
-                    Icons.open_in_new,
-                    color: VineTheme.vineGreen,
-                    size: 18,
-                  ),
-                ],
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            l10n.reportLearnMore,
+                            style: VineTheme.titleSmallFont(),
+                          ),
+                          Text(
+                            l10n.reportSafetyUrl,
+                            style: VineTheme.labelSmallFont(
+                              color: VineTheme.vineGreen,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const DivineIcon(
+                      icon: DivineIconName.arrowUpRight,
+                      color: VineTheme.vineGreen,
+                      size: 18,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -759,7 +764,9 @@ class ReportConfirmationDialog extends StatelessWidget {
           onPressed: Navigator.of(context).pop,
           child: Text(
             l10n.reportClose,
-            style: const TextStyle(color: VineTheme.vineGreen),
+            style: VineTheme.labelLargeFont(
+              color: VineTheme.vineGreen,
+            ),
           ),
         ),
       ],

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -209,7 +209,10 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
 
   void _onReasonSelected(ContentFilterReason reason) {
     final wasOther = _selectedReason == ContentFilterReason.other;
-    setState(() => _selectedReason = reason);
+    setState(() {
+      _selectedReason = reason;
+      _errorMessage = null;
+    });
 
     if (reason == ContentFilterReason.other && !wasOther) {
       final controller = widget.draggableController;
@@ -292,6 +295,10 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
                       controller: _detailsController,
                       focusNode: _detailsFocusNode,
                       enableInteractiveSelection: true,
+                      onChanged: (_) {
+                        if (_errorMessage == null) return;
+                        setState(() => _errorMessage = null);
+                      },
                       style: VineTheme.bodyLargeFont(),
                       minLines: 3,
                       maxLines: 5,
@@ -305,32 +312,38 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
               ),
             ),
           ],
-          if (_errorMessage != null) ...[
+          if (_errorMessage case final errorMessage?) ...[
             const SizedBox(height: 16),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: VineTheme.error.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Row(
-                  children: [
-                    const DivineIcon(
-                      icon: DivineIconName.warningCircle,
-                      color: VineTheme.error,
-                      size: 20,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        _errorMessage!,
-                        style: VineTheme.bodySmallFont(
-                          color: VineTheme.error,
+            Semantics(
+              container: true,
+              liveRegion: true,
+              label: errorMessage,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: VineTheme.error.withValues(alpha: 0.1),
+                  border: Border.all(color: VineTheme.error),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    children: [
+                      const DivineIcon(
+                        icon: DivineIconName.warningCircle,
+                        color: VineTheme.error,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          errorMessage,
+                          style: VineTheme.bodySmallFont(
+                            color: VineTheme.error,
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -431,9 +444,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
           }
         } else {
           setState(() {
-            _errorMessage = context.l10n.reportFailed(
-              result.error ?? '',
-            );
+            _errorMessage = context.l10n.reportFailed(result.error ?? '');
           });
         }
       }
@@ -680,26 +691,18 @@ class ReportConfirmationDialog extends StatelessWidget {
             color: VineTheme.vineGreen,
             size: 28,
           ),
-          Text(
-            l10n.reportReceivedTitle,
-            style: VineTheme.titleMediumFont(),
-          ),
+          Text(l10n.reportReceivedTitle, style: VineTheme.titleMediumFont()),
         ],
       ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            l10n.reportReceivedThankYou,
-            style: VineTheme.bodyLargeFont(),
-          ),
+          Text(l10n.reportReceivedThankYou, style: VineTheme.bodyLargeFont()),
           const SizedBox(height: 16),
           Text(
             l10n.reportReceivedReviewNotice,
-            style: VineTheme.bodyMediumFont(
-              color: VineTheme.secondaryText,
-            ),
+            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
           ),
           const SizedBox(height: 20),
           Semantics(
@@ -709,10 +712,7 @@ class ReportConfirmationDialog extends StatelessWidget {
               onTap: () async {
                 final uri = Uri.parse('https://divine.video/safety');
                 if (await canLaunchUrl(uri)) {
-                  await launchUrl(
-                    uri,
-                    mode: LaunchMode.externalApplication,
-                  );
+                  await launchUrl(uri, mode: LaunchMode.externalApplication);
                 }
               },
               child: Container(
@@ -764,9 +764,7 @@ class ReportConfirmationDialog extends StatelessWidget {
           onPressed: Navigator.of(context).pop,
           child: Text(
             l10n.reportClose,
-            style: VineTheme.labelLargeFont(
-              color: VineTheme.vineGreen,
-            ),
+            style: VineTheme.labelLargeFont(color: VineTheme.vineGreen),
           ),
         ),
       ],

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -170,6 +170,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   final ScrollController _scrollController = ScrollController();
   bool _isSubmitting = false;
   bool _submitted = false;
+  String? _errorMessage;
   bool _scrollWhenKeyboardOpens = false;
   double _previousViewInsetsBottom = 0;
 
@@ -304,6 +305,36 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
               ),
             ),
           ],
+          if (_errorMessage != null) ...[
+            const SizedBox(height: 16),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: VineTheme.error.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  children: [
+                    const DivineIcon(
+                      icon: DivineIconName.warningCircle,
+                      color: VineTheme.error,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _errorMessage!,
+                        style: VineTheme.bodySmallFont(
+                          color: VineTheme.error,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 24),
           DivineButton(
             label: l10n.reportSubmit,
@@ -319,22 +350,16 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   void _handleSubmitReport() {
     if (_isSubmitting) return;
     if (_selectedReason == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.reportSelectReason),
-          backgroundColor: VineTheme.error,
-        ),
-      );
+      setState(() {
+        _errorMessage = context.l10n.reportSelectReason;
+      });
       return;
     }
     if (_selectedReason == ContentFilterReason.other &&
         _detailsController.text.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.reportOtherRequiresDetails),
-          backgroundColor: VineTheme.error,
-        ),
-      );
+      setState(() {
+        _errorMessage = context.l10n.reportOtherRequiresDetails;
+      });
       return;
     }
     _submitReport();
@@ -343,7 +368,10 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   Future<void> _submitReport() async {
     if (_selectedReason == null) return;
 
-    setState(() => _isSubmitting = true);
+    setState(() {
+      _isSubmitting = true;
+      _errorMessage = null;
+    });
     final selectedReasonTitle = context.l10n.reportReasonTitle(
       _selectedReason!,
     );
@@ -402,12 +430,11 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
             }
           }
         } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(context.l10n.reportFailed(result.error ?? '')),
-              backgroundColor: VineTheme.error,
-            ),
-          );
+          setState(() {
+            _errorMessage = context.l10n.reportFailed(
+              result.error ?? '',
+            );
+          });
         }
       }
     } catch (e) {
@@ -418,12 +445,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
       );
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.reportFailed(e)),
-            backgroundColor: VineTheme.error,
-          ),
-        );
+        setState(() => _errorMessage = context.l10n.reportFailed(e));
       }
     } finally {
       if (mounted) {

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -105,25 +105,84 @@ void main() {
       },
     );
 
-    test('reportContent() fails when service not initialized', () async {
-      // Create new service without initializing
-      final uninitializedService = ContentReportingService(
-        nostrService: mockNostrService,
-        authService: mockAuthService,
-        prefs: prefs,
-        moderationRelayUrl: 'wss://relay.divine.video',
-      );
+    test(
+      'reportContent() fails when service not initialized '
+      'and Nostr client still unready',
+      () async {
+        when(() => mockNostrService.isInitialized).thenReturn(false);
 
-      final result = await uninitializedService.reportContent(
-        eventId: 'test_event_id',
-        authorPubkey: 'test_author',
-        reason: ContentFilterReason.spam,
-        details: 'Spam content',
-      );
+        final uninitializedService = ContentReportingService(
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          prefs: prefs,
+          moderationRelayUrl: 'wss://relay.divine.video',
+        );
 
-      expect(result.success, false);
-      expect(result.error, 'Reporting service not initialized');
-    });
+        final result = await uninitializedService.reportContent(
+          eventId: 'test_event_id',
+          authorPubkey: 'test_author',
+          reason: ContentFilterReason.spam,
+          details: 'Spam content',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.error, 'Reporting service not initialized');
+      },
+    );
+
+    test(
+      'reportContent() recovers via late initialization when '
+      'Nostr client becomes ready after construction',
+      () async {
+        when(() => mockNostrService.isInitialized).thenReturn(false);
+
+        final lateInitService = ContentReportingService(
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          prefs: prefs,
+          moderationRelayUrl: 'wss://relay.divine.video',
+        );
+
+        await lateInitService.initialize();
+        expect(lateInitService.isInitialized, isFalse);
+
+        when(() => mockNostrService.isInitialized).thenReturn(true);
+
+        final reportEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1984,
+          tags: [
+            ['e', _validEventId('a')],
+            ['p', 'test_author'],
+          ],
+          content: 'Spam content',
+        );
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => reportEvent);
+
+        when(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
+
+        final result = await lateInitService.reportContent(
+          eventId: _validEventId('a'),
+          authorPubkey: 'test_author',
+          reason: ContentFilterReason.spam,
+          details: 'Spam content',
+        );
+
+        expect(result.success, isTrue);
+      },
+    );
 
     test(
       'reportContent() succeeds for AI-generated content after initialization',

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -105,10 +105,7 @@ void main() {
     test(
       'throws when neither a video nor message identifiers are provided',
       () {
-        expect(
-          ReportContentDialog.new,
-          throwsA(isA<ArgumentError>()),
-        );
+        expect(ReportContentDialog.new, throwsA(isA<ArgumentError>()));
       },
     );
 
@@ -140,10 +137,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(
-        find.text(l10n.reportWhyReporting),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.reportWhyReporting), findsOneWidget);
     });
 
     testWidgets('renders all report reason options', (tester) async {
@@ -169,10 +163,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(
-        find.text(l10n.reportReasonHarassmentSubtitle),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.reportReasonHarassmentSubtitle), findsOneWidget);
       expect(find.text(l10n.reportReasonOtherSubtitle), findsOneWidget);
     });
 
@@ -300,11 +291,47 @@ void main() {
                 builder: (context) => ElevatedButton(
                   onPressed: () => showDialog<void>(
                     context: context,
-                    builder: (_) => Material(
-                      child: ReportContentDialog(video: testVideo),
-                    ),
+                    builder: (_) =>
+                        Material(child: ReportContentDialog(video: testVideo)),
                   ),
                   child: const Text('Open Report'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      return testProviderScope(
+        mockNostrService: mockNostrClient,
+        additionalOverrides: [
+          contentReportingServiceProvider.overrideWith(
+            (ref) async => mockReportingService,
+          ),
+          contentBlocklistRepositoryProvider.overrideWith(
+            (ref) => mockBlocklistRepository,
+          ),
+          muteServiceProvider.overrideWith((ref) async => mockMuteService),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    Widget buildBottomSheetSubject() {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () =>
+                      ReportContentDialog.show(context, video: testVideo),
+                  child: const Text('Open Bottom Sheet Report'),
                 ),
               ),
             ),
@@ -335,6 +362,13 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
       await tester.tap(find.text('Open Report'));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> openBottomSheetReport(WidgetTester tester) async {
+      await tester.pumpWidget(buildBottomSheetSubject());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open Bottom Sheet Report'));
       await tester.pumpAndSettle();
     }
 
@@ -375,10 +409,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(
-        find.text(l10n.reportReceivedThankYou),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.reportReceivedThankYou), findsOneWidget);
     });
 
     testWidgets(
@@ -442,6 +473,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('Failed to report content'), findsOneWidget);
+      expect(find.byType(SnackBar), findsNothing);
     });
 
     testWidgets('exception during report shows inline error', (tester) async {
@@ -466,7 +498,56 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('Failed to report content'), findsOneWidget);
+      expect(find.byType(SnackBar), findsNothing);
     });
+
+    testWidgets(
+      'bottom sheet path keeps report errors inline instead of using snackbars',
+      (tester) async {
+        when(
+          () => mockReportingService.reportContent(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
+            reason: any(named: 'reason'),
+            details: any(named: 'details'),
+            additionalContext: any(named: 'additionalContext'),
+            hashtags: any(named: 'hashtags'),
+          ),
+        ).thenAnswer((_) async => ReportResult.failure('Server error'));
+
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        await openBottomSheetReport(tester);
+
+        await tester.tap(find.text(l10n.reportReasonSpam));
+        await tester.pumpAndSettle();
+
+        await tester.ensureVisible(
+          find.widgetWithText(DivineButton, l10n.reportSubmit),
+        );
+        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Failed to report content'), findsOneWidget);
+        expect(find.byType(SnackBar), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'bottom sheet path surfaces validation errors inline without snackbars',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        await openBottomSheetReport(tester);
+
+        await tester.ensureVisible(
+          find.widgetWithText(DivineButton, l10n.reportSubmit),
+        );
+        await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.reportSelectReason), findsOneWidget);
+        expect(find.byType(SnackBar), findsNothing);
+      },
+    );
 
     testWidgets('Other reason with details submits successfully', (
       tester,
@@ -520,10 +601,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
-      expect(
-        find.text(l10n.reportReceivedThankYou),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.reportReceivedThankYou), findsOneWidget);
       expect(
         find.textContaining('via direct message'),
         findsOneWidget,
@@ -598,9 +676,8 @@ void main() {
                 builder: (context) => ElevatedButton(
                   onPressed: () => showDialog<void>(
                     context: context,
-                    builder: (_) => Material(
-                      child: ReportContentDialog(video: testVideo),
-                    ),
+                    builder: (_) =>
+                        Material(child: ReportContentDialog(video: testVideo)),
                   ),
                   child: const Text('Open Report'),
                 ),

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -420,7 +420,7 @@ void main() {
       },
     );
 
-    testWidgets('failed report shows error snackbar', (tester) async {
+    testWidgets('failed report shows inline error', (tester) async {
       when(
         () => mockReportingService.reportContent(
           eventId: any(named: 'eventId'),
@@ -444,7 +444,7 @@ void main() {
       expect(find.textContaining('Failed to report content'), findsOneWidget);
     });
 
-    testWidgets('exception during report shows error snackbar', (tester) async {
+    testWidgets('exception during report shows inline error', (tester) async {
       when(
         () => mockReportingService.reportContent(
           eventId: any(named: 'eventId'),


### PR DESCRIPTION
## Description

Fixes error visibility for all reporting surfaces (content reports, user reports) that were failing silently, plus a defensive init-race fix.

1. **Invisible error feedback**: Report dialog errors were shown via `ScaffoldMessenger.of(context).showSnackBar()`, but the bottom sheet uses `useRootNavigator: true`, so snackbars rendered *behind* the modal. Users saw no error and no confirmation. Fix: errors now display inline within the bottom sheet via `_errorMessage` state.

2. **Defensive init-race recovery**: `ContentReportingService.initialize()` checked `_nostrService.isInitialized` once at construction. If the relay manager hadn't finished initializing, the service was permanently dead. Fix: `reportContent()` re-checks at call time so late-ready clients recover.

**Root cause note**: Log analysis of the original report (#4586 update comment) showed the actual failures were caused by an expired Keycast OAuth token (HTTP 401 on `sign_event`), not the init race. The init race did not trigger in the observed session. The inline error display is the high-value change — it would have immediately surfaced "Failed to create and sign NIP-56 report event" instead of silent nothing, pointing directly to the auth problem. See the linked issue on #4586 for the token expiry investigation.

**Related Issue:** Relates to #4586

## Out of Scope

- Mid-session Keycast token refresh (separate issue)
- Bug report dialog error visibility (separate surface, Zendesk SDK)

## Verification

- `flutter analyze` — no issues
- `flutter test test/services/content_reporting_service_test.dart` — 21/21 passed
- `flutter test test/widgets/report_content_dialog_test.dart` — 27/27 passed
- `dart format` — 0 changes needed
- Rebased onto latest `origin/main` (2026-05-20)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)