### PR TITLE
feat(keycast): mid-session token refresh on 401 and app resume

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -222,6 +222,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   bool _storageErrorOccurred = false;
   bool _hasExpiredOAuthSession = false;
   Future<bool>? _pendingRefresh;
+  Future<KeycastSession?>? _pendingOAuthRefresh;
   KeycastRpc? _keycastSigner;
 
   // RPC capability state — separate from AuthState so the router doesn't
@@ -573,17 +574,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return;
       }
 
-      final refreshed = await _oauthClient.refreshSession().timeout(
+      final refreshed = await _refreshOAuthSession().timeout(
         rpcRefreshTimeout,
       );
 
-      if (refreshed != null && refreshed.hasRpcAccess) {
+      if (refreshed != null) {
         Log.info(
           'initialize: background RPC refresh succeeded',
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        await refreshed.save(_flutterSecureStorage);
         await _clearDismissedDivineLoginBannerForCurrentUser();
         _keycastSigner = KeycastRpc.fromSession(
           _oauthConfig,
@@ -591,7 +591,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           onTokenRefresh: _refreshAccessToken,
         );
         _currentIdentity = _buildIdentity();
-        _hasExpiredOAuthSession = false;
         _setRpcCapability(AuthRpcCapability.rpcReady);
         return;
       }
@@ -682,65 +681,85 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Shared OAuth session refresh logic used by both [initialize] and
   /// [tryRefreshExpiredSession]. Returns true if refresh succeeded.
   Future<bool> _tryRefreshOAuthSession({required String caller}) async {
-    try {
-      final refreshed = await _oauthClient!.refreshSession();
-      if (refreshed != null && refreshed.hasRpcAccess) {
-        Log.info(
-          '$caller: refresh succeeded',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        await refreshed.save(_flutterSecureStorage);
-        await _clearDismissedDivineLoginBannerForCurrentUser();
-        await signInWithDivineOAuth(refreshed);
-        return true;
-      }
-    } catch (e) {
-      Log.error(
-        '$caller: refresh failed: $e',
+    final refreshed = await _refreshOAuthSession();
+    if (refreshed != null) {
+      Log.info(
+        '$caller: refresh succeeded',
         name: 'AuthService',
         category: LogCategory.auth,
       );
+      await _clearDismissedDivineLoginBannerForCurrentUser();
+      await signInWithDivineOAuth(refreshed);
+      return true;
     }
     return false;
   }
 
-  Future<String?>? _pendingTokenRefresh;
+  /// Single-flight OAuth session refresh. Every code path that needs a
+  /// fresh [KeycastSession] MUST call this instead of
+  /// `_oauthClient.refreshSession()` directly.
+  ///
+  /// Guarantees:
+  /// - Only one `refreshSession()` call in flight at a time (concurrent
+  ///   callers share the same [Future]).
+  /// - `userPubkey` is bound before the session is persisted, so
+  ///   ownership checks on restore stay valid.
+  /// - `_hasExpiredOAuthSession` is cleared on success.
+  ///
+  /// Returns the refreshed session on success, or `null` on failure.
+  Future<KeycastSession?> _refreshOAuthSession() {
+    return _pendingOAuthRefresh ??= _doRefreshOAuthSession().whenComplete(() {
+      _pendingOAuthRefresh = null;
+    });
+  }
+
+  Future<KeycastSession?> _doRefreshOAuthSession() async {
+    if (_oauthClient == null) return null;
+    try {
+      final refreshed = await _oauthClient.refreshSession();
+      if (refreshed == null || !refreshed.hasRpcAccess) return null;
+
+      // Bind userPubkey before persisting so ownership checks on
+      // restore stay valid. _currentProfile is always set during
+      // mid-session refreshes. For cold-start recovery, callers
+      // route through signInWithDivineOAuth which binds the pubkey
+      // itself if it's still missing.
+      var session = refreshed;
+      final pubkey = _currentProfile?.publicKeyHex;
+      if (pubkey != null &&
+          pubkey.isNotEmpty &&
+          (session.userPubkey == null || session.userPubkey!.isEmpty)) {
+        session = session.copyWith(userPubkey: pubkey);
+      }
+
+      await session.save(_flutterSecureStorage);
+      _hasExpiredOAuthSession = false;
+      Log.info(
+        '_refreshOAuthSession: succeeded '
+        '(userPubkey=${session.userPubkey != null ? "bound" : "unbound"})',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return session;
+    } catch (e) {
+      Log.error(
+        '_refreshOAuthSession: failed: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+  }
 
   /// [TokenRefreshCallback] passed to [KeycastRpc] so it can recover
   /// from mid-session 401s without caller involvement.
   ///
-  /// Concurrent callers (multiple in-flight RPC calls hitting 401, or a
-  /// 401 racing with [_refreshOAuthTokenOnResume]) share a single
-  /// in-flight refresh to avoid consuming one-time-use refresh tokens.
-  Future<String?> _refreshAccessToken() {
-    return _pendingTokenRefresh ??= _doRefreshAccessToken().whenComplete(() {
-      _pendingTokenRefresh = null;
-    });
-  }
-
-  Future<String?> _doRefreshAccessToken() async {
-    if (_oauthClient == null) return null;
-    try {
-      final refreshed = await _oauthClient.refreshSession();
-      if (refreshed != null && refreshed.hasRpcAccess) {
-        Log.info(
-          '_refreshAccessToken: token refresh succeeded',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        await refreshed.save(_flutterSecureStorage);
-        _hasExpiredOAuthSession = false;
-        return refreshed.accessToken;
-      }
-    } catch (e) {
-      Log.error(
-        '_refreshAccessToken: token refresh failed: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-    return null;
+  /// Delegates to [_refreshOAuthSession] which deduplicates concurrent
+  /// callers — multiple in-flight RPC 401s and app-resume refresh all
+  /// share a single refresh token exchange.
+  Future<String?> _refreshAccessToken() async {
+    final refreshed = await _refreshOAuthSession();
+    return refreshed?.accessToken;
   }
 
   Future<void> _clearDismissedDivineLoginBannerForCurrentUser([
@@ -4818,11 +4837,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      final newToken = await _refreshAccessToken();
-      if (newToken != null) {
-        _keycastSigner = KeycastRpc(
-          nostrApi: _oauthConfig.nostrApiUrl,
-          accessToken: newToken,
+      final refreshed = await _refreshOAuthSession();
+      if (refreshed != null) {
+        _keycastSigner = KeycastRpc.fromSession(
+          _oauthConfig,
+          refreshed,
           onTokenRefresh: _refreshAccessToken,
         );
         _currentIdentity = _buildIdentity();

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -574,7 +574,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return;
       }
 
-      final refreshed = await _refreshOAuthSession().timeout(
+      final refreshed = await _refreshOAuthSession(
+        expectedOwnerPubkey: session?.userPubkey,
+      ).timeout(
         rpcRefreshTimeout,
       );
 
@@ -637,7 +639,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
     if (_oauthClient != null) {
-      final refreshed = await _tryRefreshOAuthSession(caller: 'initialize');
+      final refreshed = await _tryRefreshOAuthSession(
+        caller: 'initialize',
+        expectedOwnerPubkey: session?.userPubkey,
+      );
       if (refreshed) return;
     }
 
@@ -680,8 +685,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
   /// Shared OAuth session refresh logic used by both [initialize] and
   /// [tryRefreshExpiredSession]. Returns true if refresh succeeded.
-  Future<bool> _tryRefreshOAuthSession({required String caller}) async {
-    final refreshed = await _refreshOAuthSession();
+  Future<bool> _tryRefreshOAuthSession({
+    required String caller,
+    String? expectedOwnerPubkey,
+  }) async {
+    final refreshed = await _refreshOAuthSession(
+      expectedOwnerPubkey: expectedOwnerPubkey,
+    );
     if (refreshed != null) {
       Log.info(
         '$caller: refresh succeeded',
@@ -706,26 +716,37 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   ///   ownership checks on restore stay valid.
   /// - `_hasExpiredOAuthSession` is cleared on success.
   ///
+  /// [expectedOwnerPubkey] binds the refreshed session to a specific
+  /// account. Callers that hold a stored session should pass its
+  /// `userPubkey`; mid-session callers (401 retry, app resume) may omit
+  /// it — the method falls back to [_currentProfile].
+  ///
   /// Returns the refreshed session on success, or `null` on failure.
-  Future<KeycastSession?> _refreshOAuthSession() {
-    return _pendingOAuthRefresh ??= _doRefreshOAuthSession().whenComplete(() {
+  Future<KeycastSession?> _refreshOAuthSession({
+    String? expectedOwnerPubkey,
+  }) {
+    return _pendingOAuthRefresh ??= _doRefreshOAuthSession(
+      expectedOwnerPubkey: expectedOwnerPubkey,
+    ).whenComplete(() {
       _pendingOAuthRefresh = null;
     });
   }
 
-  Future<KeycastSession?> _doRefreshOAuthSession() async {
+  Future<KeycastSession?> _doRefreshOAuthSession({
+    String? expectedOwnerPubkey,
+  }) async {
     if (_oauthClient == null) return null;
     try {
       final refreshed = await _oauthClient.refreshSession();
       if (refreshed == null || !refreshed.hasRpcAccess) return null;
 
       // Bind userPubkey before persisting so ownership checks on
-      // restore stay valid. _currentProfile is always set during
-      // mid-session refreshes. For cold-start recovery, callers
-      // route through signInWithDivineOAuth which binds the pubkey
-      // itself if it's still missing.
+      // restore stay valid. Prefer the caller-supplied owner (from
+      // the stored session) over _currentProfile, which could point
+      // to a different account during sign-in or account switch.
       var session = refreshed;
-      final pubkey = _currentProfile?.publicKeyHex;
+      final pubkey =
+          expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
       if (pubkey != null &&
           pubkey.isNotEmpty &&
           (session.userPubkey == null || session.userPubkey!.isEmpty)) {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -577,12 +577,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return;
       }
 
-      final refreshed = await _refreshOAuthSession(
-        expectedOwnerPubkey:
-            expectedOwnerPubkey ?? session?.userPubkey,
-      ).timeout(
-        rpcRefreshTimeout,
-      );
+      final refreshed =
+          await _refreshOAuthSession(
+            expectedOwnerPubkey: expectedOwnerPubkey ?? session?.userPubkey,
+          ).timeout(
+            rpcRefreshTimeout,
+          );
 
       if (refreshed != null) {
         Log.info(
@@ -729,11 +729,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<KeycastSession?> _refreshOAuthSession({
     String? expectedOwnerPubkey,
   }) {
-    return _pendingOAuthRefresh ??= _doRefreshOAuthSession(
-      expectedOwnerPubkey: expectedOwnerPubkey,
-    ).whenComplete(() {
-      _pendingOAuthRefresh = null;
-    });
+    return _pendingOAuthRefresh ??=
+        _doRefreshOAuthSession(
+          expectedOwnerPubkey: expectedOwnerPubkey,
+        ).whenComplete(() {
+          _pendingOAuthRefresh = null;
+        });
   }
 
   Future<KeycastSession?> _doRefreshOAuthSession({
@@ -749,8 +750,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // the stored session) over _currentProfile, which could point
       // to a different account during sign-in or account switch.
       var session = refreshed;
-      final pubkey =
-          expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
+      final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
       if (pubkey != null &&
           pubkey.isNotEmpty &&
           (session.userPubkey == null || session.userPubkey!.isEmpty)) {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -561,7 +561,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// On success: rebuilds identity to [KeycastNostrIdentity] and sets
   /// [AuthRpcCapability.rpcReady]. On failure: preserves the local identity
   /// and sets capability back to [AuthRpcCapability.unavailable].
-  Future<void> _upgradeDivineRpcInBackground(KeycastSession? session) async {
+  Future<void> _upgradeDivineRpcInBackground(
+    KeycastSession? session, {
+    String? expectedOwnerPubkey,
+  }) async {
     Log.info(
       'initialize: starting background RPC refresh...',
       name: 'AuthService',
@@ -575,7 +578,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       }
 
       final refreshed = await _refreshOAuthSession(
-        expectedOwnerPubkey: session?.userPubkey,
+        expectedOwnerPubkey:
+            expectedOwnerPubkey ?? session?.userPubkey,
       ).timeout(
         rpcRefreshTimeout,
       );
@@ -1940,6 +1944,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           if (canRefresh) {
             final refreshed = await _tryRefreshOAuthSession(
               caller: 'signInForAccount',
+              expectedOwnerPubkey: pubkeyHex,
             );
             if (refreshed) break;
           }
@@ -1974,7 +1979,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
             _hasExpiredOAuthSession = true;
             _setRpcCapability(AuthRpcCapability.upgrading);
             await _setupUserSession(localKey, AuthenticationSource.divineOAuth);
-            unawaited(_upgradeDivineRpcInBackground(session));
+            unawaited(
+              _upgradeDivineRpcInBackground(
+                session,
+                expectedOwnerPubkey: pubkeyHex,
+              ),
+            );
           } else {
             Log.warning(
               'signInForAccount: no refresh, no local keys for '

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -705,9 +705,21 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return false;
   }
 
+  Future<String?>? _pendingTokenRefresh;
+
   /// [TokenRefreshCallback] passed to [KeycastRpc] so it can recover
   /// from mid-session 401s without caller involvement.
-  Future<String?> _refreshAccessToken() async {
+  ///
+  /// Concurrent callers (multiple in-flight RPC calls hitting 401, or a
+  /// 401 racing with [_refreshOAuthTokenOnResume]) share a single
+  /// in-flight refresh to avoid consuming one-time-use refresh tokens.
+  Future<String?> _refreshAccessToken() {
+    return _pendingTokenRefresh ??= _doRefreshAccessToken().whenComplete(() {
+      _pendingTokenRefresh = null;
+    });
+  }
+
+  Future<String?> _doRefreshAccessToken() async {
     if (_oauthClient == null) return null;
     try {
       final refreshed = await _oauthClient.refreshSession();
@@ -4795,27 +4807,33 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   Future<void> _refreshOAuthTokenOnResume() async {
-    if (_oauthClient == null || _keycastSigner == null) return;
+    try {
+      if (_oauthClient == null || _keycastSigner == null) return;
 
-    final session = await _oauthClient.getSession();
-    if (session != null) return;
+      final session = await _oauthClient.getSession();
+      if (session != null) return;
 
-    Log.info(
-      '📱 App resumed - OAuth token expired, refreshing',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-    final refreshed = await _oauthClient.refreshSession();
-    if (refreshed != null && refreshed.hasRpcAccess) {
-      await refreshed.save(_flutterSecureStorage);
-      _keycastSigner = KeycastRpc.fromSession(
-        _oauthConfig,
-        refreshed,
-        onTokenRefresh: _refreshAccessToken,
+      Log.info(
+        '📱 App resumed - OAuth token expired, refreshing',
+        name: 'AuthService',
+        category: LogCategory.auth,
       );
-      _hasExpiredOAuthSession = false;
-      _currentIdentity = _buildIdentity();
-      _setRpcCapability(AuthRpcCapability.rpcReady);
+      final newToken = await _refreshAccessToken();
+      if (newToken != null) {
+        _keycastSigner = KeycastRpc(
+          nostrApi: _oauthConfig.nostrApiUrl,
+          accessToken: newToken,
+          onTokenRefresh: _refreshAccessToken,
+        );
+        _currentIdentity = _buildIdentity();
+        _setRpcCapability(AuthRpcCapability.rpcReady);
+      }
+    } catch (e) {
+      Log.error(
+        '📱 App resumed - OAuth refresh failed: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
     }
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -518,7 +518,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Keycast signer before building the identity so we get a
       // KeycastNostrIdentity instead of a LocalNostrIdentity.
       if (session != null && session.hasRpcAccess) {
-        _keycastSigner = KeycastRpc.fromSession(_oauthConfig, session);
+        _keycastSigner = KeycastRpc.fromSession(
+          _oauthConfig,
+          session,
+          onTokenRefresh: _refreshAccessToken,
+        );
       }
 
       await _setupUserSession(localKey!, AuthenticationSource.divineOAuth);
@@ -581,7 +585,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         );
         await refreshed.save(_flutterSecureStorage);
         await _clearDismissedDivineLoginBannerForCurrentUser();
-        _keycastSigner = KeycastRpc.fromSession(_oauthConfig, refreshed);
+        _keycastSigner = KeycastRpc.fromSession(
+          _oauthConfig,
+          refreshed,
+          onTokenRefresh: _refreshAccessToken,
+        );
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
         _setRpcCapability(AuthRpcCapability.rpcReady);
@@ -695,6 +703,32 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       );
     }
     return false;
+  }
+
+  /// [TokenRefreshCallback] passed to [KeycastRpc] so it can recover
+  /// from mid-session 401s without caller involvement.
+  Future<String?> _refreshAccessToken() async {
+    if (_oauthClient == null) return null;
+    try {
+      final refreshed = await _oauthClient.refreshSession();
+      if (refreshed != null && refreshed.hasRpcAccess) {
+        Log.info(
+          '_refreshAccessToken: token refresh succeeded',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        await refreshed.save(_flutterSecureStorage);
+        _hasExpiredOAuthSession = false;
+        return refreshed.accessToken;
+      }
+    } catch (e) {
+      Log.error(
+        '_refreshAccessToken: token refresh failed: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+    }
+    return null;
   }
 
   Future<void> _clearDismissedDivineLoginBannerForCurrentUser([
@@ -2977,7 +3011,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
-      _keycastSigner = KeycastRpc.fromSession(_oauthConfig, session);
+      _keycastSigner = KeycastRpc.fromSession(
+        _oauthConfig,
+        session,
+        onTokenRefresh: _refreshAccessToken,
+      );
 
       // Prefer the pubkey stored in the session over an RPC call.
       // session.userPubkey is ground truth once populated — it is
@@ -4751,6 +4789,33 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       _nostrConnectSession!.ensureConnected();
+    }
+
+    unawaited(_refreshOAuthTokenOnResume());
+  }
+
+  Future<void> _refreshOAuthTokenOnResume() async {
+    if (_oauthClient == null || _keycastSigner == null) return;
+
+    final session = await _oauthClient.getSession();
+    if (session != null) return;
+
+    Log.info(
+      '📱 App resumed - OAuth token expired, refreshing',
+      name: 'AuthService',
+      category: LogCategory.auth,
+    );
+    final refreshed = await _oauthClient.refreshSession();
+    if (refreshed != null && refreshed.hasRpcAccess) {
+      await refreshed.save(_flutterSecureStorage);
+      _keycastSigner = KeycastRpc.fromSession(
+        _oauthConfig,
+        refreshed,
+        onTokenRefresh: _refreshAccessToken,
+      );
+      _hasExpiredOAuthSession = false;
+      _currentIdentity = _buildIdentity();
+      _setRpcCapability(AuthRpcCapability.rpcReady);
     }
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -742,30 +742,20 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }) async {
     if (_oauthClient == null) return null;
     try {
-      final refreshed = await _oauthClient.refreshSession();
+      final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
+      final refreshed = await _oauthClient.refreshSession(
+        userPubkey: pubkey,
+      );
       if (refreshed == null || !refreshed.hasRpcAccess) return null;
 
-      // Bind userPubkey before persisting so ownership checks on
-      // restore stay valid. Prefer the caller-supplied owner (from
-      // the stored session) over _currentProfile, which could point
-      // to a different account during sign-in or account switch.
-      var session = refreshed;
-      final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
-      if (pubkey != null &&
-          pubkey.isNotEmpty &&
-          (session.userPubkey == null || session.userPubkey!.isEmpty)) {
-        session = session.copyWith(userPubkey: pubkey);
-      }
-
-      await session.save(_flutterSecureStorage);
       _hasExpiredOAuthSession = false;
       Log.info(
         '_refreshOAuthSession: succeeded '
-        '(userPubkey=${session.userPubkey != null ? "bound" : "unbound"})',
+        '(userPubkey=${refreshed.userPubkey != null ? "bound" : "unbound"})',
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      return session;
+      return refreshed;
     } catch (e) {
       Log.error(
         '_refreshOAuthSession: failed: $e',

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -99,10 +99,13 @@ class KeycastOAuth {
   /// Returns the new [KeycastSession] on success, or `null` if refresh
   /// is not possible (no refresh token) or fails.
   ///
+  /// [userPubkey] is attached to the session before it is persisted so
+  /// the saved session is always owner-bound.
+  ///
   /// On HTTP error the consumed refresh token is cleared (server may have
   /// rotated it). On network error the token is preserved since the server
   /// may not have consumed it.
-  Future<KeycastSession?> refreshSession() async {
+  Future<KeycastSession?> refreshSession({String? userPubkey}) async {
     final refreshToken = await _storage.read(_storageKeyRefreshToken);
     if (refreshToken == null) return null;
 
@@ -120,7 +123,10 @@ class KeycastOAuth {
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as Map<String, dynamic>;
         final tokenResponse = TokenResponse.fromJson(json);
-        final session = KeycastSession.fromTokenResponse(tokenResponse);
+        var session = KeycastSession.fromTokenResponse(tokenResponse);
+        if (userPubkey != null && userPubkey.isNotEmpty) {
+          session = session.copyWith(userPubkey: userPubkey);
+        }
         await _saveSession(session);
         return session;
       }
@@ -139,10 +145,13 @@ class KeycastOAuth {
   /// Tries [getSession] first. If that returns `null` (no session stored or
   /// token expired), falls back to [refreshSession] to obtain a fresh token.
   /// Returns `null` only when no session can be recovered at all.
-  Future<KeycastSession?> getSessionOrRefresh() async {
+  ///
+  /// [userPubkey] is forwarded to [refreshSession] so the saved session
+  /// is owner-bound when a refresh is needed.
+  Future<KeycastSession?> getSessionOrRefresh({String? userPubkey}) async {
     final session = await getSession();
     if (session != null) return session;
-    return refreshSession();
+    return refreshSession(userPubkey: userPubkey);
   }
 
   /// Generate authorization URL for OAuth flow

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -11,24 +11,38 @@ import 'package:keycast_flutter/src/oauth/oauth_config.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Callback invoked when a 401 response indicates the access token has
+/// expired. Returns a fresh access token on success, or `null` if refresh
+/// is not possible.
+typedef TokenRefreshCallback = Future<String?> Function();
+
 class KeycastRpc implements NostrSigner {
   final String nostrApi;
-  final String accessToken;
+  String _accessToken;
   final http.Client _client;
+  final TokenRefreshCallback? _onTokenRefresh;
 
   KeycastRpc({
     required this.nostrApi,
-    required this.accessToken,
+    required String accessToken,
     http.Client? httpClient,
-  }) : _client = httpClient ?? http.Client();
+    TokenRefreshCallback? onTokenRefresh,
+  }) : _accessToken = accessToken,
+       _client = httpClient ?? http.Client(),
+       _onTokenRefresh = onTokenRefresh;
 
-  factory KeycastRpc.fromSession(OAuthConfig config, KeycastSession session) {
+  factory KeycastRpc.fromSession(
+    OAuthConfig config,
+    KeycastSession session, {
+    TokenRefreshCallback? onTokenRefresh,
+  }) {
     if (!session.hasRpcAccess) {
       throw SessionExpiredException();
     }
     return KeycastRpc(
       nostrApi: config.nostrApiUrl,
       accessToken: session.accessToken!,
+      onTokenRefresh: onTokenRefresh,
     );
   }
 
@@ -37,27 +51,20 @@ class KeycastRpc implements NostrSigner {
     List<dynamic> params,
     T Function(dynamic) fromResult,
   ) async {
-    Log.debug(
-      '[Keycast RPC] Calling $method...',
-      name: 'KeycastRpc',
-      category: LogCategory.auth,
-    );
-    final stopwatch = Stopwatch()..start();
-    final response = await _client.post(
-      Uri.parse(nostrApi),
-      headers: {
-        'Authorization': 'Bearer $accessToken',
-        'Content-Type': 'application/json',
-      },
-      body: jsonEncode({'method': method, 'params': params}),
-    );
+    var response = await _sendRequest(method, params);
 
-    stopwatch.stop();
-    Log.debug(
-      '[Keycast RPC] $method completed in ${stopwatch.elapsedMilliseconds}ms (HTTP ${response.statusCode})',
-      name: 'KeycastRpc',
-      category: LogCategory.auth,
-    );
+    if (response.statusCode == 401 && _onTokenRefresh != null) {
+      Log.info(
+        '[Keycast RPC] $method returned 401, attempting token refresh',
+        name: 'KeycastRpc',
+        category: LogCategory.auth,
+      );
+      final newToken = await _onTokenRefresh();
+      if (newToken != null) {
+        _accessToken = newToken;
+        response = await _sendRequest(method, params);
+      }
+    }
 
     if (response.statusCode != 200) {
       Log.error(
@@ -82,6 +89,35 @@ class KeycastRpc implements NostrSigner {
     }
 
     return fromResult(json['result']);
+  }
+
+  Future<http.Response> _sendRequest(
+    String method,
+    List<dynamic> params,
+  ) async {
+    Log.debug(
+      '[Keycast RPC] Calling $method...',
+      name: 'KeycastRpc',
+      category: LogCategory.auth,
+    );
+    final stopwatch = Stopwatch()..start();
+    final response = await _client.post(
+      Uri.parse(nostrApi),
+      headers: {
+        'Authorization': 'Bearer $_accessToken',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'method': method, 'params': params}),
+    );
+    stopwatch.stop();
+    Log.debug(
+      '[Keycast RPC] $method completed in '
+      '${stopwatch.elapsedMilliseconds}ms '
+      '(HTTP ${response.statusCode})',
+      name: 'KeycastRpc',
+      category: LogCategory.auth,
+    );
+    return response;
   }
 
   @override

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1099,6 +1099,42 @@ void main() {
           );
         },
       );
+
+      test('binds userPubkey before saving session', () async {
+        final storage = MemoryKeycastStorage();
+        await storage.write('keycast_refresh_token', 'old_refresh_token');
+
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'bunker_url': 'bunker://refreshed',
+              'access_token': 'new_access_token',
+              'token_type': 'Bearer',
+              'expires_in': 86400,
+              'refresh_token': 'new_refresh_token',
+            }),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(
+          config: config,
+          httpClient: mockClient,
+          storage: storage,
+        );
+        final result = await oauth.refreshSession(
+          userPubkey: 'abc123pubkey',
+        );
+
+        expect(result, isNotNull);
+        expect(result!.userPubkey, 'abc123pubkey');
+
+        final savedJson = await storage.read('keycast_session');
+        final saved = KeycastSession.fromJson(
+          jsonDecode(savedJson!) as Map<String, dynamic>,
+        );
+        expect(saved.userPubkey, 'abc123pubkey');
+      });
     });
 
     group('getSessionOrRefresh', () {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -273,6 +273,134 @@ void main() {
       });
     });
 
+    group('token refresh on 401', () {
+      test('retries with new token after 401 when callback succeeds', () async {
+        var callCount = 0;
+        mockClient = MockClient((request) async {
+          callCount++;
+          if (callCount == 1) {
+            expect(
+              request.headers['Authorization'],
+              'Bearer expired_token',
+            );
+            return http.Response('Unauthorized', 401);
+          }
+          expect(
+            request.headers['Authorization'],
+            'Bearer fresh_token',
+          );
+          return http.Response(
+            jsonEncode({
+              'result':
+                  '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+            }),
+            200,
+          );
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          httpClient: mockClient,
+          onTokenRefresh: () async => 'fresh_token',
+        );
+
+        final pubkey = await rpc.getPublicKey();
+        expect(
+          pubkey,
+          '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+        );
+        expect(callCount, equals(2));
+      });
+
+      test('throws RpcException when callback returns null', () async {
+        mockClient = MockClient((request) async {
+          return http.Response('Unauthorized', 401);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          httpClient: mockClient,
+          onTokenRefresh: () async => null,
+        );
+
+        expect(rpc.getPublicKey, throwsA(isA<RpcException>()));
+      });
+
+      test('throws RpcException on 401 when no callback provided', () async {
+        mockClient = MockClient((request) async {
+          return http.Response('Unauthorized', 401);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          httpClient: mockClient,
+        );
+
+        expect(rpc.getPublicKey, throwsA(isA<RpcException>()));
+      });
+
+      test('does not retry on non-401 errors', () async {
+        var callCount = 0;
+        mockClient = MockClient((request) async {
+          callCount++;
+          return http.Response('Server error', 500);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+          onTokenRefresh: () async => 'fresh_token',
+        );
+
+        expect(rpc.getPublicKey, throwsA(isA<RpcException>()));
+        await Future<void>.delayed(Duration.zero);
+        expect(callCount, equals(1));
+      });
+
+      test('throws when retry also returns 401', () async {
+        var callCount = 0;
+        mockClient = MockClient((request) async {
+          callCount++;
+          return http.Response('Unauthorized', 401);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          httpClient: mockClient,
+          onTokenRefresh: () async => 'also_expired_token',
+        );
+
+        expect(rpc.getPublicKey, throwsA(isA<RpcException>()));
+        await Future<void>.delayed(Duration.zero);
+        expect(callCount, equals(2));
+      });
+
+      test('fromSession passes onTokenRefresh to instance', () {
+        const config = OAuthConfig(
+          serverUrl: 'https://login.divine.video',
+          clientId: 'test',
+          redirectUri: 'divine://callback',
+        );
+        final session = KeycastSession(
+          bunkerUrl: 'bunker://test',
+          accessToken: 'valid_token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        );
+
+        final rpc = KeycastRpc.fromSession(
+          config,
+          session,
+          onTokenRefresh: () async => 'refreshed',
+        );
+        expect(rpc, isNotNull);
+      });
+    });
+
     group('signCanonicalPayload', () {
       test(
         'returns hex signature from RPC and base64-encodes payload',

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -142,7 +142,9 @@ void main() {
 
         // refreshSession returns null (failed)
         when(
-          () => mockOAuthClient.refreshSession(),
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
         ).thenAnswer((_) async => null);
 
         final authService = createAuthService();
@@ -176,7 +178,11 @@ void main() {
             );
 
             // Verify refresh was attempted
-            verify(() => mockOAuthClient.refreshSession()).called(1);
+            verify(
+              () => mockOAuthClient.refreshSession(
+                userPubkey: any(named: 'userPubkey'),
+              ),
+            ).called(1);
           },
           (error, stack) {
             // Ignore background relay discovery errors
@@ -200,7 +206,9 @@ void main() {
       secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
 
       when(
-        () => mockOAuthClient.refreshSession(),
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
       ).thenAnswer((_) async => null);
 
       final authService = createAuthService();
@@ -214,7 +222,11 @@ void main() {
             equals(AuthState.unauthenticated),
             reason: 'No local keys + refresh failed → unauthenticated',
           );
-          verify(() => mockOAuthClient.refreshSession()).called(1);
+          verify(
+            () => mockOAuthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).called(1);
         },
         (error, stack) {
           // Ignore background errors
@@ -239,15 +251,24 @@ void main() {
         secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
 
         // refreshSession returns a valid new session
+        final testPubkey = 'ab' * 32;
         final refreshedSession = KeycastSession(
           bunkerUrl: 'https://login.divine.video/api/nostr',
           accessToken: 'fresh_access_token',
           expiresAt: DateTime.now().add(const Duration(hours: 24)),
           refreshToken: 'new_refresh_token',
+          userPubkey: testPubkey,
         );
         when(
-          () => mockOAuthClient.refreshSession(),
-        ).thenAnswer((_) async => refreshedSession);
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async {
+          secureStorage['keycast_session'] = jsonEncode(
+            refreshedSession.toJson(),
+          );
+          return refreshedSession;
+        });
 
         final authService = createAuthService();
 
@@ -256,7 +277,11 @@ void main() {
             await authService.initialize();
 
             // Refresh was attempted
-            verify(() => mockOAuthClient.refreshSession()).called(1);
+            verify(
+              () => mockOAuthClient.refreshSession(
+                userPubkey: any(named: 'userPubkey'),
+              ),
+            ).called(1);
 
             // The refreshed session was saved to storage before
             // signInWithDivineOAuth was called

--- a/mobile/test/services/auth_service_invite_session_cleanup_test.dart
+++ b/mobile/test/services/auth_service_invite_session_cleanup_test.dart
@@ -124,7 +124,9 @@ void main() {
       ).thenAnswer((_) async {});
 
       when(
-        () => mockOAuthClient.refreshSession(),
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
       ).thenAnswer((_) async => null);
       when(() => mockOAuthClient.close()).thenReturn(null);
     });
@@ -198,7 +200,11 @@ void main() {
           restartedAuthService.authState,
           equals(AuthState.unauthenticated),
         );
-        verify(() => mockOAuthClient.refreshSession()).called(1);
+        verify(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).called(1);
       },
     );
   });

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -144,7 +144,9 @@ void main() {
 
       // refreshSession returns null (failed)
       when(
-        () => mockOAuthClient.refreshSession(),
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
       ).thenAnswer((_) async => null);
 
       final authService = createAuthService();
@@ -216,7 +218,9 @@ void main() {
         arrangeExpiredSessionWithMatchingLocalKeys();
 
         when(
-          () => mockOAuthClient.refreshSession(),
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
         ).thenAnswer((_) async => null);
 
         final authService = createAuthService();
@@ -250,7 +254,9 @@ void main() {
 
       // refreshSession hangs forever (simulates slow network)
       when(
-        () => mockOAuthClient.refreshSession(),
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
       ).thenAnswer((_) => Completer<KeycastSession?>().future);
 
       final authService = createAuthService();
@@ -290,7 +296,9 @@ void main() {
 
         // refreshSession hangs forever — will be timed out
         when(
-          () => mockOAuthClient.refreshSession(),
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
         ).thenAnswer((_) => Completer<KeycastSession?>().future);
 
         final authService = createAuthService();
@@ -324,7 +332,9 @@ void main() {
       secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
 
       when(
-        () => mockOAuthClient.refreshSession(),
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
       ).thenAnswer((_) async => null);
 
       final authService = createAuthService();

--- a/mobile/test/services/auth_service_oauth_recovery_test.dart
+++ b/mobile/test/services/auth_service_oauth_recovery_test.dart
@@ -303,7 +303,9 @@ void main() {
           userPubkey: accountA.publicKeyHex,
         );
         when(
-          () => mockOAuthClient.refreshSession(),
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
         ).thenAnswer((_) async => refreshedSession);
 
         // Create fresh AuthService (simulates app restart)
@@ -313,7 +315,11 @@ void main() {
         // The refresh was attempted — signInWithDivineOAuth is called
         // with the refreshed session. It fails due to HTTP (no server
         // in unit tests), but we can verify refresh was called.
-        verify(() => mockOAuthClient.refreshSession()).called(1);
+        verify(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).called(1);
       },
     );
 


### PR DESCRIPTION
## Summary

Fixes #4588

Keycast OAuth tokens expire after ~3 hours. Users who leave the app backgrounded (common with iOS background modes for push notifications) return to a stale token and all RPC-backed operations (reporting, signing, encryption) fail silently — this was the root cause behind reporting surfaces failing (#4586).

Two recovery paths:

- **On app resume (Option A):** `AuthService.onAppResumed()` now checks if the stored OAuth session has expired and proactively refreshes it before any RPC call is attempted.
- **On 401 response (Option B):** `KeycastRpc._call()` detects 401 responses and invokes a `TokenRefreshCallback` to obtain a fresh access token, then retries the request once. This catches tokens that expire mid-session without an intervening app backgrounding.

Both paths share the same refresh mechanism via `OAuthClient.refreshSession()`.

### Changes

**`keycast_flutter` package:**
- Added `TokenRefreshCallback` typedef
- `KeycastRpc` constructor accepts optional `onTokenRefresh` callback
- `KeycastRpc.fromSession()` factory forwards `onTokenRefresh`
- `_call()` detects 401, invokes callback, updates token, retries once
- Extracted `_sendRequest()` to avoid duplication between initial call and retry

**`auth_service.dart`:**
- Added `_refreshAccessToken()` — the callback wired into every `KeycastRpc` instance
- Added `_refreshOAuthTokenOnResume()` — proactive refresh on app resume when session is expired
- Wired `onTokenRefresh: _refreshAccessToken` at all three `KeycastRpc.fromSession()` construction sites (init, background upgrade, signInWithDivineOAuth)

## Test plan

- [x] 6 new tests for 401 retry behavior in `rpc_client_test.dart`
- [x] All 178 `keycast_flutter` package tests pass
- [x] Analyzer clean on both changed files
- [ ] Manual: sign in with Divine OAuth, wait for token expiry (~3 hours or force-expire in staging), trigger a report/sign operation → should succeed transparently
- [ ] Manual: background app past token expiry, resume → RPC operations should work without re-login