### PR TITLE
refactor(notifications): classify Bloc errors via Reportable matrix (#4591)

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -107,6 +107,12 @@ class NotificationFeedBloc
       await _notificationRepository.refresh();
       emit(state.copyWith(status: NotificationFeedStatus.loaded));
     } catch (e, s) {
+      // `NotificationRepository.refresh` propagates typed
+      // `FunnelcakeException` (4xx/5xx/timeout; transient-retry
+      // exhausted on first page). Per .claude/rules/error_handling.md
+      // they are NOT Reportable — the UI either keeps cached items
+      // with an inline `refreshError` banner or falls back to
+      // `NotificationFeedStatus.failure`.
       addError(e, s);
       // Hard-failure only fires when the cache is also empty — the
       // repository surfaces `lastRefreshError` on the snapshot, and the
@@ -140,6 +146,10 @@ class NotificationFeedBloc
       await _notificationRepository.getNotifications();
       emit(state.copyWith(isLoadingMore: false));
     } catch (e, s) {
+      // `NotificationRepository.getNotifications` (single-attempt
+      // paginate-load-more) propagates typed `FunnelcakeException`
+      // (4xx/5xx/timeout). Per .claude/rules/error_handling.md they
+      // are NOT Reportable — the BLoC recovers `isLoadingMore: false`.
       addError(e, s);
       emit(state.copyWith(isLoadingMore: false));
     }
@@ -154,6 +164,11 @@ class NotificationFeedBloc
       await _notificationRepository.refresh();
       emit(state.copyWith(status: NotificationFeedStatus.loaded));
     } catch (e, s) {
+      // `NotificationRepository.refresh` propagates typed
+      // `FunnelcakeException` (4xx/5xx/timeout). Per
+      // .claude/rules/error_handling.md they are NOT Reportable —
+      // the UI either keeps cached items with `refreshError: true`
+      // or falls back to `NotificationFeedStatus.failure`.
       addError(e, s);
       final hasCachedItems = state.notifications.isNotEmpty;
       emit(
@@ -178,6 +193,10 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.markAsRead([event.notificationId]);
     } catch (e, s) {
+      // `NotificationRepository.markAsRead` propagates
+      // `FunnelcakeException` and local Drift DAO write failures
+      // after rolling the optimistic snapshot back. Per
+      // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, s);
     }
   }
@@ -192,6 +211,11 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.markAllAsRead();
     } catch (e, s) {
+      // `NotificationRepository.markAllAsRead` propagates
+      // `FunnelcakeException` and local Drift DAO write failures
+      // after rolling the optimistic snapshot back (PR #4034
+      // semantics). Per .claude/rules/error_handling.md they are
+      // NOT Reportable.
       addError(e, s);
     }
   }
@@ -212,6 +236,11 @@ class NotificationFeedBloc
         state.copyWith(notifications: _applyFollowState(state.notifications)),
       );
     } catch (e, s) {
+      // `FollowRepository.follow` propagates `Exception('User not
+      // authenticated')` (auth/session) and relay-IO failures from
+      // contact-list broadcast — the repo rolls back the optimistic
+      // follow internally. Per .claude/rules/error_handling.md they
+      // are NOT Reportable.
       addError(e, s);
     }
   }


### PR DESCRIPTION
## Description

Audit pass over `mobile/lib/notifications/bloc/notification_feed_bloc.dart`
classifying every `addError(` site against the [Reportable decision matrix](https://github.com/divinevideo/divine-mobile/blob/main/.claude/rules/error_handling.md#decision-matrix)
in `.claude/rules/error_handling.md`. All 6 sites decide NO (Network/IO,
API/domain, Auth/session) — none of the existing generic catches isolate an
invariant-only path that would warrant `Reportable` wrapping, so no new
Crashlytics surfaces are introduced.

Each NO site now carries a 4–6 line comment naming its matrix row, following
the precedent from PR #4597 (DM area sweep) and the existing classifications
at `other_profile_bloc.dart:165` and `my_profile_bloc.dart:183`.

**Outcome: 0 YES sites + 6 NO classifications.** Since the file does not
accumulate ≥2 YES sites, `reportable_sites.dart` is not created per the
spec's threshold rule. No `Reportable` import is needed.

### Classification table

| # | Site (line) | Method | Repo method called | Catch sees | Matrix row | Decision |
|---|---|---|---|---|---|---|
| 1 | 110 | `_onStarted` | `NotificationRepository.refresh()` | `FunnelcakeApiException` (4xx/5xx), `FunnelcakeTimeoutException`, retry-exhausted | Network/IO + API/domain | **NO** |
| 2 | 143 | `_onLoadMore` | `NotificationRepository.getNotifications()` | Same as #1 (single-attempt paginate) | Network/IO + API/domain | **NO** |
| 3 | 157 | `_onRefreshed` | `NotificationRepository.refresh()` | Same as #1 | Network/IO + API/domain | **NO** |
| 4 | 181 | `_onItemTapped` | `NotificationRepository.markAsRead()` | `FunnelcakeApiException` + Drift DAO IO (after rollback) | Network/IO + API/domain | **NO** |
| 5 | 195 | `_onMarkAllRead` | `NotificationRepository.markAllAsRead()` | Same as #4 (PR #4034 rollback) | Network/IO + API/domain | **NO** |
| 6 | 215 | `_onFollowBack` | `FollowRepository.follow()` | `Exception('User not authenticated')`, `Exception('Failed to broadcast contact list')`, relay IO | Auth/session + Network/IO | **NO** |

No behaviour change. No new files. No test changes — existing
`isA<Exception>()` assertions across the 5 error blocTests remain valid
because the runtime types passed into `addError` don't change. PR #4271's
author already confirmed this contract: "BLoC's `addError(e, s)` reaches
`DivineBlocObserver` (not Crashlytics — per `error_handling.md` reportable
matrix, network/IO/HTTP errors stay un-reported)."

**Related Issue:** Closes #4591

## Out of Scope

- Narrowing the unreachable `Error.throwWithStackTrace(StateError('retry
  exhausted'))` defensive fallback in
  `NotificationRepository._fetchWithRetry`. The analyzer can't prove the
  loop's return/rethrow invariant, so the guard exists — but it never fires
  in production. Surfacing it as Reportable would belong in the repository
  layer, not the BLoC; defer to a follow-up if it ever becomes load-bearing.
- Sibling area sweeps under epic #4336: welcome/publish #4592, video editor
  + search #4594, profile editor #4593, silent-failure remediation #4595.
  Independent child issues.

## Verification

From `mobile/`:

- `dart format --output=none --set-exit-if-changed lib/notifications/bloc/notification_feed_bloc.dart` — `Formatted 1 file (0 changed)`
- `flutter analyze lib test integration_test` — `No issues found! (ran in 92.5s)`
- `flutter test test/notifications/bloc/` — 18 tests pass (no changes to test file)
- `flutter test test/notifications/` — 140 tests pass

## Test plan

- [x] All existing `notification_feed_bloc_test.dart` tests pass without modification
- [x] Notification-area widget + view tests pass (140 total)
- [x] Analyzer + format clean
- [ ] CI green (Analyze + Tests + Format + Generated Files)

## Type of Change

- [x] 🧹 Code refactor
- [x] 📝 Documentation