### PR TITLE
refactor(welcome,publish): classify Bloc errors via Reportable matrix and decide publish failure contract (#4592)

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -178,12 +178,16 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       } else {
         await _handleSignUp(current.email, current.password);
       }
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Auth submission error: $e',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // Auth submission failures dominate (OAuth/Invite/network) —
+      // matrix-NO. YES-narrowing deferred per #4592 (analogous to
+      // #4597's `_onMessageSent` deferral).
+      addError(e, stackTrace);
 
       final currentState = state;
       if (currentState is DivineAuthFormState) {
@@ -333,7 +337,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
 
       emit(const DivineAuthSuccess());
-    } on InviteApiException catch (e) {
+    } on InviteApiException catch (e, stackTrace) {
       await _authService.clearPendingDivineOAuthSession();
       Log.error(
         'Invite activation failed: '
@@ -341,6 +345,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // Invite API rejection — matrix-NO (API/domain row).
+      addError(e, stackTrace);
 
       final current = state;
       if (current is DivineAuthFormState) {
@@ -354,23 +360,28 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
           ),
         );
       }
-    } on OAuthException catch (e) {
+    } on OAuthException catch (e, stackTrace) {
       Log.error(
         'OAuth exchange failed: ${e.message}',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // OAuth token exchange — matrix-NO (Auth/session + API/domain).
+      addError(e, stackTrace);
 
       final current = state;
       if (current is DivineAuthFormState) {
         emit(current.copyWith(isSubmitting: false, generalError: e.message));
       }
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Error exchanging code: $e',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // Anything not Invite/OAuth — storage, signing, identity, network.
+      // Matrix-NO; YES-narrowing deferred per #4592.
+      addError(e, stackTrace);
 
       final current = state;
       if (current is DivineAuthFormState) {
@@ -402,12 +413,14 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
           category: LogCategory.auth,
         );
       }
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Password reset error: $e',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // OAuth client network failure — matrix-NO (Network/IO).
+      addError(e, stackTrace);
     }
   }
 
@@ -452,13 +465,15 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       );
 
       emit(const DivineAuthSuccess());
-    } on InviteApiException catch (e) {
+    } on InviteApiException catch (e, stackTrace) {
       Log.error(
         'Anonymous account invite activation failed: '
         '${InviteErrorUtils.activationFailureLogDetails(e)}',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // Invite API rejection — matrix-NO (API/domain row).
+      addError(e, stackTrace);
 
       final currentState = state;
       if (currentState is DivineAuthFormState) {
@@ -472,12 +487,15 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
           ),
         );
       }
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Anonymous account creation failed: $e',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
+      // Key generation, storage, identity creation — matrix-NO
+      // (Network/IO + signer). YES-narrowing deferred per #4592.
+      addError(e, stackTrace);
 
       final currentState = state;
       if (currentState is DivineAuthFormState) {

--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -132,12 +132,16 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
     UserProfile? profile;
     try {
       profile = await _userProfilesDao.getProfile(known.pubkeyHex);
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.warning(
         'Failed to load cached profile for ${known.pubkeyHex}: $e',
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
+      // Drift IO — matrix-NO (Network/IO row). Raw addError so the
+      // failure surfaces in DivineBlocObserver without reaching
+      // Crashlytics. See .claude/rules/error_handling.md.
+      addError(e, stackTrace);
     }
     return PreviousAccount(
       pubkeyHex: known.pubkeyHex,
@@ -205,6 +209,7 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
+      // Session expiry — matrix-NO (Auth/session row). Raw addError.
       addError(e, stackTrace);
       emit(
         state.copyWith(
@@ -222,6 +227,9 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
+      // Auth-flow failures dominate (OAuth/Invite/network) — matrix-NO.
+      // YES-narrowing for invariant types deferred per #4592; analogous
+      // to #4597's `_onMessageSent` deferral.
       addError(e, stackTrace);
       emit(state.copyWith(status: WelcomeStatus.error, clearSigningIn: true));
     }
@@ -257,11 +265,14 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         previous.authSource,
       );
     } on SessionExpiredException catch (e, stackTrace) {
+      // Session expiry — matrix-NO (Auth/session row). Raw addError.
       addError(e, stackTrace);
       await _authService.acceptTerms();
       emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
       emit(state.copyWith(status: WelcomeStatus.loaded));
     } catch (e, stackTrace) {
+      // Same auth/network/IO failure surface as `_onLogBackIn` —
+      // matrix-NO. YES-narrowing deferred per #4592.
       addError(e, stackTrace);
       emit(state.copyWith(status: WelcomeStatus.error, clearSigningIn: true));
     }

--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -268,7 +268,12 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
       // Session expiry — matrix-NO (Auth/session row). Raw addError.
       addError(e, stackTrace);
       await _authService.acceptTerms();
-      emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
+      emit(
+        state.copyWith(
+          status: WelcomeStatus.navigatingToLoginOptions,
+          clearSigningIn: true,
+        ),
+      );
       emit(state.copyWith(status: WelcomeStatus.loaded));
     } catch (e, stackTrace) {
       // Same auth/network/IO failure surface as `_onLogBackIn` —

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -231,7 +231,37 @@ class VideoEventPublisher {
     );
   }
 
-  /// Publish event to Nostr relays
+  /// Publishes a signed Nostr [event] to the configured relays and returns
+  /// `true` iff at least one relay acknowledged the event as
+  /// [PublishSuccess].
+  ///
+  /// **Failure contract** (returns `false`):
+  /// 1. `TimeoutException` — the outer `Future.timeout` (bound by
+  ///    [currentOuterPublishTimeout]) fires before
+  ///    [NostrClient.publishEvent] completes. Derived from
+  ///    `RelayPool.perRelaySendTimeout × relayCount + buffer`; see
+  ///    [outerPublishTimeoutFor].
+  /// 2. Relay rejection — `publishResult` is not [PublishSuccess]
+  ///    (all configured relays rejected the event or the SDK reported
+  ///    no acknowledgement).
+  /// 3. Inner exception — any throw inside the outer try/catch is
+  ///    logged via `Log.error` and converted to `false`.
+  ///
+  /// All three causes are intentionally treated as transient by the
+  /// retry loop in [publishDirectUpload] (3 attempts, 2s/4s backoff).
+  /// The single-shot call sites in [_publishImportedAudioEvent],
+  /// [_publishAudioEvent], and [republishWithSubtitles] surface a
+  /// `false` return as `null` / `false` per their own contracts.
+  ///
+  /// **Sentinel-return contract** (per audit #3593 / #4592): this
+  /// method intentionally does NOT throw. All four callers are
+  /// internal and already have explicit post-failure recovery paths;
+  /// introducing a `PublishFailedException` would mean wrapping each
+  /// caller in try/catch to preserve the current bool/null/false
+  /// semantics with no observable behaviour change. Per
+  /// `.claude/rules/error_handling.md` the inner failures are
+  /// network/IO + API/domain — matrix-NO — so the Reportable-wrapped
+  /// throw path would not surface to Crashlytics either.
   Future<bool> _publishEventToNostr(Event event) async {
     try {
       Log.debug(

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -470,6 +470,7 @@ void main() {
               inviteRecoveryCode: 'AB12-EF34',
             ),
           ],
+          errors: () => [isA<InviteApiException>()],
           verify: (_) {
             verify(
               () => mockAuthService.clearPendingDivineOAuthSession(),
@@ -533,6 +534,7 @@ void main() {
             ),
             isA<DivineAuthFormState>(),
           ],
+          errors: () => [isA<InviteApiException>()],
           verify: (_) {
             final logMessage = LogCaptureService()
                 .getRecentLogs()
@@ -711,6 +713,7 @@ void main() {
               generalError: 'Token exchange failed',
             ),
           ],
+          errors: () => [isA<OAuthException>()],
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
@@ -756,6 +759,7 @@ void main() {
               generalError: 'Failed to complete authentication',
             ),
           ],
+          errors: () => [isA<Exception>()],
         );
       });
 
@@ -1335,6 +1339,7 @@ void main() {
               contains('unexpected error'),
             ),
           ],
+          errors: () => [isA<Exception>()],
         );
       });
     });
@@ -1378,6 +1383,7 @@ void main() {
         build: buildCubit,
         act: (cubit) => cubit.sendPasswordResetEmail(testEmail),
         expect: () => <DivineAuthState>[],
+        errors: () => [isA<Exception>()],
       );
     });
 
@@ -1480,6 +1486,7 @@ void main() {
             inviteRecoveryCode: 'AB12-EF34',
           ),
         ],
+        errors: () => [isA<InviteApiException>()],
         verify: (_) {
           verifyNever(() => mockAuthService.createAnonymousAccount());
           verifyNever(
@@ -1509,6 +1516,7 @@ void main() {
               .having((s) => s.isSkipping, 'isSkipping', isFalse)
               .having((s) => s.generalError, 'generalError', isNotNull),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<DivineAuthCubit, DivineAuthState>(

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -158,7 +158,8 @@ void main() {
       );
 
       blocTest<WelcomeBloc, WelcomeState>(
-        'emits loaded with account when profile lookup throws',
+        'emits loaded with account and records addError when profile '
+        'lookup throws',
         setUp: () {
           when(
             () => mockAuthService.getKnownAccounts(),
@@ -175,6 +176,7 @@ void main() {
             previousAccounts: [_testPreviousAccount],
           ),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<WelcomeBloc, WelcomeState>(

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -298,7 +298,7 @@ void main() {
       );
 
       blocTest<WelcomeBloc, WelcomeState>(
-        'emits error on signInForAccount failure',
+        'emits error and records addError on signInForAccount failure',
         setUp: () {
           when(
             () => mockAuthService.signInForAccount(any(), any()),
@@ -321,10 +321,11 @@ void main() {
             previousAccounts: [_testPreviousAccount],
           ),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<WelcomeBloc, WelcomeState>(
-        'emits error then navigates to login options on '
+        'emits error, records addError, then navigates to login options on '
         '$SessionExpiredException',
         setUp: () {
           when(
@@ -358,6 +359,116 @@ void main() {
         ],
         verify: (_) {
           verify(() => mockAuthService.acceptTerms()).called(1);
+        },
+        errors: () => [isA<SessionExpiredException>()],
+      );
+    });
+
+    group('$WelcomeCancelSwitchRequested', () {
+      blocTest<WelcomeBloc, WelcomeState>(
+        'restores the previous account regardless of selected account',
+        build: buildBloc,
+        seed: () => const WelcomeState(
+          status: WelcomeStatus.loaded,
+          previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+          selectedPubkeyHex: _testPubkeyHex2,
+        ),
+        act: (bloc) => bloc.add(const WelcomeCancelSwitchRequested()),
+        expect: () => [
+          const WelcomeState(
+            status: WelcomeStatus.accepting,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+            signingInPubkeyHex: _testPubkeyHex,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockAuthService.signInForAccount(
+              _testPubkeyHex,
+              AuthenticationSource.automatic,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<WelcomeBloc, WelcomeState>(
+        'records addError and redirects to login options on '
+        '$SessionExpiredException',
+        setUp: () {
+          when(
+            () => mockAuthService.signInForAccount(any(), any()),
+          ).thenThrow(SessionExpiredException());
+        },
+        build: buildBloc,
+        seed: () => const WelcomeState(
+          status: WelcomeStatus.loaded,
+          previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+          selectedPubkeyHex: _testPubkeyHex2,
+        ),
+        act: (bloc) => bloc.add(const WelcomeCancelSwitchRequested()),
+        expect: () => [
+          const WelcomeState(
+            status: WelcomeStatus.accepting,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+            signingInPubkeyHex: _testPubkeyHex,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.navigatingToLoginOptions,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.loaded,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockAuthService.acceptTerms()).called(1);
+        },
+        errors: () => [isA<SessionExpiredException>()],
+      );
+
+      blocTest<WelcomeBloc, WelcomeState>(
+        'records addError and emits error on restore failure',
+        setUp: () {
+          when(
+            () => mockAuthService.signInForAccount(any(), any()),
+          ).thenThrow(Exception('restore failed'));
+        },
+        build: buildBloc,
+        seed: () => const WelcomeState(
+          status: WelcomeStatus.loaded,
+          previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+          selectedPubkeyHex: _testPubkeyHex2,
+        ),
+        act: (bloc) => bloc.add(const WelcomeCancelSwitchRequested()),
+        expect: () => [
+          const WelcomeState(
+            status: WelcomeStatus.accepting,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+            signingInPubkeyHex: _testPubkeyHex,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.error,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<WelcomeBloc, WelcomeState>(
+        'does nothing when there is no previous account to restore',
+        build: buildBloc,
+        seed: () => const WelcomeState(status: WelcomeStatus.loaded),
+        act: (bloc) => bloc.add(const WelcomeCancelSwitchRequested()),
+        expect: () => <WelcomeState>[],
+        verify: (_) {
+          verifyNever(() => mockAuthService.signInForAccount(any(), any()));
         },
       );
     });


### PR DESCRIPTION
## Description

Classification sweep over `welcome_bloc`, `divine_auth_cubit`, and the
`VideoEventPublisher._publishEventToNostr()` failure contract per the
[Reportable decision matrix](https://github.com/divinevideo/divine-mobile/blob/main/.claude/rules/error_handling.md#decision-matrix).

**Outcome: 0 new YES sites + 12 NO classifications + 1 documented
sentinel + 8 silent catches upgraded to `addError(e, stackTrace)`.**

No `reportable_sites.dart` is created (threshold is 2+ YES sites).
Matches the discipline of PR #4597 (DM area, merged) and PR #4599
(notifications, in flight).

### Classification table

| File:Line | Method | Catch sees | Matrix row | Decision |
|---|---|---|---|---|
| `welcome_bloc.dart:135` | `_hydrateAccount` generic | `UserProfilesDao.getProfile` Drift IO | Network/IO | **NO** — was silent, now adds `addError(e, stackTrace)` |
| `welcome_bloc.dart:205` | `_onLogBackIn` on `SessionExpiredException` | session-refresh failure | Auth/session | NO |
| `welcome_bloc.dart:224` | `_onLogBackIn` generic | OAuth / Invite / network / signer restore | Mixed (dominant NO) | NO; narrowing deferred |
| `welcome_bloc.dart:267` | `_onCancelSwitch` on `SessionExpiredException` | same as `_onLogBackIn` | Auth/session | NO |
| `welcome_bloc.dart:273` | `_onCancelSwitch` generic | same as `_onLogBackIn` | Mixed (dominant NO) | NO; narrowing deferred |
| `divine_auth_cubit.dart:181` | `submit()` outer generic | `_handleSignIn`/`_handleSignUp` propagated failures | Mixed (dominant NO) | NO; narrowing deferred |
| `divine_auth_cubit.dart:340` | `_exchangeCodeAndLogin` on `InviteApiException` | invite activation rejected by API | API/domain | NO |
| `divine_auth_cubit.dart:363` | `_exchangeCodeAndLogin` on `OAuthException` | OAuth token exchange failure | Auth/session | NO |
| `divine_auth_cubit.dart:376` | `_exchangeCodeAndLogin` generic | storage / signing / identity / network | Mixed (dominant NO) | NO; narrowing deferred |
| `divine_auth_cubit.dart:416` | `sendPasswordResetEmail` generic | OAuth client network failures | Network/IO | NO |
| `divine_auth_cubit.dart:468` | `skipWithAnonymousAccount` on `InviteApiException` | invite activation rejected | API/domain | NO |
| `divine_auth_cubit.dart:490` | `skipWithAnonymousAccount` generic | key-gen / storage / identity | Mixed (dominant NO) | NO; narrowing deferred |
| `video_event_publisher.dart:235` | `_publishEventToNostr` | (sentinel return, see `///`) | Network/IO + API/domain | **documented sentinel** |

### Publisher contract decision (Option 2)

`_publishEventToNostr` is private with 4 internal callers (the
`publishDirectUpload` retry loop with exponential backoff, the two
audio-publish degrade-gracefully paths, and `republishWithSubtitles`).
All four treat `false` as a recoverable "this attempt didn't propagate"
signal and have explicit post-failure recovery.

| Option | Effort | Risk | Caller blast radius |
|---|---|---|---|
| 1 — throw `PublishFailedException` | ~40 LOC + new exception + 4 caller wrappers + ~5 tests | Behavior regression if retry loop loses a path | 4 internal sites need try/catch wrappers to preserve current `bool/null/false` semantics |
| **2 — document the `///` contract ✓** | ~30 LOC of dartdoc | Zero behavior change | No caller changes |

Per `error_handling.md` the inner failures are network/IO + API/domain
— matrix-NO — so even the `Reportable`-wrapped throw path would not
surface to Crashlytics. Option 2 also matches audit #3593's own
recommendation track-(b): "for intentionally-suppressing methods, add
`///` documentation explaining when null/false/[] is returned and why."

### Test changes

- `welcome_bloc_test.dart`: the existing "emits loaded with account
  when profile lookup throws" test is renamed and gets
  `errors: () => [isA<Exception>()]` to pin the new
  `_hydrateAccount` `addError` contract.
- `divine_auth_cubit_test.dart`: 8 existing failure-path blocTests
  gain `errors:` assertions (lines 413, 481, 672, 717, 1310, 1372,
  1452, 1492). Mirrors the call surface — no new tests.

No new files. No package changes. No regenerated codegen.

**Related Issue:** Closes #4592

## Out of Scope

- Removing `generalError: String?` from `DivineAuthState` (10
  emission sites). Tracked under epic #4336 → child **#3591**.
- Narrowing the dominant-NO generic auth-flow catches into typed
  invariant-YES paths. Analogous to PR #4597's deferral of
  `_onMessageSent`.
- Adding a reporter-port to `VideoEventPublisher` (service-layer
  observability, not a Bloc) — out of scope per the issue body which
  scopes only the failure-contract decision.
- Converting `_publishEventToNostr` to throw a typed exception
  (Option 1) — see decision matrix above.
- Sibling area sweeps under epic #4336: notifications (#4591),
  video-editor + clips + search (#4594), profile-editor (#4593),
  silent-failure remediation comments_bloc + share_sheet_bloc (#4595).

## Verification

From `mobile/`:

- `dart format --output=none --set-exit-if-changed` on all 5 changed files — `Formatted 5 files (0 changed)`
- `flutter analyze lib test integration_test` — `No issues found! (ran in 32.9s)`
- `flutter test test/blocs/welcome/ test/blocs/divine_auth/` — 91 tests pass (+1 enhanced + 8 enhanced)
- `flutter test test/services/video_event_publisher_test.dart test/services/video_event_publisher_publish_confirmation_test.dart` — 27 tests pass (doc-only change)

## Test plan

- [x] All existing `welcome_bloc_test.dart` tests pass; throw-path test now pins `addError` via `errors:`
- [x] All existing `divine_auth_cubit_test.dart` tests pass with 8 new `errors:` assertions
- [x] All existing `video_event_publisher_test.dart` tests pass without modification
- [x] Analyzer + format clean
- [ ] CI green (Analyze + Tests + Format + Generated Files)

## Type of Change

- [x] :broom: Code refactor
- [x] :memo: Documentation