### PR TITLE
refactor(profile-editor): repair handlers and classify Bloc errors (#4593)

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -398,36 +398,34 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     );
   }
 
+  bool _shouldDropSaveBecauseUploadInFlight(String saveSource) {
+    if (state.pendingAvatarStatus == PendingAvatarStatus.uploading) {
+      Log.info(
+        'Ignoring $saveSource while avatar upload is in flight',
+        name: 'ProfileEditorBloc',
+      );
+      return true;
+    }
+
+    if (state.pendingBannerStatus == PendingBannerStatus.uploading) {
+      Log.info(
+        'Ignoring $saveSource while banner upload is in flight',
+        name: 'ProfileEditorBloc',
+      );
+      return true;
+    }
+
+    return false;
+  }
+
   Future<void> _onProfileSaved(
     ProfileSaved event,
     Emitter<ProfileEditorState> emit,
   ) async {
     try {
-      // Drop the save when an avatar upload is still in flight. Without this
-      // guard, `_resolveEffectivePicture` would fall back to
-      // `persistedPictureUrl` and publish kind 0 with the OLD picture, then
-      // the staged URL would land and the user would have to Save again. The
-      // UI also disables Save during upload (via `isSaveReady`); this is the
-      // belt-and-braces so any other caller — retry CTAs, future events —
-      // can't slip past.
-      if (state.pendingAvatarStatus == PendingAvatarStatus.uploading) {
-        Log.info(
-          'Ignoring ProfileSaved received while avatar upload is in flight',
-          name: 'ProfileEditorBloc',
-        );
-        return;
-      }
-
-      // Same belt-and-braces guard for banner uploads: drop the save if the
-      // banner is still uploading so we don't publish kind 0 with the
-      // pre-upload banner and then have a staged URL land afterwards.
-      if (state.pendingBannerStatus == PendingBannerStatus.uploading) {
-        Log.info(
-          'Ignoring ProfileSaved received while banner upload is in flight',
-          name: 'ProfileEditorBloc',
-        );
-        return;
-      }
+      // Save remains the only publish point, so every save entry point must
+      // refuse to publish while a staged upload is still in flight.
+      if (_shouldDropSaveBecauseUploadInFlight('ProfileSaved')) return;
 
       // The effective picture is owned by bloc state (staged > persisted),
       // with `event.picture` as a legacy fallback for callers that haven't
@@ -519,6 +517,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     Emitter<ProfileEditorState> emit,
   ) async {
     try {
+      if (_shouldDropSaveBecauseUploadInFlight('ProfileNip05Saved')) return;
+
       final displayName =
           event.currentProfile.displayName ?? event.currentProfile.name ?? '';
       if (displayName.trim().isEmpty) {
@@ -571,6 +571,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     Emitter<ProfileEditorState> emit,
   ) async {
     try {
+      if (_shouldDropSaveBecauseUploadInFlight('ProfileSaveConfirmed')) return;
+
       final pending = state.pendingEvent;
       if (pending == null) {
         Log.error(

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -14,6 +14,8 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_editor/reportable_sites.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:stream_transform/stream_transform.dart';
@@ -141,6 +143,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         name: 'ProfileEditorBloc',
         category: LogCategory.ui,
       );
+      // Classification: Network/IO — matrix-NO. Catch sees `DioException` /
+      // `BlossomResumableUploadException` rethrown by `BlossomUploadService`.
       addError(error, stackTrace);
       emit(
         state.copyWith(
@@ -178,6 +182,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       name: 'ProfileEditorBloc',
       category: LogCategory.ui,
     );
+    // Classification: API/domain — matrix-NO. `Exception(...)` is synthesized
+    // from a documented `success: false` result with a typed `failureReason`.
     addError(Exception(errorMessage), StackTrace.current);
     emit(
       state.copyWith(
@@ -307,6 +313,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         name: 'ProfileEditorBloc',
         category: LogCategory.ui,
       );
+      // Classification: Network/IO — matrix-NO. Catch sees `DioException` /
+      // `BlossomResumableUploadException` rethrown by `BlossomUploadService`.
       addError(error, stackTrace);
       emit(
         state.copyWith(
@@ -340,6 +348,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       name: 'ProfileEditorBloc',
       category: LogCategory.ui,
     );
+    // Classification: API/domain — matrix-NO. `Exception(...)` is synthesized
+    // from a documented `success: false` result with a typed `failureReason`.
     addError(Exception(errorMessage), StackTrace.current);
     emit(
       state.copyWith(
@@ -392,53 +402,77 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     ProfileSaved event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    // Drop the save when an avatar upload is still in flight. Without this
-    // guard, `_resolveEffectivePicture` would fall back to
-    // `persistedPictureUrl` and publish kind 0 with the OLD picture, then
-    // the staged URL would land and the user would have to Save again. The
-    // UI also disables Save during upload (via `isSaveReady`); this is the
-    // belt-and-braces so any other caller — retry CTAs, future events —
-    // can't slip past.
-    if (state.pendingAvatarStatus == PendingAvatarStatus.uploading) {
-      Log.info(
-        'Ignoring ProfileSaved received while avatar upload is in flight',
+    try {
+      // Drop the save when an avatar upload is still in flight. Without this
+      // guard, `_resolveEffectivePicture` would fall back to
+      // `persistedPictureUrl` and publish kind 0 with the OLD picture, then
+      // the staged URL would land and the user would have to Save again. The
+      // UI also disables Save during upload (via `isSaveReady`); this is the
+      // belt-and-braces so any other caller — retry CTAs, future events —
+      // can't slip past.
+      if (state.pendingAvatarStatus == PendingAvatarStatus.uploading) {
+        Log.info(
+          'Ignoring ProfileSaved received while avatar upload is in flight',
+          name: 'ProfileEditorBloc',
+        );
+        return;
+      }
+
+      // Same belt-and-braces guard for banner uploads: drop the save if the
+      // banner is still uploading so we don't publish kind 0 with the
+      // pre-upload banner and then have a staged URL land afterwards.
+      if (state.pendingBannerStatus == PendingBannerStatus.uploading) {
+        Log.info(
+          'Ignoring ProfileSaved received while banner upload is in flight',
+          name: 'ProfileEditorBloc',
+        );
+        return;
+      }
+
+      // The effective picture is owned by bloc state (staged > persisted),
+      // with `event.picture` as a legacy fallback for callers that haven't
+      // migrated to the staged-state model yet.
+      final effectivePicture = _resolveEffectivePicture(event);
+
+      // Guard: about to overwrite existing profile with minimal data?
+      if (!_hasExistingProfile && _isMinimal(event, effectivePicture)) {
+        Log.info(
+          '⚠️ Blank profile warning: no existing profile found, requesting confirmation',
+          name: 'ProfileEditorBloc',
+        );
+        emit(
+          state.copyWith(
+            status: ProfileEditorStatus.confirmationRequired,
+            pendingEvent: event,
+          ),
+        );
+        return;
+      }
+
+      await _saveProfile(event, effectivePicture, emit);
+    } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. Defensive handler-level
+      // catch for `Error` types that escape `_saveProfile`'s typed publish
+      // branches and the `claimUsername` `on Exception` swallow (StateError
+      // from a signer invariant, TypeError from cast mismatches, etc.).
+      Log.error(
+        'Profile save handler threw: $error',
         name: 'ProfileEditorBloc',
       );
-      return;
-    }
-
-    // Same belt-and-braces guard for banner uploads: drop the save if the
-    // banner is still uploading so we don't publish kind 0 with the
-    // pre-upload banner and then have a staged URL land afterwards.
-    if (state.pendingBannerStatus == PendingBannerStatus.uploading) {
-      Log.info(
-        'Ignoring ProfileSaved received while banner upload is in flight',
-        name: 'ProfileEditorBloc',
-      );
-      return;
-    }
-
-    // The effective picture is owned by bloc state (staged > persisted),
-    // with `event.picture` as a legacy fallback for callers that haven't
-    // migrated to the staged-state model yet.
-    final effectivePicture = _resolveEffectivePicture(event);
-
-    // Guard: about to overwrite existing profile with minimal data?
-    if (!_hasExistingProfile && _isMinimal(event, effectivePicture)) {
-      Log.info(
-        '⚠️ Blank profile warning: no existing profile found, requesting confirmation',
-        name: 'ProfileEditorBloc',
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.onProfileSaved,
+        ),
+        stackTrace,
       );
       emit(
         state.copyWith(
-          status: ProfileEditorStatus.confirmationRequired,
-          pendingEvent: event,
+          status: ProfileEditorStatus.failure,
+          error: ProfileEditorError.publishFailed,
         ),
       );
-      return;
     }
-
-    await _saveProfile(event, effectivePicture, emit);
   }
 
   /// Banner string the next save should write into kind 0.
@@ -484,150 +518,231 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     ProfileNip05Saved event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    final displayName =
-        event.currentProfile.displayName ?? event.currentProfile.name ?? '';
-    if (displayName.trim().isEmpty) {
+    try {
+      final displayName =
+          event.currentProfile.displayName ?? event.currentProfile.name ?? '';
+      if (displayName.trim().isEmpty) {
+        Log.error(
+          'NIP-05 save ignored because the loaded profile has no display name',
+          name: 'ProfileEditorBloc',
+        );
+        return;
+      }
+
+      final saveEvent = ProfileSaved(
+        pubkey: event.currentProfile.pubkey,
+        displayName: displayName,
+        about: event.currentProfile.about,
+        username: state.nip05Mode == Nip05Mode.divine ? state.username : null,
+        externalNip05: state.nip05Mode == Nip05Mode.external_
+            ? state.externalNip05
+            : null,
+        picture: event.currentProfile.picture,
+        banner: event.currentProfile.banner,
+      );
+
+      await _saveProfile(saveEvent, _resolveEffectivePicture(saveEvent), emit);
+    } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. Same coverage as
+      // [_onProfileSaved] — `Error` types that escape `_saveProfile`'s typed
+      // branches.
       Log.error(
-        'NIP-05 save ignored because the loaded profile has no display name',
+        'Profile NIP-05 save handler threw: $error',
         name: 'ProfileEditorBloc',
       );
-      return;
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.onProfileNip05Saved,
+        ),
+        stackTrace,
+      );
+      emit(
+        state.copyWith(
+          status: ProfileEditorStatus.failure,
+          error: ProfileEditorError.publishFailed,
+        ),
+      );
     }
-
-    final saveEvent = ProfileSaved(
-      pubkey: event.currentProfile.pubkey,
-      displayName: displayName,
-      about: event.currentProfile.about,
-      username: state.nip05Mode == Nip05Mode.divine ? state.username : null,
-      externalNip05: state.nip05Mode == Nip05Mode.external_
-          ? state.externalNip05
-          : null,
-      picture: event.currentProfile.picture,
-      banner: event.currentProfile.banner,
-    );
-
-    await _saveProfile(saveEvent, _resolveEffectivePicture(saveEvent), emit);
   }
 
   Future<void> _onProfileSaveConfirmed(
     ProfileSaveConfirmed event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    final pending = state.pendingEvent;
-    if (pending == null) {
-      Log.error(
-        'ProfileSaveConfirmed called without pending event',
+    try {
+      final pending = state.pendingEvent;
+      if (pending == null) {
+        Log.error(
+          'ProfileSaveConfirmed called without pending event',
+          name: 'ProfileEditorBloc',
+        );
+        return;
+      }
+
+      Log.info(
+        '✅ User confirmed blank profile publish',
         name: 'ProfileEditorBloc',
       );
-      return;
+
+      await _saveProfile(pending, _resolveEffectivePicture(pending), emit);
+    } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. Same coverage as
+      // [_onProfileSaved] — `Error` types that escape `_saveProfile`'s typed
+      // branches.
+      Log.error(
+        'Profile save-confirmed handler threw: $error',
+        name: 'ProfileEditorBloc',
+      );
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.onProfileSaveConfirmed,
+        ),
+        stackTrace,
+      );
+      emit(
+        state.copyWith(
+          status: ProfileEditorStatus.failure,
+          error: ProfileEditorError.publishFailed,
+        ),
+      );
     }
-
-    Log.info(
-      '✅ User confirmed blank profile publish',
-      name: 'ProfileEditorBloc',
-    );
-
-    await _saveProfile(pending, _resolveEffectivePicture(pending), emit);
   }
 
   Future<void> _onUsernameChanged(
     UsernameChanged event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    final rawUsername = event.username;
-    final username = rawUsername.trim();
+    try {
+      final rawUsername = event.username;
+      final username = rawUsername.trim();
 
-    if (username.isEmpty) {
-      emit(
-        state.copyWith(username: username, usernameStatus: UsernameStatus.idle),
-      );
-      return;
-    }
-
-    final validation = validateDivineUsername(rawUsername);
-    if (validation case DivineUsernameInvalid(:final reason)) {
-      final isLength = reason == _divineUsernameLengthFailureReason;
-      emit(
-        state.copyWith(
-          username: username,
-          usernameStatus: isLength
-              ? UsernameStatus.error
-              : UsernameStatus.invalidFormat,
-          usernameError: isLength
-              ? UsernameValidationError.invalidLength
-              : UsernameValidationError.invalidFormat,
-          usernameFormatMessage: isLength ? null : reason,
-        ),
-      );
-      return;
-    }
-
-    final normalized = (validation as DivineUsernameValid).normalized;
-
-    if (state.reservedUsernames.contains(normalized)) {
-      emit(
-        state.copyWith(
-          username: username,
-          usernameStatus: UsernameStatus.reserved,
-        ),
-      );
-      return;
-    }
-
-    // Skip API check if username matches the user's own claimed username
-    final initial = state.initialUsername;
-    if (initial != null && normalized == initial.toLowerCase()) {
-      emit(
-        state.copyWith(username: username, usernameStatus: UsernameStatus.idle),
-      );
-      return;
-    }
-
-    emit(
-      state.copyWith(
-        username: username,
-        usernameStatus: UsernameStatus.checking,
-      ),
-    );
-
-    final result = await _profileRepository.checkUsernameAvailability(
-      username: normalized,
-      currentUserPubkey: _currentUserPubkey,
-    );
-
-    switch (result) {
-      case UsernameAvailable():
-        emit(state.copyWith(usernameStatus: UsernameStatus.available));
-      case UsernameTaken():
-        emit(state.copyWith(usernameStatus: UsernameStatus.taken));
-      case UsernameReserved():
+      if (username.isEmpty) {
         emit(
           state.copyWith(
+            username: username,
+            usernameStatus: UsernameStatus.idle,
+          ),
+        );
+        return;
+      }
+
+      final validation = validateDivineUsername(rawUsername);
+      if (validation case DivineUsernameInvalid(:final reason)) {
+        final isLength = reason == _divineUsernameLengthFailureReason;
+        emit(
+          state.copyWith(
+            username: username,
+            usernameStatus: isLength
+                ? UsernameStatus.error
+                : UsernameStatus.invalidFormat,
+            usernameError: isLength
+                ? UsernameValidationError.invalidLength
+                : UsernameValidationError.invalidFormat,
+            usernameFormatMessage: isLength ? null : reason,
+          ),
+        );
+        return;
+      }
+
+      final normalized = (validation as DivineUsernameValid).normalized;
+
+      if (state.reservedUsernames.contains(normalized)) {
+        emit(
+          state.copyWith(
+            username: username,
             usernameStatus: UsernameStatus.reserved,
-            reservedUsernames: {...state.reservedUsernames, normalized},
           ),
         );
-      case UsernameBurned():
-        emit(state.copyWith(usernameStatus: UsernameStatus.burned));
-      case UsernameInvalidFormat(:final reason):
+        return;
+      }
+
+      // Skip API check if username matches the user's own claimed username
+      final initial = state.initialUsername;
+      if (initial != null && normalized == initial.toLowerCase()) {
         emit(
           state.copyWith(
-            usernameStatus: UsernameStatus.invalidFormat,
-            usernameError: UsernameValidationError.invalidFormat,
-            usernameFormatMessage: reason,
+            username: username,
+            usernameStatus: UsernameStatus.idle,
           ),
         );
-      case UsernameCheckError(:final message):
-        Log.error(
-          'Username availability check failed: $message',
-          name: 'ProfileEditorBloc',
-        );
-        emit(
-          state.copyWith(
-            usernameStatus: UsernameStatus.error,
-            usernameError: UsernameValidationError.networkError,
-          ),
-        );
+        return;
+      }
+
+      emit(
+        state.copyWith(
+          username: username,
+          usernameStatus: UsernameStatus.checking,
+        ),
+      );
+
+      final result = await _profileRepository.checkUsernameAvailability(
+        username: normalized,
+        currentUserPubkey: _currentUserPubkey,
+      );
+
+      // Restartable transformer may have cancelled this run while the API
+      // call was in flight; guard before emitting to a closed emitter.
+      if (emit.isDone) return;
+
+      switch (result) {
+        case UsernameAvailable():
+          emit(state.copyWith(usernameStatus: UsernameStatus.available));
+        case UsernameTaken():
+          emit(state.copyWith(usernameStatus: UsernameStatus.taken));
+        case UsernameReserved():
+          emit(
+            state.copyWith(
+              usernameStatus: UsernameStatus.reserved,
+              reservedUsernames: {...state.reservedUsernames, normalized},
+            ),
+          );
+        case UsernameBurned():
+          emit(state.copyWith(usernameStatus: UsernameStatus.burned));
+        case UsernameInvalidFormat(:final reason):
+          emit(
+            state.copyWith(
+              usernameStatus: UsernameStatus.invalidFormat,
+              usernameError: UsernameValidationError.invalidFormat,
+              usernameFormatMessage: reason,
+            ),
+          );
+        case UsernameCheckError(:final message):
+          Log.error(
+            'Username availability check failed: $message',
+            name: 'ProfileEditorBloc',
+          );
+          emit(
+            state.copyWith(
+              usernameStatus: UsernameStatus.error,
+              usernameError: UsernameValidationError.networkError,
+            ),
+          );
+      }
+    } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. `checkUsernameAvailability`
+      // catches `on Exception` and returns `UsernameCheckError`, but `Error`
+      // subclasses (a JSON decode `TypeError`, an unexpected `StateError`)
+      // escape past that filter.
+      if (emit.isDone) return;
+      Log.error(
+        'Username availability check threw: $error',
+        name: 'ProfileEditorBloc',
+      );
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.onUsernameChanged,
+        ),
+        stackTrace,
+      );
+      emit(
+        state.copyWith(
+          usernameStatus: UsernameStatus.error,
+          usernameError: UsernameValidationError.networkError,
+        ),
+      );
     }
   }
 
@@ -706,63 +821,95 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     UsernameRechecked event,
     Emitter<ProfileEditorState> emit,
   ) async {
-    final username = state.username;
-    if (username.isEmpty) return;
+    try {
+      final username = state.username;
+      if (username.isEmpty) return;
 
-    final validation = validateDivineUsername(username);
-    if (validation case DivineUsernameInvalid()) {
-      return;
-    }
-    final normalized = (validation as DivineUsernameValid).normalized;
+      final validation = validateDivineUsername(username);
+      if (validation case DivineUsernameInvalid()) {
+        return;
+      }
+      final normalized = (validation as DivineUsernameValid).normalized;
 
-    // Remove from local reserved cache so the check runs against the server
-    final updatedReserved = {...state.reservedUsernames}..remove(normalized);
+      // Remove from local reserved cache so the check runs against the server
+      final updatedReserved = {...state.reservedUsernames}..remove(normalized);
 
-    emit(
-      state.copyWith(
-        usernameStatus: UsernameStatus.checking,
-        reservedUsernames: updatedReserved,
-      ),
-    );
+      emit(
+        state.copyWith(
+          usernameStatus: UsernameStatus.checking,
+          reservedUsernames: updatedReserved,
+        ),
+      );
 
-    final result = await _profileRepository.checkUsernameAvailability(
-      username: normalized,
-      currentUserPubkey: _currentUserPubkey,
-    );
+      final result = await _profileRepository.checkUsernameAvailability(
+        username: normalized,
+        currentUserPubkey: _currentUserPubkey,
+      );
 
-    switch (result) {
-      case UsernameAvailable():
-        emit(state.copyWith(usernameStatus: UsernameStatus.available));
-      case UsernameTaken():
-        emit(state.copyWith(usernameStatus: UsernameStatus.taken));
-      case UsernameReserved():
-        emit(
-          state.copyWith(
-            usernameStatus: UsernameStatus.reserved,
-            reservedUsernames: {...state.reservedUsernames, normalized},
-          ),
-        );
-      case UsernameBurned():
-        emit(state.copyWith(usernameStatus: UsernameStatus.burned));
-      case UsernameInvalidFormat(:final reason):
-        emit(
-          state.copyWith(
-            usernameStatus: UsernameStatus.invalidFormat,
-            usernameError: UsernameValidationError.invalidFormat,
-            usernameFormatMessage: reason,
-          ),
-        );
-      case UsernameCheckError(:final message):
-        Log.error(
-          'Username re-check failed: $message',
-          name: 'ProfileEditorBloc',
-        );
-        emit(
-          state.copyWith(
-            usernameStatus: UsernameStatus.reserved,
-            reservedUsernames: {...state.reservedUsernames, normalized},
-          ),
-        );
+      switch (result) {
+        case UsernameAvailable():
+          emit(state.copyWith(usernameStatus: UsernameStatus.available));
+        case UsernameTaken():
+          emit(state.copyWith(usernameStatus: UsernameStatus.taken));
+        case UsernameReserved():
+          emit(
+            state.copyWith(
+              usernameStatus: UsernameStatus.reserved,
+              reservedUsernames: {...state.reservedUsernames, normalized},
+            ),
+          );
+        case UsernameBurned():
+          emit(state.copyWith(usernameStatus: UsernameStatus.burned));
+        case UsernameInvalidFormat(:final reason):
+          emit(
+            state.copyWith(
+              usernameStatus: UsernameStatus.invalidFormat,
+              usernameError: UsernameValidationError.invalidFormat,
+              usernameFormatMessage: reason,
+            ),
+          );
+        case UsernameCheckError(:final message):
+          Log.error(
+            'Username re-check failed: $message',
+            name: 'ProfileEditorBloc',
+          );
+          emit(
+            state.copyWith(
+              usernameStatus: UsernameStatus.reserved,
+              reservedUsernames: {...state.reservedUsernames, normalized},
+            ),
+          );
+      }
+    } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. Same `Error`-escape contract
+      // as [_onUsernameChanged] — `checkUsernameAvailability` swallows
+      // Exception, only Error subclasses reach here.
+      final username = state.username;
+      final validation = username.isEmpty
+          ? null
+          : validateDivineUsername(username);
+      final normalized = validation is DivineUsernameValid
+          ? validation.normalized
+          : null;
+      Log.error(
+        'Username re-check threw: $error',
+        name: 'ProfileEditorBloc',
+      );
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.onUsernameRechecked,
+        ),
+        stackTrace,
+      );
+      emit(
+        state.copyWith(
+          usernameStatus: UsernameStatus.reserved,
+          reservedUsernames: normalized == null
+              ? state.reservedUsernames
+              : {...state.reservedUsernames, normalized},
+        ),
+      );
     }
   }
 
@@ -897,16 +1044,54 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       );
       await _profileRepository.cacheProfile(savedProfile);
       emit(state.copyWith(status: ProfileEditorStatus.success));
-    } catch (error, stackTrace) {
+    } on NoRelaysConnectedException catch (error, stackTrace) {
+      // Classification: Network/IO — matrix-NO. The device has no active
+      // relay connections; user-actionable retry path.
+      Log.error(
+        'Failed to publish profile (no relays): $error',
+        name: 'ProfileEditorBloc',
+      );
       addError(error, stackTrace);
-      Log.error('Failed to publish profile: $error', name: 'ProfileEditorBloc');
-      final profileError = error is NoRelaysConnectedException
-          ? ProfileEditorError.noRelaysConnected
-          : ProfileEditorError.publishFailed;
       emit(
         state.copyWith(
           status: ProfileEditorStatus.failure,
-          error: profileError,
+          error: ProfileEditorError.noRelaysConnected,
+        ),
+      );
+    } on ProfilePublishFailedException catch (error, stackTrace) {
+      // Classification: API/domain — matrix-NO. Typed publish failure
+      // (relay rejected event or send error).
+      Log.error(
+        'Failed to publish profile: $error',
+        name: 'ProfileEditorBloc',
+      );
+      addError(error, stackTrace);
+      emit(
+        state.copyWith(
+          status: ProfileEditorStatus.failure,
+          error: ProfileEditorError.publishFailed,
+        ),
+      );
+    } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. Anything that escapes the
+      // typed `ProfileRepositoryException` branches above is unexpected:
+      // a drift `TypeError` from a schema mismatch, a `StateError` from a
+      // sync transform between `saveProfileEvent` and `cacheProfile`, etc.
+      Log.error(
+        'Failed to publish profile (unexpected): $error',
+        name: 'ProfileEditorBloc',
+      );
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.saveProfilePublish,
+        ),
+        stackTrace,
+      );
+      emit(
+        state.copyWith(
+          status: ProfileEditorStatus.failure,
+          error: ProfileEditorError.publishFailed,
         ),
       );
     }
@@ -923,11 +1108,22 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       );
       return result.canonicalText;
     } on Object catch (error, stackTrace) {
+      // Classification: Invariant — matrix-YES. `MentionResolutionService`
+      // catches `on Exception` internally; only `Error` subtypes (StateError
+      // from `_applyReplacements`, RangeError on substring edges, TypeError
+      // from API-shape casts) reach here. The save continues with the
+      // unresolved `rawAbout`.
       Log.error(
         'Profile bio mention resolution failed: $error',
         name: 'ProfileEditorBloc',
       );
-      addError(error, stackTrace);
+      addError(
+        Reportable(
+          error,
+          context: ProfileEditorReportableSites.canonicalizeProfileAbout,
+        ),
+        stackTrace,
+      );
       return rawAbout;
     }
   }

--- a/mobile/lib/blocs/profile_editor/reportable_sites.dart
+++ b/mobile/lib/blocs/profile_editor/reportable_sites.dart
@@ -1,0 +1,50 @@
+// ABOUTME: Per-feature Reportable `context:` constants for ProfileEditorBloc.
+// ABOUTME: See .claude/rules/error_handling.md — once a feature accumulates 2+
+// ABOUTME: Reportable-wrapped call sites, the identifiers lift here.
+
+/// Stable `context:` identifiers for `Reportable(...)` wraps inside
+/// [ProfileEditorBloc].
+///
+/// Per the convention in `.claude/rules/error_handling.md`, when a Bloc
+/// has more than one `addError(Reportable(e, context: ...))` site, the
+/// `context:` strings are lifted into a per-feature constants class so
+/// the Crashlytics dashboard groups them by stable identifier rather
+/// than inline string literals.
+abstract class ProfileEditorReportableSites {
+  /// `_onProfileSaved` outer wrap — any `Error` (StateError, TypeError,
+  /// RangeError) that escapes the repository's `on Exception` swallow in
+  /// `claimUsername` or the synchronous pre-publish transforms.
+  static const String onProfileSaved = '_onProfileSaved';
+
+  /// `_onProfileNip05Saved` outer wrap — same coverage as [onProfileSaved],
+  /// dispatched from the dedicated NIP-05 entry point.
+  static const String onProfileNip05Saved = '_onProfileNip05Saved';
+
+  /// `_onProfileSaveConfirmed` outer wrap — same coverage as [onProfileSaved],
+  /// dispatched after the blank-profile-overwrite confirmation dialog.
+  static const String onProfileSaveConfirmed = '_onProfileSaveConfirmed';
+
+  /// `_onUsernameChanged` outer wrap — `checkUsernameAvailability` catches
+  /// `on Exception` and returns a typed `UsernameCheckError`, but `Error`
+  /// subclasses (a JSON decode `TypeError`, an unexpected `StateError`)
+  /// escape past that filter.
+  static const String onUsernameChanged = '_onUsernameChanged';
+
+  /// `_onUsernameRechecked` outer wrap — same `Error`-escape contract as
+  /// [onUsernameChanged], dispatched from the reserved-recheck CTA.
+  static const String onUsernameRechecked = '_onUsernameRechecked';
+
+  /// Narrowed publish-path catch in `_saveProfile`: any non-typed throw
+  /// (drift `TypeError` from a schema mismatch, `StateError` from a sync
+  /// transform between `saveProfileEvent` and `cacheProfile`) that escapes
+  /// the typed `on NoRelaysConnectedException` / `on ProfilePublishFailedException`
+  /// branches.
+  static const String saveProfilePublish = '_saveProfile';
+
+  /// `_canonicalizeProfileAbout` — `MentionResolutionService` catches
+  /// `on Exception` internally; only `Error` subtypes (StateError from
+  /// `_applyReplacements`, RangeError on substring edges, TypeError from
+  /// API-shape casts) escape here. The save continues with the unresolved
+  /// `rawAbout`.
+  static const String canonicalizeProfileAbout = '_canonicalizeProfileAbout';
+}

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -2986,6 +2986,94 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfileNip05Saved while avatar upload is in flight is dropped',
+        build: createBloc,
+        seed: () => const ProfileEditorState(
+          pendingAvatarStatus: PendingAvatarStatus.uploading,
+          persistedPictureUrl: testPersistedUrl,
+        ),
+        act: (bloc) => bloc.add(
+          ProfileNip05Saved(
+            currentProfile: UserProfile(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+              rawData: const {},
+              createdAt: DateTime.now(),
+              eventId:
+                  'nip05evt-uploading-1234567890123456789012345678901234567890',
+            ),
+          ),
+        ),
+        expect: () => const <ProfileEditorState>[],
+        verify: (_) {
+          verifyNever(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: any(named: 'displayName'),
+              about: any(named: 'about'),
+              username: any(named: 'username'),
+              nip05: any(named: 'nip05'),
+              clearNip05: any(named: 'clearNip05'),
+              picture: any(named: 'picture'),
+              banner: any(named: 'banner'),
+              currentProfile: any(named: 'currentProfile'),
+            ),
+          );
+          verifyNever(
+            () => mockProfileRepository.claimUsername(
+              username: any(named: 'username'),
+            ),
+          );
+          verifyNever(
+            () => mockProfileRepository.getCachedProfile(
+              pubkey: any(named: 'pubkey'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'ProfileSaveConfirmed while banner upload is in flight is dropped',
+        build: () => createBloc(hasExistingProfile: false),
+        seed: () => const ProfileEditorState(
+          status: ProfileEditorStatus.confirmationRequired,
+          pendingEvent: ProfileSaved(
+            pubkey: testPubkey,
+            displayName: testDisplayName,
+            about: testAbout,
+          ),
+          pendingBannerStatus: PendingBannerStatus.uploading,
+        ),
+        act: (bloc) => bloc.add(const ProfileSaveConfirmed()),
+        expect: () => const <ProfileEditorState>[],
+        verify: (_) {
+          verifyNever(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: any(named: 'displayName'),
+              about: any(named: 'about'),
+              username: any(named: 'username'),
+              nip05: any(named: 'nip05'),
+              clearNip05: any(named: 'clearNip05'),
+              picture: any(named: 'picture'),
+              banner: any(named: 'banner'),
+              currentProfile: any(named: 'currentProfile'),
+            ),
+          );
+          verifyNever(
+            () => mockProfileRepository.claimUsername(
+              username: any(named: 'username'),
+            ),
+          );
+          verifyNever(
+            () => mockProfileRepository.getCachedProfile(
+              pubkey: any(named: 'pubkey'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
         'ProfilePictureUrlSet while uploading is ignored',
         build: createBloc,
         seed: () => const ProfileEditorState(

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -20,6 +21,9 @@ import 'package:profile_repository/profile_repository.dart';
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+class _MockMentionResolutionService extends Mock
+    implements MentionResolutionService {}
 
 class _FakeFile extends Fake implements File {}
 
@@ -53,6 +57,7 @@ void main() {
     }
 
     late _MockBlossomUploadService mockBlossomUploadService;
+    late _MockMentionResolutionService mockMentionResolutionService;
 
     setUpAll(() {
       registerFallbackValue(
@@ -72,6 +77,7 @@ void main() {
     setUp(() {
       mockProfileRepository = _MockProfileRepository();
       mockBlossomUploadService = _MockBlossomUploadService();
+      mockMentionResolutionService = _MockMentionResolutionService();
       when(
         () => mockProfileRepository.cacheProfile(any()),
       ).thenAnswer((_) async {});
@@ -967,6 +973,382 @@ void main() {
           ],
         );
       });
+    });
+
+    // Defensive try/catch on the 5 handlers + narrowed publish branch +
+    // mention-resolution wrap. Per .claude/rules/error_handling.md, only
+    // `Error` subclasses (StateError, TypeError, RangeError) escape the
+    // repository's `on Exception` filters; these tests pin that the bloc
+    // now wraps them as `Reportable<T>` and still emits a sensible
+    // status-enum failure value.
+    group('handler-level invariant Reportable wraps', () {
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected claimUsername Error in _onProfileSaved as '
+        'Reportable and emits failure(publishFailed)',
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.claimUsername(username: testUsername),
+          ).thenThrow(StateError('claim invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          const ProfileSaved(
+            pubkey: testPubkey,
+            displayName: testDisplayName,
+            about: testAbout,
+            picture: testPicture,
+            username: testUsername,
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.loading,
+          ),
+          isA<ProfileEditorState>()
+              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+              .having(
+                (s) => s.error,
+                'error',
+                ProfileEditorError.publishFailed,
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+        verify: (_) {
+          // Claim threw — never reach the publish step.
+          verifyNever(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: any(named: 'displayName'),
+              about: any(named: 'about'),
+              username: any(named: 'username'),
+              clearNip05: any(named: 'clearNip05'),
+              picture: any(named: 'picture'),
+              banner: any(named: 'banner'),
+              currentProfile: any(named: 'currentProfile'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected saveProfileEvent Error in narrowed publish catch '
+        'as Reportable and emits failure(publishFailed)',
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+              clearNip05: any(named: 'clearNip05'),
+            ),
+          ).thenThrow(StateError('publish invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          const ProfileSaved(
+            pubkey: testPubkey,
+            displayName: testDisplayName,
+            about: testAbout,
+            picture: testPicture,
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.loading,
+          ),
+          isA<ProfileEditorState>()
+              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+              .having(
+                (s) => s.error,
+                'error',
+                ProfileEditorError.publishFailed,
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected Error in _onProfileNip05Saved as Reportable and '
+        'emits failure(publishFailed)',
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+              banner: any(named: 'banner'),
+              clearNip05: any(named: 'clearNip05'),
+            ),
+          ).thenThrow(StateError('nip05 save invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ProfileNip05Saved(
+            currentProfile: UserProfile(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+              rawData: const {},
+              createdAt: DateTime.now(),
+              eventId:
+                  'nip05evt567890123456789012345678901234567890123456789012345678',
+            ),
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.loading,
+          ),
+          isA<ProfileEditorState>()
+              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+              .having(
+                (s) => s.error,
+                'error',
+                ProfileEditorError.publishFailed,
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected Error in _onProfileSaveConfirmed as Reportable '
+        'and emits failure(publishFailed)',
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: testDisplayName,
+              clearNip05: any(named: 'clearNip05'),
+            ),
+          ).thenThrow(StateError('confirmed save invariant'));
+        },
+        build: () => createBloc(hasExistingProfile: false),
+        seed: () => const ProfileEditorState(
+          status: ProfileEditorStatus.confirmationRequired,
+          pendingEvent: ProfileSaved(
+            pubkey: testPubkey,
+            displayName: testDisplayName,
+          ),
+        ),
+        act: (bloc) => bloc.add(const ProfileSaveConfirmed()),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.loading,
+          ),
+          isA<ProfileEditorState>()
+              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+              .having(
+                (s) => s.error,
+                'error',
+                ProfileEditorError.publishFailed,
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected checkUsernameAvailability Error in '
+        '_onUsernameChanged as Reportable and emits error(networkError)',
+        setUp: () {
+          when(
+            () => mockProfileRepository.checkUsernameAvailability(
+              username: testUsername,
+              currentUserPubkey: any(named: 'currentUserPubkey'),
+            ),
+          ).thenThrow(StateError('availability check invariant'));
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const UsernameChanged(testUsername));
+          // Wait out the 500ms debounce + buffer
+          await Future<void>.delayed(const Duration(milliseconds: 600));
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.usernameStatus,
+            'usernameStatus',
+            UsernameStatus.checking,
+          ),
+          isA<ProfileEditorState>()
+              .having(
+                (s) => s.usernameStatus,
+                'usernameStatus',
+                UsernameStatus.error,
+              )
+              .having(
+                (s) => s.usernameError,
+                'usernameError',
+                UsernameValidationError.networkError,
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected checkUsernameAvailability Error in '
+        '_onUsernameRechecked as Reportable and re-reserves the name',
+        build: createBloc,
+        seed: () => const ProfileEditorState(
+          username: testUsername,
+          usernameStatus: UsernameStatus.reserved,
+          reservedUsernames: {testUsername},
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.checkUsernameAvailability(
+              username: testUsername,
+              currentUserPubkey: any(named: 'currentUserPubkey'),
+            ),
+          ).thenThrow(StateError('recheck invariant'));
+        },
+        act: (bloc) => bloc.add(const UsernameRechecked()),
+        expect: () => [
+          isA<ProfileEditorState>()
+              .having(
+                (s) => s.usernameStatus,
+                'usernameStatus',
+                UsernameStatus.checking,
+              )
+              .having(
+                (s) => s.reservedUsernames,
+                'reservedUsernames',
+                isEmpty,
+              ),
+          isA<ProfileEditorState>()
+              .having(
+                (s) => s.usernameStatus,
+                'usernameStatus',
+                UsernameStatus.reserved,
+              )
+              .having(
+                (s) => s.reservedUsernames,
+                'reservedUsernames',
+                contains(testUsername),
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'wraps unexpected MentionResolutionService Error as Reportable '
+        'but continues the save with the raw bio text',
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: testDisplayName,
+              about: 'hi @alice',
+              picture: testPicture,
+              clearNip05: any(named: 'clearNip05'),
+            ),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockMentionResolutionService.resolveTextMentions(
+              rawText: any(named: 'rawText'),
+              currentUserPubkey: any(named: 'currentUserPubkey'),
+            ),
+          ).thenThrow(StateError('mention service invariant'));
+        },
+        build: () => createBloc(
+          mentionResolutionService: mockMentionResolutionService,
+        ),
+        act: (bloc) => bloc.add(
+          const ProfileSaved(
+            pubkey: testPubkey,
+            displayName: testDisplayName,
+            about: 'hi @alice',
+            picture: testPicture,
+          ),
+        ),
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.loading,
+          ),
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.success,
+          ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+        verify: (_) {
+          // Save still happens with the raw (unresolved) bio.
+          verify(
+            () => mockProfileRepository.saveProfileEvent(
+              displayName: testDisplayName,
+              about: 'hi @alice',
+              picture: testPicture,
+              clearNip05: any(named: 'clearNip05'),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('InitialUsernameSet', () {


### PR DESCRIPTION
## Description

Classification sweep over `mobile/lib/blocs/profile_editor/**` per the [Reportable decision matrix](https://github.com/divinevideo/divine-mobile/blob/main/.claude/rules/error_handling.md#decision-matrix). Repairs the 5 async handlers that were missing try/catch entirely, narrows the existing publish catch in `_saveProfile`, and classifies every `addError` site against the matrix.

**Outcome: 7 YES sites lifted into `mobile/lib/blocs/profile_editor/reportable_sites.dart` + 5 NO sites annotated inline.**

### Classification table

| File:Line | Method | Catch sees | Matrix row | Decision |
|---|---|---|---|---|
| `profile_editor_bloc.dart:144` | `_onProfilePictureUploadRequested` (Blossom rethrow) | `DioException` / `BlossomResumableUploadException` | Network/IO | **NO** (annotated) |
| `profile_editor_bloc.dart:181` | `_onProfilePictureUploadRequested` (`success: false`) | synthetic `Exception` + typed `failureReason` | API/domain | **NO** (annotated) |
| `profile_editor_bloc.dart:310` | `_onProfileBannerUploadRequested` (Blossom rethrow) | `DioException` / `BlossomResumableUploadException` | Network/IO | **NO** (annotated) |
| `profile_editor_bloc.dart:343` | `_onProfileBannerUploadRequested` (`success: false`) | synthetic `Exception` + typed `failureReason` | API/domain | **NO** (annotated) |
| `_saveProfile` (narrowed) `on NoRelaysConnectedException` | publish catch | typed no-relays | Network/IO | **NO** (narrowed branch) |
| `_saveProfile` (narrowed) `on ProfilePublishFailedException` | publish catch | typed publish-failed | API/domain | **NO** (narrowed branch) |
| `_saveProfile` (narrowed) `on Object` | publish catch | drift `TypeError`, sync-step `StateError` | Invariant | **YES (new)** -> `saveProfilePublish` |
| `_canonicalizeProfileAbout` (existing site) | mention resolution catch | service swallows `Exception` -> only `Error` escapes | Invariant | **YES (new)** -> `canonicalizeProfileAbout` |
| `_onProfileSaved` (new outer wrap) | handler body | claim Error escape, sync invariants | Invariant | **YES (new)** -> `onProfileSaved` |
| `_onProfileNip05Saved` (new outer wrap) | handler body | same | Invariant | **YES (new)** -> `onProfileNip05Saved` |
| `_onProfileSaveConfirmed` (new outer wrap) | handler body | same | Invariant | **YES (new)** -> `onProfileSaveConfirmed` |
| `_onUsernameChanged` (new outer wrap) | `checkUsernameAvailability` Error escape | repository swallows `Exception` -> only `Error` escapes | Invariant | **YES (new)** -> `onUsernameChanged` |
| `_onUsernameRechecked` (new outer wrap) | same | Invariant | **YES (new)** -> `onUsernameRechecked` |

### New file

- `mobile/lib/blocs/profile_editor/reportable_sites.dart` — `ProfileEditorReportableSites` with 7 `static const String` identifiers, following the precedent at `video_interactions/reportable_sites.dart` and `video_interactions/reportable_sites.dart`.

### Other notes

- `_onUsernameChanged` runs under a `restartable` event transformer, so the new catch (and the existing post-await happy path) emits under an `if (emit.isDone) return;` guard — matches the precedent at `clip_editor_bloc.dart:298,327,338`.
- Reuses the existing `ProfileEditorError` enum cases (`publishFailed`, `noRelaysConnected`) and the existing `UsernameStatus` / `UsernameValidationError` enums — no l10n churn.
- `Reportable<T>` implements `ReportableError implements Exception`, so the existing avatar/banner `errors: () => [isA<Exception>()]` assertions stay green even though the underlying catches are unchanged (still raw `Exception`).

### New tests

7 new `blocTest` cases in `mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart` under a new `'handler-level invariant Reportable wraps'` group:

1. `_onProfileSaved` — `claimUsername` throws `StateError` -> `Reportable<StateError>` + `failure(publishFailed)` + no publish step
2. `_saveProfile` narrowed `on Object` branch — `saveProfileEvent` throws `StateError` -> `Reportable<StateError>` + `failure(publishFailed)`
3. `_onProfileNip05Saved` — `saveProfileEvent` throws `StateError` -> `Reportable<StateError>` + `failure(publishFailed)`
4. `_onProfileSaveConfirmed` — `saveProfileEvent` throws `StateError` from pending event -> `Reportable<StateError>` + `failure(publishFailed)`
5. `_onUsernameChanged` — `checkUsernameAvailability` throws `StateError` -> `Reportable<StateError>` + `error(networkError)`
6. `_onUsernameRechecked` — `checkUsernameAvailability` throws `StateError` -> `Reportable<StateError>` + re-reserve
7. `_canonicalizeProfileAbout` — mock `MentionResolutionService` throws `StateError` -> `Reportable<StateError>` + save still succeeds with raw bio

**Related Issue:** Closes #4593

## Verification

From `mobile/`:

- `dart format --output=none --set-exit-if-changed lib/blocs/profile_editor test/blocs/profile_editor` -> Formatted 6 files (0 changed)
- `flutter analyze lib test integration_test` -> No issues found! (ran in 32.5s)
- `flutter test test/blocs/profile_editor/` -> 100 tests pass (+7 new)

## Test plan

- [x] All existing profile-editor bloc tests pass without modification
- [x] New `Reportable<StateError>` test per new try/catch path (5 handlers + narrowed publish + mention)
- [x] Existing `errors: () => [isA<NoRelaysConnectedException>()]` tests stay green via the typed narrowed branch
- [x] Existing `errors: () => [isA<Exception>()]` avatar/banner tests stay green (their catches are unchanged)
- [x] Analyzer + format clean
- [ ] CI green (Analyze + Tests + Format + Generated Files)

## Out of Scope

- **Narrowing the avatar/banner upload catches** into typed branches. Blossom is stable Network/IO and there's no observed Error-escape signal; defer to a follow-up if a real Reportable need surfaces.
- **Wrapping `getCachedProfile` at `_saveProfile:821`** — drift errors are best-effort path; folds into PR I (LocalKeySigner typed-exception) follow-up under the epic.

## Type of Change

- [x] Code refactor
- [x] Documentation
