### PR TITLE
refactor(video-editor,clips): classify Bloc errors via Reportable matrix (#4594)

### DIFF
--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -147,6 +147,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         name: 'ClipsLibraryBloc',
         category: LogCategory.video,
       );
+      // Matrix-NO: ClipLibraryService.getAllClips is local Drift IO.
       addError(e, stackTrace);
       emit(state.copyWith(status: ClipsLibraryStatus.error));
     }
@@ -237,6 +238,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         name: 'ClipsLibraryBloc',
         category: LogCategory.video,
       );
+      // Matrix-NO: deleteClip loop + getAllClips reload are local Drift IO.
       addError(e, stackTrace);
       emit(state.copyWith(status: ClipsLibraryStatus.error));
     }
@@ -289,6 +291,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         name: 'ClipsLibraryBloc',
         category: LogCategory.video,
       );
+      // Matrix-NO: deleteClip + getAllClips reload are local Drift IO.
       addError(e, stackTrace);
       emit(state.copyWith(status: ClipsLibraryStatus.error));
     }
@@ -340,6 +343,9 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
             failureCount++;
         }
       } catch (e, s) {
+        // Matrix-NO: GallerySaveService is documented as never throwing
+        // (returns result objects). This catch is defensive against the
+        // contract drifting; when-in-doubt classification applies.
         addError(e, s);
         emit(
           state.copyWith(
@@ -384,6 +390,8 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         name: 'ClipsLibraryBloc',
         category: LogCategory.video,
       );
+      // Matrix-NO: background recoverMissingAssets is filesystem + thumbnail
+      // IO (Network/IO category).
       addError(e, stackTrace);
     }
   }
@@ -404,6 +412,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
         name: 'ClipsLibraryBloc',
         category: LogCategory.video,
       );
+      // Matrix-NO: SharedPreferences.setString is local platform-channel IO.
       addError(e, stackTrace);
     }
     emit(

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -358,6 +358,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         category: LogCategory.video,
       );
     } catch (e, stackTrace) {
+      // Matrix-NO: rethrown FFmpeg render exceptions, RenderCanceledException
+      // (user nav-away mid-render), and file IO. ArgumentError from
+      // VideoEditorSplitService is pre-validated by isValidSplitPosition at
+      // line 259 above and cannot reach this catch.
       addError(e, stackTrace);
       Log.error(
         '❌ Failed to split clip: $e',
@@ -538,6 +542,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         stackTrace: stackTrace,
         category: LogCategory.video,
       );
+      // Matrix-NO: AudioExtractionException is the typed expected failure
+      // (Network/IO — FFmpeg + file IO).
       addError(e, stackTrace);
       emit(
         state.copyWith(

--- a/mobile/lib/blocs/video_editor/sticker/video_editor_sticker_bloc.dart
+++ b/mobile/lib/blocs/video_editor/sticker/video_editor_sticker_bloc.dart
@@ -4,6 +4,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' show StickerData, StickerPackData;
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'video_editor_sticker_event.dart';
@@ -61,7 +62,11 @@ class VideoEditorStickerBloc
       emit(VideoEditorStickerLoaded(stickers: _allStickers));
       onPrecacheStickers(_allStickers.take(maxPrecacheCount).toList());
     } catch (e, stackTrace) {
-      addError(e, stackTrace);
+      // Matrix-YES: every failure path here is a build/asset invariant —
+      // missing bundled asset (FlutterError), corrupt JSON (FormatException),
+      // or shape-mismatch cast (TypeError). Bundled assets ship inside the
+      // IPA/APK so runtime PlatformException is essentially impossible.
+      addError(Reportable(e, context: '_onLoad'), stackTrace);
       Log.error(
         '🌟 Failed to load stickers: $e',
         name: 'VideoEditorStickerBloc',

--- a/mobile/lib/blocs/video_search/video_search_bloc.dart
+++ b/mobile/lib/blocs/video_search/video_search_bloc.dart
@@ -102,6 +102,8 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
         ),
       );
     } on Exception catch (e, stackTrace) {
+      // Matrix-NO: searchVideos stream surfaces API / relay / network
+      // failures (Network/IO category).
       addError(e, stackTrace);
       emit(state.copyWith(status: VideoSearchStatus.failure));
     }
@@ -138,6 +140,8 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
         ),
       );
     } on Exception catch (e, stackTrace) {
+      // Matrix-NO: searchVideosViaApi surfaces API / network failures
+      // (Network/IO category).
       addError(e, stackTrace);
       emit(state.copyWith(isLoadingMore: false));
     }

--- a/mobile/test/blocs/video_editor/sticker_editor/video_editor_sticker_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/sticker_editor/video_editor_sticker_bloc_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show StickerData, StickerPackData;
 import 'package:openvine/blocs/video_editor/sticker/video_editor_sticker_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -88,6 +89,33 @@ void main() {
           expect(state.stickers[0].assetPath, testStickers[0].assetPath);
           expect(state.stickers[2].networkUrl, testStickers[2].networkUrl);
         },
+      );
+
+      blocTest<VideoEditorStickerBloc, VideoEditorStickerState>(
+        'wraps unexpected load error in Reportable with context',
+        setUp: () {
+          // Return malformed JSON so json.decode throws FormatException
+          // inside the bloc's catch. The mocked asset bytes themselves
+          // resolve fine — the invariant-shaped failure lands inside
+          // the bloc as designed.
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMessageHandler('flutter/assets', (_) async {
+                return ByteData.view(
+                  Uint8List.fromList(utf8.encode('not valid json {')).buffer,
+                );
+              });
+        },
+        build: () => VideoEditorStickerBloc(onPrecacheStickers: (_) {}),
+        act: (bloc) => bloc.add(const VideoEditorStickerLoad()),
+        expect: () => [
+          const VideoEditorStickerLoading(),
+          const VideoEditorStickerError(),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>()
+              .having((r) => r.unwrap(), 'unwrap', isA<FormatException>())
+              .having((r) => r.context, 'context', '_onLoad'),
+        ],
       );
 
       blocTest<VideoEditorStickerBloc, VideoEditorStickerState>(


### PR DESCRIPTION
## Description

Classification sweep over `mobile/lib/blocs/video_editor/**`, `mobile/lib/blocs/clips_library/**`, and `mobile/lib/blocs/video_search/**` per the [Reportable decision matrix](https://github.com/divinevideo/divine-mobile/blob/main/.claude/rules/error_handling.md#decision-matrix). PR F under epic #4336. Follows the merged DM-area precedent in PR #4597.

**Outcome: 1 new YES wrap + 10 NO classifications.** Two YES sites under scope (`clip_editor:556`, `user_search:197`) were already migrated in earlier PRs and stay inline. No single bloc accumulates 2+ YES sites, so no per-feature `*ReportableSites` constants class is introduced.

### Classification table

| File:Line | Method | Catch sees | Matrix row | Decision |
|---|---|---|---|---|
| `clip_editor_bloc.dart:361` | `_onSplitRequested` bare catch | Rethrown FFmpeg render, `RenderCanceledException`, file IO. `ArgumentError` from `VideoEditorSplitService` pre-validated at line 259 → unreachable. | Network/IO | **NO** |
| `clip_editor_bloc.dart:541` | `_onAudioExtractionRequested` `on AudioExtractionException` | Typed expected failure | Network/IO | **NO** |
| `clip_editor_bloc.dart:556` | `_onAudioExtractionRequested` generic catch | Unexpected non-`AudioExtractionException` | Invariant | **YES (already migrated, #4060)** |
| `video_editor_sticker_bloc.dart:64` | `_onLoad` bare catch | `rootBundle.loadString` missing asset, `json.decode` `FormatException`, `cast` `TypeError`. Bundled asset ships inside the IPA/APK so runtime `PlatformException` is essentially impossible. | Invariant | **YES (new)** → inline `context: '_onLoad'` |
| `clips_library_bloc.dart:150` | `_onLoadRequested` | `ClipLibraryService.getAllClips` Drift IO | Network/IO | **NO** |
| `clips_library_bloc.dart:240` | `_onDeleteSelected` | `deleteClip` loop + `getAllClips` reload IO | Network/IO | **NO** |
| `clips_library_bloc.dart:292` | `_onDeleteClip` | `deleteClip` + `getAllClips` reload IO | Network/IO | **NO** |
| `clips_library_bloc.dart:343` | `_onSaveToGallery` inner | `GallerySaveService.saveVideoToGallery` is documented as never throwing — defensive catch | When-in-doubt | **NO** |
| `clips_library_bloc.dart:387` | `_recoverAndReload` | Background `recoverMissingAssets` file IO | Network/IO | **NO** |
| `clips_library_bloc.dart:407` | `_onSortChanged` | `SharedPreferences.setString` IO | Network/IO | **NO** |
| `video_search_bloc.dart:105` | `_onQueryChanged` `on Exception` | `searchVideos` progressive stream (API / relay / network) | Network/IO | **NO** |
| `video_search_bloc.dart:141` | `_onLoadMore` `on Exception` | `searchVideosViaApi` | Network/IO | **NO** |
| `user_search_bloc.dart:197` | `_onQueryChanged` `on Exception` | Unexpected non-`TimeoutException` | Invariant | **YES (already migrated)** |

### New tests

- `video_editor_sticker_bloc_test.dart` — `wraps unexpected load error in Reportable with context`: returns malformed JSON bytes from the mocked asset bundle so `json.decode` throws `FormatException`. Asserts `errors: [Reportable<Object>(unwrap: FormatException, context: '_onLoad')]` and that the state transitions through `Loading → Error`.

**Related Issue:** Closes #4594

## Out of Scope

- **`GallerySaveResultError(e.toString())` storing an error string in `ClipsLibraryState`** (clips_library:347) — separate concern tracked under epic-child #3591 (error strings in state). Behavior unchanged in this PR.
- **Sibling sweeps** under epic #4336: notifications (#4591), welcome/publish (#4592), profile editor (#4593) — independent child PRs.

## Verification

From `mobile/`:

- `dart format --output=none --set-exit-if-changed` on all 5 changed files — Formatted 5 files (0 changed)
- `flutter analyze lib test integration_test` — No issues found
- `flutter test test/blocs/video_editor/clip_editor test/blocs/video_editor/sticker_editor test/blocs/clips_library test/blocs/video_search test/blocs/user_search` — 209/209 pass (+1 new sticker error test)

## Test plan

- [x] All existing scoped bloc tests pass unchanged (`Reportable<T>` extends `Exception` so existing `isA<Exception>()` assertions stay green)
- [x] New `Reportable<FormatException>` test for sticker `_onLoad` failure
- [x] Analyzer + format clean
- [ ] CI green (Analyze + Tests + Format + Generated Files)

## Type of Change

- [x] 🧹 Code refactor
- [x] 📝 Documentation