### PR TITLE
fix(categories): filter blocked users from category feeds

### DIFF
--- a/mobile/lib/blocs/categories/categories_bloc.dart
+++ b/mobile/lib/blocs/categories/categories_bloc.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Handles loading categories list and videos within a selected category
 
 import 'package:categories_repository/categories_repository.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -18,19 +19,21 @@ part 'categories_state.dart';
 class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
   CategoriesBloc({
     required CategoriesRepository categoriesRepository,
+    ContentBlocklistRepository? contentBlocklistRepository,
     this.currentUserPubkey,
   }) : _categoriesRepository = categoriesRepository,
-       _apiClient = categoriesRepository.apiClient,
+       _blocklistRepository = contentBlocklistRepository,
        super(const CategoriesState()) {
     on<CategoriesLoadRequested>(_onLoadRequested);
     on<CategorySelected>(_onCategorySelected);
     on<CategoryVideosLoadMore>(_onLoadMore);
     on<CategoryVideosSortChanged>(_onSortChanged);
     on<CategoryDeselected>(_onDeselected);
+    on<CategoriesBlocklistChanged>(_onBlocklistChanged);
   }
 
   final CategoriesRepository _categoriesRepository;
-  final FunnelcakeApiClient _apiClient;
+  final ContentBlocklistRepository? _blocklistRepository;
   final String? currentUserPubkey;
 
   Future<void> _onLoadRequested(
@@ -104,25 +107,23 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
       final lastVideo = state.videos.lastOrNull;
       final before = lastVideo?.createdAt;
 
-      final videoStats = await _apiClient.getVideosByCategory(
+      final page = await _categoriesRepository.getVideosForCategory(
         category: state.selectedCategory!.name,
         before: before,
         sort: _apiSortFor(state.sortOrder),
         platform: _platformFor(state.sortOrder),
       );
 
-      final newVideos = videoStats.toVideoEvents();
-
       // Deduplicate
       final existingIds = state.videos.map((v) => v.id).toSet();
-      final uniqueNew = newVideos
+      final uniqueNew = page.videos
           .where((v) => !existingIds.contains(v.id))
           .toList();
 
       emit(
         state.copyWith(
           videos: [...state.videos, ...uniqueNew],
-          hasMoreVideos: videoStats.length >= 50,
+          hasMoreVideos: page.hasMore,
           isLoadingMore: false,
         ),
       );
@@ -187,20 +188,20 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
         return;
       }
 
-      final hotVideoStats = await _apiClient.getVideosByCategory(
+      final hotVideosPage = await _categoriesRepository.getVideosForCategory(
         category: category.name,
       );
       emit(
         state.copyWith(
           videosStatus: CategoriesVideosStatus.loaded,
-          videos: hotVideoStats.toVideoEvents(),
+          videos: hotVideosPage.videos,
           hasMoreVideos: false,
         ),
       );
       return;
     }
 
-    final videoStats = await _apiClient.getVideosByCategory(
+    final page = await _categoriesRepository.getVideosForCategory(
       category: category.name,
       sort: _apiSortFor(sortOrder),
       platform: _platformFor(sortOrder),
@@ -209,8 +210,8 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
     emit(
       state.copyWith(
         videosStatus: CategoriesVideosStatus.loaded,
-        videos: videoStats.toVideoEvents(),
-        hasMoreVideos: videoStats.length >= 50,
+        videos: page.videos,
+        hasMoreVideos: page.hasMore,
       ),
     );
   }
@@ -223,12 +224,35 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
       return const [];
     }
 
-    final response = await _apiClient.getRecommendations(
+    return _categoriesRepository.getRecommendedVideos(
       pubkey: pubkey,
       category: category.name,
-      limit: 50,
     );
-    return response.videos.toVideoEvents();
+  }
+
+  void _onBlocklistChanged(
+    CategoriesBlocklistChanged event,
+    Emitter<CategoriesState> emit,
+  ) {
+    final pubkey = event.blockedPubkey;
+    if (pubkey != null) {
+      final filtered = state.videos.where((v) => v.pubkey != pubkey).toList();
+      if (filtered.length != state.videos.length) {
+        emit(state.copyWith(videos: filtered));
+      }
+      return;
+    }
+
+    final service = _blocklistRepository;
+    if (service == null) return;
+
+    final filtered = service.filterContent<VideoEvent>(
+      state.videos,
+      (video) => video.pubkey,
+    );
+    if (filtered.length != state.videos.length) {
+      emit(state.copyWith(videos: filtered));
+    }
   }
 
   String _apiSortFor(String sortOrder) {

--- a/mobile/lib/blocs/categories/categories_event.dart
+++ b/mobile/lib/blocs/categories/categories_event.dart
@@ -45,3 +45,14 @@ final class CategoryVideosSortChanged extends CategoriesEvent {
 final class CategoryDeselected extends CategoriesEvent {
   const CategoryDeselected();
 }
+
+/// A user was blocked or the blocklist changed.
+final class CategoriesBlocklistChanged extends CategoriesEvent {
+  const CategoriesBlocklistChanged({this.blockedPubkey});
+
+  /// The pubkey that was just blocked, or null for a full re-filter.
+  final String? blockedPubkey;
+
+  @override
+  List<Object?> get props => [blockedPubkey];
+}

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -251,7 +251,10 @@ HashtagRepository hashtagRepository(Ref ref) {
 @Riverpod(keepAlive: true)
 CategoriesRepository categoriesRepository(Ref ref) {
   final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
-  return CategoriesRepository(funnelcakeApiClient: funnelcakeClient);
+  return CategoriesRepository(
+    funnelcakeApiClient: funnelcakeClient,
+    blockFilter: createBlockedAuthorFilter(ref),
+  );
 }
 
 /// Provider for ProfileRepository instance

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -325,7 +325,7 @@ final class CategoriesRepositoryProvider
 }
 
 String _$categoriesRepositoryHash() =>
-    r'6a3a483ae2565033933e9891b1742571c6e15fa8';
+    r'674c9dc3ed951c7bf04466dcd424d0195de4273b';
 
 /// Provider for ProfileRepository instance
 ///

--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -42,9 +42,21 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
       StreamController<List<VideoEvent>>.broadcast();
   final StreamController<bool> _hasMoreStreamController =
       StreamController<bool>.broadcast();
+  late final CategoriesBloc _bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = CategoriesBloc(
+      categoriesRepository: ref.read(categoriesRepositoryProvider),
+      contentBlocklistRepository: ref.read(contentBlocklistRepositoryProvider),
+      currentUserPubkey: ref.read(authServiceProvider).currentPublicKeyHex,
+    )..add(CategorySelected(widget.category));
+  }
 
   @override
   void dispose() {
+    _bloc.close();
     _videosStreamController.close();
     _hasMoreStreamController.close();
     super.dispose();
@@ -52,16 +64,14 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final categoriesRepository = ref.watch(categoriesRepositoryProvider);
-    final currentUserPubkey = ref
-        .watch(authServiceProvider)
-        .currentPublicKeyHex;
+    ref.listen(blocklistVersionProvider, (previous, current) {
+      if (previous != null && current > previous) {
+        _bloc.add(const CategoriesBlocklistChanged());
+      }
+    });
 
-    return BlocProvider(
-      create: (_) => CategoriesBloc(
-        categoriesRepository: categoriesRepository,
-        currentUserPubkey: currentUserPubkey,
-      )..add(CategorySelected(widget.category)),
+    return BlocProvider.value(
+      value: _bloc,
       child: BlocListener<CategoriesBloc, CategoriesState>(
         listenWhen: (previous, current) =>
             previous.videos != current.videos ||

--- a/mobile/packages/categories_repository/lib/src/categories_repository.dart
+++ b/mobile/packages/categories_repository/lib/src/categories_repository.dart
@@ -2,7 +2,22 @@
 // ABOUTME: Owns the in-memory TTL cache for the categories list.
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
-import 'package:models/models.dart' show VideoCategory;
+import 'package:models/models.dart';
+
+/// Returns `true` when content from [pubkey] should be hidden.
+typedef CategoryVideoBlockFilter = bool Function(String pubkey);
+
+/// A page of category videos plus pagination metadata.
+final class CategoryVideosPage {
+  /// Creates a [CategoryVideosPage].
+  const CategoryVideosPage({required this.videos, required this.hasMore});
+
+  /// The filtered videos for this page.
+  final List<VideoEvent> videos;
+
+  /// Whether the API returned a full page and may have more results.
+  final bool hasMore;
+}
 
 /// Repository for fetching and caching video categories.
 ///
@@ -14,17 +29,15 @@ class CategoriesRepository {
   /// Creates a [CategoriesRepository].
   CategoriesRepository({
     required FunnelcakeApiClient funnelcakeApiClient,
+    CategoryVideoBlockFilter? blockFilter,
     Duration cacheDuration = const Duration(minutes: 10),
   }) : _funnelcakeApiClient = funnelcakeApiClient,
+       _blockFilter = blockFilter,
        _cacheDuration = cacheDuration;
 
   final FunnelcakeApiClient _funnelcakeApiClient;
+  final CategoryVideoBlockFilter? _blockFilter;
   final Duration _cacheDuration;
-
-  /// Exposes the underlying API client so callers can make video-level requests
-  /// (e.g. [FunnelcakeApiClient.getVideosByCategory]) directly without going
-  /// through this repository.
-  FunnelcakeApiClient get apiClient => _funnelcakeApiClient;
 
   List<VideoCategory>? _cache;
   DateTime? _cachedAt;
@@ -71,6 +84,46 @@ class CategoriesRepository {
     _cachedAt = DateTime.now();
 
     return ordered;
+  }
+
+  /// Returns a filtered page of videos for [category].
+  Future<CategoryVideosPage> getVideosForCategory({
+    required String category,
+    int? before,
+    String sort = 'trending',
+    String? platform,
+  }) async {
+    final videoStats = await _funnelcakeApiClient.getVideosByCategory(
+      category: category,
+      before: before,
+      sort: sort,
+      platform: platform,
+    );
+
+    return CategoryVideosPage(
+      videos: _filterVideos(videoStats.toVideoEvents()),
+      hasMore: videoStats.length >= 50,
+    );
+  }
+
+  /// Returns filtered personalized recommendations for [pubkey].
+  Future<List<VideoEvent>> getRecommendedVideos({
+    required String pubkey,
+    String? category,
+    int limit = 50,
+  }) async {
+    final response = await _funnelcakeApiClient.getRecommendations(
+      pubkey: pubkey,
+      category: category,
+      limit: limit,
+    );
+    return _filterVideos(response.videos.toVideoEvents());
+  }
+
+  List<VideoEvent> _filterVideos(List<VideoEvent> videos) {
+    final blockFilter = _blockFilter;
+    if (blockFilter == null) return videos;
+    return videos.where((video) => !blockFilter(video.pubkey)).toList();
   }
 
   /// Clears the in-memory cache so the next call fetches fresh data.

--- a/mobile/packages/categories_repository/test/src/categories_repository_test.dart
+++ b/mobile/packages/categories_repository/test/src/categories_repository_test.dart
@@ -1,15 +1,19 @@
 // ABOUTME: Tests for CategoriesRepository
-// ABOUTME: Verifies caching, cache invalidation, and featured-first ordering
+// ABOUTME: Verifies caching, filtering, and featured-first ordering
 
 import 'package:categories_repository/categories_repository.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' show VideoCategory;
+import 'package:models/models.dart'
+    show RecommendationsResponse, VideoCategory, VideoStats;
 import 'package:test/test.dart';
 
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 void main() {
+  const blockedPubkey = 'blocked_pubkey';
+  const allowedPubkey = 'allowed_pubkey';
+
   group(CategoriesRepository, () {
     late _MockFunnelcakeApiClient apiClient;
     late CategoriesRepository repository;
@@ -18,6 +22,7 @@ void main() {
       apiClient = _MockFunnelcakeApiClient();
       repository = CategoriesRepository(
         funnelcakeApiClient: apiClient,
+        blockFilter: (pubkey) => pubkey == blockedPubkey,
       );
     });
 
@@ -58,15 +63,11 @@ void main() {
         await repository.getCategories();
         await repository.getCategories(forceRefresh: true);
 
-        verify(
-          () => apiClient.getCategories(limit: 100),
-        ).called(2);
+        verify(() => apiClient.getCategories(limit: 100)).called(2);
       });
 
       test('filters out empty names', () async {
-        when(
-          () => apiClient.getCategories(limit: 100),
-        ).thenAnswer(
+        when(() => apiClient.getCategories(limit: 100)).thenAnswer(
           (_) async => const [
             VideoCategory(name: 'comedy', videoCount: 500),
             VideoCategory(name: '', videoCount: 100),
@@ -80,9 +81,7 @@ void main() {
       });
 
       test('filters out zero video counts', () async {
-        when(
-          () => apiClient.getCategories(limit: 100),
-        ).thenAnswer(
+        when(() => apiClient.getCategories(limit: 100)).thenAnswer(
           (_) async => const [
             VideoCategory(name: 'comedy', videoCount: 500),
             VideoCategory(name: 'empty', videoCount: 0),
@@ -95,9 +94,7 @@ void main() {
       });
 
       test('sorts featured categories first', () async {
-        when(
-          () => apiClient.getCategories(limit: 100),
-        ).thenAnswer(
+        when(() => apiClient.getCategories(limit: 100)).thenAnswer(
           (_) async => const [
             VideoCategory(name: 'comedy', videoCount: 500),
             VideoCategory(name: 'animals', videoCount: 300),
@@ -112,6 +109,68 @@ void main() {
       });
     });
 
+    group('getVideosForCategory', () {
+      test(
+        'filters blocked authors without breaking hasMore metadata',
+        () async {
+          when(
+            () => apiClient.getVideosByCategory(
+              category: 'music',
+              before: any(named: 'before'),
+              sort: any(named: 'sort'),
+              platform: any(named: 'platform'),
+            ),
+          ).thenAnswer(
+            (_) async => List<VideoStats>.generate(
+              50,
+              (index) => _videoStats(
+                id: 'id-$index',
+                pubkey: index == 0 ? blockedPubkey : allowedPubkey,
+              ),
+            ),
+          );
+
+          final page = await repository.getVideosForCategory(category: 'music');
+
+          expect(page.videos, hasLength(49));
+          expect(
+            page.videos.every((video) => video.pubkey != blockedPubkey),
+            isTrue,
+          );
+          expect(page.hasMore, isTrue);
+        },
+      );
+    });
+
+    group('getRecommendedVideos', () {
+      test('filters blocked authors from recommendations', () async {
+        when(
+          () => apiClient.getRecommendations(
+            pubkey: 'viewer_pubkey',
+            limit: 50,
+            category: 'music',
+          ),
+        ).thenAnswer(
+          (_) async => RecommendationsResponse(
+            videos: [
+              _videoStats(id: 'blocked-id', pubkey: blockedPubkey),
+              _videoStats(id: 'allowed-id', pubkey: allowedPubkey),
+            ],
+            source: 'personalized',
+          ),
+        );
+
+        final videos = await repository.getRecommendedVideos(
+          pubkey: 'viewer_pubkey',
+          category: 'music',
+        );
+
+        expect(videos, hasLength(1));
+        expect(videos.single.id, 'allowed-id');
+        expect(videos.single.pubkey, allowedPubkey);
+      });
+    });
+
     group('invalidateCache', () {
       test('clears cache so next call fetches fresh data', () async {
         when(
@@ -122,16 +181,25 @@ void main() {
         repository.invalidateCache();
         await repository.getCategories();
 
-        verify(
-          () => apiClient.getCategories(limit: 100),
-        ).called(2);
-      });
-    });
-
-    group('apiClient', () {
-      test('exposes the underlying API client', () {
-        expect(repository.apiClient, equals(apiClient));
+        verify(() => apiClient.getCategories(limit: 100)).called(2);
       });
     });
   });
+}
+
+VideoStats _videoStats({required String id, required String pubkey}) {
+  return VideoStats(
+    id: id,
+    pubkey: pubkey,
+    videoUrl: 'https://example.com/$id.mp4',
+    thumbnail: 'https://example.com/$id.jpg',
+    title: 'Video $id',
+    createdAt: DateTime(2026, 1, 1),
+    kind: 34236,
+    dTag: id,
+    reactions: 0,
+    comments: 0,
+    reposts: 0,
+    engagementScore: 0,
+  );
 }

--- a/mobile/packages/categories_repository/test/src/categories_repository_test.dart
+++ b/mobile/packages/categories_repository/test/src/categories_repository_test.dart
@@ -194,7 +194,7 @@ VideoStats _videoStats({required String id, required String pubkey}) {
     videoUrl: 'https://example.com/$id.mp4',
     thumbnail: 'https://example.com/$id.jpg',
     title: 'Video $id',
-    createdAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026),
     kind: 34236,
     dTag: id,
     reactions: 0,

--- a/mobile/test/blocs/categories/categories_bloc_test.dart
+++ b/mobile/test/blocs/categories/categories_bloc_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:categories_repository/categories_repository.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,20 +14,19 @@ import 'package:openvine/blocs/categories/categories_bloc.dart';
 
 class _MockCategoriesRepository extends Mock implements CategoriesRepository {}
 
-class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 const _viewerPubkey =
     '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
 
 void main() {
   late _MockCategoriesRepository mockRepository;
-  late _MockFunnelcakeApiClient mockApiClient;
+  late _MockContentBlocklistRepository mockBlocklistRepository;
 
   setUp(() {
-    mockApiClient = _MockFunnelcakeApiClient();
     mockRepository = _MockCategoriesRepository();
-    // CategoriesBloc uses repository.apiClient for video-level calls.
-    when(() => mockRepository.apiClient).thenReturn(mockApiClient);
+    mockBlocklistRepository = _MockContentBlocklistRepository();
   });
 
   group(CategoriesBloc, () {
@@ -124,16 +124,26 @@ void main() {
       const category = VideoCategory(name: 'music', videoCount: 1500);
 
       final mockVideoStats = [
-        _createVideoStats('id1'),
-        _createVideoStats('id2'),
+        _createDefaultVideoStats('id1'),
+        _createDefaultVideoStats('id2'),
       ];
 
       blocTest<CategoriesBloc, CategoriesState>(
         'emits [loading, loaded] with videos for selected category',
         setUp: () {
           when(
-            () => mockApiClient.getVideosByCategory(category: 'music'),
-          ).thenAnswer((_) async => mockVideoStats);
+            () => mockRepository.getVideosForCategory(
+              category: 'music',
+              before: any(named: 'before'),
+              sort: any(named: 'sort'),
+              platform: any(named: 'platform'),
+            ),
+          ).thenAnswer(
+            (_) async => CategoryVideosPage(
+              videos: mockVideoStats.toVideoEvents(),
+              hasMore: false,
+            ),
+          );
         },
         build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategorySelected(category)),
@@ -158,7 +168,12 @@ void main() {
         'emits error when API throws on category selection',
         setUp: () {
           when(
-            () => mockApiClient.getVideosByCategory(category: 'music'),
+            () => mockRepository.getVideosForCategory(
+              category: 'music',
+              before: any(named: 'before'),
+              sort: any(named: 'sort'),
+              platform: any(named: 'platform'),
+            ),
           ).thenThrow(const FunnelcakeException('Failed'));
         },
         build: () => CategoriesBloc(categoriesRepository: mockRepository),
@@ -185,23 +200,15 @@ void main() {
         'loads category-scoped recommendations when sort changes to forYou',
         setUp: () {
           when(
-            () => mockApiClient.getRecommendations(
-              pubkey: any(named: 'pubkey'),
-              limit: 50,
+            () => mockRepository.getRecommendedVideos(
+              pubkey: _viewerPubkey,
               category: 'music',
             ),
           ).thenAnswer(
-            (_) async => RecommendationsResponse(
-              videos: [_createVideoStats('recommended-id')],
-              source: 'personalized',
-            ),
+            (_) async => [
+              _createDefaultVideoStats('recommended-id').toVideoEvent(),
+            ],
           );
-          when(
-            () => mockApiClient.getVideosByCategory(
-              category: 'music',
-              sort: 'forYou',
-            ),
-          ).thenAnswer((_) async => const []);
         },
         seed: () => const CategoriesState(
           selectedCategory: category,
@@ -230,43 +237,46 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockApiClient.getRecommendations(
-              pubkey: any(named: 'pubkey'),
-              limit: 50,
+            () => mockRepository.getRecommendedVideos(
+              pubkey: _viewerPubkey,
               category: 'music',
             ),
           ).called(1);
           verifyNever(
-            () => mockApiClient.getVideosByCategory(
-              category: 'music',
-              sort: 'forYou',
+            () => mockRepository.getVideosForCategory(
+              category: any(named: 'category'),
+              before: any(named: 'before'),
+              sort: any(named: 'sort'),
+              platform: any(named: 'platform'),
             ),
           );
         },
       );
 
       blocTest<CategoriesBloc, CategoriesState>(
-        'falls back to Hot when forYou recommendations return no videos',
+        'falls back to Hot when forYou recommendations are empty after filtering',
         setUp: () {
           when(
-            () => mockApiClient.getRecommendations(
-              pubkey: any(named: 'pubkey'),
-              limit: 50,
+            () => mockRepository.getRecommendedVideos(
+              pubkey: _viewerPubkey,
               category: 'music',
-            ),
-          ).thenAnswer(
-            (_) async =>
-                const RecommendationsResponse(videos: [], source: 'popular'),
-          );
-          when(
-            () => mockApiClient.getVideosByCategory(category: 'music'),
-          ).thenAnswer((_) async => [_createVideoStats('hot-fallback-id')]);
-          when(
-            () => mockApiClient.getVideosByCategory(
-              category: 'music',
-              sort: 'forYou',
             ),
           ).thenAnswer((_) async => const []);
+          when(
+            () => mockRepository.getVideosForCategory(
+              category: 'music',
+              before: any(named: 'before'),
+              sort: any(named: 'sort'),
+              platform: any(named: 'platform'),
+            ),
+          ).thenAnswer(
+            (_) async => CategoryVideosPage(
+              videos: [
+                _createDefaultVideoStats('hot-fallback-id').toVideoEvent(),
+              ],
+              hasMore: true,
+            ),
+          );
         },
         seed: () => const CategoriesState(
           selectedCategory: category,
@@ -295,21 +305,14 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockApiClient.getRecommendations(
-              pubkey: any(named: 'pubkey'),
-              limit: 50,
+            () => mockRepository.getRecommendedVideos(
+              pubkey: _viewerPubkey,
               category: 'music',
             ),
           ).called(1);
           verify(
-            () => mockApiClient.getVideosByCategory(category: 'music'),
+            () => mockRepository.getVideosForCategory(category: 'music'),
           ).called(1);
-          verifyNever(
-            () => mockApiClient.getVideosByCategory(
-              category: 'music',
-              sort: 'forYou',
-            ),
-          );
         },
       );
 
@@ -317,12 +320,18 @@ void main() {
         'reloads videos with new sort order',
         setUp: () {
           when(
-            () => mockApiClient.getVideosByCategory(
+            () => mockRepository.getVideosForCategory(
               category: 'music',
+              before: any(named: 'before'),
               sort: 'loops',
               platform: 'vine',
             ),
-          ).thenAnswer((_) async => [_createVideoStats('id1')]);
+          ).thenAnswer(
+            (_) async => CategoryVideosPage(
+              videos: [_createDefaultVideoStats('id1').toVideoEvent()],
+              hasMore: false,
+            ),
+          );
         },
         seed: () => const CategoriesState(
           selectedCategory: category,
@@ -356,6 +365,68 @@ void main() {
       );
     });
 
+    group('CategoriesBlocklistChanged', () {
+      final blockedVideo = _createVideoStats(
+        'blocked-id',
+        pubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ).toVideoEvent();
+      final allowedVideo = _createVideoStats(
+        'allowed-id',
+        pubkey:
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ).toVideoEvent();
+
+      blocTest<CategoriesBloc, CategoriesState>(
+        'drops the just-blocked pubkey from in-memory videos',
+        seed: () => CategoriesState(
+          selectedCategory: const VideoCategory(
+            name: 'music',
+            videoCount: 1500,
+          ),
+          videosStatus: CategoriesVideosStatus.loaded,
+          videos: [blockedVideo, allowedVideo],
+        ),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
+        act: (bloc) => bloc.add(
+          CategoriesBlocklistChanged(blockedPubkey: blockedVideo.pubkey),
+        ),
+        expect: () => [
+          isA<CategoriesState>().having((s) => s.videos, 'videos', [
+            allowedVideo,
+          ]),
+        ],
+      );
+
+      blocTest<CategoriesBloc, CategoriesState>(
+        're-filters current videos when the blocklist version changes',
+        setUp: () {
+          when(
+            () =>
+                mockBlocklistRepository.filterContent<VideoEvent>(any(), any()),
+          ).thenReturn([allowedVideo]);
+        },
+        seed: () => CategoriesState(
+          selectedCategory: const VideoCategory(
+            name: 'music',
+            videoCount: 1500,
+          ),
+          videosStatus: CategoriesVideosStatus.loaded,
+          videos: [blockedVideo, allowedVideo],
+        ),
+        build: () => CategoriesBloc(
+          categoriesRepository: mockRepository,
+          contentBlocklistRepository: mockBlocklistRepository,
+        ),
+        act: (bloc) => bloc.add(const CategoriesBlocklistChanged()),
+        expect: () => [
+          isA<CategoriesState>().having((s) => s.videos, 'videos', [
+            allowedVideo,
+          ]),
+        ],
+      );
+    });
+
     group('CategoryDeselected', () {
       blocTest<CategoriesBloc, CategoriesState>(
         'clears selected category and videos',
@@ -380,10 +451,17 @@ void main() {
   });
 }
 
-VideoStats _createVideoStats(String id) {
+VideoStats _createDefaultVideoStats(String id) {
+  return _createVideoStats(id, pubkey: _defaultVideoPubkey);
+}
+
+const _defaultVideoPubkey =
+    'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+VideoStats _createVideoStats(String id, {required String pubkey}) {
   return VideoStats(
     id: id,
-    pubkey: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    pubkey: pubkey,
     videoUrl: 'https://example.com/video.mp4',
     thumbnail: 'https://example.com/thumb.jpg',
     title: 'Test Video $id',

--- a/mobile/test/screens/category_gallery_screen_test.dart
+++ b/mobile/test/screens/category_gallery_screen_test.dart
@@ -1,12 +1,24 @@
 // ABOUTME: Widget tests for the category gallery screen.
 // ABOUTME: Verifies picker-driven category navigation and gallery state handling.
 
+import 'package:categories_repository/categories_repository.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/categories/categories_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/category_gallery_screen.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockCategoriesRepository extends Mock implements CategoriesRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 void main() {
   Widget buildSubject({
@@ -202,4 +214,121 @@ void main() {
       expect(find.byKey(const Key('gallery-body')), findsOneWidget);
     });
   });
+
+  group('CategoryGalleryScreen', () {
+    late _MockCategoriesRepository categoriesRepository;
+    late _MockContentBlocklistRepository blocklistRepository;
+    late MockAuthService authService;
+    late ProviderContainer container;
+
+    const category = VideoCategory(name: 'animals', videoCount: 1500);
+    final blockedVideo = _video(
+      id: 'blocked-id',
+      pubkey:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      title: 'Blocked Video',
+      authorName: 'Blocked User',
+    );
+    final allowedVideo = _video(
+      id: 'allowed-id',
+      pubkey:
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      title: 'Allowed Video',
+      authorName: 'Allowed User',
+    );
+
+    setUp(() {
+      categoriesRepository = _MockCategoriesRepository();
+      blocklistRepository = _MockContentBlocklistRepository();
+      authService = createMockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(_viewerPubkey);
+
+      when(
+        () => categoriesRepository.getVideosForCategory(
+          category: 'animals',
+          before: any(named: 'before'),
+          sort: any(named: 'sort'),
+          platform: any(named: 'platform'),
+        ),
+      ).thenAnswer(
+        (_) async => CategoryVideosPage(
+          videos: [blockedVideo, allowedVideo],
+          hasMore: false,
+        ),
+      );
+
+      when(
+        () => blocklistRepository.filterContent<VideoEvent>(any(), any()),
+      ).thenReturn([allowedVideo]);
+
+      container = ProviderContainer(
+        overrides: [
+          categoriesRepositoryProvider.overrideWithValue(categoriesRepository),
+          contentBlocklistRepositoryProvider.overrideWithValue(
+            blocklistRepository,
+          ),
+          authServiceProvider.overrideWithValue(authService),
+          subscribedListVideoCacheProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+    });
+
+    testWidgets('removes blocked videos when blocklistVersion increments', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: CategoryGalleryScreen(category: category),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Blocked Video'), findsOneWidget);
+      expect(find.text('Allowed Video'), findsOneWidget);
+
+      container.read(blocklistVersionProvider.notifier).increment();
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Blocked Video'), findsNothing);
+      expect(find.text('Allowed Video'), findsOneWidget);
+      verify(
+        () => blocklistRepository.filterContent<VideoEvent>(any(), any()),
+      ).called(1);
+    });
+  });
+}
+
+const _viewerPubkey =
+    '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+VideoEvent _video({
+  required String id,
+  required String pubkey,
+  required String title,
+  required String authorName,
+}) {
+  return VideoStats(
+    id: id,
+    pubkey: pubkey,
+    videoUrl: 'https://example.com/$id.mp4',
+    thumbnail: 'https://example.com/$id.jpg',
+    title: title,
+    authorName: authorName,
+    createdAt: DateTime(2026),
+    kind: 34236,
+    dTag: id,
+    reactions: 0,
+    comments: 0,
+    reposts: 0,
+    engagementScore: 0,
+  ).toVideoEvent();
 }


### PR DESCRIPTION
Closes #4607

## Summary
- move category video and recommendation fetches behind `CategoriesRepository` and apply block filtering at the repository layer
- keep category pagination correct after filtering by returning page metadata instead of raw lists
- react to blocklist version changes in `CategoryGalleryScreen` and `CategoriesBloc` so blocked videos disappear immediately from the grid and pooled fullscreen feed
- add repository, bloc, and screen tests for the filtered category path

## Root cause
`CategoriesBloc` fetched category videos and recommendations directly from `FunnelcakeApiClient`, bypassing the block filtering used by the main feed repository path.

## Validation
- `flutter analyze lib test integration_test`
- `flutter test test/blocs/categories/categories_bloc_test.dart test/screens/category_gallery_screen_test.dart packages/categories_repository/test/src/categories_repository_test.dart`
