### PR TITLE
fix(crashlytics): guard fire-and-forget Bloc addError calls against post-close races (#4605)

### DIFF
--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -392,10 +392,9 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       );
       // Matrix-NO: background recoverMissingAssets is filesystem + thumbnail
       // IO (Network/IO category).
-      // _recoverAndReload is launched fire-and-forget via unawaited()
-      // from _onLoadRequested (line 142). The sibling add() above is
-      // already !isClosed-guarded; symmetric guard here prevents
-      // addError-on-closed StateError. See #4605.
+      // Guarded for symmetry with the sibling add() above: this method
+      // runs fire-and-forget via unawaited() and post-close addError
+      // throws StateError.
       if (!isClosed) {
         addError(e, stackTrace);
       }

--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -392,7 +392,13 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       );
       // Matrix-NO: background recoverMissingAssets is filesystem + thumbnail
       // IO (Network/IO category).
-      addError(e, stackTrace);
+      // _recoverAndReload is launched fire-and-forget via unawaited()
+      // from _onLoadRequested (line 142). The sibling add() above is
+      // already !isClosed-guarded; symmetric guard here prevents
+      // addError-on-closed StateError. See #4605.
+      if (!isClosed) {
+        addError(e, stackTrace);
+      }
     }
   }
 

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -289,9 +289,9 @@ class VideoInteractionsBloc
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
-      // _publishLike runs fire-and-forget via unawaited() at line 254.
-      // Guard symmetrically with the add() below (also !isClosed-gated)
-      // so addError doesn't fire on a closed bloc. See #4605.
+      // Guarded for symmetry with the sibling add() below: _publishLike
+      // runs fire-and-forget via unawaited() and post-close addError
+      // throws StateError.
       if (!isClosed) {
         addError(
           Reportable(e, context: VideoInteractionsReportableSites.publishLike),
@@ -413,9 +413,9 @@ class VideoInteractionsBloc
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
-      // _publishRepost runs fire-and-forget via unawaited() at line 375.
-      // Guard symmetrically with the add() below (also !isClosed-gated)
-      // so addError doesn't fire on a closed bloc. See #4605.
+      // Guarded for symmetry with the sibling add() below: _publishRepost
+      // runs fire-and-forget via unawaited() and post-close addError
+      // throws StateError.
       if (!isClosed) {
         addError(
           Reportable(

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -289,10 +289,15 @@ class VideoInteractionsBloc
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
-      addError(
-        Reportable(e, context: VideoInteractionsReportableSites.publishLike),
-        stackTrace,
-      );
+      // _publishLike runs fire-and-forget via unawaited() at line 254.
+      // Guard symmetrically with the add() below (also !isClosed-gated)
+      // so addError doesn't fire on a closed bloc. See #4605.
+      if (!isClosed) {
+        addError(
+          Reportable(e, context: VideoInteractionsReportableSites.publishLike),
+          stackTrace,
+        );
+      }
       outcome = _LikeSettleFailed(wasLiked: wasLiked);
     }
 
@@ -408,10 +413,18 @@ class VideoInteractionsBloc
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
-      addError(
-        Reportable(e, context: VideoInteractionsReportableSites.publishRepost),
-        stackTrace,
-      );
+      // _publishRepost runs fire-and-forget via unawaited() at line 375.
+      // Guard symmetrically with the add() below (also !isClosed-gated)
+      // so addError doesn't fire on a closed bloc. See #4605.
+      if (!isClosed) {
+        addError(
+          Reportable(
+            e,
+            context: VideoInteractionsReportableSites.publishRepost,
+          ),
+          stackTrace,
+        );
+      }
       outcome = _RepostSettleFailed(wasReposted: wasReposted);
     }
 

--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -141,7 +141,16 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
       // Drift IO — matrix-NO (Network/IO row). Raw addError so the
       // failure surfaces in DivineBlocObserver without reaching
       // Crashlytics. See .claude/rules/error_handling.md.
-      addError(e, stackTrace);
+      //
+      // _hydrateAccount runs from _hydrateProfiles which is dispatched
+      // fire-and-forget from _onWelcomeStarted (line 105). If the user
+      // navigates away from welcome before the Future.wait resolves the
+      // bloc closes, and calling addError on a closed BlocBase throws
+      // StateError. Guard the forward; local Log.warning above stays
+      // unguarded since it is safe regardless of close state. See #4605.
+      if (!isClosed) {
+        addError(e, stackTrace);
+      }
     }
     return PreviousAccount(
       pubkeyHex: known.pubkeyHex,

--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -138,16 +138,9 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
-      // Drift IO — matrix-NO (Network/IO row). Raw addError so the
-      // failure surfaces in DivineBlocObserver without reaching
-      // Crashlytics. See .claude/rules/error_handling.md.
-      //
-      // _hydrateAccount runs from _hydrateProfiles which is dispatched
-      // fire-and-forget from _onWelcomeStarted (line 105). If the user
-      // navigates away from welcome before the Future.wait resolves the
-      // bloc closes, and calling addError on a closed BlocBase throws
-      // StateError. Guard the forward; local Log.warning above stays
-      // unguarded since it is safe regardless of close state. See #4605.
+      // Matrix-NO (Drift IO). Guarded because _hydrateAccount is reached
+      // via a fire-and-forget _hydrateProfiles call; the bloc may close
+      // before the await resolves, and post-close addError throws.
       if (!isClosed) {
         addError(e, stackTrace);
       }

--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -122,8 +122,10 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
       category: LogCategory.auth,
     );
 
-    // Only update if any profiles were actually found.
-    if (withProfiles > 0) {
+    // Only update if any profiles were actually found. Guard because this
+    // method runs fire-and-forget from _onWelcomeStarted, so the bloc may
+    // already be closed by the time the parallel hydration finishes.
+    if (withProfiles > 0 && !isClosed) {
       add(WelcomeProfilesHydrated(results));
     }
   }

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for ClipsLibraryBloc - managing saved video clips
 // ABOUTME: Tests loading, selection, deletion, and gallery export
 
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,6 +19,16 @@ class _MockClipLibraryService extends Mock implements ClipLibraryService {}
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
 
 class _FakeEditorVideo extends Fake implements EditorVideo {}
+
+class _CapturingObserver extends BlocObserver {
+  final List<Object> errors = [];
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    errors.add(error);
+    super.onError(bloc, error, stackTrace);
+  }
+}
 
 void main() {
   setUpAll(() {
@@ -178,6 +191,49 @@ void main() {
             ClipsLibraryStatus.error,
           ),
         ],
+      );
+
+      test(
+        'does not addError after close when _recoverAndReload completes '
+        'post-close (regression #4605)',
+        () async {
+          // Clip with a missing ghost frame triggers the unawaited
+          // _recoverAndReload background path. The recovery future is
+          // held open via a Completer so we can close the bloc before
+          // it resolves, then fail it — exercising the post-close race.
+          final clipMissingGhost = DivineVideoClip(
+            id: 'clip-missing-ghost',
+            video: EditorVideo.file('/path/to/clip.mp4'),
+            thumbnailPath: '/path/to/thumb.jpg',
+            duration: const Duration(seconds: 5),
+            recordedAt: DateTime(2026),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
+          final completer = Completer<List<DivineVideoClip>>();
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [clipMissingGhost]);
+          when(
+            () => mockClipLibraryService.recoverMissingAssets(any()),
+          ).thenAnswer((_) => completer.future);
+
+          final observer = _CapturingObserver();
+          final priorObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = priorObserver);
+
+          final bloc = createBloc()..add(const ClipsLibraryLoadRequested());
+          // Let the handler reach unawaited(_recoverAndReload).
+          await Future<void>.delayed(Duration.zero);
+
+          await bloc.close();
+
+          completer.completeError(Exception('Recovery failed'));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(observer.errors, isEmpty);
+        },
       );
     });
 

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,6 +18,16 @@ class _MockLikesRepository extends Mock implements LikesRepository {}
 class _MockCommentsRepository extends Mock implements CommentsRepository {}
 
 class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+class _CapturingObserver extends BlocObserver {
+  final List<Object> errors = [];
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    errors.add(error);
+    super.onError(bloc, error, stackTrace);
+  }
+}
 
 void main() {
   group('VideoInteractionsBloc', () {
@@ -1100,6 +1111,42 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'does not addError after close when _publishLike completes '
+        'post-close (regression #4605)',
+        () async {
+          // _publishLike runs fire-and-forget via unawaited. The user can
+          // scroll the feed and tear down this video's bloc before the
+          // publish settles; the catch arm must not addError on a closed
+          // bloc.
+          final completer = Completer<bool>();
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) => completer.future);
+
+          final observer = _CapturingObserver();
+          final priorObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = priorObserver);
+
+          final bloc = createBloc(initialLikeCount: 10)
+            ..add(const VideoInteractionsLikeToggled());
+          // Let the handler dispatch the optimistic emit and reach the
+          // unawaited(_publishLike).
+          await Future<void>.delayed(Duration.zero);
+
+          await bloc.close();
+
+          completer.completeError(Exception('relay rejected'));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(observer.errors, isEmpty);
+        },
+      );
     });
 
     group('VideoInteractionsRepostToggled', () {
@@ -1346,6 +1393,37 @@ void main() {
         verify: (bloc) {
           expect(bloc.state.isReposted, isTrue);
           expect(bloc.state.repostCount, 6);
+        },
+      );
+
+      test(
+        'does not addError after close when _publishRepost completes '
+        'post-close (regression #4605)',
+        () async {
+          final completer = Completer<bool>();
+          when(
+            () => mockRepostsRepository.toggleRepost(
+              addressableId: testAddressableId,
+              originalAuthorPubkey: testAuthorPubkey,
+              eventId: testEventId,
+            ),
+          ).thenAnswer((_) => completer.future);
+
+          final observer = _CapturingObserver();
+          final priorObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = priorObserver);
+
+          final bloc = createBloc(addressableId: testAddressableId)
+            ..add(const VideoInteractionsRepostToggled());
+          await Future<void>.delayed(Duration.zero);
+
+          await bloc.close();
+
+          completer.completeError(Exception('relay rejected'));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(observer.errors, isEmpty);
         },
       );
     });

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for WelcomeBloc
 // ABOUTME: Verifies multi-account loading, selection, and auth actions
 
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:db_client/db_client.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,6 +17,16 @@ import 'package:openvine/services/auth_service.dart' hide UserProfile;
 class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
 
 class _MockAuthService extends Mock implements AuthService {}
+
+class _CapturingObserver extends BlocObserver {
+  final List<Object> errors = [];
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    errors.add(error);
+    super.onError(bloc, error, stackTrace);
+  }
+}
 
 const _testPubkeyHex =
     'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
@@ -177,6 +190,44 @@ void main() {
           ),
         ],
         errors: () => [isA<Exception>()],
+      );
+
+      test(
+        'does not addError after close when _hydrateAccount completes '
+        'post-close (regression #4605)',
+        () async {
+          // Pin the lifecycle race: _hydrateProfiles is dispatched
+          // fire-and-forget from _onWelcomeStarted. If the user navigates
+          // away before the in-flight getProfile resolves, the bloc closes
+          // and an unguarded addError in the catch arm would throw
+          // StateError. The guard added in #4605 must suppress the forward.
+          final completer = Completer<UserProfile?>();
+          when(
+            () => mockAuthService.getKnownAccounts(),
+          ).thenAnswer((_) async => [_testKnownAccount]);
+          when(
+            () => mockUserProfilesDao.getProfile(_testPubkeyHex),
+          ).thenAnswer((_) => completer.future);
+
+          final observer = _CapturingObserver();
+          final priorObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = priorObserver);
+
+          final bloc = buildBloc()..add(const WelcomeStarted());
+          // Let the handler reach the await on getProfile.
+          await Future<void>.delayed(Duration.zero);
+
+          // Close the bloc while _hydrateAccount is still awaiting.
+          await bloc.close();
+
+          // Now fail the in-flight future; the catch arm runs post-close.
+          completer.completeError(Exception('DB error'));
+          // Drain microtasks queued by the completion.
+          await Future<void>.delayed(Duration.zero);
+
+          expect(observer.errors, isEmpty);
+        },
       );
 
       blocTest<WelcomeBloc, WelcomeState>(

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -230,6 +230,35 @@ void main() {
         },
       );
 
+      test(
+        'does not add after close when _hydrateProfiles completes '
+        'successfully post-close (regression #4605)',
+        () async {
+          final completer = Completer<UserProfile?>();
+          when(
+            () => mockAuthService.getKnownAccounts(),
+          ).thenAnswer((_) async => [_testKnownAccount]);
+          when(
+            () => mockUserProfilesDao.getProfile(_testPubkeyHex),
+          ).thenAnswer((_) => completer.future);
+
+          final observer = _CapturingObserver();
+          final priorObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = priorObserver);
+
+          final bloc = buildBloc()..add(const WelcomeStarted());
+          await Future<void>.delayed(Duration.zero);
+
+          await bloc.close();
+
+          completer.complete(_testProfile);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(observer.errors, isEmpty);
+        },
+      );
+
       blocTest<WelcomeBloc, WelcomeState>(
         'emits loaded with multiple accounts then hydrates profiles',
         setUp: () {


### PR DESCRIPTION
## Description

Add `if (!isClosed)` guards around `addError` calls in Bloc methods invoked from a fire-and-forget context. Without the guard, the Reportable-matrix migration (#4336) is shipping new `addError` calls into closed-bloc races that surface as misleading nonfatal Crashlytics noise — exactly the noise the matrix is meant to suppress.

Closes #4605. Same bug class as #4393 (which targets the `add()` variant of the same race).

## Sites guarded

| File | Method | Fire-and-forget context | Sibling `add()` already guarded? |
|---|---|---|---|
| `mobile/lib/blocs/welcome/welcome_bloc.dart` | `_hydrateAccount` | `_hydrateProfiles(knownAccounts);` (no await/unawaited) from `_onWelcomeStarted` line 105 | n/a — no `add()` call here, only `addError` (new from #4592) |
| `mobile/lib/blocs/clips_library/clips_library_bloc.dart` | `_recoverAndReload` | `unawaited(_recoverAndReload(clips));` from `_onLoadRequested` line 142 | yes — sibling `add()` at line 374 is `!isClosed`-gated; this PR adds symmetric guard for `addError` at line 388 |
| `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart` | `_publishLike` | `unawaited(_publishLike(...))` at line 254 | yes — sibling `add()` at line 305 is `!isClosed`-gated; this PR adds symmetric guard for `addError` at line 296 |
| `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart` | `_publishRepost` | `unawaited(_publishRepost(...))` at line 376 | yes — sibling `add()` at line 432 is `!isClosed`-gated; this PR adds symmetric guard for `addError` at line 420 |

The welcome + clips_library sites are the ones the issue body called out explicitly; the two `video_interactions` sites surfaced from the audit grep required by the issue's acceptance criteria.

## Why `Reportable(...)` only at some sites

The wrap-vs-raw choice was set by the earlier matrix-classification sweeps (#4592, #4604) and is independent of this lifecycle fix. Welcome and clips_library are matrix-NO (Drift/file IO) → raw `addError`. The two video_interactions sites are matrix-YES (publish-path invariants) → `Reportable(...)` wrap. This PR preserves each existing classification and only adds the surrounding `isClosed` guard.

## Audit pass

Per issue acceptance criterion 3 — `grep -rn "unawaited(" mobile/lib/blocs/` plus a manual check of each match's callee for `addError` reachability:

- `fullscreen_feed_bloc.dart` (2 `unawaited(_processCacheQueue())` calls) — no `addError` in file
- `video_volume_cubit.dart` (3 `unawaited(_persist())` calls) — no `addError` in file
- `audio_timing_cubit.dart` (`unawaited(_onPlaybackCompleted())`) — no `addError` in file
- `video_feed_bloc.dart` (2 `unawaited(...)` calls) — no `addError` in file
- `profile_liked_videos_bloc.dart`, `profile_reposted_videos_bloc.dart` — `unawaited(...catchError(Log.warning))`, catches locally; never reaches `addError`
- `background_publish_bloc.dart` (3 `unawaited(...)` calls) — repository service calls, no `addError` reachable; the one `addError` in the file (`_onBackgroundPublishStarted` line 69) is inside the event handler, not fire-and-forget
- `dm/conversation/conversation_bloc.dart` — `unawaited(_dmRepository.markConversationAsRead(...))`, repository call

No additional `unawaited(...)` sites remain.

## Adjacent patterns explicitly out of scope

Self-review surfaced two adjacent fire-and-forget-ish patterns that are **not** in this PR's scope because they have a different lifecycle contract:

- **Stream-subscription `onError: addError` tear-offs** (`dm/unread_count/dm_unread_count_cubit.dart:25`, `notifications/badge/notification_badge_cubit.dart:28`) — these subscriptions are explicitly cancelled in `close()`, so post-close emissions are not expected. If a stream still emits an error after cancellation it is a stream-implementation bug, not the close-race this issue targets.
- **`on<E>` event handlers that `await` then `addError` in catch** (e.g. `welcome_bloc.dart:225`) — these are tracked by the bloc machinery, not fire-and-forget. The same close race technically exists if `close()` lands during an `await`, but the issue body intentionally scopes itself to fire-and-forget. A broader sweep would be a separate issue.

Filing a follow-up issue would be appropriate if reviewers want the broader sweep tracked formally.

## Tests

Four new regression tests (one per site) follow a common shape:

1. Stub the in-flight async dependency with a `Completer.future`
2. Dispatch the triggering event
3. `await Future<void>.delayed(Duration.zero)` to let the handler reach the unawaited call
4. `await bloc.close()` while the future is still pending
5. `completer.completeError(...)` — catch arm runs post-close
6. Assert `_CapturingObserver.errors` is empty

The capturing observer is a small per-test-file class implementing `BlocObserver.onError`.

**Test meaningfulness verified empirically**: removing the guard from `welcome_bloc._hydrateAccount` causes the regression test to fail with `Expected: empty, Actual: [Exception: DB error]` (the observer captures the post-close `addError`). Restoring the guard makes it pass. The other three tests follow the same shape and pin the same contract.

## Verification

From `mobile/`:

- `dart format --output=none --set-exit-if-changed` on all 6 changed files — Formatted 6 files (0 changed)
- `flutter analyze lib test integration_test` — No issues found
- `flutter test test/blocs/welcome/ test/blocs/clips_library/ test/blocs/video_interactions/` — 147/147 pass (+4 new regression tests)
- CI: all required checks green (Analyze, Tests, Format, Generated Files, Build Flutter Web Preview, VGV Tag Gate, Mobile CI)

## Test plan

- [x] Existing welcome / clips_library / video_interactions tests stay green
- [x] Four new regression tests pin the close-during-fire-and-forget contract
- [x] Each new test verified to fail without the corresponding guard (empirically confirmed for welcome; same shape for the other three)
- [x] Analyzer + format clean
- [x] CI green (Analyze + Tests + Format + Generated Files + Build + VGV Tag + Mobile CI)

## Out of scope (related but separate)

- Widget-level `mounted` checks (covered by #4396)
- `add()`-after-close races on non-fire-and-forget paths (covered by #4393 / #3734)
- Stream-subscription onError tear-offs (different lifecycle — cancelled in `close()`)
- `on<E>` event-handler post-await close races (different lifecycle — tracked by bloc machinery)
- A `BlocBase.safeAddError` extension helper (would expand scope; can be a future cleanup)

## Related

- Parent epic: #4336
- Reviewer flag that originated this issue: https://github.com/divinevideo/divine-mobile/pull/4600#pullrequestreview-4338186724

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test addition