### PR TITLE
refactor(notifications): classify NotificationFeedBloc invariants as Reportable (#4603)

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -10,6 +10,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/notifications/bloc/reportable_sites.dart';
+import 'package:openvine/observability/reportable_error.dart';
 
 part 'notification_feed_event.dart';
 part 'notification_feed_state.dart';
@@ -106,20 +108,44 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.refresh();
       emit(state.copyWith(status: NotificationFeedStatus.loaded));
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout; transient-retry
       // exhausted on first page). Per .claude/rules/error_handling.md
       // they are NOT Reportable — the UI either keeps cached items
       // with an inline `refreshError` banner or falls back to
       // `NotificationFeedStatus.failure`.
-      addError(e, s);
+      //
       // Hard-failure only fires when the cache is also empty — the
-      // repository surfaces `lastRefreshError` on the snapshot, and the
-      // view renders an inline banner on top of cached items in that
-      // case. `state.notifications` already reflects any hydrated cache
-      // because `_onSnapshotChanged` runs before this catch arm if the
-      // repository emitted before throwing.
+      // repository surfaces `lastRefreshError` on the snapshot, and
+      // the view renders an inline banner on top of cached items in
+      // that case. `state.notifications` already reflects any hydrated
+      // cache because `_onSnapshotChanged` runs before this catch arm
+      // if the repository emitted before throwing.
+      addError(e, s);
+      final hasCachedItems = state.notifications.isNotEmpty;
+      emit(
+        state.copyWith(
+          status: hasCachedItems
+              ? NotificationFeedStatus.loaded
+              : NotificationFeedStatus.failure,
+          refreshError: true,
+        ),
+      );
+      return;
+    } catch (e, s) {
+      // Errors (StateError, TypeError, RangeError) escape `on Exception`
+      // and reach here. Per .claude/rules/error_handling.md they are
+      // matrix-YES invariant violations — wrap with Reportable so
+      // DivineBlocObserver forwards to Crashlytics. Recovery emit
+      // mirrors the matrix-NO arm so the UX is preserved.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.onStarted,
+        ),
+        s,
+      );
       final hasCachedItems = state.notifications.isNotEmpty;
       emit(
         state.copyWith(
@@ -145,12 +171,22 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.getNotifications();
       emit(state.copyWith(isLoadingMore: false));
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       // `NotificationRepository.getNotifications` (single-attempt
       // paginate-load-more) propagates typed `FunnelcakeException`
       // (4xx/5xx/timeout). Per .claude/rules/error_handling.md they
       // are NOT Reportable — the BLoC recovers `isLoadingMore: false`.
       addError(e, s);
+      emit(state.copyWith(isLoadingMore: false));
+    } catch (e, s) {
+      // Errors (StateError, TypeError) — matrix-YES invariant.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.onLoadMore,
+        ),
+        s,
+      );
       emit(state.copyWith(isLoadingMore: false));
     }
   }
@@ -163,13 +199,32 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.refresh();
       emit(state.copyWith(status: NotificationFeedStatus.loaded));
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout). Per
       // .claude/rules/error_handling.md they are NOT Reportable —
       // the UI either keeps cached items with `refreshError: true`
       // or falls back to `NotificationFeedStatus.failure`.
       addError(e, s);
+      final hasCachedItems = state.notifications.isNotEmpty;
+      emit(
+        state.copyWith(
+          status: hasCachedItems
+              ? NotificationFeedStatus.loaded
+              : NotificationFeedStatus.failure,
+          refreshError: true,
+        ),
+      );
+    } catch (e, s) {
+      // Errors (StateError, TypeError) — matrix-YES invariant.
+      // Recovery emit mirrors the matrix-NO arm so the UX is preserved.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.onRefreshed,
+        ),
+        s,
+      );
       final hasCachedItems = state.notifications.isNotEmpty;
       emit(
         state.copyWith(
@@ -192,12 +247,21 @@ class NotificationFeedBloc
   ) async {
     try {
       await _notificationRepository.markAsRead([event.notificationId]);
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       // `NotificationRepository.markAsRead` propagates
       // `FunnelcakeException` and local Drift DAO write failures
       // after rolling the optimistic snapshot back. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, s);
+    } catch (e, s) {
+      // Errors (StateError, TypeError) — matrix-YES invariant.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.onItemTapped,
+        ),
+        s,
+      );
     }
   }
 
@@ -210,13 +274,22 @@ class NotificationFeedBloc
   ) async {
     try {
       await _notificationRepository.markAllAsRead();
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       // `NotificationRepository.markAllAsRead` propagates
       // `FunnelcakeException` and local Drift DAO write failures
       // after rolling the optimistic snapshot back (PR #4034
       // semantics). Per .claude/rules/error_handling.md they are
       // NOT Reportable.
       addError(e, s);
+    } catch (e, s) {
+      // Errors (StateError, TypeError) — matrix-YES invariant.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.onMarkAllRead,
+        ),
+        s,
+      );
     }
   }
 
@@ -235,13 +308,23 @@ class NotificationFeedBloc
       emit(
         state.copyWith(notifications: _applyFollowState(state.notifications)),
       );
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       // `FollowRepository.follow` propagates `Exception('User not
       // authenticated')` (auth/session) and relay-IO failures from
       // contact-list broadcast — the repo rolls back the optimistic
       // follow internally. Per .claude/rules/error_handling.md they
       // are NOT Reportable.
       addError(e, s);
+    } catch (e, s) {
+      // Errors (StateError, TypeError from the post-await
+      // `_applyFollowState` transform) — matrix-YES invariant.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.onFollowBack,
+        ),
+        s,
+      );
     }
   }
 

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Per-feature Reportable `context:` constants for NotificationFeedBloc.
+// ABOUTME: See .claude/rules/error_handling.md — once a feature accumulates 2+
+// ABOUTME: Reportable-wrapped call sites, the identifiers lift here.
+
+/// Stable `context:` identifiers for `Reportable(...)` wraps inside
+/// [NotificationFeedBloc].
+///
+/// Per the convention in `.claude/rules/error_handling.md`, when a Bloc
+/// has more than one `addError(Reportable(e, context: ...))` site, the
+/// `context:` strings are lifted into a per-feature constants class so
+/// the Crashlytics dashboard groups them by stable identifier rather
+/// than inline string literals.
+abstract class NotificationFeedBlocReportableSites {
+  /// `_onStarted` generic-catch arm — `Error` types that escape
+  /// `NotificationRepository.refresh`'s `on Exception` propagation.
+  /// Includes the defensive `StateError('retry exhausted')` from
+  /// `_fetchWithRetry` if the analyzer's loop invariant ever breaks.
+  static const String onStarted = '_onStarted';
+
+  /// `_onLoadMore` generic-catch arm — `Error` types that escape
+  /// `NotificationRepository.getNotifications`'s `on Exception`
+  /// propagation. Single-attempt paginate has no retry, so the
+  /// realistic source is a Drift schema-mismatch `TypeError`.
+  static const String onLoadMore = '_onLoadMore';
+
+  /// `_onRefreshed` generic-catch arm — same coverage as [onStarted],
+  /// dispatched from pull-to-refresh. Kept distinct from [onStarted] so
+  /// the Crashlytics dashboard distinguishes initial-load failures from
+  /// refresh failures (different user actions, different recovery UX).
+  static const String onRefreshed = '_onRefreshed';
+
+  /// `_onItemTapped` generic-catch arm — `Error` types that escape
+  /// `NotificationRepository.markAsRead`'s rollback `catch (_)` rethrow.
+  /// Realistically a Drift DAO `TypeError` from a row-shape mismatch.
+  static const String onItemTapped = '_onItemTapped';
+
+  /// `_onMarkAllRead` generic-catch arm — same coverage as
+  /// [onItemTapped], dispatched from the bulk mark-read CTA.
+  static const String onMarkAllRead = '_onMarkAllRead';
+
+  /// `_onFollowBack` generic-catch arm — `Error` types that escape
+  /// `FollowRepository.follow`'s Exception-only throws, plus a
+  /// hypothetical `TypeError` from the post-await `_applyFollowState`
+  /// transform (impossible under the current pure-`copyWith` shape; the
+  /// wrap is defence-in-depth).
+  static const String onFollowBack = '_onFollowBack';
+}

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
 
 class _MockNotificationRepository extends Mock
     implements NotificationRepository {}
@@ -262,6 +263,32 @@ void main() {
         ],
         errors: () => [isA<Exception>()],
       );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from refresh as Reportable and emits '
+        'failure with refreshError',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.refresh(),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        expect: () => [
+          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(
+            status: NotificationFeedStatus.failure,
+            refreshError: true,
+          ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
     });
 
     group('NotificationFeedLoadMore', () {
@@ -328,6 +355,40 @@ void main() {
           ),
         ],
         errors: () => [isA<Exception>()],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from getNotifications as Reportable and '
+        'recovers isLoadingMore',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.getNotifications(),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          hasMore: true,
+        ),
+        act: (bloc) => bloc.add(NotificationFeedLoadMore()),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+            isLoadingMore: true,
+          ),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+          ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
       );
     });
 
@@ -409,6 +470,31 @@ void main() {
         ],
         errors: () => [isA<Exception>()],
       );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from refresh as Reportable and emits '
+        'failure with refreshError',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.refresh(),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedRefreshed()),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.failure,
+            refreshError: true,
+          ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
     });
 
     group('NotificationFeedItemTapped', () {
@@ -432,6 +518,24 @@ void main() {
         act: (bloc) => bloc.add(NotificationFeedItemTapped('v1')),
         errors: () => [isA<Exception>()],
       );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from markAsRead as Reportable',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAsRead(any()),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedItemTapped('v1')),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+      );
     });
 
     group('NotificationFeedMarkAllRead', () {
@@ -454,6 +558,24 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
         errors: () => [isA<Exception>()],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from markAllAsRead as Reportable',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
       );
     });
 
@@ -497,6 +619,24 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedFollowBack(_bobPubkey)),
         errors: () => [isA<Exception>()],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from follow as Reportable',
+        setUp: () {
+          when(
+            () => mockFollowRepo.follow(_bobPubkey),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedFollowBack(_bobPubkey)),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
       );
     });
   });


### PR DESCRIPTION
## Description

Follow-up to PR #4599 (comment-only matrix classification). That sweep
classified each of the 6 `addError(` sites in `NotificationFeedBloc` as
matrix-NO for the **Exception types they actually see**
(`FunnelcakeException`, `Exception('User not authenticated')`, relay/DAO
IO). The broad `catch (e, s)` still silently swallows **`Error`
subclasses** (`StateError`, `TypeError`, `RangeError`), which per
[`.claude/rules/error_handling.md`](https://github.com/divinevideo/divine-mobile/blob/main/.claude/rules/error_handling.md#decision-matrix)
are matrix-YES.

This PR narrows each catch into two arms:

- `on Exception catch (e, s)` — matrix-NO domain failures, behavior
  unchanged (PR #4599 classification comment preserved verbatim).
- `catch (e, s)` — matrix-YES invariant violations, wrapped with
  `Reportable(e, context: NotificationFeedBlocReportableSites.xxx)` so
  `DivineBlocObserver` forwards them to Crashlytics. Recovery emit
  mirrors the matrix-NO arm so UX is preserved.

6 Reportable wraps > 2-site threshold → new
`mobile/lib/notifications/bloc/reportable_sites.dart` with stable
constants (per the lift-into-constants rule).

### Classification table

| # | Site (line) | Method | Repo call | matrix-NO arm sees | matrix-YES constant |
|---|---|---|---|---|---|
| 1 | `_onStarted` | `refresh()` | `FunnelcakeException` (retried 5xx/timeout) | `onStarted` | |
| 2 | `_onLoadMore` | `getNotifications()` | `FunnelcakeException` (single-attempt) | `onLoadMore` | |
| 3 | `_onRefreshed` | `refresh()` | `FunnelcakeException` | `onRefreshed` | |
| 4 | `_onItemTapped` | `markAsRead()` | `FunnelcakeException`, Drift `SqliteException` | `onItemTapped` | |
| 5 | `_onMarkAllRead` | `markAllAsRead()` | `FunnelcakeException`, Drift `SqliteException` | `onMarkAllRead` | |
| 6 | `_onFollowBack` | `FollowRepository.follow()` | `Exception('User not authenticated')`, relay IO | `onFollowBack` | |

**Outcome: 6 matrix-YES sites added; 0 behavior changes; existing 8
`isA<Exception>()` blocTest assertions stay green** because
`Exception('boom')` still lands in the `on Exception catch` arm.

**Related Issue:** Closes #4603

## Out of Scope

- Narrowing the unreachable `Error.throwWithStackTrace(StateError('retry
  exhausted'))` defensive fallback in
  `NotificationRepository._fetchWithRetry`. If it ever fires it now
  surfaces as `Reportable<StateError>` from `_onStarted` /
  `_onRefreshed`, which is a free safety win. Repository-layer
  narrowing belongs in a separate follow-up.
- `_onSnapshotChanged` — pure projection, no try/catch, not one of the
  6 sites PR #4599 classified. Out of scope per the issue body.
- Other epic-#4336 sibling sweeps (DM, welcome/publish, video editor,
  profile editor, silent-failure remediation) — independent child
  issues.

## Verification

From `mobile/`:

- `dart format --output=none --set-exit-if-changed` on all 3 changed
  files → `Formatted 3 files (0 changed)`.
- `flutter analyze lib test integration_test` → `No issues found! (ran in 33.4s)`.
- `flutter test test/notifications/bloc/notification_feed_bloc_test.dart` →
  24 tests passed (18 existing + 6 new Reportable-arm coverage).
- `flutter test test/notifications/` → 160 tests passed.

## Test plan

- [x] All 8 existing matrix-NO `errors: () => [isA<Exception>()]`
  blocTest assertions pass unchanged.
- [x] 6 new blocTests verify each site wraps `StateError`-throws as
  `Reportable<Object>.unwrap() is StateError`, with recovery emits
  identical to the matrix-NO branch.
- [x] Full `test/notifications/` suite (160 tests) green.
- [x] `flutter analyze` clean across `lib test integration_test`.
- [ ] CI green (Analyze + Tests + Format + Generated Files + build/build).

## Type of Change

- [x] 🧹 Code refactor