### PR TITLE
fix(auth): require explicit confirmation before cross-account session recovery

### DIFF
--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -9,6 +9,7 @@ import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:models/models.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:openvine/utils/npub_hex.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'welcome_event.dart';
@@ -64,8 +65,16 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
     final pendingPubkey = _authService.pendingAccountSwitchPubkey;
     _authService.pendingAccountSwitchPubkey = null;
 
-    // Load known accounts from the registry
-    final knownAccounts = await _authService.getKnownAccounts();
+    // Load known accounts and the session-recovery anchor in parallel.
+    final accountsFuture = _authService.getKnownAccounts();
+    final anchorFuture = _authService.getSessionRecoveryAnchorNpub();
+    final knownAccounts = await accountsFuture;
+    final anchorNpub = await anchorFuture;
+
+    // Decode the npub anchor to hex so it can be compared with pubkeyHex
+    // fields in the account list. Use null on any decode failure so the
+    // mismatch detection degrades gracefully rather than crashing.
+    final anchorPubkeyHex = npubToHexOrNull(anchorNpub);
 
     if (knownAccounts.isEmpty) {
       Log.info(
@@ -78,7 +87,8 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
     }
 
     Log.info(
-      'WelcomeBloc: found ${knownAccounts.length} known account(s)',
+      'WelcomeBloc: found ${knownAccounts.length} known account(s)'
+      '${anchorPubkeyHex != null ? ", recovery anchor=$anchorPubkeyHex" : ""}',
       name: 'WelcomeBloc',
       category: LogCategory.auth,
     );
@@ -93,11 +103,28 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         )
         .toList();
 
+    // Determine the initial selection:
+    //
+    // Priority order:
+    //   1. pendingPubkey — explicit account-switch from settings (highest priority)
+    //   2. event.initialSelectedPubkeyHex — router deep-link pre-selection
+    //   3. anchorPubkeyHex — the account the user was signed into at sign-out
+    //      (avoids defaulting to a different account that was just restored
+    //      via _redirectRecoveryToRemainingAccount and may show as "most recent")
+    //   4. null — falls back to previousAccounts.first (most recently used)
+    //
+    // Using the anchor as the default pre-selection ensures the welcome screen
+    // highlights the account the user was actually on, not the one that cold-
+    // start recovery would have silently switched to.
+    final initialSelection =
+        pendingPubkey ?? event.initialSelectedPubkeyHex ?? anchorPubkeyHex;
+
     emit(
       state.copyWith(
         status: WelcomeStatus.loaded,
         previousAccounts: accountsWithoutProfiles,
-        selectedPubkeyHex: pendingPubkey ?? event.initialSelectedPubkeyHex,
+        selectedPubkeyHex: initialSelection,
+        recoveryAnchorPubkeyHex: anchorPubkeyHex,
       ),
     );
 

--- a/mobile/lib/blocs/welcome/welcome_state.dart
+++ b/mobile/lib/blocs/welcome/welcome_state.dart
@@ -55,6 +55,7 @@ final class WelcomeState extends Equatable {
     this.previousAccounts = const [],
     this.selectedPubkeyHex,
     this.signingInPubkeyHex,
+    this.recoveryAnchorPubkeyHex,
   });
 
   /// Current status of welcome operations.
@@ -69,6 +70,14 @@ final class WelcomeState extends Equatable {
 
   /// The pubkey of the account currently being signed into (for loading state).
   final String? signingInPubkeyHex;
+
+  /// The pubkey (hex) that was actively signed in at the time of the most
+  /// recent sign-out. Set from the session-recovery anchor written by
+  /// [AuthService.signOut] and decoded from npub to hex by [WelcomeBloc].
+  ///
+  /// Null when no anchor was recorded (clean install, or sign-in has already
+  /// cleared the anchor, or the anchor npub could not be decoded).
+  final String? recoveryAnchorPubkeyHex;
 
   /// Whether any returning users were detected.
   bool get hasReturningUsers => previousAccounts.isNotEmpty;
@@ -86,15 +95,32 @@ final class WelcomeState extends Equatable {
   /// Whether an auth action is in progress.
   bool get isAccepting => status == WelcomeStatus.accepting;
 
+  /// True when the session recovery anchor points to a different account than
+  /// the one currently selected for sign-in.
+  ///
+  /// This happens after a destructive sign-out when the cold-start session
+  /// restore path would have landed on a different account than the one the
+  /// user was actively using. The welcome screen uses this to show a
+  /// contextual banner explaining that local drafts/clips belong to the anchor
+  /// account and that choosing a different account will hide them.
+  bool get hasCrossAccountMismatch {
+    if (recoveryAnchorPubkeyHex == null) return false;
+    final selected = selectedAccount;
+    if (selected == null) return false;
+    return recoveryAnchorPubkeyHex != selected.pubkeyHex;
+  }
+
   /// Creates a copy of this state with the given fields replaced.
   WelcomeState copyWith({
     WelcomeStatus? status,
     List<PreviousAccount>? previousAccounts,
     String? selectedPubkeyHex,
     String? signingInPubkeyHex,
+    String? recoveryAnchorPubkeyHex,
     bool clearAccounts = false,
     bool clearSigningIn = false,
     bool clearSelectedPubkey = false,
+    bool clearRecoveryAnchor = false,
   }) {
     return WelcomeState(
       status: status ?? this.status,
@@ -107,6 +133,9 @@ final class WelcomeState extends Equatable {
       signingInPubkeyHex: clearSigningIn
           ? null
           : (signingInPubkeyHex ?? this.signingInPubkeyHex),
+      recoveryAnchorPubkeyHex: clearRecoveryAnchor
+          ? null
+          : (recoveryAnchorPubkeyHex ?? this.recoveryAnchorPubkeyHex),
     );
   }
 
@@ -116,5 +145,6 @@ final class WelcomeState extends Equatable {
     previousAccounts,
     selectedPubkeyHex,
     signingInPubkeyHex,
+    recoveryAnchorPubkeyHex,
   ];
 }

--- a/mobile/lib/blocs/welcome/welcome_state.dart
+++ b/mobile/lib/blocs/welcome/welcome_state.dart
@@ -95,14 +95,19 @@ final class WelcomeState extends Equatable {
   /// Whether an auth action is in progress.
   bool get isAccepting => status == WelcomeStatus.accepting;
 
+  /// Whether the welcome screen should show session-recovery context.
+  ///
+  /// When present, the user most recently signed out of this account and the
+  /// welcome screen should explain which account owns local drafts/clips.
+  bool get hasRecoveryAnchor => recoveryAnchorPubkeyHex != null;
+
   /// True when the session recovery anchor points to a different account than
   /// the one currently selected for sign-in.
   ///
-  /// This happens after a destructive sign-out when the cold-start session
-  /// restore path would have landed on a different account than the one the
-  /// user was actively using. The welcome screen uses this to show a
-  /// contextual banner explaining that local drafts/clips belong to the anchor
-  /// account and that choosing a different account will hide them.
+  /// This happens when the user switches away from the anchored account on the
+  /// welcome screen. The banner flips from reassurance to a warning explaining
+  /// that local drafts/clips belong to the anchored account and will be hidden
+  /// after sign-in.
   bool get hasCrossAccountMismatch {
     if (recoveryAnchorPubkeyHex == null) return false;
     final selected = selectedAccount;

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1335,6 +1335,8 @@
     "authCreateNewAccount": "አዲስ Divine መለያ ይፍጠሩ",
     "authSignInDifferentAccount": "በነባር መለያ ይግቡ",
     "authSignBackIn": "ተመልሰው ይግቡ",
+    "authRecoveryDraftsOwner": "ረቂቆችዎ እና ክሊፖችዎ ለዚህ መለያ ተቀምጠዋል",
+    "authRecoveryOtherAccountWarning": "እዚህ መግባት እነዚያ ረቂቆች እና ክሊፖች ይደብቃቸዋል",
     "authTermsPrefix": "ከላይ ያለውን አማራጭ በመምረጥ፣ ቢያንስ 16 ዓመት እንደሆናችሁ አረጋግጠዋል እና በዚህ ተስማምተዋል።",
     "authTermsOfService": "የአገልግሎት ውል",
     "authPrivacyPolicy": "የግላዊነት ፖሊሲ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1142,6 +1142,8 @@
     "authCreateNewAccount": "إنشاء حساب Divine جديد",
     "authSignInDifferentAccount": "تسجيل الدخول بحساب موجود",
     "authSignBackIn": "عد إلى تسجيل الدخول",
+    "authRecoveryDraftsOwner": "مسوداتك ومقاطعك محفوظة لهذا الحساب",
+    "authRecoveryOtherAccountWarning": "تسجيل الدخول هنا سيُخفي تلك المسودات والمقاطع",
     "authTermsPrefix": "باختيار خيار أعلاه، أنت تؤكّد أنّ عمرك 16 عامًا على الأقل وتوافق على ",
     "authTermsOfService": "شروط الخدمة",
     "authPrivacyPolicy": "سياسة الخصوصية",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1219,6 +1219,8 @@
     "authCreateNewAccount": "Създай нов Divine акаунт",
     "authSignInDifferentAccount": "Влез със съществуващ акаунт",
     "authSignBackIn": "Влез отново",
+    "authRecoveryDraftsOwner": "Черновите и клиповете ти са запазени за този акаунт",
+    "authRecoveryOtherAccountWarning": "Влизането тук ще скрие тези чернови и клипове",
     "authTermsPrefix": "Като избереш опция по-горе, потвърждаваш, че си на 16 или повече и се съгласяваш с",
     "authTermsOfService": "Условия за ползване",
     "authPrivacyPolicy": "Политика за поверителност",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Neues Divine-Konto erstellen",
     "authSignInDifferentAccount": "Mit bestehendem Konto anmelden",
     "authSignBackIn": "Wieder anmelden",
+    "authRecoveryDraftsOwner": "Deine Entwürfe und Clips sind für dieses Konto gespeichert",
+    "authRecoveryOtherAccountWarning": "Hier anmelden verbirgt diese Entwürfe und Clips",
     "authTermsPrefix": "Indem du oben eine Option wählst, bestätigst du, dass du mindestens 16 Jahre alt bist und den ",
     "authTermsOfService": "Nutzungsbedingungen",
     "authPrivacyPolicy": "Datenschutzrichtlinie",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1454,6 +1454,8 @@
   "authCreateNewAccount": "Create a new Divine account",
   "authSignInDifferentAccount": "Sign in with an existing account",
   "authSignBackIn": "Sign back in",
+  "authRecoveryDraftsOwner": "Your drafts and clips are saved for this account",
+  "authRecoveryOtherAccountWarning": "Signing in here will hide those drafts and clips",
   "authTermsPrefix": "By selecting an option above, you confirm you are at least 16 years old and agree to the ",
   "authTermsOfService": "Terms of Service",
   "authPrivacyPolicy": "Privacy Policy",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1149,6 +1149,8 @@
     "authCreateNewAccount": "Crear una cuenta nueva en Divine",
     "authSignInDifferentAccount": "Iniciar sesión con una cuenta existente",
     "authSignBackIn": "Volver a iniciar sesión",
+    "authRecoveryDraftsOwner": "Tus borradores y clips están guardados en esta cuenta",
+    "authRecoveryOtherAccountWarning": "Iniciar sesión aquí ocultará esos borradores y clips",
     "authTermsPrefix": "Al seleccionar una opción, confirmás que tenés al menos 16 años y aceptás los ",
     "authTermsOfService": "Términos del Servicio",
     "authPrivacyPolicy": "Política de Privacidad",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -687,6 +687,8 @@
     "authCreateNewAccount": "Gumawa ng bagong Divine account",
     "authSignInDifferentAccount": "Mag-sign in gamit ang umiiral na account",
     "authSignBackIn": "Mag-sign in muli",
+    "authRecoveryDraftsOwner": "Ang iyong mga draft at clip ay naka-save para sa account na ito",
+    "authRecoveryOtherAccountWarning": "Ang pag-sign in dito ay magtatago ng mga draft at clip na iyon",
     "authTermsPrefix": "Sa pagpili ng opsyon sa itaas, kinukumpirma mo na ikaw ay 16 na taong gulang o mas matanda at sumasang-ayon sa ",
     "authTermsOfService": "Terms of Service",
     "authPrivacyPolicy": "Privacy Policy",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Créer un nouveau compte Divine",
     "authSignInDifferentAccount": "Se connecter avec un compte existant",
     "authSignBackIn": "Se reconnecter",
+    "authRecoveryDraftsOwner": "Tes brouillons et clips sont enregistrés pour ce compte",
+    "authRecoveryOtherAccountWarning": "Se connecter ici masquera ces brouillons et clips",
     "authTermsPrefix": "En choisissant une option ci-dessus, tu confirmes avoir au moins 16 ans et accepter les ",
     "authTermsOfService": "Conditions d'utilisation",
     "authPrivacyPolicy": "Politique de confidentialité",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1142,6 +1142,8 @@
     "authCreateNewAccount": "Buat akun Divine baru",
     "authSignInDifferentAccount": "Masuk dengan akun yang sudah ada",
     "authSignBackIn": "Masuk kembali",
+    "authRecoveryDraftsOwner": "Draf dan klip kamu tersimpan untuk akun ini",
+    "authRecoveryOtherAccountWarning": "Masuk di sini akan menyembunyikan draf dan klip tersebut",
     "authTermsPrefix": "Dengan memilih opsi di atas, kamu mengonfirmasi bahwa kamu berusia minimal 16 tahun dan setuju dengan ",
     "authTermsOfService": "Ketentuan Layanan",
     "authPrivacyPolicy": "Kebijakan Privasi",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Crea un nuovo account Divine",
     "authSignInDifferentAccount": "Accedi con un account esistente",
     "authSignBackIn": "Rientra",
+    "authRecoveryDraftsOwner": "Le tue bozze e i tuoi clip sono salvati per questo account",
+    "authRecoveryOtherAccountWarning": "Accedere qui nasconderà quelle bozze e quei clip",
     "authTermsPrefix": "Selezionando un'opzione sopra, confermi di avere almeno 16 anni e accetti i ",
     "authTermsOfService": "Termini di servizio",
     "authPrivacyPolicy": "Informativa sulla privacy",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1142,6 +1142,8 @@
     "authCreateNewAccount": "新しい Divine アカウントを作ろう",
     "authSignInDifferentAccount": "既存のアカウントでサインイン",
     "authSignBackIn": "もう一回サインイン",
+    "authRecoveryDraftsOwner": "下書きとクリップはこのアカウントに保存されています",
+    "authRecoveryOtherAccountWarning": "ここでサインインするとそれらが非表示になります",
     "authTermsPrefix": "上のオプションを選ぶと、16歳以上であることを確認し、次に同意したことになるよ: ",
     "authTermsOfService": "利用規約",
     "authPrivacyPolicy": "プライバシーポリシー",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -624,6 +624,8 @@
     "authCreateNewAccount": "새 Divine 계정 만들기",
     "authSignInDifferentAccount": "기존 계정으로 로그인",
     "authSignBackIn": "다시 로그인",
+    "authRecoveryDraftsOwner": "임시저장 및 클립이 이 계정에 저장되어 있어요",
+    "authRecoveryOtherAccountWarning": "여기서 로그인하면 해당 임시저장과 클립이 숨겨져요",
     "authTermsPrefix": "위에서 옵션을 선택하면 만 16세 이상임을 확인하고 다음 내용에 동의하는 것이에요: ",
     "authTermsOfService": "이용약관",
     "authPrivacyPolicy": "개인정보 처리방침",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Nieuw Divine-account aanmaken",
     "authSignInDifferentAccount": "Inloggen met een bestaand account",
     "authSignBackIn": "Opnieuw inloggen",
+    "authRecoveryDraftsOwner": "Je concepten en clips zijn opgeslagen voor dit account",
+    "authRecoveryOtherAccountWarning": "Hier inloggen verbergt die concepten en clips",
     "authTermsPrefix": "Door hierboven een optie te kiezen bevestig je dat je minstens 16 jaar bent en ga je akkoord met de ",
     "authTermsOfService": "Servicevoorwaarden",
     "authPrivacyPolicy": "Privacybeleid",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Utwórz nowe konto Divine",
     "authSignInDifferentAccount": "Zaloguj się na istniejące konto",
     "authSignBackIn": "Zaloguj się z powrotem",
+    "authRecoveryDraftsOwner": "Twoje szkice i klipy są zapisane dla tego konta",
+    "authRecoveryOtherAccountWarning": "Zalogowanie się tutaj ukryje te szkice i klipy",
     "authTermsPrefix": "Wybierając opcję powyżej, potwierdzasz, że masz przynajmniej 16 lat i zgadzasz się z ",
     "authTermsOfService": "Regulaminem",
     "authPrivacyPolicy": "Polityką prywatności",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Criar uma nova conta Divine",
     "authSignInDifferentAccount": "Entrar com uma conta existente",
     "authSignBackIn": "Entrar de novo",
+    "authRecoveryDraftsOwner": "Seus rascunhos e clipes estão salvos nesta conta",
+    "authRecoveryOtherAccountWarning": "Entrar aqui vai esconder esses rascunhos e clipes",
     "authTermsPrefix": "Ao selecionar uma opção acima, você confirma que tem pelo menos 16 anos e concorda com os ",
     "authTermsOfService": "Termos de Serviço",
     "authPrivacyPolicy": "Política de Privacidade",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Creează un cont Divine nou",
     "authSignInDifferentAccount": "Autentifică-te cu un cont existent",
     "authSignBackIn": "Reautentifică-te",
+    "authRecoveryDraftsOwner": "Ciornele și clipurile tale sunt salvate pentru acest cont",
+    "authRecoveryOtherAccountWarning": "Autentificarea aici le va ascunde",
     "authTermsPrefix": "Selecționând o opțiune de mai sus, confirmi că ai cel puțin 16 ani și ești de acord cu ",
     "authTermsOfService": "Termenii serviciului",
     "authPrivacyPolicy": "Politica de confidențialitate",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1145,6 +1145,8 @@
     "authCreateNewAccount": "Skapa ett nytt Divine-konto",
     "authSignInDifferentAccount": "Logga in med ett befintligt konto",
     "authSignBackIn": "Logga in igen",
+    "authRecoveryDraftsOwner": "Dina utkast och klipp är sparade för det här kontot",
+    "authRecoveryOtherAccountWarning": "Loggar du in här döljs de utkasten och klippen",
     "authTermsPrefix": "Genom att välja ett alternativ ovan bekräftar du att du är minst 16 år gammal och godkänner ",
     "authTermsOfService": "Användarvillkor",
     "authPrivacyPolicy": "Integritetspolicy",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1142,6 +1142,8 @@
     "authCreateNewAccount": "Yeni bir Divine hesabı oluştur",
     "authSignInDifferentAccount": "Mevcut bir hesapla giriş yap",
     "authSignBackIn": "Tekrar giriş yap",
+    "authRecoveryDraftsOwner": "Taslakların ve kliplerin bu hesaba kaydedildi",
+    "authRecoveryOtherAccountWarning": "Buradan giriş yaparsan o taslaklar ve klipler gizlenir",
     "authTermsPrefix": "Yukarıdaki bir seçeneği seçerek en az 16 yaşında olduğunu onayladığını ve ",
     "authTermsOfService": "Hizmet Şartları",
     "authPrivacyPolicy": "Gizlilik Politikası",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4568,6 +4568,18 @@ abstract class AppLocalizations {
   /// **'Sign back in'**
   String get authSignBackIn;
 
+  /// No description provided for @authRecoveryDraftsOwner.
+  ///
+  /// In en, this message translates to:
+  /// **'Your drafts and clips are saved for this account'**
+  String get authRecoveryDraftsOwner;
+
+  /// No description provided for @authRecoveryOtherAccountWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'Signing in here will hide those drafts and clips'**
+  String get authRecoveryOtherAccountWarning;
+
   /// No description provided for @authTermsPrefix.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2539,6 +2539,14 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authSignBackIn => 'ተመልሰው ይግቡ';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'ከላይ ያለውን አማራጭ በመምረጥ፣ ቢያንስ 16 ዓመት እንደሆናችሁ አረጋግጠዋል እና በዚህ ተስማምተዋል።';
 

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2539,12 +2539,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authSignBackIn => 'ተመልሰው ይግቡ';
 
   @override
-  String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+  String get authRecoveryDraftsOwner => 'ረቂቆችዎ እና ክሊፖችዎ ለዚህ መለያ ተቀምጠዋል';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'እዚህ መግባት እነዚያ ረቂቆች እና ክሊፖች ይደብቃቸዋል';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2557,12 +2557,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authSignBackIn => 'عد إلى تسجيل الدخول';
 
   @override
-  String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+  String get authRecoveryDraftsOwner => 'مسوداتك ومقاطعك محفوظة لهذا الحساب';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'تسجيل الدخول هنا سيُخفي تلك المسودات والمقاطع';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2557,6 +2557,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authSignBackIn => 'عد إلى تسجيل الدخول';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'باختيار خيار أعلاه، أنت تؤكّد أنّ عمرك 16 عامًا على الأقل وتوافق على ';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2630,6 +2630,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authSignBackIn => 'Влез отново';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Като избереш опция по-горе, потвърждаваш, че си на 16 или повече и се съгласяваш с';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2631,11 +2631,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Черновите и клиповете ти са запазени за този акаунт';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Влизането тук ще скрие тези чернови и клипове';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2617,6 +2617,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authSignBackIn => 'Wieder anmelden';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Indem du oben eine Option wählst, bestätigst du, dass du mindestens 16 Jahre alt bist und den ';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2618,11 +2618,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Deine Entwürfe und Clips sind für dieses Konto gespeichert';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Hier anmelden verbirgt diese Entwürfe und Clips';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2588,6 +2588,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authSignBackIn => 'Sign back in';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'By selecting an option above, you confirm you are at least 16 years old and agree to the ';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2620,11 +2620,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Tus borradores y clips están guardados en esta cuenta';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Iniciar sesión aquí ocultará esos borradores y clips';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2619,6 +2619,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authSignBackIn => 'Volver a iniciar sesión';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Al seleccionar una opción, confirmás que tenés al menos 16 años y aceptás los ';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2630,6 +2630,14 @@ class AppLocalizationsFil extends AppLocalizations {
   String get authSignBackIn => 'Mag-sign in muli';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Sa pagpili ng opsyon sa itaas, kinukumpirma mo na ikaw ay 16 na taong gulang o mas matanda at sumasang-ayon sa ';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2631,11 +2631,11 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Ang iyong mga draft at clip ay naka-save para sa account na ito';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Ang pag-sign in dito ay magtatago ng mga draft at clip na iyon';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2626,6 +2626,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authSignBackIn => 'Se reconnecter';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'En choisissant une option ci-dessus, tu confirmes avoir au moins 16 ans et accepter les ';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2627,11 +2627,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Tes brouillons et clips sont enregistrés pour ce compte';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Se connecter ici masquera ces brouillons et clips';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2562,11 +2562,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Draf dan klip kamu tersimpan untuk akun ini';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Masuk di sini akan menyembunyikan draf dan klip tersebut';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2561,6 +2561,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get authSignBackIn => 'Masuk kembali';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Dengan memilih opsi di atas, kamu mengonfirmasi bahwa kamu berusia minimal 16 tahun dan setuju dengan ';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2617,11 +2617,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Le tue bozze e i tuoi clip sono salvati per questo account';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Accedere qui nasconderà quelle bozze e quei clip';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2616,6 +2616,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authSignBackIn => 'Rientra';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Selezionando un\'opzione sopra, confermi di avere almeno 16 anni e accetti i ';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2458,12 +2458,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authSignBackIn => 'もう一回サインイン';
 
   @override
-  String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+  String get authRecoveryDraftsOwner => '下書きとクリップはこのアカウントに保存されています';
 
   @override
-  String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+  String get authRecoveryOtherAccountWarning => 'ここでサインインするとそれらが非表示になります';
 
   @override
   String get authTermsPrefix => '上のオプションを選ぶと、16歳以上であることを確認し、次に同意したことになるよ: ';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2458,6 +2458,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authSignBackIn => 'もう一回サインイン';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix => '上のオプションを選ぶと、16歳以上であることを確認し、次に同意したことになるよ: ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2468,6 +2468,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authSignBackIn => '다시 로그인';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       '위에서 옵션을 선택하면 만 16세 이상임을 확인하고 다음 내용에 동의하는 것이에요: ';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2468,12 +2468,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authSignBackIn => '다시 로그인';
 
   @override
-  String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+  String get authRecoveryDraftsOwner => '임시저장 및 클립이 이 계정에 저장되어 있어요';
 
   @override
-  String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+  String get authRecoveryOtherAccountWarning => '여기서 로그인하면 해당 임시저장과 클립이 숨겨져요';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2596,6 +2596,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authSignBackIn => 'Opnieuw inloggen';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Door hierboven een optie te kiezen bevestig je dat je minstens 16 jaar bent en ga je akkoord met de ';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2597,11 +2597,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Je concepten en clips zijn opgeslagen voor dit account';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Hier inloggen verbergt die concepten en clips';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2660,6 +2660,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authSignBackIn => 'Zaloguj się z powrotem';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Wybierając opcję powyżej, potwierdzasz, że masz przynajmniej 16 lat i zgadzasz się z ';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2661,11 +2661,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Twoje szkice i klipy są zapisane dla tego konta';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Zalogowanie się tutaj ukryje te szkice i klipy';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2608,6 +2608,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authSignBackIn => 'Entrar de novo';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Ao selecionar uma opção acima, você confirma que tem pelo menos 16 anos e concorda com os ';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2609,11 +2609,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Seus rascunhos e clipes estão salvos nesta conta';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Entrar aqui vai esconder esses rascunhos e clipes';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2676,11 +2676,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Ciornele și clipurile tale sunt salvate pentru acest cont';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Autentificarea aici le va ascunde';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2675,6 +2675,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authSignBackIn => 'Reautentifică-te';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Selecționând o opțiune de mai sus, confirmi că ai cel puțin 16 ani și ești de acord cu ';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2584,11 +2584,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Dina utkast och klipp är sparade för det här kontot';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Loggar du in här döljs de utkasten och klippen';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2583,6 +2583,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authSignBackIn => 'Logga in igen';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Genom att välja ett alternativ ovan bekräftar du att du är minst 16 år gammal och godkänner ';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2570,11 +2570,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get authRecoveryDraftsOwner =>
-      'Your drafts and clips are saved for this account';
+      'Taslakların ve kliplerin bu hesaba kaydedildi';
 
   @override
   String get authRecoveryOtherAccountWarning =>
-      'Signing in here will hide those drafts and clips';
+      'Buradan giriş yaparsan o taslaklar ve klipler gizlenir';
 
   @override
   String get authTermsPrefix =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2569,6 +2569,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authSignBackIn => 'Tekrar giriş yap';
 
   @override
+  String get authRecoveryDraftsOwner =>
+      'Your drafts and clips are saved for this account';
+
+  @override
+  String get authRecoveryOtherAccountWarning =>
+      'Signing in here will hide those drafts and clips';
+
+  @override
   String get authTermsPrefix =>
       'Yukarıdaki bir seçeneği seçerek en az 16 yaşında olduğunu onayladığını ve ';
 

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -5,6 +5,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -285,10 +286,10 @@ class _ReturningUserLayout extends StatelessWidget {
                 profile: account.profile,
               ),
 
-              // Cross-account recovery banner: visible when the cold-start
-              // session restore would have landed on a different account than
-              // the one the user was actively using at sign-out.
-              if (state.hasCrossAccountMismatch)
+              // Session-recovery banner: visible when sign-out left an anchor
+              // so the welcome screen can explain where local drafts/clips
+              // live before the user confirms a sign-in.
+              if (state.hasRecoveryAnchor)
                 _CrossAccountRecoveryBanner(
                   isSelectedAccountAnchor:
                       account.pubkeyHex == state.recoveryAnchorPubkeyHex,
@@ -352,26 +353,52 @@ class _ReturningUserLayout extends StatelessWidget {
   }
 }
 
-/// Contextual banner shown on the welcome screen when a cold-start session
-/// restore would have landed on a different account than the one the user was
-/// actively using at sign-out.
+/// Contextual banner shown when sign-out left a session-recovery anchor.
 ///
 /// When [isSelectedAccountAnchor] is true the selected account IS the anchor
 /// account (the safe default), so the banner reassures the user that their
 /// local drafts/clips belong here. When false, the user has explicitly switched
 /// the dropdown to a different account, and the banner warns that those
 /// drafts/clips will be hidden after sign-in.
-class _CrossAccountRecoveryBanner extends StatelessWidget {
+class _CrossAccountRecoveryBanner extends StatefulWidget {
   const _CrossAccountRecoveryBanner({required this.isSelectedAccountAnchor});
 
   final bool isSelectedAccountAnchor;
 
   @override
-  Widget build(BuildContext context) {
-    final message = isSelectedAccountAnchor
+  State<_CrossAccountRecoveryBanner> createState() =>
+      _CrossAccountRecoveryBannerState();
+}
+
+class _CrossAccountRecoveryBannerState
+    extends State<_CrossAccountRecoveryBanner> {
+  String? _announcedMessage;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final message = _message(context);
+    if (_announcedMessage == message) return;
+    _announcedMessage = message;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        message,
+        Directionality.of(context),
+      );
+    });
+  }
+
+  String _message(BuildContext context) {
+    return widget.isSelectedAccountAnchor
         ? context.l10n.authRecoveryDraftsOwner
         : context.l10n.authRecoveryOtherAccountWarning;
+  }
 
+  @override
+  Widget build(BuildContext context) {
+    final message = _message(context);
     return Padding(
       padding: const EdgeInsets.only(top: 12),
       child: Container(
@@ -381,13 +408,15 @@ class _CrossAccountRecoveryBanner extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(
+          spacing: 8,
           children: [
-            const Icon(
-              Icons.info_outline,
-              size: 16,
-              color: VineTheme.accentYellow,
+            const ExcludeSemantics(
+              child: DivineIcon(
+                icon: DivineIconName.warningCircle,
+                size: 16,
+                color: VineTheme.accentYellow,
+              ),
             ),
-            const SizedBox(width: 8),
             Expanded(
               child: Text(
                 message,

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -285,6 +285,15 @@ class _ReturningUserLayout extends StatelessWidget {
                 profile: account.profile,
               ),
 
+              // Cross-account recovery banner: visible when the cold-start
+              // session restore would have landed on a different account than
+              // the one the user was actively using at sign-out.
+              if (state.hasCrossAccountMismatch)
+                _CrossAccountRecoveryBanner(
+                  isSelectedAccountAnchor:
+                      account.pubkeyHex == state.recoveryAnchorPubkeyHex,
+                ),
+
               const Spacer(),
 
               if (lastError != null) ...[
@@ -339,6 +348,55 @@ class _ReturningUserLayout extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Contextual banner shown on the welcome screen when a cold-start session
+/// restore would have landed on a different account than the one the user was
+/// actively using at sign-out.
+///
+/// When [isSelectedAccountAnchor] is true the selected account IS the anchor
+/// account (the safe default), so the banner reassures the user that their
+/// local drafts/clips belong here. When false, the user has explicitly switched
+/// the dropdown to a different account, and the banner warns that those
+/// drafts/clips will be hidden after sign-in.
+class _CrossAccountRecoveryBanner extends StatelessWidget {
+  const _CrossAccountRecoveryBanner({required this.isSelectedAccountAnchor});
+
+  final bool isSelectedAccountAnchor;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = isSelectedAccountAnchor
+        ? context.l10n.authRecoveryDraftsOwner
+        : context.l10n.authRecoveryOtherAccountWarning;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: VineTheme.accentYellowBackground,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.info_outline,
+              size: 16,
+              color: VineTheme.accentYellow,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                message,
+                style: VineTheme.bodySmallFont(color: VineTheme.accentYellow),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -46,6 +46,13 @@ const _kAuthSourceKey = 'authentication_source';
 // Key for the last-used account npub (used to restore the correct identity on restart)
 const _kLastUsedNpubKey = 'last_used_npub';
 
+// Key for the session recovery anchor: the npub that was actively signed in at
+// the time of the most recent sign-out. Written at the start of signOut() so
+// the welcome screen can detect cross-account cold-start restores and surface
+// a confirmation banner before silently completing a switch. Cleared by
+// _setupUserSession() once the user has explicitly signed back in.
+const _kSessionRecoveryAnchorKey = 'session_recovery_anchor_npub';
+
 // Keys for bunker connection persistence
 const _kBunkerInfoKey = 'bunker_info';
 
@@ -624,8 +631,30 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> _restoreDivineRpcOrFallbackUnauthenticated(
     KeycastSession? session,
   ) async {
-    // If session is valid with RPC access, sign in directly.
+    // Read the session recovery anchor once. Both the direct-restore and the
+    // refresh paths below use it to detect cross-account cold-start restores.
+    final prefs = await SharedPreferences.getInstance();
+    final anchorNpub = prefs.getString(_kSessionRecoveryAnchorKey);
+
+    // If session is valid with RPC access, check whether it belongs to the
+    // same account the user was signed into when they last signed out.
+    //
+    // If a session-recovery anchor exists and the session belongs to a
+    // DIFFERENT account (cross-account cold-start restore), do NOT silently
+    // complete the sign-in. Instead route to unauthenticated so the welcome
+    // screen can surface a confirmation banner — the user gets to decide
+    // explicitly which account they want. If no anchor exists (fresh install,
+    // or first sign-out after the fix) we fall through to the original
+    // behaviour to avoid breaking the normal single-account flow.
     if (session != null && session.hasRpcAccess) {
+      if (_isCrossAccountRestore(
+        candidatePubkey: session.userPubkey,
+        anchorNpub: anchorNpub,
+      )) {
+        _setAuthState(AuthState.unauthenticated);
+        return;
+      }
+
       Log.info(
         'initialize: Divine OAuth session found with RPC access '
         '(no local key)',
@@ -643,11 +672,37 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
     if (_oauthClient != null) {
-      final refreshed = await _tryRefreshOAuthSession(
-        caller: 'initialize',
+      final refreshed = await _refreshOAuthSession(
         expectedOwnerPubkey: session?.userPubkey,
       );
-      if (refreshed) return;
+
+      if (refreshed != null) {
+        // Apply the same cross-account guard to the refreshed session.
+        // The OAuth server is authoritative about which account a token
+        // belongs to, but we must not silently complete a sign-in as a
+        // different account than the one the user was on at sign-out.
+        if (_isCrossAccountRestore(
+          candidatePubkey: refreshed.userPubkey,
+          anchorNpub: anchorNpub,
+        )) {
+          // Do NOT consume the refresh or set _hasExpiredOAuthSession=false
+          // here — leave the user unauthenticated and let the welcome screen
+          // handle the confirmation. The refreshed token is discarded; the
+          // user will go through a full re-auth for whichever account they
+          // confirm.
+          _setAuthState(AuthState.unauthenticated);
+          return;
+        }
+
+        Log.info(
+          'initialize: refresh succeeded',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        await _clearDismissedDivineLoginBannerForCurrentUser();
+        await signInWithDivineOAuth(refreshed);
+        return;
+      }
     }
 
     // Refresh failed, no local keys — unauthenticated.
@@ -659,6 +714,31 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
     _setAuthState(AuthState.unauthenticated);
+  }
+
+  /// Returns true when [candidatePubkey] belongs to a different account than
+  /// the one recorded in [anchorNpub] at sign-out time.
+  ///
+  /// Returns false (no block) when either side is absent — if there is no
+  /// anchor (fresh install, pre-fix first run) or the session has no bound
+  /// pubkey, the cross-account guard degrades gracefully rather than breaking
+  /// the normal single-account flow.
+  bool _isCrossAccountRestore({
+    required String? candidatePubkey,
+    required String? anchorNpub,
+  }) {
+    if (anchorNpub == null || candidatePubkey == null) return false;
+    final candidateNpub = NostrKeyUtils.encodePubKey(candidatePubkey);
+    if (anchorNpub == candidateNpub) return false;
+
+    Log.warning(
+      'initialize: cross-account session restore blocked — '
+      'anchor=$anchorNpub, candidate=$candidateNpub. '
+      'Routing to unauthenticated for explicit confirmation.',
+      name: 'AuthService',
+      category: LogCategory.auth,
+    );
+    return true;
   }
 
   /// Attempt to silently refresh an expired OAuth session.
@@ -685,6 +765,20 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
     return _tryRefreshOAuthSession(caller: 'tryRefreshExpiredSession');
+  }
+
+  /// Returns the npub that was actively signed in at the time of the most
+  /// recent sign-out, or null if no anchor has been recorded.
+  ///
+  /// The welcome screen uses this to detect when a cold-start session restore
+  /// would land on a different account than the one the user was just using,
+  /// and surfaces a confirmation banner before the switch completes silently.
+  ///
+  /// The anchor is written at the start of [signOut] and cleared by
+  /// [_setupUserSession] once the user has explicitly signed back in.
+  Future<String?> getSessionRecoveryAnchorNpub() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_kSessionRecoveryAnchorKey);
   }
 
   /// Shared OAuth session refresh logic used by both [initialize] and
@@ -3296,6 +3390,42 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Clear TOS acceptance on any logout - user must re-accept when logging
       // back in
       final prefs = await SharedPreferences.getInstance();
+
+      // Capture the leaving account as the session recovery anchor BEFORE any
+      // teardown — but only for non-destructive sign-out (account switch).
+      //
+      // The welcome screen reads this after sign-out to detect when a cold-
+      // start restore would land on a different account, and surfaces a
+      // confirmation banner so the user can redirect the switch explicitly.
+      //
+      // On DESTRUCTIVE sign-out (deleteKeys=true), the user is intentionally
+      // removing the account. The _redirectRecoveryToRemainingAccount path
+      // points initialize() at the next-best account, which should restore
+      // automatically without requiring confirmation. Clear any stale anchor
+      // so it does not block that automatic restore.
+      //
+      // The anchor is cleared by _setupUserSession() after a successful sign-in.
+      final leavingNpub = _currentKeyContainer?.npub;
+      if (!deleteKeys && leavingNpub != null) {
+        await prefs.setString(_kSessionRecoveryAnchorKey, leavingNpub);
+        Log.debug(
+          'signOut: recorded session recovery anchor=$leavingNpub',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+      } else {
+        // Destructive sign-out: clear any stale anchor so the remaining
+        // account's automatic restore is not blocked by the guard in
+        // _restoreDivineRpcOrFallbackUnauthenticated.
+        await prefs.remove(_kSessionRecoveryAnchorKey);
+        Log.debug(
+          'signOut: cleared session recovery anchor '
+          '(deleteKeys=$deleteKeys)',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+      }
+
       // On destructive sign-out, redirect recovery prefs to the next
       // remaining account so initialize() can restore it. Only clear when
       // no accounts remain — otherwise the user loses access to account A
@@ -4270,6 +4400,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       await prefs.setString(_kAuthSourceKey, source.code);
 
       await prefs.setString(_kLastUsedNpubKey, keyContainer.npub);
+
+      // Clear the session recovery anchor now that the user has explicitly
+      // signed in. A stale anchor must not persist to interfere with future
+      // welcome-screen mismatch detection after the next sign-out.
+      await prefs.remove(_kSessionRecoveryAnchorKey);
 
       final followingCacheKey = 'following_list_${keyContainer.publicKeyHex}';
       final hasFollowingCache = prefs.containsKey(followingCacheKey);

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2381,26 +2381,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2381,26 +2381,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -91,6 +91,9 @@ void main() {
     mockUserProfilesDao = _MockUserProfilesDao();
     mockAuthService = _MockAuthService();
 
+    when(
+      () => mockUserProfilesDao.getProfile(any()),
+    ).thenAnswer((_) async => null);
     when(() => mockAuthService.getKnownAccounts()).thenAnswer((_) async => []);
     when(
       () => mockAuthService.getSessionRecoveryAnchorNpub(),
@@ -680,6 +683,17 @@ void main() {
       const state = WelcomeState(recoveryAnchorPubkeyHex: _testPubkeyHex);
       final cleared = state.copyWith(clearRecoveryAnchor: true);
       expect(cleared.recoveryAnchorPubkeyHex, isNull);
+    });
+
+    test('copyWith status resets from error', () {
+      const state = WelcomeState(status: WelcomeStatus.error);
+      final cleared = state.copyWith(status: WelcomeStatus.loaded);
+      expect(cleared.status, equals(WelcomeStatus.loaded));
+    });
+
+    test('hasRecoveryAnchor is true when recovery anchor is set', () {
+      const state = WelcomeState(recoveryAnchorPubkeyHex: _testPubkeyHex);
+      expect(state.hasRecoveryAnchor, isTrue);
     });
 
     group('hasCrossAccountMismatch', () {

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -13,6 +13,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/welcome/welcome_bloc.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:openvine/utils/nostr_key_utils.dart';
 
 class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
 
@@ -91,6 +92,9 @@ void main() {
     mockAuthService = _MockAuthService();
 
     when(() => mockAuthService.getKnownAccounts()).thenAnswer((_) async => []);
+    when(
+      () => mockAuthService.getSessionRecoveryAnchorNpub(),
+    ).thenAnswer((_) async => null);
     when(() => mockAuthService.acceptTerms()).thenAnswer((_) async {});
     when(
       () => mockAuthService.signInForAccount(any(), any()),
@@ -672,10 +676,195 @@ void main() {
       expect(cleared.signingInPubkeyHex, isNull);
     });
 
-    test('copyWith status resets from error', () {
-      const state = WelcomeState(status: WelcomeStatus.error);
-      final cleared = state.copyWith(status: WelcomeStatus.loaded);
-      expect(cleared.status, equals(WelcomeStatus.loaded));
+    test('copyWith clearRecoveryAnchor removes anchor', () {
+      const state = WelcomeState(recoveryAnchorPubkeyHex: _testPubkeyHex);
+      final cleared = state.copyWith(clearRecoveryAnchor: true);
+      expect(cleared.recoveryAnchorPubkeyHex, isNull);
     });
+
+    group('hasCrossAccountMismatch', () {
+      test('is false when no recovery anchor is set', () {
+        const state = WelcomeState(
+          previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+        );
+        expect(state.hasCrossAccountMismatch, isFalse);
+      });
+
+      test('is false when no accounts are present', () {
+        const state = WelcomeState(
+          recoveryAnchorPubkeyHex: _testPubkeyHex,
+        );
+        expect(state.hasCrossAccountMismatch, isFalse);
+      });
+
+      test(
+        'is false when the selected account matches the recovery anchor',
+        () {
+          // Anchor IS the selected account — safe default, no banner needed.
+          const state = WelcomeState(
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex,
+            recoveryAnchorPubkeyHex: _testPubkeyHex,
+          );
+          expect(state.hasCrossAccountMismatch, isFalse);
+        },
+      );
+
+      test(
+        'is true when the selected account differs from the recovery anchor',
+        () {
+          // User has switched dropdown to account 2, but anchor is account 1.
+          const state = WelcomeState(
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+            recoveryAnchorPubkeyHex: _testPubkeyHex,
+          );
+          expect(state.hasCrossAccountMismatch, isTrue);
+        },
+      );
+
+      test(
+        'is true when selectedPubkeyHex is null (defaults to first account) '
+        'and first account differs from anchor',
+        () {
+          // Anchor points to account 2, but no explicit selection so
+          // selectedAccount falls back to previousAccounts.first (account 1).
+          const state = WelcomeState(
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            recoveryAnchorPubkeyHex: _testPubkeyHex2,
+          );
+          expect(state.hasCrossAccountMismatch, isTrue);
+        },
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Session recovery anchor — WelcomeBloc._onStarted (#4624)
+  // ---------------------------------------------------------------------------
+
+  group('WelcomeStarted with session recovery anchor', () {
+    test(
+      'pre-selects the anchor account when anchor differs from '
+      'most-recently-used first account (cross-account scenario)',
+      () async {
+        // Simulate the incident: most-recently-used account is account 2
+        // (stamped by _redirectRecoveryToRemainingAccount), but the recovery
+        // anchor is account 1 (what the user was actually signed into).
+        // The bloc should pre-select account 1 so the welcome screen shows
+        // the right account by default.
+
+        // _testKnownAccount has pubkey1, _testKnownAccount2 has pubkey2.
+        // Arrange the list so account2 is "first" (most recently used).
+        final knownAccounts = [_testKnownAccount2, _testKnownAccount];
+        when(
+          () => mockAuthService.getKnownAccounts(),
+        ).thenAnswer((_) async => knownAccounts);
+
+        // Anchor points to account 1 (the user's actual active account).
+        final anchorNpub = NostrKeyUtils.encodePubKey(_testPubkeyHex);
+        when(
+          () => mockAuthService.getSessionRecoveryAnchorNpub(),
+        ).thenAnswer((_) async => anchorNpub);
+
+        final bloc = WelcomeBloc(
+          userProfilesDao: mockUserProfilesDao,
+          authService: mockAuthService,
+        );
+        bloc.add(const WelcomeStarted());
+        // Wait for _onStarted to complete (accounts load is async).
+        await Future<void>.delayed(Duration.zero);
+
+        final state = bloc.state;
+        expect(
+          state.selectedPubkeyHex,
+          equals(_testPubkeyHex),
+          reason:
+              'The anchor account should be pre-selected on the welcome '
+              'screen even when it is not the most-recently-used account, '
+              'preventing the user from unknowingly signing into the wrong '
+              'account',
+        );
+        expect(
+          state.recoveryAnchorPubkeyHex,
+          equals(_testPubkeyHex),
+          reason: 'The recovery anchor pubkey should be stored in state',
+        );
+        expect(
+          state.hasCrossAccountMismatch,
+          isFalse,
+          reason:
+              'hasCrossAccountMismatch should be false because the '
+              'pre-selected account matches the anchor (safe default)',
+        );
+
+        await bloc.close();
+      },
+    );
+
+    test(
+      'does not set recoveryAnchorPubkeyHex when no anchor is stored '
+      '(normal single-account flow)',
+      () async {
+        when(
+          () => mockAuthService.getKnownAccounts(),
+        ).thenAnswer((_) async => [_testKnownAccount]);
+        when(
+          () => mockAuthService.getSessionRecoveryAnchorNpub(),
+        ).thenAnswer((_) async => null);
+
+        final bloc = WelcomeBloc(
+          userProfilesDao: mockUserProfilesDao,
+          authService: mockAuthService,
+        );
+        bloc.add(const WelcomeStarted());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.recoveryAnchorPubkeyHex, isNull);
+        expect(bloc.state.hasCrossAccountMismatch, isFalse);
+
+        await bloc.close();
+      },
+    );
+
+    test(
+      'event.initialSelectedPubkeyHex takes priority over the recovery anchor '
+      'for pre-selection (router deep-link flow)',
+      () async {
+        // When the router passes initialSelectedPubkeyHex (e.g., from the
+        // account-switcher deep link ?selectedPubkey=...), that explicit
+        // selection must win over the recovery anchor.
+        final knownAccounts = [_testKnownAccount, _testKnownAccount2];
+        when(
+          () => mockAuthService.getKnownAccounts(),
+        ).thenAnswer((_) async => knownAccounts);
+
+        final anchorNpub = NostrKeyUtils.encodePubKey(_testPubkeyHex);
+        when(
+          () => mockAuthService.getSessionRecoveryAnchorNpub(),
+        ).thenAnswer((_) async => anchorNpub);
+
+        final bloc = WelcomeBloc(
+          userProfilesDao: mockUserProfilesDao,
+          authService: mockAuthService,
+        );
+        // Pass account2 as the router-provided initial selection.
+        bloc.add(
+          const WelcomeStarted(initialSelectedPubkeyHex: _testPubkeyHex2),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        // Router-provided selection wins over anchor.
+        expect(
+          bloc.state.selectedPubkeyHex,
+          equals(_testPubkeyHex2),
+          reason:
+              'An explicit initialSelectedPubkeyHex from the router '
+              'must take priority over the recovery anchor pre-selection',
+        );
+
+        await bloc.close();
+      },
+    );
   });
 }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -453,6 +453,13 @@ const _knownUntranslatedDebt = {
   // Translators will pick this up in a follow-up pass; until then non-English
   // locales fall back to the English source.
   'feedLoadingMore',
+  // Added by the cross-account session recovery banner on the welcome screen
+  // (#4624). The banner warns when a cold-start restore would land on a
+  // different account than the one the user was using. Translators will pick
+  // these up in a follow-up pass; until then non-English locales fall back to
+  // the English source.
+  'authRecoveryDraftsOwner',
+  'authRecoveryOtherAccountWarning',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -453,13 +453,6 @@ const _knownUntranslatedDebt = {
   // Translators will pick this up in a follow-up pass; until then non-English
   // locales fall back to the English source.
   'feedLoadingMore',
-  // Added by the cross-account session recovery banner on the welcome screen
-  // (#4624). The banner warns when a cold-start restore would land on a
-  // different account than the one the user was using. Translators will pick
-  // these up in a follow-up pass; until then non-English locales fall back to
-  // the English source.
-  'authRecoveryDraftsOwner',
-  'authRecoveryOtherAccountWarning',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -5,6 +5,7 @@
 import 'package:db_client/db_client.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -17,6 +18,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/auth/auth_hero_section.dart';
 import 'package:openvine/widgets/error_message.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -45,6 +47,16 @@ final _testKnownAccount = KnownAccount(
   authSource: AuthenticationSource.automatic,
   addedAt: DateTime(2024),
   lastUsedAt: DateTime(2024, 6),
+);
+
+const _testPubkeyHex2 =
+    'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3';
+
+final _testKnownAccount2 = KnownAccount(
+  pubkeyHex: _testPubkeyHex2,
+  authSource: AuthenticationSource.amber,
+  addedAt: DateTime(2024),
+  lastUsedAt: DateTime(2024, 5),
 );
 
 void main() {
@@ -82,7 +94,10 @@ void main() {
     ).thenAnswer((_) async {});
   });
 
-  Widget createTestWidget({AuthState authState = AuthState.unauthenticated}) {
+  Widget createTestWidget({
+    AuthState authState = AuthState.unauthenticated,
+    String? initialSelectedPubkeyHex,
+  }) {
     return ProviderScope(
       overrides: [
         authServiceProvider.overrideWithValue(mockAuthService),
@@ -98,7 +113,9 @@ void main() {
           routes: [
             GoRoute(
               path: WelcomeScreen.path,
-              builder: (context, state) => const WelcomeScreen(),
+              builder: (context, state) => WelcomeScreen(
+                initialSelectedPubkeyHex: initialSelectedPubkeyHex,
+              ),
               routes: [
                 GoRoute(
                   path: 'invite',
@@ -308,6 +325,87 @@ void main() {
 
         expect(find.text('Create a new Divine account'), findsOneWidget);
       });
+
+      testWidgets(
+        'shows the recovery owner banner when the selected account matches the anchor',
+        (tester) async {
+          final anchorNpub = NostrKeyUtils.encodePubKey(_testPubkeyHex);
+          when(
+            () => mockAuthService.getSessionRecoveryAnchorNpub(),
+          ).thenAnswer((_) async => anchorNpub);
+
+          final announcements = <Map<Object?, Object?>>[];
+          tester.binding.defaultBinaryMessenger
+              .setMockDecodedMessageHandler<Object?>(
+                SystemChannels.accessibility,
+                (Object? message) async {
+                  if (message is Map) announcements.add(message);
+                  return null;
+                },
+              );
+          addTearDown(
+            () => tester.binding.defaultBinaryMessenger
+                .setMockDecodedMessageHandler<Object?>(
+                  SystemChannels.accessibility,
+                  null,
+                ),
+          );
+
+          await tester.binding.setSurfaceSize(const Size(800, 1200));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+          await tester.pumpWidget(createTestWidget());
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text('Your drafts and clips are saved for this account'),
+            findsOneWidget,
+          );
+          expect(
+            find.byWidgetPredicate(
+              (widget) =>
+                  widget is DivineIcon &&
+                  widget.icon == DivineIconName.warningCircle,
+            ),
+            findsOneWidget,
+          );
+
+          final announceCalls = announcements.where(
+            (message) => message['type'] == 'announce',
+          );
+          expect(announceCalls, isNotEmpty);
+          expect(
+            announceCalls
+                .map((message) => (message['data'] as Map?)?['message'])
+                .toList(),
+            contains('Your drafts and clips are saved for this account'),
+          );
+        },
+      );
+
+      testWidgets(
+        'shows the cross-account warning when selection differs from the anchor',
+        (tester) async {
+          final anchorNpub = NostrKeyUtils.encodePubKey(_testPubkeyHex);
+          when(
+            () => mockAuthService.getKnownAccounts(),
+          ).thenAnswer((_) async => [_testKnownAccount, _testKnownAccount2]);
+          when(
+            () => mockAuthService.getSessionRecoveryAnchorNpub(),
+          ).thenAnswer((_) async => anchorNpub);
+
+          await tester.binding.setSurfaceSize(const Size(800, 1200));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+          await tester.pumpWidget(
+            createTestWidget(initialSelectedPubkeyHex: _testPubkeyHex2),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text('Signing in here will hide those drafts and clips'),
+            findsOneWidget,
+          );
+        },
+      );
 
       testWidgets('tapping "Sign back in" calls signInForAccount', (
         tester,

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -73,6 +73,9 @@ void main() {
       () => mockAuthService.authStateStream,
     ).thenAnswer((_) => const Stream.empty());
     when(() => mockAuthService.getKnownAccounts()).thenAnswer((_) async => []);
+    when(
+      () => mockAuthService.getSessionRecoveryAnchorNpub(),
+    ).thenAnswer((_) async => null);
     when(() => mockAuthService.acceptTerms()).thenAnswer((_) async {});
     when(
       () => mockAuthService.signInForAccount(any(), any()),

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -26,6 +26,8 @@ class _MockUserDataCleanupService extends Mock
 
 class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
 
+class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
 // Test nsec from a known keypair (same one used in other auth_service tests)
 const _testNsec =
     'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
@@ -2036,4 +2038,473 @@ void main() {
       expect(authService.currentPublicKeyHex, equals(accountA.publicKeyHex));
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Session recovery anchor (#4624)
+  // ---------------------------------------------------------------------------
+
+  group('session recovery anchor', () {
+    test(
+      'signOut records the signed-in npub as the session recovery anchor',
+      () async {
+        // Arrange: sign in with the test identity.
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          kKnownAccountsKey: '[]',
+        });
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+        expect(authService.isAuthenticated, isTrue);
+        final expectedNpub = testKeyContainer.npub;
+
+        // Act: non-destructive sign-out (account switch).
+        await authService.signOut();
+
+        // Assert: recovery anchor is written for the account that just
+        // signed out so the welcome screen can detect cross-account
+        // cold-start restores.
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('session_recovery_anchor_npub'),
+          equals(expectedNpub),
+          reason:
+              'signOut should record the leaving account as the '
+              'session recovery anchor before teardown',
+        );
+      },
+    );
+
+    test(
+      'signOut records the anchor on destructive sign-out too',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          kKnownAccountsKey: '[]',
+        });
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+        await authService.signOut(deleteKeys: true);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('session_recovery_anchor_npub'),
+          isNull,
+          reason:
+              'destructive signOut should CLEAR the recovery anchor so that '
+              '_redirectRecoveryToRemainingAccount can restore the next '
+              'account automatically without being blocked by the guard',
+        );
+      },
+    );
+
+    test(
+      '_setupUserSession clears the session recovery anchor after '
+      'successful sign-in',
+      () async {
+        // Arrange: pre-seed the anchor so we can verify it is cleared.
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'session_recovery_anchor_npub': testKeyContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        // Act: sign in — _setupUserSession should clear the anchor.
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+        // Assert: anchor is gone.
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('session_recovery_anchor_npub'),
+          isNull,
+          reason:
+              '_setupUserSession should clear the recovery anchor once '
+              'the user has explicitly signed in',
+        );
+      },
+    );
+
+    test(
+      'getSessionRecoveryAnchorNpub returns null when no anchor is stored',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+
+        final anchor = await authService.getSessionRecoveryAnchorNpub();
+
+        expect(anchor, isNull);
+      },
+    );
+
+    test(
+      'getSessionRecoveryAnchorNpub returns the stored npub',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'session_recovery_anchor_npub': testKeyContainer.npub,
+        });
+
+        final anchor = await authService.getSessionRecoveryAnchorNpub();
+
+        expect(anchor, equals(testKeyContainer.npub));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cross-account cold-start restore guard (#4624)
+  // ---------------------------------------------------------------------------
+
+  group(
+    'initialize (divineOAuth): cross-account cold-start restore guard',
+    () {
+      late SecureKeyContainer accountA;
+      late SecureKeyContainer accountB;
+
+      setUp(() {
+        // Account A is the recovery anchor (user was signed in here at sign-out).
+        accountA = SecureKeyContainer.fromNsec(
+          'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl',
+        );
+        // Account B is a different account whose OAuth session ended up in
+        // the global slot (placed there by _redirectRecoveryToRemainingAccount).
+        accountB = testKeyContainer;
+      });
+
+      test(
+        'routes to unauthenticated when cold-start session belongs to a '
+        'different account than the recovery anchor (incident scenario)',
+        () async {
+          // Scenario: user was signed into account A, then destructive
+          // sign-out ran _redirectRecoveryToRemainingAccount which stamped
+          // B's npub as last_used_npub and placed B's OAuth session in the
+          // global slot. The session recovery anchor was written as A's npub.
+          //
+          // On next cold start, _initializeDivineOAuth loads B's session
+          // (via the divergence tiebreaker) and reaches
+          // _restoreDivineRpcOrFallbackUnauthenticated. The guard must
+          // detect the anchor/session mismatch and route to unauthenticated
+          // instead of silently completing the cross-account sign-in.
+
+          final storage = <String, String>{};
+          final sessionData = {
+            'bunker_url': 'wss://keycast.example.com',
+            'access_token': 'account_b_token',
+            'scope': 'policy:full',
+            'expires_at': DateTime.now()
+                .add(const Duration(hours: 1))
+                .toIso8601String(),
+            'user_pubkey': accountB.publicKeyHex,
+          };
+          storage['keycast_session'] = jsonEncode(sessionData);
+
+          when(
+            () => mockSecureStorage.read(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            return storage[key];
+          });
+          when(
+            () => mockSecureStorage.write(
+              key: any(named: 'key'),
+              value: any(named: 'value'),
+            ),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            final value = invocation.namedArguments[#value] as String;
+            storage[key] = value;
+          });
+          when(
+            () => mockSecureStorage.delete(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            storage.remove(key);
+          });
+
+          // No local key — forces the slow path into
+          // _restoreDivineRpcOrFallbackUnauthenticated with B's session.
+          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'divineOAuth',
+            // B is the "most recently used" (set by
+            // _redirectRecoveryToRemainingAccount), but A was the anchor.
+            'last_used_npub': accountB.npub,
+            // Recovery anchor records the account the user was actually on.
+            'session_recovery_anchor_npub': accountA.npub,
+            kKnownAccountsKey: '[]',
+          });
+
+          await authService.initialize();
+
+          // Must stay unauthenticated — no silent cross-account sign-in.
+          expect(
+            authService.authState,
+            equals(AuthState.unauthenticated),
+            reason:
+                'A cold-start restore that would land on a different '
+                'account than the recovery anchor must not complete '
+                'silently; the user must confirm the switch explicitly '
+                'via the welcome screen',
+          );
+          // Must not be signed in as account B.
+          expect(
+            authService.currentPublicKeyHex,
+            isNull,
+            reason:
+                'No account should be signed in after a blocked '
+                'cross-account restore',
+          );
+        },
+      );
+
+      test(
+        'completes sign-in when cold-start session matches the recovery anchor '
+        '(same-account restore — normal flow)',
+        () async {
+          // Scenario: user was on account B, signed out, and the session is
+          // still B's. The anchor is also B. This is the normal single-
+          // account flow and should complete silently as before.
+
+          final storage = <String, String>{};
+          final sessionData = {
+            'bunker_url': 'wss://keycast.example.com',
+            'access_token': 'account_b_token',
+            'scope': 'policy:full',
+            'expires_at': DateTime.now()
+                .add(const Duration(hours: 1))
+                .toIso8601String(),
+            'user_pubkey': accountB.publicKeyHex,
+          };
+          storage['keycast_session'] = jsonEncode(sessionData);
+
+          when(
+            () => mockSecureStorage.read(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            return storage[key];
+          });
+          when(
+            () => mockSecureStorage.write(
+              key: any(named: 'key'),
+              value: any(named: 'value'),
+            ),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            final value = invocation.namedArguments[#value] as String;
+            storage[key] = value;
+          });
+          when(
+            () => mockSecureStorage.delete(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            storage.remove(key);
+          });
+
+          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'divineOAuth',
+            'last_used_npub': accountB.npub,
+            // Anchor matches the session — same-account restore.
+            'session_recovery_anchor_npub': accountB.npub,
+            kKnownAccountsKey: '[]',
+          });
+
+          await _ignoringDiscoveryErrors(authService.initialize);
+
+          // Normal same-account restore must complete as authenticated.
+          expect(
+            authService.authState,
+            equals(AuthState.authenticated),
+            reason:
+                'When the recovery anchor matches the session account, '
+                'the normal restore path should complete without '
+                'interruption',
+          );
+          expect(
+            authService.currentPublicKeyHex,
+            equals(accountB.publicKeyHex),
+          );
+        },
+      );
+
+      test(
+        'completes sign-in when no recovery anchor is set '
+        '(fresh install / pre-fix first use)',
+        () async {
+          // When no anchor exists, the guard must not activate — the original
+          // "restore directly from session" behaviour must be preserved for
+          // backward compatibility.
+
+          final storage = <String, String>{};
+          final sessionData = {
+            'bunker_url': 'wss://keycast.example.com',
+            'access_token': 'token',
+            'scope': 'policy:full',
+            'expires_at': DateTime.now()
+                .add(const Duration(hours: 1))
+                .toIso8601String(),
+            'user_pubkey': accountB.publicKeyHex,
+          };
+          storage['keycast_session'] = jsonEncode(sessionData);
+
+          when(
+            () => mockSecureStorage.read(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            return storage[key];
+          });
+          when(
+            () => mockSecureStorage.write(
+              key: any(named: 'key'),
+              value: any(named: 'value'),
+            ),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            final value = invocation.namedArguments[#value] as String;
+            storage[key] = value;
+          });
+          when(
+            () => mockSecureStorage.delete(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            storage.remove(key);
+          });
+
+          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'divineOAuth',
+            'last_used_npub': accountB.npub,
+            // No anchor — simulates pre-fix first run or clean install.
+            kKnownAccountsKey: '[]',
+          });
+
+          await _ignoringDiscoveryErrors(authService.initialize);
+
+          // Without an anchor the guard is inactive; normal restore completes.
+          expect(
+            authService.authState,
+            equals(AuthState.authenticated),
+            reason:
+                'With no recovery anchor present, the cross-account guard '
+                'must not activate and the normal session restore must '
+                'complete successfully',
+          );
+          expect(
+            authService.currentPublicKeyHex,
+            equals(accountB.publicKeyHex),
+          );
+        },
+      );
+
+      test(
+        'blocks cross-account restore when expired session belongs to a '
+        'different account than the recovery anchor (expired-session path)',
+        () async {
+          // Scenario — the exact incident pattern, expired-session variant:
+          //   anchor = A's npub (user was signed into A at sign-out)
+          //   stored session = B's, but EXPIRED (hasRpcAccess == false)
+          //   OAuth refresh succeeds and returns a new token — still for B
+          //
+          // Without the guard, _tryRefreshOAuthSession would call
+          // signInWithDivineOAuth(B's refreshed session) silently.
+          // With the guard, the refresh is discarded and the user is
+          // routed to unauthenticated for explicit confirmation.
+
+          final mockOAuthClient = _MockKeycastOAuth();
+
+          // Expired session for B
+          final expiredSessionData = {
+            'bunker_url': 'wss://keycast.example.com',
+            'access_token': 'expired_b_token',
+            'scope': 'policy:full',
+            'expires_at': DateTime.now()
+                .subtract(const Duration(seconds: 1))
+                .toIso8601String(),
+            'user_pubkey': accountB.publicKeyHex,
+          };
+          final storage = <String, String>{
+            'keycast_session': jsonEncode(expiredSessionData),
+            'keycast_refresh_token': 'b_refresh_token',
+          };
+
+          when(
+            () => mockSecureStorage.read(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            return storage[key];
+          });
+          when(
+            () => mockSecureStorage.write(
+              key: any(named: 'key'),
+              value: any(named: 'value'),
+            ),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            final value = invocation.namedArguments[#value] as String;
+            storage[key] = value;
+          });
+          when(
+            () => mockSecureStorage.delete(key: any(named: 'key')),
+          ).thenAnswer((invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            storage.remove(key);
+          });
+
+          // Refresh succeeds — returns a fresh token still bound to B.
+          final refreshedSession = KeycastSession(
+            bunkerUrl: 'wss://keycast.example.com',
+            accessToken: 'refreshed_b_token',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            userPubkey: accountB.publicKeyHex,
+          );
+          when(
+            () => mockOAuthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) async => refreshedSession);
+          when(mockOAuthClient.close).thenReturn(null);
+          when(mockOAuthClient.logout).thenAnswer((_) async {});
+
+          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+          // anchor = A, last_used_npub = B (stamped by
+          // _redirectRecoveryToRemainingAccount after a prior sign-out)
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'divineOAuth',
+            'last_used_npub': accountB.npub,
+            'session_recovery_anchor_npub': accountA.npub,
+            kKnownAccountsKey: '[]',
+          });
+
+          final localAuthService = AuthService(
+            userDataCleanupService: mockCleanupService,
+            keyStorage: mockKeyStorage,
+            nostrKeyManager: mockNostrKeyManager,
+            flutterSecureStorage: mockSecureStorage,
+            oauthClient: mockOAuthClient,
+          );
+
+          try {
+            await localAuthService.initialize();
+
+            // Must stay unauthenticated — the refreshed session is B's, not A's.
+            expect(
+              localAuthService.authState,
+              equals(AuthState.unauthenticated),
+              reason:
+                  'Cross-account guard must block even when the expired '
+                  'session is refreshed successfully — if the refreshed '
+                  'session still belongs to B but the anchor is A, the '
+                  'user must confirm explicitly via the welcome screen',
+            );
+            expect(
+              localAuthService.currentPublicKeyHex,
+              isNull,
+            );
+          } finally {
+            await localAuthService.dispose();
+          }
+        },
+      );
+    },
+  );
 }

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -2074,7 +2074,7 @@ void main() {
     );
 
     test(
-      'signOut records the anchor on destructive sign-out too',
+      'signOut clears the anchor on destructive sign-out',
       () async {
         SharedPreferences.setMockInitialValues({
           'authentication_source': 'automatic',


### PR DESCRIPTION
## Description

After a non-destructive sign-out with two accounts on device, `_redirectRecoveryToRemainingAccount` would stamp account B's npub as `last_used_npub` and place B's OAuth session in the global slot. On the next cold start — whether the session was still valid or had expired and been refreshed — the app would silently complete sign-in as B even though the user's active session belonged to account A. Users saw this as their local drafts and clips suddenly disappearing.

The fix introduces a session-recovery anchor (`session_recovery_anchor_npub`) written by `signOut()` on non-destructive sign-outs. The cold-start restore path in `_restoreDivineRpcOrFallbackUnauthenticated` checks this anchor against the candidate session's pubkey (for both the direct-restore and post-refresh paths) and blocks the auto sign-in when they differ, routing to unauthenticated instead. The welcome screen reads the anchor, pre-selects the correct account, and shows a contextual banner explaining draft ownership when a different account is highlighted.

**Related Issue:** Closes #4624

## Out of Scope

Full redesign of the returning-user layout to show both accounts side-by-side. The minimal banner approach is sufficient for the fix.

## Verification

- `flutter analyze` — no issues
- `dart format` — no changes
- `flutter test test/blocs/welcome/welcome_bloc_test.dart` — 40 tests pass
- `flutter test test/services/auth_service_multi_account_test.dart` — 83 tests pass (15 new)
- `flutter test test/services/auth_service_oauth_recovery_test.dart` — all pass
- `flutter test test/l10n/arb_consistency_test.dart` — passes (keys fully translated, removed from debt list)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore