### PR TITLE
fix(settings): disable built-in Divine moderation toggle

### DIFF
--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -217,17 +217,8 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
   Widget _buildDivineProvider() {
     return SwitchListTile(
       value: _isDivineLabelerEnabled,
-      onChanged: (value) async {
-        final labelService = ref.read(moderationLabelServiceProvider);
-        if (value) {
-          await labelService.addDivineLabeler();
-        } else {
-          await labelService.removeDivineLabeler();
-        }
-        setState(() {
-          _isDivineLabelerEnabled = value;
-        });
-      },
+      // The built-in Divine moderation labeler is always on by product design.
+      onChanged: null,
       secondary: const Icon(Icons.verified_user, color: VineTheme.vineGreen),
       title: Text(
         context.l10n.safetySettingsDivine,

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -31,7 +31,6 @@ class SafetySettingsScreen extends ConsumerStatefulWidget {
 class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
   bool _isLoading = true;
   bool _isAgeVerified = false;
-  bool _isDivineLabelerEnabled = true;
   bool _isPeopleIFollowEnabled = false;
   bool _showDivineHostedOnly = true;
 
@@ -49,7 +48,6 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
     if (mounted) {
       setState(() {
         _isAgeVerified = service.isAdultContentVerified;
-        _isDivineLabelerEnabled = labelService.isDivineLabelerSubscribed;
         _isPeopleIFollowEnabled = labelService.isFollowingModerationEnabled;
         _showDivineHostedOnly = divineHostFilterService.showDivineHostedOnly;
         _isLoading = false;
@@ -216,7 +214,7 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
 
   Widget _buildDivineProvider() {
     return SwitchListTile(
-      value: _isDivineLabelerEnabled,
+      value: true,
       // The built-in Divine moderation labeler is always on by product design.
       onChanged: null,
       secondary: const Icon(Icons.verified_user, color: VineTheme.vineGreen),

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -122,13 +122,6 @@ class ModerationLabelService {
   bool get isDivineLabelerSubscribed =>
       _subscribedLabelers.contains(_divineModerationPubkey);
 
-  /// Subscribe to the Divine official labeler.
-  Future<void> addDivineLabeler() => addLabeler(_divineModerationPubkey);
-
-  /// Unsubscribe from the Divine official labeler (no-op by design —
-  /// [removeLabeler] guards against removing the built-in labeler).
-  Future<void> removeDivineLabeler() => removeLabeler(_divineModerationPubkey);
-
   /// Subscribed labelers excluding the built-in Divine labeler.
   Set<String> get customLabelers =>
       _subscribedLabelers.difference({_divineModerationPubkey});

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -315,8 +315,6 @@ MockModerationLabelService createMockModerationLabelService() {
   when(() => mock.subscribeToLabeler(any())).thenAnswer((_) async {});
   when(() => mock.addLabeler(any())).thenAnswer((_) async {});
   when(() => mock.removeLabeler(any())).thenAnswer((_) async {});
-  when(mock.addDivineLabeler).thenAnswer((_) async {});
-  when(mock.removeDivineLabeler).thenAnswer((_) async {});
   when(
     () => mock.setFollowingModerationEnabled(
       any(),

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -82,6 +82,7 @@ class MockContentFilterService extends Mock implements ContentFilterService {
 
 void main() {
   group('SafetySettingsScreen Widget Tests', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
     late MockContentBlocklistRepository mockBlocklistRepository;
     late MockContentReportingService mockReportingService;
     late MockAccountLabelService mockAccountLabelService;
@@ -124,12 +125,6 @@ void main() {
       ).thenAnswer((_) async {});
       when(
         () => mockModerationLabelService.removeLabeler(any()),
-      ).thenAnswer((_) async {});
-      when(
-        mockModerationLabelService.addDivineLabeler,
-      ).thenAnswer((_) async {});
-      when(
-        mockModerationLabelService.removeDivineLabeler,
       ).thenAnswer((_) async {});
       when(
         () => mockModerationLabelService.setFollowingModerationEnabled(
@@ -283,15 +278,18 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        final tile = find.widgetWithText(SwitchListTile, 'Divine');
+        final tile = find.widgetWithText(
+          SwitchListTile,
+          l10n.safetySettingsDivine,
+        );
         expect(tile, findsOneWidget);
 
         final switchTile = tester.widget<SwitchListTile>(tile);
         expect(switchTile.value, isTrue);
         expect(switchTile.onChanged, isNull);
 
-        verifyNever(mockModerationLabelService.removeDivineLabeler);
-        verifyNever(mockModerationLabelService.addDivineLabeler);
+        verifyNever(() => mockModerationLabelService.removeLabeler(any()));
+        verifyNever(() => mockModerationLabelService.addLabeler(any()));
       },
     );
 
@@ -302,11 +300,17 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        expect(find.text('Only show Divine-hosted videos'), findsOneWidget);
+        expect(
+          find.text(l10n.safetySettingsShowDivineHostedOnly),
+          findsOneWidget,
+        );
         expect(divineHostFilterService.showDivineHostedOnly, isTrue);
 
         await tester.tap(
-          find.widgetWithText(SwitchListTile, 'Only show Divine-hosted videos'),
+          find.widgetWithText(
+            SwitchListTile,
+            l10n.safetySettingsShowDivineHostedOnly,
+          ),
         );
         await tester.pumpAndSettle();
 
@@ -351,7 +355,10 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        final tile = find.widgetWithText(SwitchListTile, 'People I follow');
+        final tile = find.widgetWithText(
+          SwitchListTile,
+          l10n.safetySettingsPeopleIFollow,
+        );
         expect(tile, findsOneWidget);
         expect(tester.widget<SwitchListTile>(tile).value, isFalse);
 

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -278,6 +278,24 @@ void main() {
     });
 
     testWidgets(
+      'shows Divine moderation as enabled and non-interactive',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final tile = find.widgetWithText(SwitchListTile, 'Divine');
+        expect(tile, findsOneWidget);
+
+        final switchTile = tester.widget<SwitchListTile>(tile);
+        expect(switchTile.value, isTrue);
+        expect(switchTile.onChanged, isNull);
+
+        verifyNever(mockModerationLabelService.removeDivineLabeler);
+        verifyNever(mockModerationLabelService.addDivineLabeler);
+      },
+    );
+
+    testWidgets(
       'shows Divine-hosted-only toggle enabled by default and persists '
       'opt-out',
       (tester) async {

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -124,12 +124,6 @@ void main() {
     ).thenReturn(false);
     when(() => moderationLabelService.customLabelers).thenReturn(<String>{});
     when(
-      () => moderationLabelService.addDivineLabeler(),
-    ).thenAnswer((_) async {});
-    when(
-      () => moderationLabelService.removeDivineLabeler(),
-    ).thenAnswer((_) async {});
-    when(
       () => moderationLabelService.setFollowingModerationEnabled(
         any(),
         followedPubkeys: any(named: 'followedPubkeys'),


### PR DESCRIPTION
Closes #4630

## What changed
- disabled the built-in Divine moderation switch in Content & Safety so it no longer pretends users can turn off the official labeler
- added widget coverage asserting the Divine row stays enabled but non-interactive

## Why
The settings UI exposed the Divine labeler as a normal toggle, but the service contract keeps that labeler always on. Tapping the switch only flipped local widget state and then snapped back on the next load, which matched the reported "switches itself back" behavior.

## Impact
Users now see the real product contract in settings instead of a broken off switch. This removes a misleading control while preserving the existing always-on moderation behavior.

## Validation
- `flutter test test/screens/safety_settings_screen_test.dart`
- `flutter test test/screens/settings/settings_taxonomy_test.dart`
- `dart analyze lib/screens/safety_settings_screen.dart test/screens/safety_settings_screen_test.dart`
- pre-push hook: scoped analyzer + affected widget test pass
- `flutter analyze` still reports the repo's existing info-level baseline outside this diff; no new issues in touched files
