### PR TITLE
feat(dm): basic markdown formatting support (bold, italic, etc.) (#4621)

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3811,5 +3811,9 @@
     "videoEditorTimelineSlideToAdjust": "ለማስተካከል ያንሸራትቱ",
     "videoEditorVolumeSemanticLabel": "ድምጽ አስተካክል",
     "videoEditorOriginalAudioLabel": "ዋናው ኦዲዮ",
-    "videoEditorClipVolumeLabel": "ቅንጥብ {index}"
+    "videoEditorClipVolumeLabel": "ቅንጥብ {index}",
+    "dmFormatBold": "ደማቅ",
+    "dmFormatItalic": "አዘንብል",
+    "dmFormatStrikethrough": "መሰረዝ",
+    "dmFormatCode": "ኮድ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "اسحب للضبط",
     "videoEditorVolumeSemanticLabel": "ضبط مستوى الصوت",
     "videoEditorOriginalAudioLabel": "الصوت الأصلي",
-    "videoEditorClipVolumeLabel": "مقطع {index}"
+    "videoEditorClipVolumeLabel": "مقطع {index}",
+    "dmFormatBold": "عريض",
+    "dmFormatItalic": "مائل",
+    "dmFormatStrikethrough": "يتوسطه خط",
+    "dmFormatCode": "رمز"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3817,5 +3817,9 @@
     "videoEditorTimelineSlideToAdjust": "Плъзнете за регулиране",
     "videoEditorVolumeSemanticLabel": "Регулиране на силата на звука",
     "videoEditorOriginalAudioLabel": "Оригинален звук",
-    "videoEditorClipVolumeLabel": "Клип {index}"
+    "videoEditorClipVolumeLabel": "Клип {index}",
+    "dmFormatBold": "Получер",
+    "dmFormatItalic": "Курсив",
+    "dmFormatStrikethrough": "Зачеркнат",
+    "dmFormatCode": "Код"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Zum Anpassen schieben",
     "videoEditorVolumeSemanticLabel": "Lautstärke anpassen",
     "videoEditorOriginalAudioLabel": "Originalton",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Fett",
+    "dmFormatItalic": "Kursiv",
+    "dmFormatStrikethrough": "Durchgestrichen",
+    "dmFormatCode": "Code"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3009,6 +3009,22 @@
   "@dmMessageActionReport": {
     "description": "Long-press menu action on a received DM bubble that opens the report flow for that specific message."
   },
+  "dmFormatBold": "Bold",
+  "@dmFormatBold": {
+    "description": "Label for the Bold formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown bold markers (e.g. **text**)."
+  },
+  "dmFormatItalic": "Italic",
+  "@dmFormatItalic": {
+    "description": "Label for the Italic formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown italic markers (e.g. _text_)."
+  },
+  "dmFormatStrikethrough": "Strikethrough",
+  "@dmFormatStrikethrough": {
+    "description": "Label for the Strikethrough formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown strikethrough markers (e.g. ~~text~~)."
+  },
+  "dmFormatCode": "Code",
+  "@dmFormatCode": {
+    "description": "Label for the inline-code formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown inline-code markers (e.g. `text`)."
+  },
   "dmStatusPending": "Sending",
   "@dmStatusPending": {
     "description": "Accessibility label / tooltip on the clock indicator at the bottom of a sent DM bubble whose recipient gift wrap has not yet landed."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Desliza para ajustar",
     "videoEditorVolumeSemanticLabel": "Ajustar volumen",
     "videoEditorOriginalAudioLabel": "Audio original",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Negrita",
+    "dmFormatItalic": "Cursiva",
+    "dmFormatStrikethrough": "Tachado",
+    "dmFormatCode": "Código"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2224,5 +2224,9 @@
     "videoEditorTimelineSlideToAdjust": "I-slide para i-adjust",
     "videoEditorVolumeSemanticLabel": "Ayusin ang volume",
     "videoEditorOriginalAudioLabel": "Orihinal na audio",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Makapal",
+    "dmFormatItalic": "Pahilis",
+    "dmFormatStrikethrough": "May guhit",
+    "dmFormatCode": "Code"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Faites glisser pour ajuster",
     "videoEditorVolumeSemanticLabel": "Régler le volume",
     "videoEditorOriginalAudioLabel": "Audio original",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Gras",
+    "dmFormatItalic": "Italique",
+    "dmFormatStrikethrough": "Barré",
+    "dmFormatCode": "Code"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Geser untuk menyesuaikan",
     "videoEditorVolumeSemanticLabel": "Sesuaikan volume",
     "videoEditorOriginalAudioLabel": "Audio asli",
-    "videoEditorClipVolumeLabel": "Klip {index}"
+    "videoEditorClipVolumeLabel": "Klip {index}",
+    "dmFormatBold": "Tebal",
+    "dmFormatItalic": "Miring",
+    "dmFormatStrikethrough": "Coret",
+    "dmFormatCode": "Kode"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Scorri per regolare",
     "videoEditorVolumeSemanticLabel": "Regola volume",
     "videoEditorOriginalAudioLabel": "Audio originale",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Grassetto",
+    "dmFormatItalic": "Corsivo",
+    "dmFormatStrikethrough": "Barrato",
+    "dmFormatCode": "Codice"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "スライドして調整",
     "videoEditorVolumeSemanticLabel": "音量を調整",
     "videoEditorOriginalAudioLabel": "元の音声",
-    "videoEditorClipVolumeLabel": "クリップ {index}"
+    "videoEditorClipVolumeLabel": "クリップ {index}",
+    "dmFormatBold": "太字",
+    "dmFormatItalic": "斜体",
+    "dmFormatStrikethrough": "取り消し線",
+    "dmFormatCode": "コード"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2972,5 +2972,9 @@
     "videoEditorTimelineSlideToAdjust": "슬라이드하여 조절",
     "videoEditorVolumeSemanticLabel": "볼륨 조절",
     "videoEditorOriginalAudioLabel": "원본 오디오",
-    "videoEditorClipVolumeLabel": "클립 {index}"
+    "videoEditorClipVolumeLabel": "클립 {index}",
+    "dmFormatBold": "굵게",
+    "dmFormatItalic": "기울임꼴",
+    "dmFormatStrikethrough": "취소선",
+    "dmFormatCode": "코드"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Schuif om aan te passen",
     "videoEditorVolumeSemanticLabel": "Volume aanpassen",
     "videoEditorOriginalAudioLabel": "Origineel geluid",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Vet",
+    "dmFormatItalic": "Cursief",
+    "dmFormatStrikethrough": "Doorgestreept",
+    "dmFormatCode": "Code"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Przesuń, aby dostosować",
     "videoEditorVolumeSemanticLabel": "Dostosuj głośność",
     "videoEditorOriginalAudioLabel": "Oryginalne audio",
-    "videoEditorClipVolumeLabel": "Klip {index}"
+    "videoEditorClipVolumeLabel": "Klip {index}",
+    "dmFormatBold": "Pogrubienie",
+    "dmFormatItalic": "Kursywa",
+    "dmFormatStrikethrough": "Przekreślenie",
+    "dmFormatCode": "Kod"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Deslize para ajustar",
     "videoEditorVolumeSemanticLabel": "Ajustar volume",
     "videoEditorOriginalAudioLabel": "Áudio original",
-    "videoEditorClipVolumeLabel": "Clipe {index}"
+    "videoEditorClipVolumeLabel": "Clipe {index}",
+    "dmFormatBold": "Negrito",
+    "dmFormatItalic": "Itálico",
+    "dmFormatStrikethrough": "Tachado",
+    "dmFormatCode": "Código"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Glisează pentru ajustare",
     "videoEditorVolumeSemanticLabel": "Reglare volum",
     "videoEditorOriginalAudioLabel": "Audio original",
-    "videoEditorClipVolumeLabel": "Clip {index}"
+    "videoEditorClipVolumeLabel": "Clip {index}",
+    "dmFormatBold": "Aldin",
+    "dmFormatItalic": "Cursiv",
+    "dmFormatStrikethrough": "Tăiat",
+    "dmFormatCode": "Cod"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Dra för att justera",
     "videoEditorVolumeSemanticLabel": "Justera volym",
     "videoEditorOriginalAudioLabel": "Originalljud",
-    "videoEditorClipVolumeLabel": "Klipp {index}"
+    "videoEditorClipVolumeLabel": "Klipp {index}",
+    "dmFormatBold": "Fet",
+    "dmFormatItalic": "Kursiv",
+    "dmFormatStrikethrough": "Genomstruken",
+    "dmFormatCode": "Kod"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3683,5 +3683,9 @@
     "videoEditorTimelineSlideToAdjust": "Ayarlamak için kaydır",
     "videoEditorVolumeSemanticLabel": "Sesi ayarla",
     "videoEditorOriginalAudioLabel": "Orijinal ses",
-    "videoEditorClipVolumeLabel": "Klip {index}"
+    "videoEditorClipVolumeLabel": "Klip {index}",
+    "dmFormatBold": "Kalın",
+    "dmFormatItalic": "İtalik",
+    "dmFormatStrikethrough": "Üstü çizili",
+    "dmFormatCode": "Kod"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9638,6 +9638,30 @@ abstract class AppLocalizations {
   /// **'Report'**
   String get dmMessageActionReport;
 
+  /// Label for the Bold formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown bold markers (e.g. **text**).
+  ///
+  /// In en, this message translates to:
+  /// **'Bold'**
+  String get dmFormatBold;
+
+  /// Label for the Italic formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown italic markers (e.g. _text_).
+  ///
+  /// In en, this message translates to:
+  /// **'Italic'**
+  String get dmFormatItalic;
+
+  /// Label for the Strikethrough formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown strikethrough markers (e.g. ~~text~~).
+  ///
+  /// In en, this message translates to:
+  /// **'Strikethrough'**
+  String get dmFormatStrikethrough;
+
+  /// Label for the inline-code formatting action in the DM composer's text-selection context menu. Wraps the selected text with markdown inline-code markers (e.g. `text`).
+  ///
+  /// In en, this message translates to:
+  /// **'Code'**
+  String get dmFormatCode;
+
   /// Accessibility label / tooltip on the clock indicator at the bottom of a sent DM bubble whose recipient gift wrap has not yet landed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5342,16 +5342,16 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'ደማቅ';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'አዘንብል';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'መሰረዝ';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'ኮድ';
 
   @override
   String get dmStatusPending => 'በመላክ ላይ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5342,6 +5342,18 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'በመላክ ላይ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5403,16 +5403,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'عريض';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'مائل';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'يتوسطه خط';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'رمز';
 
   @override
   String get dmStatusPending => 'جاري الإرسال';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5403,6 +5403,18 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'جاري الإرسال';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5507,6 +5507,18 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Изпращаме';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5507,16 +5507,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Получер';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Курсив';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Зачеркнат';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Код';
 
   @override
   String get dmStatusPending => 'Изпращаме';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5521,6 +5521,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Wird gesendet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5521,13 +5521,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Fett';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Kursiv';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Durchgestrichen';
 
   @override
   String get dmFormatCode => 'Code';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5455,6 +5455,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Sending';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5503,16 +5503,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Negrita';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Cursiva';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Tachado';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Código';
 
   @override
   String get dmStatusPending => 'Enviando';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5503,6 +5503,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Enviando';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5523,6 +5523,18 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Nagpapadala';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5523,13 +5523,13 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Makapal';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Pahilis';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'May guhit';
 
   @override
   String get dmFormatCode => 'Code';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5526,13 +5526,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Gras';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Italique';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Barré';
 
   @override
   String get dmFormatCode => 'Code';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5526,6 +5526,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Envoi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5429,16 +5429,16 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Tebal';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Miring';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Coret';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Kode';
 
   @override
   String get dmStatusPending => 'Mengirim';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5429,6 +5429,18 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Mengirim';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5502,6 +5502,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Invio';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5502,16 +5502,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Grassetto';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Corsivo';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Barrato';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Codice';
 
   @override
   String get dmStatusPending => 'Invio';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5227,6 +5227,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => '送信中';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5227,16 +5227,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => '太字';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => '斜体';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => '取り消し線';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'コード';
 
   @override
   String get dmStatusPending => '送信中';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5244,6 +5244,18 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => '보내는 중';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5244,16 +5244,16 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => '굵게';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => '기울임꼴';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => '취소선';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => '코드';
 
   @override
   String get dmStatusPending => '보내는 중';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5477,6 +5477,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Versturen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5477,13 +5477,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Vet';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Cursief';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Doorgestreept';
 
   @override
   String get dmFormatCode => 'Code';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5589,16 +5589,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Pogrubienie';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Kursywa';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Przekreślenie';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Kod';
 
   @override
   String get dmStatusPending => 'Wysyłanie';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5589,6 +5589,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Wysyłanie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5487,6 +5487,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Enviando';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5487,16 +5487,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Negrito';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Itálico';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Tachado';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Código';
 
   @override
   String get dmStatusPending => 'Enviando';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5602,6 +5602,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Se trimite';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5602,16 +5602,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Aldin';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Cursiv';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Tăiat';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Cod';
 
   @override
   String get dmStatusPending => 'Se trimite';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5454,16 +5454,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Fet';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'Kursiv';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Genomstruken';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Kod';
 
   @override
   String get dmStatusPending => 'Skickar';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5454,6 +5454,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Skickar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5435,6 +5435,18 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
+  String get dmFormatBold => 'Bold';
+
+  @override
+  String get dmFormatItalic => 'Italic';
+
+  @override
+  String get dmFormatStrikethrough => 'Strikethrough';
+
+  @override
+  String get dmFormatCode => 'Code';
+
+  @override
   String get dmStatusPending => 'Gönderiliyor';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5435,16 +5435,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmMessageActionReport => 'Report';
 
   @override
-  String get dmFormatBold => 'Bold';
+  String get dmFormatBold => 'Kalın';
 
   @override
-  String get dmFormatItalic => 'Italic';
+  String get dmFormatItalic => 'İtalik';
 
   @override
-  String get dmFormatStrikethrough => 'Strikethrough';
+  String get dmFormatStrikethrough => 'Üstü çizili';
 
   @override
-  String get dmFormatCode => 'Code';
+  String get dmFormatCode => 'Kod';
 
   @override
   String get dmStatusPending => 'Gönderiliyor';

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -24,6 +24,7 @@ import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/utils/divine_video_url.dart';
 import 'package:openvine/utils/string_utils.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/markdown/markdown.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
@@ -377,17 +378,7 @@ class _MessageTextState extends ConsumerState<_MessageText> {
   }
 
   String _profileDisplayText(String hexPubkey) {
-    final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
-    final profileText = switch (profile) {
-      UserProfile(:final displayName?) when displayName.isNotEmpty =>
-        displayName,
-      UserProfile(:final name?) when name.isNotEmpty => name,
-      UserProfile(:final shortDisplayNip05?)
-          when shortDisplayNip05.isNotEmpty =>
-        shortDisplayNip05,
-      _ => UserProfile.defaultDisplayNameFor(hexPubkey),
-    };
-    return profileText.startsWith('@') ? profileText : '@$profileText';
+    return LinkifiedTextSupport.profileDisplayText(ref, hexPubkey);
   }
 
   void _navigateToHashtag(String hashtag) {
@@ -411,22 +402,12 @@ class _MessageTextState extends ConsumerState<_MessageText> {
   void _replaceCurrentSpans(List<InlineSpan> spans) {
     final previousSpans = _currentSpans;
     _currentSpans = spans;
-    _disposeSpans(previousSpans);
-  }
-
-  void _disposeSpans(List<InlineSpan> spans) {
-    for (final span in spans) {
-      if (span is TextSpan) {
-        span.recognizer?.dispose();
-        final children = span.children;
-        if (children != null) _disposeSpans(children);
-      }
-    }
+    LinkifiedTextSupport.disposeSpans(previousSpans);
   }
 
   @override
   void dispose() {
-    _disposeSpans(_currentSpans);
+    LinkifiedTextSupport.disposeSpans(_currentSpans);
     super.dispose();
   }
 

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -3,6 +3,8 @@
 // ABOUTME: conditional timestamp display, clickable URLs, long-press actions,
 // ABOUTME: and inline video preview cards for divine.video links.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -14,12 +16,16 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/router/universal_link_resolver.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/utils/divine_video_url.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:openvine/widgets/markdown/markdown.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -270,12 +276,25 @@ bool _isTrustedDomain(String host) {
   return _trustedDomains.any((d) => lower == d || lower.endsWith('.$d'));
 }
 
-/// Renders message text with clickable URLs and Nostr references.
-class _MessageText extends StatelessWidget {
+/// Renders message text with inline markdown (bold / italic / strike /
+/// inline code / `[label](url)`) plus clickable URLs and Nostr
+/// references.
+///
+/// Markdown parsing produces an AST; plain leaves are delegated to
+/// [LinkifiedTextSpanBuilder] so URLs / @mentions / #hashtags / nostr
+/// references inside, e.g., a `**bold**` run remain tappable.
+class _MessageText extends ConsumerStatefulWidget {
   const _MessageText({required this.message, required this.isSent});
 
   final String message;
   final bool isSent;
+
+  @override
+  ConsumerState<_MessageText> createState() => _MessageTextState();
+}
+
+class _MessageTextState extends ConsumerState<_MessageText> {
+  List<InlineSpan> _currentSpans = const [];
 
   @override
   Widget build(BuildContext context) {
@@ -283,19 +302,132 @@ class _MessageText extends StatelessWidget {
     // Sent bubbles have a primaryAccessible background → use white for
     // contrast. Received bubbles use surfaceContainer → primary green
     // reads cleanly there.
-    final linkColor = isSent ? VineTheme.whiteText : VineTheme.primary;
+    final linkColor = widget.isSent ? VineTheme.whiteText : VineTheme.primary;
     final referenceStyle = defaultStyle.copyWith(
       color: linkColor,
       decoration: TextDecoration.underline,
       decorationColor: linkColor,
     );
-    return LinkifiedText(
-      text: message,
-      style: defaultStyle,
-      linkStyle: referenceStyle,
-      mentionStyle: referenceStyle,
-      onUrlTap: (link) => _openLink(context, link),
+    // Translucent white overlay reads on both bubble colors without
+    // needing a per-side palette swap.
+    final codeBackground = VineTheme.whiteText.withValues(
+      alpha: widget.isSent ? 0.18 : 0.10,
     );
+    final codeStyle = VineTheme.codeFont(color: defaultStyle.color!);
+
+    final ast = const InlineMarkdownParser().parse(widget.message);
+    final builder = MarkdownTextSpanBuilder(
+      defaultStyle: defaultStyle,
+      codeStyle: codeStyle,
+      codeBackgroundColor: codeBackground,
+      linkStyle: referenceStyle,
+      buildPlainSpans: (text, effectiveStyle) =>
+          _buildLinkifiedPlain(text, effectiveStyle, referenceStyle),
+      onLinkTap: (rawUrl) => _openLink(context, rawUrl),
+    );
+    final spans = builder.build(ast);
+    _replaceCurrentSpans(spans);
+
+    if (spans.isEmpty) {
+      return Text(widget.message, style: defaultStyle);
+    }
+    return Text.rich(TextSpan(children: spans));
+  }
+
+  /// Delegates plain markdown leaves to [LinkifiedTextSpanBuilder] so
+  /// the linkifier's URL / @mention / #hashtag / nostr-ref pipeline
+  /// runs inside markdown wrappers.
+  List<InlineSpan> _buildLinkifiedPlain(
+    String text,
+    TextStyle plainStyle,
+    TextStyle linkStyle,
+  ) {
+    if (text.isEmpty) return const [];
+    // Apply the surrounding emphasis to linked / mentioned tokens too
+    // so `**check @alice**` renders the mention in bold + reference
+    // color.
+    final emphasizedLink = linkStyle.copyWith(
+      fontWeight: plainStyle.fontWeight,
+      fontStyle: plainStyle.fontStyle,
+      decoration:
+          plainStyle.decoration == null ||
+              plainStyle.decoration == TextDecoration.none
+          ? linkStyle.decoration
+          : TextDecoration.combine([
+              linkStyle.decoration ?? TextDecoration.none,
+              plainStyle.decoration!,
+            ]),
+    );
+    return LinkifiedTextSpanBuilder(
+      text: text,
+      defaultStyle: plainStyle,
+      linkStyle: emphasizedLink,
+      mentionStyle: emphasizedLink,
+      videoLabel: Localizations.of<AppLocalizations>(
+        context,
+        AppLocalizations,
+      )?.clickableTextViewVideoLink,
+      profileLabelForHex: _profileDisplayText,
+      onHashtagTap: _navigateToHashtag,
+      onProfileTap: _navigateToProfile,
+      onVideoTap: _navigateToVideo,
+      onMentionTap: _navigateToSearch,
+      onUrlTap: (rawUrl) => _openLink(context, rawUrl),
+    ).build();
+  }
+
+  String _profileDisplayText(String hexPubkey) {
+    final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
+    final profileText = switch (profile) {
+      UserProfile(:final displayName?) when displayName.isNotEmpty =>
+        displayName,
+      UserProfile(:final name?) when name.isNotEmpty => name,
+      UserProfile(:final shortDisplayNip05?)
+          when shortDisplayNip05.isNotEmpty =>
+        shortDisplayNip05,
+      _ => UserProfile.defaultDisplayNameFor(hexPubkey),
+    };
+    return profileText.startsWith('@') ? profileText : '@$profileText';
+  }
+
+  void _navigateToHashtag(String hashtag) {
+    context.push(HashtagScreenRouter.pathForTag(hashtag));
+  }
+
+  void _navigateToProfile(String hexPubkey) {
+    context.pushOtherProfile(hexPubkey);
+  }
+
+  void _navigateToVideo(String routeReference) {
+    context.push(VideoDetailScreen.pathForId(routeReference));
+  }
+
+  void _navigateToSearch(String username) {
+    context.go(
+      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+    );
+  }
+
+  void _replaceCurrentSpans(List<InlineSpan> spans) {
+    final previousSpans = _currentSpans;
+    _currentSpans = spans;
+    _disposeSpans(previousSpans);
+  }
+
+  void _disposeSpans(List<InlineSpan> spans) {
+    for (final span in spans) {
+      if (span is TextSpan) {
+        span.recognizer?.dispose();
+        final children = span.children;
+        if (children != null) _disposeSpans(children);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeSpans(_currentSpans);
+    super.dispose();
   }
 
   Future<void> _openLink(BuildContext context, String link) async {

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -403,7 +403,7 @@ class _MessageTextState extends ConsumerState<_MessageText> {
   }
 
   void _navigateToSearch(String username) {
-    context.go(
+    context.push(
       SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
     );
   }

--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -1,9 +1,23 @@
 // ABOUTME: Text input bar for composing and sending messages.
 // ABOUTME: Matches Figma "commenting v2" component with send button.
+// ABOUTME: Selection context menu adds wrap/unwrap actions for inline
+// ABOUTME: markdown (bold / italic / strike / code) — #4621.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
+
+/// Markdown delimiters the selection toolbar can wrap selected text
+/// with. Kept package-private so the bar's tests can target the
+/// individual handlers by delimiter.
+@visibleForTesting
+const String boldDelimiter = '**';
+@visibleForTesting
+const String italicDelimiter = '_';
+@visibleForTesting
+const String strikeDelimiter = '~~';
+@visibleForTesting
+const String codeDelimiter = '`';
 
 /// Message input bar at the bottom of the conversation screen.
 ///
@@ -79,6 +93,7 @@ class _MessageInputBarState extends State<MessageInputBar> {
                     cursorColor: VineTheme.primary,
                     textInputAction: TextInputAction.send,
                     onSubmitted: (_) => _handleSend(),
+                    contextMenuBuilder: _buildContextMenu,
                     decoration: InputDecoration(
                       hintText: context.l10n.dmMessageInputHint,
                       hintStyle: VineTheme.bodyLargeFont(
@@ -132,5 +147,102 @@ class _MessageInputBarState extends State<MessageInputBar> {
         ),
       ),
     );
+  }
+
+  /// Selection toolbar with the platform's default items (cut / copy /
+  /// paste / select all) plus four markdown formatting actions when
+  /// the user has a non-empty selection. Each action wraps the
+  /// selection with the corresponding markdown delimiter, or unwraps
+  /// it if the selection is already enclosed by that delimiter.
+  Widget _buildContextMenu(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    final items = <ContextMenuButtonItem>[];
+    final selection = editableTextState.textEditingValue.selection;
+    if (selection.isValid && !selection.isCollapsed) {
+      final l10n = context.l10n;
+      items.addAll([
+        ContextMenuButtonItem(
+          label: l10n.dmFormatBold,
+          onPressed: () => _wrapSelection(editableTextState, boldDelimiter),
+        ),
+        ContextMenuButtonItem(
+          label: l10n.dmFormatItalic,
+          onPressed: () => _wrapSelection(editableTextState, italicDelimiter),
+        ),
+        ContextMenuButtonItem(
+          label: l10n.dmFormatStrikethrough,
+          onPressed: () => _wrapSelection(editableTextState, strikeDelimiter),
+        ),
+        ContextMenuButtonItem(
+          label: l10n.dmFormatCode,
+          onPressed: () => _wrapSelection(editableTextState, codeDelimiter),
+        ),
+      ]);
+    }
+    items.addAll(editableTextState.contextMenuButtonItems);
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: items,
+    );
+  }
+
+  /// Wraps the current selection in [editableTextState] with
+  /// [delimiter] on both sides — or, if the selection is already
+  /// surrounded by that delimiter, unwraps it. Updates the underlying
+  /// controller via [EditableTextState.userUpdateTextEditingValue] so
+  /// the platform's undo / redo stack tracks the change.
+  void _wrapSelection(EditableTextState state, String delimiter) {
+    final value = state.textEditingValue;
+    final selection = value.selection;
+    if (!selection.isValid || selection.isCollapsed) return;
+
+    final text = value.text;
+    final start = selection.start;
+    final end = selection.end;
+    final selected = text.substring(start, end);
+
+    final before = text.substring(0, start);
+    final after = text.substring(end);
+
+    final hasDelimiterBefore =
+        start >= delimiter.length &&
+        text.substring(start - delimiter.length, start) == delimiter;
+    final hasDelimiterAfter =
+        end + delimiter.length <= text.length &&
+        text.substring(end, end + delimiter.length) == delimiter;
+
+    final TextEditingValue newValue;
+    if (hasDelimiterBefore && hasDelimiterAfter) {
+      // Unwrap: drop the surrounding delimiters, keep selection on
+      // the original content.
+      final newText =
+          before.substring(0, before.length - delimiter.length) +
+          selected +
+          after.substring(delimiter.length);
+      newValue = TextEditingValue(
+        text: newText,
+        selection: TextSelection(
+          baseOffset: start - delimiter.length,
+          extentOffset: end - delimiter.length,
+        ),
+      );
+    } else {
+      // Wrap: insert delimiters around the selection, then keep the
+      // (now-wrapped) text selected so a second tap can unwrap.
+      final newText = '$before$delimiter$selected$delimiter$after';
+      newValue = TextEditingValue(
+        text: newText,
+        selection: TextSelection(
+          baseOffset: start + delimiter.length,
+          extentOffset: end + delimiter.length,
+        ),
+      );
+    }
+
+    state
+      ..userUpdateTextEditingValue(newValue, SelectionChangedCause.toolbar)
+      ..hideToolbar();
   }
 }

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -4,14 +4,13 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class LinkifiedText extends ConsumerStatefulWidget {
@@ -99,17 +98,7 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
   }
 
   String _profileDisplayText(String hexPubkey) {
-    final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
-    final profileText = switch (profile) {
-      UserProfile(:final displayName?) when displayName.isNotEmpty =>
-        displayName,
-      UserProfile(:final name?) when name.isNotEmpty => name,
-      UserProfile(:final shortDisplayNip05?)
-          when shortDisplayNip05.isNotEmpty =>
-        shortDisplayNip05,
-      _ => UserProfile.defaultDisplayNameFor(hexPubkey),
-    };
-    return profileText.startsWith('@') ? profileText : '@$profileText';
+    return LinkifiedTextSupport.profileDisplayText(ref, hexPubkey);
   }
 
   void _navigateToHashtagFeed(BuildContext context, String hashtag) {
@@ -169,31 +158,12 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
   void _replaceCurrentSpans(List<TextSpan> spans) {
     final previousSpans = _currentSpans;
     _currentSpans = spans;
-    _disposeSpans(previousSpans);
-  }
-
-  void _disposeSpans(List<TextSpan> spans) {
-    for (final span in spans) {
-      span.recognizer?.dispose();
-      final children = span.children;
-      if (children == null) continue;
-      _disposeInlineSpans(children);
-    }
-  }
-
-  void _disposeInlineSpans(List<InlineSpan> spans) {
-    for (final span in spans) {
-      if (span is TextSpan) {
-        span.recognizer?.dispose();
-        final children = span.children;
-        if (children != null) _disposeInlineSpans(children);
-      }
-    }
+    LinkifiedTextSupport.disposeSpans(previousSpans);
   }
 
   @override
   void dispose() {
-    _disposeSpans(_currentSpans);
+    LinkifiedTextSupport.disposeSpans(_currentSpans);
     super.dispose();
   }
 }

--- a/mobile/lib/widgets/linkified_text/linkified_text_support.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_support.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' show UserProfile;
+import 'package:openvine/providers/user_profile_providers.dart';
+
+/// Shared helpers for linkified-text renderers.
+final class LinkifiedTextSupport {
+  const LinkifiedTextSupport._();
+
+  /// Resolves the display label used for profile references.
+  static String profileDisplayText(WidgetRef ref, String hexPubkey) {
+    final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
+    final profileText = switch (profile) {
+      UserProfile(:final displayName?) when displayName.isNotEmpty =>
+        displayName,
+      UserProfile(:final name?) when name.isNotEmpty => name,
+      UserProfile(:final shortDisplayNip05?)
+          when shortDisplayNip05.isNotEmpty =>
+        shortDisplayNip05,
+      _ => UserProfile.defaultDisplayNameFor(hexPubkey),
+    };
+    return profileText.startsWith('@') ? profileText : '@$profileText';
+  }
+
+  /// Recursively disposes gesture recognizers owned by inline spans.
+  static void disposeSpans(List<InlineSpan> spans) {
+    for (final span in spans) {
+      if (span is! TextSpan) continue;
+      span.recognizer?.dispose();
+      final children = span.children;
+      if (children != null) disposeSpans(children);
+    }
+  }
+}

--- a/mobile/lib/widgets/markdown/inline_markdown_node.dart
+++ b/mobile/lib/widgets/markdown/inline_markdown_node.dart
@@ -1,0 +1,83 @@
+// ABOUTME: Sealed AST for inline markdown produced by InlineMarkdownParser.
+// ABOUTME: Markdown_text_span_builder walks this tree to emit InlineSpans.
+
+import 'package:equatable/equatable.dart';
+
+/// Inline markdown node.
+///
+/// Sealed: parser produces only the variants defined here so the span
+/// builder's switch stays exhaustive.
+sealed class InlineMarkdownNode extends Equatable {
+  const InlineMarkdownNode();
+}
+
+/// Terminal: literal text with no inline formatting applied. Leaf
+/// rendering delegates this back to the existing linkified-text span
+/// builder so URLs / @mentions / #hashtags / nostr references inside a
+/// formatted run remain tappable.
+class PlainNode extends InlineMarkdownNode {
+  const PlainNode(this.text);
+
+  final String text;
+
+  @override
+  List<Object?> get props => [text];
+}
+
+/// `**bold**` run. Children are inline nodes so `**hello _world_**`
+/// resolves to a `BoldNode` containing a `PlainNode('hello ')` and an
+/// `ItalicNode([PlainNode('world')])`.
+class BoldNode extends InlineMarkdownNode {
+  const BoldNode(this.children);
+
+  final List<InlineMarkdownNode> children;
+
+  @override
+  List<Object?> get props => [children];
+}
+
+/// `_italic_` run. Snake-case identifiers like `foo_bar_baz` are kept
+/// as a single [PlainNode] by enforcing a word-boundary rule on the
+/// opening `_` in the parser.
+class ItalicNode extends InlineMarkdownNode {
+  const ItalicNode(this.children);
+
+  final List<InlineMarkdownNode> children;
+
+  @override
+  List<Object?> get props => [children];
+}
+
+/// `~~strikethrough~~` run.
+class StrikeNode extends InlineMarkdownNode {
+  const StrikeNode(this.children);
+
+  final List<InlineMarkdownNode> children;
+
+  @override
+  List<Object?> get props => [children];
+}
+
+/// Terminal: `` `inline code` ``. Contents are rendered as a literal
+/// monospace run — no nested formatting, no linkification.
+class CodeNode extends InlineMarkdownNode {
+  const CodeNode(this.literal);
+
+  final String literal;
+
+  @override
+  List<Object?> get props => [literal];
+}
+
+/// `[label](url)` run. [label] is parsed as inline markdown so
+/// `[**bold link**](https://example.com)` works; [url] is taken
+/// verbatim and tapping the rendered label opens it.
+class LinkNode extends InlineMarkdownNode {
+  const LinkNode({required this.label, required this.url});
+
+  final List<InlineMarkdownNode> label;
+  final String url;
+
+  @override
+  List<Object?> get props => [label, url];
+}

--- a/mobile/lib/widgets/markdown/inline_markdown_parser.dart
+++ b/mobile/lib/widgets/markdown/inline_markdown_parser.dart
@@ -1,0 +1,392 @@
+// ABOUTME: Inline markdown parser that produces an InlineMarkdownNode AST.
+// ABOUTME: Supports **bold**, _italic_, ~~strike~~, `code`, [label](url).
+// ABOUTME: Code spans are literal (no nesting, no linkification).
+
+import 'package:openvine/widgets/markdown/inline_markdown_node.dart';
+
+/// Maximum nesting depth for inline markdown.
+///
+/// Beyond this, the opener that would push past the cap is rendered as
+/// literal text so pathological inputs (`*****…*****`) can't blow the
+/// stack.
+const int _maxDepth = 8;
+
+/// Inline markdown parser for chat-style text.
+///
+/// Scans left-to-right, recursive-descent for nestable runs
+/// (`**`, `_`, `~~`, `[…](…)`). `` ` `` is terminal: contents are taken
+/// verbatim until the matching closing backtick, no nesting allowed.
+class InlineMarkdownParser {
+  const InlineMarkdownParser();
+
+  /// Parses [text] into a list of inline nodes. Returns an empty list
+  /// for empty input. Never throws on malformed input — unmatched
+  /// openers fall through as literal characters in a [PlainNode].
+  List<InlineMarkdownNode> parse(String text) {
+    if (text.isEmpty) return const [];
+    final scanner = _Scanner(text);
+    return scanner.parseUntil(_terminatorEnd, depth: 0);
+  }
+}
+
+/// Terminator sentinel meaning "consume to end of input".
+const String _terminatorEnd = '';
+
+class _Scanner {
+  _Scanner(this.input);
+
+  final String input;
+  int _pos = 0;
+
+  /// Parses inline nodes from the current position until [terminator]
+  /// is matched at the current position, or end-of-input.
+  ///
+  /// When the terminator is matched, the scanner advances past it and
+  /// returns. Callers detect "matched" vs "ran to EOF" by checking
+  /// whether `_pos` advanced past where the terminator would sit.
+  List<InlineMarkdownNode> parseUntil(
+    String terminator, {
+    required int depth,
+  }) {
+    final nodes = <InlineMarkdownNode>[];
+    final buffer = StringBuffer();
+
+    void flushBuffer() {
+      if (buffer.isEmpty) return;
+      nodes.add(PlainNode(buffer.toString()));
+      buffer.clear();
+    }
+
+    while (_pos < input.length) {
+      if (terminator.isNotEmpty && _matchesAt(_pos, terminator)) {
+        flushBuffer();
+        _pos += terminator.length;
+        return nodes;
+      }
+
+      final char = input[_pos];
+
+      // Backslash escapes the next character (markdown delimiter or
+      // backslash itself). Anything else falls through literal.
+      if (char == r'\' && _pos + 1 < input.length) {
+        final next = input[_pos + 1];
+        if (_isEscapableDelimiter(next)) {
+          buffer.write(next);
+          _pos += 2;
+          continue;
+        }
+      }
+
+      // `code`: terminal, no nesting, no recursion. We deliberately
+      // do not consume a leading backtick when no closing backtick
+      // exists later in the input — fall through to literal.
+      if (char == '`') {
+        final close = input.indexOf('`', _pos + 1);
+        if (close != -1 && close > _pos + 1) {
+          flushBuffer();
+          nodes.add(CodeNode(input.substring(_pos + 1, close)));
+          _pos = close + 1;
+          continue;
+        }
+      }
+
+      // `**bold**`. Require non-empty content so `****` falls through
+      // literal rather than producing an empty BoldNode.
+      if (_matchesAt(_pos, '**') && depth < _maxDepth) {
+        final savedPos = _pos;
+        _pos += 2;
+        final children = parseUntil('**', depth: depth + 1);
+        if (_terminatorWasMatched(savedPos + 2, '**', _pos) &&
+            children.isNotEmpty) {
+          flushBuffer();
+          nodes.add(BoldNode(children));
+          continue;
+        }
+        // Unclosed or empty — restore and treat the openers as
+        // literal so `**incomplete` and `****` both render verbatim.
+        _pos = savedPos;
+        buffer.write('**');
+        _pos += 2;
+        continue;
+      }
+
+      // `~~strike~~`.
+      if (_matchesAt(_pos, '~~') && depth < _maxDepth) {
+        final savedPos = _pos;
+        _pos += 2;
+        final children = parseUntil('~~', depth: depth + 1);
+        if (_terminatorWasMatched(savedPos + 2, '~~', _pos) &&
+            children.isNotEmpty) {
+          flushBuffer();
+          nodes.add(StrikeNode(children));
+          continue;
+        }
+        _pos = savedPos;
+        buffer.write('~~');
+        _pos += 2;
+        continue;
+      }
+
+      // `_italic_`. CommonMark left-flanking rule (simplified):
+      // require the char before the opening `_` to not be a word
+      // character, so `foo_bar_baz` stays literal. End delimiter
+      // analogously requires the char after the closing `_` to not be
+      // a word character.
+      if (char == '_' && depth < _maxDepth && _isItalicOpener(_pos)) {
+        final savedPos = _pos;
+        _pos += 1;
+        final children = parseUntilItalicClose(depth: depth + 1);
+        if (children != null && children.isNotEmpty) {
+          flushBuffer();
+          nodes.add(ItalicNode(children));
+          continue;
+        }
+        _pos = savedPos;
+        buffer.write('_');
+        _pos += 1;
+        continue;
+      }
+
+      // `[label](url)`.
+      if (char == '[' && depth < _maxDepth) {
+        final link = _tryParseLink(depth);
+        if (link != null) {
+          flushBuffer();
+          nodes.add(link);
+          continue;
+        }
+      }
+
+      buffer.write(char);
+      _pos++;
+    }
+
+    flushBuffer();
+    return nodes;
+  }
+
+  /// Variant of [parseUntil] specialised for italic, which has a
+  /// word-boundary constraint on the closing delimiter. Returns the
+  /// child nodes on success and advances past the closing `_`;
+  /// returns `null` if no qualifying close was found before EOF.
+  List<InlineMarkdownNode>? parseUntilItalicClose({required int depth}) {
+    final nodes = <InlineMarkdownNode>[];
+    final buffer = StringBuffer();
+
+    void flushBuffer() {
+      if (buffer.isEmpty) return;
+      nodes.add(PlainNode(buffer.toString()));
+      buffer.clear();
+    }
+
+    while (_pos < input.length) {
+      final char = input[_pos];
+
+      if (char == '_' && _isItalicCloser(_pos)) {
+        flushBuffer();
+        _pos += 1;
+        return nodes;
+      }
+
+      // Nested formatting reuses the generic path so e.g.
+      // `_a **b** c_` works. Backslash escapes apply as in the outer.
+      if (char == r'\' && _pos + 1 < input.length) {
+        final next = input[_pos + 1];
+        if (_isEscapableDelimiter(next)) {
+          buffer.write(next);
+          _pos += 2;
+          continue;
+        }
+      }
+
+      if (char == '`') {
+        final close = input.indexOf('`', _pos + 1);
+        if (close != -1 && close > _pos + 1) {
+          flushBuffer();
+          nodes.add(CodeNode(input.substring(_pos + 1, close)));
+          _pos = close + 1;
+          continue;
+        }
+      }
+
+      if (_matchesAt(_pos, '**') && depth < _maxDepth) {
+        final savedPos = _pos;
+        _pos += 2;
+        final children = parseUntil('**', depth: depth + 1);
+        if (_terminatorWasMatched(savedPos + 2, '**', _pos) &&
+            children.isNotEmpty) {
+          flushBuffer();
+          nodes.add(BoldNode(children));
+          continue;
+        }
+        _pos = savedPos;
+        buffer.write('**');
+        _pos += 2;
+        continue;
+      }
+
+      if (_matchesAt(_pos, '~~') && depth < _maxDepth) {
+        final savedPos = _pos;
+        _pos += 2;
+        final children = parseUntil('~~', depth: depth + 1);
+        if (_terminatorWasMatched(savedPos + 2, '~~', _pos) &&
+            children.isNotEmpty) {
+          flushBuffer();
+          nodes.add(StrikeNode(children));
+          continue;
+        }
+        _pos = savedPos;
+        buffer.write('~~');
+        _pos += 2;
+        continue;
+      }
+
+      if (char == '[' && depth < _maxDepth) {
+        final link = _tryParseLink(depth);
+        if (link != null) {
+          flushBuffer();
+          nodes.add(link);
+          continue;
+        }
+      }
+
+      buffer.write(char);
+      _pos++;
+    }
+
+    // EOF without close — bail.
+    return null;
+  }
+
+  /// Tries to parse a `[label](url)` starting at the current `[`.
+  /// Returns `null` if the syntax doesn't match (including any
+  /// nesting in label that escapes its closing `]`); leaves `_pos`
+  /// unchanged in that case.
+  LinkNode? _tryParseLink(int depth) {
+    final start = _pos;
+    // Find matching `]` allowing for escaped `\]` inside label.
+    var labelEnd = -1;
+    for (var i = _pos + 1; i < input.length; i++) {
+      final c = input[i];
+      if (c == r'\' && i + 1 < input.length) {
+        i += 1;
+        continue;
+      }
+      if (c == ']') {
+        labelEnd = i;
+        break;
+      }
+      if (c == '[') {
+        // Nested `[` aborts — keep parser simple.
+        break;
+      }
+    }
+    if (labelEnd == -1) return null;
+    if (labelEnd + 1 >= input.length || input[labelEnd + 1] != '(') {
+      return null;
+    }
+
+    // Find matching `)` allowing for escaped `\)`.
+    var urlEnd = -1;
+    for (var i = labelEnd + 2; i < input.length; i++) {
+      final c = input[i];
+      if (c == r'\' && i + 1 < input.length) {
+        i += 1;
+        continue;
+      }
+      if (c == ')') {
+        urlEnd = i;
+        break;
+      }
+    }
+    if (urlEnd == -1) return null;
+
+    final labelText = input.substring(start + 1, labelEnd);
+    final url = input.substring(labelEnd + 2, urlEnd).trim();
+    if (url.isEmpty) return null;
+
+    final labelNodes = const InlineMarkdownParser().parse(labelText);
+    if (labelNodes.isEmpty) return null;
+
+    _pos = urlEnd + 1;
+    if (depth + 1 > _maxDepth) {
+      // Should not happen with current cap, but guard anyway.
+      return LinkNode(label: const [PlainNode('')], url: url);
+    }
+    return LinkNode(label: labelNodes, url: url);
+  }
+
+  bool _matchesAt(int pos, String needle) {
+    if (pos + needle.length > input.length) return false;
+    for (var i = 0; i < needle.length; i++) {
+      if (input[pos + i] != needle[i]) return false;
+    }
+    return true;
+  }
+
+  /// True iff [parseUntil] consumed the terminator at the recursion
+  /// it just returned from. We detect it by checking that `_pos`
+  /// points past the location where the terminator would have sat
+  /// AND the character there matches. Cheaper: compare `_pos` to
+  /// `contentStart` — if equal, recursion bailed at EOF.
+  bool _terminatorWasMatched(int contentStart, String terminator, int endPos) {
+    if (endPos == input.length) {
+      // EOF: check if last `terminator.length` chars match.
+      final tailStart = endPos - terminator.length;
+      if (tailStart < contentStart) return false;
+      return _matchesAt(tailStart, terminator);
+    }
+    final tailStart = endPos - terminator.length;
+    return tailStart >= contentStart && _matchesAt(tailStart, terminator);
+  }
+
+  /// Left-flanking constraint for opening italic `_`.
+  ///
+  /// Treat `_` as an opener only when the character immediately
+  /// preceding it (or BOF) is not a word character, so `foo_bar` and
+  /// `snake_case_thing` remain plain.
+  bool _isItalicOpener(int pos) {
+    if (pos == 0) return true;
+    final prev = input.codeUnitAt(pos - 1);
+    return !_isWordCodeUnit(prev);
+  }
+
+  /// Right-flanking constraint for closing italic `_`.
+  ///
+  /// Treat `_` as a closer only when the character immediately
+  /// following it (or EOF) is not a word character.
+  bool _isItalicCloser(int pos) {
+    if (pos + 1 >= input.length) return true;
+    final next = input.codeUnitAt(pos + 1);
+    return !_isWordCodeUnit(next);
+  }
+
+  /// ASCII word character: `[A-Za-z0-9_]`. Non-ASCII characters
+  /// (CJK, accented letters, emoji) are treated as non-word here
+  /// to favour formatting over identifier protection in those
+  /// scripts — adjust if it produces false positives in the wild.
+  bool _isWordCodeUnit(int cu) {
+    if (cu >= 0x30 && cu <= 0x39) return true; // 0-9
+    if (cu >= 0x41 && cu <= 0x5A) return true; // A-Z
+    if (cu >= 0x61 && cu <= 0x7A) return true; // a-z
+    if (cu == 0x5F) return true; // _
+    return false;
+  }
+
+  bool _isEscapableDelimiter(String char) {
+    switch (char) {
+      case '*':
+      case '_':
+      case '~':
+      case '`':
+      case '[':
+      case ']':
+      case '(':
+      case ')':
+      case r'\':
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/mobile/lib/widgets/markdown/markdown.dart
+++ b/mobile/lib/widgets/markdown/markdown.dart
@@ -1,2 +1,3 @@
 export 'inline_markdown_node.dart';
 export 'inline_markdown_parser.dart';
+export 'markdown_text_span_builder.dart';

--- a/mobile/lib/widgets/markdown/markdown.dart
+++ b/mobile/lib/widgets/markdown/markdown.dart
@@ -1,0 +1,2 @@
+export 'inline_markdown_node.dart';
+export 'inline_markdown_parser.dart';

--- a/mobile/lib/widgets/markdown/markdown_text_span_builder.dart
+++ b/mobile/lib/widgets/markdown/markdown_text_span_builder.dart
@@ -1,0 +1,145 @@
+// ABOUTME: Walks an InlineMarkdownNode AST to emit a flat List<InlineSpan>
+// ABOUTME: with style merging across nesting. PlainNode leaves are
+// ABOUTME: delegated back to LinkifiedTextSpanBuilder so URLs / @mentions /
+// ABOUTME: #hashtags / nostr references stay tappable inside markdown runs.
+
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/painting.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
+import 'package:openvine/widgets/markdown/inline_markdown_node.dart';
+
+/// Builds a `List<InlineSpan>` from an [InlineMarkdownNode] tree.
+///
+/// The leaf-renderer closure ([buildPlainSpans]) is responsible for
+/// turning a plain-text leaf into spans. In DM rendering that closure
+/// wires the leaf into [LinkifiedTextSpanBuilder] with a per-style
+/// override so that, e.g., a URL inside `**bold**` renders as a bold
+/// tappable link.
+///
+/// Lifetime: each call to [build] returns fresh spans whose
+/// [TapGestureRecognizer]s the caller owns and must dispose of when the
+/// widget rebuilds or unmounts. Mirror the dispose helpers in
+/// `LinkifiedText._disposeSpans` to handle nested children.
+class MarkdownTextSpanBuilder {
+  /// Creates a builder that paints inline markdown.
+  ///
+  /// Styles default to the same family as [defaultStyle] with the
+  /// appropriate `fontWeight` / `fontStyle` / `decoration` overlaid.
+  /// Callers can pass explicit styles for finer control (e.g. picking
+  /// a bold weight other than `w700`).
+  const MarkdownTextSpanBuilder({
+    required this.defaultStyle,
+    required this.codeStyle,
+    required this.codeBackgroundColor,
+    required this.linkStyle,
+    required this.buildPlainSpans,
+    this.onLinkTap,
+    this.boldWeight = FontWeight.w700,
+  });
+
+  /// Base style applied to plain runs.
+  final TextStyle defaultStyle;
+
+  /// Style for `` `code` `` runs. Caller-supplied so the bubble can
+  /// pick a Chivo Mono variant matching its own contrast budget.
+  final TextStyle codeStyle;
+
+  /// Painted background for code runs. Applied as
+  /// `TextStyle.background` so wraps look acceptable without needing
+  /// a `WidgetSpan` pill.
+  final Color codeBackgroundColor;
+
+  /// Style for `[label](url)` runs (the label).
+  final TextStyle linkStyle;
+
+  /// Tap handler for markdown-link nodes. The raw URL is passed through.
+  final Future<void> Function(String rawUrl)? onLinkTap;
+
+  /// Weight to apply for `**bold**` nodes.
+  final FontWeight boldWeight;
+
+  /// How a [PlainNode]'s text is converted to spans. In production
+  /// this delegates to [LinkifiedTextSpanBuilder] so URLs / mentions /
+  /// hashtags / nostr references remain tappable inside markdown runs.
+  /// The closure receives the *effective* style derived from current
+  /// nesting (e.g. bold-italic merged) so linkified tokens inherit
+  /// the surrounding emphasis weight or slant.
+  final List<InlineSpan> Function(String text, TextStyle effectiveStyle)
+  buildPlainSpans;
+
+  /// Walks [nodes] and emits a flat list of [InlineSpan]s.
+  List<InlineSpan> build(List<InlineMarkdownNode> nodes) {
+    final spans = <InlineSpan>[];
+    for (final node in nodes) {
+      _emit(node, defaultStyle, spans);
+    }
+    return spans;
+  }
+
+  void _emit(
+    InlineMarkdownNode node,
+    TextStyle currentStyle,
+    List<InlineSpan> sink,
+  ) {
+    switch (node) {
+      case PlainNode():
+        sink.addAll(buildPlainSpans(node.text, currentStyle));
+      case BoldNode():
+        final next = currentStyle.copyWith(fontWeight: boldWeight);
+        for (final child in node.children) {
+          _emit(child, next, sink);
+        }
+      case ItalicNode():
+        final next = currentStyle.copyWith(fontStyle: FontStyle.italic);
+        for (final child in node.children) {
+          _emit(child, next, sink);
+        }
+      case StrikeNode():
+        final existingDecoration = currentStyle.decoration;
+        final mergedDecoration =
+            existingDecoration == null ||
+                existingDecoration == TextDecoration.none
+            ? TextDecoration.lineThrough
+            : TextDecoration.combine([
+                existingDecoration,
+                TextDecoration.lineThrough,
+              ]);
+        final next = currentStyle.copyWith(decoration: mergedDecoration);
+        for (final child in node.children) {
+          _emit(child, next, sink);
+        }
+      case CodeNode():
+        sink.add(
+          TextSpan(
+            text: node.literal,
+            style: codeStyle.copyWith(
+              background: Paint()..color = codeBackgroundColor,
+            ),
+          ),
+        );
+      case LinkNode():
+        final labelStyle = linkStyle.merge(
+          TextStyle(
+            fontWeight: currentStyle.fontWeight,
+            fontStyle: currentStyle.fontStyle,
+            decoration: currentStyle.decoration,
+          ),
+        );
+        final recognizer = TapGestureRecognizer()
+          ..onTap = () {
+            final cb = onLinkTap;
+            if (cb != null) unawaited(cb(node.url));
+          };
+        final children = <InlineSpan>[];
+        for (final child in node.label) {
+          _emit(child, labelStyle, children);
+        }
+        // Re-wrap children in a parent TextSpan with the tap
+        // recognizer. Flutter's hit-testing applies the parent's
+        // recognizer to children that don't have their own.
+        sink.add(TextSpan(children: children, recognizer: recognizer));
+    }
+  }
+}

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -234,6 +234,20 @@ class VineTheme {
         color: color,
       );
 
+  /// Inline code: Chivo Mono 400 13/20/0.25 — sized to sit flush with
+  /// `bodyMediumFont` in chat bubbles so a monospace run inside a DM
+  /// message doesn't shift the baseline. Callers pair this with a
+  /// translucent background paint so the code chip reads on both
+  /// sent-bubble (primaryAccessible) and received-bubble
+  /// (surfaceContainer) backgrounds.
+  static TextStyle codeFont({Color color = whiteText}) => GoogleFonts.chivoMono(
+    fontSize: 13,
+    fontWeight: FontWeight.w400,
+    height: 20 / 13,
+    letterSpacing: 0.25,
+    color: color,
+  );
+
   /// Status bar style for dark backgrounds: light icons on both platforms.
   ///
   /// [SystemUiOverlayStyle.light] uses `statusBarBrightness: Brightness.light`

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -234,15 +234,17 @@ class VineTheme {
         color: color,
       );
 
-  /// Inline code: Chivo Mono 400 13/20/0.25 — sized to sit flush with
+  /// Inline code: Chivo Mono 300 13/20/0.25 — sized to sit flush with
   /// `bodyMediumFont` in chat bubbles so a monospace run inside a DM
-  /// message doesn't shift the baseline. Callers pair this with a
-  /// translucent background paint so the code chip reads on both
-  /// sent-bubble (primaryAccessible) and received-bubble
-  /// (surfaceContainer) backgrounds.
+  /// message doesn't shift the baseline. Uses the same Chivo Mono
+  /// weight already bundled for `captionPillFont` so tests don't need
+  /// runtime font fetching. Callers pair this with a translucent
+  /// background paint so the code chip reads on both sent-bubble
+  /// (primaryAccessible) and received-bubble (surfaceContainer)
+  /// backgrounds.
   static TextStyle codeFont({Color color = whiteText}) => GoogleFonts.chivoMono(
     fontSize: 13,
-    fontWeight: FontWeight.w400,
+    fontWeight: FontWeight.w300,
     height: 20 / 13,
     letterSpacing: 0.25,
     color: color,

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -197,6 +197,20 @@ void main() {
         expect(style.color, VineTheme.vineGreen);
       });
 
+      testWidgets('codeFont returns Chivo Mono 400 13/20/0.25', (tester) async {
+        final style = VineTheme.codeFont();
+        expect(style.fontSize, 13);
+        expect(style.fontWeight, FontWeight.w400);
+        expect(style.height, 20 / 13);
+        expect(style.letterSpacing, 0.25);
+        expect(style.color, VineTheme.whiteText);
+      });
+
+      testWidgets('codeFont accepts a color override', (tester) async {
+        final style = VineTheme.codeFont(color: VineTheme.vineGreen);
+        expect(style.color, VineTheme.vineGreen);
+      });
+
       testWidgets('labelSmallFont returns correct style', (tester) async {
         final style = VineTheme.labelSmallFont();
         expect(style.fontSize, 11);

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -197,10 +197,10 @@ void main() {
         expect(style.color, VineTheme.vineGreen);
       });
 
-      testWidgets('codeFont returns Chivo Mono 400 13/20/0.25', (tester) async {
+      testWidgets('codeFont returns Chivo Mono 300 13/20/0.25', (tester) async {
         final style = VineTheme.codeFont();
         expect(style.fontSize, 13);
-        expect(style.fontWeight, FontWeight.w400);
+        expect(style.fontWeight, FontWeight.w300);
         expect(style.height, 20 / 13);
         expect(style.letterSpacing, 0.25);
         expect(style.color, VineTheme.whiteText);

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -453,13 +453,6 @@ const _knownUntranslatedDebt = {
   // Translators will pick this up in a follow-up pass; until then non-English
   // locales fall back to the English source.
   'feedLoadingMore',
-  // Added by the DM markdown-formatting selection toolbar (#4621).
-  // Short labels — translators will pick them up in a follow-up pass;
-  // until then non-English locales fall back to the English source.
-  'dmFormatBold',
-  'dmFormatItalic',
-  'dmFormatStrikethrough',
-  'dmFormatCode',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -453,6 +453,13 @@ const _knownUntranslatedDebt = {
   // Translators will pick this up in a follow-up pass; until then non-English
   // locales fall back to the English source.
   'feedLoadingMore',
+  // Added by the DM markdown-formatting selection toolbar (#4621).
+  // Short labels — translators will pick them up in a follow-up pass;
+  // until then non-English locales fall back to the English source.
+  'dmFormatBold',
+  'dmFormatItalic',
+  'dmFormatStrikethrough',
+  'dmFormatCode',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -1002,5 +1002,174 @@ void main() {
         expect(find.text('No callback'), findsOneWidget);
       });
     });
+
+    group('markdown rendering', () {
+      /// Walks the rendered span tree and collects every TextSpan that
+      /// satisfies [predicate]. Used to assert on the inline-style
+      /// flags applied to the rendered content.
+      List<TextSpan> spansMatching(
+        WidgetTester tester,
+        bool Function(TextSpan span) predicate,
+      ) {
+        final hits = <TextSpan>[];
+        final richTexts = tester
+            .widgetList<RichText>(find.byType(RichText))
+            .toList();
+        for (final richText in richTexts) {
+          void visit(InlineSpan span) {
+            if (span is TextSpan) {
+              if (predicate(span)) hits.add(span);
+              for (final child in span.children ?? const <InlineSpan>[]) {
+                visit(child);
+              }
+            }
+          }
+
+          visit(richText.text);
+        }
+        return hits;
+      }
+
+      Widget bubble(String message, {bool isSent = true}) {
+        return MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: testProviderScope(
+              child: MessageBubble(
+                message: message,
+                timestamp: '2:30 PM',
+                isSent: isSent,
+              ),
+            ),
+          ),
+        );
+      }
+
+      testWidgets('bold span renders with FontWeight.w700', (tester) async {
+        await tester.pumpWidget(bubble('say **hi** please'));
+
+        final boldSpans = spansMatching(
+          tester,
+          (span) =>
+              span.text == 'hi' && span.style?.fontWeight == FontWeight.w700,
+        );
+        expect(boldSpans, hasLength(1));
+      });
+
+      testWidgets('italic span renders with FontStyle.italic', (tester) async {
+        await tester.pumpWidget(bubble('be _kind_ today'));
+
+        final italicSpans = spansMatching(
+          tester,
+          (span) =>
+              span.text == 'kind' && span.style?.fontStyle == FontStyle.italic,
+        );
+        expect(italicSpans, hasLength(1));
+      });
+
+      testWidgets('strikethrough span renders with lineThrough decoration', (
+        tester,
+      ) async {
+        await tester.pumpWidget(bubble('that is ~~wrong~~ now'));
+
+        final strikeSpans = spansMatching(
+          tester,
+          (span) =>
+              span.text == 'wrong' &&
+              span.style?.decoration == TextDecoration.lineThrough,
+        );
+        expect(strikeSpans, hasLength(1));
+      });
+
+      testWidgets('inline code renders with monospace + translucent bg', (
+        tester,
+      ) async {
+        await tester.pumpWidget(bubble('run `flutter test` first'));
+
+        final codeSpans = spansMatching(
+          tester,
+          (span) => span.text == 'flutter test',
+        );
+        expect(codeSpans, hasLength(1));
+        final style = codeSpans.single.style!;
+        // Chivo Mono comes through google_fonts so the fontFamily
+        // string includes a hash suffix — match by prefix.
+        expect(style.fontFamily, startsWith('ChivoMono'));
+        expect(style.background, isNotNull);
+      });
+
+      testWidgets('received bubble uses a lighter code background', (
+        tester,
+      ) async {
+        await tester.pumpWidget(bubble('try `x()`', isSent: false));
+
+        final codeSpan = spansMatching(
+          tester,
+          (span) => span.text == 'x()',
+        ).single;
+        final bgAlpha = codeSpan.style!.background!.color.a;
+        // Received variant uses 0.10 alpha; sent uses 0.18. Match the
+        // received bucket here.
+        expect(bgAlpha, closeTo(0.10, 0.02));
+      });
+
+      testWidgets('snake_case identifiers do not italicize', (tester) async {
+        await tester.pumpWidget(bubble('try foo_bar_baz today'));
+
+        final italicSpans = spansMatching(
+          tester,
+          (span) =>
+              (span.text?.contains('bar') ?? false) &&
+              span.style?.fontStyle == FontStyle.italic,
+        );
+        expect(italicSpans, isEmpty);
+      });
+
+      testWidgets('unmatched ** does not crash and renders as literal', (
+        tester,
+      ) async {
+        await tester.pumpWidget(bubble('half **incomplete'));
+
+        // No bold span emitted.
+        final boldSpans = spansMatching(
+          tester,
+          (span) => span.style?.fontWeight == FontWeight.w700,
+        );
+        expect(boldSpans, isEmpty);
+        // The literal markers reach the rendered text.
+        expect(find.textContaining('**incomplete'), findsOneWidget);
+      });
+
+      testWidgets('plain message without markdown markers renders unchanged', (
+        tester,
+      ) async {
+        await tester.pumpWidget(bubble('just regular text here'));
+
+        // No span carries any of the markdown style overrides.
+        expect(
+          spansMatching(
+            tester,
+            (span) => span.style?.fontWeight == FontWeight.w700,
+          ),
+          isEmpty,
+        );
+        expect(
+          spansMatching(
+            tester,
+            (span) => span.style?.fontStyle == FontStyle.italic,
+          ),
+          isEmpty,
+        );
+        expect(
+          spansMatching(
+            tester,
+            (span) => span.style?.decoration == TextDecoration.lineThrough,
+          ),
+          isEmpty,
+        );
+        expect(find.textContaining('just regular text here'), findsOneWidget);
+      });
+    });
   });
 }

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -479,6 +479,44 @@ void main() {
         expect(find.text('video:$naddr'), findsOneWidget);
       });
 
+      testWidgets('pushes search route on @mention tap so back returns', (
+        tester,
+      ) async {
+        // Regression: tapping a `@username` mention used to call `context.go`
+        // and replace the stack, which broke back navigation from the
+        // resulting search page in a DM conversation. Pushing preserves the
+        // DM under the search so the user can pop back.
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const Scaffold(
+                body: MessageBubble(
+                  message: 'Hey @hm21',
+                  timestamp: '2:30 PM',
+                  isSent: true,
+                ),
+              ),
+            ),
+            GoRoute(
+              path: '/search-results/:query',
+              builder: (context, state) => Scaffold(
+                body: Text('search:${state.pathParameters['query']}'),
+              ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(_routerTestApp(router));
+        await tester.pump();
+
+        _linkRecognizer(tester, '@hm21').onTap!();
+        await tester.pumpAndSettle();
+
+        expect(find.text('search:hm21'), findsOneWidget);
+        expect(router.canPop(), isTrue);
+      });
+
       testWidgets('URL span has $TapGestureRecognizer', (tester) async {
         await tester.pumpWidget(
           const MaterialApp(

--- a/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for MessageInputBar.
 // ABOUTME: Tests rendering of text field, send button visibility,
-// ABOUTME: and send/clear interactions.
+// ABOUTME: send/clear interactions, and the markdown formatting items
+// ABOUTME: in the text-selection context menu.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -122,6 +123,197 @@ void main() {
         expect(find.byType(DivineIcon), findsNothing);
         expect(sendCalled, isFalse);
       });
+    });
+
+    group('selection toolbar', () {
+      /// Pumps the input bar, enters [seedText], selects the range
+      /// `[selStart, selEnd]`, and invokes the TextField's
+      /// `contextMenuBuilder`. Returns the resolved widget tree plus the
+      /// `EditableTextState` and `TextEditingController` so individual
+      /// tests can drive button taps and inspect controller state.
+      Future<
+        ({
+          Widget toolbar,
+          EditableTextState state,
+          TextEditingController controller,
+          AppLocalizations l10n,
+        })
+      >
+      pumpAndBuildToolbar(
+        WidgetTester tester, {
+        required String seedText,
+        required int selStart,
+        required int selEnd,
+      }) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: MessageInputBar(onSend: (_) {})),
+          ),
+        );
+
+        final textFieldFinder = find.byType(TextField);
+        await tester.enterText(textFieldFinder, seedText);
+        await tester.pump();
+
+        final state = tester.state<EditableTextState>(
+          find.byType(EditableText),
+        );
+        state.userUpdateTextEditingValue(
+          state.textEditingValue.copyWith(
+            selection: TextSelection(
+              baseOffset: selStart,
+              extentOffset: selEnd,
+            ),
+          ),
+          SelectionChangedCause.toolbar,
+        );
+        await tester.pump();
+
+        final textField = tester.widget<TextField>(textFieldFinder);
+        final builder = textField.contextMenuBuilder!;
+        final element = tester.element(textFieldFinder);
+        final toolbar = builder(element, state);
+        return (
+          toolbar: toolbar,
+          state: state,
+          controller: textField.controller!,
+          l10n: AppLocalizations.of(element),
+        );
+      }
+
+      testWidgets('omits formatting items when selection is collapsed', (
+        tester,
+      ) async {
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'hello',
+          selStart: 3,
+          selEnd: 3,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        final labels = toolbar.buttonItems!.map((item) => item.label).toList();
+        expect(labels, isNot(contains(harness.l10n.dmFormatBold)));
+        expect(labels, isNot(contains(harness.l10n.dmFormatItalic)));
+        expect(labels, isNot(contains(harness.l10n.dmFormatStrikethrough)));
+        expect(labels, isNot(contains(harness.l10n.dmFormatCode)));
+      });
+
+      testWidgets(
+        'prepends Bold/Italic/Strikethrough/Code when selection is non-empty',
+        (tester) async {
+          final harness = await pumpAndBuildToolbar(
+            tester,
+            seedText: 'hello world',
+            selStart: 0,
+            selEnd: 5,
+          );
+          final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+          final labels = toolbar.buttonItems!
+              .map((item) => item.label)
+              .toList();
+          expect(labels.take(4), [
+            harness.l10n.dmFormatBold,
+            harness.l10n.dmFormatItalic,
+            harness.l10n.dmFormatStrikethrough,
+            harness.l10n.dmFormatCode,
+          ]);
+        },
+      );
+
+      testWidgets('Bold wraps the selection with **', (tester) async {
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'say hi please',
+          selStart: 4,
+          selEnd: 6,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        toolbar.buttonItems!.first.onPressed!();
+        await tester.pump();
+        expect(harness.controller.text, equals('say **hi** please'));
+      });
+
+      testWidgets('Italic wraps the selection with _', (tester) async {
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'be _ kind',
+          selStart: 0,
+          selEnd: 2,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        toolbar.buttonItems![1].onPressed!();
+        await tester.pump();
+        expect(harness.controller.text, equals('_be_ _ kind'));
+      });
+
+      testWidgets('Strikethrough wraps the selection with ~~', (tester) async {
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'gone now',
+          selStart: 0,
+          selEnd: 4,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        toolbar.buttonItems![2].onPressed!();
+        await tester.pump();
+        expect(harness.controller.text, equals('~~gone~~ now'));
+      });
+
+      testWidgets('Code wraps the selection with `', (tester) async {
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'use foo() here',
+          selStart: 4,
+          selEnd: 9,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        toolbar.buttonItems![3].onPressed!();
+        await tester.pump();
+        expect(harness.controller.text, equals('use `foo()` here'));
+      });
+
+      testWidgets(
+        'Bold on already-bold selection unwraps the surrounding **',
+        (tester) async {
+          // `**hi**` — select just the inner `hi` so the surrounding
+          // `**` markers can be detected and stripped.
+          final harness = await pumpAndBuildToolbar(
+            tester,
+            seedText: 'say **hi** please',
+            selStart: 6,
+            selEnd: 8,
+          );
+          final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+          toolbar.buttonItems!.first.onPressed!();
+          await tester.pump();
+          expect(harness.controller.text, equals('say hi please'));
+        },
+      );
+
+      testWidgets(
+        'selection labels resolve from l10n, not hardcoded English',
+        (tester) async {
+          // Sanity guard against accidentally hardcoding the label —
+          // if the widget ever stops reading from context.l10n, this
+          // test breaks loudly.
+          final harness = await pumpAndBuildToolbar(
+            tester,
+            seedText: 'hello',
+            selStart: 0,
+            selEnd: 5,
+          );
+          final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+          final labels = toolbar.buttonItems!.take(4).map((b) => b.label);
+          expect(labels, [
+            lookupAppLocalizations(const Locale('en')).dmFormatBold,
+            lookupAppLocalizations(const Locale('en')).dmFormatItalic,
+            lookupAppLocalizations(const Locale('en')).dmFormatStrikethrough,
+            lookupAppLocalizations(const Locale('en')).dmFormatCode,
+          ]);
+        },
+      );
     });
   });
 }

--- a/mobile/test/widgets/markdown/inline_markdown_parser_test.dart
+++ b/mobile/test/widgets/markdown/inline_markdown_parser_test.dart
@@ -1,0 +1,318 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/markdown/markdown.dart';
+
+void main() {
+  group(InlineMarkdownParser, () {
+    const parser = InlineMarkdownParser();
+
+    group('plain text', () {
+      test('returns empty list for empty input', () {
+        expect(parser.parse(''), isEmpty);
+      });
+
+      test('returns single PlainNode for unformatted text', () {
+        expect(
+          parser.parse('hello world'),
+          equals([
+            const PlainNode('hello world'),
+          ]),
+        );
+      });
+    });
+
+    group('bold', () {
+      test('parses **text** to BoldNode', () {
+        expect(
+          parser.parse('**hi**'),
+          equals([
+            const BoldNode([PlainNode('hi')]),
+          ]),
+        );
+      });
+
+      test('parses bold surrounded by plain text', () {
+        expect(
+          parser.parse('say **hi** there'),
+          equals([
+            const PlainNode('say '),
+            const BoldNode([PlainNode('hi')]),
+            const PlainNode(' there'),
+          ]),
+        );
+      });
+
+      test('unclosed ** falls through as literal', () {
+        expect(
+          parser.parse('**unclosed'),
+          equals([
+            const PlainNode('**unclosed'),
+          ]),
+        );
+      });
+
+      test('empty bold **** falls through as literal', () {
+        expect(parser.parse('****'), equals([const PlainNode('****')]));
+      });
+
+      test(r'escapes work: \*\*literal\*\* renders **literal**', () {
+        expect(
+          parser.parse(r'\*\*literal\*\*'),
+          equals([
+            const PlainNode('**literal**'),
+          ]),
+        );
+      });
+    });
+
+    group('italic', () {
+      test('parses _text_ to ItalicNode', () {
+        expect(
+          parser.parse('_hi_'),
+          equals([
+            const ItalicNode([PlainNode('hi')]),
+          ]),
+        );
+      });
+
+      test('snake_case identifier stays literal', () {
+        expect(
+          parser.parse('foo_bar_baz'),
+          equals([
+            const PlainNode('foo_bar_baz'),
+          ]),
+        );
+      });
+
+      test('italic surrounded by spaces parses', () {
+        expect(
+          parser.parse('say _hi_ there'),
+          equals([
+            const PlainNode('say '),
+            const ItalicNode([PlainNode('hi')]),
+            const PlainNode(' there'),
+          ]),
+        );
+      });
+
+      test('unclosed _ falls through as literal', () {
+        expect(
+          parser.parse('_incomplete'),
+          equals([
+            const PlainNode('_incomplete'),
+          ]),
+        );
+      });
+    });
+
+    group('strikethrough', () {
+      test('parses ~~text~~ to StrikeNode', () {
+        expect(
+          parser.parse('~~gone~~'),
+          equals([
+            const StrikeNode([PlainNode('gone')]),
+          ]),
+        );
+      });
+
+      test('unclosed ~~ falls through as literal', () {
+        expect(parser.parse('~~half'), equals([const PlainNode('~~half')]));
+      });
+    });
+
+    group('inline code', () {
+      test('parses `text` to CodeNode', () {
+        expect(parser.parse('`x = 1`'), equals([const CodeNode('x = 1')]));
+      });
+
+      test('code prevents nested markdown parsing', () {
+        expect(
+          parser.parse('`*not bold*`'),
+          equals([
+            const CodeNode('*not bold*'),
+          ]),
+        );
+      });
+
+      test('unclosed backtick falls through as literal', () {
+        expect(parser.parse('`half'), equals([const PlainNode('`half')]));
+      });
+
+      test('empty backticks `` fall through as literal', () {
+        expect(parser.parse('``'), equals([const PlainNode('``')]));
+      });
+    });
+
+    group('nesting', () {
+      test('**bold _italic_** nests italic inside bold', () {
+        expect(
+          parser.parse('**bold _italic_**'),
+          equals([
+            const BoldNode([
+              PlainNode('bold '),
+              ItalicNode([PlainNode('italic')]),
+            ]),
+          ]),
+        );
+      });
+
+      test('_italic **bold**_ nests bold inside italic', () {
+        expect(
+          parser.parse('_italic **bold**_'),
+          equals([
+            const ItalicNode([
+              PlainNode('italic '),
+              BoldNode([PlainNode('bold')]),
+            ]),
+          ]),
+        );
+      });
+
+      test('~~strike **bold**~~ nests bold inside strike', () {
+        expect(
+          parser.parse('~~strike **bold**~~'),
+          equals([
+            const StrikeNode([
+              PlainNode('strike '),
+              BoldNode([PlainNode('bold')]),
+            ]),
+          ]),
+        );
+      });
+
+      test('code inside bold renders as CodeNode child', () {
+        expect(
+          parser.parse('**`code`**'),
+          equals([
+            const BoldNode([CodeNode('code')]),
+          ]),
+        );
+      });
+    });
+
+    group('markdown links', () {
+      test('parses [label](url) to LinkNode', () {
+        expect(
+          parser.parse('[click](https://example.com)'),
+          equals([
+            const LinkNode(
+              label: [PlainNode('click')],
+              url: 'https://example.com',
+            ),
+          ]),
+        );
+      });
+
+      test('link label may contain formatting', () {
+        expect(
+          parser.parse('[**bold link**](https://x.io)'),
+          equals([
+            const LinkNode(
+              label: [
+                BoldNode([PlainNode('bold link')]),
+              ],
+              url: 'https://x.io',
+            ),
+          ]),
+        );
+      });
+
+      test('missing url paren falls through as literal', () {
+        expect(
+          parser.parse('[a](no-paren'),
+          equals([
+            const PlainNode('[a](no-paren'),
+          ]),
+        );
+      });
+
+      test('empty url falls through as literal', () {
+        expect(parser.parse('[a]()'), equals([const PlainNode('[a]()')]));
+      });
+
+      test('two links in a row both parse', () {
+        expect(
+          parser.parse('[a](https://a.com) and [b](https://b.com)'),
+          equals([
+            const LinkNode(
+              label: [PlainNode('a')],
+              url: 'https://a.com',
+            ),
+            const PlainNode(' and '),
+            const LinkNode(
+              label: [PlainNode('b')],
+              url: 'https://b.com',
+            ),
+          ]),
+        );
+      });
+
+      test('nested [ inside label aborts link parse', () {
+        expect(
+          parser.parse('[a[b](url)'),
+          equals([
+            const PlainNode('[a'),
+            const LinkNode(
+              label: [PlainNode('b')],
+              url: 'url',
+            ),
+          ]),
+        );
+      });
+    });
+
+    group('safety', () {
+      test('depth cap prevents stack blow on pathological input', () {
+        // 32 nested asterisks — depth cap (8) should kick in and
+        // surface the excess as literal without throwing.
+        final stars = '*' * 32;
+        final input = '${stars}x$stars';
+        expect(() => parser.parse(input), returnsNormally);
+      });
+
+      test('lone delimiter characters are literal', () {
+        expect(
+          parser.parse('a * b _ c ~ d'),
+          equals([
+            const PlainNode('a * b _ c ~ d'),
+          ]),
+        );
+      });
+
+      test('backslash before non-delimiter passes through literal', () {
+        expect(
+          parser.parse(r'\n is not escaped here'),
+          equals([
+            const PlainNode(r'\n is not escaped here'),
+          ]),
+        );
+      });
+    });
+
+    group('real-world chat shapes', () {
+      test('mixed formatting and plain text', () {
+        expect(
+          parser.parse('Hey **bob**, check `code` and _this_'),
+          equals([
+            const PlainNode('Hey '),
+            const BoldNode([PlainNode('bob')]),
+            const PlainNode(', check '),
+            const CodeNode('code'),
+            const PlainNode(' and '),
+            const ItalicNode([PlainNode('this')]),
+          ]),
+        );
+      });
+
+      test('text containing @ and # passes through verbatim for linkifier', () {
+        // Markdown parser keeps these as plain text — the span builder
+        // delegates the leaf to LinkifiedTextSpanBuilder.
+        expect(
+          parser.parse('hi @alice and #tag'),
+          equals([
+            const PlainNode('hi @alice and #tag'),
+          ]),
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/markdown/markdown_text_span_builder_test.dart
+++ b/mobile/test/widgets/markdown/markdown_text_span_builder_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/markdown/markdown.dart';
+
+void main() {
+  group(MarkdownTextSpanBuilder, () {
+    const defaultStyle = TextStyle(
+      color: Color(0xFFFFFFFF),
+      fontSize: 14,
+      fontWeight: FontWeight.w400,
+    );
+    const linkStyle = TextStyle(
+      color: Color(0xFF27C58B),
+      fontWeight: FontWeight.w500,
+    );
+    const codeStyle = TextStyle(
+      color: Color(0xFFFFFFFF),
+      fontSize: 13,
+      fontFamily: 'ChivoMono',
+    );
+    const codeBg = Color(0x1FFFFFFF);
+
+    /// Test-only plain builder: yields a single span with the effective
+    /// style. Real callers route through LinkifiedTextSpanBuilder.
+    List<InlineSpan> identityPlain(String text, TextStyle style) => [
+      TextSpan(text: text, style: style),
+    ];
+
+    MarkdownTextSpanBuilder makeBuilder({
+      Future<void> Function(String)? onLinkTap,
+      List<InlineSpan> Function(String, TextStyle)? buildPlainSpans,
+    }) {
+      return MarkdownTextSpanBuilder(
+        defaultStyle: defaultStyle,
+        codeStyle: codeStyle,
+        codeBackgroundColor: codeBg,
+        linkStyle: linkStyle,
+        buildPlainSpans: buildPlainSpans ?? identityPlain,
+        onLinkTap: onLinkTap,
+      );
+    }
+
+    test('emits a single plain span for plain AST', () {
+      final spans = makeBuilder().build(const [PlainNode('hello')]);
+      expect(spans, hasLength(1));
+      final span = spans.single as TextSpan;
+      expect(span.text, equals('hello'));
+      expect(span.style?.fontWeight, equals(FontWeight.w400));
+    });
+
+    test('BoldNode applies w700 weight to its plain children', () {
+      final spans = makeBuilder().build(const [
+        BoldNode([PlainNode('strong')]),
+      ]);
+      final span = spans.single as TextSpan;
+      expect(span.text, equals('strong'));
+      expect(span.style?.fontWeight, equals(FontWeight.w700));
+    });
+
+    test('ItalicNode applies FontStyle.italic to children', () {
+      final spans = makeBuilder().build(const [
+        ItalicNode([PlainNode('slant')]),
+      ]);
+      final span = spans.single as TextSpan;
+      expect(span.text, equals('slant'));
+      expect(span.style?.fontStyle, equals(FontStyle.italic));
+    });
+
+    test('StrikeNode applies lineThrough decoration', () {
+      final spans = makeBuilder().build(const [
+        StrikeNode([PlainNode('gone')]),
+      ]);
+      final span = spans.single as TextSpan;
+      expect(span.text, equals('gone'));
+      expect(span.style?.decoration, equals(TextDecoration.lineThrough));
+    });
+
+    test('nested Bold inside Italic merges fontWeight + fontStyle', () {
+      final spans = makeBuilder().build(const [
+        ItalicNode([
+          BoldNode([PlainNode('both')]),
+        ]),
+      ]);
+      final span = spans.single as TextSpan;
+      expect(span.style?.fontWeight, equals(FontWeight.w700));
+      expect(span.style?.fontStyle, equals(FontStyle.italic));
+    });
+
+    test(
+      'CodeNode is terminal: single TextSpan with code style + background',
+      () {
+        final spans = makeBuilder().build(const [CodeNode('x = 1')]);
+        expect(spans, hasLength(1));
+        final span = spans.single as TextSpan;
+        expect(span.text, equals('x = 1'));
+        expect(span.style?.fontFamily, equals('ChivoMono'));
+        expect(span.style?.background, isNotNull);
+        expect(
+          span.style?.background?.color.toARGB32(),
+          equals(codeBg.toARGB32()),
+        );
+      },
+    );
+
+    test('LinkNode produces a parent TextSpan with TapGestureRecognizer', () {
+      final tapped = <String>[];
+      final spans =
+          makeBuilder(
+            onLinkTap: (url) async => tapped.add(url),
+          ).build(const [
+            LinkNode(
+              label: [PlainNode('click me')],
+              url: 'https://example.com',
+            ),
+          ]);
+      expect(spans, hasLength(1));
+      final parent = spans.single as TextSpan;
+      expect(parent.recognizer, isA<TapGestureRecognizer>());
+      (parent.recognizer! as TapGestureRecognizer).onTap?.call();
+      expect(tapped, equals(['https://example.com']));
+
+      // Label child carries the link style + the (unset) base
+      // emphasis flags from the surrounding default style.
+      final labelChild = parent.children!.single as TextSpan;
+      expect(labelChild.text, equals('click me'));
+      expect(labelChild.style?.color, equals(linkStyle.color));
+    });
+
+    test('LinkNode label honors surrounding bold', () {
+      // **[label](url)** — bold wrapping a link.
+      final spans = makeBuilder().build(const [
+        BoldNode([
+          LinkNode(label: [PlainNode('go')], url: 'https://x.io'),
+        ]),
+      ]);
+      final parent = spans.single as TextSpan;
+      final labelChild = parent.children!.single as TextSpan;
+      expect(labelChild.style?.fontWeight, equals(FontWeight.w700));
+    });
+
+    test('plain builder receives merged style for delegation', () {
+      final received = <(String, TextStyle)>[];
+      final builder = makeBuilder(
+        buildPlainSpans: (text, style) {
+          received.add((text, style));
+          return [TextSpan(text: text, style: style)];
+        },
+      );
+
+      builder.build(const [
+        BoldNode([PlainNode('hello @alice')]),
+      ]);
+
+      expect(received, hasLength(1));
+      expect(received.single.$1, equals('hello @alice'));
+      expect(received.single.$2.fontWeight, equals(FontWeight.w700));
+    });
+
+    test('mixed AST produces correctly ordered spans', () {
+      final spans = makeBuilder().build(const [
+        PlainNode('Hey '),
+        BoldNode([PlainNode('bob')]),
+        PlainNode(', '),
+        CodeNode('x()'),
+        PlainNode(' and '),
+        ItalicNode([PlainNode('this')]),
+      ]);
+      expect(spans, hasLength(6));
+      expect((spans[0] as TextSpan).text, equals('Hey '));
+      expect((spans[1] as TextSpan).style?.fontWeight, equals(FontWeight.w700));
+      expect((spans[2] as TextSpan).text, equals(', '));
+      expect((spans[3] as TextSpan).style?.fontFamily, equals('ChivoMono'));
+      expect((spans[4] as TextSpan).text, equals(' and '));
+      expect((spans[5] as TextSpan).style?.fontStyle, equals(FontStyle.italic));
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds inline markdown rendering and a compose-side selection toolbar to DM messages, matching what users expect from WhatsApp / Telegram / Signal / Slack. The wire format stays untouched — NIP-17 `kind 14` content is still plain text, so non-Divine Nostr clients see readable markdown source.

**Supported inline syntax (this PR):**

| Syntax | Result |
|---|---|
| `**bold**` | **bold** |
| `_italic_` | *italic* |
| `~~strikethrough~~` | ~~strikethrough~~ |
| `` `code` `` | `code` with a translucent monospace chip |
| `[label](url)` | tappable `label`, opens URL with the same external-link confirm sheet plain URLs already use |

**What's new in compose:** when the user has a non-empty selection in the DM composer, the system text-selection toolbar gains four prepended actions — **Bold / Italic / Strikethrough / Code** — each of which wraps the selection with the corresponding markdown delimiter. Re-tapping the same action on a selection that's already wrapped unwraps it. Toolbar state changes flow through `EditableTextState.userUpdateTextEditingValue(..., SelectionChangedCause.toolbar)` so the platform's undo/redo stack tracks edits cleanly.

**Architecture (zero blast radius on linkified text):** a new `mobile/lib/widgets/markdown/` module ships a small hand-rolled inline parser (`InlineMarkdownParser` + sealed AST) and a `MarkdownTextSpanBuilder` that walks the AST into `List<InlineSpan>`. Plain leaves are *delegated* back into the existing `LinkifiedTextSpanBuilder`, so URLs / @mentions / #hashtags / nostr refs keep their tap recognizers inside markdown wraps (e.g. `**check @alice**` renders bold *and* keeps `@alice` tappable). `LinkifiedText` and its ~20 other call sites (comments, profile bios, video descriptions, …) are not modified.

The parser uses a CommonMark left/right-flanking word-boundary rule for `_italic_` so `snake_case_identifiers` stay literal, applies a recursion-depth cap of 8 so pathological input can't blow the stack, and falls through to literal characters on any unclosed / empty / malformed delimiter — no throws.

**Related Issue:** Closes #4621

## Out of Scope

- Block markdown (headings, lists, quotes, fenced code blocks, tables, images, footnotes) — per the issue's explicit scope.
- Single-`*` italic / single-`~` strikethrough (collides with arithmetic and casual prose).
- Translations for the four new ARB keys (`dmFormatBold`, `dmFormatItalic`, `dmFormatStrikethrough`, `dmFormatCode`) — added to `_knownUntranslatedDebt` until the next l10n pass picks them up.
- Markdown rendering in comments / profile bios / video descriptions — the parser + builder are reusable, but only the DM bubble opts in this PR.
- Multi-line composer (tracked separately in #4620) — markdown parsing is line-agnostic, so it'll activate automatically there once #4620 lands.

## Verification

- `flutter analyze lib test integration_test` from `mobile/`: no issues.
- `flutter test test/widgets/markdown test/screens/inbox/conversation test/l10n/arb_consistency_test.dart`: **149 / 149 pass**, including 32 parser unit tests, 10 span-builder tests, 8 markdown render tests, 8 selection-toolbar tests.
- `flutter test test/screens/inbox test/blocs/dm`: **365 / 365 pass** (full DM stack regression sweep — no existing bubble / input / bloc test broke).
- `flutter test` inside `mobile/packages/divine_ui`: **572 / 572 pass** (the strict-coverage gate stays green after adding `VineTheme.codeFont()`).
- Manual on-device sweep (iOS sim + physical Android): bold / italic / strike / code / link render correctly on both sent and received bubbles; selection toolbar wraps and unwraps as expected; plain DMs render unchanged; cross-client send to Damus shows the literal markdown source as expected per NIP-17.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore