### PR TITLE
fix: saved edits and account data disappear after reopening app

### DIFF
--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -132,9 +132,21 @@ Future<void> migrateLegacyDatabase({
 
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    if (!_databaseHasActionableLocalOnlyData(newPath) &&
-        _databaseHasActionableLocalOnlyData(legacyPath)) {
+    final legacySidecars = _readDatabaseSidecars(legacyPath);
+    final newHasActionableData = _databaseHasActionableLocalOnlyData(newPath);
+    final legacyHasActionableData = _databaseHasActionableLocalOnlyData(
+      legacyPath,
+    );
+
+    if (!newHasActionableData && legacyHasActionableData) {
       _backupDestinationDatabase(newPath);
+    } else if (newHasActionableData && legacyHasActionableData) {
+      _backupLegacyConflictDatabase(
+        legacyPath: legacyPath,
+        newPath: newPath,
+        sidecars: legacySidecars,
+      );
+      return;
     } else {
       return;
     }
@@ -152,7 +164,10 @@ Future<void> migrateLegacyDatabase({
 }
 
 void _backupDestinationDatabase(String dbPath) {
-  final backupPath = _nextDestinationBackupPath(dbPath);
+  final backupPath = _nextDatabaseBackupPath(
+    dbPath,
+    suffix: '.pre_legacy_migration_backup',
+  );
 
   File(dbPath).renameSync(backupPath);
   for (final suffix in const ['-wal', '-shm']) {
@@ -163,14 +178,46 @@ void _backupDestinationDatabase(String dbPath) {
   }
 }
 
-String _nextDestinationBackupPath(String dbPath) {
-  const backupSuffix = '.pre_legacy_migration_backup';
-  var candidate = '$dbPath$backupSuffix';
+void _backupLegacyConflictDatabase({
+  required String legacyPath,
+  required String newPath,
+  required Map<String, List<int>> sidecars,
+}) {
+  final backupPath = _nextDatabaseBackupPath(
+    newPath,
+    suffix: '.legacy_conflict_backup',
+  );
+
+  Directory(p.dirname(newPath)).createSync(recursive: true);
+  File(legacyPath).renameSync(backupPath);
+  for (final suffix in const ['-wal', '-shm']) {
+    final sidecar = File('$legacyPath$suffix');
+    if (sidecar.existsSync()) {
+      sidecar.renameSync('$backupPath$suffix');
+    } else if (sidecars.containsKey(suffix)) {
+      File('$backupPath$suffix').writeAsBytesSync(sidecars[suffix]!);
+    }
+  }
+}
+
+Map<String, List<int>> _readDatabaseSidecars(String dbPath) {
+  final sidecars = <String, List<int>>{};
+  for (final suffix in const ['-wal', '-shm']) {
+    final sidecar = File('$dbPath$suffix');
+    if (sidecar.existsSync()) {
+      sidecars[suffix] = sidecar.readAsBytesSync();
+    }
+  }
+  return sidecars;
+}
+
+String _nextDatabaseBackupPath(String dbPath, {required String suffix}) {
+  var candidate = '$dbPath$suffix';
   var index = 1;
   while (File(candidate).existsSync() ||
       File('$candidate-wal').existsSync() ||
       File('$candidate-shm').existsSync()) {
-    candidate = '$dbPath$backupSuffix.$index';
+    candidate = '$dbPath$suffix.$index';
     index += 1;
   }
   return candidate;

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -115,8 +115,9 @@ void applyDbCacheVersionReset(String dbPath) {
 /// Handles three cases:
 /// 1. Legacy does not exist → no-op (fresh install or already migrated).
 /// 2. Legacy exists, new does not → rename legacy to new.
-/// 3. Both exist → the legacy DB predates the path change and contains the
-///    user's real history. Replace the new DB with the legacy one.
+/// 3. Both exist → keep the current Application Support DB. A destination DB
+///    means the app has already written to the new location, so replacing it
+///    with an older legacy file can discard local-only data.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -130,9 +131,7 @@ Future<void> migrateLegacyDatabase({
 
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    // Both databases exist. The legacy DB predates the path change and
-    // has more history — always prefer it.
-    _deleteDatabaseAndSidecars(newPath);
+    return;
   }
 
   Directory(p.dirname(newPath)).createSync(recursive: true);
@@ -143,14 +142,6 @@ Future<void> migrateLegacyDatabase({
     if (legacySidecar.existsSync()) {
       legacySidecar.renameSync('$newPath$suffix');
     }
-  }
-}
-
-/// Deletes a database file and its `-wal` / `-shm` sidecars.
-void _deleteDatabaseAndSidecars(String dbPath) {
-  for (final suffix in const ['', '-wal', '-shm']) {
-    final file = File('$dbPath$suffix');
-    if (file.existsSync()) file.deleteSync();
   }
 }
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -57,11 +57,9 @@ Future<String> getSharedDatabasePath() async {
   return newPath;
 }
 
-/// Bump this version to force a full database reset on next app launch.
-///
-/// All local data is re-fetchable from Nostr relays, so the database is
-/// effectively a cache. When a schema change, path migration, or data
-/// corruption requires a clean slate, increment this constant.
+/// Bump this version when startup needs to mark that a database compatibility
+/// check has run. Version adoption must not delete the database: it contains
+/// local-only user data such as drafts and pending actions.
 ///
 /// Version history:
 ///   1 — initial (implicit, no version file exists yet)
@@ -91,12 +89,10 @@ void writeDbCacheVersion(String dbDir, int version) {
   File(p.join(dbDir, dbVersionFileName)).writeAsStringSync('$version');
 }
 
-/// Deletes the database and its `-wal` / `-shm` sidecars when the stored
-/// cache version is stale. Writes the current [dbCacheVersion] afterwards.
+/// Writes the current [dbCacheVersion] when the stored version is stale.
 ///
-/// On first run (no version file), writes the current version without
-/// deleting anything — existing users are not wiped by the mechanism's
-/// introduction.
+/// On first run (no version file), also writes the current version without
+/// deleting anything.
 @visibleForTesting
 void applyDbCacheVersionReset(String dbPath) {
   final dbDir = p.dirname(dbPath);
@@ -109,7 +105,6 @@ void applyDbCacheVersionReset(String dbPath) {
   }
 
   if (stored < dbCacheVersion) {
-    _deleteDatabaseAndSidecars(dbPath);
     writeDbCacheVersion(dbDir, dbCacheVersion);
   }
 }

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -227,7 +227,7 @@ bool _databaseHasActionableLocalOnlyData(String dbPath) {
   Database db;
   try {
     db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
-  } catch (_) {
+  } on SqliteException {
     return true;
   }
 
@@ -239,7 +239,7 @@ bool _databaseHasActionableLocalOnlyData(String dbPath) {
       if (rows.isNotEmpty) return true;
     }
     return false;
-  } catch (_) {
+  } on SqliteException {
     return true;
   } finally {
     db.dispose();
@@ -257,7 +257,8 @@ bool _databaseHasTable(Database db, String tableName) {
 const _localOnlyDataQueries = [
   _LocalOnlyDataQuery(
     'pending_uploads',
-    "SELECT 1 FROM pending_uploads WHERE status NOT IN ('published', 'failed') LIMIT 1",
+    'SELECT 1 FROM pending_uploads WHERE status NOT IN '
+        "('published', 'failed') LIMIT 1",
   ),
   _LocalOnlyDataQuery(
     'pending_actions',
@@ -265,7 +266,8 @@ const _localOnlyDataQueries = [
   ),
   _LocalOnlyDataQuery(
     'outgoing_dms',
-    "SELECT 1 FROM outgoing_dms WHERE recipient_wrap_status != 'sent' OR self_wrap_status != 'sent' LIMIT 1",
+    "SELECT 1 FROM outgoing_dms WHERE recipient_wrap_status != 'sent' "
+        "OR self_wrap_status != 'sent' LIMIT 1",
   ),
   _LocalOnlyDataQuery(
     'personal_reactions',

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -7,6 +7,7 @@ import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3/sqlite3.dart';
 
 /// Open a database connection for native platforms
 /// Uses file-based SQLite through drift's native implementation
@@ -115,9 +116,9 @@ void applyDbCacheVersionReset(String dbPath) {
 /// Handles three cases:
 /// 1. Legacy does not exist → no-op (fresh install or already migrated).
 /// 2. Legacy exists, new does not → rename legacy to new.
-/// 3. Both exist → keep the current Application Support DB. A destination DB
-///    means the app has already written to the new location, so replacing it
-///    with an older legacy file can discard local-only data.
+/// 3. Both exist → migrate legacy only if the destination has no local rows.
+///    Otherwise preserve both; replacing a populated destination can discard
+///    local-only data.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -131,7 +132,13 @@ Future<void> migrateLegacyDatabase({
 
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    return;
+    if (!_hasDatabaseSidecars(newPath) &&
+        !_databaseHasLocalData(newPath) &&
+        _databaseHasLocalData(legacyPath)) {
+      newFile.deleteSync();
+    } else {
+      return;
+    }
   }
 
   Directory(p.dirname(newPath)).createSync(recursive: true);
@@ -142,6 +149,39 @@ Future<void> migrateLegacyDatabase({
     if (legacySidecar.existsSync()) {
       legacySidecar.renameSync('$newPath$suffix');
     }
+  }
+}
+
+bool _hasDatabaseSidecars(String dbPath) {
+  return File('$dbPath-wal').existsSync() || File('$dbPath-shm').existsSync();
+}
+
+bool _databaseHasLocalData(String dbPath) {
+  Database db;
+  try {
+    db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
+  } catch (_) {
+    return true;
+  }
+
+  try {
+    final tables = db.select(
+      "SELECT name FROM sqlite_master "
+      "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+    );
+    for (final table in tables) {
+      final tableName = table['name'] as String;
+      final escapedName = tableName.replaceAll('"', '""');
+      final rows = db.select(
+        'SELECT 1 FROM "$escapedName" LIMIT 1',
+      );
+      if (rows.isNotEmpty) return true;
+    }
+    return false;
+  } catch (_) {
+    return true;
+  } finally {
+    db.dispose();
   }
 }
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -116,9 +116,9 @@ void applyDbCacheVersionReset(String dbPath) {
 /// Handles three cases:
 /// 1. Legacy does not exist → no-op (fresh install or already migrated).
 /// 2. Legacy exists, new does not → rename legacy to new.
-/// 3. Both exist → migrate legacy only if the destination has no local rows.
-///    Otherwise preserve both; replacing a populated destination can discard
-///    local-only data.
+/// 3. Both exist → migrate legacy only if the destination has no local-only
+///    rows and no non-empty sidecars. Otherwise preserve both; replacing a
+///    populated destination can discard local-only data.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -132,10 +132,10 @@ Future<void> migrateLegacyDatabase({
 
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    if (!_hasDatabaseSidecars(newPath) &&
-        !_databaseHasLocalData(newPath) &&
-        _databaseHasLocalData(legacyPath)) {
-      newFile.deleteSync();
+    if (!_hasNonEmptyDatabaseSidecars(newPath) &&
+        !_databaseHasLocalOnlyData(newPath) &&
+        _databaseHasLocalOnlyData(legacyPath)) {
+      _backupDestinationDatabase(newPath);
     } else {
       return;
     }
@@ -152,11 +152,40 @@ Future<void> migrateLegacyDatabase({
   }
 }
 
-bool _hasDatabaseSidecars(String dbPath) {
-  return File('$dbPath-wal').existsSync() || File('$dbPath-shm').existsSync();
+bool _hasNonEmptyDatabaseSidecars(String dbPath) {
+  for (final suffix in const ['-wal', '-shm']) {
+    final sidecar = File('$dbPath$suffix');
+    if (sidecar.existsSync() && sidecar.lengthSync() > 0) return true;
+  }
+  return false;
 }
 
-bool _databaseHasLocalData(String dbPath) {
+void _backupDestinationDatabase(String dbPath) {
+  final backupPath = _nextDestinationBackupPath(dbPath);
+
+  File(dbPath).renameSync(backupPath);
+  for (final suffix in const ['-wal', '-shm']) {
+    final sidecar = File('$dbPath$suffix');
+    if (sidecar.existsSync()) {
+      sidecar.renameSync('$backupPath$suffix');
+    }
+  }
+}
+
+String _nextDestinationBackupPath(String dbPath) {
+  const backupSuffix = '.pre_legacy_migration_backup';
+  var candidate = '$dbPath$backupSuffix';
+  var index = 1;
+  while (File(candidate).existsSync() ||
+      File('$candidate-wal').existsSync() ||
+      File('$candidate-shm').existsSync()) {
+    candidate = '$dbPath$backupSuffix.$index';
+    index += 1;
+  }
+  return candidate;
+}
+
+bool _databaseHasLocalOnlyData(String dbPath) {
   Database db;
   try {
     db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
@@ -165,15 +194,11 @@ bool _databaseHasLocalData(String dbPath) {
   }
 
   try {
-    final tables = db.select(
-      "SELECT name FROM sqlite_master "
-      "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
-    );
-    for (final table in tables) {
-      final tableName = table['name'] as String;
-      final escapedName = tableName.replaceAll('"', '""');
+    for (final tableName in _localOnlyTableNames) {
+      if (!_databaseHasTable(db, tableName)) continue;
+
       final rows = db.select(
-        'SELECT 1 FROM "$escapedName" LIMIT 1',
+        'SELECT 1 FROM "${tableName.replaceAll('"', '""')}" LIMIT 1',
       );
       if (rows.isNotEmpty) return true;
     }
@@ -184,6 +209,26 @@ bool _databaseHasLocalData(String dbPath) {
     db.dispose();
   }
 }
+
+bool _databaseHasTable(Database db, String tableName) {
+  final rows = db.select(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+    [tableName],
+  );
+  return rows.isNotEmpty;
+}
+
+const _localOnlyTableNames = [
+  'pending_uploads',
+  'personal_reactions',
+  'personal_reposts',
+  'pending_actions',
+  'drafts',
+  'clips',
+  'direct_messages',
+  'conversations',
+  'outgoing_dms',
+];
 
 /// Builds the shared database path from a platform-specific writable base.
 ///

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -20,9 +20,7 @@ QueryExecutor openConnection() {
   return LazyDatabase(() async {
     final dbPath = await getSharedDatabasePath();
     final dbFile = prepareDatabaseFile(dbPath);
-    return NativeDatabase(
-      dbFile,
-    );
+    return NativeDatabase(dbFile);
   });
 }
 
@@ -117,8 +115,9 @@ void applyDbCacheVersionReset(String dbPath) {
 /// 1. Legacy does not exist → no-op (fresh install or already migrated).
 /// 2. Legacy exists, new does not → rename legacy to new.
 /// 3. Both exist → migrate legacy only if the destination has no actionable
-///    local-only rows. Otherwise preserve both; replacing a populated
-///    destination can discard local-only data.
+///    local-only rows and legacy does. If neither side has actionable local
+///    data, delete the orphaned legacy file. Otherwise preserve both;
+///    replacing a populated destination can discard local-only data.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -130,9 +129,10 @@ Future<void> migrateLegacyDatabase({
   final legacyFile = File(legacyPath);
   if (!legacyFile.existsSync()) return;
 
+  Map<String, List<int>>? legacySidecars;
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    final legacySidecars = _readDatabaseSidecars(legacyPath);
+    legacySidecars = _readDatabaseSidecars(legacyPath);
     final newHasActionableData = _databaseHasActionableLocalOnlyData(newPath);
     final legacyHasActionableData = _databaseHasActionableLocalOnlyData(
       legacyPath,
@@ -148,19 +148,18 @@ Future<void> migrateLegacyDatabase({
       );
       return;
     } else {
+      _deleteDatabaseAndSidecars(legacyPath);
       return;
     }
   }
 
   Directory(p.dirname(newPath)).createSync(recursive: true);
   legacyFile.renameSync(newPath);
-
-  for (final suffix in const ['-wal', '-shm']) {
-    final legacySidecar = File('$legacyPath$suffix');
-    if (legacySidecar.existsSync()) {
-      legacySidecar.renameSync('$newPath$suffix');
-    }
-  }
+  _moveSidecars(
+    fromPath: legacyPath,
+    toPath: newPath,
+    preservedSidecars: legacySidecars,
+  );
 }
 
 void _backupDestinationDatabase(String dbPath) {
@@ -190,14 +189,11 @@ void _backupLegacyConflictDatabase({
 
   Directory(p.dirname(newPath)).createSync(recursive: true);
   File(legacyPath).renameSync(backupPath);
-  for (final suffix in const ['-wal', '-shm']) {
-    final sidecar = File('$legacyPath$suffix');
-    if (sidecar.existsSync()) {
-      sidecar.renameSync('$backupPath$suffix');
-    } else if (sidecars.containsKey(suffix)) {
-      File('$backupPath$suffix').writeAsBytesSync(sidecars[suffix]!);
-    }
-  }
+  _moveSidecars(
+    fromPath: legacyPath,
+    toPath: backupPath,
+    preservedSidecars: sidecars,
+  );
 }
 
 Map<String, List<int>> _readDatabaseSidecars(String dbPath) {
@@ -209,6 +205,28 @@ Map<String, List<int>> _readDatabaseSidecars(String dbPath) {
     }
   }
   return sidecars;
+}
+
+void _moveSidecars({
+  required String fromPath,
+  required String toPath,
+  Map<String, List<int>>? preservedSidecars,
+}) {
+  for (final suffix in const ['-wal', '-shm']) {
+    final sidecar = File('$fromPath$suffix');
+    if (sidecar.existsSync()) {
+      sidecar.renameSync('$toPath$suffix');
+    } else if (preservedSidecars?.containsKey(suffix) ?? false) {
+      File('$toPath$suffix').writeAsBytesSync(preservedSidecars![suffix]!);
+    }
+  }
+}
+
+void _deleteDatabaseAndSidecars(String dbPath) {
+  for (final suffix in const ['', '-wal', '-shm']) {
+    final file = File('$dbPath$suffix');
+    if (file.existsSync()) file.deleteSync();
+  }
 }
 
 String _nextDatabaseBackupPath(String dbPath, {required String suffix}) {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -116,9 +116,9 @@ void applyDbCacheVersionReset(String dbPath) {
 /// Handles three cases:
 /// 1. Legacy does not exist → no-op (fresh install or already migrated).
 /// 2. Legacy exists, new does not → rename legacy to new.
-/// 3. Both exist → migrate legacy only if the destination has no local-only
-///    rows and no non-empty sidecars. Otherwise preserve both; replacing a
-///    populated destination can discard local-only data.
+/// 3. Both exist → migrate legacy only if the destination has no actionable
+///    local-only rows. Otherwise preserve both; replacing a populated
+///    destination can discard local-only data.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -132,9 +132,8 @@ Future<void> migrateLegacyDatabase({
 
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    if (!_hasNonEmptyDatabaseSidecars(newPath) &&
-        !_databaseHasLocalOnlyData(newPath) &&
-        _databaseHasLocalOnlyData(legacyPath)) {
+    if (!_databaseHasActionableLocalOnlyData(newPath) &&
+        _databaseHasActionableLocalOnlyData(legacyPath)) {
       _backupDestinationDatabase(newPath);
     } else {
       return;
@@ -150,14 +149,6 @@ Future<void> migrateLegacyDatabase({
       legacySidecar.renameSync('$newPath$suffix');
     }
   }
-}
-
-bool _hasNonEmptyDatabaseSidecars(String dbPath) {
-  for (final suffix in const ['-wal', '-shm']) {
-    final sidecar = File('$dbPath$suffix');
-    if (sidecar.existsSync() && sidecar.lengthSync() > 0) return true;
-  }
-  return false;
 }
 
 void _backupDestinationDatabase(String dbPath) {
@@ -185,7 +176,7 @@ String _nextDestinationBackupPath(String dbPath) {
   return candidate;
 }
 
-bool _databaseHasLocalOnlyData(String dbPath) {
+bool _databaseHasActionableLocalOnlyData(String dbPath) {
   Database db;
   try {
     db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
@@ -194,12 +185,10 @@ bool _databaseHasLocalOnlyData(String dbPath) {
   }
 
   try {
-    for (final tableName in _localOnlyTableNames) {
-      if (!_databaseHasTable(db, tableName)) continue;
+    for (final query in _localOnlyDataQueries) {
+      if (!_databaseHasTable(db, query.tableName)) continue;
 
-      final rows = db.select(
-        'SELECT 1 FROM "${tableName.replaceAll('"', '""')}" LIMIT 1',
-      );
+      final rows = db.select(query.sql);
       if (rows.isNotEmpty) return true;
     }
     return false;
@@ -218,17 +207,42 @@ bool _databaseHasTable(Database db, String tableName) {
   return rows.isNotEmpty;
 }
 
-const _localOnlyTableNames = [
-  'pending_uploads',
-  'personal_reactions',
-  'personal_reposts',
-  'pending_actions',
-  'drafts',
-  'clips',
-  'direct_messages',
-  'conversations',
-  'outgoing_dms',
+const _localOnlyDataQueries = [
+  _LocalOnlyDataQuery(
+    'pending_uploads',
+    "SELECT 1 FROM pending_uploads WHERE status NOT IN ('published', 'failed') LIMIT 1",
+  ),
+  _LocalOnlyDataQuery(
+    'pending_actions',
+    "SELECT 1 FROM pending_actions WHERE status != 'completed' LIMIT 1",
+  ),
+  _LocalOnlyDataQuery(
+    'outgoing_dms',
+    "SELECT 1 FROM outgoing_dms WHERE recipient_wrap_status != 'sent' OR self_wrap_status != 'sent' LIMIT 1",
+  ),
+  _LocalOnlyDataQuery(
+    'personal_reactions',
+    'SELECT 1 FROM personal_reactions LIMIT 1',
+  ),
+  _LocalOnlyDataQuery(
+    'personal_reposts',
+    'SELECT 1 FROM personal_reposts LIMIT 1',
+  ),
+  _LocalOnlyDataQuery('drafts', 'SELECT 1 FROM drafts LIMIT 1'),
+  _LocalOnlyDataQuery('clips', 'SELECT 1 FROM clips LIMIT 1'),
+  _LocalOnlyDataQuery(
+    'direct_messages',
+    'SELECT 1 FROM direct_messages LIMIT 1',
+  ),
+  _LocalOnlyDataQuery('conversations', 'SELECT 1 FROM conversations LIMIT 1'),
 ];
+
+class _LocalOnlyDataQuery {
+  const _LocalOnlyDataQuery(this.tableName, this.sql);
+
+  final String tableName;
+  final String sql;
+}
 
 /// Builds the shared database path from a platform-specific writable base.
 ///

--- a/mobile/packages/db_client/pubspec.yaml
+++ b/mobile/packages/db_client/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
     path: ../nostr_sdk
   path: ^1.9.1
   path_provider: ^2.1.5
+  sqlite3: ^2.7.6
 
 dev_dependencies:
   build_runner: ^2.7.1
@@ -27,5 +28,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  sqlite3: ^2.7.6
   very_good_analysis: ^10.2.0

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -247,16 +247,54 @@ void main() {
     test(
       'restores legacy DB when destination exists but has no local data',
       () async {
-        _createSqliteDatabase(legacyPath, rowCount: 1);
-        _createSqliteDatabase(newPath, rowCount: 0);
+        _createSqliteDatabase(legacyPath, draftCount: 1);
+        _createSqliteDatabase(newPath, draftCount: 0);
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
           newPath: newPath,
         );
 
-        expect(_localRecordCount(newPath), equals(1));
+        expect(_draftCount(newPath), equals(1));
         expect(File(legacyPath).existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'restores legacy DB when destination has only replaceable cache rows',
+      () async {
+        _createSqliteDatabase(legacyPath, draftCount: 1);
+        _createSqliteDatabase(newPath, eventCount: 1);
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        expect(_draftCount(newPath), equals(1));
+        expect(File(legacyPath).existsSync(), isFalse);
+        expect(File(_destinationBackupPath(newPath)).existsSync(), isTrue);
+        expect(_eventCount(_destinationBackupPath(newPath)), equals(1));
+      },
+    );
+
+    test(
+      'restores legacy DB when destination only has empty sidecars',
+      () async {
+        _createSqliteDatabase(legacyPath, draftCount: 1);
+        _createSqliteDatabase(newPath, draftCount: 0);
+        File('$newPath-wal').createSync();
+        File('$newPath-shm').createSync();
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        expect(_draftCount(newPath), equals(1));
+        expect(File(legacyPath).existsSync(), isFalse);
+        expect(File('$newPath-wal').existsSync(), isFalse);
+        expect(File('$newPath-shm').existsSync(), isFalse);
       },
     );
 
@@ -330,25 +368,47 @@ void main() {
   });
 }
 
-void _createSqliteDatabase(String path, {required int rowCount}) {
+void _createSqliteDatabase(
+  String path, {
+  int draftCount = 0,
+  int eventCount = 0,
+}) {
   File(path).parent.createSync(recursive: true);
   final db = sqlite3.open(path);
   try {
-    db.execute('CREATE TABLE local_records (id INTEGER PRIMARY KEY)');
-    for (var i = 0; i < rowCount; i += 1) {
-      db.execute('INSERT INTO local_records DEFAULT VALUES');
+    db.execute('CREATE TABLE drafts (id TEXT PRIMARY KEY)');
+    for (var i = 0; i < draftCount; i += 1) {
+      db.execute('INSERT INTO drafts (id) VALUES (?)', ['draft_$i']);
+    }
+
+    db.execute('CREATE TABLE event (id TEXT PRIMARY KEY)');
+    for (var i = 0; i < eventCount; i += 1) {
+      db.execute('INSERT INTO event (id) VALUES (?)', ['event_$i']);
     }
   } finally {
     db.dispose();
   }
 }
 
-int _localRecordCount(String path) {
+int _draftCount(String path) {
   final db = sqlite3.open(path);
   try {
-    return db.select('SELECT COUNT(*) AS count FROM local_records').first['count']
+    return db.select('SELECT COUNT(*) AS count FROM drafts').first['count']
         as int;
   } finally {
     db.dispose();
   }
 }
+
+int _eventCount(String path) {
+  final db = sqlite3.open(path);
+  try {
+    return db.select('SELECT COUNT(*) AS count FROM event').first['count']
+        as int;
+  } finally {
+    db.dispose();
+  }
+}
+
+String _destinationBackupPath(String path) =>
+    '$path.pre_legacy_migration_backup';

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -238,9 +238,12 @@ void main() {
           newPath: newPath,
         );
 
-        expect(File(legacyPath).existsSync(), isTrue);
-        expect(File(legacyPath).readAsBytesSync(), equals(const [1, 2, 3]));
+        expect(File(legacyPath).existsSync(), isFalse);
         expect(File(newPath).readAsBytesSync(), equals(const [9, 9, 9]));
+        expect(
+          File(_legacyConflictBackupPath(newPath)).readAsBytesSync(),
+          equals(const [1, 2, 3]),
+        );
       },
     );
 
@@ -343,8 +346,9 @@ void main() {
           newPath: newPath,
         );
 
-        expect(File(legacyPath).existsSync(), isTrue);
-        expect(_draftCount(legacyPath), equals(1));
+        final legacyBackupPath = _legacyConflictBackupPath(newPath);
+        expect(File(legacyPath).existsSync(), isFalse);
+        expect(_draftCount(legacyBackupPath), equals(1));
         expect(_pendingUploadCount(newPath), equals(1));
         expect(_pendingActionCount(newPath), equals(1));
         expect(File(_destinationBackupPath(newPath)).existsSync(), isFalse);
@@ -352,7 +356,7 @@ void main() {
     );
 
     test(
-      'preserves destination when both legacy and new databases have local data',
+      'preserves destination and backs up legacy beside it when both databases have local data',
       () async {
         _createSqliteDatabase(legacyPath, draftCount: 1);
         File('$legacyPath-wal').writeAsBytesSync(const [4]);
@@ -362,6 +366,9 @@ void main() {
         File('$newPath-wal').writeAsBytesSync(const [2]);
         File('$newPath-shm').writeAsBytesSync(const [3]);
 
+        expect(File('$legacyPath-wal').readAsBytesSync(), equals([4]));
+        expect(File('$legacyPath-shm').readAsBytesSync(), equals([5]));
+
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
           newPath: newPath,
@@ -369,8 +376,17 @@ void main() {
 
         expect(File(newPath).existsSync(), isTrue);
         expect(_draftCount(newPath), equals(1));
-        expect(_draftCount(legacyPath), equals(1));
+        expect(File(legacyPath).existsSync(), isFalse);
+        expect(File('$legacyPath-wal').existsSync(), isFalse);
+        expect(File('$legacyPath-shm').existsSync(), isFalse);
         expect(File(_destinationBackupPath(newPath)).existsSync(), isFalse);
+
+        final legacyBackupPath = _legacyConflictBackupPath(newPath);
+        expect(File(legacyBackupPath).existsSync(), isTrue);
+        expect(File('$legacyBackupPath-wal').readAsBytesSync(), equals([4]));
+        expect(File('$legacyBackupPath-shm').existsSync(), isTrue);
+        expect(File('$legacyBackupPath-shm').lengthSync(), greaterThan(0));
+        expect(_draftCount(legacyBackupPath), equals(1));
       },
     );
 
@@ -500,3 +516,5 @@ int _tableCount(String path, String table) {
 
 String _destinationBackupPath(String path) =>
     '$path.pre_legacy_migration_backup';
+
+String _legacyConflictBackupPath(String path) => '$path.legacy_conflict_backup';

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -244,7 +244,8 @@ void main() {
         expect(File(legacyPath).existsSync(), isFalse);
         expect(File(_destinationBackupPath(newPath)).existsSync(), isTrue);
         expect(_eventCount(_destinationBackupPath(newPath)), equals(1));
-        expect(File('$newPath-wal').readAsBytesSync(), equals([4]));
+        expect(File('$newPath-wal').existsSync(), isTrue);
+        expect(File('$newPath-wal').lengthSync(), greaterThan(0));
         expect(File('$newPath-shm').existsSync(), isTrue);
         expect(File('$newPath-shm').lengthSync(), greaterThan(0));
       },

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -40,10 +40,7 @@ void main() {
     test('uses Application Support-style base path with openvine/database', () {
       final path = buildSharedDatabasePath('/tmp/app-support');
 
-      expect(
-        path,
-        equals('/tmp/app-support/openvine/database/divine_db.db'),
-      );
+      expect(path, equals('/tmp/app-support/openvine/database/divine_db.db'));
     });
   });
 
@@ -73,25 +70,7 @@ void main() {
       applyDbCacheVersionReset(dbPath);
 
       expect(File(dbPath).existsSync(), isTrue);
-      expect(
-        File(dbPath).readAsBytesSync(),
-        equals(const [1, 2, 3]),
-      );
-      expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
-    });
-
-    test('adopts current version when stored version is stale', () {
-      Directory(dbDir).createSync(recursive: true);
-      File(dbPath).writeAsBytesSync(const [1]);
-      File('$dbPath-wal').writeAsBytesSync(const [2]);
-      File('$dbPath-shm').writeAsBytesSync(const [3]);
-      writeDbCacheVersion(dbDir, 1);
-
-      applyDbCacheVersionReset(dbPath);
-
-      expect(File(dbPath).existsSync(), isTrue);
-      expect(File('$dbPath-wal').existsSync(), isTrue);
-      expect(File('$dbPath-shm').existsSync(), isTrue);
+      expect(File(dbPath).readAsBytesSync(), equals(const [1, 2, 3]));
       expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
     });
 
@@ -118,10 +97,7 @@ void main() {
       applyDbCacheVersionReset(dbPath);
 
       expect(File(dbPath).existsSync(), isTrue);
-      expect(
-        File(dbPath).readAsBytesSync(),
-        equals(const [9, 9]),
-      );
+      expect(File(dbPath).readAsBytesSync(), equals(const [9, 9]));
     });
 
     test('no-op when DB does not exist and no version file', () {
@@ -222,30 +198,24 @@ void main() {
       expect(File(newPath).existsSync(), isTrue);
     });
 
-    test(
-      'preserves new DB when both legacy and new databases exist',
-      () async {
-        final legacyFile = File(legacyPath);
-        legacyFile.parent.createSync(recursive: true);
-        legacyFile.writeAsBytesSync(const [1, 2, 3]);
+    test('preserves new DB when both legacy and new databases exist', () async {
+      final legacyFile = File(legacyPath);
+      legacyFile.parent.createSync(recursive: true);
+      legacyFile.writeAsBytesSync(const [1, 2, 3]);
 
-        final newFile = File(newPath);
-        newFile.parent.createSync(recursive: true);
-        newFile.writeAsBytesSync(const [9, 9, 9]);
+      final newFile = File(newPath);
+      newFile.parent.createSync(recursive: true);
+      newFile.writeAsBytesSync(const [9, 9, 9]);
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
-        expect(File(legacyPath).existsSync(), isFalse);
-        expect(File(newPath).readAsBytesSync(), equals(const [9, 9, 9]));
-        expect(
-          File(_legacyConflictBackupPath(newPath)).readAsBytesSync(),
-          equals(const [1, 2, 3]),
-        );
-      },
-    );
+      expect(File(legacyPath).existsSync(), isFalse);
+      expect(File(newPath).readAsBytesSync(), equals(const [9, 9, 9]));
+      expect(
+        File(_legacyConflictBackupPath(newPath)).readAsBytesSync(),
+        equals(const [1, 2, 3]),
+      );
+    });
 
     test(
       'restores legacy DB when destination exists but has no local data',
@@ -253,10 +223,7 @@ void main() {
         _createSqliteDatabase(legacyPath, draftCount: 1);
         _createSqliteDatabase(newPath);
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         expect(_draftCount(newPath), equals(1));
         expect(File(legacyPath).existsSync(), isFalse);
@@ -267,17 +234,19 @@ void main() {
       'restores legacy DB when destination has only replaceable cache rows',
       () async {
         _createSqliteDatabase(legacyPath, draftCount: 1);
+        File('$legacyPath-wal').writeAsBytesSync(const [4]);
+        File('$legacyPath-shm').writeAsBytesSync(const [5]);
         _createSqliteDatabase(newPath, eventCount: 1);
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         expect(_draftCount(newPath), equals(1));
         expect(File(legacyPath).existsSync(), isFalse);
         expect(File(_destinationBackupPath(newPath)).existsSync(), isTrue);
         expect(_eventCount(_destinationBackupPath(newPath)), equals(1));
+        expect(File('$newPath-wal').readAsBytesSync(), equals([4]));
+        expect(File('$newPath-shm').existsSync(), isTrue);
+        expect(File('$newPath-shm').lengthSync(), greaterThan(0));
       },
     );
 
@@ -289,10 +258,7 @@ void main() {
         File('$newPath-wal').createSync();
         File('$newPath-shm').createSync();
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         expect(_draftCount(newPath), equals(1));
         expect(File(legacyPath).existsSync(), isFalse);
@@ -313,10 +279,7 @@ void main() {
         File('$newPath-wal').writeAsBytesSync(const [7]);
         File('$newPath-shm').writeAsBytesSync(const [8]);
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         final backupPath = _destinationBackupPath(newPath);
         expect(_draftCount(newPath), equals(1));
@@ -341,10 +304,7 @@ void main() {
           pendingActionStatuses: const ['pending'],
         );
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         final legacyBackupPath = _legacyConflictBackupPath(newPath);
         expect(File(legacyPath).existsSync(), isFalse);
@@ -369,10 +329,7 @@ void main() {
         expect(File('$legacyPath-wal').readAsBytesSync(), equals([4]));
         expect(File('$legacyPath-shm').readAsBytesSync(), equals([5]));
 
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         expect(File(newPath).existsSync(), isTrue);
         expect(_draftCount(newPath), equals(1));
@@ -387,6 +344,24 @@ void main() {
         expect(File('$legacyBackupPath-shm').existsSync(), isTrue);
         expect(File('$legacyBackupPath-shm').lengthSync(), greaterThan(0));
         expect(_draftCount(legacyBackupPath), equals(1));
+      },
+    );
+
+    test(
+      'deletes orphaned legacy database when neither side has actionable data',
+      () async {
+        _createSqliteDatabase(legacyPath);
+        File('$legacyPath-wal').writeAsBytesSync(const [4]);
+        File('$legacyPath-shm').writeAsBytesSync(const [5]);
+        _createSqliteDatabase(newPath, eventCount: 1);
+
+        await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+        expect(File(newPath).existsSync(), isTrue);
+        expect(_eventCount(newPath), equals(1));
+        expect(File(legacyPath).existsSync(), isFalse);
+        expect(File('$legacyPath-wal').existsSync(), isFalse);
+        expect(File('$legacyPath-shm').existsSync(), isFalse);
       },
     );
 

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:db_client/src/database/connection/connection_native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
 
 void main() {
   group('prepareDatabaseFile', () {
@@ -244,6 +245,22 @@ void main() {
     );
 
     test(
+      'restores legacy DB when destination exists but has no local data',
+      () async {
+        _createSqliteDatabase(legacyPath, rowCount: 1);
+        _createSqliteDatabase(newPath, rowCount: 0);
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        expect(_localRecordCount(newPath), equals(1));
+        expect(File(legacyPath).existsSync(), isFalse);
+      },
+    );
+
+    test(
       'preserves new DB sidecars when both legacy and new databases exist',
       () async {
         final legacyFile = File(legacyPath);
@@ -311,4 +328,27 @@ void main() {
       expect(File('$newPath-shm').existsSync(), isFalse);
     });
   });
+}
+
+void _createSqliteDatabase(String path, {required int rowCount}) {
+  File(path).parent.createSync(recursive: true);
+  final db = sqlite3.open(path);
+  try {
+    db.execute('CREATE TABLE local_records (id INTEGER PRIMARY KEY)');
+    for (var i = 0; i < rowCount; i += 1) {
+      db.execute('INSERT INTO local_records DEFAULT VALUES');
+    }
+  } finally {
+    db.dispose();
+  }
+}
+
+int _localRecordCount(String path) {
+  final db = sqlite3.open(path);
+  try {
+    return db.select('SELECT COUNT(*) AS count FROM local_records').first['count']
+        as int;
+  } finally {
+    db.dispose();
+  }
 }

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -238,16 +238,16 @@ void main() {
         File('$legacyPath-shm').writeAsBytesSync(const [5]);
         _createSqliteDatabase(newPath, eventCount: 1);
 
+        expect(File('$legacyPath-wal').existsSync(), isTrue);
+
         await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
 
         expect(_draftCount(newPath), equals(1));
         expect(File(legacyPath).existsSync(), isFalse);
+        expect(File('$legacyPath-wal').existsSync(), isFalse);
+        expect(File('$legacyPath-shm').existsSync(), isFalse);
         expect(File(_destinationBackupPath(newPath)).existsSync(), isTrue);
         expect(_eventCount(_destinationBackupPath(newPath)), equals(1));
-        expect(File('$newPath-wal').existsSync(), isTrue);
-        expect(File('$newPath-wal').lengthSync(), greaterThan(0));
-        expect(File('$newPath-shm').existsSync(), isTrue);
-        expect(File('$newPath-shm').lengthSync(), greaterThan(0));
       },
     );
 

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -79,7 +79,7 @@ void main() {
       expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
     });
 
-    test('deletes DB and sidecars when stored version is stale', () {
+    test('adopts current version when stored version is stale', () {
       Directory(dbDir).createSync(recursive: true);
       File(dbPath).writeAsBytesSync(const [1]);
       File('$dbPath-wal').writeAsBytesSync(const [2]);
@@ -88,9 +88,24 @@ void main() {
 
       applyDbCacheVersionReset(dbPath);
 
-      expect(File(dbPath).existsSync(), isFalse);
-      expect(File('$dbPath-wal').existsSync(), isFalse);
-      expect(File('$dbPath-shm').existsSync(), isFalse);
+      expect(File(dbPath).existsSync(), isTrue);
+      expect(File('$dbPath-wal').existsSync(), isTrue);
+      expect(File('$dbPath-shm').existsSync(), isTrue);
+      expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
+    });
+
+    test('preserves existing DB and sidecars when stored version is stale', () {
+      Directory(dbDir).createSync(recursive: true);
+      File(dbPath).writeAsBytesSync(const [1]);
+      File('$dbPath-wal').writeAsBytesSync(const [2]);
+      File('$dbPath-shm').writeAsBytesSync(const [3]);
+      writeDbCacheVersion(dbDir, 1);
+
+      applyDbCacheVersionReset(dbPath);
+
+      expect(File(dbPath).readAsBytesSync(), equals(const [1]));
+      expect(File('$dbPath-wal').readAsBytesSync(), equals(const [2]));
+      expect(File('$dbPath-shm').readAsBytesSync(), equals(const [3]));
       expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
     });
 

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -251,7 +251,7 @@ void main() {
       'restores legacy DB when destination exists but has no local data',
       () async {
         _createSqliteDatabase(legacyPath, draftCount: 1);
-        _createSqliteDatabase(newPath, draftCount: 0);
+        _createSqliteDatabase(newPath);
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
@@ -285,7 +285,7 @@ void main() {
       'restores legacy DB when destination only has empty sidecars',
       () async {
         _createSqliteDatabase(legacyPath, draftCount: 1);
-        _createSqliteDatabase(newPath, draftCount: 0);
+        _createSqliteDatabase(newPath);
         File('$newPath-wal').createSync();
         File('$newPath-shm').createSync();
 
@@ -302,7 +302,7 @@ void main() {
     );
 
     test(
-      'restores legacy DB and backs up non-empty destination sidecars when destination has no actionable local rows',
+      'backs up sidecars when destination has no actionable local rows',
       () async {
         _createSqliteDatabase(legacyPath, draftCount: 1);
         _createSqliteDatabase(
@@ -356,7 +356,7 @@ void main() {
     );
 
     test(
-      'preserves destination and backs up legacy beside it when both databases have local data',
+      'backs up legacy beside destination when both DBs have local data',
       () async {
         _createSqliteDatabase(legacyPath, draftCount: 1);
         File('$legacyPath-wal').writeAsBytesSync(const [4]);

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -222,7 +222,7 @@ void main() {
     });
 
     test(
-      'replaces new DB with legacy when both exist',
+      'preserves new DB when both legacy and new databases exist',
       () async {
         final legacyFile = File(legacyPath);
         legacyFile.parent.createSync(recursive: true);
@@ -237,18 +237,20 @@ void main() {
           newPath: newPath,
         );
 
-        // Legacy always wins — it predates the path change.
-        expect(File(legacyPath).existsSync(), isFalse);
-        expect(File(newPath).readAsBytesSync(), equals(const [1, 2, 3]));
+        expect(File(legacyPath).existsSync(), isTrue);
+        expect(File(legacyPath).readAsBytesSync(), equals(const [1, 2, 3]));
+        expect(File(newPath).readAsBytesSync(), equals(const [9, 9, 9]));
       },
     );
 
     test(
-      'cleans up new DB sidecars before replacing with legacy',
+      'preserves new DB sidecars when both legacy and new databases exist',
       () async {
         final legacyFile = File(legacyPath);
         legacyFile.parent.createSync(recursive: true);
         legacyFile.writeAsBytesSync(const [1]);
+        File('$legacyPath-wal').writeAsBytesSync(const [4]);
+        File('$legacyPath-shm').writeAsBytesSync(const [5]);
 
         final newFile = File(newPath);
         newFile.parent.createSync(recursive: true);
@@ -262,9 +264,12 @@ void main() {
         );
 
         expect(File(newPath).existsSync(), isTrue);
-        expect(File(newPath).readAsBytesSync(), equals(const [1]));
-        expect(File('$newPath-wal').existsSync(), isFalse);
-        expect(File('$newPath-shm').existsSync(), isFalse);
+        expect(File(newPath).readAsBytesSync(), equals(const [9]));
+        expect(File('$newPath-wal').readAsBytesSync(), equals(const [2]));
+        expect(File('$newPath-shm').readAsBytesSync(), equals(const [3]));
+        expect(File(legacyPath).readAsBytesSync(), equals(const [1]));
+        expect(File('$legacyPath-wal').readAsBytesSync(), equals(const [4]));
+        expect(File('$legacyPath-shm').readAsBytesSync(), equals(const [5]));
       },
     );
 

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -299,17 +299,66 @@ void main() {
     );
 
     test(
-      'preserves new DB sidecars when both legacy and new databases exist',
+      'restores legacy DB and backs up non-empty destination sidecars when destination has no actionable local rows',
       () async {
-        final legacyFile = File(legacyPath);
-        legacyFile.parent.createSync(recursive: true);
-        legacyFile.writeAsBytesSync(const [1]);
+        _createSqliteDatabase(legacyPath, draftCount: 1);
+        _createSqliteDatabase(
+          newPath,
+          pendingUploadStatuses: const ['published'],
+          pendingActionStatuses: const ['completed'],
+        );
+        File('$newPath-wal').writeAsBytesSync(const [7]);
+        File('$newPath-shm').writeAsBytesSync(const [8]);
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        final backupPath = _destinationBackupPath(newPath);
+        expect(_draftCount(newPath), equals(1));
+        expect(File(legacyPath).existsSync(), isFalse);
+        expect(File('$newPath-wal').existsSync(), isFalse);
+        expect(File('$newPath-shm').existsSync(), isFalse);
+        expect(File(backupPath).existsSync(), isTrue);
+        expect(File('$backupPath-wal').existsSync(), isTrue);
+        expect(File('$backupPath-shm').existsSync(), isTrue);
+        expect(File('$backupPath-wal').lengthSync(), greaterThan(0));
+        expect(File('$backupPath-shm').lengthSync(), greaterThan(0));
+      },
+    );
+
+    test(
+      'preserves destination when queue rows still require action',
+      () async {
+        _createSqliteDatabase(legacyPath, draftCount: 1);
+        _createSqliteDatabase(
+          newPath,
+          pendingUploadStatuses: const ['uploading'],
+          pendingActionStatuses: const ['pending'],
+        );
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        expect(File(legacyPath).existsSync(), isTrue);
+        expect(_draftCount(legacyPath), equals(1));
+        expect(_pendingUploadCount(newPath), equals(1));
+        expect(_pendingActionCount(newPath), equals(1));
+        expect(File(_destinationBackupPath(newPath)).existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'preserves destination when both legacy and new databases have local data',
+      () async {
+        _createSqliteDatabase(legacyPath, draftCount: 1);
         File('$legacyPath-wal').writeAsBytesSync(const [4]);
         File('$legacyPath-shm').writeAsBytesSync(const [5]);
 
-        final newFile = File(newPath);
-        newFile.parent.createSync(recursive: true);
-        newFile.writeAsBytesSync(const [9]);
+        _createSqliteDatabase(newPath, draftCount: 1);
         File('$newPath-wal').writeAsBytesSync(const [2]);
         File('$newPath-shm').writeAsBytesSync(const [3]);
 
@@ -319,12 +368,9 @@ void main() {
         );
 
         expect(File(newPath).existsSync(), isTrue);
-        expect(File(newPath).readAsBytesSync(), equals(const [9]));
-        expect(File('$newPath-wal').readAsBytesSync(), equals(const [2]));
-        expect(File('$newPath-shm').readAsBytesSync(), equals(const [3]));
-        expect(File(legacyPath).readAsBytesSync(), equals(const [1]));
-        expect(File('$legacyPath-wal').readAsBytesSync(), equals(const [4]));
-        expect(File('$legacyPath-shm').readAsBytesSync(), equals(const [5]));
+        expect(_draftCount(newPath), equals(1));
+        expect(_draftCount(legacyPath), equals(1));
+        expect(File(_destinationBackupPath(newPath)).existsSync(), isFalse);
       },
     );
 
@@ -372,6 +418,8 @@ void _createSqliteDatabase(
   String path, {
   int draftCount = 0,
   int eventCount = 0,
+  List<String> pendingUploadStatuses = const [],
+  List<String> pendingActionStatuses = const [],
 }) {
   File(path).parent.createSync(recursive: true);
   final db = sqlite3.open(path);
@@ -384,6 +432,32 @@ void _createSqliteDatabase(
     db.execute('CREATE TABLE event (id TEXT PRIMARY KEY)');
     for (var i = 0; i < eventCount; i += 1) {
       db.execute('INSERT INTO event (id) VALUES (?)', ['event_$i']);
+    }
+
+    db.execute('''
+      CREATE TABLE pending_uploads (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL
+      )
+    ''');
+    for (var i = 0; i < pendingUploadStatuses.length; i += 1) {
+      db.execute('INSERT INTO pending_uploads (id, status) VALUES (?, ?)', [
+        'upload_$i',
+        pendingUploadStatuses[i],
+      ]);
+    }
+
+    db.execute('''
+      CREATE TABLE pending_actions (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL
+      )
+    ''');
+    for (var i = 0; i < pendingActionStatuses.length; i += 1) {
+      db.execute('INSERT INTO pending_actions (id, status) VALUES (?, ?)', [
+        'action_$i',
+        pendingActionStatuses[i],
+      ]);
     }
   } finally {
     db.dispose();
@@ -404,6 +478,20 @@ int _eventCount(String path) {
   final db = sqlite3.open(path);
   try {
     return db.select('SELECT COUNT(*) AS count FROM event').first['count']
+        as int;
+  } finally {
+    db.dispose();
+  }
+}
+
+int _pendingUploadCount(String path) => _tableCount(path, 'pending_uploads');
+
+int _pendingActionCount(String path) => _tableCount(path, 'pending_actions');
+
+int _tableCount(String path, String table) {
+  final db = sqlite3.open(path);
+  try {
+    return db.select('SELECT COUNT(*) AS count FROM $table').first['count']
         as int;
   } finally {
     db.dispose();


### PR DESCRIPTION
## Summary

Saved edits and other local app data could disappear after reopening the app.
The confirmed bug was in native SQLite startup, not in the auth session cleanup path.
This change stops stale database version handling from deleting the active database and makes legacy database recovery preserve user data instead of guessing which database should win.

**Related Issue:** Part of #4577

## What Changed

The app now treats the local SQLite database as user data, not disposable cache.
It preserves the current database during version adoption and handles the old Documents-to-Application-Support path move safely.

- Preserve the current Application Support database when the stored database version is stale.
- Restore the legacy Documents database when the current destination is empty or only contains replaceable/cache state.
- Classify actionable local-only rows before deciding whether a destination database owns user data.
- Back up cache-only destination files and SQLite sidecars before restoring legacy data.
- When both databases contain active local rows, keep the current database active and move the legacy database beside it as a conflict backup.
- Move `sqlite3` to package dependencies because production startup code now reads SQLite metadata directly.

## Background

The two database locations come from a previous app-data path move.
PR #2840 changed the SQLite path from Documents to Application Support while fixing notifications; that location is defensible for hidden app data, but it originally shipped without a migration.
PR #2887 then added a one-time migration from the legacy Documents database to the new Application Support database.

This PR handles the cases left after that history.
Some users can have a stale version marker, an empty or cache-only destination database, or both a legacy database and a current database with local rows.
Those cases need data-preserving startup behavior instead of deleting, clobbering, or silently orphaning one database.

## Not Auth-Related

The original report mentioned account data and following state, so I checked that path separately.
The reproducible failure we found was SQLite data loss on app startup; same-user auth restore and the SharedPreferences following cache did not reproduce as the cause.

- This does not change OAuth session restore.
- This does not change `following_list_<pubkey>` SharedPreferences cache behavior.
- Focused follow/reopen E2E coverage is split into #4639.

## Testing

I tested the native database startup path directly and also verified the CI failure that appeared after the final review fix.
The regression tests cover stale version adoption, legacy restore over empty and cache-only destinations, actionable queue-row classification, sidecar backup, populated destination preservation, conflict backup, and WAL/SHM migration.

- `flutter analyze lib test` from `mobile/packages/db_client`
- `flutter test test/src/database/connection/connection_native_test.dart` from `mobile/packages/db_client`
- `mise exec -- flutter analyze lib test integration_test` from `mobile`

## Risks

The main risk is the conflicted two-database case.
This change preserves both databases there, but it does not merge rows automatically because drafts, pending actions, reactions, reposts, and direct messages can conflict.

- Current behavior: keep the current database active and save the legacy database as a conflict backup.
- Remaining work: add a deliberate reconciliation flow if we want to merge or surface those conflicts in the app.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
