### PR TITLE
test(auth): cover follow persistence after reopen

### DIFF
--- a/mobile/integration_test/auth/follow_reopen_persistence_test.dart
+++ b/mobile/integration_test/auth/follow_reopen_persistence_test.dart
@@ -1,0 +1,133 @@
+// ABOUTME: Verifies authenticated follow state survives app background/reopen
+// ABOUTME: Covers the #4577 auth/following persistence path end-to-end
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/providers/app_providers.dart';
+import 'package:patrol/patrol.dart';
+
+import '../helpers/db_helpers.dart';
+import '../helpers/navigation_helpers.dart';
+import '../helpers/relay_helpers.dart';
+import '../helpers/test_setup.dart';
+
+void main() {
+  group('Follow persistence after reopen', () {
+    patrolTest(
+      'authenticated following survives app reopen and repository reload',
+      ($) async {
+        final tester = $.tester;
+        final testEmail =
+            'follow-reopen-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';
+        const password = 'TestPass123!';
+
+        final originalOnError = suppressSetStateErrors();
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        final semanticsHandle = tester.ensureSemantics();
+
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        await navigateToCreateAccount(tester);
+        await registerNewUser(tester, testEmail, password);
+
+        final foundVerifyScreen = await waitForText(
+          tester,
+          'Complete your registration',
+        );
+        expect(
+          foundVerifyScreen,
+          isTrue,
+          reason: 'Registration should navigate to email verification',
+        );
+
+        final verifyToken = await getVerificationToken(testEmail);
+        expect(
+          verifyToken,
+          isNotEmpty,
+          reason: 'Local Keycast DB should contain verification token',
+        );
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MaterialApp)),
+        );
+        await container
+            .read(emailVerificationListenerProvider)
+            .handleUri(
+              Uri.parse(
+                'https://login.divine.video/verify-email?token=$verifyToken',
+              ),
+            );
+
+        final leftVerifyScreen = await waitForTextGone(
+          tester,
+          'Complete your registration',
+        );
+        expect(
+          leftVerifyScreen,
+          isTrue,
+          reason: 'Verification should complete and leave verification screen',
+        );
+        await pumpUntilSettled(tester, maxSeconds: 3);
+
+        final author = await publishTestVideoEvent(
+          title: 'Follow Reopen Persistence Video',
+        );
+        await publishTestProfileEvent(
+          name: 'Follow Reopen Author',
+          displayName: 'Follow Reopen Author',
+          about: 'E2E follow persistence author',
+          privateKey: author.privateKey,
+        );
+
+        final followRepository = container.read(followRepositoryProvider);
+        await followRepository.follow(author.pubkey);
+        expect(
+          followRepository.isFollowing(author.pubkey),
+          isTrue,
+          reason: 'FollowRepository should record the followed author',
+        );
+        expect(
+          container.read(cachedFollowingListProvider),
+          contains(author.pubkey),
+          reason: 'Cached following list should include the followed author',
+        );
+
+        await $.platformAutomator.mobile.pressHome();
+        await Future<void>.delayed(const Duration(seconds: 2));
+        await $.platformAutomator.mobile.openApp();
+        await tester.pump(const Duration(seconds: 3));
+
+        container.invalidate(followRepositoryProvider);
+        await tester.pump(const Duration(milliseconds: 250));
+        final reloadedFollowRepository = container.read(
+          followRepositoryProvider,
+        );
+        for (var i = 0; i < 40; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          if (reloadedFollowRepository.isFollowing(author.pubkey)) break;
+        }
+
+        expect(
+          reloadedFollowRepository.isFollowing(author.pubkey),
+          isTrue,
+          reason:
+              'Follow state should survive app reopen and repository reload',
+        );
+        expect(
+          container.read(cachedFollowingListProvider),
+          contains(author.pubkey),
+          reason: 'Cached following list should still include followed author',
+        );
+
+        semanticsHandle.dispose();
+        drainAsyncErrors(tester);
+        restoreErrorHandler(originalOnError);
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+      timeout: const Timeout(Duration(minutes: 4)),
+    );
+  });
+}

--- a/mobile/integration_test/auth/follow_reopen_persistence_test.dart
+++ b/mobile/integration_test/auth/follow_reopen_persistence_test.dart
@@ -116,6 +116,9 @@ void main() {
           reason:
               'Follow state should survive app reopen and repository reload',
         );
+        // cachedFollowingListProvider is keepAlive, so force it to re-read
+        // SharedPreferences rather than reusing the pre-background value.
+        container.invalidate(cachedFollowingListProvider);
         expect(
           container.read(cachedFollowingListProvider),
           contains(author.pubkey),


### PR DESCRIPTION
## Summary

The follow-cache part of #4577 needed direct coverage.
This adds a focused E2E test that signs in, follows a seeded author, backgrounds and reopens the app, then verifies the follow state still loads.
It keeps that auth/following check separate from the SQLite database recovery fix in #4637.

**Related Issue:** Part of #4577

## What Changed

This adds one focused Patrol journey for follow persistence across app reopen.
The test uses the real OAuth test flow and the real follow repository instead of only checking widget state.

- Register and verify a real OAuth-backed test user.
- Publish a seeded author/profile/video fixture.
- Follow the seeded author through `FollowRepository`.
- Verify both repository state and cached following-list provider state.
- Background and reopen the app through Patrol native automation.
- Recreate the follow repository provider and verify the follow still loads after reopen.

## Testing

I ran the focused E2E test against the local stack.
The run passed and showed cached follow state being loaded after `pressHome()` and `openApp()`.

- `mise run e2e_test integration_test/auth/follow_reopen_persistence_test.dart` from `mobile`
- `flutter analyze integration_test/auth/follow_reopen_persistence_test.dart` from `mobile`

## Risks

The risk is mostly E2E runtime cost and local-stack dependency.
The test is intentionally narrow so it covers the user journey without expanding #4637's SQLite fix.

- This does not change app behavior.
- This does not prove every auth/session path is correct.
- This specifically covers follow persistence after same-user app reopen.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Test coverage change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
