### PR TITLE
fix(feed): stop native feed playback when home is inactive

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -93,6 +93,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
   FeedAutoAdvanceCubit get _autoAdvanceCubit =>
       context.read<FeedAutoAdvanceCubit>();
   final _feedKey = GlobalKey<InfiniteVideoFeedState>();
+  bool _routeAllowsPlayback = true;
 
   /// Last error type reported per video.id to
   /// [VideoPlaybackStatusCubit]. Used to dedupe at the call site so
@@ -112,13 +113,6 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
   @override
   void didUpdateWidget(covariant FeedVideos oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.isActive != oldWidget.isActive) {
-      if (widget.isActive) {
-        _feedKey.currentState?.resumeActive();
-      } else {
-        _feedKey.currentState?.pauseActive();
-      }
-    }
     // When pagination settles (hasMore / isLoadingMore changed), flush any
     // pending auto-advance that was waiting on more content.
     if (widget.hasMore != oldWidget.hasMore ||
@@ -155,12 +149,14 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
 
   @override
   void didPushNext() {
-    _feedKey.currentState?.pauseActive();
+    if (!_routeAllowsPlayback) return;
+    setState(() => _routeAllowsPlayback = false);
   }
 
   @override
   void didPopNext() {
-    _feedKey.currentState?.resumeActive();
+    if (_routeAllowsPlayback) return;
+    setState(() => _routeAllowsPlayback = true);
   }
 
   bool _isAutoAdvanceAvailable() {
@@ -201,6 +197,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
+    final isFeedActive = widget.isActive && _routeAllowsPlayback;
     return BlocListener<VideoVolumeCubit, VideoVolumeState>(
       // Sync volume when hardware buttons change system volume.
       listener: (_, state) {
@@ -209,6 +206,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
       child: InfiniteVideoFeed(
         key: _feedKey,
         videos: widget.videos,
+        isActive: isFeedActive,
         // mediaCacheProvider is a keepAlive singleton; identity is stable for
         // the app lifetime, so ref.read is safe here. See
         // .claude/rules/state_management.md → "Bridging Riverpod-provided

--- a/mobile/lib/widgets/video_feed_item/paused_video_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/paused_video_overlay.dart
@@ -206,9 +206,10 @@ class _PausedVideoOverlayState extends State<PausedVideoOverlay>
         final isPaused = snapshot.data?.isPaused ?? false;
         final isPlaying = snapshot.data?.isPlaying ?? false;
 
+        final hasVisiblePausedFrame = isPaused && isFirstFrameRendered;
         final shouldShow =
             widget.isVisible &&
-            _hasStartedPlaying &&
+            (_hasStartedPlaying || hasVisiblePausedFrame) &&
             isPaused &&
             !isBuffering &&
             isFirstFrameRendered;

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -51,6 +51,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.onVideoStalled,
     this.slowLoadThreshold = const Duration(seconds: 8),
     this.preloadGracePeriod = const Duration(seconds: 3),
+    this.isActive = true,
     super.key,
   });
 
@@ -129,6 +130,12 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// Defaults to `1.0`. Use [InfiniteVideoFeedState.setVolume] to change the
   /// volume after the feed is mounted.
   final double initialVolume;
+
+  /// Whether the feed is allowed to play its active video.
+  ///
+  /// When `false`, the feed pauses the current video and suppresses any
+  /// internal resume/play side effects until it becomes active again.
+  final bool isActive;
 
   /// Hook: Called when the playback volume changes (mute/unmute/setVolume).
   ///
@@ -262,6 +269,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // Current playback volume applied to the active controller and all
   // controllers that become active. Seeded from widget.initialVolume.
   late double _volume;
+  late bool _isActive;
 
   // Generation counter for the player window so async neighbour-init can
   // detect that the user scrolled away mid-load.
@@ -292,12 +300,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
   /// Pauses the currently active video without changing the page.
   void pauseActive() {
-    unawaited(_controllers[_currentIndex]?.pause());
+    _setPlaybackActive(false);
   }
 
   /// Resumes the currently active video without changing the page.
   void resumeActive() {
-    unawaited(_controllers[_currentIndex]?.play());
+    _setPlaybackActive(true);
   }
 
   /// Sets the playback volume (0.0 silent, 1.0 full).
@@ -346,6 +354,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     super.initState();
     _currentIndex = widget.initialIndex;
     _volume = widget.initialVolume;
+    _isActive = widget.isActive;
     _pagePosition = ValueNotifier<double>(_currentIndex.toDouble());
     _pageController = PageController(initialPage: _currentIndex)
       ..addListener(_syncPagePosition);
@@ -374,6 +383,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   @override
   void didUpdateWidget(InfiniteVideoFeed oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.isActive != oldWidget.isActive) {
+      _setPlaybackActive(widget.isActive);
+    }
     if (widget.videos == oldWidget.videos) return;
 
     // Append-only: the new list starts with exactly the same items in the
@@ -463,14 +475,51 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
   // ─── Logging / setState wrapper ─────────────────────────────────────────
 
-  void _log(String message) => Log.debug(
-    message,
-    name: _logName,
-    category: LogCategory.video,
-  );
+  void _log(String message) =>
+      Log.debug(message, name: _logName, category: LogCategory.video);
 
   void _rebuild() {
     if (mounted) setState(() {});
+  }
+
+  void _setPlaybackActive(bool isActive) {
+    if (_isActive == isActive) return;
+    _isActive = isActive;
+    if (_isActive) {
+      _resumeCurrentPlaybackIfReady();
+    } else {
+      _pauseCurrentPlayback();
+    }
+  }
+
+  void _pauseCurrentPlayback() {
+    _watchdog.stop(_currentIndex);
+    _staleDetector.stop();
+    final controller = _controllers[_currentIndex];
+    if (controller != null && controller.isInitialized) {
+      unawaited(controller.pause());
+    }
+  }
+
+  void _resumeCurrentPlaybackIfReady() {
+    final controller = _controllers[_currentIndex];
+    if (controller == null || !controller.isInitialized) return;
+    unawaited(_activateCurrentController(controller, _currentIndex));
+  }
+
+  Future<void> _activateCurrentController(
+    DivineVideoPlayerController controller,
+    int index,
+  ) async {
+    if (!_isActive || index != _currentIndex || !controller.isInitialized) {
+      return;
+    }
+    await controller.setVolume(_volume);
+    if (!_isActive || index != _currentIndex) return;
+    await controller.play();
+    if (!_isActive || index != _currentIndex) return;
+    _watchdog.start(index, controller);
+    _staleDetector.start(index, controller);
   }
 
   // coverage:ignore-start
@@ -775,12 +824,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       await controller.setVolume(_volume);
       if (!guardInitOwnership('setVolume')) return;
 
-      if (index == _currentIndex) {
+      if (index == _currentIndex && _isActive) {
         _log('Playing index $index (${video.id})');
-        await controller.play();
+        await _activateCurrentController(controller, index);
         if (!guardInitOwnership('play')) return;
-        _watchdog.start(index, controller);
-        _staleDetector.start(index, controller);
       }
 
       _errors.remove(index);
@@ -877,11 +924,13 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     try {
       await controller.stop();
       await controller.setSource(VideoClip.network(nextSource));
-      if (index == _currentIndex) {
+      if (index == _currentIndex && _isActive) {
         await controller.setVolume(_volume);
         await controller.play();
-        _watchdog.start(index, controller);
-        _staleDetector.resetGrace();
+        if (index == _currentIndex && _isActive) {
+          _watchdog.start(index, controller);
+          _staleDetector.resetGrace();
+        }
       }
     } on Object catch (e, stackTrace) {
       _log('Source failover failed index $index source=$nextSource: $e');
@@ -1056,13 +1105,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     // Play the current video if it is already initialized. Otherwise
     // _initController will play it and start the watchdog + stale detector
     // once the source is ready.
-    if (_controllers.containsKey(index)) {
+    if (_isActive && _controllers.containsKey(index)) {
       final curr = _controllers[index]!;
       if (curr.isInitialized) {
-        unawaited(curr.setVolume(_volume));
-        unawaited(curr.play());
-        _watchdog.start(index, curr);
-        _staleDetector.start(index, curr);
+        unawaited(_activateCurrentController(curr, index));
       }
     }
 

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -892,7 +892,6 @@ void main() {
               InfiniteVideoFeed(
                 videos: [_makeVideo('reactivate')],
                 cache: cache,
-                isActive: true,
                 prefetchCount: 0,
                 preloadGracePeriod: Duration.zero,
               ),

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -14,6 +14,97 @@ class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
 
 class _MockCancellable extends Mock implements CancellableCacheOperation {}
 
+class _NativePlayerHarness {
+  _NativePlayerHarness(this.tester);
+
+  final WidgetTester tester;
+  final List<String> methodCalls = <String>[];
+  final Map<int, Completer<void>> setClipsDelays = <int, Completer<void>>{};
+  final Set<int> _installedPlayerIds = <int>{};
+  static const _globalChannel = MethodChannel('divine_video_player');
+  static const _codec = StandardMethodCodec();
+
+  Future<void> install({Iterable<int> playerIds = const <int>[0, 1, 2]}) async {
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      _globalChannel,
+      (call) async {
+        if (call.method == 'create') return <Object?, Object?>{};
+        return null;
+      },
+    );
+
+    for (final playerId in playerIds) {
+      _installedPlayerIds.add(playerId);
+      final playerChannel = MethodChannel(
+        'divine_video_player/player_$playerId',
+      );
+      final eventChannelName = 'divine_video_player/player_$playerId/events';
+
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        playerChannel,
+        (call) async {
+          methodCalls.add('player_$playerId:${call.method}');
+          if (call.method == 'setClips') {
+            final delay = setClipsDelays[playerId];
+            if (delay != null && !delay.isCompleted) {
+              await delay.future;
+            }
+          }
+          return null;
+        },
+      );
+
+      tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+        eventChannelName,
+        (message) async {
+          final call = _codec.decodeMethodCall(message);
+          if (call.method == 'listen') {
+            scheduleMicrotask(() async {
+              await sendEvent(playerId, const <Object?, Object?>{
+                'status': 'ready',
+                'videoWidth': 1280,
+                'videoHeight': 720,
+                'isFirstFrameRendered': true,
+              });
+            });
+          }
+          return _codec.encodeSuccessEnvelope(null);
+        },
+      );
+    }
+  }
+
+  int countCalls(String method) =>
+      methodCalls.where((call) => call.endsWith(':$method')).length;
+
+  Future<void> sendEvent(int playerId, Map<Object?, Object?> event) async {
+    final eventChannelName = 'divine_video_player/player_$playerId/events';
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      eventChannelName,
+      _codec.encodeSuccessEnvelope(event),
+      (_) {},
+    );
+  }
+
+  Future<void> dispose() async {
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      _globalChannel,
+      null,
+    );
+    for (final playerId in _installedPlayerIds) {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        MethodChannel('divine_video_player/player_$playerId'),
+        null,
+      );
+      tester.binding.defaultBinaryMessenger.setMockMessageHandler(
+        'divine_video_player/player_$playerId/events',
+        null,
+      );
+    }
+    _installedPlayerIds.clear();
+  }
+}
+
 VideoEvent _makeVideo(String id, {String? videoUrl}) => VideoEvent(
   id: id,
   pubkey: 'pk',
@@ -613,6 +704,209 @@ void main() {
         );
 
         expect(key.currentState!.currentIndex, equals(0));
+      });
+
+      testWidgets('does not autoplay when mounted inactive', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('inactive_mount')],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(0));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('does not autoplay after becoming inactive mid-init', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+        harness.setClipsDelays[0] = Completer<void>();
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('mid_init_pause')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('mid_init_pause')],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          harness.setClipsDelays[0]!.complete();
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(0));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('page change does not autoplay while inactive', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1]);
+        final key = GlobalKey<InfiniteVideoFeedState>();
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: [_makeVideo('page0'), _makeVideo('page1')],
+                cache: cache,
+                isActive: false,
+                keepPreviousAlive: false,
+                keepNextAlive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          unawaited(key.currentState!.animateToPage(1));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pump();
+
+          expect(key.currentState!.currentIndex, equals(1));
+          expect(harness.countCalls('play'), equals(0));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('source failover does not autoplay while inactive', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+
+        const divineUrl =
+            'https://media.divine.video/'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/'
+            '720p.mp4';
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('failover_inactive', videoUrl: divineUrl)],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await harness.sendEvent(0, const <Object?, Object?>{
+            'status': 'error',
+            'errorCode': 'parse_error',
+            'errorMessage': 'parse failed',
+          });
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('setClips'), greaterThanOrEqualTo(2));
+          expect(harness.countCalls('play'), equals(0));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('autoplays current controller when reactivated', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('reactivate')],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+          expect(harness.countCalls('play'), equals(0));
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('reactivate')],
+                cache: cache,
+                isActive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(1));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
       });
     });
 

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -780,6 +780,67 @@ void main() {
         }
       });
 
+      testWidgets('autoplays after returning active from mid-init inactivity', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+        harness.setClipsDelays[0] = Completer<void>();
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('mid_init_route_return')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('mid_init_route_return')],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          harness.setClipsDelays[0]!.complete();
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(0));
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('mid_init_route_return')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(1));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
       testWidgets('page change does not autoplay while inactive', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Widget tests for FeedVideos — covers loading/restricted overlay,
 // ABOUTME: overlay mode switching (forbidden/ageRestricted/contentWarning/interactive),
-// ABOUTME: isActive toggling, and pagination flush via didUpdateWidget.
+// ABOUTME: effective isActive propagation, route-aware pausing, and pagination flush.
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
@@ -21,6 +21,7 @@ import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
@@ -74,10 +75,7 @@ const _testVideoId =
 const _testPubkey =
     'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3';
 
-VideoEvent _makeVideo({
-  String? id,
-  List<String> warnLabels = const [],
-}) {
+VideoEvent _makeVideo({String? id, List<String> warnLabels = const []}) {
   return VideoEvent(
     id: id ?? _testVideoId,
     pubkey: _testPubkey,
@@ -147,9 +145,7 @@ extension _RepostsRepoStub on _MockRepostsRepository {
     when(
       watchRepostedAddressableIds,
     ).thenAnswer((_) => const Stream<Set<String>>.empty());
-    when(
-      () => getRepostCountByEventId(any()),
-    ).thenAnswer((_) async => 0);
+    when(() => getRepostCountByEventId(any())).thenAnswer((_) async => 0);
   }
 }
 
@@ -202,6 +198,7 @@ Future<void> _pumpFeedVideos(
   bool hasMore = false,
   bool isLoadingMore = false,
   void Function(VideoEvent, int)? onActiveVideoChanged,
+  List<NavigatorObserver> navigatorObservers = const <NavigatorObserver>[],
 }) async {
   final mockPlaybackCubit =
       videoPlaybackStatusCubit ??
@@ -227,6 +224,7 @@ Future<void> _pumpFeedVideos(
     UncontrolledProviderScope(
       container: container,
       child: MaterialApp(
+        navigatorObservers: navigatorObservers,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: MultiBlocProvider(
@@ -391,25 +389,24 @@ void main() {
       },
     );
 
-    testWidgets(
-      'shows $ContentWarningBlurOverlay when video has warnLabels',
-      (tester) async {
-        final video = _makeVideo(warnLabels: ['nsfw']);
-        final cubit = _MockVideoPlaybackStatusCubit()
-          ..stub(PlaybackStatus.ready, video.id);
+    testWidgets('shows $ContentWarningBlurOverlay when video has warnLabels', (
+      tester,
+    ) async {
+      final video = _makeVideo(warnLabels: ['nsfw']);
+      final cubit = _MockVideoPlaybackStatusCubit()
+        ..stub(PlaybackStatus.ready, video.id);
 
-        await _pumpFeedVideos(
-          tester,
-          videos: [video],
-          videoPlaybackStatusCubit: cubit,
-        );
-        await tester.pump();
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        videoPlaybackStatusCubit: cubit,
+      );
+      await tester.pump();
 
-        expect(find.byType(ContentWarningBlurOverlay), findsOneWidget);
-        // Neither moderation overlay should be showing.
-        expect(find.byType(ModeratedContentOverlay), findsNothing);
-      },
-    );
+      expect(find.byType(ContentWarningBlurOverlay), findsOneWidget);
+      // Neither moderation overlay should be showing.
+      expect(find.byType(ModeratedContentOverlay), findsNothing);
+    });
 
     testWidgets(
       'shows interactive overlay when status is ready and no content warning',
@@ -461,82 +458,123 @@ void main() {
     });
   });
 
+  group('activity wiring', () {
+    testWidgets('passes widget isActive through to InfiniteVideoFeed', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+
+      await _pumpFeedVideos(tester, videos: [video], isActive: false);
+      await tester.pump();
+
+      final feed = tester.widget<InfiniteVideoFeed>(
+        find.byType(InfiniteVideoFeed),
+      );
+      expect(feed.isActive, isFalse);
+    });
+
+    testWidgets('route-aware callbacks toggle InfiniteVideoFeed activity', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        navigatorObservers: <NavigatorObserver>[routeObserver],
+      );
+      await tester.pump();
+
+      final feedFinder = find.byType(InfiniteVideoFeed);
+      final state = tester.state<FeedVideosState>(find.byType(FeedVideos));
+
+      expect(tester.widget<InfiniteVideoFeed>(feedFinder).isActive, isTrue);
+
+      state.didPushNext();
+      await tester.pump();
+      expect(tester.widget<InfiniteVideoFeed>(feedFinder).isActive, isFalse);
+
+      state.didPopNext();
+      await tester.pump();
+      expect(tester.widget<InfiniteVideoFeed>(feedFinder).isActive, isTrue);
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Pagination flush (didUpdateWidget)
   // -------------------------------------------------------------------------
   group('pagination flush', () {
-    testWidgets(
-      'does not throw when hasMore and isLoadingMore change',
-      (tester) async {
-        final video = _makeVideo();
-        var hasMore = false;
-        var isLoadingMore = false;
-        late StateSetter rebuildState;
+    testWidgets('does not throw when hasMore and isLoadingMore change', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+      var hasMore = false;
+      var isLoadingMore = false;
+      late StateSetter rebuildState;
 
-        final mockPlaybackCubit = _MockVideoPlaybackStatusCubit()
-          ..stub(PlaybackStatus.ready, video.id);
-        final mockAutoAdvanceCubit = _MockFeedAutoAdvanceCubit()
-          ..stub(const FeedAutoAdvanceState());
-        final mockVolumeCubit = _MockVideoVolumeCubit()..stub();
+      final mockPlaybackCubit = _MockVideoPlaybackStatusCubit()
+        ..stub(PlaybackStatus.ready, video.id);
+      final mockAutoAdvanceCubit = _MockFeedAutoAdvanceCubit()
+        ..stub(const FeedAutoAdvanceState());
+      final mockVolumeCubit = _MockVideoVolumeCubit()..stub();
 
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: ProviderContainer(overrides: _buildOverrides().cast()),
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: MultiBlocProvider(
-                providers: [
-                  BlocProvider<FeedAutoAdvanceCubit>.value(
-                    value: mockAutoAdvanceCubit,
-                  ),
-                  BlocProvider<VideoPlaybackStatusCubit>.value(
-                    value: mockPlaybackCubit,
-                  ),
-                  BlocProvider<VideoVolumeCubit>.value(value: mockVolumeCubit),
-                ],
-                child: Scaffold(
-                  body: StatefulBuilder(
-                    builder: (context, setState) {
-                      rebuildState = setState;
-                      return FeedVideos(
-                        videos: [video],
-                        onNearEnd: () {},
-                        hasMore: hasMore,
-                        isLoadingMore: isLoadingMore,
-                      );
-                    },
-                  ),
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: ProviderContainer(overrides: _buildOverrides().cast()),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<FeedAutoAdvanceCubit>.value(
+                  value: mockAutoAdvanceCubit,
+                ),
+                BlocProvider<VideoPlaybackStatusCubit>.value(
+                  value: mockPlaybackCubit,
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: mockVolumeCubit),
+              ],
+              child: Scaffold(
+                body: StatefulBuilder(
+                  builder: (context, setState) {
+                    rebuildState = setState;
+                    return FeedVideos(
+                      videos: [video],
+                      onNearEnd: () {},
+                      hasMore: hasMore,
+                      isLoadingMore: isLoadingMore,
+                    );
+                  },
                 ),
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.pump(const Duration(seconds: 4));
+      await tester.pump(const Duration(seconds: 4));
 
-        // Simulate a pagination start.
-        rebuildState(() {
-          hasMore = true;
-          isLoadingMore = true;
-        });
-        // Advance past InfiniteVideoFeed's 3-second grace-period timer.
-        await tester.pump(const Duration(seconds: 4));
+      // Simulate a pagination start.
+      rebuildState(() {
+        hasMore = true;
+        isLoadingMore = true;
+      });
+      // Advance past InfiniteVideoFeed's 3-second grace-period timer.
+      await tester.pump(const Duration(seconds: 4));
 
-        // Simulate pagination complete.
-        rebuildState(() {
-          hasMore = false;
-          isLoadingMore = false;
-        });
-        // Drain any pending 3-second grace-period timers created by
-        // InfiniteVideoFeed._waitForFirstFrameOrGracePeriod so that the
-        // widget tree can be disposed cleanly by the test framework.
-        await tester.pump(const Duration(seconds: 4));
-        // Replace the widget tree to stop InfiniteVideoFeed's async chain
-        // from scheduling new timers, then drain the cleared queue.
-        await tester.pumpWidget(const SizedBox());
-        await tester.pump(const Duration(seconds: 4));
-      },
-    );
+      // Simulate pagination complete.
+      rebuildState(() {
+        hasMore = false;
+        isLoadingMore = false;
+      });
+      // Drain any pending 3-second grace-period timers created by
+      // InfiniteVideoFeed._waitForFirstFrameOrGracePeriod so that the
+      // widget tree can be disposed cleanly by the test framework.
+      await tester.pump(const Duration(seconds: 4));
+      // Replace the widget tree to stop InfiniteVideoFeed's async chain
+      // from scheduling new timers, then drain the cleared queue.
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump(const Duration(seconds: 4));
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/paused_video_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/paused_video_overlay_test.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
+import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
+
+class _FakeDivineVideoPlayerController extends DivineVideoPlayerController {
+  _FakeDivineVideoPlayerController() : super();
+
+  final _streamController =
+      StreamController<DivineVideoPlayerState>.broadcast();
+  DivineVideoPlayerState _state = const DivineVideoPlayerState();
+
+  @override
+  DivineVideoPlayerState get state => _state;
+
+  @override
+  Stream<DivineVideoPlayerState> get stateStream => _streamController.stream;
+
+  void pushState(DivineVideoPlayerState state) {
+    _state = state;
+    _streamController.add(state);
+  }
+
+  @override
+  Future<void> dispose() => _streamController.close();
+}
+
+void main() {
+  group(PausedVideoOverlay, () {
+    late _FakeDivineVideoPlayerController controller;
+
+    setUp(() {
+      controller = _FakeDivineVideoPlayerController();
+    });
+
+    tearDown(() async {
+      await controller.dispose();
+    });
+
+    Widget buildSubject() {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: PausedVideoOverlay(controller: controller),
+        ),
+      );
+    }
+
+    Finder findPlayControl() => find.byWidgetPredicate(
+      (widget) =>
+          widget is CenterPlaybackControl &&
+          widget.state == CenterPlaybackControlState.play,
+    );
+
+    testWidgets(
+      'shows play affordance for a first-frame paused controller even when '
+      'visible playback was never observed',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+
+        controller.pushState(
+          const DivineVideoPlayerState(
+            status: PlaybackStatus.paused,
+            isFirstFrameRendered: true,
+            videoWidth: 1280,
+            videoHeight: 720,
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 220));
+
+        expect(findPlayControl(), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #4640.

This fixes a regression in the native home-feed player path where feed audio could continue playing after the home feed became inactive, especially when opening the recorder while the active video was still initializing.

## Problem

The native `InfiniteVideoFeed` implementation only exposed imperative `pauseActive()` / `resumeActive()` methods. It did not have a durable internal playback-active state.

That meant async code paths inside the package could still call `play()` after the feed had already been paused:

- initial controller init completion
- page changes
- source failover

In the recorder repro from #4640, the home feed could be paused while the controller was still loading, then the async init would complete and unconditionally restart playback underneath the recorder.

The package also treated pause as only a direct controller pause. It did not stop the active watchdog and stale-playback detector when the feed became inactive.

## What changed

### `InfiniteVideoFeed`

- Added a declarative `isActive` input, defaulting to `true`.
- Introduced internal `_isActive` state so playback eligibility survives async work.
- Centralized active/inactive transitions:
  - inactive pauses the current controller when ready
  - inactive stops the load watchdog
  - inactive stops stale playback detection
  - active resumes the current ready controller and restarts watchdog/detector
- Gated all internal autoplay paths on `_isActive`:
  - controller init completion
  - page changes
  - source failover
- Kept `pauseActive()` / `resumeActive()` as public API, but made them thin wrappers over the same source of truth.

### `FeedVideos`

- Removed the imperative `didUpdateWidget` pause/resume side channel.
- Passed a declarative `isActive` flag into `InfiniteVideoFeed`.
- Combined parent activity with `RouteAware` visibility into one effective feed-active boolean.
- Kept route-aware pause/resume behavior for pushed routes, but now via declarative state instead of direct player pokes.

## Tests

Added race-focused coverage for the native player path:

- no autoplay when the feed mounts inactive
- no autoplay when the feed becomes inactive during controller init
- no autoplay on page change while inactive
- no autoplay on source failover while inactive
- playback resumes when the current controller becomes active again
- `FeedVideos` propagates effective activity into `InfiniteVideoFeed`
- route-aware callbacks toggle that activity state correctly

## Verification

Ran locally:

- `flutter analyze lib test integration_test`
- `flutter test packages/infinite_video_feed`
- `flutter test test/widgets/video_feed_item`
- `flutter test test/screens/feed`

These also re-ran as part of the branch push hook for the changed files.
