### PR TITLE
fix(invite): guard invite status lifecycle and auth gating

### DIFF
--- a/mobile/lib/blocs/invite_status/invite_status_cubit.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_cubit.dart
@@ -8,46 +8,71 @@ import 'package:invite_api_client/invite_api_client.dart';
 part 'invite_status_state.dart';
 
 class InviteStatusCubit extends Cubit<InviteStatusState> {
-  InviteStatusCubit({required InviteApiClient inviteApiClient})
-    : _inviteApiClient = inviteApiClient,
-      super(const InviteStatusState());
+  InviteStatusCubit({
+    required InviteApiClient inviteApiClient,
+    bool Function()? isInviteAuthReady,
+  }) : _inviteApiClient = inviteApiClient,
+       _isInviteAuthReady = isInviteAuthReady ?? (() => true),
+       super(const InviteStatusState());
 
   final InviteApiClient _inviteApiClient;
+  final bool Function() _isInviteAuthReady;
 
   Future<void> load() async {
     if (state.status == InviteStatusLoadingStatus.loading) return;
+    if (!_isInviteAuthReady()) return;
 
+    final previousState = state;
     emit(state.copyWith(status: InviteStatusLoadingStatus.loading));
     try {
       final inviteStatus = await _inviteApiClient.getInviteStatus();
-      emit(
+      _emitIfOpen(
         state.copyWith(
           status: InviteStatusLoadingStatus.loaded,
           inviteStatus: inviteStatus,
         ),
       );
+    } on InviteApiException catch (e) {
+      if (e.statusCode == 401) {
+        _emitIfOpen(previousState);
+        return;
+      }
+      rethrow;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(status: InviteStatusLoadingStatus.error));
+      _emitIfOpen(state.copyWith(status: InviteStatusLoadingStatus.error));
     }
   }
 
   Future<void> generateInvite() async {
     if (state.status == InviteStatusLoadingStatus.loading) return;
+    if (!_isInviteAuthReady()) return;
 
+    final previousState = state;
     emit(state.copyWith(status: InviteStatusLoadingStatus.loading));
     try {
       await _inviteApiClient.generateInvite();
       final inviteStatus = await _inviteApiClient.getInviteStatus();
-      emit(
+      _emitIfOpen(
         state.copyWith(
           status: InviteStatusLoadingStatus.loaded,
           inviteStatus: inviteStatus,
         ),
       );
+    } on InviteApiException catch (e) {
+      if (e.statusCode == 401) {
+        _emitIfOpen(previousState);
+        return;
+      }
+      rethrow;
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(status: InviteStatusLoadingStatus.error));
+      _emitIfOpen(state.copyWith(status: InviteStatusLoadingStatus.error));
     }
+  }
+
+  void _emitIfOpen(InviteStatusState nextState) {
+    if (isClosed) return;
+    emit(nextState);
   }
 }

--- a/mobile/lib/blocs/invite_status/invite_status_cubit.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_cubit.dart
@@ -32,15 +32,14 @@ class InviteStatusCubit extends Cubit<InviteStatusState> {
           inviteStatus: inviteStatus,
         ),
       );
-    } on InviteApiException catch (e) {
-      if (e.statusCode == 401) {
-        _emitIfOpen(previousState);
-        return;
-      }
-      rethrow;
+    } on InviteApiException catch (e, stackTrace) {
+      _handleInviteApiException(
+        previousState: previousState,
+        error: e,
+        stackTrace: stackTrace,
+      );
     } catch (e, stackTrace) {
-      addError(e, stackTrace);
-      _emitIfOpen(state.copyWith(status: InviteStatusLoadingStatus.error));
+      _emitErrorState(error: e, stackTrace: stackTrace);
     }
   }
 
@@ -59,20 +58,40 @@ class InviteStatusCubit extends Cubit<InviteStatusState> {
           inviteStatus: inviteStatus,
         ),
       );
-    } on InviteApiException catch (e) {
-      if (e.statusCode == 401) {
-        _emitIfOpen(previousState);
-        return;
-      }
-      rethrow;
+    } on InviteApiException catch (e, stackTrace) {
+      _handleInviteApiException(
+        previousState: previousState,
+        error: e,
+        stackTrace: stackTrace,
+      );
     } catch (e, stackTrace) {
-      addError(e, stackTrace);
-      _emitIfOpen(state.copyWith(status: InviteStatusLoadingStatus.error));
+      _emitErrorState(error: e, stackTrace: stackTrace);
     }
   }
 
   void _emitIfOpen(InviteStatusState nextState) {
     if (isClosed) return;
     emit(nextState);
+  }
+
+  void _handleInviteApiException({
+    required InviteStatusState previousState,
+    required InviteApiException error,
+    required StackTrace stackTrace,
+  }) {
+    if (error.statusCode == 401) {
+      _emitIfOpen(previousState);
+      return;
+    }
+
+    _emitErrorState(error: error, stackTrace: stackTrace);
+  }
+
+  void _emitErrorState({
+    required Object error,
+    required StackTrace stackTrace,
+  }) {
+    addError(error, stackTrace);
+    _emitIfOpen(state.copyWith(status: InviteStatusLoadingStatus.error));
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1926,6 +1926,8 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           BlocProvider(
             create: (context) => InviteStatusCubit(
               inviteApiClient: context.read<InviteApiClient>(),
+              isInviteAuthReady: () =>
+                  ref.read(nip98AuthServiceProvider).canCreateTokens,
             ),
           ),
           BlocProvider(

--- a/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
+++ b/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
@@ -1,5 +1,7 @@
 // ABOUTME: Unit tests for InviteStatusCubit
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:invite_api_client/invite_api_client.dart';
@@ -31,8 +33,11 @@ void main() {
       mockInviteApiClient = _MockInviteApiClient();
     });
 
-    InviteStatusCubit buildCubit() =>
-        InviteStatusCubit(inviteApiClient: mockInviteApiClient);
+    InviteStatusCubit buildCubit({bool Function()? isInviteAuthReady}) =>
+        InviteStatusCubit(
+          inviteApiClient: mockInviteApiClient,
+          isInviteAuthReady: isInviteAuthReady,
+        );
 
     test('initial state is correct', () {
       final cubit = buildCubit();
@@ -96,6 +101,16 @@ void main() {
     );
 
     blocTest<InviteStatusCubit, InviteStatusState>(
+      'load does not fetch when invite auth is not ready',
+      build: () => buildCubit(isInviteAuthReady: () => false),
+      act: (cubit) => cubit.load(),
+      expect: () => <InviteStatusState>[],
+      verify: (_) {
+        verifyNever(() => mockInviteApiClient.getInviteStatus());
+      },
+    );
+
+    blocTest<InviteStatusCubit, InviteStatusState>(
       'load after error re-fetches successfully',
       setUp: () {
         when(
@@ -116,15 +131,41 @@ void main() {
     );
 
     blocTest<InviteStatusCubit, InviteStatusState>(
+      'load restores previous state on expected 401 auth gap',
+      setUp: () {
+        when(() => mockInviteApiClient.getInviteStatus()).thenThrow(
+          const InviteApiException(
+            'Authorization header required',
+            statusCode: 401,
+            code: InviteApiErrorCode.authRequired,
+          ),
+        );
+      },
+      build: buildCubit,
+      seed: () => const InviteStatusState(
+        status: InviteStatusLoadingStatus.loaded,
+        inviteStatus: testStatus,
+      ),
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const InviteStatusState(
+          status: InviteStatusLoadingStatus.loading,
+          inviteStatus: testStatus,
+        ),
+        const InviteStatusState(
+          status: InviteStatusLoadingStatus.loaded,
+          inviteStatus: testStatus,
+        ),
+      ],
+      errors: () => <Object>[],
+    );
+
+    blocTest<InviteStatusCubit, InviteStatusState>(
       'generateInvite creates one code then reloads invite status',
       setUp: () {
-        when(
-          () => mockInviteApiClient.generateInvite(),
-        ).thenAnswer(
-          (_) async => const GenerateInviteResult(
-            code: 'WX56-3MKT',
-            remaining: 4,
-          ),
+        when(() => mockInviteApiClient.generateInvite()).thenAnswer(
+          (_) async =>
+              const GenerateInviteResult(code: 'WX56-3MKT', remaining: 4),
         );
         when(
           () => mockInviteApiClient.getInviteStatus(),
@@ -142,6 +183,43 @@ void main() {
       verify: (_) {
         verify(() => mockInviteApiClient.generateInvite()).called(1);
         verify(() => mockInviteApiClient.getInviteStatus()).called(1);
+      },
+    );
+
+    test(
+      'load does not emit after close when request completes late',
+      () async {
+        final completer = Completer<InviteStatus>();
+        when(
+          () => mockInviteApiClient.getInviteStatus(),
+        ).thenAnswer((_) => completer.future);
+
+        final cubit = buildCubit();
+        final emittedStates = <InviteStatusState>[];
+        final subscription = cubit.stream.listen(emittedStates.add);
+
+        unawaited(cubit.load());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emittedStates,
+          equals([
+            const InviteStatusState(status: InviteStatusLoadingStatus.loading),
+          ]),
+        );
+
+        await cubit.close();
+        completer.complete(testStatus);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emittedStates,
+          equals([
+            const InviteStatusState(status: InviteStatusLoadingStatus.loading),
+          ]),
+        );
+
+        await subscription.cancel();
       },
     );
 

--- a/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
+++ b/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
@@ -161,6 +161,26 @@ void main() {
     );
 
     blocTest<InviteStatusCubit, InviteStatusState>(
+      'load emits error on non-401 invite api failure',
+      setUp: () {
+        when(() => mockInviteApiClient.getInviteStatus()).thenThrow(
+          const InviteApiException(
+            'Invite service unavailable',
+            statusCode: 500,
+            code: InviteApiErrorCode.internalError,
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const InviteStatusState(status: InviteStatusLoadingStatus.loading),
+        const InviteStatusState(status: InviteStatusLoadingStatus.error),
+      ],
+      errors: () => [isA<InviteApiException>()],
+    );
+
+    blocTest<InviteStatusCubit, InviteStatusState>(
       'generateInvite creates one code then reloads invite status',
       setUp: () {
         when(() => mockInviteApiClient.generateInvite()).thenAnswer(
@@ -184,6 +204,26 @@ void main() {
         verify(() => mockInviteApiClient.generateInvite()).called(1);
         verify(() => mockInviteApiClient.getInviteStatus()).called(1);
       },
+    );
+
+    blocTest<InviteStatusCubit, InviteStatusState>(
+      'generateInvite emits error on non-401 invite api failure',
+      setUp: () {
+        when(() => mockInviteApiClient.generateInvite()).thenThrow(
+          const InviteApiException(
+            'Invite service unavailable',
+            statusCode: 500,
+            code: InviteApiErrorCode.internalError,
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.generateInvite(),
+      expect: () => [
+        const InviteStatusState(status: InviteStatusLoadingStatus.loading),
+        const InviteStatusState(status: InviteStatusLoadingStatus.error),
+      ],
+      errors: () => [isA<InviteApiException>()],
     );
 
     test(


### PR DESCRIPTION
## Summary

Fixes #4393.

This hardens `InviteStatusCubit` against the two failure modes currently showing up around invite-status loads:
- async completion after the cubit has already been closed
- expected cold-start auth gaps that briefly make invite requests unauthenticated and return `401 auth_required`

## Root cause

`InviteStatusCubit.load()` and `generateInvite()` emitted state unconditionally after awaited network work completed. If the settings surface or app shell disposed the cubit first, Bloc would raise an `emit after close` error.

Separately, invite-status loads could run before NIP-98 auth was ready to mint headers on cold start or resume. That produced a transient `401` from the invite service, which the cubit treated as a generic failure even though the underlying app session had not actually failed.

## What changed

- Added an `isInviteAuthReady` gate to `InviteStatusCubit` and wired it from `nip98AuthServiceProvider.canCreateTokens` in `main.dart`.
- Prevented invite-status requests from starting while invite auth is not ready.
- Restored the previous invite state instead of surfacing a generic error when the invite API returns the expected `401 auth_required` gap.
- Added `_emitIfOpen(...)` so late async completions do not emit after the cubit has been closed.
- Added focused tests for:
  - auth-not-ready no-op behavior
  - `401 auth_required` rollback to previous state
  - close-before-completion lifecycle safety

## Why this is safe

- The change is local to the invite cubit boundary and its provider wiring.
- Successful invite fetch and invite generation paths are unchanged.
- Unexpected failures still flow through `addError(...)` and the existing error state.
- The new auth gate only blocks invite calls when the app cannot currently create the required NIP-98 header.

## Validation

Local:
- `flutter test test/blocs/invite_status/invite_status_cubit_test.dart`
- `flutter analyze lib/blocs/invite_status/invite_status_cubit.dart lib/main.dart test/blocs/invite_status/invite_status_cubit_test.dart`
- pre-push repo gate: changed-file analyze + changed-file tests

Notes:
- A full `flutter analyze` in this checkout still reports the repo's pre-existing `avoid_print` infos in `integration_test_manual/`, `scripts/`, and `tools/`. The touched invite files are clean.
