### PR TITLE
fix(profile): render svg avatars without codec warnings

### DIFF
--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -53,6 +54,20 @@ class UserAvatar extends StatelessWidget {
   /// instead of the size-derived default.
   final double? cornerRadius;
 
+  @visibleForTesting
+  static bool isSvgImageUrl(String? url) {
+    if (url == null || url.isEmpty) return false;
+
+    final lower = url.toLowerCase();
+    if (lower.endsWith('.svg')) return true;
+
+    try {
+      return Uri.parse(url).path.toLowerCase().endsWith('.svg');
+    } on FormatException {
+      return false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final avatar = SizedBox.square(
@@ -91,33 +106,47 @@ class UserAvatar extends StatelessWidget {
 
   double get _borderWidth => size >= 120 ? 3 : 1;
 
+  bool get _hasNetworkImage => imageUrl != null && imageUrl!.isNotEmpty;
+
+  bool get _isSvgImageUrl => isSvgImageUrl(imageUrl);
+
+  Widget _buildPlaceholder() => _Placeholder(
+    size: size,
+    placeholderTone: placeholderTone,
+    placeholderSeed: placeholderSeed,
+    semanticLabel: semanticLabel,
+    imageUrl: imageUrl,
+    name: name,
+  );
+
   Widget _buildContent() {
     if (imageProvider != null) {
       return Image(
         image: imageProvider!,
         fit: BoxFit.cover,
-        errorBuilder: (context, error, stackTrace) => _Placeholder(
-          size: size,
-          placeholderTone: placeholderTone,
-          placeholderSeed: placeholderSeed,
-          semanticLabel: semanticLabel,
-          imageUrl: imageUrl,
-          name: name,
-        ),
+        errorBuilder: (context, error, stackTrace) => _buildPlaceholder(),
       );
     }
 
-    if (imageUrl != null && imageUrl!.isNotEmpty) {
+    if (_hasNetworkImage && _isSvgImageUrl) {
+      return SvgPicture.network(
+        imageUrl!,
+        fit: BoxFit.cover,
+        placeholderBuilder: (context) => _buildPlaceholder(),
+        errorBuilder: (context, error, stackTrace) {
+          UnifiedLogger.debug(
+            'Avatar SVG failed to load URL: $imageUrl - Error: $error',
+            name: 'UserAvatar',
+          );
+          return _buildPlaceholder();
+        },
+      );
+    }
+
+    if (_hasNetworkImage) {
       return VineCachedImage(
         imageUrl: imageUrl!,
-        placeholder: (context, url) => _Placeholder(
-          size: size,
-          placeholderTone: placeholderTone,
-          placeholderSeed: placeholderSeed,
-          semanticLabel: semanticLabel,
-          imageUrl: imageUrl,
-          name: name,
-        ),
+        placeholder: (context, url) => _buildPlaceholder(),
         errorWidget: (context, url, error) {
           if (error.toString().contains('Invalid image data') ||
               error.toString().contains('Image codec failed')) {
@@ -131,26 +160,12 @@ class UserAvatar extends StatelessWidget {
               name: 'UserAvatar',
             );
           }
-          return _Placeholder(
-            size: size,
-            placeholderTone: placeholderTone,
-            placeholderSeed: placeholderSeed,
-            semanticLabel: semanticLabel,
-            imageUrl: imageUrl,
-            name: name,
-          );
+          return _buildPlaceholder();
         },
       );
     }
 
-    return _Placeholder(
-      size: size,
-      placeholderTone: placeholderTone,
-      placeholderSeed: placeholderSeed,
-      semanticLabel: semanticLabel,
-      imageUrl: imageUrl,
-      name: name,
-    );
+    return _buildPlaceholder();
   }
 }
 

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -1,0 +1,145 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+final Uint8List _transparentImageBytes = Uint8List.fromList(<int>[
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0D,
+  0x0A,
+  0x2D,
+  0xB4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE,
+  0x42,
+  0x60,
+  0x82,
+]);
+
+void main() {
+  Widget buildAvatar({String? imageUrl}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: UserAvatar(imageUrl: imageUrl, name: 'Test User'),
+      ),
+    );
+  }
+
+  group('UserAvatar.isSvgImageUrl', () {
+    test('returns true for svg URLs', () {
+      expect(
+        UserAvatar.isSvgImageUrl('https://divine.video/divine-logo.svg'),
+        isTrue,
+      );
+      expect(
+        UserAvatar.isSvgImageUrl(
+          'https://divine.video/divine-logo.svg?size=128',
+        ),
+        isTrue,
+      );
+      expect(
+        UserAvatar.isSvgImageUrl(
+          'https://divine.video/assets/DIVINE-LOGO.SVG#avatar',
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-svg or invalid URLs', () {
+      expect(
+        UserAvatar.isSvgImageUrl('https://divine.video/avatar.png'),
+        isFalse,
+      );
+      expect(UserAvatar.isSvgImageUrl('not a url'), isFalse);
+      expect(UserAvatar.isSvgImageUrl(null), isFalse);
+      expect(UserAvatar.isSvgImageUrl(''), isFalse);
+    });
+  });
+
+  group('UserAvatar rendering', () {
+    testWidgets('keeps raster avatar URLs on VineCachedImage', (tester) async {
+      await tester.pumpWidget(
+        buildAvatar(imageUrl: 'https://divine.video/avatar.png'),
+      );
+
+      expect(find.byType(VineCachedImage), findsOneWidget);
+    });
+
+    testWidgets('renders direct image providers without network widgets', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UserAvatar(
+              imageProvider: MemoryImage(_transparentImageBytes),
+              name: 'Test User',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byType(VineCachedImage), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- render SVG avatar URLs through `SvgPicture.network` instead of raster decoding them through `VineCachedImage`
- keep the existing placeholder path for load failures and invalid avatar data
- add regression coverage for SVG URL classification and non-network avatar rendering branches

## Root Cause
Avatar URLs were always routed through the raster image cache path. When profile metadata or upstream defaults supplied an `.svg` URL, Flutter attempted bitmap decoding, logged codec warnings, and rebuilt the placeholder repeatedly.

## Changes
- add `UserAvatar.isSvgImageUrl(...)` so SVG URL detection is explicit and regression-tested
- branch SVG network avatars to `SvgPicture.network` with the same placeholder safety net
- keep raster URLs on `VineCachedImage` and keep direct `imageProvider` inputs on the existing local image path

## Safety
- raster avatar behavior is unchanged
- invalid or failed SVG loads still fall back to the existing placeholder
- the regression tests avoid brittle network mocking and cover the branch selection logic directly

## Validation
- `flutter test test/widgets/user_avatar_svg_test.dart`
- `flutter analyze lib/widgets/user_avatar.dart test/widgets/user_avatar_svg_test.dart`
- pre-push changed-file analyzer and test gates

Fixes #4647
