### PR TITLE
fix(feed): cancel video feed subscriptions on close

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -84,6 +84,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   final Duration _autoRefreshMinInterval;
   final FeedPerformanceTracker? _feedTracker;
   final HomeFeedCache _homeFeedCache;
+  StreamSubscription<List<String>>? _followingSubscription;
+  StreamSubscription<List<CuratedList>>? _curatedListsSubscription;
 
   /// Whether the cache has already been served for this BLoC instance.
   ///
@@ -113,9 +115,6 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   ///
   /// Also subscribes to [CuratedListRepository.subscribedListsStream]
   /// (skipping the first replay) so curated list changes refresh the feed.
-  ///
-  /// Both subscriptions use `unawaited` on the first so neither blocks the
-  /// other — `emit.onEach` never completes for BehaviorSubject streams.
   ///
   /// If a feed mode was previously saved to SharedPreferences, that mode is
   /// restored. Otherwise [event.mode] is used.
@@ -149,6 +148,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     );
 
     await _loadVideos(source, emit);
+    if (emit.isDone) return;
 
     // After the initial load, check for the "no follows" CTA. Needed for
     // BLoC re-creation (e.g. navigating back to home) when the follow repo
@@ -169,6 +169,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       }
     }
 
+    if (emit.isDone) return;
+
+    await _followingSubscription?.cancel();
+    await _curatedListsSubscription?.cancel();
+
     // Subscribe to following list changes.
     //
     // The first replay can mean one of two things:
@@ -180,27 +185,39 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     // Distinguish those cases by comparing the first replay with the list
     // used for the initial fetch instead of relying on isInitialized.
     var isFirstFollowingEmission = true;
-    unawaited(
-      emit.onEach<List<String>>(
-        _followRepository.followingStream,
-        onData: (pubkeys) {
-          if (isFirstFollowingEmission) {
-            isFirstFollowingEmission = false;
-            if (_listsEqual(pubkeys, initialFollowingPubkeys)) {
-              return;
-            }
-          }
+    _followingSubscription = _followRepository.followingStream.listen((
+      pubkeys,
+    ) {
+      if (isFirstFollowingEmission) {
+        isFirstFollowingEmission = false;
+        if (_listsEqual(pubkeys, initialFollowingPubkeys)) {
+          return;
+        }
+      }
 
-          add(VideoFeedFollowingListChanged(pubkeys));
-        },
-      ),
-    );
+      _addIfOpen(VideoFeedFollowingListChanged(pubkeys));
+    });
 
     // Subscribe to curated list changes.
-    await emit.onEach<List<CuratedList>>(
-      _curatedListRepository.subscribedListsStream.skip(1),
-      onData: (lists) => add(VideoFeedCuratedListsChanged(lists)),
-    );
+    _curatedListsSubscription = _curatedListRepository.subscribedListsStream
+        .skip(1)
+        .listen((lists) {
+          _addIfOpen(VideoFeedCuratedListsChanged(lists));
+        });
+  }
+
+  void _addIfOpen(VideoFeedEvent event) {
+    if (isClosed) return;
+    add(event);
+  }
+
+  @override
+  Future<void> close() async {
+    await _followingSubscription?.cancel();
+    await _curatedListsSubscription?.cancel();
+    _followingSubscription = null;
+    _curatedListsSubscription = null;
+    return super.close();
   }
 
   VideoFeedSource _restoreSource(FeedMode fallbackMode) {

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -2029,7 +2029,7 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'subscribes to subscribedListsStream via emit.onEach on startup',
+        'subscribes to subscribedListsStream on startup',
         setUp: () {
           final videos = createTestVideos(pageSize);
 
@@ -2153,12 +2153,39 @@ void main() {
 
     group('close', () {
       test('does not throw when stream emits after close', () async {
+        final videos = createTestVideos(pageSize);
+
+        when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
+        when(
+          () => mockVideosRepository.getHomeFeedVideos(
+            authors: any(named: 'authors'),
+            videoRefs: any(named: 'videoRefs'),
+            userPubkey: any(named: 'userPubkey'),
+            limit: any(named: 'limit'),
+            until: any(named: 'until'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+
         final bloc = createBloc();
+        bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(followingController.hasListener, isTrue);
+        expect(curatedListsController.hasListener, isTrue);
 
         await bloc.close();
+        expect(followingController.hasListener, isFalse);
+        expect(curatedListsController.hasListener, isFalse);
 
         // After closing, stream events should not cause errors
         expect(() => followingController.add(['a']), returnsNormally);
+        expect(
+          () => curatedListsController.add([createTestList()]),
+          returnsNormally,
+        );
+        await Future<void>.delayed(Duration.zero);
       });
     });
 


### PR DESCRIPTION
## Summary
- replace `emit.onEach` startup listeners in `VideoFeedBloc` with explicitly owned `StreamSubscription`s
- cancel feed subscriptions during bloc shutdown and guard internal `add(...)` calls after close
- extend the bloc regression test to prove both listeners are torn down before post-close stream emissions

## Root Cause
`VideoFeedStarted` installed long-lived stream listeners without owning their lifecycle in `close()`. During navigation away from Home, a late follow or curated-list emission could still call `add(...)` after bloc shutdown and throw `Bad state: Cannot add new events after calling close`.

## Changes
- store startup subscriptions for `followingStream` and `subscribedListsStream` on the bloc
- cancel and clear those subscriptions in `close()` before delegating to `super.close()`
- use a small `_addIfOpen(...)` guard for any callback racing with shutdown
- keep the existing first-following-emission dedupe behavior intact

## Safety
- no feed selection or fetch behavior changed outside shutdown handling
- subscriptions are still created only after the initial load completes
- tests now verify both listener cleanup and post-close stream safety

## Validation
- `flutter analyze lib/blocs/video_feed/video_feed_bloc.dart test/blocs/video_feed/video_feed_bloc_test.dart`
- `flutter test test/blocs/video_feed/video_feed_bloc_test.dart`
- pre-push changed-file analyzer and test gates

Fixes #4644
