### PR TITLE
fix(video): fail over on critical ready-state playback errors

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -1722,11 +1722,12 @@ class VideoFeedController extends ChangeNotifier {
       // Classify the error immediately so the type is available if retry
       // exhausts all sources and _markLoadError is called without a message.
       _errorTypes[index] = _classifyError(error, index);
-      // Only act on errors during initial load. Once the video is playing
-      // successfully (LoadState.ready), mpv may emit non-critical errors
-      // (e.g. on loop seeks, transient network hiccups) that should not
-      // trigger a source failover.
-      if (loadState == LoadState.loading) {
+      // Only fail over on ready-state errors when the error is classified as
+      // a critical source failure (401/403/404). Generic ready-state errors
+      // are often transient mpv noise during loops or rebuffers.
+      if (loadState == LoadState.loading ||
+          (loadState == LoadState.ready &&
+              _errorTypes[index] != VideoErrorType.generic)) {
         unawaited(_retryCurrentVideoWithNextSource(index));
       }
     });

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -4827,7 +4827,7 @@ void main() {
         controller.dispose();
       });
 
-      test('error during ready state does not retry', () async {
+      test('generic error during ready state does not retry', () async {
         final controller = VideoFeedController(
           videos: createTestVideos(count: 1),
           pool: pool,
@@ -4857,6 +4857,44 @@ void main() {
         verifyNever(
           () => setup.player.open(any(), play: any(named: 'play')),
         );
+
+        controller.dispose();
+      });
+
+      test('404 error during ready state retries with next source', () async {
+        const hash =
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+        const rawUrl = 'https://media.divine.video/$hash';
+        const hlsUrl = 'https://media.divine.video/$hash/hls/master.m3u8';
+        final controller = VideoFeedController(
+          videos: const [VideoItem(id: 'divine-video', url: rawUrl)],
+          pool: pool,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final setup = playerSetups[rawUrl]!;
+
+        setup.bufferingController.add(false);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(controller.isVideoReady(0), isTrue);
+
+        clearInteractions(setup.player);
+
+        setup.errorController.add('404 Not Found');
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        verify(setup.player.pause).called(1);
+        verify(
+          () => setup.player.open(
+            any(that: isA<Media>().having((m) => m.uri, 'uri', hlsUrl)),
+            play: false,
+          ),
+        ).called(1);
+        expect(controller.getLoadState(0), equals(LoadState.ready));
 
         controller.dispose();
       });


### PR DESCRIPTION
## Summary
- treat classified 401/403/404 ready-state playback errors as real source failures in `VideoFeedController`
- keep ignoring generic ready-state player noise so loop/rebuffer churn does not trigger unnecessary source swaps
- add regression coverage for a Divine raw source that becomes ready, then 404s, and must fall through to HLS

## Root Cause
The controller only retried sources while `loadState == LoadState.loading`. If a raw or progressive Divine source opened successfully and only later emitted a hard 404-style player error, the error stream stored the classification but deliberately ignored failover because the player had already reached `LoadState.ready`.

## Changes
- allow `_retryCurrentVideoWithNextSource(...)` to run for ready-state errors when classification is not `VideoErrorType.generic`
- leave generic ready-state errors alone so non-critical mpv noise still does not flap sources
- update the existing ready-state error regression and add a 404-ready failover test that verifies pause + reopen on the HLS fallback

## Safety
- generic ready-state errors are still ignored
- initial load failover behavior is unchanged
- the new behavior only applies to already-classified critical source failures after ready

## Validation
- `flutter test test/controllers/video_feed_controller_test.dart` from `mobile/packages/pooled_video_player`
- `flutter analyze lib/src/controllers/video_feed_controller.dart test/controllers/video_feed_controller_test.dart` from `mobile/packages/pooled_video_player`
- pre-push changed-file analyzer and test gates

Fixes #4645
