### PR TITLE
fix(ios): update stale cupertino_http linker workaround

### DIFF
--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -185,7 +185,7 @@ post_install do |installer|
   cupertino_http_framework_re =
     /\s*-framework\s+(?:"cupertino_http"|'cupertino_http'|cupertino_http\b)/
   cupertino_http_keep_symbol =
-    '-u "__NativeCupertinoHttp_wrapListenerBlock_1pl9qdv"'
+    '-u "__NativeCupertinoHttp_wrapListenerBlock_1tz5yf"'
   linked_any = false
 
   installer.aggregate_targets.each do |aggregate_target|
@@ -199,7 +199,7 @@ post_install do |installer|
       linked_any ||= content.match?(cupertino_http_framework_re)
       new_content = content.dup
 
-      if new_content !~ /-u\s+"?__NativeCupertinoHttp_wrapListenerBlock_1pl9qdv"?/
+      if new_content !~ /-u\s+"?__NativeCupertinoHttp_wrapListenerBlock_1tz5yf"?/
         if new_content =~ /^OTHER_LDFLAGS\s*=\s*(.*)$/
           existing = Regexp.last_match(1).strip
           replacement = "OTHER_LDFLAGS = #{existing} #{cupertino_http_keep_symbol}".strip


### PR DESCRIPTION
## Summary
- update the temporary iOS Podfile keep-symbol workaround for the current cupertino_http native binding suffix
- keep the existing workaround shape from #4146, but point it at the symbols actually emitted by cupertino_http 2.4.0
- verify CocoaPods integration rewrites the Runner xcconfigs with the new keep symbol in Debug, Profile, and Release

## Root Cause
The repository still force-linked the old __NativeCupertinoHttp_wrapListenerBlock_1pl9qdv symbol. After cupertino_http moved to the current 1tz5yf native binding suffix, iOS builds still linked the framework but no longer preserved the generated trampoline/objective-c entrypoints used at runtime. That is why production logs showed the missing _NativeCupertinoHttp_protocolTrampoline_1tz5yf warning and fell back to dart:io networking.

## Changes
- update the Podfile workaround to keep __NativeCupertinoHttp_wrapListenerBlock_1tz5yf
- update the Podfile regex guard so repeated pod install runs stay idempotent with the new symbol
- re-run pod install and confirm the generated Pods-Runner.debug.xcconfig, Pods-Runner.profile.xcconfig, and Pods-Runner.release.xcconfig each contain the cupertino_http framework link plus the new keep symbol

## Safety
- this is scoped to the existing cupertino_http workaround only; no app Dart code or runtime networking logic changed
- the change stays aligned with the current generated symbols in cupertino_http 2.4.0 instead of widening the workaround further
- the Podfile remains idempotent across repeated CocoaPods installs

## Validation
Local:
- flutter pub get
- pod install
- flutter analyze ios/Podfile
- inspected generated xcconfigs to confirm the new keep symbol is present in Debug, Profile, and Release
- release-style simulator xcodebuild advanced past the previous Swift package deployment-target blocker and into normal Runner build phases; it then stopped at Flutters expected simulator packaging guard for release/profile builds

Notes:
- This follows up on the existing workaround tracked in #4146; it does not remove that workaround yet.

Fixes #4646
Refs #4146