### PR TITLE
fix(notifications): guard owned-video notification attribution

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1038,6 +1038,18 @@ class NotificationRepository {
       if (!isVideoAnchored(kind)) continue;
       final eventId = _videoAnchorEventId(kind, n);
       if (eventId == null || eventId.isEmpty) continue;
+      if (_hasKnownReferencedVideoOwnerMismatch(
+        referencedVideoEventId: eventId,
+        videosById: videosById,
+      )) {
+        _logDroppedKnownOwnerMismatch(
+          notificationId: n.id,
+          sourcePubkey: n.sourcePubkey,
+          referencedVideoEventId: eventId,
+          referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
+        );
+        continue;
+      }
       final key = _VideoGroupKey(eventId, kind);
       (groups[key] ??= []).add(n);
     }
@@ -1060,7 +1072,10 @@ class NotificationRepository {
       final dTag = group
           .map((n) => n.referencedDTag)
           .firstWhere((d) => d != null, orElse: () => null);
-      final addressableId = _buildVideoAddressableId(dTag);
+      final addressableId = _buildVideoAddressableId(
+        dTag,
+        ownerPubkey: video?.pubkey,
+      );
       // Prefer thumbnail from the notification payload — it comes directly from
       // the server and is stable even after a metadata update (unlike the stats
       // lookup which uses the mutable event ID and may 404 post-edit).
@@ -1182,7 +1197,22 @@ class NotificationRepository {
     if (isVideoAnchored) {
       if (referenced == null || referenced.isEmpty) return null;
       final video = videosById[referenced];
-      final addressableId = _buildVideoAddressableId(raw.referencedDTag);
+      if (_hasKnownReferencedVideoOwnerMismatch(
+        referencedVideoEventId: referenced,
+        videosById: videosById,
+      )) {
+        _logDroppedKnownOwnerMismatch(
+          notificationId: raw.id,
+          sourcePubkey: raw.sourcePubkey,
+          referencedVideoEventId: referenced,
+          referencedVideoOwnerPubkey: video?.pubkey,
+        );
+        return null;
+      }
+      final addressableId = _buildVideoAddressableId(
+        raw.referencedDTag,
+        ownerPubkey: video?.pubkey,
+      );
       return VideoNotification(
         id: raw.dedupeKey,
         type: kind,
@@ -1261,15 +1291,16 @@ class NotificationRepository {
     _ => null,
   };
 
-  /// Builds the stable NIP-33 addressable ID for a video the current
-  /// user owns.
-  ///
-  /// All notifications surfaced here are about the current user's own
-  /// content, so [_userPubkey] is always the right author component.
+  /// Builds the stable NIP-33 addressable ID for a referenced video whose
+  /// owner is known.
   /// Returns null when the server didn't provide a usable [dTag].
-  String? _buildVideoAddressableId(String? dTag) {
+  static String? _buildVideoAddressableId(
+    String? dTag, {
+    required String? ownerPubkey,
+  }) {
     if (dTag == null || dTag.isEmpty) return null;
-    return '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag';
+    if (ownerPubkey == null || ownerPubkey.isEmpty) return null;
+    return '${NIP71VideoKinds.addressableShortVideo}:$ownerPubkey:$dTag';
   }
 
   /// Returns the stable NIP-33 addressable ID for an actor-anchored
@@ -1282,13 +1313,40 @@ class NotificationRepository {
   /// realtime path ([enrichOne]) to stay in lockstep.
   String? _actorVideoAddressableId(
     NotificationKind mapped,
-    RelayNotification n,
+    RelayNotification notification,
   ) {
-    if (mapped != NotificationKind.likeComment &&
-        mapped != NotificationKind.reply) {
-      return null;
-    }
-    return _buildVideoAddressableId(n.referencedDTag);
+    // The current payload does not include the owning pubkey for the parent
+    // video, so synthesizing a stable route here can point at the wrong
+    // creator's addressable video. Fall back to resolver-based navigation
+    // until the API includes an authoritative owner component.
+    return null;
+  }
+
+  bool _hasKnownReferencedVideoOwnerMismatch({
+    required String referencedVideoEventId,
+    required Map<String, VideoStats> videosById,
+  }) {
+    final ownerPubkey = videosById[referencedVideoEventId]?.pubkey;
+    if (ownerPubkey == null || ownerPubkey.isEmpty) return false;
+    return ownerPubkey != _userPubkey;
+  }
+
+  void _logDroppedKnownOwnerMismatch({
+    required String notificationId,
+    required String sourcePubkey,
+    required String referencedVideoEventId,
+    required String? referencedVideoOwnerPubkey,
+  }) {
+    Log.warning(
+      'Dropping misattributed video notification: '
+      'notificationId=$notificationId '
+      'sourcePubkey=$sourcePubkey '
+      'referencedVideoEventId=$referencedVideoEventId '
+      'referencedVideoOwnerPubkey=${referencedVideoOwnerPubkey ?? 'unknown'} '
+      'currentUserPubkey=$_userPubkey',
+      name: 'NotificationRepository',
+      category: LogCategory.api,
+    );
   }
 
   /// Consolidates follow notifications — keeps the earliest per pubkey.

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -196,12 +196,13 @@ void main() {
 
   VideoStats makeVideoStats({
     required String id,
+    String pubkey = userPubkey,
     String? thumbnail,
     String? title,
   }) {
     return VideoStats(
       id: id,
-      pubkey: 'author_pub',
+      pubkey: pubkey,
       createdAt: DateTime(2025),
       kind: 34236,
       dTag: 'd_$id',
@@ -782,7 +783,7 @@ void main() {
       });
 
       test('grouped video notifications build addressable id from '
-          'user pubkey and d-tag', () async {
+          'referenced video owner pubkey and d-tag', () async {
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -801,6 +802,10 @@ void main() {
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
+        stubVideoStats(
+          'video_x',
+          makeVideoStats(id: 'video_x'),
+        );
 
         final page = await repository.getNotifications();
 
@@ -1051,6 +1056,22 @@ void main() {
         expect(item.type, equals(NotificationKind.like));
       });
 
+      test('reaction on a non-owned video is dropped instead of rendering '
+          'as liked your video', () async {
+        stubNotifications([
+          makeNotification(referencedEventId: 'foreign_video'),
+        ]);
+        stubProfiles({});
+        stubVideoStats(
+          'foreign_video',
+          makeVideoStats(id: 'foreign_video', pubkey: 'other_owner_pubkey'),
+        );
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, isEmpty);
+      });
+
       test('reaction on a non-video target maps to likeComment '
           '($ActorNotification)', () async {
         stubNotifications([makeNotification(isReferencedVideo: false)]);
@@ -1077,11 +1098,9 @@ void main() {
       });
 
       test(
-        'likeComment carries videoAddressableId when referencedDTag is set',
+        'likeComment leaves videoAddressableId null even when referencedDTag '
+        'is set without an authoritative owner pubkey',
         () async {
-          // When the server provides the d_tag for the video the comment was
-          // on, the repository builds the stable NIP-33 addressable ID so the
-          // tap handler can skip the resolver entirely.
           stubNotifications([
             makeNotification(
               isReferencedVideo: false,
@@ -1094,7 +1113,7 @@ void main() {
           final page = await repository.getNotifications();
           final item = page.items.single as ActorNotification;
           expect(item.type, equals(NotificationKind.likeComment));
-          expect(item.videoAddressableId, equals('34236:$userPubkey:vine-abc'));
+          expect(item.videoAddressableId, isNull);
         },
       );
 
@@ -2248,12 +2267,16 @@ void main() {
         },
       );
 
-      test('builds addressable id from user pubkey and d-tag for realtime '
-          'video notifications', () async {
+      test('builds addressable id from referenced video owner pubkey and '
+          'd-tag for realtime video notifications', () async {
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
         stubVideoStats(
           'video_x',
-          makeVideoStats(id: 'video_x', thumbnail: 'thumb', title: 'T'),
+          makeVideoStats(
+            id: 'video_x',
+            thumbnail: 'thumb',
+            title: 'T',
+          ),
         );
 
         final result = await repository.enrichOne(
@@ -2279,6 +2302,19 @@ void main() {
         expect(result, isA<VideoNotification>());
         final video = result! as VideoNotification;
         expect(video.videoAddressableId, isNull);
+      });
+
+      test('drops a realtime like when the referenced video is owned by '
+          'someone else', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats(
+          'video_x',
+          makeVideoStats(id: 'video_x', pubkey: 'other_owner_pubkey'),
+        );
+
+        final result = await repository.enrichOne(raw());
+
+        expect(result, isNull);
       });
 
       test('returns null for like with null referencedEventId', () async {
@@ -2320,8 +2356,8 @@ void main() {
         expect(actor.targetEventId, equals('comment_evt_id'));
       });
 
-      test('enrichOne: likeComment carries videoAddressableId when '
-          'referencedDTag is set', () async {
+      test('enrichOne: likeComment leaves videoAddressableId null when '
+          'referencedDTag is set but owner is unknown', () async {
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
         final result = await repository.enrichOne(
@@ -2335,7 +2371,7 @@ void main() {
         expect(result, isA<ActorNotification>());
         final actor = result! as ActorNotification;
         expect(actor.type, equals(NotificationKind.likeComment));
-        expect(actor.videoAddressableId, equals('34236:$userPubkey:vine-xyz'));
+        expect(actor.videoAddressableId, isNull);
       });
 
       test('enrichOne: likeComment videoAddressableId is null when '
@@ -2530,6 +2566,25 @@ void main() {
           expect(await repository.watchUnreadCount().first, equals(1));
         },
       );
+
+      test('acceptRealtime drops a video-anchored notification whose '
+          'referenced video is known to be owned by someone else', () async {
+        stubProfiles({
+          allowedPubkey: makeProfile(allowedPubkey, displayName: 'Allowed'),
+        });
+        stubVideoStats(
+          'video_default',
+          makeVideoStats(id: 'video_default', pubkey: 'other_owner_pubkey'),
+        );
+
+        await repository.acceptRealtime(
+          makeNotification(sourcePubkey: allowedPubkey),
+        );
+
+        final snapshot = await repository.watchSnapshot().first;
+        expect(snapshot.items, isEmpty);
+        expect(await repository.watchUnreadCount().first, equals(0));
+      });
 
       test('acceptRealtime drops a video-anchored notification from a '
           'blocked actor', () async {


### PR DESCRIPTION
## Summary
- validate referenced video ownership before rendering first-party video notifications
- drop misattributed video-like notifications when the fetched video owner is known not to match the signed-in user
- stop forging NIP-33 video routes for actor-anchored comment notifications when the payload does not carry authoritative owner metadata
- add regression coverage for paged fetch, realtime enrichment, and snapshot insertion paths

## Root Cause
The notification repository treated any reaction with a referenced video as a like on the current user's video and synthesized `34236:<current-user-pubkey>:<d-tag>` routes from that assumption. When the backend returned a notification tied to a video owned by someone else, the client rendered a false "liked your video" row and built the wrong destination.

## What Changed
- gate video-anchored notification grouping and realtime enrichment on known video ownership
- build stable video addressable IDs from the referenced video's owner pubkey instead of the signed-in user's pubkey
- suppress actor-anchored stable route synthesis until the API includes authoritative owner metadata for the parent video
- log dropped misattributed notifications with enough context to debug backend payload attribution

## Safety
- only suppresses notifications when the owner mismatch is positively known from fetched video stats
- keeps existing behavior when ownership metadata is absent, so the change is narrowly scoped to the proven bad path
- leaves actor-anchored notifications resolver-based instead of sending users to a forged stable route
- adds tests for both valid owned-video notifications and rejected foreign-video notifications

## Validation
- `cd mobile/packages/notification_repository && flutter test test/src/notification_repository_test.dart`
- `cd mobile/packages/notification_repository && flutter analyze lib/src/notification_repository.dart test/src/notification_repository_test.dart`

Fixes #4656
Refs #4200
Refs #4202
