### PR TITLE
test(notifications): replace flaky row goldens with layout assertions

### DIFF
--- a/mobile/test/goldens/widgets/notification_rows_golden_test.dart
+++ b/mobile/test/goldens/widgets/notification_rows_golden_test.dart
@@ -1,17 +1,15 @@
-// ABOUTME: Layout tests for notification rows, covering the default and
-// ABOUTME: large-text layouts that were stabilized for issues #4206 and #3387.
-import 'dart:typed_data';
-
+// ABOUTME: Combined layout tests for notification rows, covering the default
+// ABOUTME: and large-text layouts that were stabilized for issues #4206/#3387.
 import 'package:clock/clock.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/widgets/actor_notification_row.dart';
 import 'package:openvine/notifications/widgets/notification_video_thumbnail.dart';
 import 'package:openvine/notifications/widgets/video_notification_row.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 
 const _alice = ActorInfo(
   pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -25,31 +23,17 @@ const _bob = ActorInfo(
 
 final _goldenNow = DateTime.utc(2026, 5, 15, 23);
 final _notificationTimestamp = DateTime.utc(2026, 5, 15, 12);
-const _notificationGoldenTolerance = 0.03;
 final AppLocalizations _l10n = lookupAppLocalizations(const Locale('en'));
 
 void main() {
-  final previousGoldenFileComparator = goldenFileComparator;
-  goldenFileComparator = _TolerantGoldenFileComparator(
-    Uri.parse('test/goldens/widgets/notification_rows_golden_test.dart'),
-    precisionTolerance: _notificationGoldenTolerance,
-  );
-  tearDownAll(() => goldenFileComparator = previousGoldenFileComparator);
-
   group('Notification row layouts', () {
-    testGoldens('notification rows render default layout', (tester) async {
+    testWidgets('notification rows render default layout', (tester) async {
       await withClock(Clock(() => _goldenNow), () async {
-        await tester.pumpWidgetBuilder(
-          _scenarioColumn(textScaleFactor: 1),
-          wrapper: materialAppWrapper(
-            theme: VineTheme.theme,
-            localizations: AppLocalizations.localizationsDelegates,
-            localeOverrides: AppLocalizations.supportedLocales,
-          ),
+        await _pumpScenario(
+          tester,
+          textScaleFactor: 1,
           surfaceSize: const Size(420, 560),
         );
-        addTearDown(() => tester.binding.setSurfaceSize(null));
-        await tester.pumpAndSettle();
 
         expect(find.byType(ActorNotificationRow), findsOneWidget);
         expect(find.byType(VideoNotificationRow), findsOneWidget);
@@ -59,24 +43,43 @@ void main() {
           findsOneWidget,
           reason: 'Default layout should keep the thumbnail inline.',
         );
-        expect(tester.takeException(), isNull);
-        await screenMatchesGolden(tester, 'notification_rows_default');
-      });
-    }, tags: 'golden');
-
-    testGoldens('notification rows render max-font layout', (tester) async {
-      await withClock(Clock(() => _goldenNow), () async {
-        await tester.pumpWidgetBuilder(
-          _scenarioColumn(textScaleFactor: 2),
-          wrapper: materialAppWrapper(
-            theme: VineTheme.theme,
-            localizations: AppLocalizations.localizationsDelegates,
-            localeOverrides: AppLocalizations.supportedLocales,
+        final actorAvatar = find.descendant(
+          of: find.byType(ActorNotificationRow),
+          matching: find.byType(UserAvatar),
+        );
+        final avatarRow = find
+            .ancestor(of: actorAvatar, matching: find.byType(Row))
+            .first;
+        expect(
+          find.descendant(of: avatarRow, matching: find.byType(DivineButton)),
+          findsOneWidget,
+          reason: 'Default layout should keep Follow back inline with avatar.',
+        );
+        final message = tester.getTopLeft(
+          find.descendant(
+            of: find.byType(VideoNotificationRow),
+            matching: find.textContaining('Alice'),
           ),
+        );
+        final thumbnail = tester.getTopLeft(
+          find.byType(NotificationVideoThumbnail),
+        );
+        expect(
+          thumbnail.dy,
+          lessThan(message.dy),
+          reason: 'Default layout should keep the thumbnail inline.',
+        );
+        expect(tester.takeException(), isNull);
+      });
+    });
+
+    testWidgets('notification rows render max-font layout', (tester) async {
+      await withClock(Clock(() => _goldenNow), () async {
+        await _pumpScenario(
+          tester,
+          textScaleFactor: 2,
           surfaceSize: const Size(420, 1200),
         );
-        addTearDown(() => tester.binding.setSurfaceSize(null));
-        await tester.pumpAndSettle();
 
         expect(find.byType(ActorNotificationRow), findsOneWidget);
         expect(find.byType(VideoNotificationRow), findsOneWidget);
@@ -86,44 +89,35 @@ void main() {
           findsOneWidget,
           reason: 'Large-text layout should still render the thumbnail.',
         );
+        final actorAvatar = find.descendant(
+          of: find.byType(ActorNotificationRow),
+          matching: find.byType(UserAvatar),
+        );
+        final avatar = tester.getTopLeft(actorAvatar);
+        final button = tester.getTopLeft(find.byType(DivineButton));
+        expect(
+          button.dy,
+          greaterThan(avatar.dy),
+          reason: 'Large-text layout should stack Follow back below avatar.',
+        );
+        final message = tester.getTopLeft(
+          find.descendant(
+            of: find.byType(VideoNotificationRow),
+            matching: find.textContaining('Alice'),
+          ),
+        );
+        final thumbnail = tester.getTopLeft(
+          find.byType(NotificationVideoThumbnail),
+        );
+        expect(
+          thumbnail.dy,
+          greaterThan(message.dy),
+          reason: 'Large-text layout should stack the thumbnail below text.',
+        );
         expect(tester.takeException(), isNull);
-        await screenMatchesGolden(tester, 'notification_rows_max_font');
       });
-    }, tags: 'golden');
+    });
   });
-}
-
-class _TolerantGoldenFileComparator extends LocalFileComparator {
-  _TolerantGoldenFileComparator(
-    super.testFile, {
-    required double precisionTolerance,
-  }) : assert(
-         0 <= precisionTolerance && precisionTolerance <= 1,
-         'precisionTolerance must be between 0 and 1',
-       ),
-       _precisionTolerance = precisionTolerance;
-
-  final double _precisionTolerance;
-
-  @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
-    final result = await GoldenFileComparator.compareLists(
-      imageBytes,
-      await getGoldenBytes(golden),
-    );
-
-    // Linux CI shows a small amount of text antialiasing drift versus macOS.
-    // Keep the threshold tight so real layout regressions still fail.
-    final passed = result.passed || result.diffPercent <= _precisionTolerance;
-    if (passed) {
-      result.dispose();
-      return true;
-    }
-
-    final error = await generateFailureOutput(result, golden, basedir);
-    result.dispose();
-    throw FlutterError(error);
-  }
 }
 
 Widget _scenarioColumn({required double textScaleFactor}) {
@@ -170,6 +164,24 @@ Widget _scenarioColumn({required double textScaleFactor}) {
       ),
     ],
   );
+}
+
+Future<void> _pumpScenario(
+  WidgetTester tester, {
+  required double textScaleFactor,
+  required Size surfaceSize,
+}) async {
+  await tester.binding.setSurfaceSize(surfaceSize);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: VineTheme.theme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: _scenarioColumn(textScaleFactor: textScaleFactor)),
+    ),
+  );
+  await tester.pumpAndSettle();
 }
 
 Widget _scenario({required double textScaleFactor, required Widget child}) {


### PR DESCRIPTION
## What changed

This replaces the combined notification-row pixel golden with deterministic widget layout assertions in `mobile/test/goldens/widgets/notification_rows_golden_test.dart`.

The updated test still verifies the behaviors that mattered:

- default layout keeps `Follow back` inline with the avatar
- default layout keeps the video thumbnail inline with the text row
- max-font layout stacks `Follow back` below the avatar
- max-font layout stacks the video thumbnail below the text
- both scenarios render without exceptions

## Why

`main` was failing in GitHub Actions because this golden was flaky on Linux CI. The file already documented Linux/macOS text antialiasing drift and used a custom tolerance, but the test still depended on pixel output for a text-heavy widget.

These assertions validate the intended layout behavior directly, which removes the platform-specific rasterization failure without weakening the actual coverage.

Closes #4660

## Validation

- `flutter test test/goldens/widgets/notification_rows_golden_test.dart`
- `flutter test test/notifications/widgets/actor_notification_row_test.dart`
- `flutter test test/notifications/widgets/video_notification_row_test.dart`
- `flutter analyze` surfaced existing repo-wide `avoid_print` infos in manual scripts/tools; the branch adds no new analyze failures, and the corresponding GitHub `Analyze` job on the failing `main` run was green
