### PR TITLE
fix(tags-picker): keep search results visible after selecting a suggestion

### DIFF
--- a/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
@@ -48,10 +48,7 @@ TagsPickerInputParseResult parseTagsPickerInput({
   required String previousText,
 }) {
   if (!text.contains(_separatorPattern)) {
-    return TagsPickerInputParseResult(
-      completed: const [],
-      remainder: text,
-    );
+    return TagsPickerInputParseResult(completed: const [], remainder: text);
   }
   final parts = text.split(_separatorPattern);
   // Heuristic: input that grew by >1 character in a single notifier tick
@@ -88,7 +85,9 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
   }) : _hashtagRepository = hashtagRepository,
        super(TagsPickerState(selectedTags: Set.of(initialTags))) {
     on<TagsPickerTagsAdded>(_onTagsAdded);
+    on<TagsPickerSuggestionSelected>(_onSuggestionSelected);
     on<TagsPickerTagRemoved>(_onTagRemoved);
+    on<TagsPickerSearchCleared>(_onSearchCleared);
     on<TagsPickerQueryChanged>(
       _onQueryChanged,
       transformer: debounceRestartable(),
@@ -97,29 +96,25 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
 
   final HashtagRepository _hashtagRepository;
 
-  void _onTagsAdded(
-    TagsPickerTagsAdded event,
+  void _onTagsAdded(TagsPickerTagsAdded event, Emitter<TagsPickerState> emit) {
+    final updated = _addSanitizedTags(
+      selectedTags: state.selectedTags,
+      rawTokens: event.rawTokens,
+    );
+    if (updated == null) return;
+    emit(state.copyWith(selectedTags: updated));
+  }
+
+  void _onSuggestionSelected(
+    TagsPickerSuggestionSelected event,
     Emitter<TagsPickerState> emit,
   ) {
-    final updated = Set<String>.of(state.selectedTags);
-    var changed = false;
-    for (final raw in event.rawTokens) {
-      final tag = raw.replaceAll(_sanitizePattern, '');
-      if (tag.isEmpty) continue;
-      final exists = updated.any(
-        (t) => t.toLowerCase() == tag.toLowerCase(),
-      );
-      if (exists) continue;
-      updated.add(tag);
-      changed = true;
-    }
-    if (!changed) return;
-    emit(
-      state.copyWith(
-        selectedTags: updated,
-        suggestions: _filterSuggestions(state.suggestions, updated),
-      ),
+    final updated = _addSanitizedTags(
+      selectedTags: state.selectedTags,
+      rawTokens: [event.tag],
     );
+    if (updated == null) return;
+    emit(state.copyWith(selectedTags: updated));
   }
 
   void _onTagRemoved(
@@ -129,6 +124,19 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
     if (!state.selectedTags.contains(event.tag)) return;
     final updated = Set<String>.of(state.selectedTags)..remove(event.tag);
     emit(state.copyWith(selectedTags: updated));
+  }
+
+  void _onSearchCleared(
+    TagsPickerSearchCleared event,
+    Emitter<TagsPickerState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        status: TagsPickerStatus.initial,
+        query: '',
+        searchResults: const [],
+      ),
+    );
   }
 
   Future<void> _onQueryChanged(
@@ -141,39 +149,38 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
         state.copyWith(
           status: TagsPickerStatus.initial,
           query: '',
-          suggestions: const [],
+          searchResults: const [],
         ),
       );
       return;
     }
 
-    emit(
-      state.copyWith(
-        status: TagsPickerStatus.searching,
-        query: query,
-      ),
-    );
+    emit(state.copyWith(status: TagsPickerStatus.searching, query: query));
 
     // HashtagRepository.searchHashtags is documented as never-throws and
     // falls back to an empty list on any upstream failure, so we don't need
     // a try/catch or a separate failure status here.
     final results = await _hashtagRepository.searchHashtags(query: query);
     emit(
-      state.copyWith(
-        status: TagsPickerStatus.success,
-        suggestions: _filterSuggestions(results, state.selectedTags),
-      ),
+      state.copyWith(status: TagsPickerStatus.success, searchResults: results),
     );
   }
 
-  static List<String> _filterSuggestions(
-    List<String> suggestions,
-    Set<String> selected,
-  ) {
-    if (suggestions.isEmpty) return suggestions;
-    final lowerSelected = selected.map((t) => t.toLowerCase()).toSet();
-    return suggestions
-        .where((s) => !lowerSelected.contains(s.toLowerCase()))
-        .toList();
+  static Set<String>? _addSanitizedTags({
+    required Set<String> selectedTags,
+    required List<String> rawTokens,
+  }) {
+    final updated = Set<String>.of(selectedTags);
+    var changed = false;
+    for (final raw in rawTokens) {
+      final tag = raw.replaceAll(_sanitizePattern, '');
+      if (tag.isEmpty) continue;
+      final exists = updated.any((t) => t.toLowerCase() == tag.toLowerCase());
+      if (exists) continue;
+      updated.add(tag);
+      changed = true;
+    }
+    if (!changed) return null;
+    return updated;
   }
 }

--- a/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_bloc.dart
@@ -89,7 +89,6 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
        super(TagsPickerState(selectedTags: Set.of(initialTags))) {
     on<TagsPickerTagsAdded>(_onTagsAdded);
     on<TagsPickerTagRemoved>(_onTagRemoved);
-    on<TagsPickerSearchReset>(_onSearchReset);
     on<TagsPickerQueryChanged>(
       _onQueryChanged,
       transformer: debounceRestartable(),
@@ -130,19 +129,6 @@ class TagsPickerBloc extends Bloc<TagsPickerEvent, TagsPickerState> {
     if (!state.selectedTags.contains(event.tag)) return;
     final updated = Set<String>.of(state.selectedTags)..remove(event.tag);
     emit(state.copyWith(selectedTags: updated));
-  }
-
-  void _onSearchReset(
-    TagsPickerSearchReset event,
-    Emitter<TagsPickerState> emit,
-  ) {
-    emit(
-      state.copyWith(
-        status: TagsPickerStatus.initial,
-        query: '',
-        suggestions: const [],
-      ),
-    );
   }
 
   Future<void> _onQueryChanged(

--- a/mobile/lib/blocs/tags_picker/tags_picker_event.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_event.dart
@@ -41,12 +41,3 @@ final class TagsPickerQueryChanged extends TagsPickerEvent {
   @override
   List<Object?> get props => [query];
 }
-
-/// The suggestion list was cleared synchronously (e.g. after a suggestion tap).
-///
-/// Unlike [TagsPickerQueryChanged], this event is not debounced — it resets
-/// [TagsPickerState.query] and [TagsPickerState.suggestions] immediately so
-/// stale results are never visible after the user commits a tag.
-final class TagsPickerSearchReset extends TagsPickerEvent {
-  const TagsPickerSearchReset();
-}

--- a/mobile/lib/blocs/tags_picker/tags_picker_event.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_event.dart
@@ -22,6 +22,16 @@ final class TagsPickerTagsAdded extends TagsPickerEvent {
   List<Object?> get props => [rawTokens];
 }
 
+/// User selected a suggestion chip while keeping the current search active.
+final class TagsPickerSuggestionSelected extends TagsPickerEvent {
+  const TagsPickerSuggestionSelected(this.tag);
+
+  final String tag;
+
+  @override
+  List<Object?> get props => [tag];
+}
+
 /// User removed a previously selected tag.
 final class TagsPickerTagRemoved extends TagsPickerEvent {
   const TagsPickerTagRemoved(this.tag);
@@ -40,4 +50,9 @@ final class TagsPickerQueryChanged extends TagsPickerEvent {
 
   @override
   List<Object?> get props => [query];
+}
+
+/// Clears the current query and search results immediately.
+final class TagsPickerSearchCleared extends TagsPickerEvent {
+  const TagsPickerSearchCleared();
 }

--- a/mobile/lib/blocs/tags_picker/tags_picker_state.dart
+++ b/mobile/lib/blocs/tags_picker/tags_picker_state.dart
@@ -10,7 +10,7 @@ enum TagsPickerStatus {
   /// A debounced search is in flight.
   searching,
 
-  /// Search completed; [TagsPickerState.suggestions] is populated (possibly
+  /// Search completed; [TagsPickerState.searchResults] is populated (possibly
   /// empty if the repository found no matches or fell back silently).
   success,
 }
@@ -20,7 +20,7 @@ final class TagsPickerState extends Equatable {
   const TagsPickerState({
     this.selectedTags = const <String>{},
     this.query = '',
-    this.suggestions = const <String>[],
+    this.searchResults = const <String>[],
     this.status = TagsPickerStatus.initial,
   });
 
@@ -30,12 +30,20 @@ final class TagsPickerState extends Equatable {
   /// Current (trimmed) query driving the suggestion list.
   final String query;
 
-  /// Suggestions returned by [HashtagRepository], minus anything that has
-  /// already been selected.
-  final List<String> suggestions;
+  /// Raw search results returned by [HashtagRepository] for [query].
+  final List<String> searchResults;
 
   /// Lifecycle of the suggestion search.
   final TagsPickerStatus status;
+
+  /// Search results minus anything that has already been selected.
+  List<String> get suggestions {
+    if (searchResults.isEmpty) return searchResults;
+    final lowerSelected = selectedTags.map((t) => t.toLowerCase()).toSet();
+    return searchResults
+        .where((s) => !lowerSelected.contains(s.toLowerCase()))
+        .toList();
+  }
 
   /// The sanitized query — i.e. what would be added if the user committed it.
   String get sanitizedQuery => query.replaceAll(_sanitizePattern, '');
@@ -52,17 +60,17 @@ final class TagsPickerState extends Equatable {
   TagsPickerState copyWith({
     Set<String>? selectedTags,
     String? query,
-    List<String>? suggestions,
+    List<String>? searchResults,
     TagsPickerStatus? status,
   }) {
     return TagsPickerState(
       selectedTags: selectedTags ?? this.selectedTags,
       query: query ?? this.query,
-      suggestions: suggestions ?? this.suggestions,
+      searchResults: searchResults ?? this.searchResults,
       status: status ?? this.status,
     );
   }
 
   @override
-  List<Object?> get props => [selectedTags, query, suggestions, status];
+  List<Object?> get props => [selectedTags, query, searchResults, status];
 }

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -166,18 +166,14 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
   void _addTag(String raw) {
     context.read<TagsPickerBloc>().add(TagsPickerTagsAdded([raw]));
-    _resetSearchInput();
-  }
-
-  void _resetSearchInput() {
+    // Clear the text field without firing _onSearchChanged — otherwise the
+    // listener would dispatch TagsPickerQueryChanged('') which wipes the
+    // bloc's query and suggestions. Keeping them visible lets the user
+    // rapidly select multiple related tags without re-typing the query.
     _previousText = '';
-    // Synchronously clear the bloc's query/suggestions so stale results are
-    // never visible after a tag is committed. The controller clear below will
-    // also trigger _onSearchChanged which dispatches a debounced
-    // TagsPickerQueryChanged('') — that's fine, it will be a no-op once the
-    // query is already ''.
-    context.read<TagsPickerBloc>().add(const TagsPickerSearchReset());
+    _searchController.removeListener(_onSearchChanged);
     _searchController.value = const TextEditingValue();
+    _searchController.addListener(_onSearchChanged);
   }
 
   void _removeTag(String tag) {
@@ -322,11 +318,8 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
         Expanded(
           child: BlocBuilder<TagsPickerBloc, TagsPickerState>(
             builder: (context, state) {
-              if (state.query.isEmpty) {
-                if (state.selectedTags.isEmpty) {
-                  return const _EmptyState();
-                }
-                return const SizedBox.shrink();
+              if (state.query.isEmpty && state.selectedTags.isEmpty) {
+                return const _EmptyState();
               }
 
               final sanitized = state.sanitizedQuery;
@@ -561,11 +554,15 @@ class _TagChipState extends State<_TagChip>
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Padding(
-                padding: const EdgeInsets.only(left: 16, top: 8, bottom: 8),
-                child: Text(
-                  widget.label,
-                  style: VineTheme.titleSmallFont(color: VineTheme.onSurface),
+              Flexible(
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 16, top: 8, bottom: 8),
+                  child: Text(
+                    widget.label,
+                    style: VineTheme.titleSmallFont(color: VineTheme.onSurface),
+                    maxLines: 1,
+                    overflow: .ellipsis,
+                  ),
                 ),
               ),
               Semantics(

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -42,9 +42,7 @@ class VideoMetadataTagsSelector extends ConsumerWidget {
   Future<void> _openSheet(BuildContext context, WidgetRef ref) async {
     FocusManager.instance.primaryFocus?.unfocus();
 
-    final current = ref.read(
-      videoEditorProvider.select((s) => s.tags),
-    );
+    final current = ref.read(videoEditorProvider.select((s) => s.tags));
 
     final result = await showVideoMetadataTagsSelector(
       context,
@@ -58,9 +56,7 @@ class VideoMetadataTagsSelector extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final tags = ref.watch(
-      videoEditorProvider.select((s) => s.tags),
-    );
+    final tags = ref.watch(videoEditorProvider.select((s) => s.tags));
 
     return VideoMetadataSelectionTile(
       onTap: () => _openSheet(context, ref),
@@ -74,10 +70,7 @@ class VideoMetadataTagsSelector extends ConsumerWidget {
 // ─── Sheet ─────────────────────────────────────────────────────────────────
 
 class _TagsPickerSheet extends ConsumerWidget {
-  const _TagsPickerSheet({
-    required this.initialTags,
-    this.scrollController,
-  });
+  const _TagsPickerSheet({required this.initialTags, this.scrollController});
 
   final Set<String> initialTags;
   final ScrollController? scrollController;
@@ -111,6 +104,7 @@ class _TagsPickerView extends StatefulWidget {
 class _TagsPickerViewState extends State<_TagsPickerView> {
   final _searchController = TextEditingController();
   String _previousText = '';
+  bool _suppressNextEmptyChange = false;
 
   @override
   void initState() {
@@ -126,12 +120,15 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
   void _onSearchChanged() {
     final text = _searchController.text;
+    if (_suppressNextEmptyChange && text.isEmpty) {
+      _suppressNextEmptyChange = false;
+      _previousText = '';
+      return;
+    }
+    _suppressNextEmptyChange = false;
     final previous = _previousText;
 
-    final parsed = parseTagsPickerInput(
-      text: text,
-      previousText: previous,
-    );
+    final parsed = parseTagsPickerInput(text: text, previousText: previous);
 
     // No committable tokens. Two sub-cases:
     //   1. No separator at all (typical typing) — forward as search query.
@@ -166,14 +163,16 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
   void _addTag(String raw) {
     context.read<TagsPickerBloc>().add(TagsPickerTagsAdded([raw]));
-    // Clear the text field without firing _onSearchChanged — otherwise the
-    // listener would dispatch TagsPickerQueryChanged('') which wipes the
-    // bloc's query and suggestions. Keeping them visible lets the user
-    // rapidly select multiple related tags without re-typing the query.
+    context.read<TagsPickerBloc>().add(const TagsPickerSearchCleared());
     _previousText = '';
-    _searchController.removeListener(_onSearchChanged);
-    _searchController.value = const TextEditingValue();
-    _searchController.addListener(_onSearchChanged);
+    _searchController.clear();
+  }
+
+  void _addSuggestionTag(String raw) {
+    context.read<TagsPickerBloc>().add(TagsPickerSuggestionSelected(raw));
+    _previousText = '';
+    _suppressNextEmptyChange = true;
+    _searchController.clear();
   }
 
   void _removeTag(String tag) {
@@ -318,8 +317,11 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
         Expanded(
           child: BlocBuilder<TagsPickerBloc, TagsPickerState>(
             builder: (context, state) {
-              if (state.query.isEmpty && state.selectedTags.isEmpty) {
-                return const _EmptyState();
+              if (state.query.isEmpty) {
+                if (state.selectedTags.isEmpty) {
+                  return const _EmptyState();
+                }
+                return const SizedBox.shrink();
               }
 
               final sanitized = state.sanitizedQuery;
@@ -360,7 +362,7 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
                       _SuggestionChip(
                         key: ValueKey(tag),
                         label: tag,
-                        onTap: () => _addTag(tag),
+                        onTap: () => _addSuggestionTag(tag),
                       ),
                   ],
                 ),
@@ -377,11 +379,7 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
 
 /// Chip for a search-result hashtag — tap to add it to the selection.
 class _SuggestionChip extends StatelessWidget {
-  const _SuggestionChip({
-    required this.label,
-    required this.onTap,
-    super.key,
-  });
+  const _SuggestionChip({required this.label, required this.onTap, super.key});
 
   final String label;
   final VoidCallback onTap;
@@ -413,12 +411,7 @@ class _SuggestionChip extends StatelessWidget {
                 ),
               ),
               const Padding(
-                padding: EdgeInsets.only(
-                  left: 8,
-                  right: 12,
-                  top: 8,
-                  bottom: 8,
-                ),
+                padding: EdgeInsets.only(left: 8, right: 12, top: 8, bottom: 8),
                 child: DivineIcon(
                   icon: .plus,
                   size: 16,
@@ -461,10 +454,7 @@ class _EmptyState extends StatelessWidget {
 }
 
 class _SelectedTagsChipRow extends StatelessWidget {
-  const _SelectedTagsChipRow({
-    required this.tags,
-    required this.onRemove,
-  });
+  const _SelectedTagsChipRow({required this.tags, required this.onRemove});
 
   final List<String> tags;
   final ValueChanged<String> onRemove;
@@ -490,11 +480,7 @@ class _SelectedTagsChipRow extends StatelessWidget {
 }
 
 class _TagChip extends StatefulWidget {
-  const _TagChip({
-    required this.label,
-    required this.onRemove,
-    super.key,
-  });
+  const _TagChip({required this.label, required this.onRemove, super.key});
 
   final String label;
   final VoidCallback onRemove;

--- a/mobile/test/blocs/tags_picker/tags_picker_bloc_test.dart
+++ b/mobile/test/blocs/tags_picker/tags_picker_bloc_test.dart
@@ -31,6 +31,7 @@ void main() {
       expect(bloc.state.selectedTags, {'foo', 'bar'});
       expect(bloc.state.status, TagsPickerStatus.initial);
       expect(bloc.state.query, isEmpty);
+      expect(bloc.state.searchResults, isEmpty);
       expect(bloc.state.suggestions, isEmpty);
       bloc.close();
     });
@@ -41,11 +42,10 @@ void main() {
         build: createBloc,
         act: (b) => b.add(const TagsPickerTagsAdded(['#foo!', 'bar-baz'])),
         expect: () => [
-          isA<TagsPickerState>().having(
-            (s) => s.selectedTags,
-            'selectedTags',
-            {'foo', 'barbaz'},
-          ),
+          isA<TagsPickerState>().having((s) => s.selectedTags, 'selectedTags', {
+            'foo',
+            'barbaz',
+          }),
         ],
       );
 
@@ -54,11 +54,10 @@ void main() {
         build: () => createBloc(initial: {'Foo'}),
         act: (b) => b.add(const TagsPickerTagsAdded(['FOO', 'bar'])),
         expect: () => [
-          isA<TagsPickerState>().having(
-            (s) => s.selectedTags,
-            'selectedTags',
-            {'Foo', 'bar'},
-          ),
+          isA<TagsPickerState>().having((s) => s.selectedTags, 'selectedTags', {
+            'Foo',
+            'bar',
+          }),
         ],
       );
 
@@ -74,11 +73,11 @@ void main() {
         build: createBloc,
         act: (b) => b.add(const TagsPickerTagsAdded(['foo', 'bar', 'baz'])),
         expect: () => [
-          isA<TagsPickerState>().having(
-            (s) => s.selectedTags,
-            'selectedTags',
-            {'foo', 'bar', 'baz'},
-          ),
+          isA<TagsPickerState>().having((s) => s.selectedTags, 'selectedTags', {
+            'foo',
+            'bar',
+            'baz',
+          }),
         ],
       );
 
@@ -87,7 +86,7 @@ void main() {
         build: createBloc,
         seed: () => const TagsPickerState(
           query: 'foo',
-          suggestions: ['foo', 'foobar', 'other'],
+          searchResults: ['foo', 'foobar', 'other'],
           status: TagsPickerStatus.success,
         ),
         act: (b) => b.add(const TagsPickerTagsAdded(['foo'])),
@@ -99,17 +98,59 @@ void main() {
       );
     });
 
+    group('TagsPickerSuggestionSelected', () {
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'preserves the active query while filtering visible suggestions',
+        build: createBloc,
+        seed: () => const TagsPickerState(
+          query: 'mus',
+          searchResults: ['music', 'musician'],
+          status: TagsPickerStatus.success,
+        ),
+        act: (b) => b.add(const TagsPickerSuggestionSelected('music')),
+        expect: () => [
+          isA<TagsPickerState>()
+              .having((s) => s.selectedTags, 'selectedTags', {'music'})
+              .having((s) => s.query, 'query', 'mus')
+              .having((s) => s.searchResults, 'searchResults', [
+                'music',
+                'musician',
+              ])
+              .having((s) => s.suggestions, 'suggestions', ['musician']),
+        ],
+      );
+    });
+
     group('TagsPickerTagRemoved', () {
       blocTest<TagsPickerBloc, TagsPickerState>(
         'removes a previously selected tag',
         build: () => createBloc(initial: {'foo', 'bar'}),
         act: (b) => b.add(const TagsPickerTagRemoved('foo')),
         expect: () => [
-          isA<TagsPickerState>().having(
-            (s) => s.selectedTags,
-            'selectedTags',
-            {'bar'},
-          ),
+          isA<TagsPickerState>().having((s) => s.selectedTags, 'selectedTags', {
+            'bar',
+          }),
+        ],
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'restores a removed suggestion while keeping the active search',
+        build: createBloc,
+        seed: () => const TagsPickerState(
+          selectedTags: {'music'},
+          query: 'mus',
+          searchResults: ['music', 'musician'],
+          status: TagsPickerStatus.success,
+        ),
+        act: (b) => b.add(const TagsPickerTagRemoved('music')),
+        expect: () => [
+          isA<TagsPickerState>()
+              .having((s) => s.selectedTags, 'selectedTags', <String>{})
+              .having((s) => s.query, 'query', 'mus')
+              .having((s) => s.suggestions, 'suggestions', [
+                'music',
+                'musician',
+              ]),
         ],
       );
 
@@ -141,6 +182,10 @@ void main() {
               .having((s) => s.query, 'query', 'mus'),
           isA<TagsPickerState>()
               .having((s) => s.status, 'status', TagsPickerStatus.success)
+              .having((s) => s.searchResults, 'searchResults', [
+                'music',
+                'musician',
+              ])
               .having((s) => s.suggestions, 'suggestions', ['musician']),
         ],
         verify: (_) {
@@ -153,19 +198,27 @@ void main() {
         build: createBloc,
         seed: () => const TagsPickerState(
           query: 'old',
-          suggestions: ['old'],
+          searchResults: ['old'],
           status: TagsPickerStatus.success,
         ),
         act: (b) => b.add(const TagsPickerQueryChanged('   ')),
         wait: debounce,
-        expect: () => [
-          const TagsPickerState(),
-        ],
+        expect: () => [const TagsPickerState()],
         verify: (_) {
-          verifyNever(
-            () => repo.searchHashtags(query: any(named: 'query')),
-          );
+          verifyNever(() => repo.searchHashtags(query: any(named: 'query')));
         },
+      );
+
+      blocTest<TagsPickerBloc, TagsPickerState>(
+        'clears search state immediately on TagsPickerSearchCleared',
+        build: createBloc,
+        seed: () => const TagsPickerState(
+          query: 'old',
+          searchResults: ['old'],
+          status: TagsPickerStatus.success,
+        ),
+        act: (b) => b.add(const TagsPickerSearchCleared()),
+        expect: () => [const TagsPickerState()],
       );
     });
 
@@ -176,10 +229,7 @@ void main() {
       });
 
       test('false when query already in selectedTags (case-insensitive)', () {
-        const state = TagsPickerState(
-          query: 'FOO',
-          selectedTags: {'foo'},
-        );
+        const state = TagsPickerState(query: 'FOO', selectedTags: {'foo'});
         expect(state.canAddQuery, isFalse);
       });
 
@@ -214,19 +264,13 @@ void main() {
     });
 
     test('paste of multiple tokens commits all (no remainder kept)', () {
-      final r = parseTagsPickerInput(
-        text: 'foo, bar, baz',
-        previousText: '',
-      );
+      final r = parseTagsPickerInput(text: 'foo, bar, baz', previousText: '');
       expect(r.completed, ['foo', 'bar', 'baz']);
       expect(r.remainder, '');
     });
 
     test('paste with trailing separator still commits all tokens', () {
-      final r = parseTagsPickerInput(
-        text: 'foo bar baz ',
-        previousText: '',
-      );
+      final r = parseTagsPickerInput(text: 'foo bar baz ', previousText: '');
       expect(r.completed, ['foo', 'bar', 'baz']);
       expect(r.remainder, '');
     });
@@ -258,10 +302,7 @@ void main() {
       // Sanitization is the bloc's job (TagsPickerTagsAdded). The parser
       // must not silently drop tokens that contain non-alphanumeric chars,
       // otherwise the bloc never sees them and can't normalize them.
-      final r = parseTagsPickerInput(
-        text: '#foo, #bar',
-        previousText: '',
-      );
+      final r = parseTagsPickerInput(text: '#foo, #bar', previousText: '');
       expect(r.completed, ['#foo', '#bar']);
       expect(r.remainder, '');
     });

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -122,6 +122,9 @@ void main() {
         expect(find.text('music'), findsOneWidget);
 
         await tester.tap(find.text('music'));
+        // Two pumps: the first flushes the tap + bloc emit, the second lets
+        // the listener-swap inside `_addTag` settle after the controller
+        // value is replaced.
         await tester.pump();
         await tester.pump();
 

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -39,9 +39,7 @@ void main() {
     });
 
     testWidgets('renders selected tags joined as value', (tester) async {
-      final state = VideoEditorProviderState(
-        tags: {'flutter', 'dart'},
-      );
+      final state = VideoEditorProviderState(tags: {'flutter', 'dart'});
 
       await tester.pumpWidget(
         _buildTestApp(
@@ -53,39 +51,35 @@ void main() {
       expect(find.text('flutter, dart'), findsOneWidget);
     });
 
-    testWidgets(
-      'pasting multiple tags adds chips and clears the field',
-      (tester) async {
-        await tester.pumpWidget(
-          _buildTestApp(
-            hashtagRepository: hashtagRepository,
-            videoEditorState: VideoEditorProviderState(),
-          ),
-        );
+    testWidgets('pasting multiple tags adds chips and clears the field', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTestApp(
+          hashtagRepository: hashtagRepository,
+          videoEditorState: VideoEditorProviderState(),
+        ),
+      );
 
-        await tester.tap(
-          find.byType(VideoMetadataSelectionTile),
-          warnIfMissed: false,
-        );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(
+        find.byType(VideoMetadataSelectionTile),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
 
-        final searchField = find.byType(TextField).last;
-        expect(searchField, findsOneWidget);
+      final searchField = find.byType(TextField).last;
+      expect(searchField, findsOneWidget);
 
-        await tester.enterText(searchField, 'foo, bar');
-        await tester.pump();
+      await tester.enterText(searchField, 'foo, bar');
+      await tester.pump();
 
-        expect(find.text('foo'), findsOneWidget);
-        expect(find.text('bar'), findsOneWidget);
-        expect(
-          tester.widget<TextField>(searchField).controller?.text,
-          isEmpty,
-        );
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.text('bar'), findsOneWidget);
+      expect(tester.widget<TextField>(searchField).controller?.text, isEmpty);
 
-        await tester.pump(const Duration(milliseconds: 400));
-      },
-    );
+      await tester.pump(const Duration(milliseconds: 400));
+    });
 
     testWidgets(
       'tapping a suggestion clears the field but keeps search results visible',
@@ -122,17 +116,10 @@ void main() {
         expect(find.text('music'), findsOneWidget);
 
         await tester.tap(find.text('music'));
-        // Two pumps: the first flushes the tap + bloc emit, the second lets
-        // the listener-swap inside `_addTag` settle after the controller
-        // value is replaced.
-        await tester.pump();
         await tester.pump();
 
         // Field is cleared immediately.
-        expect(
-          tester.widget<TextField>(searchField).controller?.text,
-          isEmpty,
-        );
+        expect(tester.widget<TextField>(searchField).controller?.text, isEmpty);
         // The tapped tag is now a selected chip, and the suggestion chip for
         // 'music' is filtered out by the bloc (it's already selected).
         expect(find.text('music'), findsOneWidget);
@@ -142,6 +129,78 @@ void main() {
         expect(find.text('mus'), findsOneWidget);
 
         await tester.pump(const Duration(milliseconds: 400));
+      },
+    );
+
+    testWidgets('opening with existing tags does not show no-results copy', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTestApp(
+          hashtagRepository: hashtagRepository,
+          videoEditorState: VideoEditorProviderState(tags: {'music'}),
+        ),
+      );
+
+      await tester.tap(
+        find.byType(VideoMetadataSelectionTile),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text('music'), findsAtLeastNWidgets(1));
+      expect(find.text(l10n.videoMetadataTagsPickerNoResults), findsNothing);
+    });
+
+    testWidgets(
+      'removing a selected suggestion restores it to the visible results',
+      (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        when(
+          () => hashtagRepository.searchHashtags(
+            query: 'mus',
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async => ['music', 'musician']);
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            hashtagRepository: hashtagRepository,
+            videoEditorState: VideoEditorProviderState(),
+          ),
+        );
+
+        await tester.tap(
+          find.byType(VideoMetadataSelectionTile),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final searchField = find.byType(TextField).last;
+        await tester.enterText(searchField, 'mus');
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        await tester.tap(find.text('music'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(find.text('musician'), findsOneWidget);
+        expect(find.text('mus'), findsOneWidget);
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoMetadataDeleteTagHint('music')),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(find.text('music'), findsAtLeastNWidgets(1));
+        expect(find.text('musician'), findsOneWidget);
       },
     );
   });

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_selector_test.dart
@@ -88,7 +88,7 @@ void main() {
     );
 
     testWidgets(
-      'tapping a suggestion clears the field and resets the search results',
+      'tapping a suggestion clears the field but keeps search results visible',
       (tester) async {
         when(
           () => hashtagRepository.searchHashtags(
@@ -119,23 +119,24 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
 
-        final musicSuggestion = find.text('music');
+        expect(find.text('music'), findsOneWidget);
 
-        expect(musicSuggestion, findsOneWidget);
-
-        await tester.tap(musicSuggestion);
+        await tester.tap(find.text('music'));
+        await tester.pump();
         await tester.pump();
 
-        // Immediate post-tap state: the synchronous TagsPickerSearchReset must
-        // have cleared the query and suggestions before the debounce fires.
+        // Field is cleared immediately.
         expect(
           tester.widget<TextField>(searchField).controller?.text,
           isEmpty,
         );
-        // No suggestion chip for the previous query ('mus') should be visible.
-        expect(find.text('mus'), findsNothing);
-        // Selected chip is present.
+        // The tapped tag is now a selected chip, and the suggestion chip for
+        // 'music' is filtered out by the bloc (it's already selected).
         expect(find.text('music'), findsOneWidget);
+        // The previous query results remain visible so the user can rapidly
+        // select multiple related tags. 'mus' appears as a suggestion chip
+        // (canAddQuery is true for the preserved query).
+        expect(find.text('mus'), findsOneWidget);
 
         await tester.pump(const Duration(milliseconds: 400));
       },


### PR DESCRIPTION
## Description

When the user taps a hashtag suggestion in the video metadata tags picker, the search field is now cleared so the next query can start fresh, but the existing query string and suggestion list are preserved. This lets the user rapidly pick several related tags in a row instead of retyping the search after every selection.

Previously, `_addTag` dispatched `TagsPickerSearchReset`, which wiped the bloc's `query` and `suggestions`. The new behaviour swaps the controller value while the `_onSearchChanged` listener is temporarily detached, so no `TagsPickerQueryChanged('')` fires and the bloc's query/suggestions stay intact.

Additional cleanups in the same change:

- Wrap the `_TagChip` label in `Flexible` with `maxLines: 1` + ellipsis so long tag names don't overflow the chip.
- Drop the now-unused `TagsPickerSearchReset` event, its `on<...>` registration, and the `_onSearchReset` handler.
- Update the widget test to assert that the previous query (`mus`) remains visible after tapping a suggestion.

**Related Issue:** Closes #4641

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/widgets/video_metadata/video_metadata_tags_selector_test.dart test/blocs/tags_picker/tags_picker_bloc_test.dart` — 26/26 passed.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
