### PR TITLE
fix(security): strip BYOK nsec from Keycast OAuth and gate secure-account upgrade

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -152,6 +152,17 @@ jobs:
             exit 1
           fi
           echo "✅ VGV tag count OK: current=$current, baseline=$baseline"
+  nsec-leak-guard:
+    name: NSec Leak Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🛡️ Verify production code does not use nsec as a payload key
+        # Locks in the Phase 1 fix for divinevideo/divine-mobile#3359 — fails
+        # if any production .dart file under mobile/lib or mobile/packages
+        # re-introduces nsec as a JSON / map key in an HTTP body. The guard
+        # script uses POSIX find + grep -E, no extra deps needed.
+        run: bash mobile/tools/ci/grep_for_nsec_payload.sh
   mobile-ci:
     name: Mobile CI
     if: ${{ always() }}
@@ -161,6 +172,7 @@ jobs:
       - analyze
       - tests
       - vgv-tag-gate
+      - nsec-leak-guard
     runs-on: ubuntu-24.04-16core
     steps:
       - name: Verify upstream jobs
@@ -170,18 +182,21 @@ jobs:
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
           VGV_TAG_GATE_RESULT: ${{ needs.vgv-tag-gate.result }}
+          NSEC_LEAK_GUARD_RESULT: ${{ needs.nsec-leak-guard.result }}
         run: |
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
           echo "vgv-tag-gate: ${VGV_TAG_GATE_RESULT}"
+          echo "nsec-leak-guard: ${NSEC_LEAK_GUARD_RESULT}"
 
           if [[ "${GENERATED_FILES_RESULT}" != "success" || \
                 "${FORMAT_RESULT}" != "success" || \
                 "${ANALYZE_RESULT}" != "success" || \
                 "${TESTS_RESULT}" != "success" || \
-                "${VGV_TAG_GATE_RESULT}" != "success" ]]; then
+                "${VGV_TAG_GATE_RESULT}" != "success" || \
+                "${NSEC_LEAK_GUARD_RESULT}" != "success" ]]; then
             echo "One or more Mobile CI jobs failed."
             exit 1
           fi

--- a/mobile/integration_test/auth/session_expired_banner_test.dart
+++ b/mobile/integration_test/auth/session_expired_banner_test.dart
@@ -42,12 +42,15 @@ void main() {
         final authService = container.read(authServiceProvider);
 
         // ════════════════════════════════════════════════════════════
-        // Phase 1: Generate local keys, then register with Keycast
-        //          passing the nsec so both share the same pubkey.
+        // Phase 1: Generate local keys, then register with Keycast so the
+        //          local key shares the account's pubkey (BYOK binding).
         //
-        // This mirrors the real "started anonymous → secured account"
-        // flow where the user's local nsec is imported into Keycast
-        // via headlessRegister(nsec: ...).
+        // SKIPPED (#3359): the nsec-passing path was removed because it
+        // leaked the user's private key over the wire. This banner only
+        // appears because the local key shares the OAuth pubkey and keeps
+        // the user authenticated after the session expires — i.e. it relies
+        // on BYOK identity preservation. #3786 restores that binding via
+        // proof-of-possession (byok_pubkey + byok_proof); re-enable then.
         // ════════════════════════════════════════════════════════════
 
         // 1a. Generate local private key
@@ -60,13 +63,14 @@ void main() {
         final localPubkey = keyContainer!.publicKeyHex;
         logPhase('Phase 1a: local keys generated — pubkey=$localPubkey');
 
-        // 1b. Register with Keycast passing the same nsec
+        // 1b. Register with Keycast. #3786 will re-bind the local pubkey here
+        // via proof-of-possession (byok_pubkey + byok_proof) instead of the
+        // removed nsec transfer.
         final oauthClient = container.read(oauthClientProvider);
         final result = (await tester.runAsync(
           () => oauthClient.headlessRegister(
             email: testEmail,
             password: testPassword,
-            nsec: nsec,
             scope: 'policy:full',
           ),
         ))!;
@@ -227,6 +231,10 @@ void main() {
         restoreErrorHandler(originalOnError);
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
+      // Skipped pending #3786 (see Phase 1 comment): the expired-session
+      // banner relies on the BYOK local-key fallback that the #3359 nsec
+      // strip removes until proof-of-possession binding is restored.
+      skip: true,
       timeout: const Timeout(Duration(minutes: 5)),
     );
   });

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -291,10 +291,14 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
           if (result.code != null && _pendingVerifier != null) {
             await _exchangeCodeAndLogin(result.code!, _pendingVerifier!);
           } else {
-            // Edge case: completion detected but missing code or verifier
+            // Edge case: completion detected but missing code or verifier.
+            // Never log the verifier value — it is the PKCE secret and, on
+            // pre-fix installs, could carry the nsec (#3359). Log presence
+            // booleans only.
             Log.error(
               'Verification complete but missing code or verifier! '
-              'code=${result.code}, verifier=$_pendingVerifier',
+              'hasCode=${result.code != null}, '
+              'hasVerifier=${_pendingVerifier != null}',
               name: 'EmailVerificationCubit',
               category: LogCategory.auth,
             );

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1586,6 +1586,10 @@
   "authUnexpectedError": "An unexpected error occurred. Please try again.",
   "authUpdatePassword": "Update password",
   "authSecureAccountTitle": "Secure account",
+  "authSecureAccountUnavailableMessage": "Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.",
+  "@authSecureAccountUnavailableMessage": {
+    "description": "Shown on the secure-account screen while the email/password upgrade is temporarily disabled (divine-mobile#3359 / #3786). Reassures the user their keys remain safe on-device."
+  },
   "authUnableToAccessKeys": "Unable to access your keys. Please try again.",
   "authRegistrationFailed": "Registration failed",
   "authRegistrationComplete": "Registration complete. Please check your email.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5216,6 +5216,12 @@ abstract class AppLocalizations {
   /// **'Secure account'**
   String get authSecureAccountTitle;
 
+  /// Shown on the secure-account screen while the email/password upgrade is temporarily disabled (divine-mobile#3359 / #3786). Reassures the user their keys remain safe on-device.
+  ///
+  /// In en, this message translates to:
+  /// **'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.'**
+  String get authSecureAccountUnavailableMessage;
+
   /// No description provided for @authUnableToAccessKeys.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2889,6 +2889,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authSecureAccountTitle => 'ደህንነቱ የተጠበቀ መለያ';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys => 'ቁልፎችዎን መድረስ አልተቻለም። እባክዎ እንደገና ይሞክሩ።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2910,6 +2910,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authSecureAccountTitle => 'حساب آمن';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'تعذّر الوصول إلى مفاتيحك. حاول مرّة أخرى.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2989,6 +2989,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authSecureAccountTitle => 'Защитен акаунт';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Няма достъп до ключовете ти. Опитай пак.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2981,6 +2981,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authSecureAccountTitle => 'Konto absichern';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Zugriff auf deine Schlüssel nicht möglich. Bitte versuch es nochmal.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2946,6 +2946,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authSecureAccountTitle => 'Secure account';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Unable to access your keys. Please try again.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2982,6 +2982,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authSecureAccountTitle => 'Asegurá tu cuenta';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'No se pudo acceder a tus claves. Probá de nuevo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2994,6 +2994,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get authSecureAccountTitle => 'I-secure ang account';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Hindi ma-access ang iyong mga key. Pakisubukang ulit.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2991,6 +2991,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authSecureAccountTitle => 'Sécuriser le compte';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Impossible d\'accéder à tes clés. Réessaie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2920,6 +2920,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get authSecureAccountTitle => 'Amankan akun';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Tidak bisa mengakses kuncimu. Silakan coba lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2978,6 +2978,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authSecureAccountTitle => 'Metti al sicuro l\'account';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Impossibile accedere alle tue chiavi. Riprova.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2797,6 +2797,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authSecureAccountTitle => 'アカウントを守ろう';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys => '鍵にアクセスできなかった。もう一回試してみて。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2810,6 +2810,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authSecureAccountTitle => '계정 보호';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys => '키에 접근할 수 없어요. 다시 시도해보세요.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2954,6 +2954,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authSecureAccountTitle => 'Account beveiligen';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Toegang tot je sleutels mislukt. Probeer het opnieuw.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3019,6 +3019,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authSecureAccountTitle => 'Zabezpiecz konto';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Nie można uzyskać dostępu do twoich kluczy. Spróbuj ponownie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2968,6 +2968,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authSecureAccountTitle => 'Proteger conta';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Não foi possível acessar suas chaves. Tente novamente.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3036,6 +3036,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authSecureAccountTitle => 'Securizează contul';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Nu am putut accesa cheile tale. Încearcă din nou.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2940,6 +2940,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authSecureAccountTitle => 'Säkra konto';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Kunde inte komma åt dina nycklar. Försök igen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2928,6 +2928,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authSecureAccountTitle => 'Güvenli hesap';
 
   @override
+  String get authSecureAccountUnavailableMessage =>
+      'Securing your account is paused for a quick security update. Your keys stay safe on this device — check back soon.';
+
+  @override
   String get authUnableToAccessKeys =>
       'Anahtarlarına erişilemiyor. Lütfen tekrar dene.';
 

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -1,390 +1,66 @@
-// ABOUTME: Secure account screen for existing anonymous users
-// ABOUTME: Allows adding email/password to an existing anonymous account
+// ABOUTME: Secure-account upgrade entry point. The key-importing upgrade was
+// ABOUTME: removed (#3359); shows a paused notice until #3786 restores it.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:keycast_flutter/keycast_flutter.dart';
-import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
-import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/screens/explore_screen.dart';
-import 'package:openvine/utils/validators.dart';
-import 'package:openvine/widgets/auth/auth_error_box.dart';
-import 'package:openvine/widgets/auth/auth_form_scaffold.dart';
-import 'package:unified_logger/unified_logger.dart';
+import 'package:openvine/widgets/auth_back_button.dart';
 
-class SecureAccountScreen extends ConsumerStatefulWidget {
+/// Secure-account upgrade screen.
+///
+/// The email/password upgrade used to export the user's local nsec and send it
+/// to Keycast over the wire — in the registration request body and embedded in
+/// the PKCE `code_verifier` — leaking the private key (#3359). That path is
+/// removed entirely.
+///
+/// Until the key-safe proof-of-possession registration lands (#3786), this
+/// screen shows a notice instead of the registration form. Falling through to
+/// the server's auto-generate path would silently re-create the user's
+/// identity under a new server-managed key (and wipe their local social-graph
+/// caches via `shouldClearDataForUser`), so the upgrade is paused rather than
+/// regressed.
+// TODO(#3786): restore the secure-account upgrade via proof-of-possession.
+class SecureAccountScreen extends StatelessWidget {
+  const SecureAccountScreen({super.key});
+
   /// Route name for this screen.
   static const routeName = 'secure-account';
 
   /// Path for this route.
   static const path = '/secure-account';
 
-  const SecureAccountScreen({super.key});
-
-  @override
-  ConsumerState<SecureAccountScreen> createState() =>
-      _SecureAccountScreenState();
-}
-
-class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
-  final _emailController = TextEditingController();
-  final _passwordController = TextEditingController();
-  final _confirmPasswordController = TextEditingController();
-  bool _isLoading = false;
-  String? _emailError;
-  String? _passwordError;
-  String? _confirmPasswordError;
-  String? _generalError;
-
-  void _setGeneralError(String? message) {
-    if (mounted) {
-      setState(() => _generalError = message);
-    }
-  }
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    _confirmPasswordController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _handleSubmit() async {
-    final messages = AuthValidationMessages.fromL10n(context.l10n);
-    final emailError = Validators.validateEmail(
-      _emailController.text.trim(),
-      messages: messages,
-    );
-    final passwordError = Validators.validatePassword(
-      _passwordController.text,
-      messages: messages,
-    );
-    final confirmPasswordError = Validators.validateConfirmPassword(
-      _confirmPasswordController.text,
-      password: _passwordController.text,
-      messages: messages,
-    );
-
-    if (emailError != null ||
-        passwordError != null ||
-        confirmPasswordError != null) {
-      setState(() {
-        _emailError = emailError;
-        _passwordError = passwordError;
-        _confirmPasswordError = confirmPasswordError;
-      });
-      return;
-    }
-
-    setState(() {
-      _isLoading = true;
-      _emailError = null;
-      _passwordError = null;
-      _confirmPasswordError = null;
-      _generalError = null;
-    });
-
-    final l10n = context.l10n;
-    try {
-      final oauth = ref.read(oauthClientProvider);
-      final email = _emailController.text.trim();
-      final password = _passwordController.text;
-
-      // Use authService.exportNsec() which accesses keys from secure storage
-      // This works for both auto-generated and imported keys
-      final authService = ref.read(authServiceProvider);
-      final nsec = await authService.exportNsec();
-
-      if (nsec == null) {
-        _setGeneralError(l10n.authUnableToAccessKeys);
-        return;
-      }
-
-      await _handleRegister(
-        oauth: oauth,
-        email: email,
-        password: password,
-        nsec: nsec,
-      );
-    } catch (e) {
-      Log.error(
-        'Auth error: $e',
-        name: 'SecureAccountScreen',
-        category: LogCategory.auth,
-      );
-      _setGeneralError(l10n.authUnexpectedError);
-    } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      }
-    }
-  }
-
-  Future<void> _handleRegister({
-    required KeycastOAuth oauth,
-    required String email,
-    required String password,
-    required String nsec,
-  }) async {
-    final (result, verifier) = await oauth.headlessRegister(
-      email: email,
-      nsec: nsec,
-      password: password,
-      scope: 'policy:full',
-    );
-
-    if (!result.success) {
-      _setGeneralError(
-        result.errorDescription ?? context.l10n.authRegistrationFailed,
-      );
-      return;
-    }
-
-    if (result.verificationRequired && result.deviceCode != null) {
-      // Start polling
-      if (mounted) {
-        context.read<EmailVerificationCubit>().startPolling(
-          deviceCode: result.deviceCode!,
-          verifier: verifier,
-          email: email,
-        );
-
-        // Show verification dialog but let user continue
-        _showVerificationDialog(email);
-      }
-    } else {
-      _setGeneralError(context.l10n.authRegistrationComplete);
-    }
-  }
-
-  void _showVerificationDialog(String email) {
-    showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) => PopScope(
-        canPop: false,
-        child: _VerificationDialog(
-          email: email,
-          onContinue: () {
-            Navigator.of(dialogContext).pop();
-            _continueToApp();
-          },
-          onSuccess: () {
-            // Signal password managers to save credentials BEFORE we unmount
-            // the form via navigation.
-            if (!mounted) return;
-            TextInput.finishAutofillContext();
-            context.go(ExploreScreen.path);
-          },
-        ),
-      ),
-    );
-  }
-
-  void _continueToApp() {
-    if (!mounted) return;
-    // Signal password managers to save credentials BEFORE we unmount
-    // the form via navigation.
-    TextInput.finishAutofillContext();
-    context.go(ExploreScreen.path);
-  }
-
   @override
   Widget build(BuildContext context) {
-    return AuthFormScaffold(
-      title: context.l10n.authSecureAccountTitle,
-      emailController: _emailController,
-      passwordController: _passwordController,
-      confirmPasswordController: _confirmPasswordController,
-      emailLabel: context.l10n.authEmailLabel,
-      passwordLabel: context.l10n.authPasswordLabel,
-      confirmPasswordLabel: context.l10n.authConfirmPasswordLabel,
-      emailError: _emailError,
-      passwordError: _passwordError,
-      confirmPasswordError: _confirmPasswordError,
-      enabled: !_isLoading,
-      onEmailChanged: (_) {
-        if (_emailError != null) setState(() => _emailError = null);
-      },
-      onPasswordChanged: (_) {
-        if (_passwordError != null || _confirmPasswordError != null) {
-          setState(() {
-            _passwordError = null;
-            _confirmPasswordError = null;
-          });
-        }
-      },
-      onConfirmPasswordChanged: (_) {
-        if (_confirmPasswordError != null) {
-          setState(() => _confirmPasswordError = null);
-        }
-      },
-      errorWidget: _generalError != null
-          ? AuthErrorBox(message: _generalError!)
-          : null,
-      primaryButton: DivineButton(
-        expanded: true,
-        label: context.l10n.authSecureAccountTitle,
-        isLoading: _isLoading,
-        onPressed: _handleSubmit,
-      ),
-    );
-  }
-}
-
-/// Reactive dialog that watches verification state and auto-closes on success
-class _VerificationDialog extends ConsumerWidget {
-  const _VerificationDialog({
-    required this.email,
-    required this.onContinue,
-    required this.onSuccess,
-  });
-
-  final String email;
-  final VoidCallback onContinue;
-  final VoidCallback onSuccess;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final authService = ref.watch(authServiceProvider);
-
-    return BlocBuilder<EmailVerificationCubit, EmailVerificationState>(
-      builder: (context, verificationState) {
-        // Auto-close when verification completes (user is no longer anonymous)
-        if (!verificationState.isPolling &&
-            verificationState.errorCode == null &&
-            !authService.isAnonymous) {
-          // Use post-frame callback to avoid calling Navigator during build
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            onSuccess();
-          });
-        }
-
-        // Show error state if verification failed
-        final errorCode = verificationState.errorCode;
-        if (errorCode != null) {
-          return AlertDialog(
-            backgroundColor: VineTheme.cardBackground,
-            title: const Row(
-              children: [
-                Icon(Icons.error_outline, color: VineTheme.error),
-                SizedBox(width: 12),
-                Text(
-                  'Verification Failed',
-                  style: TextStyle(color: VineTheme.whiteText),
-                ),
-              ],
-            ),
-            content: Text(
-              context.l10n.emailVerificationErrorMessage(errorCode),
-              style: const TextStyle(color: VineTheme.secondaryText),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text(
-                  'Close',
-                  style: TextStyle(color: VineTheme.vineGreen),
-                ),
-              ),
-            ],
-          );
-        }
-
-        // Show success state briefly before auto-closing
-        if (!authService.isAnonymous) {
-          return const AlertDialog(
-            backgroundColor: VineTheme.cardBackground,
-            title: Row(
-              children: [
-                Icon(Icons.check_circle, color: VineTheme.vineGreen),
-                SizedBox(width: 12),
-                Text(
-                  'Account Secured!',
-                  style: TextStyle(color: VineTheme.whiteText),
-                ),
-              ],
-            ),
-            content: Text(
-              'Your account is now linked to your email.',
-              style: TextStyle(color: VineTheme.onSurfaceVariant),
-            ),
-          );
-        }
-
-        // Show waiting state
-        return AlertDialog(
-          backgroundColor: VineTheme.cardBackground,
-          title: const Row(
-            children: [
-              Icon(Icons.email_outlined, color: VineTheme.vineGreen),
-              SizedBox(width: 12),
-              Text(
-                'Verify Your Email',
-                style: TextStyle(color: VineTheme.whiteText),
-              ),
-            ],
-          ),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
+    final l10n = context.l10n;
+    return Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Text(
-                'We sent a verification link to:',
-                style: TextStyle(color: VineTheme.secondaryText),
-              ),
               const SizedBox(height: 8),
+              const AuthBackButton(),
+              const SizedBox(height: 32),
               Text(
-                email,
+                l10n.authSecureAccountTitle,
                 style: const TextStyle(
-                  color: VineTheme.whiteText,
+                  fontFamily: VineTheme.fontFamilyBricolage,
+                  fontSize: 32,
                   fontWeight: FontWeight.bold,
+                  color: VineTheme.whiteText,
                 ),
               ),
-              const SizedBox(height: 16),
-              const Text(
-                'Click the link in your email to complete registration. '
-                'You can continue using the app in the meantime.',
-                style: TextStyle(color: VineTheme.secondaryText, fontSize: 14),
-              ),
-              const SizedBox(height: 16),
-              const Row(
-                children: [
-                  SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: VineTheme.vineGreen,
-                    ),
-                  ),
-                  SizedBox(width: 12),
-                  Text(
-                    'Waiting for verification...',
-                    style: TextStyle(color: VineTheme.vineGreen, fontSize: 12),
-                  ),
-                ],
+              const SizedBox(height: 24),
+              Text(
+                l10n.authSecureAccountUnavailableMessage,
+                style: VineTheme.bodyLargeFont(color: VineTheme.secondaryText),
               ),
             ],
           ),
-          actions: [
-            TextButton(
-              onPressed: onContinue,
-              child: const Text(
-                'Continue to App',
-                style: TextStyle(color: VineTheme.vineGreen),
-              ),
-            ),
-          ],
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -45,12 +45,7 @@ class SecureAccountScreen extends StatelessWidget {
               const SizedBox(height: 32),
               Text(
                 l10n.authSecureAccountTitle,
-                style: const TextStyle(
-                  fontFamily: VineTheme.fontFamilyBricolage,
-                  fontSize: 32,
-                  fontWeight: FontWeight.bold,
-                  color: VineTheme.whiteText,
-                ),
+                style: VineTheme.headlineLargeFont(),
               ),
               const SizedBox(height: 24),
               Text(

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -23,7 +23,6 @@ import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/apps/apps_directory_screen.dart';
 import 'package:openvine/screens/apps/apps_permissions_screen.dart';
-import 'package:openvine/screens/auth/secure_account_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/screens/creator_analytics_screen.dart';
@@ -193,12 +192,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     onSwitchAccount: _handleSwitchAccount,
                     accountSwitchingEnabled: accountSwitchingEnabled,
                   ),
-                  if (authService.isAnonymous)
-                    _SettingsTile(
-                      icon: Icons.security,
-                      title: context.l10n.settingsSecureAccount,
-                      onTap: () => context.push(SecureAccountScreen.path),
-                    ),
+                  // TODO(#3786): restore the "Secure account" tile once the
+                  // key-safe proof-of-possession upgrade lands. The upgrade is
+                  // paused in #3359 — it used to transmit the user's nsec.
                   if (!authService.isAnonymous &&
                       authService.hasExpiredOAuthSession)
                     _SettingsTile(

--- a/mobile/lib/services/pending_verification_service.dart
+++ b/mobile/lib/services/pending_verification_service.dart
@@ -105,6 +105,22 @@ class PendingVerificationService {
         return null;
       }
 
+      // Migration guard (divinevideo/divine-mobile#3359): pre-fix builds
+      // embedded the user's nsec in the PKCE verifier as a `<random>.<nsec1…>`
+      // suffix. Discard any persisted verifier still carrying that material so
+      // it can never be replayed to the token endpoint, and force a clean
+      // re-registration. `nsec1` cannot occur in a fresh base64url verifier.
+      if (verifier.contains('nsec1')) {
+        Log.info(
+          'Discarding pending verification with a legacy nsec-bearing verifier '
+          'for ${redactEmailForLogs(email)}, clearing',
+          name: 'PendingVerificationService',
+          category: LogCategory.auth,
+        );
+        await clear();
+        return null;
+      }
+
       // Parse createdAt, default to epoch if missing (legacy data)
       final createdAt = createdAtStr != null
           ? DateTime.tryParse(createdAtStr) ??

--- a/mobile/lib/widgets/profile/profile_actions_sheet/profile_action_type.dart
+++ b/mobile/lib/widgets/profile/profile_actions_sheet/profile_action_type.dart
@@ -33,7 +33,10 @@ enum ProfileActionType {
     if (!isOwnProfile) return const [];
 
     return [
-      if (isAnonymous) secureAccount,
+      // The "Secure account" prompt is paused (#3359): the email/password
+      // upgrade transmitted the user's nsec, and its key-safe replacement is
+      // tracked in #3786. `isAnonymous` is retained for that restoration.
+      // TODO(#3786): re-add `if (isAnonymous) secureAccount,` here.
       if (!hasAnyProfileInfo) completeProfile,
     ];
   }

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:keycast_flutter/src/crypto/key_utils.dart';
 import 'package:keycast_flutter/src/models/exceptions.dart';
 import 'package:keycast_flutter/src/models/keycast_session.dart';
 import 'package:keycast_flutter/src/oauth/callback_result.dart';
@@ -162,21 +161,12 @@ class KeycastOAuth {
   ///   - 'consent': Force consent screen even if previously approved
   ///   - 'none': Silent auth only, fail if interaction required
   Future<(String url, String verifier)> getAuthorizationUrl({
-    String? nsec,
     String scope = 'policy:social',
     bool defaultRegister = true,
     String? authorizationHandle,
     String? prompt,
   }) async {
-    String? byokPubkey;
-    if (nsec != null) {
-      byokPubkey = KeyUtils.derivePublicKeyFromNsec(nsec);
-      if (byokPubkey == null) {
-        return ('', '');
-      }
-    }
-
-    final verifier = Pkce.generateVerifier(nsec: nsec);
+    final verifier = Pkce.generateVerifier();
     final challenge = Pkce.generateChallenge(verifier);
 
     final params = <String, String>{
@@ -187,10 +177,6 @@ class KeycastOAuth {
       'code_challenge_method': 'S256',
       'default_register': defaultRegister.toString(),
     };
-
-    if (byokPubkey != null) {
-      params['byok_pubkey'] = byokPubkey;
-    }
 
     final handle = authorizationHandle ?? await getAuthorizationHandle();
     if (handle != null) {
@@ -277,21 +263,13 @@ class KeycastOAuth {
   /// polling.
   /// After registration, poll [pollForCode] until email is verified, then
   /// [exchangeCode].
-  ///
-  /// [nsec] - Optional: import existing Nostr key instead of generating new one
   Future<(HeadlessRegisterResult, String verifier)> headlessRegister({
     required String email,
     required String password,
     String scope = 'policy:social',
-    String? nsec,
     String? state,
   }) async {
-    String? byokPubkey;
-    if (nsec != null) {
-      byokPubkey = KeyUtils.derivePublicKeyFromNsec(nsec);
-    }
-
-    final verifier = Pkce.generateVerifier(nsec: nsec);
+    final verifier = Pkce.generateVerifier();
     final challenge = Pkce.generateChallenge(verifier);
 
     try {
@@ -304,10 +282,6 @@ class KeycastOAuth {
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
       };
-
-      if (byokPubkey != null) {
-        body['nsec'] = nsec;
-      }
 
       if (state != null) {
         body['state'] = state;

--- a/mobile/packages/keycast_flutter/lib/src/oauth/pkce.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/pkce.dart
@@ -1,24 +1,25 @@
 // ABOUTME: PKCE (Proof Key for Code Exchange) utilities for OAuth 2.0
-// ABOUTME: Generates verifiers and challenges, with optional BYOK nsec embedding
+// ABOUTME: Generates RFC 7636 random verifiers and their S256 challenges
 
 import 'dart:convert';
 import 'dart:math';
 import 'package:crypto/crypto.dart';
 
 class Pkce {
-  static String generateVerifier({String? nsec}) {
-    final random = _generateRandomPart();
-    return nsec != null ? '$random.$nsec' : random;
+  /// Generates a high-entropy RFC 7636 `code_verifier`: 32 cryptographically
+  /// random bytes, base64url-encoded with padding stripped.
+  ///
+  /// The verifier never carries caller-supplied material. Embedding the user's
+  /// nsec here used to leak the private key into the OAuth challenge — see
+  /// divinevideo/divine-mobile#3359.
+  static String generateVerifier() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
   }
 
   static String generateChallenge(String verifier) {
     final hash = sha256.convert(utf8.encode(verifier));
     return base64Url.encode(hash.bytes).replaceAll('=', '');
-  }
-
-  static String _generateRandomPart() {
-    final random = Random.secure();
-    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
-    return base64Url.encode(bytes).replaceAll('=', '');
   }
 }

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -71,31 +71,18 @@ void main() {
         expect(uri.queryParameters['default_register'], 'false');
       });
 
-      test('omits byok_pubkey when nsec not provided', () async {
+      test('never sets byok_pubkey and never embeds an nsec (#3359)', () async {
+        // Pre-fix code accepted an nsec, derived byok_pubkey into the query,
+        // and suffixed the verifier with the nsec. That surface is removed:
+        // the URL must carry no byok_pubkey and the verifier no nsec/dot.
         final oauth = KeycastOAuth(config: config);
-        final (url, _) = await oauth.getAuthorizationUrl();
+        final (url, verifier) = await oauth.getAuthorizationUrl();
 
         final uri = Uri.parse(url);
         expect(uri.queryParameters.containsKey('byok_pubkey'), isFalse);
-      });
-
-      test('includes byok_pubkey when nsec provided', () async {
-        final oauth = KeycastOAuth(config: config);
-        final (url, verifier) = await oauth.getAuthorizationUrl(
-          nsec:
-              'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
-        );
-
-        final uri = Uri.parse(url);
-        expect(uri.queryParameters.containsKey('byok_pubkey'), isTrue);
-        expect(uri.queryParameters['byok_pubkey']?.length, 64);
-        expect(verifier, contains('.nsec1'));
-      });
-
-      test('returns null URL for invalid nsec', () async {
-        final oauth = KeycastOAuth(config: config);
-        final (url, _) = await oauth.getAuthorizationUrl(nsec: 'invalid');
-        expect(url, isEmpty);
+        expect(uri.toString(), isNot(contains('nsec1')));
+        expect(verifier, isNot(contains('nsec1')));
+        expect(verifier, isNot(contains('.')));
       });
     });
 
@@ -368,14 +355,18 @@ void main() {
         expect(result.success, isTrue);
       });
 
-      test('includes nsec in body when provided', () async {
+      test('never sends an nsec in the body or embeds it in the verifier '
+          '(#3359)', () async {
+        // Capture the body and assert OUTSIDE the mock closure: an in-closure
+        // expect() failure would be swallowed by headlessRegister's try/catch
+        // and surface as a benign "network error", greening a real leak.
+        String? capturedBody;
         final mockClient = MockClient((request) async {
-          final body = jsonDecode(request.body) as Map<String, dynamic>;
-          expect(body['nsec'], contains('nsec1'));
+          capturedBody = request.body;
           return http.Response(
             jsonEncode({
               'success': true,
-              'pubkey': 'byok_pubkey',
+              'pubkey': 'server_pubkey',
               'verification_required': true,
             }),
             200,
@@ -383,12 +374,18 @@ void main() {
         });
 
         final oauth = KeycastOAuth(config: config, httpClient: mockClient);
-        await oauth.headlessRegister(
+        final (result, verifier) = await oauth.headlessRegister(
           email: 'test@example.com',
           password: 'password123',
-          nsec:
-              'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
         );
+
+        expect(result.success, isTrue);
+        expect(capturedBody, isNotNull);
+        final body = jsonDecode(capturedBody!) as Map<String, dynamic>;
+        expect(body.containsKey('nsec'), isFalse);
+        expect(capturedBody, isNot(contains('nsec1')));
+        expect(verifier, isNot(contains('nsec1')));
+        expect(verifier, isNot(contains('.')));
       });
 
       test('includes state parameter when provided', () async {

--- a/mobile/packages/keycast_flutter/test/pkce_test.dart
+++ b/mobile/packages/keycast_flutter/test/pkce_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for PKCE (Proof Key for Code Exchange) utilities
-// ABOUTME: Verifies verifier generation, challenge computation, and BYOK embedding
+// ABOUTME: Verifies verifier generation and challenge computation
 
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
@@ -29,28 +29,17 @@ void main() {
       });
     });
 
-    group('generateVerifier with BYOK', () {
-      test('embeds nsec in format {random}.{nsec}', () {
-        const nsec = 'nsec1test123';
-        final verifier = Pkce.generateVerifier(nsec: nsec);
-        expect(verifier, contains('.'));
-        expect(verifier, endsWith('.nsec1test123'));
-      });
-
-      test('random part is base64url without padding', () {
-        const nsec = 'nsec1abc';
-        final verifier = Pkce.generateVerifier(nsec: nsec);
-        final parts = verifier.split('.');
-        expect(parts.length, 2);
-        final randomPart = parts[0];
-        expect(randomPart, isNot(contains('=')));
-        expect(randomPart, isNot(contains('+')));
-        expect(randomPart, isNot(contains('/')));
-      });
-
-      test('without nsec, returns plain verifier (no dot)', () {
-        final verifier = Pkce.generateVerifier();
-        expect(verifier, isNot(contains('.')));
+    group('leak-prevention regression guard (#3359)', () {
+      test('never embeds an nsec — no nsec1 substring, no dot separator', () {
+        // Pre-fix code built the verifier as `<random>.<nsec1...>`, leaking
+        // the user's private key into the OAuth challenge. The nsec parameter
+        // is removed; the verifier must always be pure random with no embedded
+        // material. Loop to make an accidental reintroduction fail loudly.
+        for (var i = 0; i < 64; i++) {
+          final verifier = Pkce.generateVerifier();
+          expect(verifier, isNot(contains('nsec1')));
+          expect(verifier, isNot(contains('.')));
+        }
       });
     });
 
@@ -93,21 +82,6 @@ void main() {
         final challenge1 = Pkce.generateChallenge('verifier1');
         final challenge2 = Pkce.generateChallenge('verifier2');
         expect(challenge1, isNot(equals(challenge2)));
-      });
-    });
-
-    group('BYOK verifier with challenge', () {
-      test('challenge is computed on full verifier including nsec', () {
-        const nsec = 'nsec1secret';
-        final verifier = Pkce.generateVerifier(nsec: nsec);
-        final challenge = Pkce.generateChallenge(verifier);
-
-        final expectedHash = sha256.convert(utf8.encode(verifier));
-        final expectedChallenge = base64Url
-            .encode(expectedHash.bytes)
-            .replaceAll('=', '');
-
-        expect(challenge, equals(expectedChallenge));
       });
     });
   });

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -472,6 +472,10 @@ const _knownUntranslatedDebt = {
   // Translators will pick this up in a follow-up pass; until then non-English
   // locales fall back to the English source.
   'feedLoadingMore',
+  // Added by the #3359 secure-account nsec-leak fix: the upgrade flow is
+  // paused behind a notice until the proof-of-possession path (#3786) lands.
+  // Non-English locales fall back to English until the next translation pass.
+  'authSecureAccountUnavailableMessage',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -1,22 +1,17 @@
-// ABOUTME: Tests for SecureAccountScreen
-// ABOUTME: Verifies registration form, validation, and email verification flow
+// ABOUTME: Tests for SecureAccountScreen — verifies the #3359 paused-upgrade
+// ABOUTME: notice renders and that the screen never touches the nsec/OAuth path.
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/secure_account_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../helpers/autofill_context_mock.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
@@ -28,22 +23,15 @@ void main() {
     late _MockKeycastOAuth mockOAuth;
     late _MockAuthService mockAuthService;
 
+    setUpAll(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
     setUp(() {
       mockOAuth = _MockKeycastOAuth();
       mockAuthService = _MockAuthService();
-
-      // Default stubs
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.isAnonymous).thenReturn(true);
-      when(() => mockAuthService.isRegistered).thenReturn(false);
-      when(() => mockAuthService.currentNpub).thenReturn('npub1test...');
-      when(
-        () => mockAuthService.exportNsec(),
-      ).thenAnswer((_) async => 'nsec1testabc123xyz');
-    });
-
-    setUpAll(() async {
-      SharedPreferences.setMockInitialValues({});
     });
 
     Widget buildTestWidget() {
@@ -53,657 +41,50 @@ void main() {
           oauthClientProvider.overrideWithValue(mockOAuth),
           authServiceProvider.overrideWithValue(mockAuthService),
         ],
-        child: BlocProvider<EmailVerificationCubit>(
-          create: (_) => EmailVerificationCubit(
-            oauthClient: mockOAuth,
-            authService: mockAuthService,
-          ),
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: SecureAccountScreen(),
-          ),
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SecureAccountScreen(),
         ),
       );
     }
 
-    Future<void> setRegistrationTestSurface(WidgetTester tester) async {
-      await tester.binding.setSurfaceSize(const Size(900, 1200));
-      addTearDown(() => tester.binding.setSurfaceSize(null));
-    }
+    testWidgets('renders the paused-upgrade notice', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
 
-    group('Form Display', () {
-      testWidgets('displays email field', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        expect(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          findsOneWidget,
-        );
-      });
-
-      testWidgets('displays password field', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        expect(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          findsOneWidget,
-        );
-      });
-
-      testWidgets('displays confirm password field', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        expect(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          findsOneWidget,
-        );
-      });
-
-      testWidgets('displays Secure account button', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        expect(
-          find.widgetWithText(DivineButton, 'Secure account'),
-          findsOneWidget,
-        );
-      });
-
-      testWidgets('displays back button', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        expect(find.byIcon(Icons.chevron_left), findsOneWidget);
-      });
-    });
-
-    group('Form Validation', () {
-      testWidgets('shows error for invalid email', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        // Enter invalid email
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'invalid-email',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'password123',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'password123',
-        );
-
-        // Tap submit
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pumpAndSettle();
-
-        // Should show validation error
-        expect(find.textContaining('valid email'), findsOneWidget);
-      });
-
-      testWidgets('shows error for malformed email domain', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'person@gmail..com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pumpAndSettle();
-
-        expect(find.text('Please enter a valid email'), findsOneWidget);
-        verifyNever(() => mockAuthService.exportNsec());
-      });
-
-      testWidgets('shows error for password mismatch', (tester) async {
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'DifferentPass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pumpAndSettle();
-
-        expect(find.text("Passwords don't match"), findsOneWidget);
-        verifyNever(() => mockAuthService.exportNsec());
-      });
-    });
-
-    group('Password Visibility Toggle', () {
-      testWidgets('toggles password visibility', (tester) async {
-        await setRegistrationTestSurface(tester);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        // DivineAuthTextField uses DivineIcon (SVG) for password visibility
-        // toggles. The password and confirmation fields each have one.
-        expect(find.byType(DivineIcon), findsNWidgets(2));
-
-        // Password should be obscured initially
-        final textField = tester.widget<TextField>(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-        );
-        expect(textField.obscureText, isTrue);
-
-        // Tap the visibility toggle (GestureDetector wrapping DivineIcon)
-        await tester.tap(find.byType(DivineIcon).first);
-        await tester.pumpAndSettle();
-
-        // Password should now be visible
-        final textFieldAfter = tester.widget<TextField>(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-        );
-        expect(textFieldAfter.obscureText, isFalse);
-      });
-    });
-
-    group('Registration Flow', () {
-      testWidgets('calls headlessRegister on valid form submission', (
-        tester,
-      ) async {
-        // Use verificationRequired: false to avoid triggering polling
-        when(
-          () => mockOAuth.headlessRegister(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessRegisterResult(
-              success: true,
-              pubkey: 'test-pubkey',
-              verificationRequired: false,
-              email: 'test@example.com',
-            ),
-            'test-verifier',
-          ),
-        );
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        // Use pump() instead of pumpAndSettle() to avoid timer issues
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-
-        verify(
-          () => mockOAuth.headlessRegister(
-            email: 'test@example.com',
-            password: 'SecurePass123!',
-            nsec: any(named: 'nsec'),
-            scope: 'policy:full',
-          ),
-        ).called(1);
-      });
-
-      testWidgets('shows error message on registration failure', (
-        tester,
-      ) async {
-        when(
-          () => mockOAuth.headlessRegister(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessRegisterResult.error('Email already registered'),
-            'test-verifier',
-          ),
-        );
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'existing@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pumpAndSettle();
-
-        expect(find.text('Email already registered'), findsOneWidget);
-      });
-
-      testWidgets('shows error when nsec export fails', (tester) async {
-        when(() => mockAuthService.exportNsec()).thenAnswer((_) async => null);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pumpAndSettle();
-
-        expect(
-          find.text('Unable to access your keys. Please try again.'),
-          findsOneWidget,
-        );
-      });
-    });
-
-    group('Autofill Context', () {
-      testWidgets(
-        'calls TextInput.finishAutofillContext when tapping Continue to App',
-        (tester) async {
-          await setRegistrationTestSurface(tester);
-
-          final recorder = AutofillContextRecorder.install();
-
-          // Return verification-required result so the dialog is shown.
-          when(
-            () => mockOAuth.headlessRegister(
-              email: any(named: 'email'),
-              password: any(named: 'password'),
-              nsec: any(named: 'nsec'),
-              scope: any(named: 'scope'),
-            ),
-          ).thenAnswer(
-            (_) async => (
-              HeadlessRegisterResult(
-                success: true,
-                pubkey: 'test-pubkey',
-                verificationRequired: true,
-                deviceCode: 'test-device-code',
-                email: 'test@example.com',
-              ),
-              'test-verifier',
-            ),
-          );
-
-          // Build with GoRouter so context.go() in _continueToApp() succeeds.
-          // BlocProvider and ProviderScope must wrap MaterialApp.router so
-          // that dialogs opened via showDialog (which uses the root overlay)
-          // can find both the BLoC and Riverpod providers.
-          final router = GoRouter(
-            routes: [
-              GoRoute(
-                path: '/',
-                builder: (_, _) => const SecureAccountScreen(),
-              ),
-              GoRoute(path: '/explore', builder: (_, _) => const Scaffold()),
-            ],
-          );
-
-          await tester.pumpWidget(
-            ProviderScope(
-              overrides: [
-                ...getStandardTestOverrides(),
-                oauthClientProvider.overrideWithValue(mockOAuth),
-                authServiceProvider.overrideWithValue(mockAuthService),
-              ],
-              child: BlocProvider<EmailVerificationCubit>(
-                create: (_) => EmailVerificationCubit(
-                  oauthClient: mockOAuth,
-                  authService: mockAuthService,
-                ),
-                child: MaterialApp.router(
-                  theme: VineTheme.theme,
-                  localizationsDelegates:
-                      AppLocalizations.localizationsDelegates,
-                  supportedLocales: AppLocalizations.supportedLocales,
-                  routerConfig: router,
-                ),
-              ),
-            ),
-          );
-          await tester.pumpAndSettle();
-
-          // Enter valid credentials.
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Email'),
-              matching: find.byType(TextField),
-            ),
-            'test@example.com',
-          );
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Password'),
-              matching: find.byType(TextField),
-            ),
-            'SecurePass123!',
-          );
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-              matching: find.byType(TextField),
-            ),
-            'SecurePass123!',
-          );
-
-          // Submit the form — triggers headlessRegister → dialog shown.
-          await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-          // Pump through the async headlessRegister call and showDialog.
-          // Use pump() + pump(duration) to drain microtask + timer queues
-          // without relying on pumpAndSettle (which hangs on polling timers).
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 500));
-
-          // Tap "Continue to App" in the verification dialog.
-          await tester.tap(find.text('Continue to App'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 100));
-
-          expect(recorder.didFinishAutofillContext, isTrue);
-        },
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.authSecureAccountTitle), findsOneWidget);
+      expect(
+        find.text(l10n.authSecureAccountUnavailableMessage),
+        findsOneWidget,
       );
-
-      testWidgets('verification dialog is not dismissed by tapping outside', (
-        tester,
-      ) async {
-        await setRegistrationTestSurface(tester);
-
-        when(
-          () => mockOAuth.headlessRegister(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessRegisterResult(
-              success: true,
-              pubkey: 'test-pubkey',
-              verificationRequired: true,
-              deviceCode: 'test-device-code',
-              email: 'test@example.com',
-            ),
-            'test-verifier',
-          ),
-        );
-
-        final router = GoRouter(
-          routes: [
-            GoRoute(path: '/', builder: (_, _) => const SecureAccountScreen()),
-            GoRoute(path: '/explore', builder: (_, _) => const Scaffold()),
-          ],
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              ...getStandardTestOverrides(),
-              oauthClientProvider.overrideWithValue(mockOAuth),
-              authServiceProvider.overrideWithValue(mockAuthService),
-            ],
-            child: BlocProvider<EmailVerificationCubit>(
-              create: (_) => EmailVerificationCubit(
-                oauthClient: mockOAuth,
-                authService: mockAuthService,
-              ),
-              child: MaterialApp.router(
-                theme: VineTheme.theme,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: router,
-              ),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-
-        await tester.tapAt(const Offset(10, 10));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-      });
-
-      testWidgets('verification dialog is not dismissed by system back', (
-        tester,
-      ) async {
-        await setRegistrationTestSurface(tester);
-
-        when(
-          () => mockOAuth.headlessRegister(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessRegisterResult(
-              success: true,
-              pubkey: 'test-pubkey',
-              verificationRequired: true,
-              deviceCode: 'test-device-code',
-              email: 'test@example.com',
-            ),
-            'test-verifier',
-          ),
-        );
-
-        final router = GoRouter(
-          routes: [
-            GoRoute(path: '/', builder: (_, _) => const SecureAccountScreen()),
-            GoRoute(path: '/explore', builder: (_, _) => const Scaffold()),
-          ],
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              ...getStandardTestOverrides(),
-              oauthClientProvider.overrideWithValue(mockOAuth),
-              authServiceProvider.overrideWithValue(mockAuthService),
-            ],
-            child: BlocProvider<EmailVerificationCubit>(
-              create: (_) => EmailVerificationCubit(
-                oauthClient: mockOAuth,
-                authService: mockAuthService,
-              ),
-              child: MaterialApp.router(
-                theme: VineTheme.theme,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: router,
-              ),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-
-        await tester.binding.handlePopRoute();
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-      });
     });
+
+    testWidgets('does not render a registration form', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // The form (and therefore the nsec export + OAuth register path) is gone.
+      expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets(
+      'never exports the local nsec or calls OAuth registration — '
+      'leak-prevention regression guard (#3359)',
+      (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        verifyNever(() => mockAuthService.exportNsec());
+        verifyNever(
+          () => mockOAuth.headlessRegister(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+            scope: any(named: 'scope'),
+          ),
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/pending_verification_service_test.dart
+++ b/mobile/test/services/pending_verification_service_test.dart
@@ -1,0 +1,81 @@
+// ABOUTME: Tests for PendingVerificationService persistence and the #3359
+// ABOUTME: migration guard that purges legacy nsec-bearing PKCE verifiers.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  group(PendingVerificationService, () {
+    late MockSecureStorage storage;
+    late PendingVerificationService service;
+
+    setUp(() {
+      storage = MockSecureStorage();
+      service = PendingVerificationService(storage);
+    });
+
+    group('load', () {
+      test('returns null when nothing is stored', () async {
+        expect(await service.load(), isNull);
+      });
+
+      test('returns a clean random-only verifier unchanged', () async {
+        const cleanVerifier = 'abc123randomVerifierWithNoEmbeddedMaterial456';
+        await service.save(
+          deviceCode: 'device_code_clean',
+          verifier: cleanVerifier,
+          email: 'user@example.com',
+        );
+
+        final result = await service.load();
+
+        expect(result, isNotNull);
+        expect(result!.verifier, cleanVerifier);
+        expect(result.deviceCode, 'device_code_clean');
+        expect(result.email, 'user@example.com');
+      });
+    });
+
+    group('load migration guard (#3359)', () {
+      test(
+        'discards a legacy <random>.<nsec1...> verifier and clears storage',
+        () async {
+          const leakedVerifier =
+              'abc123randomPart.nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9'
+              'k0t9af8935ke9laqsnlfe5';
+          await service.save(
+            deviceCode: 'device_code_leaked',
+            verifier: leakedVerifier,
+            email: 'user@example.com',
+          );
+
+          final result = await service.load();
+
+          // The tainted verifier must never be returned, and storage must be
+          // cleared so it can't be replayed to the token endpoint on restart.
+          expect(result, isNull);
+          expect(await service.hasPending(), isFalse);
+        },
+      );
+
+      test(
+        'discards a bare nsec1 verifier with no leading dot (defense in depth)',
+        () async {
+          await service.save(
+            deviceCode: 'device_code_bare',
+            verifier:
+                'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsn',
+            email: 'user@example.com',
+          );
+
+          final result = await service.load();
+
+          expect(result, isNull);
+          expect(await service.hasPending(), isFalse);
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/profile/profile_actions_sheet/profile_action_type_test.dart
+++ b/mobile/test/widgets/profile/profile_actions_sheet/profile_action_type_test.dart
@@ -7,20 +7,40 @@ import 'package:openvine/widgets/profile/profile_actions_sheet/profile_action_ty
 void main() {
   group(ProfileActionType, () {
     group('pending', () {
-      test('returns both actions when anonymous without profile info', () {
-        final actions = ProfileActionType.pending(
-          isOwnProfile: true,
-          isAnonymous: true,
-          hasExpiredSession: false,
-          hasAnyProfileInfo: false,
-        );
-
-        expect(actions, hasLength(2));
-        expect(actions[0], equals(ProfileActionType.secureAccount));
-        expect(actions[1], equals(ProfileActionType.completeProfile));
+      test('never emits secureAccount while the upgrade is paused (#3359)', () {
+        // The secureAccount prompt is paused until the key-safe
+        // proof-of-possession upgrade lands (#3786), so pending() never emits
+        // it regardless of anonymity / profile / session state.
+        for (final hasProfileInfo in [false, true]) {
+          for (final expired in [false, true]) {
+            final actions = ProfileActionType.pending(
+              isOwnProfile: true,
+              isAnonymous: true,
+              hasExpiredSession: expired,
+              hasAnyProfileInfo: hasProfileInfo,
+            );
+            expect(actions, isNot(contains(ProfileActionType.secureAccount)));
+          }
+        }
       });
 
-      test('returns only secureAccount when anonymous with profile info', () {
+      test(
+        'emits only completeProfile for an anonymous user without profile info',
+        () {
+          // Was [secureAccount, completeProfile] before #3359.
+          final actions = ProfileActionType.pending(
+            isOwnProfile: true,
+            isAnonymous: true,
+            hasExpiredSession: false,
+            hasAnyProfileInfo: false,
+          );
+
+          expect(actions, equals([ProfileActionType.completeProfile]));
+        },
+      );
+
+      test('is empty for an anonymous user who has profile info (#3359)', () {
+        // Was [secureAccount] before #3359 paused the upgrade prompt.
         final actions = ProfileActionType.pending(
           isOwnProfile: true,
           isAnonymous: true,
@@ -28,7 +48,7 @@ void main() {
           hasAnyProfileInfo: true,
         );
 
-        expect(actions, equals([ProfileActionType.secureAccount]));
+        expect(actions, isEmpty);
       });
 
       test(
@@ -67,22 +87,11 @@ void main() {
         expect(actions, isEmpty);
       });
 
-      test('shows secureAccount for anonymous even with expired session', () {
-        final actions = ProfileActionType.pending(
-          isOwnProfile: true,
-          isAnonymous: true,
-          hasExpiredSession: true,
-          hasAnyProfileInfo: false,
-        );
-
-        expect(actions, hasLength(2));
-        expect(actions[0], equals(ProfileActionType.secureAccount));
-        expect(actions[1], equals(ProfileActionType.completeProfile));
-      });
-
       test(
-        'returns only secureAccount when session expired and has profile info',
+        'is empty for an anonymous user with profile info and expired session '
+        '(#3359)',
         () {
+          // Was [secureAccount] before #3359 paused the upgrade prompt.
           final actions = ProfileActionType.pending(
             isOwnProfile: true,
             isAnonymous: true,
@@ -90,7 +99,7 @@ void main() {
             hasAnyProfileInfo: true,
           );
 
-          expect(actions, equals([ProfileActionType.secureAccount]));
+          expect(actions, isEmpty);
         },
       );
     });

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -823,28 +823,32 @@ void main() {
     });
 
     group('Action Label', () {
-      testWidgets('shows Secure label when anonymous with custom name', (
-        tester,
-      ) async {
-        final testProfile = createTestProfile(displayName: 'Test User');
+      testWidgets(
+        'hides the action label for an anonymous user with a custom name '
+        '(secure-account paused #3359)',
+        (tester) async {
+          final testProfile = createTestProfile(displayName: 'Test User');
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            userIdHex: testUserHex,
-            isOwnProfile: true,
-            profile: testProfile,
-            isAnonymous: true,
-          ),
-        );
-        await tester.pumpAndSettle();
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              isAnonymous: true,
+            ),
+          );
+          await tester.pumpAndSettle();
 
-        expect(find.text('Secure your account'), findsOneWidget);
-        // 1 action — badge shows "1"
-        expect(find.text('1'), findsOneWidget);
-      });
+          // Was [secureAccount] before #3359; the upgrade prompt is now gated
+          // and the profile already has a name, so nothing is pending.
+          expect(find.text('Secure your account'), findsNothing);
+          expect(find.text('Complete your profile'), findsNothing);
+        },
+      );
 
       testWidgets(
-        'shows Secure label with count badge when anonymous and no name',
+        'shows the Complete-profile label (not Secure) for an anonymous user '
+        'with no name (#3359)',
         (tester) async {
           final profileWithDefaultName = createTestProfile();
 
@@ -858,10 +862,10 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          // Secure takes precedence
-          expect(find.text('Secure your account'), findsOneWidget);
-          // 2 actions — red badge with "2"
-          expect(find.text('2'), findsOneWidget);
+          // Was [secureAccount, completeProfile] (badge "2") before #3359.
+          // The secure-account prompt is paused, leaving only completeProfile.
+          expect(find.text('Secure your account'), findsNothing);
+          expect(find.text('Complete your profile'), findsOneWidget);
         },
       );
 
@@ -914,13 +918,13 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // Tap on the action label
-        await tester.tap(find.text('Secure your account'));
+        // secureAccount is gated (#3359), so the pill is the completeProfile
+        // action; tapping it opens the sheet for that action.
+        await tester.tap(find.text('Complete your profile'));
         await tester.pumpAndSettle();
 
-        // The bottom sheet should show the first action
-        expect(find.text('Secure Your Account'), findsOneWidget);
-        expect(find.text('Add Email & Password'), findsOneWidget);
+        expect(find.text('Complete Your Profile'), findsOneWidget);
+        expect(find.text('Update Your Profile'), findsOneWidget);
         expect(find.text('Maybe Later'), findsOneWidget);
       });
     });
@@ -985,7 +989,8 @@ void main() {
       );
 
       testWidgets(
-        'shows secure account label for anonymous users with expired session',
+        'anonymous users see no action pill and no session-expired sheet when '
+        'the session is expired (#3359)',
         (tester) async {
           final testProfile = createTestProfile(displayName: 'Test User');
           SharedPreferences.setMockInitialValues({});
@@ -1003,8 +1008,10 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          // Anonymous users see the action label pill, not session expired
-          expect(find.text('Secure your account'), findsOneWidget);
+          // secure-account pill gated (#3359); the session-expired sheet only
+          // shows for non-anonymous users.
+          expect(find.text('Secure your account'), findsNothing);
+          expect(find.text('Complete your profile'), findsNothing);
           expect(find.text('Session Expired'), findsNothing);
         },
       );

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -407,19 +407,22 @@ void main() {
       await tester.pump();
     });
 
-    testWidgets('renders Secure Your Account tile for anonymous users', (
-      tester,
-    ) async {
-      when(() => mockAuthService.isAnonymous).thenReturn(true);
+    testWidgets(
+      'hides the Secure Your Account tile while the upgrade is paused (#3359)',
+      (tester) async {
+        when(() => mockAuthService.isAnonymous).thenReturn(true);
 
-      await tester.pumpWidget(buildSubject());
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
 
-      expect(find.text('Secure Your Account'), findsOneWidget);
+        // Upgrade paused until #3786 restores a key-safe path; the tile is
+        // hidden even for anonymous users.
+        expect(find.text('Secure Your Account'), findsNothing);
 
-      await tester.pumpWidget(const SizedBox());
-      await tester.pump();
-    });
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
 
     testWidgets('renders Session Expired tile when session expired', (
       tester,
@@ -436,8 +439,8 @@ void main() {
     });
 
     testWidgets(
-      'shows secure account tile instead of session expired for anonymous '
-      'users',
+      'shows neither the secure-account nor session-expired tile for '
+      'anonymous users (#3359)',
       (tester) async {
         when(() => mockAuthService.isAnonymous).thenReturn(true);
         when(() => mockAuthService.hasExpiredOAuthSession).thenReturn(true);
@@ -471,7 +474,9 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsOneWidget);
+        // Secure-account upgrade is paused (#3359); the session-expired tile
+        // is gated on !isAnonymous — an anonymous user sees neither.
+        expect(find.text('Secure Your Account'), findsNothing);
         expect(find.text('Session Expired'), findsNothing);
 
         await tester.pumpWidget(const SizedBox());

--- a/mobile/tools/ci/grep_for_nsec_payload.sh
+++ b/mobile/tools/ci/grep_for_nsec_payload.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ABOUTME: Fails CI if production code uses `nsec` as an HTTP payload key.
+# ABOUTME: Locks in the Phase 1 fix for divinevideo/divine-mobile#3359.
+#
+# Background: pre-fix code in `keycast_flutter` set `body['nsec'] = nsec`
+# in OAuth registration requests, transmitting the user's Nostr private
+# key over the wire. The fix removes that surface entirely. This guard
+# fires if a future change re-introduces the same shape (or a moral
+# equivalent like `'nsec':` / `"nsec":` in a map literal) anywhere in
+# production code.
+#
+# Legitimate uses NOT flagged:
+# - `nsec:` as a Dart named parameter (no quotes).
+# - `'nsec'` in test assertions like `containsKey('nsec')` (no colon
+#   immediately after the closing quote).
+# - Comments and doc strings.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Search roots: production code only.
+ROOTS=(
+  "mobile/lib"
+  "mobile/packages"
+)
+
+# Patterns that uniquely indicate `nsec` is being used as a payload key.
+PATTERN="(body\[['\"]nsec['\"]\])|(['\"]nsec['\"][[:space:]]*:)"
+
+# File suffixes / paths to exclude.
+EXCLUDES=(
+  "_test.dart"
+  ".g.dart"
+  ".freezed.dart"
+  ".mocks.dart"
+  "/l10n/generated/"
+)
+
+tmpfile="$(mktemp)"
+trap 'rm -f "$tmpfile"' EXIT
+
+# Find dart files, run grep, exclude generated/test files in post-filter.
+find "${ROOTS[@]}" -type f -name "*.dart" 2>/dev/null \
+  | while IFS= read -r f; do
+      skip=0
+      for ex in "${EXCLUDES[@]}"; do
+        case "$f" in *"$ex"*) skip=1; break;; esac
+      done
+      [ "$skip" -eq 1 ] && continue
+      grep -nE "$PATTERN" "$f" 2>/dev/null \
+        | sed "s|^|$f:|" \
+        || true
+    done > "$tmpfile"
+
+if [ -s "$tmpfile" ]; then
+  cat "$tmpfile"
+  echo
+  echo "❌ One or more files use 'nsec' as a payload key in production code."
+  echo "   This pattern is banned by the Phase 1 fix for"
+  echo "   divinevideo/divine-mobile#3359 (BYOK nsec leak prevention)."
+  echo
+  echo "   If you are intentionally re-introducing BYOK identity binding,"
+  echo "   use the proof-of-possession contract from divinevideo/keycast#197"
+  echo "   (byok_pubkey + byok_proof) instead of forwarding the nsec."
+  exit 1
+fi
+
+echo "✅ No nsec-as-payload-key usages detected in production code."


### PR DESCRIPTION
## Description

**Phase 1 (mobile emergency block) for the BYOK `nsec` leak.** The secure-account upgrade exported the user's local `nsec` (Nostr private key) and sent it to Keycast over the wire — in the `POST /api/headless/register` body as `body['nsec']`, and embedded in the PKCE `code_verifier` as a `<random>.<nsec1…>` suffix (which is then hashed into the OAuth `code_challenge`), plus a derived `byok_pubkey` query param. The private key left on-device custody.

This PR removes that surface entirely and **gates** the upgrade behind a notice rather than falling through to the server's auto-generate path — which would silently re-create the user's identity under a new server-managed pubkey and wipe their local social-graph caches (via `shouldClearDataForUser`). That destructive auto-generate behavior is what closed the prior attempt (#3784); gating avoids it. Identity preservation is restored separately by #3786 via the proof-of-possession contract (divinevideo/keycast#197).

> **Draft on purpose.** #3359 is the home of an unresolved product decision (custodial-secure key transport vs. local-only proof-of-possession). This PR implements the *decision-independent* interim: stop the live key leak now, without the destructive regression that closed #3784. It does **not** pre-commit the durable direction.

**Related Issue:** Relates to #3359 · Follow-up: #3786 · Server contract: divinevideo/keycast#197

## Reproducing the leak (before this PR)

1. Launch the app as a fresh anonymous user (auto-generated local key).
2. Go to **Settings → Secure Your Account** (or tap the profile "Secure your account" prompt). Enter an email + password and submit.
3. Inspect the outbound `POST /api/headless/register` body → it contains `"nsec": "nsec1…"` — the user's private key.
4. Inspect the subsequent `POST /api/oauth/token` body → `code_verifier` is `<random>.nsec1…`; the same nsec is therefore also hashed into the `code_challenge` on the authorize URL and persisted in `pending_verification` secure storage.

→ The private key has left the device in plaintext over the network and is embedded in the OAuth challenge. (Audit evidence: `pkce.dart:9-12`, `oauth_client.dart:155-171/280-310`, `secure_account_screen.dart:100-141`.)

## Verifying the fix

- `nsec` / `byok_pubkey` no longer exist on the `keycast_flutter` OAuth API, so no caller can send them.
- The secure-account entry points are hidden; the screen shows a paused notice and makes **no** registration request.
- `bash mobile/tools/ci/grep_for_nsec_payload.sh` passes, and a new `nsec-leak-guard` CI job fails any future reintroduction of `body['nsec']` / `'nsec':`.
- Negative-regression tests assert the nsec never appears in the verifier, request body, or persisted state.

## What changed

**Client (`keycast_flutter`)**
- `pkce.dart` — `generateVerifier()` drops the `nsec` param; always returns pure-random base64url.
- `oauth_client.dart` — removed `nsec`/`byokPubkey` from `getAuthorizationUrl` and `headlessRegister`, the `body['nsec']` field, the `byok_pubkey` query param, and the now-orphaned `KeyUtils` import.

**App**
- `pending_verification_service.dart` — `load()` purges any persisted `*nsec1*` verifier (from pre-fix devices) before it can be replayed to the token endpoint.
- `email_verification_cubit.dart` — stops logging the verifier value (presence booleans only).
- `secure_account_screen.dart` — gutted to an l10n notice (no form / no `exportNsec` / no registration).
- `settings_screen.dart` + `profile_action_type.dart` — both entry points hidden, each with a `// TODO(#3786):` restore marker.
- New `authSecureAccountUnavailableMessage` l10n key (registered in `arb_consistency_test` untranslated-debt; non-English falls back to English until the next pass).

**CI**
- `tools/ci/grep_for_nsec_payload.sh` + a `nsec-leak-guard` job wired into the `mobile-ci` aggregate gate.

## Out of Scope

- **Restoring BYOK identity preservation** — #3786 (proof-of-possession), gated on divinevideo/keycast#197 reaching production. Until then the upgrade is paused; anonymous users cannot upgrade / back up their key.
- **Already-exfiltrated keys** captured in infra/proxy logs pre-fix — retention review tracked in keycast#197; whether to prompt affected users to rotate keys is a separate product/security decision.
- The durable architecture decision (custodial-secure vs. local-only) — needs product sign-off here / on #3359.

## Verification

- `flutter analyze lib test integration_test` → No issues found; `keycast_flutter` analyze → clean
- `dart format --output=none --set-exit-if-changed` (15 changed files) → clean
- `keycast_flutter`: 78 tests pass (`pkce_test`, `oauth_client_test`)
- App tests pass: `pending_verification_service_test` (new, 4), `secure_account_screen_test`, `profile_action_type_test`, `settings_screen_test`, `email_verification_cubit_test`, `arb_consistency_test`
- `bash mobile/tools/ci/grep_for_nsec_payload.sh` → passes
- `integration_test/auth/session_expired_banner_test.dart` is **skipped** pending #3786 — it relies on the BYOK local-key fallback this PR removes (the expired-session banner only appears because the local key shares the OAuth pubkey), so it cannot run meaningfully until identity preservation is restored.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change

> Reviewer note: this intentionally **pauses** the secure-account upgrade UX until #3786. Existing secured users are unaffected; only new anonymous→secured upgrades are paused. Please weigh the interim UX gap against keeping the live private-key leak open.
