### PR TITLE
feat(observability): enrich Bloc error reports with last event, state, and build tag (#3758)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -944,6 +944,16 @@ Future<void> _startOpenVineApp() async {
   // investigation as a missing observability hook. See #3526.
   Bloc.observer = DivineBlocObserver();
 
+  // Tag every crash report with the running build so per-error triage doesn't
+  // have to cross-reference the release dashboard. Set once, not per-error.
+  // See #3758.
+  unawaited(
+    CrashReportingService.instance.setCustomKey(
+      'build_tag',
+      '${packageInfo.version}+${packageInfo.buildNumber}',
+    ),
+  );
+
   runApp(
     UncontrolledProviderScope(
       container: container,

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -1,5 +1,5 @@
 // ABOUTME: BlocObserver that forwards Bloc errors to Crashlytics + UnifiedLogger
-// ABOUTME: Wired once in main.dart before runApp; covers addError, handler throws, emit failures
+// ABOUTME: Enriches forwarded reports with the bloc's last event/state/transition
 
 import 'dart:async';
 
@@ -7,6 +7,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Crashlytics custom-key names for the per-bloc diagnostics attached when a
+/// [ReportableError] is forwarded. Public so dashboards and tests share one
+/// source of truth.
+const String kBlocLastEventKey = 'bloc.lastEvent';
+const String kBlocLastStateKey = 'bloc.lastState';
+const String kBlocLastTransitionAtKey = 'bloc.lastTransitionAt';
 
 /// Forwards Bloc/Cubit errors to the project's crash reporter and the unified
 /// log.
@@ -23,6 +30,15 @@ import 'package:unified_logger/unified_logger.dart';
 /// 4xx responses, validation failures) flood the dashboard and drown the
 /// real bugs. See the decision matrix in `.claude/rules/error_handling.md`.
 ///
+/// On a forwarded error the observer also attaches the bloc's most recent
+/// event, state, and transition time as Crashlytics custom keys
+/// ([kBlocLastEventKey] / [kBlocLastStateKey] / [kBlocLastTransitionAtKey]),
+/// each sanitized through [sanitizeForCrashReport]. Event and state are
+/// tracked per bloc via [onEvent] / [onChange] with no IO until [onError]
+/// fires, so the hot path stays allocation-light. The triage gap this closes
+/// is the one that made the #3503 auth-timing investigation expensive. See
+/// #3758.
+///
 /// Wire once at app start, before `runApp`:
 ///
 /// ```dart
@@ -35,6 +51,30 @@ class DivineBlocObserver extends BlocObserver {
 
   final CrashReportingService _crashReporting;
 
+  /// Per-bloc diagnostics. An [Expando] holds its keys weakly, so a bloc's
+  /// entry becomes collectible the moment the bloc itself is — observing every
+  /// bloc in the app does not retain any of them.
+  final Expando<_BlocDiagnostics> _diagnostics = Expando<_BlocDiagnostics>(
+    'DivineBlocObserver',
+  );
+
+  _BlocDiagnostics _diagnosticsFor(BlocBase<dynamic> bloc) =>
+      _diagnostics[bloc] ??= _BlocDiagnostics();
+
+  @override
+  void onEvent(Bloc<dynamic, dynamic> bloc, Object? event) {
+    super.onEvent(bloc, event);
+    _diagnosticsFor(bloc).lastEvent = event;
+  }
+
+  @override
+  void onChange(BlocBase<dynamic> bloc, Change<dynamic> change) {
+    super.onChange(bloc, change);
+    _diagnosticsFor(bloc)
+      ..lastState = change.nextState
+      ..lastTransitionAt = DateTime.now();
+  }
+
   @override
   void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
     super.onError(bloc, error, stackTrace);
@@ -46,10 +86,53 @@ class DivineBlocObserver extends BlocObserver {
       stackTrace: stackTrace,
     );
     if (error is! ReportableError) return;
+    // Dispatch the diagnostic keys before recordError so they attach to the
+    // report it emits. Both are fire-and-forget, but invoked synchronously and
+    // in order, so the platform-channel messages stay ordered without blocking
+    // the bloc error path. recordError and setCustomKey each swallow their own
+    // failures and return early when uninitialized (see
+    // crash_reporting_service.dart).
+    _attachDiagnosticKeys(_diagnostics[bloc]);
     final reason = sanitizeForCrashReport('Bloc.addError $runtimeType');
-    // CrashReportingService.recordError swallows its own failures (returns
-    // early when uninitialized, wraps the FirebaseCrashlytics call in
-    // try/catch); see crash_reporting_service.dart for the contract.
     unawaited(_crashReporting.recordError(error, stackTrace, reason: reason));
   }
+
+  void _attachDiagnosticKeys(_BlocDiagnostics? diagnostics) {
+    if (diagnostics == null) return;
+    final event = diagnostics.lastEvent;
+    if (event != null) {
+      unawaited(
+        _crashReporting.setCustomKey(
+          kBlocLastEventKey,
+          sanitizeForCrashReport(event.toString()),
+        ),
+      );
+    }
+    final state = diagnostics.lastState;
+    if (state != null) {
+      unawaited(
+        _crashReporting.setCustomKey(
+          kBlocLastStateKey,
+          sanitizeForCrashReport(state.toString()),
+        ),
+      );
+    }
+    final transitionAt = diagnostics.lastTransitionAt;
+    if (transitionAt != null) {
+      unawaited(
+        _crashReporting.setCustomKey(
+          kBlocLastTransitionAtKey,
+          transitionAt.toUtc().toIso8601String(),
+        ),
+      );
+    }
+  }
+}
+
+/// Latest observed event, state, and transition time for a single bloc,
+/// attached as Crashlytics custom keys when that bloc forwards an error.
+class _BlocDiagnostics {
+  Object? lastEvent;
+  Object? lastState;
+  DateTime? lastTransitionAt;
 }

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -1,5 +1,5 @@
 // ABOUTME: BlocObserver that forwards Bloc errors to Crashlytics + UnifiedLogger
-// ABOUTME: Enriches forwarded reports with the bloc's last event/state/transition
+// ABOUTME: Wired once in main.dart before runApp; covers addError, handler throws, emit failures, and attaches last event/state/transition
 
 import 'dart:async';
 
@@ -14,6 +14,7 @@ import 'package:unified_logger/unified_logger.dart';
 const String kBlocLastEventKey = 'bloc.lastEvent';
 const String kBlocLastStateKey = 'bloc.lastState';
 const String kBlocLastTransitionAtKey = 'bloc.lastTransitionAt';
+const String kBlocDiagnosticNotObserved = '<not observed>';
 
 /// Forwards Bloc/Cubit errors to the project's crash reporter and the unified
 /// log.
@@ -98,34 +99,30 @@ class DivineBlocObserver extends BlocObserver {
   }
 
   void _attachDiagnosticKeys(_BlocDiagnostics? diagnostics) {
-    if (diagnostics == null) return;
-    final event = diagnostics.lastEvent;
-    if (event != null) {
-      unawaited(
-        _crashReporting.setCustomKey(
-          kBlocLastEventKey,
-          sanitizeForCrashReport(event.toString()),
-        ),
-      );
-    }
-    final state = diagnostics.lastState;
-    if (state != null) {
-      unawaited(
-        _crashReporting.setCustomKey(
-          kBlocLastStateKey,
-          sanitizeForCrashReport(state.toString()),
-        ),
-      );
-    }
-    final transitionAt = diagnostics.lastTransitionAt;
-    if (transitionAt != null) {
-      unawaited(
-        _crashReporting.setCustomKey(
-          kBlocLastTransitionAtKey,
-          transitionAt.toUtc().toIso8601String(),
-        ),
-      );
-    }
+    unawaited(
+      _crashReporting.setCustomKey(
+        kBlocLastEventKey,
+        _stringValueOrSentinel(diagnostics?.lastEvent),
+      ),
+    );
+    unawaited(
+      _crashReporting.setCustomKey(
+        kBlocLastStateKey,
+        _stringValueOrSentinel(diagnostics?.lastState),
+      ),
+    );
+    unawaited(
+      _crashReporting.setCustomKey(
+        kBlocLastTransitionAtKey,
+        diagnostics?.lastTransitionAt?.toUtc().toIso8601String() ??
+            kBlocDiagnosticNotObserved,
+      ),
+    );
+  }
+
+  String _stringValueOrSentinel(Object? value) {
+    if (value == null) return kBlocDiagnosticNotObserved;
+    return sanitizeForCrashReport(value.toString());
   }
 }
 

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -76,11 +76,7 @@ void main() {
       final cubit = _CountCubit();
       addTearDown(cubit.close);
 
-      observer.onError(
-        cubit,
-        Reportable(StateError('x')),
-        StackTrace.current,
-      );
+      observer.onError(cubit, Reportable(StateError('x')), StackTrace.current);
 
       verify(
         () => mockCrash.recordError(
@@ -193,19 +189,13 @@ void main() {
         final error = Reportable(StateError('boom'), context: 'test');
         observer.onError(bloc, error, StackTrace.current);
 
-        // _recordEnriched runs unawaited; drain the microtask before verifying.
+        // _attachDiagnosticKeys runs unawaited; drain the microtask before
+        // verifying.
         await Future<void>.delayed(Duration.zero);
 
         verifyInOrder([
           () => mockCrash.setCustomKey(kBlocLastEventKey, 'IncrementPressed'),
           () => mockCrash.setCustomKey(kBlocLastStateKey, '1'),
-          () => mockCrash.recordError(
-            error,
-            any<StackTrace?>(),
-            reason: any(named: 'reason'),
-          ),
-        ]);
-        verify(
           () => mockCrash.setCustomKey(
             kBlocLastTransitionAtKey,
             any<dynamic>(
@@ -214,12 +204,17 @@ void main() {
               ),
             ),
           ),
-        ).called(1);
+          () => mockCrash.recordError(
+            error,
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ]);
       },
     );
 
     test(
-      'does not set diagnostic keys when no event or state was observed',
+      'overwrites missing diagnostics with sentinels before recordError',
       () async {
         final cubit = _CountCubit();
         addTearDown(cubit.close);
@@ -231,7 +226,82 @@ void main() {
         );
         await Future<void>.delayed(Duration.zero);
 
-        verifyNever(() => mockCrash.setCustomKey(any(), any<dynamic>()));
+        verifyInOrder([
+          () => mockCrash.setCustomKey(
+            kBlocLastEventKey,
+            kBlocDiagnosticNotObserved,
+          ),
+          () => mockCrash.setCustomKey(
+            kBlocLastStateKey,
+            kBlocDiagnosticNotObserved,
+          ),
+          () => mockCrash.setCustomKey(
+            kBlocLastTransitionAtKey,
+            kBlocDiagnosticNotObserved,
+          ),
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ]);
+      },
+    );
+
+    test(
+      'does not leak a previous bloc event into a later cubit error report',
+      () async {
+        final bloc = _CounterBloc();
+        final cubit = _CountCubit();
+        addTearDown(bloc.close);
+        addTearDown(cubit.close);
+
+        observer
+          ..onEvent(bloc, 'IncrementPressed')
+          ..onChange(bloc, const Change<int>(currentState: 0, nextState: 1))
+          ..onError(bloc, Reportable(StateError('first')), StackTrace.current)
+          ..onError(
+            cubit,
+            Reportable(StateError('second')),
+            StackTrace.current,
+          );
+
+        await Future<void>.delayed(Duration.zero);
+
+        verifyInOrder([
+          () => mockCrash.setCustomKey(kBlocLastEventKey, 'IncrementPressed'),
+          () => mockCrash.setCustomKey(kBlocLastStateKey, '1'),
+          () => mockCrash.setCustomKey(
+            kBlocLastTransitionAtKey,
+            any<dynamic>(
+              that: predicate<dynamic>(
+                (v) => v is String && DateTime.tryParse(v) != null,
+              ),
+            ),
+          ),
+          () => mockCrash.recordError(
+            any<dynamic>(that: isA<ReportableError>()),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+          () => mockCrash.setCustomKey(
+            kBlocLastEventKey,
+            kBlocDiagnosticNotObserved,
+          ),
+          () => mockCrash.setCustomKey(
+            kBlocLastStateKey,
+            kBlocDiagnosticNotObserved,
+          ),
+          () => mockCrash.setCustomKey(
+            kBlocLastTransitionAtKey,
+            kBlocDiagnosticNotObserved,
+          ),
+          () => mockCrash.recordError(
+            any<dynamic>(that: isA<ReportableError>()),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ]);
       },
     );
 

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -19,6 +19,16 @@ class _CountCubit extends Cubit<int> {
   void boom(Object error, StackTrace stackTrace) => addError(error, stackTrace);
 }
 
+class _CounterBloc extends Bloc<String, int> {
+  _CounterBloc() : super(0) {
+    on<String>((event, emit) => emit(state + 1));
+  }
+}
+
+class _NoteCubit extends Cubit<String> {
+  _NoteCubit() : super('');
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(StackTrace.current);
@@ -37,6 +47,9 @@ void main() {
           any<StackTrace?>(),
           reason: any(named: 'reason'),
         ),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockCrash.setCustomKey(any(), any<dynamic>()),
       ).thenAnswer((_) async {});
       observer = DivineBlocObserver(crashReporting: mockCrash);
     });
@@ -164,6 +177,90 @@ void main() {
             reason: 'Bloc.addError _CountCubit',
           ),
         ).called(1);
+      },
+    );
+
+    test(
+      'attaches last event and state as custom keys before recordError',
+      () async {
+        final bloc = _CounterBloc();
+        addTearDown(bloc.close);
+
+        observer
+          ..onEvent(bloc, 'IncrementPressed')
+          ..onChange(bloc, const Change<int>(currentState: 0, nextState: 1));
+
+        final error = Reportable(StateError('boom'), context: 'test');
+        observer.onError(bloc, error, StackTrace.current);
+
+        // _recordEnriched runs unawaited; drain the microtask before verifying.
+        await Future<void>.delayed(Duration.zero);
+
+        verifyInOrder([
+          () => mockCrash.setCustomKey(kBlocLastEventKey, 'IncrementPressed'),
+          () => mockCrash.setCustomKey(kBlocLastStateKey, '1'),
+          () => mockCrash.recordError(
+            error,
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ]);
+        verify(
+          () => mockCrash.setCustomKey(
+            kBlocLastTransitionAtKey,
+            any<dynamic>(
+              that: predicate<dynamic>(
+                (v) => v is String && DateTime.tryParse(v) != null,
+              ),
+            ),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'does not set diagnostic keys when no event or state was observed',
+      () async {
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+
+        observer.onError(
+          cubit,
+          Reportable(StateError('x')),
+          StackTrace.current,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(() => mockCrash.setCustomKey(any(), any<dynamic>()));
+      },
+    );
+
+    test(
+      'sanitizes the state snapshot before attaching it as a custom key',
+      () async {
+        final cubit = _NoteCubit();
+        addTearDown(cubit.close);
+
+        const npub =
+            'npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvw';
+        observer
+          ..onChange(
+            cubit,
+            const Change<String>(
+              currentState: '',
+              nextState: 'pubkey $npub failed',
+            ),
+          )
+          ..onError(cubit, Reportable(StateError('x')), StackTrace.current);
+        await Future<void>.delayed(Duration.zero);
+
+        final captured = verify(
+          () =>
+              mockCrash.setCustomKey(kBlocLastStateKey, captureAny<dynamic>()),
+        ).captured;
+        expect(captured, hasLength(1));
+        expect(captured.single, contains('npub1<redacted>'));
+        expect(captured.single, isNot(contains(npub)));
       },
     );
   });


### PR DESCRIPTION
## Description

`DivineBlocObserver` now enriches the Crashlytics reports it forwards with the bloc's most recent **event**, **state**, and **transition time** — closing the per-error triage gap raised as concern #3 in PR #3534's review (the same gap that made the #3503 auth-timing investigation expensive).

- Tracks the latest event per bloc via `onEvent` and the latest state via `onChange`, stored in a per-bloc `Expando` (keys held weakly → observing every bloc retains nothing; **no IO until `onError`**).
- On a forwarded `ReportableError`, attaches `bloc.lastEvent` / `bloc.lastState` / `bloc.lastTransitionAt` as Crashlytics custom keys — each run through `sanitizeForCrashReport` (npub/nsec/email stripped) — **before** `recordError`, so they attach to the report it emits.
- `main.dart` sets a `build_tag` custom key (`"${version}+${buildNumber}"`) once at startup, so per-error triage no longer needs to cross-reference the release dashboard.

Dispatch is fire-and-forget but **synchronous and in order**, so the platform-channel messages stay ordered without blocking the bloc error path. (First cut routed `recordError` through an `await`ed helper, which deferred it past a microtask and broke the suite's synchronous-dispatch contract — restructured to preserve both that contract and the keys-before-recordError ordering.)

**Related Issue:** Closes #3758 (part of epic #4336)

## Out of Scope

- The per-feature `addError` Reportable migration sweeps — already shipped under #4336.
- #3415 (upload-timeout fatal misclassification) — coordinates with this PR's `recordError` path but ships separately.

## Verification

- `flutter analyze lib/observability/divine_bloc_observer.dart lib/main.dart test/observability/divine_bloc_observer_test.dart` → **No issues found**
- `flutter test test/observability/` → **27/27 pass** (9 observer tests, incl. 3 new: key-ordering via `verifyInOrder`, no-keys-when-nothing-observed, state-snapshot PII sanitization)
- `flutter test test/main_*` (transitive `main.dart` consumers) → **13/13 pass**

> ⚠️ **Pre-merge manual check:** the observer hot path now does an `Expando` lookup + `DateTime.now()` per `onChange` across all blocs. Cheap, but please confirm low-end-Android feed-scroll shows no regression before merge.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
