### PR TITLE
fix(notification_repository): stabilize notification video routes

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1072,10 +1072,7 @@ class NotificationRepository {
       final dTag = group
           .map((n) => n.referencedDTag)
           .firstWhere((d) => d != null, orElse: () => null);
-      final addressableId = _buildVideoAddressableId(
-        dTag,
-        ownerPubkey: video?.pubkey,
-      );
+      final addressableId = _buildRecipientOwnedVideoAddressableId(dTag);
       // Prefer thumbnail from the notification payload — it comes directly from
       // the server and is stable even after a metadata update (unlike the stats
       // lookup which uses the mutable event ID and may 404 post-edit).
@@ -1209,9 +1206,8 @@ class NotificationRepository {
         );
         return null;
       }
-      final addressableId = _buildVideoAddressableId(
+      final addressableId = _buildRecipientOwnedVideoAddressableId(
         raw.referencedDTag,
-        ownerPubkey: video?.pubkey,
       );
       return VideoNotification(
         id: raw.dedupeKey,
@@ -1291,16 +1287,16 @@ class NotificationRepository {
     _ => null,
   };
 
-  /// Builds the stable NIP-33 addressable ID for a referenced video whose
-  /// owner is known.
-  /// Returns null when the server didn't provide a usable [dTag].
-  static String? _buildVideoAddressableId(
-    String? dTag, {
-    required String? ownerPubkey,
-  }) {
+  /// Builds the stable NIP-33 addressable ID for a video owned by the
+  /// current notification recipient.
+  ///
+  /// Video-anchored notifications are already validated against the current
+  /// user when Funnelcake can resolve ownership. Using [_userPubkey] keeps
+  /// route construction stable when the referenced event ID is stale and the
+  /// metadata lookup misses.
+  String? _buildRecipientOwnedVideoAddressableId(String? dTag) {
     if (dTag == null || dTag.isEmpty) return null;
-    if (ownerPubkey == null || ownerPubkey.isEmpty) return null;
-    return '${NIP71VideoKinds.addressableShortVideo}:$ownerPubkey:$dTag';
+    return '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag';
   }
 
   /// Returns the stable NIP-33 addressable ID for an actor-anchored

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -783,7 +783,7 @@ void main() {
       });
 
       test('grouped video notifications build addressable id from '
-          'referenced video owner pubkey and d-tag', () async {
+          'the current user pubkey and d-tag', () async {
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -802,10 +802,40 @@ void main() {
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
-        stubVideoStats(
-          'video_x',
-          makeVideoStats(id: 'video_x'),
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(
+          item.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:vine-id',
+          ),
         );
+      });
+
+      test('grouped video notifications still build addressable id when '
+          'video stats miss for a stale referenced event id', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'l1',
+            sourcePubkey: 'pub_a',
+            referencedEventId: 'video_x',
+            referencedDTag: 'vine-id',
+          ),
+          makeNotification(
+            id: 'l2',
+            sourcePubkey: 'pub_b',
+            referencedEventId: 'video_x',
+            referencedDTag: 'vine-id',
+          ),
+        ]);
+        stubProfiles({
+          'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+        });
 
         final page = await repository.getNotifications();
 
@@ -2267,17 +2297,28 @@ void main() {
         },
       );
 
-      test('builds addressable id from referenced video owner pubkey and '
-          'd-tag for realtime video notifications', () async {
+      test('builds addressable id from the current user pubkey and d-tag '
+          'for realtime video notifications', () async {
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
-        stubVideoStats(
-          'video_x',
-          makeVideoStats(
-            id: 'video_x',
-            thumbnail: 'thumb',
-            title: 'T',
+
+        final result = await repository.enrichOne(
+          raw(referencedDTag: 'vine-id'),
+        );
+
+        expect(result, isA<VideoNotification>());
+        final video = result! as VideoNotification;
+        expect(
+          video.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:vine-id',
           ),
         );
+      });
+
+      test('builds addressable id for realtime video notifications when '
+          'video stats miss for a stale referenced event id', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
         final result = await repository.enrichOne(
           raw(referencedDTag: 'vine-id'),


### PR DESCRIPTION
Closes #4670

## What changed
- build stable video notification routes from `referencedDTag` plus the current user pubkey instead of depending on stale-event Funnelcake owner metadata
- keep the existing owner-mismatch guard in place when metadata is available
- add regression coverage for grouped and realtime notification paths when the referenced event id is stale and stats lookup misses

## Why
Notifications for edited NIP-71 videos could arrive with a stale event id. In that case the stats lookup misses, `videoAddressableId` stayed null, and notification taps fell back to an event-id route that could no longer resolve the current video revision.

## Impact
Video notifications with a valid `referencedDTag` now route through the stable addressable path even when the old event id no longer resolves, matching the already-working behavior seen on newer notifications.

## Validation
- `flutter test test/src/notification_repository_test.dart` in `mobile/packages/notification_repository`
- `flutter analyze` in `mobile/packages/notification_repository`
- `flutter test test/src/videos_repository_test.dart` in `mobile/packages/videos_repository`
- repo pre-push gate: changed-file analyze + notification_repository tests