### PR TITLE
fix(nostr): standardize Divine client tags

### DIFF
--- a/docs/NIP89_CLIENT_TAG.md
+++ b/docs/NIP89_CLIENT_TAG.md
@@ -1,0 +1,43 @@
+# NIP-89 Client Tag
+
+Divine emits a canonical NIP-89 `client` tag on publishable events unless the
+user opts out in Nostr settings.
+
+Current identity:
+
+- `name`: `Divine`
+- `handler pubkey`: `d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540`
+- `d`: `divine-mobile`
+- `relay hint`: `wss://relay.divine.video`
+
+Tag shape:
+
+```json
+["client", "Divine", "31990:d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540:divine-mobile", "wss://relay.divine.video"]
+```
+
+The app injects this centrally in `nostr_client` and skips protocol-sensitive
+outer wrapper kinds such as `kind:1059` gift wraps.
+
+## Handler event
+
+`mobile/tools/build_nip89_handler_event.dart` builds the Divine `kind:31990`
+handler event. Without any environment variables it prints the unsigned event
+JSON. With `NIP89_HANDLER_NSEC` set to the matching handler key, it signs the
+event, and `--publish` also sends it to `wss://relay.divine.video`.
+
+Examples:
+
+```bash
+cd mobile
+dart run tools/build_nip89_handler_event.dart
+```
+
+```bash
+cd mobile
+NIP89_HANDLER_NSEC=nsec1... dart run tools/build_nip89_handler_event.dart --publish
+```
+
+If the handler identity changes, update `Nip89ClientTag` in
+`packages/nostr_client/lib/src/nip89_client_tag.dart` and republish the handler
+event before shipping a client that references the new coordinate.

--- a/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
+++ b/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
@@ -358,7 +358,7 @@ class NIP17MessageService {
       'created_at': (DateTime.now().millisecondsSinceEpoch ~/ 1000),
       'tags': [
         ['p', recipientPubkey],
-        ['client', 'diVine_bug_report'],
+        ['client', 'Divine', '31990:d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540:divine-mobile', 'wss://relay.divine.video'],
         ...additionalTags,
       ],
     };

--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -250,7 +250,7 @@ The `.content` field is optional and could contain a free-form note.
 | `e` | `["e", "<event-id>", "<relay-url>"]` | Event ID reference (specific version viewed) | **Required** |
 | `viewed` | `["viewed", "<start>", "<end>"]` | Start/end timestamps in seconds (can repeat) | **Required** |
 | `source` | `["source", "<source-type>"]` | Traffic source: `home`, `discovery`, `profile`, `share`, `search` | Optional |
-| `client` | `["client", "<client-identifier>"]` | Client identifier (e.g., "divine-mobile/1.0") | Optional |
+| `client` | `["client", "<name>", "31990:<app-pubkey>:<d-identifier>", "<relay-url>"]` | NIP-89 client attribution for Divine | Optional |
 
 ### Traffic Sources
 
@@ -276,7 +276,7 @@ The `.content` field is optional and could contain a free-form note.
     ["e", "<event-id>", "<relay-url>"],
     ["viewed", "0", "6"],
     ["source", "discovery"],
-    ["client", "divine-mobile/1.0"]
+    ["client", "Divine", "31990:d95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540:divine-mobile", "wss://relay.divine.video"]
   ]
 }
 ```

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -983,6 +983,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "ሊያደናቅፉ የሚችሉ የባህሪ ባንዲራዎችን ቀይር።",
     "nostrSettingsKeyManagement": "የቁልፍ አስተዳደር",
     "nostrSettingsKeyManagementSubtitle": "የNostr ቁልፎችዎን ወደ ውጭ ይላኩ፣ ምትኬ ያስቀምጡ እና ይመልሱ",
+    "nostrSettingsClientAttribution": "የደንበኛ መለያ",
+    "nostrSettingsClientAttributionSubtitle": "በሚያትሟቸው ክስተቶች ላይ የDivine ደንበኛ መለያ ያክሉ፣ ሌሎች የNostr መተግበሪያዎች በትክክል እንዲጠቅሷቸው።",
     "nostrSettingsRemoveKeys": "ቁልፎችን ከመሣሪያው አስወግድ",
     "nostrSettingsRemoveKeysSubtitle": "የግል ቁልፍዎን ከዚህ መሣሪያ ብቻ ይሰርዙ። ይዘትዎ በቅብብሎሾች ላይ ይቆያል፣ ግን መለያዎን እንደገና ለመጠቀም የnsec ምትኬዎን ያስፈልግዎታል።",
     "nostrSettingsCouldNotRemoveKeys": "ቁልፎችን ከዚህ መሣሪያ ማስወገድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -983,8 +983,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "ሊያደናቅፉ የሚችሉ የባህሪ ባንዲራዎችን ቀይር።",
     "nostrSettingsKeyManagement": "የቁልፍ አስተዳደር",
     "nostrSettingsKeyManagementSubtitle": "የNostr ቁልፎችዎን ወደ ውጭ ይላኩ፣ ምትኬ ያስቀምጡ እና ይመልሱ",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "ቁልፎችን ከመሣሪያው አስወግድ",
     "nostrSettingsRemoveKeysSubtitle": "የግል ቁልፍዎን ከዚህ መሣሪያ ብቻ ይሰርዙ። ይዘትዎ በቅብብሎሾች ላይ ይቆያል፣ ግን መለያዎን እንደገና ለመጠቀም የnsec ምትኬዎን ያስፈልግዎታል።",
     "nostrSettingsCouldNotRemoveKeys": "ቁልፎችን ከዚህ መሣሪያ ማስወገድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -983,6 +983,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "ሊያደናቅፉ የሚችሉ የባህሪ ባንዲራዎችን ቀይር።",
     "nostrSettingsKeyManagement": "የቁልፍ አስተዳደር",
     "nostrSettingsKeyManagementSubtitle": "የNostr ቁልፎችዎን ወደ ውጭ ይላኩ፣ ምትኬ ያስቀምጡ እና ይመልሱ",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "ቁልፎችን ከመሣሪያው አስወግድ",
     "nostrSettingsRemoveKeysSubtitle": "የግል ቁልፍዎን ከዚህ መሣሪያ ብቻ ይሰርዙ። ይዘትዎ በቅብብሎሾች ላይ ይቆያል፣ ግን መለያዎን እንደገና ለመጠቀም የnsec ምትኬዎን ያስፈልግዎታል።",
     "nostrSettingsCouldNotRemoveKeys": "ቁልፎችን ከዚህ መሣሪያ ማስወገድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3243,6 +3243,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "تعديلات قد تتعثّر.",
     "nostrSettingsKeyManagement": "إدارة المفاتيح",
     "nostrSettingsKeyManagementSubtitle": "تصدير مفاتيح Nostr ونسخها واستعادتها",
+    "nostrSettingsClientAttribution": "إسناد العميل",
+    "nostrSettingsClientAttributionSubtitle": "أضِف وسم عميل Divine إلى الأحداث التي تنشرها حتى تتمكن تطبيقات Nostr الأخرى من إسنادها بشكل صحيح.",
     "nostrSettingsRemoveKeys": "إزالة المفاتيح من الجهاز",
     "nostrSettingsRemoveKeysSubtitle": "احذف مفتاحك الخاص من هذا الجهاز فقط. سيبقى محتواك على المحولات، لكنّك ستحتاج إلى نسخة nsec الاحتياطية للوصول إلى حسابك مرّة أخرى.",
     "nostrSettingsCouldNotRemoveKeys": "تعذّرت إزالة المفاتيح من هذا الجهاز. حاول مرّة أخرى.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3243,6 +3243,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "تعديلات قد تتعثّر.",
     "nostrSettingsKeyManagement": "إدارة المفاتيح",
     "nostrSettingsKeyManagementSubtitle": "تصدير مفاتيح Nostr ونسخها واستعادتها",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "إزالة المفاتيح من الجهاز",
     "nostrSettingsRemoveKeysSubtitle": "احذف مفتاحك الخاص من هذا الجهاز فقط. سيبقى محتواك على المحولات، لكنّك ستحتاج إلى نسخة nsec الاحتياطية للوصول إلى حسابك مرّة أخرى.",
     "nostrSettingsCouldNotRemoveKeys": "تعذّرت إزالة المفاتيح من هذا الجهاز. حاول مرّة أخرى.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3243,8 +3243,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "تعديلات قد تتعثّر.",
     "nostrSettingsKeyManagement": "إدارة المفاتيح",
     "nostrSettingsKeyManagementSubtitle": "تصدير مفاتيح Nostr ونسخها واستعادتها",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "إزالة المفاتيح من الجهاز",
     "nostrSettingsRemoveKeysSubtitle": "احذف مفتاحك الخاص من هذا الجهاز فقط. سيبقى محتواك على المحولات، لكنّك ستحتاج إلى نسخة nsec الاحتياطية للوصول إلى حسابك مرّة أخرى.",
     "nostrSettingsCouldNotRemoveKeys": "تعذّرت إزالة المفاتيح من هذا الجهاز. حاول مرّة أخرى.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3384,6 +3384,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Превключвай функции, които може да се държат странно.",
     "nostrSettingsKeyManagement": "Управление на ключове",
     "nostrSettingsKeyManagementSubtitle": "Експортирай, архивирай и възстановявай Nostr ключовете си",
+    "nostrSettingsClientAttribution": "Атрибуция на клиента",
+    "nostrSettingsClientAttributionSubtitle": "Добавяй клиентски таг на Divine към събитията, които публикуваш, за да могат другите Nostr приложения да ги приписват правилно.",
     "nostrSettingsRemoveKeys": "Махни ключовете от устройството",
     "nostrSettingsRemoveKeysSubtitle": "Изтрий частния си ключ само от това устройство. Съдържанието ти остава на релетата, но ще ти трябва nsec резервно копие, за да влезеш отново в акаунта си.",
     "nostrSettingsCouldNotRemoveKeys": "Не успяхме да махнем ключовете от това устройство. Опитай пак.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3384,6 +3384,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Превключвай функции, които може да се държат странно.",
     "nostrSettingsKeyManagement": "Управление на ключове",
     "nostrSettingsKeyManagementSubtitle": "Експортирай, архивирай и възстановявай Nostr ключовете си",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Махни ключовете от устройството",
     "nostrSettingsRemoveKeysSubtitle": "Изтрий частния си ключ само от това устройство. Съдържанието ти остава на релетата, но ще ти трябва nsec резервно копие, за да влезеш отново в акаунта си.",
     "nostrSettingsCouldNotRemoveKeys": "Не успяхме да махнем ключовете от това устройство. Опитай пак.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3384,8 +3384,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Превключвай функции, които може да се държат странно.",
     "nostrSettingsKeyManagement": "Управление на ключове",
     "nostrSettingsKeyManagementSubtitle": "Експортирай, архивирай и възстановявай Nostr ключовете си",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Махни ключовете от устройството",
     "nostrSettingsRemoveKeysSubtitle": "Изтрий частния си ключ само от това устройство. Съдържанието ти остава на релетата, но ще ти трябва nsec резервно копие, за да влезеш отново в акаунта си.",
     "nostrSettingsCouldNotRemoveKeys": "Не успяхме да махнем ключовете от това устройство. Опитай пак.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Feature-Flags an- und ausschalten — kann holpern.",
     "nostrSettingsKeyManagement": "Schlüsselverwaltung",
     "nostrSettingsKeyManagementSubtitle": "Deine Nostr-Schlüssel exportieren, sichern und wiederherstellen",
+    "nostrSettingsClientAttribution": "Client-Zuordnung",
+    "nostrSettingsClientAttributionSubtitle": "Füge den Events, die du veröffentlichst, einen Divine-Client-Tag hinzu, damit andere Nostr-Apps sie korrekt zuordnen können.",
     "nostrSettingsRemoveKeys": "Schlüssel vom Gerät entfernen",
     "nostrSettingsRemoveKeysSubtitle": "Lösch deinen privaten Schlüssel nur von diesem Gerät. Deine Inhalte bleiben auf den Relays, aber du brauchst dein nsec-Backup, um wieder auf dein Konto zuzugreifen.",
     "nostrSettingsCouldNotRemoveKeys": "Schlüssel konnten nicht von diesem Gerät entfernt werden. Versuch es nochmal.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Feature-Flags an- und ausschalten — kann holpern.",
     "nostrSettingsKeyManagement": "Schlüsselverwaltung",
     "nostrSettingsKeyManagementSubtitle": "Deine Nostr-Schlüssel exportieren, sichern und wiederherstellen",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Schlüssel vom Gerät entfernen",
     "nostrSettingsRemoveKeysSubtitle": "Lösch deinen privaten Schlüssel nur von diesem Gerät. Deine Inhalte bleiben auf den Relays, aber du brauchst dein nsec-Backup, um wieder auf dein Konto zuzugreifen.",
     "nostrSettingsCouldNotRemoveKeys": "Schlüssel konnten nicht von diesem Gerät entfernt werden. Versuch es nochmal.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Feature-Flags an- und ausschalten — kann holpern.",
     "nostrSettingsKeyManagement": "Schlüsselverwaltung",
     "nostrSettingsKeyManagementSubtitle": "Deine Nostr-Schlüssel exportieren, sichern und wiederherstellen",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Schlüssel vom Gerät entfernen",
     "nostrSettingsRemoveKeysSubtitle": "Lösch deinen privaten Schlüssel nur von diesem Gerät. Deine Inhalte bleiben auf den Relays, aber du brauchst dein nsec-Backup, um wieder auf dein Konto zuzugreifen.",
     "nostrSettingsCouldNotRemoveKeys": "Schlüssel konnten nicht von diesem Gerät entfernt werden. Versuch es nochmal.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1130,6 +1130,8 @@
   "nostrSettingsExperimentalFeaturesSubtitle": "Toggle feature flags that may hiccup.",
   "nostrSettingsKeyManagement": "Key Management",
   "nostrSettingsKeyManagementSubtitle": "Export, backup, and restore your Nostr keys",
+  "nostrSettingsClientAttribution": "Client Attribution",
+  "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
   "nostrSettingsRemoveKeys": "Remove Keys from Device",
   "nostrSettingsRemoveKeysSubtitle": "Delete your private key from this device only. Your content stays on relays, but you'll need your nsec backup to access your account again.",
   "nostrSettingsCouldNotRemoveKeys": "Could not remove keys from this device. Please try again.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3254,6 +3254,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Activá flags de funciones que pueden fallar.",
     "nostrSettingsKeyManagement": "Gestión de claves",
     "nostrSettingsKeyManagementSubtitle": "Exportá, respaldá y restaurá tus claves de Nostr",
+    "nostrSettingsClientAttribution": "Atribución del cliente",
+    "nostrSettingsClientAttributionSubtitle": "Incluí una etiqueta de cliente Divine en los eventos que publicás para que otras apps de Nostr puedan atribuirlos correctamente.",
     "nostrSettingsRemoveKeys": "Quitar claves del dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Eliminá tu clave privada solo de este dispositivo. Tu contenido sigue en los relays, pero vas a necesitar tu respaldo de nsec para volver a entrar a tu cuenta.",
     "nostrSettingsCouldNotRemoveKeys": "No se pudieron quitar las claves de este dispositivo. Probá de nuevo.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3254,6 +3254,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Activá flags de funciones que pueden fallar.",
     "nostrSettingsKeyManagement": "Gestión de claves",
     "nostrSettingsKeyManagementSubtitle": "Exportá, respaldá y restaurá tus claves de Nostr",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Quitar claves del dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Eliminá tu clave privada solo de este dispositivo. Tu contenido sigue en los relays, pero vas a necesitar tu respaldo de nsec para volver a entrar a tu cuenta.",
     "nostrSettingsCouldNotRemoveKeys": "No se pudieron quitar las claves de este dispositivo. Probá de nuevo.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3254,8 +3254,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Activá flags de funciones que pueden fallar.",
     "nostrSettingsKeyManagement": "Gestión de claves",
     "nostrSettingsKeyManagementSubtitle": "Exportá, respaldá y restaurá tus claves de Nostr",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Quitar claves del dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Eliminá tu clave privada solo de este dispositivo. Tu contenido sigue en los relays, pero vas a necesitar tu respaldo de nsec para volver a entrar a tu cuenta.",
     "nostrSettingsCouldNotRemoveKeys": "No se pudieron quitar las claves de este dispositivo. Probá de nuevo.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2082,6 +2082,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "I-toggle ang mga feature flag na maaaring magka-hiccup.",
     "nostrSettingsKeyManagement": "Key Management",
     "nostrSettingsKeyManagementSubtitle": "I-export, i-backup, at i-restore ang iyong Nostr keys",
+    "nostrSettingsClientAttribution": "Pagkilala sa kliyente",
+    "nostrSettingsClientAttributionSubtitle": "Maglagay ng Divine client tag sa mga event na pina-publish mo para maituro ito nang tama ng ibang Nostr apps.",
     "nostrSettingsRemoveKeys": "Alisin ang mga Key sa Device",
     "nostrSettingsRemoveKeysSubtitle": "Burahin ang private key mo sa device na ito lang. Mananatili ang content mo sa mga relay, pero kakailanganin mo ang nsec backup mo para ma-access ulit ang account mo.",
     "nostrSettingsCouldNotRemoveKeys": "Hindi naalis ang mga key sa device na ito. Subukan ulit.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2082,8 +2082,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "I-toggle ang mga feature flag na maaaring magka-hiccup.",
     "nostrSettingsKeyManagement": "Key Management",
     "nostrSettingsKeyManagementSubtitle": "I-export, i-backup, at i-restore ang iyong Nostr keys",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Alisin ang mga Key sa Device",
     "nostrSettingsRemoveKeysSubtitle": "Burahin ang private key mo sa device na ito lang. Mananatili ang content mo sa mga relay, pero kakailanganin mo ang nsec backup mo para ma-access ulit ang account mo.",
     "nostrSettingsCouldNotRemoveKeys": "Hindi naalis ang mga key sa device na ito. Subukan ulit.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2082,6 +2082,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "I-toggle ang mga feature flag na maaaring magka-hiccup.",
     "nostrSettingsKeyManagement": "Key Management",
     "nostrSettingsKeyManagementSubtitle": "I-export, i-backup, at i-restore ang iyong Nostr keys",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Alisin ang mga Key sa Device",
     "nostrSettingsRemoveKeysSubtitle": "Burahin ang private key mo sa device na ito lang. Mananatili ang content mo sa mga relay, pero kakailanganin mo ang nsec backup mo para ma-access ulit ang account mo.",
     "nostrSettingsCouldNotRemoveKeys": "Hindi naalis ang mga key sa device na ito. Subukan ulit.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Active des feature flags qui peuvent avoir des ratés.",
     "nostrSettingsKeyManagement": "Gestion des clés",
     "nostrSettingsKeyManagementSubtitle": "Exporte, sauvegarde et restaure tes clés Nostr",
+    "nostrSettingsClientAttribution": "Attribution du client",
+    "nostrSettingsClientAttributionSubtitle": "Ajoute un tag client Divine aux événements que tu publies pour que les autres apps Nostr puissent les attribuer correctement.",
     "nostrSettingsRemoveKeys": "Retirer les clés de l'appareil",
     "nostrSettingsRemoveKeysSubtitle": "Supprime ta clé privée de cet appareil uniquement. Ton contenu reste sur les relays, mais tu auras besoin de ta sauvegarde nsec pour accéder à nouveau à ton compte.",
     "nostrSettingsCouldNotRemoveKeys": "Impossible de retirer les clés de cet appareil. Réessaie.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Active des feature flags qui peuvent avoir des ratés.",
     "nostrSettingsKeyManagement": "Gestion des clés",
     "nostrSettingsKeyManagementSubtitle": "Exporte, sauvegarde et restaure tes clés Nostr",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Retirer les clés de l'appareil",
     "nostrSettingsRemoveKeysSubtitle": "Supprime ta clé privée de cet appareil uniquement. Ton contenu reste sur les relays, mais tu auras besoin de ta sauvegarde nsec pour accéder à nouveau à ton compte.",
     "nostrSettingsCouldNotRemoveKeys": "Impossible de retirer les clés de cet appareil. Réessaie.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Active des feature flags qui peuvent avoir des ratés.",
     "nostrSettingsKeyManagement": "Gestion des clés",
     "nostrSettingsKeyManagementSubtitle": "Exporte, sauvegarde et restaure tes clés Nostr",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Retirer les clés de l'appareil",
     "nostrSettingsRemoveKeysSubtitle": "Supprime ta clé privée de cet appareil uniquement. Ton contenu reste sur les relays, mais tu auras besoin de ta sauvegarde nsec pour accéder à nouveau à ton compte.",
     "nostrSettingsCouldNotRemoveKeys": "Impossible de retirer les clés de cet appareil. Réessaie.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Aktifkan fitur eksperimen yang mungkin bermasalah.",
     "nostrSettingsKeyManagement": "Manajemen Kunci",
     "nostrSettingsKeyManagementSubtitle": "Ekspor, backup, dan pulihkan kunci Nostr-mu",
+    "nostrSettingsClientAttribution": "Atribusi klien",
+    "nostrSettingsClientAttributionSubtitle": "Tambahkan tag klien Divine ke event yang kamu publikasikan agar aplikasi Nostr lain bisa mengatribusikannya dengan benar.",
     "nostrSettingsRemoveKeys": "Hapus Kunci dari Perangkat",
     "nostrSettingsRemoveKeysSubtitle": "Hapus kunci privatmu hanya dari perangkat ini. Kontenmu tetap di relay, tapi kamu butuh backup nsec untuk masuk lagi.",
     "nostrSettingsCouldNotRemoveKeys": "Gagal menghapus kunci dari perangkat ini. Coba lagi.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Aktifkan fitur eksperimen yang mungkin bermasalah.",
     "nostrSettingsKeyManagement": "Manajemen Kunci",
     "nostrSettingsKeyManagementSubtitle": "Ekspor, backup, dan pulihkan kunci Nostr-mu",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Hapus Kunci dari Perangkat",
     "nostrSettingsRemoveKeysSubtitle": "Hapus kunci privatmu hanya dari perangkat ini. Kontenmu tetap di relay, tapi kamu butuh backup nsec untuk masuk lagi.",
     "nostrSettingsCouldNotRemoveKeys": "Gagal menghapus kunci dari perangkat ini. Coba lagi.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Aktifkan fitur eksperimen yang mungkin bermasalah.",
     "nostrSettingsKeyManagement": "Manajemen Kunci",
     "nostrSettingsKeyManagementSubtitle": "Ekspor, backup, dan pulihkan kunci Nostr-mu",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Hapus Kunci dari Perangkat",
     "nostrSettingsRemoveKeysSubtitle": "Hapus kunci privatmu hanya dari perangkat ini. Kontenmu tetap di relay, tapi kamu butuh backup nsec untuk masuk lagi.",
     "nostrSettingsCouldNotRemoveKeys": "Gagal menghapus kunci dari perangkat ini. Coba lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Attiva feature flag che potrebbero fare i capricci.",
     "nostrSettingsKeyManagement": "Gestione chiavi",
     "nostrSettingsKeyManagementSubtitle": "Esporta, fai il backup e ripristina le tue chiavi Nostr",
+    "nostrSettingsClientAttribution": "Attribuzione del client",
+    "nostrSettingsClientAttributionSubtitle": "Includi un tag client Divine negli eventi che pubblichi, così le altre app Nostr possono attribuirli correttamente.",
     "nostrSettingsRemoveKeys": "Rimuovi le chiavi dal dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Elimina la tua chiave privata solo da questo dispositivo. I tuoi contenuti restano sui relay, ma ti servirà il backup della nsec per accedere di nuovo al tuo account.",
     "nostrSettingsCouldNotRemoveKeys": "Impossibile rimuovere le chiavi da questo dispositivo. Riprova.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Attiva feature flag che potrebbero fare i capricci.",
     "nostrSettingsKeyManagement": "Gestione chiavi",
     "nostrSettingsKeyManagementSubtitle": "Esporta, fai il backup e ripristina le tue chiavi Nostr",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Rimuovi le chiavi dal dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Elimina la tua chiave privata solo da questo dispositivo. I tuoi contenuti restano sui relay, ma ti servirà il backup della nsec per accedere di nuovo al tuo account.",
     "nostrSettingsCouldNotRemoveKeys": "Impossibile rimuovere le chiavi da questo dispositivo. Riprova.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Attiva feature flag che potrebbero fare i capricci.",
     "nostrSettingsKeyManagement": "Gestione chiavi",
     "nostrSettingsKeyManagementSubtitle": "Esporta, fai il backup e ripristina le tue chiavi Nostr",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Rimuovi le chiavi dal dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Elimina la tua chiave privata solo da questo dispositivo. I tuoi contenuti restano sui relay, ma ti servirà il backup della nsec per accedere di nuovo al tuo account.",
     "nostrSettingsCouldNotRemoveKeys": "Impossibile rimuovere le chiavi da questo dispositivo. Riprova.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3243,6 +3243,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "バグるかもしれない機能フラグを切り替える。",
     "nostrSettingsKeyManagement": "鍵の管理",
     "nostrSettingsKeyManagementSubtitle": "Nostr 鍵をエクスポート、バックアップ、復元",
+    "nostrSettingsClientAttribution": "クライアント表記",
+    "nostrSettingsClientAttributionSubtitle": "公開するイベントに Divine のクライアントタグを含めて、他の Nostr アプリが正しく出典を示せるようにするよ。",
     "nostrSettingsRemoveKeys": "このデバイスから鍵を削除",
     "nostrSettingsRemoveKeysSubtitle": "このデバイスから秘密鍵だけを消すよ。コンテンツはリレーに残るけど、もう一回アカウントを使うには nsec のバックアップが必要になるよ。",
     "nostrSettingsCouldNotRemoveKeys": "このデバイスから鍵を削除できなかった。もう一回試してみて。",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3243,6 +3243,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "バグるかもしれない機能フラグを切り替える。",
     "nostrSettingsKeyManagement": "鍵の管理",
     "nostrSettingsKeyManagementSubtitle": "Nostr 鍵をエクスポート、バックアップ、復元",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "このデバイスから鍵を削除",
     "nostrSettingsRemoveKeysSubtitle": "このデバイスから秘密鍵だけを消すよ。コンテンツはリレーに残るけど、もう一回アカウントを使うには nsec のバックアップが必要になるよ。",
     "nostrSettingsCouldNotRemoveKeys": "このデバイスから鍵を削除できなかった。もう一回試してみて。",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3243,8 +3243,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "バグるかもしれない機能フラグを切り替える。",
     "nostrSettingsKeyManagement": "鍵の管理",
     "nostrSettingsKeyManagementSubtitle": "Nostr 鍵をエクスポート、バックアップ、復元",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "このデバイスから鍵を削除",
     "nostrSettingsRemoveKeysSubtitle": "このデバイスから秘密鍵だけを消すよ。コンテンツはリレーに残るけど、もう一回アカウントを使うには nsec のバックアップが必要になるよ。",
     "nostrSettingsCouldNotRemoveKeys": "このデバイスから鍵を削除できなかった。もう一回試してみて。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2539,6 +2539,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "삐걱댈 수 있는 기능 플래그를 켜고 꺼봐요.",
     "nostrSettingsKeyManagement": "키 관리",
     "nostrSettingsKeyManagementSubtitle": "Nostr 키를 내보내고, 백업하고, 복원해요",
+    "nostrSettingsClientAttribution": "클라이언트 표시",
+    "nostrSettingsClientAttributionSubtitle": "게시하는 이벤트에 Divine 클라이언트 태그를 포함해 다른 Nostr 앱이 올바르게 표시할 수 있게 해요.",
     "nostrSettingsRemoveKeys": "기기에서 키 제거",
     "nostrSettingsRemoveKeysSubtitle": "이 기기에서만 개인 키를 삭제해요. 콘텐츠는 릴레이에 그대로 남지만, 다시 계정에 접근하려면 nsec 백업이 필요해요.",
     "nostrSettingsCouldNotRemoveKeys": "이 기기에서 키를 제거하지 못했어요. 다시 시도해주세요.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2539,8 +2539,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "삐걱댈 수 있는 기능 플래그를 켜고 꺼봐요.",
     "nostrSettingsKeyManagement": "키 관리",
     "nostrSettingsKeyManagementSubtitle": "Nostr 키를 내보내고, 백업하고, 복원해요",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "기기에서 키 제거",
     "nostrSettingsRemoveKeysSubtitle": "이 기기에서만 개인 키를 삭제해요. 콘텐츠는 릴레이에 그대로 남지만, 다시 계정에 접근하려면 nsec 백업이 필요해요.",
     "nostrSettingsCouldNotRemoveKeys": "이 기기에서 키를 제거하지 못했어요. 다시 시도해주세요.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2539,6 +2539,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "삐걱댈 수 있는 기능 플래그를 켜고 꺼봐요.",
     "nostrSettingsKeyManagement": "키 관리",
     "nostrSettingsKeyManagementSubtitle": "Nostr 키를 내보내고, 백업하고, 복원해요",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "기기에서 키 제거",
     "nostrSettingsRemoveKeysSubtitle": "이 기기에서만 개인 키를 삭제해요. 콘텐츠는 릴레이에 그대로 남지만, 다시 계정에 접근하려면 nsec 백업이 필요해요.",
     "nostrSettingsCouldNotRemoveKeys": "이 기기에서 키를 제거하지 못했어요. 다시 시도해주세요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Zet feature flags aan die soms haperen.",
     "nostrSettingsKeyManagement": "Sleutelbeheer",
     "nostrSettingsKeyManagementSubtitle": "Exporteer, back-up en herstel je Nostr-sleutels",
+    "nostrSettingsClientAttribution": "Clienttoeschrijving",
+    "nostrSettingsClientAttributionSubtitle": "Voeg een Divine-clienttag toe aan events die je publiceert, zodat andere Nostr-apps ze correct kunnen toeschrijven.",
     "nostrSettingsRemoveKeys": "Sleutels van apparaat verwijderen",
     "nostrSettingsRemoveKeysSubtitle": "Verwijder je privésleutel alleen van dit apparaat. Je inhoud blijft op relays staan, maar je hebt je nsec-back-up nodig om weer bij je account te komen.",
     "nostrSettingsCouldNotRemoveKeys": "Sleutels konden niet van dit apparaat verwijderd worden. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Zet feature flags aan die soms haperen.",
     "nostrSettingsKeyManagement": "Sleutelbeheer",
     "nostrSettingsKeyManagementSubtitle": "Exporteer, back-up en herstel je Nostr-sleutels",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Sleutels van apparaat verwijderen",
     "nostrSettingsRemoveKeysSubtitle": "Verwijder je privésleutel alleen van dit apparaat. Je inhoud blijft op relays staan, maar je hebt je nsec-back-up nodig om weer bij je account te komen.",
     "nostrSettingsCouldNotRemoveKeys": "Sleutels konden niet van dit apparaat verwijderd worden. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Zet feature flags aan die soms haperen.",
     "nostrSettingsKeyManagement": "Sleutelbeheer",
     "nostrSettingsKeyManagementSubtitle": "Exporteer, back-up en herstel je Nostr-sleutels",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Sleutels van apparaat verwijderen",
     "nostrSettingsRemoveKeysSubtitle": "Verwijder je privésleutel alleen van dit apparaat. Je inhoud blijft op relays staan, maar je hebt je nsec-back-up nodig om weer bij je account te komen.",
     "nostrSettingsCouldNotRemoveKeys": "Sleutels konden niet van dit apparaat verwijderd worden. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Włączaj flagi funkcji, które mogą czkać.",
     "nostrSettingsKeyManagement": "Zarządzanie kluczami",
     "nostrSettingsKeyManagementSubtitle": "Eksportuj, twórz kopie zapasowe i przywracaj swoje klucze Nostr",
+    "nostrSettingsClientAttribution": "Atrybucja klienta",
+    "nostrSettingsClientAttributionSubtitle": "Dodawaj tag klienta Divine do publikowanych zdarzeń, aby inne aplikacje Nostr mogły je poprawnie przypisać.",
     "nostrSettingsRemoveKeys": "Usuń klucze z urządzenia",
     "nostrSettingsRemoveKeysSubtitle": "Usuń swój klucz prywatny tylko z tego urządzenia. Twoje treści zostają na przekaźnikach, ale do ponownego dostępu do konta potrzebna będzie kopia zapasowa nsec.",
     "nostrSettingsCouldNotRemoveKeys": "Nie udało się usunąć kluczy z tego urządzenia. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Włączaj flagi funkcji, które mogą czkać.",
     "nostrSettingsKeyManagement": "Zarządzanie kluczami",
     "nostrSettingsKeyManagementSubtitle": "Eksportuj, twórz kopie zapasowe i przywracaj swoje klucze Nostr",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Usuń klucze z urządzenia",
     "nostrSettingsRemoveKeysSubtitle": "Usuń swój klucz prywatny tylko z tego urządzenia. Twoje treści zostają na przekaźnikach, ale do ponownego dostępu do konta potrzebna będzie kopia zapasowa nsec.",
     "nostrSettingsCouldNotRemoveKeys": "Nie udało się usunąć kluczy z tego urządzenia. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Włączaj flagi funkcji, które mogą czkać.",
     "nostrSettingsKeyManagement": "Zarządzanie kluczami",
     "nostrSettingsKeyManagementSubtitle": "Eksportuj, twórz kopie zapasowe i przywracaj swoje klucze Nostr",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Usuń klucze z urządzenia",
     "nostrSettingsRemoveKeysSubtitle": "Usuń swój klucz prywatny tylko z tego urządzenia. Twoje treści zostają na przekaźnikach, ale do ponownego dostępu do konta potrzebna będzie kopia zapasowa nsec.",
     "nostrSettingsCouldNotRemoveKeys": "Nie udało się usunąć kluczy z tego urządzenia. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Ative flags de recursos que podem dar chilique.",
     "nostrSettingsKeyManagement": "Gerenciamento de chaves",
     "nostrSettingsKeyManagementSubtitle": "Exporte, faça backup e restaure suas chaves Nostr",
+    "nostrSettingsClientAttribution": "Atribuição do cliente",
+    "nostrSettingsClientAttributionSubtitle": "Inclua uma tag de cliente Divine nos eventos que você publica para que outros apps Nostr possam atribuí-los corretamente.",
     "nostrSettingsRemoveKeys": "Remover chaves do dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Apague sua chave privada apenas deste dispositivo. Seu conteúdo continua nos relays, mas você vai precisar do backup da nsec para acessar sua conta de novo.",
     "nostrSettingsCouldNotRemoveKeys": "Não foi possível remover as chaves deste dispositivo. Tente novamente.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Ative flags de recursos que podem dar chilique.",
     "nostrSettingsKeyManagement": "Gerenciamento de chaves",
     "nostrSettingsKeyManagementSubtitle": "Exporte, faça backup e restaure suas chaves Nostr",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Remover chaves do dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Apague sua chave privada apenas deste dispositivo. Seu conteúdo continua nos relays, mas você vai precisar do backup da nsec para acessar sua conta de novo.",
     "nostrSettingsCouldNotRemoveKeys": "Não foi possível remover as chaves deste dispositivo. Tente novamente.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Ative flags de recursos que podem dar chilique.",
     "nostrSettingsKeyManagement": "Gerenciamento de chaves",
     "nostrSettingsKeyManagementSubtitle": "Exporte, faça backup e restaure suas chaves Nostr",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Remover chaves do dispositivo",
     "nostrSettingsRemoveKeysSubtitle": "Apague sua chave privada apenas deste dispositivo. Seu conteúdo continua nos relays, mas você vai precisar do backup da nsec para acessar sua conta de novo.",
     "nostrSettingsCouldNotRemoveKeys": "Não foi possível remover as chaves deste dispositivo. Tente novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Activează indicatoare de funcții care s-ar putea să sughițe.",
     "nostrSettingsKeyManagement": "Gestionare chei",
     "nostrSettingsKeyManagementSubtitle": "Exportă, fă backup și restaurează cheile tale Nostr",
+    "nostrSettingsClientAttribution": "Atribuirea clientului",
+    "nostrSettingsClientAttributionSubtitle": "Include o etichetă de client Divine în evenimentele pe care le publici, ca alte aplicații Nostr să le poată atribui corect.",
     "nostrSettingsRemoveKeys": "Elimină cheile de pe dispozitiv",
     "nostrSettingsRemoveKeysSubtitle": "Șterge cheia ta privată doar de pe acest dispozitiv. Conținutul tău rămâne pe relay-uri, dar vei avea nevoie de backup-ul nsec ca să-ți accesezi din nou contul.",
     "nostrSettingsCouldNotRemoveKeys": "N-am putut elimina cheile de pe acest dispozitiv. Încearcă din nou.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Activează indicatoare de funcții care s-ar putea să sughițe.",
     "nostrSettingsKeyManagement": "Gestionare chei",
     "nostrSettingsKeyManagementSubtitle": "Exportă, fă backup și restaurează cheile tale Nostr",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Elimină cheile de pe dispozitiv",
     "nostrSettingsRemoveKeysSubtitle": "Șterge cheia ta privată doar de pe acest dispozitiv. Conținutul tău rămâne pe relay-uri, dar vei avea nevoie de backup-ul nsec ca să-ți accesezi din nou contul.",
     "nostrSettingsCouldNotRemoveKeys": "N-am putut elimina cheile de pe acest dispozitiv. Încearcă din nou.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Activează indicatoare de funcții care s-ar putea să sughițe.",
     "nostrSettingsKeyManagement": "Gestionare chei",
     "nostrSettingsKeyManagementSubtitle": "Exportă, fă backup și restaurează cheile tale Nostr",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Elimină cheile de pe dispozitiv",
     "nostrSettingsRemoveKeysSubtitle": "Șterge cheia ta privată doar de pe acest dispozitiv. Conținutul tău rămâne pe relay-uri, dar vei avea nevoie de backup-ul nsec ca să-ți accesezi din nou contul.",
     "nostrSettingsCouldNotRemoveKeys": "N-am putut elimina cheile de pe acest dispozitiv. Încearcă din nou.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Slå på funktioner som kan hicka.",
     "nostrSettingsKeyManagement": "Nyckelhantering",
     "nostrSettingsKeyManagementSubtitle": "Exportera, säkerhetskopiera och återställ dina Nostr-nycklar",
+    "nostrSettingsClientAttribution": "Klientattribuering",
+    "nostrSettingsClientAttributionSubtitle": "Lägg till en Divine-klienttagg på events du publicerar så att andra Nostr-appar kan attribuera dem korrekt.",
     "nostrSettingsRemoveKeys": "Ta bort nycklar från enheten",
     "nostrSettingsRemoveKeysSubtitle": "Radera din privata nyckel från endast den här enheten. Ditt innehåll stannar på relerna, men du behöver din nsec-säkerhetskopia för att komma åt kontot igen.",
     "nostrSettingsCouldNotRemoveKeys": "Kunde inte ta bort nycklar från enheten. Försök igen.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Slå på funktioner som kan hicka.",
     "nostrSettingsKeyManagement": "Nyckelhantering",
     "nostrSettingsKeyManagementSubtitle": "Exportera, säkerhetskopiera och återställ dina Nostr-nycklar",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Ta bort nycklar från enheten",
     "nostrSettingsRemoveKeysSubtitle": "Radera din privata nyckel från endast den här enheten. Ditt innehåll stannar på relerna, men du behöver din nsec-säkerhetskopia för att komma åt kontot igen.",
     "nostrSettingsCouldNotRemoveKeys": "Kunde inte ta bort nycklar från enheten. Försök igen.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Slå på funktioner som kan hicka.",
     "nostrSettingsKeyManagement": "Nyckelhantering",
     "nostrSettingsKeyManagementSubtitle": "Exportera, säkerhetskopiera och återställ dina Nostr-nycklar",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Ta bort nycklar från enheten",
     "nostrSettingsRemoveKeysSubtitle": "Radera din privata nyckel från endast den här enheten. Ditt innehåll stannar på relerna, men du behöver din nsec-säkerhetskopia för att komma åt kontot igen.",
     "nostrSettingsCouldNotRemoveKeys": "Kunde inte ta bort nycklar från enheten. Försök igen.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Aksaklık çıkarabilecek özellik bayraklarını aç/kapat.",
     "nostrSettingsKeyManagement": "Anahtar Yönetimi",
     "nostrSettingsKeyManagementSubtitle": "Nostr anahtarlarını dışa aktar, yedekle ve geri yükle",
+    "nostrSettingsClientAttribution": "İstemci Atfı",
+    "nostrSettingsClientAttributionSubtitle": "Yayınladığın etkinliklere Divine istemci etiketini ekle, böylece diğer Nostr uygulamaları bunları doğru şekilde atfedebilir.",
     "nostrSettingsRemoveKeys": "Anahtarları Cihazdan Kaldır",
     "nostrSettingsRemoveKeysSubtitle": "Özel anahtarını yalnızca bu cihazdan sil. İçeriğin rölelerde kalır, ancak hesabına tekrar erişmek için nsec yedeğine ihtiyacın olur.",
     "nostrSettingsCouldNotRemoveKeys": "Anahtarlar bu cihazdan kaldırılamadı. Lütfen tekrar dene.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3250,8 +3250,6 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Aksaklık çıkarabilecek özellik bayraklarını aç/kapat.",
     "nostrSettingsKeyManagement": "Anahtar Yönetimi",
     "nostrSettingsKeyManagementSubtitle": "Nostr anahtarlarını dışa aktar, yedekle ve geri yükle",
-    "nostrSettingsClientAttribution": "Client Attribution",
-    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Anahtarları Cihazdan Kaldır",
     "nostrSettingsRemoveKeysSubtitle": "Özel anahtarını yalnızca bu cihazdan sil. İçeriğin rölelerde kalır, ancak hesabına tekrar erişmek için nsec yedeğine ihtiyacın olur.",
     "nostrSettingsCouldNotRemoveKeys": "Anahtarlar bu cihazdan kaldırılamadı. Lütfen tekrar dene.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3250,6 +3250,8 @@
     "nostrSettingsExperimentalFeaturesSubtitle": "Aksaklık çıkarabilecek özellik bayraklarını aç/kapat.",
     "nostrSettingsKeyManagement": "Anahtar Yönetimi",
     "nostrSettingsKeyManagementSubtitle": "Nostr anahtarlarını dışa aktar, yedekle ve geri yükle",
+    "nostrSettingsClientAttribution": "Client Attribution",
+    "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
     "nostrSettingsRemoveKeys": "Anahtarları Cihazdan Kaldır",
     "nostrSettingsRemoveKeysSubtitle": "Özel anahtarını yalnızca bu cihazdan sil. İçeriğin rölelerde kalır, ancak hesabına tekrar erişmek için nsec yedeğine ihtiyacın olur.",
     "nostrSettingsCouldNotRemoveKeys": "Anahtarlar bu cihazdan kaldırılamadı. Lütfen tekrar dene.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3586,6 +3586,18 @@ abstract class AppLocalizations {
   /// **'Export, backup, and restore your Nostr keys'**
   String get nostrSettingsKeyManagementSubtitle;
 
+  /// No description provided for @nostrSettingsClientAttribution.
+  ///
+  /// In en, this message translates to:
+  /// **'Client Attribution'**
+  String get nostrSettingsClientAttribution;
+
+  /// No description provided for @nostrSettingsClientAttributionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.'**
+  String get nostrSettingsClientAttributionSubtitle;
+
   /// No description provided for @nostrSettingsRemoveKeys.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1995,11 +1995,11 @@ class AppLocalizationsAm extends AppLocalizations {
       'የNostr ቁልፎችዎን ወደ ውጭ ይላኩ፣ ምትኬ ያስቀምጡ እና ይመልሱ';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'የደንበኛ መለያ';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'በሚያትሟቸው ክስተቶች ላይ የDivine ደንበኛ መለያ ያክሉ፣ ሌሎች የNostr መተግበሪያዎች በትክክል እንዲጠቅሷቸው።';
 
   @override
   String get nostrSettingsRemoveKeys => 'ቁልፎችን ከመሣሪያው አስወግድ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1995,6 +1995,13 @@ class AppLocalizationsAm extends AppLocalizations {
       'የNostr ቁልፎችዎን ወደ ውጭ ይላኩ፣ ምትኬ ያስቀምጡ እና ይመልሱ';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'ቁልፎችን ከመሣሪያው አስወግድ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2011,6 +2011,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'تصدير مفاتيح Nostr ونسخها واستعادتها';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'إزالة المفاتيح من الجهاز';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2011,11 +2011,11 @@ class AppLocalizationsAr extends AppLocalizations {
       'تصدير مفاتيح Nostr ونسخها واستعادتها';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'إسناد العميل';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'أضِف وسم عميل Divine إلى الأحداث التي تنشرها حتى تتمكن تطبيقات Nostr الأخرى من إسنادها بشكل صحيح.';
 
   @override
   String get nostrSettingsRemoveKeys => 'إزالة المفاتيح من الجهاز';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2070,6 +2070,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Експортирай, архивирай и възстановявай Nostr ключовете си';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Махни ключовете от устройството';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2070,11 +2070,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'Експортирай, архивирай и възстановявай Nostr ключовете си';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Атрибуция на клиента';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Добавяй клиентски таг на Divine към събитията, които публикуваш, за да могат другите Nostr приложения да ги приписват правилно.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Махни ключовете от устройството';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2058,11 +2058,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Deine Nostr-Schlüssel exportieren, sichern und wiederherstellen';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Client-Zuordnung';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Füge den Events, die du veröffentlichst, einen Divine-Client-Tag hinzu, damit andere Nostr-Apps sie korrekt zuordnen können.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Schlüssel vom Gerät entfernen';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2058,6 +2058,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Deine Nostr-Schlüssel exportieren, sichern und wiederherstellen';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Schlüssel vom Gerät entfernen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2036,6 +2036,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Export, backup, and restore your Nostr keys';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Remove Keys from Device';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2056,6 +2056,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Exportá, respaldá y restaurá tus claves de Nostr';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Quitar claves del dispositivo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2056,11 +2056,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Exportá, respaldá y restaurá tus claves de Nostr';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Atribución del cliente';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Incluí una etiqueta de cliente Divine en los eventos que publicás para que otras apps de Nostr puedan atribuirlos correctamente.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Quitar claves del dispositivo';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2067,6 +2067,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-export, i-backup, at i-restore ang iyong Nostr keys';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Alisin ang mga Key sa Device';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2067,11 +2067,11 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-export, i-backup, at i-restore ang iyong Nostr keys';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Pagkilala sa kliyente';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Maglagay ng Divine client tag sa mga event na pina-publish mo para maituro ito nang tama ng ibang Nostr apps.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Alisin ang mga Key sa Device';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2065,11 +2065,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Exporte, sauvegarde et restaure tes clés Nostr';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Attribution du client';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Ajoute un tag client Divine aux événements que tu publies pour que les autres apps Nostr puissent les attribuer correctement.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Retirer les clés de l\'appareil';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2065,6 +2065,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Exporte, sauvegarde et restaure tes clés Nostr';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Retirer les clés de l\'appareil';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2007,11 +2007,11 @@ class AppLocalizationsId extends AppLocalizations {
       'Ekspor, backup, dan pulihkan kunci Nostr-mu';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Atribusi klien';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Tambahkan tag klien Divine ke event yang kamu publikasikan agar aplikasi Nostr lain bisa mengatribusikannya dengan benar.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Hapus Kunci dari Perangkat';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2007,6 +2007,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Ekspor, backup, dan pulihkan kunci Nostr-mu';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Hapus Kunci dari Perangkat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2058,6 +2058,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Esporta, fai il backup e ripristina le tue chiavi Nostr';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Rimuovi le chiavi dal dispositivo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2058,11 +2058,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Esporta, fai il backup e ripristina le tue chiavi Nostr';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Attribuzione del client';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Includi un tag client Divine negli eventi che pubblichi, così le altre app Nostr possono attribuirli correttamente.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Rimuovi le chiavi dal dispositivo';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1927,6 +1927,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get nostrSettingsKeyManagementSubtitle => 'Nostr 鍵をエクスポート、バックアップ、復元';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'このデバイスから鍵を削除';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1927,11 +1927,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get nostrSettingsKeyManagementSubtitle => 'Nostr 鍵をエクスポート、バックアップ、復元';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'クライアント表記';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      '公開するイベントに Divine のクライアントタグを含めて、他の Nostr アプリが正しく出典を示せるようにするよ。';
 
   @override
   String get nostrSettingsRemoveKeys => 'このデバイスから鍵を削除';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1936,11 +1936,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get nostrSettingsKeyManagementSubtitle => 'Nostr 키를 내보내고, 백업하고, 복원해요';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => '클라이언트 표시';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      '게시하는 이벤트에 Divine 클라이언트 태그를 포함해 다른 Nostr 앱이 올바르게 표시할 수 있게 해요.';
 
   @override
   String get nostrSettingsRemoveKeys => '기기에서 키 제거';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1936,6 +1936,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get nostrSettingsKeyManagementSubtitle => 'Nostr 키를 내보내고, 백업하고, 복원해요';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => '기기에서 키 제거';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2041,11 +2041,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Exporteer, back-up en herstel je Nostr-sleutels';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Clienttoeschrijving';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Voeg een Divine-clienttag toe aan events die je publiceert, zodat andere Nostr-apps ze correct kunnen toeschrijven.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Sleutels van apparaat verwijderen';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2041,6 +2041,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Exporteer, back-up en herstel je Nostr-sleutels';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Sleutels van apparaat verwijderen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2069,6 +2069,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Eksportuj, twórz kopie zapasowe i przywracaj swoje klucze Nostr';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Usuń klucze z urządzenia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2069,11 +2069,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'Eksportuj, twórz kopie zapasowe i przywracaj swoje klucze Nostr';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Atrybucja klienta';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Dodawaj tag klienta Divine do publikowanych zdarzeń, aby inne aplikacje Nostr mogły je poprawnie przypisać.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Usuń klucze z urządzenia';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2052,6 +2052,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Exporte, faça backup e restaure suas chaves Nostr';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Remover chaves do dispositivo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2052,11 +2052,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Exporte, faça backup e restaure suas chaves Nostr';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Atribuição do cliente';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Inclua uma tag de cliente Divine nos eventos que você publica para que outros apps Nostr possam atribuí-los corretamente.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Remover chaves do dispositivo';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2087,6 +2087,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Exportă, fă backup și restaurează cheile tale Nostr';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Elimină cheile de pe dispozitiv';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2087,11 +2087,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Exportă, fă backup și restaurează cheile tale Nostr';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Atribuirea clientului';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Include o etichetă de client Divine în evenimentele pe care le publici, ca alte aplicații Nostr să le poată atribui corect.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Elimină cheile de pe dispozitiv';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2028,11 +2028,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Exportera, säkerhetskopiera och återställ dina Nostr-nycklar';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'Klientattribuering';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Lägg till en Divine-klienttagg på events du publicerar så att andra Nostr-appar kan attribuera dem korrekt.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Ta bort nycklar från enheten';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Exportera, säkerhetskopiera och återställ dina Nostr-nycklar';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Ta bort nycklar från enheten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2014,6 +2014,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Nostr anahtarlarını dışa aktar, yedekle ve geri yükle';
 
   @override
+  String get nostrSettingsClientAttribution => 'Client Attribution';
+
+  @override
+  String get nostrSettingsClientAttributionSubtitle =>
+      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+
+  @override
   String get nostrSettingsRemoveKeys => 'Anahtarları Cihazdan Kaldır';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2014,11 +2014,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Nostr anahtarlarını dışa aktar, yedekle ve geri yükle';
 
   @override
-  String get nostrSettingsClientAttribution => 'Client Attribution';
+  String get nostrSettingsClientAttribution => 'İstemci Atfı';
 
   @override
   String get nostrSettingsClientAttributionSubtitle =>
-      'Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.';
+      'Yayınladığın etkinliklere Divine istemci etiketini ekle, böylece diğer Nostr uygulamaları bunları doğru şekilde atfedebilir.';
 
   @override
   String get nostrSettingsRemoveKeys => 'Anahtarları Cihazdan Kaldır';

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -97,6 +97,10 @@ class NostrSession extends Notifier<NostrSessionReadiness> {
 final nostrSessionProvider =
     NotifierProvider<NostrSession, NostrSessionReadiness>(NostrSession.new);
 
+final nip89ClientTagEnabledProvider = FutureProvider<bool>((ref) async {
+  return Nip89ClientTag.isEnabled();
+});
+
 /// Signature for constructing a [NostrClient]. The default implementation
 /// delegates to [NostrServiceFactory.create]. Tests override
 /// [nostrClientFactoryProvider] to inject fake clients and observe the
@@ -167,11 +171,7 @@ class NostrService extends _$NostrService {
 
     // NIP-65 discovered-relays callback — see _userRelaysDiscoveredCallbackFor.
     authService.registerUserRelaysDiscoveredCallback(
-      _userRelaysDiscoveredCallbackFor(
-        client,
-        initialPubkey,
-        clientGeneration,
-      ),
+      _userRelaysDiscoveredCallbackFor(client, initialPubkey, clientGeneration),
     );
 
     // Bootstrap kind:10002 publisher — see _bootstrapCallbackFor.

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nostr_client/nostr_client.dart' show Nip89ClientTag;
 import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -15,6 +16,7 @@ import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/blossom_settings_screen.dart';
 import 'package:openvine/screens/developer_options_screen.dart';
 import 'package:openvine/screens/key_management_screen.dart';
@@ -113,6 +115,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   subtitle: context.l10n.nostrSettingsKeyManagementSubtitle,
                   onTap: () => context.push(KeyManagementScreen.path),
                 ),
+                const _ClientAttributionToggle(),
                 _SettingsTile(
                   icon: Icons.alternate_email,
                   title: context.l10n.nostrSettingsNip05Address,
@@ -239,6 +242,40 @@ class _DeleteAccountTile extends StatelessWidget {
         authService: authService,
         screenName: 'NostrSettingsScreen',
       ),
+    );
+  }
+}
+
+class _ClientAttributionToggle extends ConsumerWidget {
+  const _ClientAttributionToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabledAsync = ref.watch(nip89ClientTagEnabledProvider);
+    final enabled = enabledAsync.value ?? true;
+
+    return SwitchListTile.adaptive(
+      value: enabled,
+      onChanged: enabledAsync.isLoading
+          ? null
+          : (value) async {
+              await Nip89ClientTag.setEnabled(enabled: value);
+              ref.invalidate(nip89ClientTagEnabledProvider);
+            },
+      title: Text(
+        context.l10n.nostrSettingsClientAttribution,
+        style: const TextStyle(
+          color: VineTheme.whiteText,
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      subtitle: Text(
+        context.l10n.nostrSettingsClientAttributionSubtitle,
+        style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
+      ),
+      activeThumbColor: VineTheme.vineGreen,
+      secondary: const Icon(Icons.travel_explore, color: VineTheme.vineGreen),
     );
   }
 }

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:nostr_client/nostr_client.dart' show Nip89ClientTag;
 import 'package:nostr_key_manager/nostr_key_manager.dart'
     show
         NostrKeyManager,
@@ -584,12 +585,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return;
       }
 
-      final refreshed =
-          await _refreshOAuthSession(
-            expectedOwnerPubkey: expectedOwnerPubkey ?? session?.userPubkey,
-          ).timeout(
-            rpcRefreshTimeout,
-          );
+      final refreshed = await _refreshOAuthSession(
+        expectedOwnerPubkey: expectedOwnerPubkey ?? session?.userPubkey,
+      ).timeout(rpcRefreshTimeout);
 
       if (refreshed != null) {
         Log.info(
@@ -820,9 +818,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// it — the method falls back to [_currentProfile].
   ///
   /// Returns the refreshed session on success, or `null` on failure.
-  Future<KeycastSession?> _refreshOAuthSession({
-    String? expectedOwnerPubkey,
-  }) {
+  Future<KeycastSession?> _refreshOAuthSession({String? expectedOwnerPubkey}) {
     return _pendingOAuthRefresh ??=
         _doRefreshOAuthSession(
           expectedOwnerPubkey: expectedOwnerPubkey,
@@ -837,9 +833,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     if (_oauthClient == null) return null;
     try {
       final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
-      final refreshed = await _oauthClient.refreshSession(
-        userPubkey: pubkey,
-      );
+      final refreshed = await _oauthClient.refreshSession(userPubkey: pubkey);
       if (refreshed == null || !refreshed.hasRpcAccess) return null;
 
       _hasExpiredOAuthSession = false;
@@ -3844,6 +3838,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
             (DateTime.now().millisecondsSinceEpoch ~/ 1000) +
             (72 * 60 * 60); // 72 hours
         eventTags.add(['expiration', expirationTimestamp.toString()]);
+      }
+
+      if (!Nip89ClientTag.shouldSkipKind(kind) &&
+          !Nip89ClientTag.hasClientTag(eventTags) &&
+          await Nip89ClientTag.isEnabled()) {
+        eventTags.add(Nip89ClientTag.tag);
       }
 
       // Create the unsigned event with the identity's pubkey — both the

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -220,9 +220,7 @@ class BookmarkService with NostrListServiceMixin {
 
   /// Remove a video event from global bookmarks (kind 10003 `e` tag).
   Future<bool> removeVideoFromGlobalBookmarks(String videoEventId) async {
-    return removeFromGlobalBookmarks(
-      BookmarkItem(type: 'e', id: videoEventId),
-    );
+    return removeFromGlobalBookmarks(BookmarkItem(type: 'e', id: videoEventId));
   }
 
   /// If [videoEventId] is globally bookmarked, removes it; otherwise adds it.
@@ -615,9 +613,7 @@ class BookmarkService with NostrListServiceMixin {
       }
 
       // Create NIP-51 kind 10003 tags
-      final tags = <List<String>>[
-        ['client', 'diVine'],
-      ];
+      final tags = <List<String>>[];
 
       // Add bookmark items as tags
       for (final item in _globalBookmarks) {
@@ -665,7 +661,6 @@ class BookmarkService with NostrListServiceMixin {
       final tags = <List<String>>[
         ['d', set.id], // Identifier for replaceable event
         ['title', set.name],
-        ['client', 'diVine'],
       ];
 
       // Add description if present

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -16,6 +16,7 @@ import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart'
     show BugReportData, BugReportResult, LogEntry;
+import 'package:nostr_client/nostr_client.dart' show Nip89ClientTag;
 import 'package:openvine/config/bug_report_config.dart';
 import 'package:openvine/services/error_analytics_tracker.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -325,7 +326,7 @@ class BugReportService {
         recipientPubkey: recipientPubkey,
         content: messageContent,
         additionalTags: [
-          ['client', 'diVine_bug_report'],
+          Nip89ClientTag.tag,
           ['report_id', data.reportId],
           ['app_version', data.appVersion],
           if (bugReportUrl != null) ['bug_report_url', bugReportUrl],
@@ -920,10 +921,7 @@ class BugReportService {
       );
 
       if (location == null) {
-        Log.info(
-          'Log export cancelled by user',
-          category: LogCategory.system,
-        );
+        Log.info('Log export cancelled by user', category: LogCategory.system);
         return const LogExportResult.cancelled();
       }
 

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -345,7 +345,6 @@ class ContentDeletionService {
           'k',
           originalEventKind.toString(),
         ], // Kind of event being deleted (NIP-09)
-        ['client', 'diVine'], // Deleting client
       ];
 
       // Add additional context as tags if provided

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -380,7 +380,6 @@ class ContentReportingService {
       final tags = <List<String>>[
         for (final nip56EventId in eventTagIds) ['e', nip56EventId, nip56Type],
         ['p', authorPubkey, nip56Type],
-        ['client', 'diVine'],
         ['L', _reportLabelNamespace],
         // These label values are a cross-repo wire contract consumed by
         // divine-web and divine-relay-manager.

--- a/mobile/lib/services/mute_service.dart
+++ b/mobile/lib/services/mute_service.dart
@@ -511,9 +511,7 @@ class MuteService {
       }
 
       // Create NIP-51 kind 10000 tags
-      final tags = <List<String>>[
-        ['client', 'diVine'],
-      ];
+      final tags = <List<String>>[];
 
       // Add muted items as tags (only non-expired, permanent mutes for Nostr)
       for (final item in mutedItems.where((item) => item.isPermanent)) {

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -878,9 +878,6 @@ class VideoEventPublisher {
         }
       }
 
-      // Add client tag
-      tags.add(['client', 'diVine']);
-
       // Add published_at tag (current timestamp)
       tags.add([
         'published_at',

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -254,8 +254,6 @@ class VideoMetadataUpdateService {
         ]);
       }
 
-      tags.add(['client', 'diVine']);
-
       if (editorState.allowAudioReuse) {
         tags.add(['allow_audio_reuse', 'true']);
       }

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -171,7 +171,6 @@ class VideoSharingService {
   }) async {
     final tags = <List<String>>[
       ['p', recipientPubkey],
-      ['client', 'diVine'],
       ['e', video.id],
     ];
 

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -57,9 +57,6 @@ class ViewEventPublisher {
   final AuthService _authService;
   final String _defaultRelayHint;
 
-  /// Client identifier for analytics
-  static const String _clientId = 'divine-mobile/1.0';
-
   /// Publish a video view event.
   ///
   /// [video] - The video that was viewed
@@ -145,8 +142,6 @@ class ViewEventPublisher {
           ['source', _sourceToString(source)],
         // Loop count (optional, omitted if 0 or null)
         if (loopCount != null && loopCount > 0) ['loops', loopCount.toString()],
-        // Client identifier (optional)
-        ['client', _clientId],
       ];
 
       Log.debug(
@@ -268,7 +263,6 @@ class ViewEventPublisher {
           ['source', _sourceToString(source), sourceDetail]
         else
           ['source', _sourceToString(source)],
-        ['client', _clientId],
       ];
 
       final event = await _authService.createAndSignEvent(

--- a/mobile/lib/utils/curated_list_ext.dart
+++ b/mobile/lib/utils/curated_list_ext.dart
@@ -9,7 +9,6 @@ extension CuratedListExt on CuratedList {
     final tags = <List<String>>[
       ['d', id], // Identifier for replaceable event
       ['title', name],
-      ['client', 'diVine'],
     ];
 
     // Add description if present

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -295,7 +295,6 @@ class ContentBlocklistRepository {
       final tags = <List<String>>[
         ['d', 'block'],
         ['title', 'Block List'],
-        ['client', 'diVine'],
       ];
 
       for (final pubkey in _runtimeBlocklist) {
@@ -391,9 +390,7 @@ class ContentBlocklistRepository {
     if (!_runtimeBlocklist.contains(pubkey)) {
       _runtimeBlocklist.add(pubkey);
       await _saveBlockedUsers();
-      _emitChange(
-        BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked),
-      );
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
       _notifyChanged();
       await _publishBlockListToNostr();
 
@@ -421,9 +418,7 @@ class ContentBlocklistRepository {
     if (_runtimeBlocklist.contains(pubkey)) {
       _runtimeBlocklist.remove(pubkey);
       await _saveBlockedUsers();
-      _emitChange(
-        BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked),
-      );
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
       _notifyChanged();
       await _publishBlockListToNostr();
 
@@ -618,10 +613,7 @@ class ContentBlocklistRepository {
       // Filter 2: Our own block list (for relay-based restoration)
       // Omit the d-tag constraint here — not all relays support #d
       // filtering, and _handleBlockListEvent already checks for d=block.
-      final ownFilter = Filter(
-        authors: [ourPubkey],
-        kinds: const [30000],
-      );
+      final ownFilter = Filter(authors: [ourPubkey], kinds: const [30000]);
 
       nostrService
           .subscribe([othersFilter, ownFilter])
@@ -757,9 +749,7 @@ class ContentBlocklistRepository {
     _runtimeBlocklist.addAll(added);
     unawaited(_saveBlockedUsers());
     for (final pubkey in added) {
-      _emitChange(
-        BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked),
-      );
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
     }
     _notifyChanged();
 

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_converter.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_converter.dart
@@ -110,7 +110,6 @@ abstract final class CuratedListConverter {
     final tags = <List<String>>[
       ['d', list.id],
       ['title', list.name],
-      ['client', 'diVine'],
     ];
 
     if (list.description != null && list.description!.isNotEmpty) {

--- a/mobile/packages/curated_list_repository/test/src/curated_list_converter_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_converter_test.dart
@@ -146,14 +146,8 @@ void main() {
           list.videoEventIds,
           contains('34235:pubkey123:horizontal-video'),
         );
-        expect(
-          list.videoEventIds,
-          contains('34236:pubkey456:vertical-video'),
-        );
-        expect(
-          list.videoEventIds,
-          contains('34237:pubkey789:live-video'),
-        );
+        expect(list.videoEventIds, contains('34236:pubkey456:vertical-video'));
+        expect(list.videoEventIds, contains('34237:pubkey789:live-video'));
       });
 
       test('ignores a-tags with non-video kinds', () {
@@ -284,7 +278,7 @@ void main() {
         expect(tags, contains(equals(['title', 'My List'])));
       });
 
-      test('includes client tag', () {
+      test('does not inline a client tag', () {
         final list = CuratedList(
           id: 'my-list',
           name: 'Test',
@@ -295,7 +289,7 @@ void main() {
 
         final tags = CuratedListConverter.toEventTags(list);
 
-        expect(tags, contains(equals(['client', 'diVine'])));
+        expect(tags.any((tag) => tag.first == 'client'), isFalse);
       });
 
       test('includes description when present', () {
@@ -478,10 +472,7 @@ void main() {
           ],
         );
 
-        expect(
-          CuratedListConverter.extractDTag(event),
-          equals('my-list-id'),
-        );
+        expect(CuratedListConverter.extractDTag(event), equals('my-list-id'));
       });
 
       test('returns first d-tag when multiple exist', () {

--- a/mobile/packages/curation_repository/lib/src/curation_repository.dart
+++ b/mobile/packages/curation_repository/lib/src/curation_repository.dart
@@ -1004,7 +1004,6 @@ class CurationRepository {
     final tags = <List<String>>[
       ['d', id], // Replaceable event identifier
       ['title', title],
-      ['client', 'diVine'], // Attribution
     ];
 
     if (description != null) {

--- a/mobile/packages/curation_repository/test/src/curation_repository_create_test.dart
+++ b/mobile/packages/curation_repository/test/src/curation_repository_create_test.dart
@@ -137,7 +137,7 @@ void main() {
       },
     );
 
-    test('creates event with correct tags', () async {
+    test('creates event with correct content tags before publish', () async {
       final signedEvent = Event(
         _testPubkey,
         30005,
@@ -186,9 +186,9 @@ void main() {
       final imageTag = tags.firstWhere((tag) => tag[0] == 'image');
       expect(imageTag[1], 'https://example.com/img.jpg');
 
-      // Verify client attribution tag
-      final clientTag = tags.firstWhere((tag) => tag[0] == 'client');
-      expect(clientTag[1], 'diVine');
+      // Client attribution is injected centrally during publish, not
+      // in repository-specific tag construction.
+      expect(tags.where((tag) => tag[0] == 'client'), isEmpty);
 
       // Verify video references as 'e' tags
       final eTags = tags.where((tag) => tag[0] == 'e').toList();

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -71,20 +71,20 @@ void main() {
 
         // At least the recipient gift wrap is published; self-wrap may
         // silently fail with synthetic test keys.
-        verify(() => mockNostrClient.publishEvent(any())).called(
-          greaterThanOrEqualTo(1),
-        );
+        verify(
+          () => mockNostrClient.publishEvent(any()),
+        ).called(greaterThanOrEqualTo(1));
       });
 
       test('creates gift wrap with kind 1059', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event;
-            return PublishSuccess(event: capturedEvent!);
-          },
-        );
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return PublishSuccess(event: capturedEvent!);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -98,12 +98,12 @@ void main() {
       test('includes p tag with recipient pubkey', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event;
-            return PublishSuccess(event: capturedEvent!);
-          },
-        );
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return PublishSuccess(event: capturedEvent!);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -121,13 +121,13 @@ void main() {
       test('uses random ephemeral key for each gift wrap', () async {
         final capturedEvents = <Event>[];
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            final event = invocation.positionalArguments[0] as Event;
-            capturedEvents.add(event);
-            return PublishSuccess(event: event);
-          },
-        );
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          final event = invocation.positionalArguments[0] as Event;
+          capturedEvents.add(event);
+          return PublishSuccess(event: event);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -153,12 +153,12 @@ void main() {
       test('obfuscates timestamp with random offset', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event;
-            return PublishSuccess(event: capturedEvent!);
-          },
-        );
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return PublishSuccess(event: capturedEvent!);
+        });
 
         final beforeSend = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         await service.sendPrivateMessage(
@@ -193,18 +193,18 @@ void main() {
       test('includes additional tags in the gift wrap', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            capturedEvent = invocation.positionalArguments[0] as Event;
-            return PublishSuccess(event: capturedEvent!);
-          },
-        );
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return PublishSuccess(event: capturedEvent!);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
           content: 'Test message',
           additionalTags: [
-            ['client', 'diVine_bug_report'],
+            Nip89ClientTag.tag,
             ['report_id', 'test-123'],
           ],
         );
@@ -235,17 +235,17 @@ void main() {
           'publish throws (recipient delivered, sender will not see this '
           'message on other devices)', () async {
         var callCount = 0;
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            callCount++;
-            if (callCount == 1) {
-              return PublishSuccess(
-                event: invocation.positionalArguments[0] as Event,
-              );
-            }
-            throw Exception('self-wrap relay error');
-          },
-        );
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          callCount++;
+          if (callCount == 1) {
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
+          }
+          throw Exception('self-wrap relay error');
+        });
 
         final result = await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -310,52 +310,74 @@ void main() {
         );
       });
 
+      test('returns success with selfWrapPublished=false '
+          'when self-wrap publish returns PublishFailed', () async {
+        final signer = LocalNostrSigner(_testPrivateKey);
+        final senderPublicKey = (await signer.getPublicKey())!;
+        final matchingService = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: senderPublicKey,
+          nostrService: mockNostrClient,
+        );
+        var callCount = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          callCount++;
+          if (callCount == 1) {
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
+          }
+          return const PublishFailed();
+        });
+
+        final result = await matchingService.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'Test message',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.rumorEventId, isNotNull);
+        expect(result.selfWrapPublished, isFalse);
+      });
+
+      test('returns success with selfWrapPublished=false '
+          'when self-wrap publish returns PublishNoRelays', () async {
+        final signer = LocalNostrSigner(_testPrivateKey);
+        final senderPublicKey = (await signer.getPublicKey())!;
+        final matchingService = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: senderPublicKey,
+          nostrService: mockNostrClient,
+        );
+        var callCount = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          callCount++;
+          if (callCount == 1) {
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
+          }
+          return const PublishNoRelays();
+        });
+
+        final result = await matchingService.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'Test message',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.rumorEventId, isNotNull);
+        expect(result.selfWrapPublished, isFalse);
+      });
+
       test(
-        'returns success with selfWrapPublished=false '
-        'when self-wrap publish returns PublishFailed',
+        'returns success with selfWrapPublished=false when self-wrap '
+        'publish returns PublishFailed (relay rejected with no exception)',
         () async {
-          final signer = LocalNostrSigner(_testPrivateKey);
-          final senderPublicKey = (await signer.getPublicKey())!;
-          final matchingService = NIP17MessageService(
-            signer: signer,
-            senderPublicKey: senderPublicKey,
-            nostrService: mockNostrClient,
-          );
-          var callCount = 0;
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async {
-              callCount++;
-              if (callCount == 1) {
-                return PublishSuccess(
-                  event: invocation.positionalArguments[0] as Event,
-                );
-              }
-              return const PublishFailed();
-            },
-          );
-
-          final result = await matchingService.sendPrivateMessage(
-            recipientPubkey: _recipientPubkey,
-            content: 'Test message',
-          );
-
-          expect(result.success, isTrue);
-          expect(result.rumorEventId, isNotNull);
-          expect(result.selfWrapPublished, isFalse);
-        },
-      );
-
-      test(
-        'returns success with selfWrapPublished=false '
-        'when self-wrap publish returns PublishNoRelays',
-        () async {
-          final signer = LocalNostrSigner(_testPrivateKey);
-          final senderPublicKey = (await signer.getPublicKey())!;
-          final matchingService = NIP17MessageService(
-            signer: signer,
-            senderPublicKey: senderPublicKey,
-            nostrService: mockNostrClient,
-          );
           var callCount = 0;
           when(() => mockNostrClient.publishEvent(any())).thenAnswer((
             invocation,
@@ -366,36 +388,8 @@ void main() {
                 event: invocation.positionalArguments[0] as Event,
               );
             }
-            return const PublishNoRelays();
+            return const PublishFailed();
           });
-
-          final result = await matchingService.sendPrivateMessage(
-            recipientPubkey: _recipientPubkey,
-            content: 'Test message',
-          );
-
-          expect(result.success, isTrue);
-          expect(result.rumorEventId, isNotNull);
-          expect(result.selfWrapPublished, isFalse);
-        },
-      );
-
-      test(
-        'returns success with selfWrapPublished=false when self-wrap '
-        'publish returns PublishFailed (relay rejected with no exception)',
-        () async {
-          var callCount = 0;
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async {
-              callCount++;
-              if (callCount == 1) {
-                return PublishSuccess(
-                  event: invocation.positionalArguments[0] as Event,
-                );
-              }
-              return const PublishFailed();
-            },
-          );
 
           final result = await service.sendPrivateMessage(
             recipientPubkey: _recipientPubkey,
@@ -421,13 +415,13 @@ void main() {
             nostrService: mockNostrClient,
           );
 
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async {
-              final event = invocation.positionalArguments[0] as Event;
-              capturedEvents.add(event);
-              return PublishSuccess(event: event);
-            },
-          );
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+            invocation,
+          ) async {
+            final event = invocation.positionalArguments[0] as Event;
+            capturedEvents.add(event);
+            return PublishSuccess(event: event);
+          });
 
           final result = await matchingService.sendPrivateMessage(
             recipientPubkey: _recipientPubkey,
@@ -622,145 +616,125 @@ void main() {
         );
       });
 
-      test(
-        'returns failure when signer throws during key refresh',
-        () async {
-          final mockSigner = _MockNostrSigner();
-          when(
-            mockSigner.getPublicKey,
-          ).thenThrow(Exception('signer unavailable'));
+      test('returns failure when signer throws during key refresh', () async {
+        final mockSigner = _MockNostrSigner();
+        when(
+          mockSigner.getPublicKey,
+        ).thenThrow(Exception('signer unavailable'));
 
-          final brokenService = NIP17MessageService(
-            signer: mockSigner,
-            senderPublicKey: _testPublicKey,
-            nostrService: mockNostrClient,
-          );
+        final brokenService = NIP17MessageService(
+          signer: mockSigner,
+          senderPublicKey: _testPublicKey,
+          nostrService: mockNostrClient,
+        );
 
-          final result = await brokenService.sendPrivateMessage(
-            recipientPubkey: _recipientPubkey,
-            content: 'Test message',
-          );
+        final result = await brokenService.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'Test message',
+        );
 
-          expect(result.success, isFalse);
-          expect(result.error, isNotNull);
-        },
-      );
+        expect(result.success, isFalse);
+        expect(result.error, isNotNull);
+      });
     });
 
     group('buildRumor + sendRumor split', () {
-      test(
-        'buildRumor returns the unsigned rumor event without touching '
-        'the relay or signer',
-        () async {
-          final rumor = service.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'queue this before publishing',
-          );
+      test('buildRumor returns the unsigned rumor event without touching '
+          'the relay or signer', () async {
+        final rumor = service.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'queue this before publishing',
+        );
 
-          expect(rumor.kind, equals(EventKind.privateDirectMessage));
-          expect(rumor.content, equals('queue this before publishing'));
-          expect(rumor.pubkey, equals(_testPublicKey));
-          expect(
-            rumor.tags.first,
-            equals(['p', _recipientPubkey]),
-            reason: 'p-tag must be the first tag for NIP-17 compliance',
-          );
-          expect(
-            rumor.id,
-            isNotEmpty,
-            reason:
-                'Event constructor computes the rumor id deterministically '
-                'from its fields — DmRepository keys the queue row by it',
-          );
-          // No publish should fire from a pure build call.
-          verifyNever(() => mockNostrClient.publishEvent(any()));
-        },
-      );
+        expect(rumor.kind, equals(EventKind.privateDirectMessage));
+        expect(rumor.content, equals('queue this before publishing'));
+        expect(rumor.pubkey, equals(_testPublicKey));
+        expect(
+          rumor.tags.first,
+          equals(['p', _recipientPubkey]),
+          reason: 'p-tag must be the first tag for NIP-17 compliance',
+        );
+        expect(
+          rumor.id,
+          isNotEmpty,
+          reason:
+              'Event constructor computes the rumor id deterministically '
+              'from its fields — DmRepository keys the queue row by it',
+        );
+        // No publish should fire from a pure build call.
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
 
-      test(
-        'sendRumor wraps and publishes a pre-built rumor with the same '
-        'rumor id as buildRumor returned',
-        () async {
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async => PublishSuccess(
-              event: invocation.positionalArguments[0] as Event,
-            ),
-          );
+      test('sendRumor wraps and publishes a pre-built rumor with the same '
+          'rumor id as buildRumor returned', () async {
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+          (invocation) async =>
+              PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        );
 
-          final rumor = service.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'split-flow message',
-          );
-          final rumorIdBeforeSend = rumor.id;
+        final rumor = service.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'split-flow message',
+        );
+        final rumorIdBeforeSend = rumor.id;
 
-          final result = await service.sendRumor(
-            rumorEvent: rumor,
-            recipientPubkey: _recipientPubkey,
-          );
+        final result = await service.sendRumor(
+          rumorEvent: rumor,
+          recipientPubkey: _recipientPubkey,
+        );
 
-          expect(result.success, isTrue);
-          expect(
-            result.rumorEventId,
-            equals(rumorIdBeforeSend),
-            reason:
-                'sendRumor must surface the same rumor id the caller saw '
-                'from buildRumor — the queue row PK depends on this',
-          );
-          expect(result.recipientPubkey, equals(_recipientPubkey));
-        },
-      );
+        expect(result.success, isTrue);
+        expect(
+          result.rumorEventId,
+          equals(rumorIdBeforeSend),
+          reason:
+              'sendRumor must surface the same rumor id the caller saw '
+              'from buildRumor — the queue row PK depends on this',
+        );
+        expect(result.recipientPubkey, equals(_recipientPubkey));
+      });
 
-      test(
-        'buildRumor includes additional tags after the recipient p-tag',
-        () {
-          final rumor = service.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'reply test',
-            additionalTags: [
-              ['e', 'parent-message-id'],
-            ],
-          );
-
-          expect(rumor.tags, [
-            ['p', _recipientPubkey],
+      test('buildRumor includes additional tags after the recipient p-tag', () {
+        final rumor = service.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'reply test',
+          additionalTags: [
             ['e', 'parent-message-id'],
-          ]);
-        },
-      );
+          ],
+        );
 
-      test(
-        'buildRumor honors a non-default eventKind so kind 15 file '
-        'messages can be enqueued before publishing',
-        () {
-          final rumor = service.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'https://example.com/file.enc',
-            eventKind: EventKind.fileMessage,
-          );
+        expect(rumor.tags, [
+          ['p', _recipientPubkey],
+          ['e', 'parent-message-id'],
+        ]);
+      });
 
-          expect(rumor.kind, equals(EventKind.fileMessage));
-        },
-      );
+      test('buildRumor honors a non-default eventKind so kind 15 file '
+          'messages can be enqueued before publishing', () {
+        final rumor = service.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'https://example.com/file.enc',
+          eventKind: EventKind.fileMessage,
+        );
 
-      test(
-        'sendPrivateMessage convenience wrapper still works (delegates '
-        'to buildRumor + sendRumor)',
-        () async {
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async => PublishSuccess(
-              event: invocation.positionalArguments[0] as Event,
-            ),
-          );
+        expect(rumor.kind, equals(EventKind.fileMessage));
+      });
 
-          final result = await service.sendPrivateMessage(
-            recipientPubkey: _recipientPubkey,
-            content: 'convenience-wrapper smoke test',
-          );
+      test('sendPrivateMessage convenience wrapper still works (delegates '
+          'to buildRumor + sendRumor)', () async {
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+          (invocation) async =>
+              PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        );
 
-          expect(result.success, isTrue);
-          expect(result.rumorEventId, isNotNull);
-        },
-      );
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'convenience-wrapper smoke test',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.rumorEventId, isNotNull);
+      });
     });
 
     group('publishSelfWrap', () {
@@ -782,130 +756,114 @@ void main() {
         );
       });
 
-      test(
-        'returns success when the self-wrap publish succeeds and '
-        'never publishes a recipient wrap',
-        () async {
-          final captured = <Event>[];
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async {
-              final event = invocation.positionalArguments[0] as Event;
-              captured.add(event);
-              return PublishSuccess(event: event);
-            },
-          );
+      test('returns success when the self-wrap publish succeeds and '
+          'never publishes a recipient wrap', () async {
+        final captured = <Event>[];
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          final event = invocation.positionalArguments[0] as Event;
+          captured.add(event);
+          return PublishSuccess(event: event);
+        });
 
-          final rumor = realKeyService.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'recovery smoke test',
-          );
+        final rumor = realKeyService.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'recovery smoke test',
+        );
 
-          final result = await realKeyService.publishSelfWrap(
-            rumorEvent: rumor,
-          );
+        final result = await realKeyService.publishSelfWrap(rumorEvent: rumor);
 
-          expect(result.success, isTrue);
-          expect(result.selfWrapPublished, isTrue);
-          expect(
-            result.rumorEventId,
-            equals(rumor.id),
-            reason:
-                'rumor id must be preserved across recovery — receiver-side '
-                'gift-wrap dedup keys on it',
-          );
-          expect(
-            result.recipientPubkey,
-            equals(getPublicKey(_testPrivateKey)),
-            reason:
-                'recovery republishes a self-addressed wrap; the result '
-                "exposes the sender's pubkey in the recipientPubkey slot",
-          );
-          expect(
-            captured,
-            hasLength(1),
-            reason:
-                'publishSelfWrap must NOT republish the recipient wrap — '
-                'doing so would double-deliver the message',
-          );
-          expect(captured.single.kind, equals(EventKind.giftWrap));
-        },
-      );
+        expect(result.success, isTrue);
+        expect(result.selfWrapPublished, isTrue);
+        expect(
+          result.rumorEventId,
+          equals(rumor.id),
+          reason:
+              'rumor id must be preserved across recovery — receiver-side '
+              'gift-wrap dedup keys on it',
+        );
+        expect(
+          result.recipientPubkey,
+          equals(getPublicKey(_testPrivateKey)),
+          reason:
+              'recovery republishes a self-addressed wrap; the result '
+              "exposes the sender's pubkey in the recipientPubkey slot",
+        );
+        expect(
+          captured,
+          hasLength(1),
+          reason:
+              'publishSelfWrap must NOT republish the recipient wrap — '
+              'doing so would double-deliver the message',
+        );
+        expect(captured.single.kind, equals(EventKind.giftWrap));
+      });
 
-      test(
-        'returns failure when the self-wrap publish returns '
-        'PublishFailed without throwing',
-        () async {
-          when(
-            () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => const PublishFailed());
+      test('returns failure when the self-wrap publish returns '
+          'PublishFailed without throwing', () async {
+        when(
+          () => mockNostrClient.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
 
-          final rumor = realKeyService.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'PublishFailed path',
-          );
+        final rumor = realKeyService.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'PublishFailed path',
+        );
 
-          final result = await realKeyService.publishSelfWrap(
-            rumorEvent: rumor,
-          );
+        final result = await realKeyService.publishSelfWrap(rumorEvent: rumor);
 
-          expect(result.success, isFalse);
-          expect(result.error, isNotNull);
-          expect(result.selfWrapPublished, isNull);
-          verify(() => mockNostrClient.publishEvent(any())).called(1);
-        },
-      );
+        expect(result.success, isFalse);
+        expect(result.error, isNotNull);
+        expect(result.selfWrapPublished, isNull);
+        verify(() => mockNostrClient.publishEvent(any())).called(1);
+      });
 
-      test(
-        'returns failure when the gift-wrap builder returns null',
-        () async {
-          final nullBuilderService = NIP17MessageService(
-            signer: LocalNostrSigner(_testPrivateKey),
-            senderPublicKey: getPublicKey(_testPrivateKey),
-            nostrService: mockNostrClient,
-            giftWrapBuilder: (_, _, _) async => null,
-          );
+      test('returns failure when the gift-wrap builder returns null', () async {
+        final nullBuilderService = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: getPublicKey(_testPrivateKey),
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, _) async => null,
+        );
 
-          final rumor = nullBuilderService.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'null builder path',
-          );
+        final rumor = nullBuilderService.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'null builder path',
+        );
 
-          final result = await nullBuilderService.publishSelfWrap(
-            rumorEvent: rumor,
-          );
+        final result = await nullBuilderService.publishSelfWrap(
+          rumorEvent: rumor,
+        );
 
-          expect(result.success, isFalse);
-          expect(result.error, isNotNull);
-          verifyNever(() => mockNostrClient.publishEvent(any()));
-        },
-      );
+        expect(result.success, isFalse);
+        expect(result.error, isNotNull);
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
 
-      test(
-        'returns failure when the gift-wrap builder throws',
-        () async {
-          final throwingBuilderService = NIP17MessageService(
-            signer: LocalNostrSigner(_testPrivateKey),
-            senderPublicKey: getPublicKey(_testPrivateKey),
-            nostrService: mockNostrClient,
-            giftWrapBuilder: (_, _, _) async {
-              throw Exception('builder boom');
-            },
-          );
+      test('returns failure when the gift-wrap builder throws', () async {
+        final throwingBuilderService = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: getPublicKey(_testPrivateKey),
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, _) async {
+            throw Exception('builder boom');
+          },
+        );
 
-          final rumor = throwingBuilderService.buildRumor(
-            recipientPubkey: _recipientPubkey,
-            content: 'throwing builder path',
-          );
+        final rumor = throwingBuilderService.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'throwing builder path',
+        );
 
-          final result = await throwingBuilderService.publishSelfWrap(
-            rumorEvent: rumor,
-          );
+        final result = await throwingBuilderService.publishSelfWrap(
+          rumorEvent: rumor,
+        );
 
-          expect(result.success, isFalse);
-          expect(result.error, isNotNull);
-          verifyNever(() => mockNostrClient.publishEvent(any()));
-        },
-      );
+        expect(result.success, isFalse);
+        expect(result.error, isNotNull);
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
 
       test(
         'returns failure when the signer throws during key refresh',
@@ -926,9 +884,7 @@ void main() {
             content: 'signer-key-failure path',
           );
 
-          final result = await brokenService.publishSelfWrap(
-            rumorEvent: rumor,
-          );
+          final result = await brokenService.publishSelfWrap(rumorEvent: rumor);
 
           expect(result.success, isFalse);
           expect(result.error, isNotNull);

--- a/mobile/packages/nostr_client/lib/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/nostr_client.dart
@@ -6,6 +6,7 @@
 library;
 
 export 'src/models/models.dart';
+export 'src/nip89_client_tag.dart';
 export 'src/nostr_client.dart';
 export 'src/publish_result.dart';
 export 'src/relay_manager.dart';

--- a/mobile/packages/nostr_client/lib/src/nip89_client_tag.dart
+++ b/mobile/packages/nostr_client/lib/src/nip89_client_tag.dart
@@ -1,0 +1,112 @@
+import 'package:meta/meta.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Divine's published NIP-89 application handler identity.
+abstract final class Nip89ClientTag {
+  /// Shared preferences key controlling whether attribution is emitted.
+  static const String preferenceKey = 'nip89_client_tag_enabled';
+
+  /// Human-readable client name advertised in the `client` tag.
+  static const String clientName = 'Divine';
+
+  /// Pubkey of Divine's published kind `31990` handler event.
+  static const String handlerPubkey =
+      'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540';
+
+  /// Stable `d` identifier of Divine's published kind `31990` handler event.
+  static const String handlerDIdentifier = 'divine-mobile';
+
+  /// Relay hint embedded in the NIP-89 client tag.
+  static const String relayHint = 'wss://relay.divine.video';
+
+  static const Set<int> _excludedKinds = {
+    EventKind.sealEventKind,
+    EventKind.giftWrap,
+    EventKind.authentication,
+    EventKind.nostrRemoteSigning,
+    EventKind.blossomHttpAuth,
+    EventKind.httpAuth,
+    EventKind.zap,
+  };
+
+  static SharedPreferences? _prefs;
+  static bool? _cachedEnabled;
+
+  /// Canonical Divine NIP-89 client tag.
+  static List<String> get tag => const [
+    'client',
+    clientName,
+    '31990:$handlerPubkey:$handlerDIdentifier',
+    relayHint,
+  ];
+
+  /// Returns whether [kind] should never receive a public client tag.
+  static bool shouldSkipKind(int kind) => _excludedKinds.contains(kind);
+
+  /// Returns whether [tags] already contain a `client` tag.
+  static bool hasClientTag(Iterable<List<String>> tags) =>
+      tags.any(_isClientTag);
+
+  /// Returns whether Divine should emit the `client` tag for new events.
+  static Future<bool> isEnabled() async {
+    final cachedEnabled = _cachedEnabled;
+    if (cachedEnabled != null) {
+      return cachedEnabled;
+    }
+
+    final prefs = await _getPrefs();
+    final enabled = prefs.getBool(preferenceKey) ?? true;
+    _cachedEnabled = enabled;
+    return enabled;
+  }
+
+  /// Persists whether Divine should emit the `client` tag for new events.
+  static Future<void> setEnabled({required bool enabled}) async {
+    final prefs = await _getPrefs();
+    _cachedEnabled = enabled;
+    await prefs.setBool(preferenceKey, enabled);
+  }
+
+  /// Ensures [event] has the canonical Divine NIP-89 client tag.
+  ///
+  /// Returns `true` when the event was changed. The event is updated in place
+  /// so callers that keep a reference observe the final id/signature.
+  static Future<bool> applyToEvent(Event event) async {
+    if (shouldSkipKind(event.kind) || hasClientTag(event.tags)) {
+      return false;
+    }
+
+    if (!await isEnabled()) {
+      return false;
+    }
+
+    final rebuilt = Event(
+      event.pubkey,
+      event.kind,
+      <List<String>>[...event.tags.map(List<String>.from), tag],
+      event.content,
+      createdAt: event.createdAt,
+    );
+
+    event
+      ..tags = rebuilt.tags
+      ..id = rebuilt.id
+      ..sig = '';
+    return true;
+  }
+
+  static bool _isClientTag(List<String> tag) =>
+      tag.isNotEmpty && tag.first == 'client';
+
+  static Future<SharedPreferences> _getPrefs() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  @visibleForTesting
+  /// Clears cached preference state between tests.
+  static void resetForTest() {
+    _prefs = null;
+    _cachedEnabled = null;
+  }
+}

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:meta/meta.dart';
 import 'package:nostr_client/src/models/models.dart';
+import 'package:nostr_client/src/nip89_client_tag.dart';
 import 'package:nostr_client/src/publish_result.dart';
 import 'package:nostr_client/src/relay_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
@@ -187,6 +188,16 @@ class NostrClient {
   /// Tracks whether dispose() has been called
   bool _isDisposed = false;
 
+  Future<void> _prepareEventForPublish(Event event) async {
+    final changed = await Nip89ClientTag.applyToEvent(event);
+    if (!changed) {
+      return;
+    }
+
+    // publishEvent()/publishEventAwaitOk() both delegate signing to nostr_sdk
+    // when sig is blank, so clearing the signature is enough here.
+  }
+
   /// Completes the first time [initialize] finishes, so consumers can await
   /// readiness without polling `hasKeys`. `NostrClient` is one-shot — after
   /// `dispose()` a fresh instance is constructed for the next session, so
@@ -284,6 +295,7 @@ class NostrClient {
     Event event, {
     List<String>? targetRelays,
   }) async {
+    await _prepareEventForPublish(event);
     final useOptimisticCache = _canOptimisticallyCache(event.kind);
 
     // Optimistic cache for regular events only
@@ -361,6 +373,7 @@ class NostrClient {
     Duration timeout = const Duration(seconds: 15),
     String? diagnosticTag,
   }) async {
+    await _prepareEventForPublish(event);
     final useOptimisticCache = _canOptimisticallyCache(event.kind);
 
     if (useOptimisticCache) {
@@ -535,10 +548,7 @@ class NostrClient {
         relayTypes: relayTypes,
       );
 
-      return CountResult(
-        count: events.length,
-        source: CountSource.clientSide,
-      );
+      return CountResult(count: events.length, source: CountSource.clientSide);
     }
   }
 
@@ -595,10 +605,7 @@ class NostrClient {
   /// Falls back to WebSocket query if cache miss.
   ///
   /// Results from websocket are cached for future queries.
-  Future<Event?> fetchProfile(
-    String pubkey, {
-    bool useCache = true,
-  }) async {
+  Future<Event?> fetchProfile(String pubkey, {bool useCache = true}) async {
     // 1. Check cache first
     final dao = _nostrEventsDao;
     if (useCache && dao != null) {
@@ -863,19 +870,30 @@ class NostrClient {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    final likeEvent = await _nostr.sendLike(
-      eventId,
-      pubkey: targetAuthorPubkey,
-      content: content,
-      addressableId: addressableId,
-      targetKind: targetKind,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
+    final tags = <List<String>>[
+      ['e', eventId],
+      if (addressableId != null && addressableId.isNotEmpty)
+        ['a', addressableId],
+      if (targetAuthorPubkey != null && targetAuthorPubkey.isNotEmpty)
+        ['p', targetAuthorPubkey],
+      if (targetKind != null) ['k', targetKind.toString()],
+    ];
+
+    final likeEvent = Event(
+      publicKey,
+      EventKind.reaction,
+      tags,
+      content ?? '+',
     );
-    if (likeEvent != null) {
-      _cacheEvent(likeEvent);
+
+    final result = await publishEvent(
+      likeEvent,
+      targetRelays: targetRelays ?? tempRelays,
+    );
+    if (result case PublishSuccess(:final event)) {
+      return event;
     }
-    return likeEvent;
+    return null;
   }
 
   /// Sends a user profile (Kind 0 metadata event).
@@ -912,17 +930,23 @@ class NostrClient {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    final repostEvent = await _nostr.sendRepost(
-      eventId,
-      relayAddr: relayAddr,
-      content: content,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
+    final tags = <List<String>>[
+      if (relayAddr != null && relayAddr.isNotEmpty)
+        ['e', eventId, relayAddr]
+      else
+        ['e', eventId],
+    ];
+
+    final repostEvent = Event(publicKey, EventKind.repost, tags, content);
+
+    final result = await publishEvent(
+      repostEvent,
+      targetRelays: targetRelays ?? tempRelays,
     );
-    if (repostEvent != null) {
-      _cacheEvent(repostEvent);
+    if (result case PublishSuccess(:final event)) {
+      return event;
     }
-    return repostEvent;
+    return null;
   }
 
   /// Sends a generic repost (Kind 16) for addressable events.
@@ -963,12 +987,7 @@ class NostrClient {
       tags.add(['e', eventId]);
     }
 
-    final event = Event(
-      publicKey,
-      EventKind.genericRepost,
-      tags,
-      content,
-    );
+    final event = Event(publicKey, EventKind.genericRepost, tags, content);
 
     final sentEvent = await _nostr.sendEvent(
       event,
@@ -992,16 +1011,19 @@ class NostrClient {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    final deletionEvent = await _nostr.deleteEvent(
-      eventId,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
+    final deletionEvent = Event(publicKey, EventKind.eventDeletion, [
+      ['e', eventId],
+    ], 'delete');
+
+    final result = await publishEvent(
+      deletionEvent,
+      targetRelays: targetRelays ?? tempRelays,
     );
-    if (deletionEvent != null) {
-      // Delete target event from local database
-      _handleDeletionEvent(deletionEvent);
+    if (result case PublishSuccess(:final event)) {
+      _handleDeletionEvent(event);
+      return event;
     }
-    return deletionEvent;
+    return null;
   }
 
   /// Deletes multiple events
@@ -1013,16 +1035,22 @@ class NostrClient {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    final deletionEvent = await _nostr.deleteEvents(
-      eventIds,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
+    final deletionEvent = Event(
+      publicKey,
+      EventKind.eventDeletion,
+      eventIds.map((eventId) => ['e', eventId]).toList(),
+      'delete',
     );
-    if (deletionEvent != null) {
-      // Delete target events from local database
-      _handleDeletionEvent(deletionEvent);
+
+    final result = await publishEvent(
+      deletionEvent,
+      targetRelays: targetRelays ?? tempRelays,
+    );
+    if (result case PublishSuccess(:final event)) {
+      _handleDeletionEvent(event);
+      return event;
     }
-    return deletionEvent;
+    return null;
   }
 
   /// Sends a contact list
@@ -1034,16 +1062,21 @@ class NostrClient {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    final contactListEvent = await _nostr.sendContactList(
-      contacts,
+    final contactListEvent = Event(
+      publicKey,
+      EventKind.contactList,
+      contacts.toJson(),
       content,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
     );
-    if (contactListEvent != null) {
-      _cacheEvent(contactListEvent);
+
+    final result = await publishEvent(
+      contactListEvent,
+      targetRelays: targetRelays ?? tempRelays,
+    );
+    if (result case PublishSuccess(:final event)) {
+      return event;
     }
-    return contactListEvent;
+    return null;
   }
 
   /// Known NIP-50 compatible search relays.
@@ -1078,10 +1111,7 @@ class NostrClient {
   /// Searches for user profiles using NIP-50 search.
   ///
   /// Includes known NIP-50 relays for better coverage.
-  Stream<Event> searchUsers(
-    String query, {
-    int? limit,
-  }) {
+  Stream<Event> searchUsers(String query, {int? limit}) {
     final filter = Filter(
       kinds: const [EventKind.metadata],
       limit: limit ?? 100,
@@ -1098,10 +1128,7 @@ class NostrClient {
   ///
   /// Unlike [searchUsers], this returns a Future that completes once,
   /// making it suitable for one-time search operations.
-  Future<List<Event>> queryUsers(
-    String query, {
-    int? limit,
-  }) {
+  Future<List<Event>> queryUsers(String query, {int? limit}) {
     final filter = Filter(
       kinds: const [EventKind.metadata],
       limit: limit ?? 100,

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -989,17 +989,14 @@ class NostrClient {
 
     final event = Event(publicKey, EventKind.genericRepost, tags, content);
 
-    final sentEvent = await _nostr.sendEvent(
+    final result = await publishEvent(
       event,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
+      targetRelays: targetRelays ?? tempRelays,
     );
-
-    if (sentEvent != null) {
-      _cacheEvent(sentEvent);
+    if (result case PublishSuccess(:final event)) {
+      return event;
     }
-
-    return sentEvent;
+    return null;
   }
 
   /// Deletes an event

--- a/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
+++ b/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostr extends Mock implements Nostr {}
+
+class _MockRelayManager extends Mock implements RelayManager {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _pubkey =
+    '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+Event _event({
+  int kind = EventKind.textNote,
+  List<List<String>> tags = const [],
+}) {
+  return Event(
+    _pubkey,
+    kind,
+    tags.map(List<String>.from).toList(),
+    'hello',
+    createdAt: 1700000000,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    Nip89ClientTag.resetForTest();
+  });
+
+  group('Nip89ClientTag', () {
+    test('adds the canonical Divine tag', () async {
+      final event = _event();
+      final originalId = event.id;
+
+      final changed = await Nip89ClientTag.applyToEvent(event);
+
+      expect(changed, isTrue);
+      expect(event.tags, contains(Nip89ClientTag.tag));
+      expect(event.id, isNot(originalId));
+      expect(event.sig, isEmpty);
+    });
+
+    test('skips excluded wrapper kinds', () async {
+      final event = _event(
+        kind: EventKind.giftWrap,
+        tags: const [
+          ['p', _pubkey],
+        ],
+      );
+      final originalId = event.id;
+
+      final changed = await Nip89ClientTag.applyToEvent(event);
+
+      expect(changed, isFalse);
+      expect(event.tags, isNot(contains(Nip89ClientTag.tag)));
+      expect(event.id, originalId);
+    });
+
+    test('respects opt-out preference', () async {
+      await Nip89ClientTag.setEnabled(enabled: false);
+      final event = _event();
+
+      final changed = await Nip89ClientTag.applyToEvent(event);
+
+      expect(changed, isFalse);
+      expect(event.tags, isNot(contains(Nip89ClientTag.tag)));
+    });
+
+    test('does not duplicate an existing client tag', () async {
+      final event = _event(tags: [Nip89ClientTag.tag]);
+
+      final changed = await Nip89ClientTag.applyToEvent(event);
+
+      expect(changed, isFalse);
+      expect(event.tags.where((tag) => tag.first == 'client'), hasLength(1));
+    });
+  });
+
+  group('NostrClient publish augmentation', () {
+    late _MockNostr mockNostr;
+    late _MockRelayManager mockRelayManager;
+    late NostrClient client;
+
+    setUp(() {
+      mockNostr = _MockNostr();
+      mockRelayManager = _MockRelayManager();
+      client = NostrClient.forTesting(
+        nostr: mockNostr,
+        relayManager: mockRelayManager,
+      );
+
+      when(() => mockRelayManager.connectedRelays).thenReturn(['wss://relay']);
+      when(
+        () => mockNostr.sendEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          tempRelays: any(named: 'tempRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        return invocation.positionalArguments.first as Event;
+      });
+    });
+
+    test('mutates a signed event in place before publish', () async {
+      final event = _event()..sig = 'already-signed';
+      final originalId = event.id;
+
+      final result = await client.publishEvent(event);
+
+      expect(result, isA<PublishSuccess>());
+      expect(event.tags, contains(Nip89ClientTag.tag));
+      expect(event.id, isNot(originalId));
+      expect(event.sig, isEmpty);
+      verify(
+        () => mockNostr.sendEvent(
+          event,
+          targetRelays: any(named: 'targetRelays'),
+          tempRelays: any(named: 'tempRelays'),
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1714,6 +1714,7 @@ void main() {
             ['k', '$targetKind'],
             ['a', addressableId],
             ['p', authorPubkey],
+            Nip89ClientTag.tag,
           ]),
         );
       });
@@ -1746,7 +1747,7 @@ void main() {
             verify(
                   () => mockNostr.sendEvent(
                     captureAny(),
-                    tempRelays: tempRelays,
+                    tempRelays: targetRelays,
                     targetRelays: targetRelays,
                   ),
                 ).captured.single
@@ -1800,17 +1801,19 @@ void main() {
                 ).captured.single
                 as Event;
 
-        // Verify tags are in correct order: k, a, p
-        expect(captured.tags.length, equals(3));
+        // Verify tags are in correct order: k, a, p, client
+        expect(captured.tags.length, equals(4));
         final tag0 = captured.tags[0] as List<dynamic>;
         final tag1 = captured.tags[1] as List<dynamic>;
         final tag2 = captured.tags[2] as List<dynamic>;
+        final tag3 = captured.tags[3] as List<dynamic>;
         expect(tag0[0], equals('k'));
         expect(tag0[1], equals('$targetKind'));
         expect(tag1[0], equals('a'));
         expect(tag1[1], equals(addressableId));
         expect(tag2[0], equals('p'));
         expect(tag2[1], equals(authorPubkey));
+        expect(tag3, equals(Nip89ClientTag.tag));
       });
     });
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/utils/hash_util.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockNostr extends Mock implements Nostr {}
 
@@ -64,12 +65,15 @@ Event _createTestEvent({
 // =============================================================================
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('NostrClient', () {
     late _MockNostr mockNostr;
     late _MockRelayManager mockRelayManager;
     late NostrClient client;
 
     setUpAll(() {
+      SharedPreferences.setMockInitialValues(const <String, Object>{});
       registerFallbackValue(_FakeEvent());
       registerFallbackValue(_FakeFilter());
       registerFallbackValue(_FakeContactList());
@@ -1359,9 +1363,8 @@ void main() {
         final likeEvent = _createTestEvent(kind: EventKind.reaction);
 
         when(
-          () => mockNostr.sendLike(
+          () => mockNostr.sendEvent(
             any(),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1370,11 +1373,25 @@ void main() {
         final result = await client.sendLike(eventId);
 
         expect(result, equals(likeEvent));
-        verify(
-          () => mockNostr.sendLike(
-            eventId,
-          ),
-        ).called(1);
+        final captured =
+            verify(
+                  () => mockNostr.sendEvent(
+                    captureAny(),
+                    tempRelays: any(named: 'tempRelays'),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.kind, EventKind.reaction);
+        expect(captured.content, '+');
+        expect(captured.tags.firstWhere((tag) => tag[0] == 'e'), [
+          'e',
+          eventId,
+        ]);
+        expect(
+          captured.tags.firstWhere((tag) => tag[0] == 'client'),
+          Nip89ClientTag.tag,
+        );
       });
 
       test('sends like with custom content', () async {
@@ -1383,9 +1400,8 @@ void main() {
         final likeEvent = _createTestEvent(kind: EventKind.reaction);
 
         when(
-          () => mockNostr.sendLike(
+          () => mockNostr.sendEvent(
             any(),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1393,12 +1409,16 @@ void main() {
 
         await client.sendLike(eventId, content: content);
 
-        verify(
-          () => mockNostr.sendLike(
-            eventId,
-            content: content,
-          ),
-        ).called(1);
+        final captured =
+            verify(
+                  () => mockNostr.sendEvent(
+                    captureAny(),
+                    tempRelays: any(named: 'tempRelays'),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.content, content);
       });
 
       test('sends like with relay parameters', () async {
@@ -1408,9 +1428,8 @@ void main() {
         final likeEvent = _createTestEvent(kind: EventKind.reaction);
 
         when(
-          () => mockNostr.sendLike(
+          () => mockNostr.sendEvent(
             any(),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1423,9 +1442,9 @@ void main() {
         );
 
         verify(
-          () => mockNostr.sendLike(
-            eventId,
-            tempRelays: tempRelays,
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: targetRelays,
             targetRelays: targetRelays,
           ),
         ).called(1);
@@ -1435,9 +1454,8 @@ void main() {
         const eventId = 'event-to-like';
 
         when(
-          () => mockNostr.sendLike(
+          () => mockNostr.sendEvent(
             any(),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1565,10 +1583,8 @@ void main() {
         final repostEvent = _createTestEvent(kind: EventKind.repost);
 
         when(
-          () => mockNostr.sendRepost(
+          () => mockNostr.sendEvent(
             any(),
-            relayAddr: any(named: 'relayAddr'),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1577,11 +1593,25 @@ void main() {
         final result = await client.sendRepost(eventId);
 
         expect(result, equals(repostEvent));
-        verify(
-          () => mockNostr.sendRepost(
-            eventId,
-          ),
-        ).called(1);
+        final captured =
+            verify(
+                  () => mockNostr.sendEvent(
+                    captureAny(),
+                    tempRelays: any(named: 'tempRelays'),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.kind, EventKind.repost);
+        expect(captured.content, isEmpty);
+        expect(captured.tags.firstWhere((tag) => tag[0] == 'e'), [
+          'e',
+          eventId,
+        ]);
+        expect(
+          captured.tags.firstWhere((tag) => tag[0] == 'client'),
+          Nip89ClientTag.tag,
+        );
       });
 
       test('sends repost with all parameters', () async {
@@ -1593,10 +1623,8 @@ void main() {
         final repostEvent = _createTestEvent(kind: EventKind.repost);
 
         when(
-          () => mockNostr.sendRepost(
+          () => mockNostr.sendEvent(
             any(),
-            relayAddr: any(named: 'relayAddr'),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1610,25 +1638,27 @@ void main() {
           targetRelays: targetRelays,
         );
 
-        verify(
-          () => mockNostr.sendRepost(
-            eventId,
-            relayAddr: relayAddr,
-            content: content,
-            tempRelays: tempRelays,
+        final verification = verify(
+          () => mockNostr.sendEvent(
+            captureAny(),
+            tempRelays: targetRelays,
             targetRelays: targetRelays,
           ),
-        ).called(1);
+        );
+        final captured = verification.captured.single as Event;
+        expect(captured.content, content);
+        expect(
+          captured.tags.firstWhere((tag) => tag[0] == 'e'),
+          ['e', eventId, relayAddr],
+        );
       });
 
       test('returns null when sendRepost fails', () async {
         const eventId = 'event-to-repost';
 
         when(
-          () => mockNostr.sendRepost(
+          () => mockNostr.sendEvent(
             any(),
-            relayAddr: any(named: 'relayAddr'),
-            content: any(named: 'content'),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
           ),
@@ -1790,7 +1820,7 @@ void main() {
         final deleteEvent = _createTestEvent(kind: EventKind.eventDeletion);
 
         when(
-          () => mockNostr.deleteEvent(
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1800,11 +1830,25 @@ void main() {
         final result = await client.deleteEvent(eventId);
 
         expect(result, equals(deleteEvent));
-        verify(
-          () => mockNostr.deleteEvent(
-            eventId,
-          ),
-        ).called(1);
+        final captured =
+            verify(
+                  () => mockNostr.sendEvent(
+                    captureAny(),
+                    tempRelays: any(named: 'tempRelays'),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.kind, EventKind.eventDeletion);
+        expect(captured.content, 'delete');
+        expect(captured.tags.firstWhere((tag) => tag[0] == 'e'), [
+          'e',
+          eventId,
+        ]);
+        expect(
+          captured.tags.firstWhere((tag) => tag[0] == 'client'),
+          Nip89ClientTag.tag,
+        );
       });
 
       test('deletes event with relay parameters', () async {
@@ -1814,7 +1858,7 @@ void main() {
         final deleteEvent = _createTestEvent(kind: EventKind.eventDeletion);
 
         when(
-          () => mockNostr.deleteEvent(
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1828,9 +1872,9 @@ void main() {
         );
 
         verify(
-          () => mockNostr.deleteEvent(
-            eventId,
-            tempRelays: tempRelays,
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: targetRelays,
             targetRelays: targetRelays,
           ),
         ).called(1);
@@ -1840,7 +1884,7 @@ void main() {
         const eventId = 'event-to-delete';
 
         when(
-          () => mockNostr.deleteEvent(
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1859,7 +1903,7 @@ void main() {
         final deleteEvent = _createTestEvent(kind: EventKind.eventDeletion);
 
         when(
-          () => mockNostr.deleteEvents(
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1869,11 +1913,24 @@ void main() {
         final result = await client.deleteEvents(eventIds);
 
         expect(result, equals(deleteEvent));
-        verify(
-          () => mockNostr.deleteEvents(
-            eventIds,
-          ),
-        ).called(1);
+        final captured =
+            verify(
+                  () => mockNostr.sendEvent(
+                    captureAny(),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.kind, EventKind.eventDeletion);
+        expect(captured.content, 'delete');
+        expect(
+          captured.tags.where((tag) => tag[0] == 'e').toList(),
+          eventIds.map((eventId) => ['e', eventId]).toList(),
+        );
+        expect(
+          captured.tags.firstWhere((tag) => tag[0] == 'client'),
+          Nip89ClientTag.tag,
+        );
       });
 
       test('deletes events with relay parameters', () async {
@@ -1883,7 +1940,7 @@ void main() {
         final deleteEvent = _createTestEvent(kind: EventKind.eventDeletion);
 
         when(
-          () => mockNostr.deleteEvents(
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1897,9 +1954,9 @@ void main() {
         );
 
         verify(
-          () => mockNostr.deleteEvents(
-            eventIds,
-            tempRelays: tempRelays,
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: targetRelays,
             targetRelays: targetRelays,
           ),
         ).called(1);
@@ -1909,7 +1966,7 @@ void main() {
         final eventIds = ['event-1', 'event-2'];
 
         when(
-          () => mockNostr.deleteEvents(
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1929,8 +1986,7 @@ void main() {
         final contactListEvent = _createTestEvent(kind: EventKind.contactList);
 
         when(
-          () => mockNostr.sendContactList(
-            any(),
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1940,12 +1996,20 @@ void main() {
         final result = await client.sendContactList(contacts, content);
 
         expect(result, equals(contactListEvent));
-        verify(
-          () => mockNostr.sendContactList(
-            contacts,
-            content,
-          ),
-        ).called(1);
+        final captured =
+            verify(
+                  () => mockNostr.sendEvent(
+                    captureAny(),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.kind, EventKind.contactList);
+        expect(captured.content, content);
+        expect(
+          captured.tags.firstWhere((tag) => tag[0] == 'client'),
+          Nip89ClientTag.tag,
+        );
       });
 
       test('sends contact list with relay parameters', () async {
@@ -1956,8 +2020,7 @@ void main() {
         final contactListEvent = _createTestEvent(kind: EventKind.contactList);
 
         when(
-          () => mockNostr.sendContactList(
-            any(),
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
@@ -1972,10 +2035,9 @@ void main() {
         );
 
         verify(
-          () => mockNostr.sendContactList(
-            contacts,
-            content,
-            tempRelays: tempRelays,
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: targetRelays,
             targetRelays: targetRelays,
           ),
         ).called(1);
@@ -1986,8 +2048,7 @@ void main() {
         const content = '{"relay":"preferences"}';
 
         when(
-          () => mockNostr.sendContactList(
-            any(),
+          () => mockNostr.sendEvent(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -150,6 +150,10 @@ const _knownUntranslatedDebt = {
   'nostrSettingsExperimentalFeaturesSubtitle',
   'nostrSettingsKeyManagement',
   'nostrSettingsKeyManagementSubtitle',
+  // Added by the NIP-89 client attribution settings toggle. Existing locales
+  // fall back to English until the next full translation pass.
+  'nostrSettingsClientAttribution',
+  'nostrSettingsClientAttributionSubtitle',
   'nostrSettingsRemoveKeys',
   'nostrSettingsRemoveKeysSubtitle',
   'nostrSettingsCouldNotRemoveKeys',

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -150,10 +150,6 @@ const _knownUntranslatedDebt = {
   'nostrSettingsExperimentalFeaturesSubtitle',
   'nostrSettingsKeyManagement',
   'nostrSettingsKeyManagementSubtitle',
-  // Added by the NIP-89 client attribution settings toggle. Existing locales
-  // fall back to English until the next full translation pass.
-  'nostrSettingsClientAttribution',
-  'nostrSettingsClientAttributionSubtitle',
   'nostrSettingsRemoveKeys',
   'nostrSettingsRemoveKeysSubtitle',
   'nostrSettingsCouldNotRemoveKeys',

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -374,8 +374,9 @@ void main() {
         final clientTags = tags.where((t) => t[0] == 'client').toList();
         expect(
           clientTags,
-          hasLength(1),
-          reason: 'Missing client tag for ${reason.name}',
+          isEmpty,
+          reason:
+              'Client tag should be injected during signing for ${reason.name}',
         );
 
         final lNamespaceTags = tags.where((t) => t[0] == 'L').toList();

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -77,7 +77,7 @@ void main() {
       ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
       ['title', 'Test Video'],
       ['t', 'test'],
-      ['client', 'diVine'],
+      Nip89ClientTag.tag,
     ];
 
     final existingEvent = VideoEvent(

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -173,9 +173,8 @@ void main() {
         final sourceTag = tags.firstWhere((t) => t[0] == 'source');
         expect(sourceTag[1], equals('home'));
 
-        // Check client
-        final clientTag = tags.firstWhere((t) => t[0] == 'client');
-        expect(clientTag[1], contains('divine-mobile'));
+        // Client attribution is added centrally during signing/publish.
+        expect(tags.where((t) => t[0] == 'client'), isEmpty);
       });
 
       test('falls back to event ID when vineId is null', () async {

--- a/mobile/test/services/vine_tag_requirement_test.dart
+++ b/mobile/test/services/vine_tag_requirement_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies AuthService automatically adds staging-relay.divine.video relay requirement
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 void main() {
@@ -71,7 +72,7 @@ void main() {
     test('vine tag should be automatically added to existing tags', () async {
       // Simulate adding vine tag to existing tags
       final existingTags = [
-        ['client', 'diVine'],
+        Nip89ClientTag.tag,
         ['t', 'hashtag'],
         ['p', 'somepubkey'],
       ];
@@ -80,7 +81,7 @@ void main() {
       finalTags.add(['h', 'vine']);
 
       expect(finalTags, containsOnce(['h', 'vine']));
-      expect(finalTags, containsOnce(['client', 'diVine']));
+      expect(finalTags, containsOnce(Nip89ClientTag.tag));
       expect(finalTags, containsOnce(['t', 'hashtag']));
       expect(finalTags, containsOnce(['p', 'somepubkey']));
 

--- a/mobile/test/unit/curated_list_relay_sync_test.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.dart
@@ -126,7 +126,7 @@ void main() {
           ['t', 'demo'],
           ['e', 'video1'],
           ['e', 'video2'],
-          ['client', 'diVine'],
+          Nip89ClientTag.tag,
           [
             'expiration',
             '${(DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600}',

--- a/mobile/test/unit/nostr_sdk/vine_tag_filter_test.dart
+++ b/mobile/test/unit/nostr_sdk/vine_tag_filter_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Constructs filters and events in memory; no network or relay involved
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 
@@ -94,7 +95,7 @@ void main() {
         [
           ['h', 'vine'],
           ['url', 'https://example.com/video.mp4'],
-          ['client', 'diVine'],
+          Nip89ClientTag.tag,
           [
             'expiration',
             '${(DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600}',
@@ -110,7 +111,7 @@ void main() {
         22,
         [
           ['url', 'https://example.com/video.mp4'],
-          ['client', 'diVine'],
+          Nip89ClientTag.tag,
           [
             'expiration',
             '${(DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600}',

--- a/mobile/test/unit/services/nip17_message_service_test.dart
+++ b/mobile/test/unit/services/nip17_message_service_test.dart
@@ -188,7 +188,7 @@ void main() {
         recipientPubkey: _recipientPubkey,
         content: 'Test message',
         additionalTags: [
-          ['client', 'diVine_bug_report'],
+          Nip89ClientTag.tag,
           ['report_id', 'test-123'],
         ],
       );

--- a/mobile/tools/build_nip89_handler_event.dart
+++ b/mobile/tools/build_nip89_handler_event.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nip19/nip19.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+const _supportedKinds = <int>[
+  0,
+  3,
+  4,
+  5,
+  6,
+  7,
+  14,
+  15,
+  1111,
+  1984,
+  10000,
+  10003,
+  30000,
+  30003,
+  30005,
+  34235,
+  34236,
+  22236,
+];
+
+Event buildHandlerEvent() {
+  final tags = <List<String>>[
+    ['d', Nip89ClientTag.handlerDIdentifier],
+    ['alt', 'Divine mobile app handler'],
+    ['web', 'https://divine.video'],
+    ['r', 'https://divine.video'],
+    for (final kind in _supportedKinds) ['k', '$kind'],
+  ];
+
+  final content = jsonEncode(<String, Object?>{
+    'name': Nip89ClientTag.clientName,
+    'display_name': Nip89ClientTag.clientName,
+    'about': 'Short-form looping video app on Nostr.',
+    'website': 'https://divine.video',
+  });
+
+  return Event(Nip89ClientTag.handlerPubkey, 31990, tags, content);
+}
+
+Future<void> main(List<String> args) async {
+  final publish = args.contains('--publish');
+  final rawSecret = Platform.environment['NIP89_HANDLER_NSEC'];
+  final event = buildHandlerEvent();
+
+  if (rawSecret == null || rawSecret.isEmpty) {
+    stdout.writeln(const JsonEncoder.withIndent('  ').convert(event.toJson()));
+    if (publish) {
+      stderr.writeln(
+        'Set NIP89_HANDLER_NSEC to the handler private key before using '
+        '--publish.',
+      );
+      exitCode = 64;
+    }
+    return;
+  }
+
+  final privateKey = rawSecret.startsWith('nsec1')
+      ? Nip19.decode(rawSecret)
+      : rawSecret;
+  final signer = LocalNostrSigner(privateKey);
+  final derivedPubkey = await signer.getPublicKey();
+  if (derivedPubkey != Nip89ClientTag.handlerPubkey) {
+    stderr.writeln(
+      'NIP89_HANDLER_NSEC does not match '
+      '${Nip89ClientTag.handlerPubkey}.',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final signed = await signer.signEvent(event);
+  if (signed == null) {
+    stderr.writeln('Failed to sign handler event.');
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln(const JsonEncoder.withIndent('  ').convert(signed.toJson()));
+
+  if (!publish) {
+    return;
+  }
+
+  final nostr = Nostr(
+    signer,
+    const [],
+    (url) => RelayBase(url, RelayStatus(url)),
+  );
+  await nostr.refreshPublicKey();
+
+  final sent = await nostr.sendEvent(
+    signed,
+    tempRelays: const [Nip89ClientTag.relayHint],
+    targetRelays: const [Nip89ClientTag.relayHint],
+  );
+  if (sent == null) {
+    stderr.writeln('Publish failed.');
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln(
+    'Published kind 31990 event ${sent.id} to ${Nip89ClientTag.relayHint}.',
+  );
+}


### PR DESCRIPTION
Closes #4672

## Summary
- standardize Divine NIP-89 client attribution around one canonical tag and inject it centrally before signing/publish
- cover missing publish paths, preserve protocol-specific wrapper kinds, and add a user opt-out setting
- add handler-event tooling/docs and update tests/docs to match the new publish flow

## Testing
- flutter test packages/nostr_client/test
- flutter test packages/dm_repository/test/src/nip17_message_service_test.dart
- flutter test packages/curation_repository/test/src/curation_repository_create_test.dart
- flutter test test/unit/services/nip17_message_service_test.dart test/unit/curated_list_relay_sync_test.dart test/unit/nostr_sdk/vine_tag_filter_test.dart test/services/video_event_publisher_subtitle_test.dart test/services/vine_tag_requirement_test.dart
- flutter test test/services/content_deletion_service_test.dart test/services/content_reporting_service_test.dart test/services/video_event_publisher_test.dart test/services/video_metadata_update_service_test.dart test/services/video_sharing_service_test.dart test/services/view_event_publisher_test.dart
- flutter analyze lib packages/nostr_client/lib packages/nostr_client/test tools/build_nip89_handler_event.dart