### PR TITLE
fix(notifications): classify comment replies separately

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1465,10 +1465,12 @@ class NotificationRepository {
   /// comment — map to [NotificationKind.likeComment] so the UI can
   /// render "liked your comment" instead of "liked your video".
   ///
-  /// Replies (kind 1111) split the same way: a reply directly on a video
+  /// Replies (kind 1111) split by the immediate target, not by whether the
+  /// payload also carries root video metadata. A reply directly on a video
   /// is indistinguishable from a comment for the user, so we map it to
-  /// [NotificationKind.comment]. A reply on a non-video (i.e. on one of
-  /// the user's own comments) maps to [NotificationKind.reply].
+  /// [NotificationKind.comment]. A reply on another comment maps to
+  /// [NotificationKind.reply], even when Funnelcake also includes the root
+  /// video's metadata for navigation.
   static NotificationKind _mapNotificationKind(RelayNotification n) {
     final isReaction = switch (n.notificationType) {
       'reaction' || 'zap' => true,
@@ -1478,6 +1480,9 @@ class NotificationRepository {
       return n.isReferencedVideo
           ? NotificationKind.like
           : NotificationKind.likeComment;
+    }
+    if (_isNestedCommentReply(n)) {
+      return NotificationKind.reply;
     }
     if (n.notificationType != 'reply' &&
         n.sourceKind == 1111 &&
@@ -1497,6 +1502,29 @@ class NotificationRepository {
       _ when n.sourceKind == 1 => NotificationKind.comment,
       _ => NotificationKind.system,
     };
+  }
+
+  static bool _isNestedCommentReply(RelayNotification n) {
+    if (n.notificationType != 'reply' && n.notificationType != 'comment') {
+      return false;
+    }
+    if (n.sourceKind != 1111) return false;
+    final rootEventId = n.rootEventId;
+    if (rootEventId == null || rootEventId.isEmpty) return false;
+
+    final referencedEventId = n.referencedEventId;
+    if (referencedEventId != null &&
+        referencedEventId.isNotEmpty &&
+        referencedEventId != rootEventId) {
+      return true;
+    }
+
+    final targetCommentId = n.targetCommentId;
+    return targetCommentId != null &&
+        targetCommentId.isNotEmpty &&
+        n.sourceEventId.isNotEmpty &&
+        targetCommentId != n.sourceEventId &&
+        targetCommentId != rootEventId;
   }
 
   /// Returns the video event ID a video-anchored notification should group by.

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1178,6 +1178,54 @@ void main() {
         expect(item.type, equals(NotificationKind.comment));
       });
 
+      test(
+        'reply to user comment with root video metadata maps to reply '
+        '($ActorNotification)',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'reply',
+              sourceKind: 1111,
+              sourceEventId: 'reply_event_id',
+              referencedEventId: 'parent_comment_id',
+              rootEventId: 'someone_else_video_id',
+              targetCommentId: 'parent_comment_id',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.reply));
+          expect(item.targetEventId, equals('parent_comment_id'));
+        },
+      );
+
+      test(
+        'comment-typed nested NIP-22 reply maps to reply '
+        '($ActorNotification)',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1111,
+              sourceEventId: 'reply_event_id',
+              referencedEventId: 'parent_comment_id',
+              rootEventId: 'someone_else_video_id',
+              targetCommentId: 'parent_comment_id',
+              content: 'Nested reply to my comment',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.reply));
+          expect(item.targetEventId, equals('parent_comment_id'));
+          expect(item.commentText, equals('Nested reply to my comment'));
+        },
+      );
+
       test('reply on a non-video target maps to reply ($ActorNotification) '
           'with targetEventId', () async {
         stubNotifications([


### PR DESCRIPTION
Closes #4674

## Summary
- Classify nested NIP-22 replies to comments as reply notifications even when root video metadata is present.
- Keep top-level video comments classified as comments on the user's video.
- Add regression coverage for reply-typed and comment-typed nested reply payloads.

## Verification
- `flutter test test/src/notification_repository_test.dart --plain-name "type mapping"`
- `flutter test --no-pub test/notifications/widgets/actor_notification_row_test.dart`
- `python3 ~/.codex/skills/divine-mobile-l10n-pr-check/scripts/check_divine_mobile_l10n.py`
- `flutter test --no-pub test/l10n/arb_consistency_test.dart --plain-name "all locales define the same message keys as app_en.arb"`
- `flutter analyze packages/notification_repository`
- `flutter analyze --no-fatal-infos`

Note: plain `flutter analyze` still exits non-zero on existing `avoid_print` infos in manual integration/script/tool files outside this PR.
