### PR TITLE
fix: make view tracking durable

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1827,6 +1827,10 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     // without an explicit read it would never be created. See #4124.
     ref.watch(outgoingDmRetryServiceProvider);
 
+    // Eagerly create the view-event retry service so foreground sweeps
+    // run for the durable pending_view_events queue without a UI consumer.
+    ref.watch(viewEventRetryServiceProvider);
+
     // Eagerly create the notification realtime bridge so WS arrivals
     // land in the new repository snapshot the moment the repository is
     // available. The provider returns `null` until the repo is built;

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -34,6 +34,7 @@ import 'package:openvine/services/pending_action_service.dart';
 import 'package:openvine/services/social_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/services/view_event_retry_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -215,13 +216,64 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   return service;
 }
 
+/// Auto-sweep service for the durable `pending_view_events` queue.
+@Riverpod(keepAlive: true)
+ViewEventRetryService? viewEventRetryService(Ref ref) {
+  final authService = ref.watch(authServiceProvider);
+
+  ref.watch(currentAuthStateProvider);
+
+  final userPubkey = authService.currentPublicKeyHex;
+  if (userPubkey == null) return null;
+
+  final readiness = ref.watch(nostrSessionProvider);
+  if (!readiness.isReadyForActiveClient || readiness.pubkey != userPubkey) {
+    return null;
+  }
+
+  final db = ref.watch(databaseProvider);
+  final viewPublisher = ref.watch(viewEventPublisherProvider);
+  final foregroundController = StreamController<bool>();
+  ref.onDispose(foregroundController.close);
+
+  final service = ViewEventRetryService(
+    viewEventPublisher: viewPublisher,
+    pendingViewEventsDao: db.pendingViewEventsDao,
+    userPubkey: userPubkey,
+    appForegroundStream: foregroundController.stream,
+  );
+
+  service.initialize().catchError((e) {
+    Log.error(
+      'Failed to initialize ViewEventRetryService',
+      name: 'AppProviders',
+      error: e,
+    );
+  });
+
+  ref.listen<bool>(appForegroundProvider, (_, next) {
+    if (!foregroundController.isClosed) {
+      foregroundController.add(next);
+    }
+  }, fireImmediately: true);
+
+  ref.onDispose(service.dispose);
+  return service;
+}
+
 /// Analytics service with opt-out support.
 ///
 /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
 @Riverpod(keepAlive: true) // Keep alive to maintain singleton behavior
 AnalyticsService analyticsService(Ref ref) {
+  final db = ref.watch(databaseProvider);
   final viewPublisher = ref.watch(viewEventPublisherProvider);
-  final service = AnalyticsService(viewEventPublisher: viewPublisher);
+  final retryService = ref.watch(viewEventRetryServiceProvider);
+  final service = AnalyticsService(
+    viewEventPublisher: viewPublisher,
+    pendingViewEventsDao: db.pendingViewEventsDao,
+    flushPendingViewEvents: retryService?.sweep,
+  );
 
   // Ensure cleanup on disposal
   ref.onDispose(service.dispose);

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -159,6 +159,59 @@ final class OutgoingDmRetryServiceProvider
 String _$outgoingDmRetryServiceHash() =>
     r'ccbee39cf920a0847be410ca804e048200962d38';
 
+/// Auto-sweep service for the durable `pending_view_events` queue.
+
+@ProviderFor(viewEventRetryService)
+const viewEventRetryServiceProvider = ViewEventRetryServiceProvider._();
+
+/// Auto-sweep service for the durable `pending_view_events` queue.
+
+final class ViewEventRetryServiceProvider
+    extends
+        $FunctionalProvider<
+          ViewEventRetryService?,
+          ViewEventRetryService?,
+          ViewEventRetryService?
+        >
+    with $Provider<ViewEventRetryService?> {
+  /// Auto-sweep service for the durable `pending_view_events` queue.
+  const ViewEventRetryServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'viewEventRetryServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$viewEventRetryServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<ViewEventRetryService?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ViewEventRetryService? create(Ref ref) {
+    return viewEventRetryService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ViewEventRetryService? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ViewEventRetryService?>(value),
+    );
+  }
+}
+
+String _$viewEventRetryServiceHash() =>
+    r'3d2bf5f8def6302b9cb64d60bc35e8a792dcc15f';
+
 /// Analytics service with opt-out support.
 ///
 /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
@@ -214,7 +267,7 @@ final class AnalyticsServiceProvider
   }
 }
 
-String _$analyticsServiceHash() => r'e6375a363ad078b11017d729f4a53e062b855f4e';
+String _$analyticsServiceHash() => r'afdabdf0b1d7c769d7b1219062de928f17d34633';
 
 /// Hashtag cache service for persistent hashtag storage
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -54,6 +54,7 @@ import 'package:openvine/widgets/video_feed_item/video_author_info_section.dart'
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
 import 'package:openvine/widgets/video_feed_item/video_player_subtitle_layer.dart';
+import 'package:openvine/widgets/video_metrics_tracker.dart';
 import 'package:openvine/widgets/web_video_auth_header_provider.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:openvine/widgets/web_video_player.dart';
@@ -891,6 +892,8 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                                         currentIndex: state.currentIndex,
                                         hasMore: state.canLoadMore,
                                         isLoadingMore: state.isLoadingMore,
+                                        trafficSource: widget.trafficSource,
+                                        sourceDetail: widget.sourceDetail,
                                         onActiveVideoChanged: (video, index) {
                                           _resumeAutoAdvanceAfterSwipe();
                                           FeedPerformanceTracker()
@@ -962,6 +965,9 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                                                   video.pubkey,
                                               controller: controller,
                                               contextTitle: widget.contextTitle,
+                                              trafficSource:
+                                                  widget.trafficSource,
+                                              sourceDetail: widget.sourceDetail,
                                               onInteracted:
                                                   _suppressAutoAdvance,
                                             );
@@ -1154,6 +1160,8 @@ class _WebFullscreenItem extends ConsumerWidget {
     required this.isOwnVideo,
     this.controller,
     this.contextTitle,
+    this.trafficSource = ViewTrafficSource.unknown,
+    this.sourceDetail,
     this.onInteracted,
   });
 
@@ -1162,6 +1170,8 @@ class _WebFullscreenItem extends ConsumerWidget {
   final bool isOwnVideo;
   final VideoPlayerController? controller;
   final String? contextTitle;
+  final ViewTrafficSource trafficSource;
+  final String? sourceDetail;
   final VoidCallback? onInteracted;
 
   @override
@@ -1206,70 +1216,76 @@ class _WebFullscreenItem extends ConsumerWidget {
                 ..add(const VideoInteractionsFetchRequested()),
         ),
       ],
-      child: Stack(
-        children: [
-          VideoOverlayActions(
-            video: video,
-            isVisible: true,
-            isActive: isActive,
-            hasBottomNavigation: false,
-            contextTitle: contextTitle,
-            isFullscreen: true,
-            topOffset: isOwnVideo ? 64 : 8,
-            onInteracted: onInteracted,
-            omitAuthorBlock: true,
-            // See _PooledFullscreenItemContent.build for the rationale —
-            // the action column lives in this outer Stack so it shares the
-            // same bottom anchor as the author info below and the two
-            // cannot vertically drift apart.
-            omitActionColumn: true,
-            // Top-of-screen scrim so the transparent app bar's white
-            // title / back button / More popover stay readable over
-            // light video frames.
-            showTopGradient: true,
-          ),
-          // 20 px above the Stack bottom (= comment-bar top). See
-          // _PooledFullscreenItemContent.build for why we drop the
-          // `viewPadding.bottom` term that the home feed uses.
-          PositionedDirectional(
-            bottom: 20,
-            start: 16,
-            end: 80,
-            child: AnimatedOpacity(
-              opacity: isActive ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 200),
-              child: VideoAuthorInfoSection(
-                video: video,
-                hasTextContent:
-                    video.content.isNotEmpty ||
-                    (video.title != null && video.title!.isNotEmpty),
-                subtitleLayer: video.hasSubtitles && controller != null
-                    ? VideoPlayerSubtitleLayer(
-                        video: video,
-                        controller: controller!,
-                      )
-                    : null,
-                onInteracted: onInteracted,
-              ),
+      child: VideoMetricsTracker(
+        video: video,
+        controller: isActive ? controller : null,
+        trafficSource: trafficSource,
+        sourceDetail: sourceDetail,
+        child: Stack(
+          children: [
+            VideoOverlayActions(
+              video: video,
+              isVisible: true,
+              isActive: isActive,
+              hasBottomNavigation: false,
+              contextTitle: contextTitle,
+              isFullscreen: true,
+              topOffset: isOwnVideo ? 64 : 8,
+              onInteracted: onInteracted,
+              omitAuthorBlock: true,
+              // See _PooledFullscreenItemContent.build for the rationale —
+              // the action column lives in this outer Stack so it shares the
+              // same bottom anchor as the author info below and the two
+              // cannot vertically drift apart.
+              omitActionColumn: true,
+              // Top-of-screen scrim so the transparent app bar's white
+              // title / back button / More popover stay readable over
+              // light video frames.
+              showTopGradient: true,
             ),
-          ),
-          PositionedDirectional(
-            bottom: 20,
-            end: 12,
-            child: AnimatedOpacity(
-              opacity: isActive ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 200),
-              child: KeyboardAwareTopFade(
-                child: VideoOverlayActionColumn(
+            // 20 px above the Stack bottom (= comment-bar top). See
+            // _PooledFullscreenItemContent.build for why we drop the
+            // `viewPadding.bottom` term that the home feed uses.
+            PositionedDirectional(
+              bottom: 20,
+              start: 16,
+              end: 80,
+              child: AnimatedOpacity(
+                opacity: isActive ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 200),
+                child: VideoAuthorInfoSection(
                   video: video,
-                  isFullscreen: true,
+                  hasTextContent:
+                      video.content.isNotEmpty ||
+                      (video.title != null && video.title!.isNotEmpty),
+                  subtitleLayer: video.hasSubtitles && controller != null
+                      ? VideoPlayerSubtitleLayer(
+                          video: video,
+                          controller: controller!,
+                        )
+                      : null,
                   onInteracted: onInteracted,
                 ),
               ),
             ),
-          ),
-          _WebFullscreenLoadingModerationOverlay(video: video),
-        ],
+            PositionedDirectional(
+              bottom: 20,
+              end: 12,
+              child: AnimatedOpacity(
+                opacity: isActive ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 200),
+                child: KeyboardAwareTopFade(
+                  child: VideoOverlayActionColumn(
+                    video: video,
+                    isFullscreen: true,
+                    onInteracted: onInteracted,
+                  ),
+                ),
+              ),
+            ),
+            _WebFullscreenLoadingModerationOverlay(video: video),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -33,15 +33,19 @@ import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/services/view_event_publisher.dart'
+    show ViewTrafficSource;
 import 'package:openvine/utils/pooled_player_logger.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
+import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
+import 'package:openvine/widgets/video_metrics_tracker.dart';
 import 'package:openvine/widgets/web_video_auth_header_provider.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:openvine/widgets/web_video_player.dart';
@@ -51,6 +55,7 @@ import 'package:pooled_video_player/pooled_video_player.dart'
     as pvp
     show VideoErrorType;
 import 'package:unified_logger/unified_logger.dart';
+import 'package:video_player/video_player.dart';
 
 class VideoFeedPage extends ConsumerWidget {
   /// Route name for this screen.
@@ -641,6 +646,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                         isActive: _isNewFeedActive,
                         hasMore: state.hasMore,
                         isLoadingMore: state.isLoadingMore,
+                        trafficSource: ViewTrafficSource.home,
                         onActiveVideoChanged: (video, index) {
                           _resumeAutoAdvanceAfterSwipe();
                           FeedPerformanceTracker().startVideoSwipeTracking(
@@ -704,6 +710,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                                 video: video,
                                 index: index,
                                 isActive: isActive,
+                                controller: controller,
                                 pagePosition: _pagePosition,
                                 contextTitle: state.feedContextTitle,
                                 listSources: listSources,
@@ -1103,6 +1110,7 @@ class _WebVideoFeedItem extends ConsumerWidget {
     required this.index,
     required this.isActive,
     required this.pagePosition,
+    this.controller,
     this.contextTitle,
     this.listSources,
     this.onInteracted,
@@ -1111,6 +1119,7 @@ class _WebVideoFeedItem extends ConsumerWidget {
   final VideoEvent video;
   final int index;
   final bool isActive;
+  final VideoPlayerController? controller;
   final ValueNotifier<double> pagePosition;
   final String? contextTitle;
   final Set<String>? listSources;
@@ -1145,13 +1154,18 @@ class _WebVideoFeedItem extends ConsumerWidget {
             )
             ..add(const VideoInteractionsSubscriptionRequested())
             ..add(const VideoInteractionsFetchRequested()),
-      child: FeedVideoOverlay(
+      child: VideoMetricsTracker(
         video: video,
-        isActive: isActive,
-        pagePosition: pagePosition,
-        index: index,
-        listSources: listSources,
-        onInteracted: onInteracted,
+        controller: isActive ? controller : null,
+        trafficSource: ViewTrafficSource.home,
+        child: FeedVideoOverlay(
+          video: video,
+          isActive: isActive,
+          pagePosition: pagePosition,
+          index: index,
+          listSources: listSources,
+          onInteracted: onInteracted,
+        ),
       ),
     );
   }
@@ -1280,35 +1294,45 @@ class _PooledVideoFeedItemContentState
               ),
             );
           },
-          overlayBuilder: (context, videoController, player, feedController) =>
-              FeedAutoAdvanceCompletionListener(
-                player: player,
-                isEnabled: widget.isActive && widget.isAutoAdvanceActive,
-                onCompleted: widget.onAutoAdvanceCompleted ?? () {},
-                child: Stack(
-                  children: [
-                    FeedVideoOverlay(
-                      video: video,
-                      isActive: widget.isActive,
-                      pagePosition: widget.pagePosition,
-                      index: widget.index,
-                      player: player,
-                      firstFrameFuture:
-                          videoController?.waitUntilFirstFrameRendered,
-                      listSources: widget.listSources,
-                      onInteracted: widget.onInteracted,
-                      onContentWarningRevealed: () {
-                        _contentWarningRevealed = true;
-                      },
-                    ),
-                    Positioned.fill(
-                      child: DoubleTapHeartOverlay(trigger: _heartTrigger),
-                    ),
-                    if (!video.isFromDivineServer)
-                      _SlowExternalVideoOverlay(index: widget.index),
-                  ],
+          overlayBuilder: (context, videoController, player, feedController) {
+            final overlay = Stack(
+              children: [
+                FeedVideoOverlay(
+                  video: video,
+                  isActive: widget.isActive,
+                  pagePosition: widget.pagePosition,
+                  index: widget.index,
+                  player: player,
+                  firstFrameFuture:
+                      videoController?.waitUntilFirstFrameRendered,
+                  listSources: widget.listSources,
+                  onInteracted: widget.onInteracted,
+                  onContentWarningRevealed: () {
+                    _contentWarningRevealed = true;
+                  },
                 ),
-              ),
+                Positioned.fill(
+                  child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                ),
+                if (!video.isFromDivineServer)
+                  _SlowExternalVideoOverlay(index: widget.index),
+              ],
+            );
+            return FeedAutoAdvanceCompletionListener(
+              player: player,
+              isEnabled: widget.isActive && widget.isAutoAdvanceActive,
+              onCompleted: widget.onAutoAdvanceCompleted ?? () {},
+              child: player == null
+                  ? overlay
+                  : PooledVideoMetricsTracker(
+                      video: video,
+                      player: player,
+                      isActive: widget.isActive,
+                      trafficSource: ViewTrafficSource.home,
+                      child: overlay,
+                    ),
+            );
+          },
         ),
       ),
     );

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:db_client/db_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/services/background_activity_manager.dart';
@@ -22,12 +23,19 @@ import 'package:unified_logger/unified_logger.dart';
 class AnalyticsService implements BackgroundAwareService {
   AnalyticsService({
     ViewEventPublisher? viewEventPublisher,
+    PendingViewEventsDao? pendingViewEventsDao,
+    Future<void> Function()? flushPendingViewEvents,
     @visibleForTesting bool? disableNostrPublishing,
   }) : _viewEventPublisher = viewEventPublisher,
+       _pendingViewEventsDao = pendingViewEventsDao,
+       _flushPendingViewEvents = flushPendingViewEvents,
        _disableNostrPublishing = disableNostrPublishing ?? false;
 
   /// The view event publisher for Kind 22236 Nostr events.
   ViewEventPublisher? _viewEventPublisher;
+
+  final PendingViewEventsDao? _pendingViewEventsDao;
+  final Future<void> Function()? _flushPendingViewEvents;
 
   /// Testing flag to disable Nostr publishing in unit tests.
   final bool _disableNostrPublishing;
@@ -210,19 +218,94 @@ class AnalyticsService implements BackgroundAwareService {
       category: LogCategory.video,
     );
 
-    // Publish Kind 22236 Nostr view event for view_end with meaningful data
     if (eventType == 'view_end' &&
         watchDuration != null &&
         watchDuration.inSeconds >= 1 &&
         !_disableNostrPublishing) {
-      _publishNostrViewEvent(
+      final enqueued = await _enqueuePendingViewEvent(
         video: video,
+        userPubkey: userId,
         watchDuration: watchDuration,
+        totalDuration: totalDuration,
         trafficSource: trafficSource,
         sourceDetail: sourceDetail,
         loopCount: loopCount,
       );
+      if (!enqueued) {
+        _publishNostrViewEvent(
+          video: video,
+          watchDuration: watchDuration,
+          trafficSource: trafficSource,
+          sourceDetail: sourceDetail,
+          loopCount: loopCount,
+        );
+      }
     }
+  }
+
+  Future<bool> _enqueuePendingViewEvent({
+    required VideoEvent video,
+    required String? userPubkey,
+    required Duration watchDuration,
+    required Duration? totalDuration,
+    required ViewTrafficSource trafficSource,
+    String? sourceDetail,
+    int? loopCount,
+  }) async {
+    final dao = _pendingViewEventsDao;
+    if (dao == null || userPubkey == null) return false;
+
+    final createdAt = DateTime.now();
+    try {
+      await dao.enqueue(
+        PendingViewEvent(
+          id: '${video.id}_${userPubkey}_${createdAt.microsecondsSinceEpoch}',
+          videoId: video.id,
+          videoPubkey: video.pubkey,
+          videoVineId: video.vineId,
+          userPubkey: userPubkey,
+          watchDurationMs: watchDuration.inMilliseconds,
+          totalDurationMs: totalDuration?.inMilliseconds,
+          loopCount: loopCount,
+          trafficSource: _trafficSourceToString(trafficSource),
+          sourceDetail: sourceDetail,
+          status: PendingViewEventStatus.pending,
+          createdAt: createdAt,
+        ),
+      );
+    } catch (e) {
+      Log.warning(
+        'Failed to enqueue pending view event: $e',
+        name: 'AnalyticsService',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+
+    try {
+      await _flushPendingViewEvents?.call();
+    } catch (e) {
+      Log.debug(
+        'Failed to flush pending view events immediately: $e',
+        name: 'AnalyticsService',
+        category: LogCategory.video,
+      );
+    }
+    return true;
+  }
+
+  String _trafficSourceToString(ViewTrafficSource source) {
+    return switch (source) {
+      ViewTrafficSource.home => 'home',
+      ViewTrafficSource.discoveryNew => 'discovery:new',
+      ViewTrafficSource.discoveryClassic => 'discovery:classic',
+      ViewTrafficSource.discoveryForYou => 'discovery:foryou',
+      ViewTrafficSource.discoveryPopular => 'discovery:popular',
+      ViewTrafficSource.profile => 'profile',
+      ViewTrafficSource.share => 'share',
+      ViewTrafficSource.search => 'search',
+      ViewTrafficSource.unknown => 'unknown',
+    };
   }
 
   /// Publish Kind 22236 ephemeral view event to Nostr relays.

--- a/mobile/lib/services/view_event_retry_service.dart
+++ b/mobile/lib/services/view_event_retry_service.dart
@@ -1,0 +1,165 @@
+// ABOUTME: Service that auto-sweeps durable pending view events.
+// ABOUTME: Publishes queued kind 22236 views until relay delivery succeeds.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:meta/meta.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/services/view_event_publisher.dart';
+
+/// Backoff configuration for [ViewEventRetryService].
+class ViewEventRetryConfig {
+  const ViewEventRetryConfig({
+    this.maxRetries = 5,
+    this.initialDelay = const Duration(seconds: 2),
+    this.maxDelay = const Duration(minutes: 5),
+    this.backoffMultiplier = 2.0,
+  });
+
+  final int maxRetries;
+  final Duration initialDelay;
+  final Duration maxDelay;
+  final double backoffMultiplier;
+
+  Duration backoffFor(int retryCount) {
+    if (retryCount <= 0) return Duration.zero;
+    var ms = initialDelay.inMilliseconds.toDouble();
+    for (var i = 0; i < retryCount; i++) {
+      ms *= backoffMultiplier;
+      if (ms >= maxDelay.inMilliseconds) return maxDelay;
+    }
+    return Duration(milliseconds: ms.round());
+  }
+}
+
+/// Sweeps the durable `pending_view_events` queue for relay publish retries.
+class ViewEventRetryService {
+  ViewEventRetryService({
+    required ViewEventPublisher viewEventPublisher,
+    required PendingViewEventsDao pendingViewEventsDao,
+    required String userPubkey,
+    required Stream<bool> appForegroundStream,
+    ViewEventRetryConfig retryConfig = const ViewEventRetryConfig(),
+    DateTime Function() now = DateTime.now,
+  }) : _viewEventPublisher = viewEventPublisher,
+       _dao = pendingViewEventsDao,
+       _userPubkey = userPubkey,
+       _appForegroundStream = appForegroundStream,
+       _retryConfig = retryConfig,
+       _now = now;
+
+  final ViewEventPublisher _viewEventPublisher;
+  final PendingViewEventsDao _dao;
+  final String _userPubkey;
+  final Stream<bool> _appForegroundStream;
+  final ViewEventRetryConfig _retryConfig;
+  final DateTime Function() _now;
+
+  StreamSubscription<bool>? _foregroundSubscription;
+  bool _isInitialized = false;
+  bool _isSweeping = false;
+
+  bool get isInitialized => _isInitialized;
+
+  @visibleForTesting
+  bool get isSweeping => _isSweeping;
+
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    _isInitialized = true;
+
+    await _dao.resetPublishingToPending(_userPubkey);
+    _foregroundSubscription = _appForegroundStream.listen((foreground) {
+      if (foreground) {
+        unawaited(sweep());
+      }
+    });
+  }
+
+  Future<void> dispose() async {
+    await _foregroundSubscription?.cancel();
+    _foregroundSubscription = null;
+    _isInitialized = false;
+  }
+
+  Future<void> sweep() async {
+    if (_isSweeping) return;
+    _isSweeping = true;
+
+    try {
+      final retryable = await _dao.getRetryableForUser(
+        userPubkey: _userPubkey,
+        maxRetries: _retryConfig.maxRetries,
+      );
+
+      for (final row in retryable) {
+        if (_isTerminal(row)) {
+          await _dao.deleteById(row.id);
+          continue;
+        }
+
+        final lastAttempt = row.lastAttemptAt;
+        if (lastAttempt != null) {
+          final gap = _now().difference(lastAttempt);
+          if (gap < _retryConfig.backoffFor(row.retryCount)) continue;
+        }
+
+        final marked = await _dao.markPublishing(row.id);
+        if (!marked) continue;
+
+        try {
+          final success = await _viewEventPublisher.publishViewEvent(
+            video: _toVideoEvent(row),
+            startSeconds: 0,
+            endSeconds: row.watchDurationMs ~/ 1000,
+            source: _trafficSourceFrom(row.trafficSource),
+            sourceDetail: row.sourceDetail,
+            loopCount: row.loopCount,
+          );
+          if (success) {
+            await _dao.deleteById(row.id);
+          } else {
+            await _dao.markFailed(row.id, 'publish returned false');
+          }
+        } on Object catch (e) {
+          await _dao.markFailed(row.id, e.toString());
+        }
+      }
+    } finally {
+      _isSweeping = false;
+    }
+  }
+
+  bool _isTerminal(PendingViewEvent row) {
+    return row.videoPubkey == _userPubkey || row.watchDurationMs < 1000;
+  }
+
+  VideoEvent _toVideoEvent(PendingViewEvent row) {
+    return VideoEvent(
+      id: row.videoId,
+      pubkey: row.videoPubkey,
+      createdAt: row.createdAt.millisecondsSinceEpoch ~/ 1000,
+      content: '',
+      timestamp: row.createdAt,
+      vineId: row.videoVineId,
+    );
+  }
+
+  ViewTrafficSource _trafficSourceFrom(String raw) {
+    return switch (raw) {
+      'home' => ViewTrafficSource.home,
+      'profile' => ViewTrafficSource.profile,
+      'search' => ViewTrafficSource.search,
+      'share' => ViewTrafficSource.share,
+      'discovery:new' || 'discovery_new' => ViewTrafficSource.discoveryNew,
+      'discovery:popular' ||
+      'discovery_popular' => ViewTrafficSource.discoveryPopular,
+      'discovery:classic' ||
+      'discovery_classic' => ViewTrafficSource.discoveryClassic,
+      'discovery:foryou' ||
+      'discovery_for_you' => ViewTrafficSource.discoveryForYou,
+      _ => ViewTrafficSource.unknown,
+    };
+  }
+}

--- a/mobile/lib/widgets/divine_video_metrics_tracker.dart
+++ b/mobile/lib/widgets/divine_video_metrics_tracker.dart
@@ -1,0 +1,254 @@
+// ABOUTME: Widget that tracks native DivineVideoPlayerController playback metrics
+// ABOUTME: Publishes view analytics for native InfiniteVideoFeed playback sessions
+
+import 'dart:async';
+
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
+import 'package:openvine/services/view_event_publisher.dart'
+    show ViewTrafficSource;
+import 'package:unified_logger/unified_logger.dart';
+
+class DivineVideoMetricsTracker extends ConsumerStatefulWidget {
+  const DivineVideoMetricsTracker({
+    required this.video,
+    required this.controller,
+    required this.isActive,
+    required this.child,
+    this.trafficSource = ViewTrafficSource.unknown,
+    this.sourceDetail,
+    @visibleForTesting DateTime Function()? clock,
+    super.key,
+  }) : _clock = clock ?? DateTime.now;
+
+  final VideoEvent video;
+  final DivineVideoPlayerController? controller;
+  final bool isActive;
+  final Widget child;
+  final ViewTrafficSource trafficSource;
+  final String? sourceDetail;
+  final DateTime Function() _clock;
+
+  @override
+  ConsumerState<DivineVideoMetricsTracker> createState() =>
+      _DivineVideoMetricsTrackerState();
+}
+
+class _DivineVideoMetricsTrackerState
+    extends ConsumerState<DivineVideoMetricsTracker> {
+  DateTime? _viewStartTime;
+  DateTime? _lastPlayStartTime;
+  Duration _totalWatchDuration = Duration.zero;
+  Duration? _lastPosition;
+  int _loopCount = 0;
+  bool _hasTrackedView = false;
+  bool _hasSentEndEvent = false;
+  bool _isPlaying = false;
+  StreamSubscription<DivineVideoPlayerState>? _stateSubscription;
+
+  late AnalyticsService _analyticsService;
+  ProviderSubscription<AnalyticsService>? _analyticsServiceSubscription;
+  late AuthService _authService;
+  late SeenVideosService _seenVideosService;
+
+  @override
+  void initState() {
+    super.initState();
+    _analyticsService = ref.read(analyticsServiceProvider);
+    _analyticsServiceSubscription = ref.listenManual<AnalyticsService>(
+      analyticsServiceProvider,
+      (_, next) => _analyticsService = next,
+    );
+    _authService = ref.read(authServiceProvider);
+    _seenVideosService = ref.read(seenVideosServiceProvider);
+    if (widget.isActive) _startTracking();
+  }
+
+  @override
+  void didUpdateWidget(DivineVideoMetricsTracker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final videoChanged = oldWidget.video.id != widget.video.id;
+    final controllerChanged = oldWidget.controller != widget.controller;
+    final becameInactive = oldWidget.isActive && !widget.isActive;
+    final becameActive = !oldWidget.isActive && widget.isActive;
+
+    if (videoChanged) {
+      _finalizeAndPublish(finalizedVideo: oldWidget.video);
+      _resetTracking();
+    } else if (becameInactive) {
+      _finalizeAndPublish();
+    }
+
+    if (controllerChanged || videoChanged || becameInactive) {
+      unawaited(_stateSubscription?.cancel());
+      _stateSubscription = null;
+    }
+
+    if (widget.isActive &&
+        (videoChanged || becameActive || controllerChanged)) {
+      _startTracking();
+    }
+  }
+
+  void _startTracking() {
+    final controller = widget.controller;
+    if (controller == null) return;
+
+    if (!_hasTrackedView) {
+      _trackViewStart();
+    }
+
+    _subscribeToController(controller);
+
+    try {
+      _handleState(controller.state);
+    } catch (e) {
+      Log.warning(
+        'DivineVideoMetricsTracker: controller state unavailable - $e',
+        name: 'DivineVideoMetricsTracker',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  void _subscribeToController(DivineVideoPlayerController controller) {
+    unawaited(_stateSubscription?.cancel());
+    _stateSubscription = controller.stateStream.listen(
+      _handleState,
+      onError: (Object error) {
+        Log.warning(
+          'DivineVideoMetricsTracker: state stream error - $error',
+          name: 'DivineVideoMetricsTracker',
+          category: LogCategory.video,
+        );
+      },
+    );
+  }
+
+  void _handleState(DivineVideoPlayerState state) {
+    if (!_hasTrackedView || !widget.isActive) return;
+
+    final now = widget._clock();
+    if (state.isPlaying && !_isPlaying) {
+      _isPlaying = true;
+      _lastPlayStartTime = now;
+    } else if (!state.isPlaying && _isPlaying) {
+      _totalWatchDuration += now.difference(_lastPlayStartTime!);
+      _lastPlayStartTime = null;
+      _isPlaying = false;
+    }
+
+    final position = state.position;
+    final duration = state.duration;
+    if (_lastPosition != null &&
+        position < _lastPosition! &&
+        position < const Duration(seconds: 1) &&
+        duration > Duration.zero &&
+        _lastPosition!.inMilliseconds > duration.inMilliseconds - 1000) {
+      _loopCount++;
+    }
+    _lastPosition = position;
+  }
+
+  void _trackViewStart() {
+    _viewStartTime = widget._clock();
+    _hasTrackedView = true;
+    _hasSentEndEvent = false;
+
+    _analyticsService.trackDetailedVideoViewWithUser(
+      widget.video,
+      userId: _authService.currentPublicKeyHex,
+      source: 'mobile',
+      eventType: 'view_start',
+    );
+  }
+
+  void _finalizeAndPublish({VideoEvent? finalizedVideo}) {
+    if (!_hasTrackedView || _hasSentEndEvent) return;
+    if (_viewStartTime == null) return;
+
+    if (_isPlaying && _lastPlayStartTime != null) {
+      _totalWatchDuration += widget._clock().difference(_lastPlayStartTime!);
+      _lastPlayStartTime = null;
+    }
+    _isPlaying = false;
+
+    final video = finalizedVideo ?? widget.video;
+    _publishEvents(video);
+  }
+
+  void _publishEvents(VideoEvent video) {
+    if (_hasSentEndEvent) return;
+    if (_totalWatchDuration.inSeconds < 1) return;
+
+    Duration? totalDuration;
+    try {
+      totalDuration = widget.controller?.state.duration;
+    } catch (_) {
+      totalDuration = null;
+    }
+
+    try {
+      _analyticsService.trackDetailedVideoViewWithUser(
+        video,
+        userId: _authService.currentPublicKeyHex,
+        source: 'mobile',
+        eventType: 'view_end',
+        watchDuration: _totalWatchDuration,
+        totalDuration: totalDuration,
+        loopCount: _loopCount,
+        completedVideo:
+            _loopCount > 0 ||
+            (totalDuration != null &&
+                totalDuration > Duration.zero &&
+                _totalWatchDuration.inMilliseconds >=
+                    totalDuration.inMilliseconds * 0.9),
+        trafficSource: widget.trafficSource,
+        sourceDetail: widget.sourceDetail,
+      );
+
+      _seenVideosService.recordVideoView(
+        video.id,
+        loopCount: _loopCount,
+        watchDuration: _totalWatchDuration,
+      );
+
+      _hasSentEndEvent = true;
+    } catch (e) {
+      Log.warning(
+        'Failed to send video end event: $e',
+        name: 'DivineVideoMetricsTracker',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  void _resetTracking() {
+    _viewStartTime = null;
+    _lastPlayStartTime = null;
+    _totalWatchDuration = Duration.zero;
+    _lastPosition = null;
+    _loopCount = 0;
+    _hasTrackedView = false;
+    _hasSentEndEvent = false;
+    _isPlaying = false;
+  }
+
+  @override
+  void dispose() {
+    _finalizeAndPublish();
+    unawaited(_stateSubscription?.cancel());
+    _analyticsServiceSubscription?.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/mobile/lib/widgets/pooled_video_metrics_tracker.dart
+++ b/mobile/lib/widgets/pooled_video_metrics_tracker.dart
@@ -8,6 +8,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/view_event_publisher.dart'
     show ViewTrafficSource;
 import 'package:pooled_video_player/pooled_video_player.dart';
@@ -26,8 +29,9 @@ class PooledVideoMetricsTracker extends ConsumerStatefulWidget {
     required this.child,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
+    @visibleForTesting DateTime Function()? clock,
     super.key,
-  });
+  }) : _clock = clock ?? DateTime.now;
 
   final VideoEvent video;
   final Player player;
@@ -39,6 +43,8 @@ class PooledVideoMetricsTracker extends ConsumerStatefulWidget {
 
   /// Additional context for the traffic source (e.g., hashtag name).
   final String? sourceDetail;
+
+  final DateTime Function() _clock;
 
   @override
   ConsumerState<PooledVideoMetricsTracker> createState() =>
@@ -59,14 +65,19 @@ class _PooledVideoMetricsTrackerState
 
   // Save provider references for safe access during dispose
   // CRITICAL: Never use ref.read() in dispose-related methods
-  dynamic _analyticsService;
-  dynamic _authService;
-  dynamic _seenVideosService;
+  late AnalyticsService _analyticsService;
+  ProviderSubscription<AnalyticsService>? _analyticsServiceSubscription;
+  late AuthService _authService;
+  late SeenVideosService _seenVideosService;
 
   @override
   void initState() {
     super.initState();
     _analyticsService = ref.read(analyticsServiceProvider);
+    _analyticsServiceSubscription = ref.listenManual<AnalyticsService>(
+      analyticsServiceProvider,
+      (_, next) => _analyticsService = next,
+    );
     _authService = ref.read(authServiceProvider);
     _seenVideosService = ref.read(seenVideosServiceProvider);
 
@@ -81,7 +92,7 @@ class _PooledVideoMetricsTrackerState
 
     // Video changed — publish for old video, start tracking new one
     if (oldWidget.video.id != widget.video.id) {
-      _finalizeAndPublish();
+      _finalizeAndPublish(finalizedVideo: oldWidget.video);
       _resetTracking();
       if (widget.isActive) _startTracking();
       return;
@@ -144,10 +155,10 @@ class _PooledVideoMetricsTrackerState
     _playingSub = player.stream.playing.listen((isPlaying) {
       if (isPlaying && !_isPlaying) {
         // Started playing
-        _lastPlayStartTime = DateTime.now();
+        _lastPlayStartTime = widget._clock();
       } else if (!isPlaying && _isPlaying && _lastPlayStartTime != null) {
         // Stopped playing — accumulate watch time
-        _totalWatchDuration += DateTime.now().difference(_lastPlayStartTime!);
+        _totalWatchDuration += widget._clock().difference(_lastPlayStartTime!);
         _lastPlayStartTime = null;
       }
       _isPlaying = isPlaying;
@@ -179,7 +190,7 @@ class _PooledVideoMetricsTrackerState
     try {
       if (player.state.playing) {
         _isPlaying = true;
-        _lastPlayStartTime = DateTime.now();
+        _lastPlayStartTime = widget._clock();
       }
     } catch (_) {
       // Player may be disposed
@@ -193,17 +204,17 @@ class _PooledVideoMetricsTrackerState
     _positionSub = null;
   }
 
-  void _finalizeAndPublish() {
+  void _finalizeAndPublish({VideoEvent? finalizedVideo}) {
     // Accumulate any remaining playing time
     if (_isPlaying && _lastPlayStartTime != null) {
-      _totalWatchDuration += DateTime.now().difference(_lastPlayStartTime!);
+      _totalWatchDuration += widget._clock().difference(_lastPlayStartTime!);
       _lastPlayStartTime = null;
     }
     _isPlaying = false;
-    _publishEvents();
+    _publishEvents(finalizedVideo ?? widget.video);
   }
 
-  void _publishEvents() {
+  void _publishEvents(VideoEvent video) {
     if (_hasSentEndEvent) return;
     if (_totalWatchDuration.inSeconds < 1) return;
 
@@ -219,7 +230,7 @@ class _PooledVideoMetricsTrackerState
 
       // Analytics service — publishes Kind 22236 Nostr view event
       _analyticsService.trackDetailedVideoViewWithUser(
-        widget.video,
+        video,
         userId: _authService.currentPublicKeyHex,
         source: 'mobile',
         eventType: 'view_end',
@@ -238,7 +249,7 @@ class _PooledVideoMetricsTrackerState
 
       // Persist to local storage for "show fresh content" feature
       _seenVideosService.recordVideoView(
-        widget.video.id,
+        video.id,
         loopCount: _loopCount,
         watchDuration: _totalWatchDuration,
       );
@@ -271,6 +282,7 @@ class _PooledVideoMetricsTrackerState
   void dispose() {
     _cancelSubscriptions();
     _finalizeAndPublish();
+    _analyticsServiceSubscription?.close();
     super.dispose();
   }
 

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -24,7 +24,10 @@ import 'package:openvine/screens/feed/feed_auto_advance_error_listener.dart';
 import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
+import 'package:openvine/services/view_event_publisher.dart'
+    show ViewTrafficSource;
 import 'package:openvine/utils/scroll_driven_opacity.dart';
+import 'package:openvine/widgets/divine_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
@@ -47,6 +50,8 @@ class FeedVideos extends ConsumerStatefulWidget {
     this.hasMore = false,
     this.isLoadingMore = false,
     this.onActiveVideoChanged,
+    this.trafficSource = ViewTrafficSource.unknown,
+    this.sourceDetail,
     super.key,
   });
 
@@ -76,6 +81,9 @@ class FeedVideos extends ConsumerStatefulWidget {
 
   /// Called when the active (visible) video changes.
   final void Function(VideoEvent video, int index)? onActiveVideoChanged;
+
+  final ViewTrafficSource trafficSource;
+  final String? sourceDetail;
 
   @override
   ConsumerState<FeedVideos> createState() => FeedVideosState();
@@ -302,14 +310,22 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           if (index < 0 || index >= widget.videos.length) {
             return const SizedBox.shrink();
           }
-          return _Overlay(
+          final video = widget.videos[index];
+          return DivineVideoMetricsTracker(
+            video: video,
             controller: controller,
-            video: widget.videos[index],
-            index: index,
-            isActive: isActive,
-            contextTitle: widget.contextTitle,
-            onToggleAutoAdvance: _toggleAutoAdvance,
-            onSuppressAutoAdvance: _suppressAutoAdvance,
+            isActive: isFeedActive && isActive,
+            trafficSource: widget.trafficSource,
+            sourceDetail: widget.sourceDetail,
+            child: _Overlay(
+              controller: controller,
+              video: video,
+              index: index,
+              isActive: isActive,
+              contextTitle: widget.contextTitle,
+              onToggleAutoAdvance: _toggleAutoAdvance,
+              onSuppressAutoAdvance: _suppressAutoAdvance,
+            ),
           );
         },
       ),

--- a/mobile/lib/widgets/video_metrics_tracker.dart
+++ b/mobile/lib/widgets/video_metrics_tracker.dart
@@ -8,7 +8,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/view_event_publisher.dart'
     show ViewTrafficSource;
 import 'package:unified_logger/unified_logger.dart';
@@ -22,8 +25,9 @@ class VideoMetricsTracker extends ConsumerStatefulWidget {
     required this.child,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
+    @visibleForTesting DateTime Function()? clock,
     super.key,
-  });
+  }) : _clock = clock ?? DateTime.now;
 
   final VideoEvent video;
   final VideoPlayerController? controller;
@@ -34,6 +38,8 @@ class VideoMetricsTracker extends ConsumerStatefulWidget {
 
   /// Additional context for the traffic source (e.g., hashtag name).
   final String? sourceDetail;
+
+  final DateTime Function() _clock;
 
   @override
   ConsumerState<VideoMetricsTracker> createState() =>
@@ -57,15 +63,19 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
   bool _hasCompletedPlaybackTrace = false;
 
   // Save provider references for safe access during dispose
-  dynamic _analyticsService;
-  dynamic _authService;
-  dynamic _seenVideosService;
+  late AnalyticsService _analyticsService;
+  ProviderSubscription<AnalyticsService>? _analyticsServiceSubscription;
+  late AuthService _authService;
+  late SeenVideosService _seenVideosService;
 
   @override
   void initState() {
     super.initState();
-    // CRITICAL: Save provider references BEFORE any async work
     _analyticsService = ref.read(analyticsServiceProvider);
+    _analyticsServiceSubscription = ref.listenManual<AnalyticsService>(
+      analyticsServiceProvider,
+      (_, next) => _analyticsService = next,
+    );
     _authService = ref.read(authServiceProvider);
     _seenVideosService = ref.read(seenVideosServiceProvider);
     _initializeTracking();
@@ -75,15 +85,39 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
   void didUpdateWidget(VideoMetricsTracker oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    // If video changed, send end event for previous video and start tracking new one
-    if (oldWidget.video.id != widget.video.id) {
-      _sendVideoEndEvent();
+    final videoChanged = oldWidget.video.id != widget.video.id;
+    final controllerChanged = oldWidget.controller != widget.controller;
+    final becameInactive =
+        oldWidget.controller != null && widget.controller == null;
+    final becameActive =
+        oldWidget.controller == null && widget.controller != null;
+
+    if (videoChanged) {
+      _sendVideoEndEvent(
+        finalizedVideo: oldWidget.video,
+        finalizedController: oldWidget.controller,
+      );
+      _positionTimer?.cancel();
+      _removeControllerListeners(oldWidget.controller);
       _resetTracking();
       _initializeTracking();
+      return;
     }
 
-    // If controller changed, update listeners
-    if (oldWidget.controller != widget.controller) {
+    if (becameInactive) {
+      _sendVideoEndEvent(finalizedController: oldWidget.controller);
+      _positionTimer?.cancel();
+      _removeControllerListeners(oldWidget.controller);
+      return;
+    }
+
+    if (becameActive) {
+      _resetTracking();
+      _initializeTracking();
+      return;
+    }
+
+    if (controllerChanged) {
       _removeControllerListeners(oldWidget.controller);
       _addControllerListeners();
     }
@@ -177,19 +211,21 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
     });
   }
 
-  void _updateWatchDuration() {
+  void _updateWatchDuration({VideoPlayerController? controller}) {
     if (_viewStartTime == null) return;
 
-    final controller = widget.controller;
-    if (controller == null || !controller.value.isInitialized) return;
+    final activeController = controller ?? widget.controller;
+    if (activeController == null || !activeController.value.isInitialized) {
+      return;
+    }
 
     // Only count time when video is actually playing
-    if (controller.value.isPlaying) {
-      final now = DateTime.now();
+    if (activeController.value.isPlaying) {
+      final now = widget._clock();
       final sessionDuration = now.difference(_viewStartTime!);
 
       // Update total watch duration (capped by actual video length to handle pauses)
-      final videoDuration = controller.value.duration;
+      final videoDuration = activeController.value.duration;
       if (videoDuration > Duration.zero) {
         final effectiveDuration = sessionDuration > videoDuration
             ? videoDuration
@@ -200,7 +236,7 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
   }
 
   void _trackViewStart() {
-    _viewStartTime = DateTime.now();
+    _viewStartTime = widget._clock();
     _hasTrackedView = true;
     _hasSentEndEvent = false;
 
@@ -219,14 +255,18 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
     );
   }
 
-  void _sendVideoEndEvent() {
+  void _sendVideoEndEvent({
+    VideoEvent? finalizedVideo,
+    VideoPlayerController? finalizedController,
+  }) {
     if (!_hasTrackedView || _hasSentEndEvent) return;
     if (_viewStartTime == null) return;
 
-    _updateWatchDuration(); // Final update
+    _updateWatchDuration(controller: finalizedController); // Final update
 
-    final controller = widget.controller;
+    final controller = finalizedController ?? widget.controller;
     final totalDuration = controller?.value.duration;
+    final video = finalizedVideo ?? widget.video;
 
     // Only send if we have meaningful data
     if (_totalWatchDuration.inSeconds > 0) {
@@ -235,7 +275,7 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
         // CRITICAL: Never use ref.read() in dispose-related methods
         // Analytics service publishes Kind 22236 Nostr view event
         _analyticsService.trackDetailedVideoViewWithUser(
-          widget.video,
+          video,
           userId: _authService.currentPublicKeyHex,
           source: 'mobile',
           eventType: 'view_end',
@@ -252,7 +292,7 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
 
         // Persist to local storage for "show fresh content" feature
         _seenVideosService.recordVideoView(
-          widget.video.id,
+          video.id,
           loopCount: _loopCount,
           watchDuration: _totalWatchDuration,
         );
@@ -289,6 +329,7 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
     _positionTimer?.cancel();
     _sendVideoEndEvent(); // Send final metrics when widget is disposed
     _removeControllerListeners(widget.controller);
+    _analyticsServiceSubscription?.close();
     super.dispose();
   }
 

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -34,6 +34,7 @@ const _notificationRetentionDays = 7;
     DmMessageReactions,
     Conversations,
     OutgoingDms,
+    PendingViewEvents,
   ],
   daos: [
     UserProfilesDao,
@@ -53,6 +54,7 @@ const _notificationRetentionDays = 7;
     DmReactionsDao,
     ConversationsDao,
     OutgoingDmsDao,
+    PendingViewEventsDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -530,6 +532,41 @@ class AppDatabase extends _$AppDatabase {
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_dm_reactions_owner_created
       ON dm_message_reactions (owner_pubkey, created_at)
+    ''');
+
+    final pendingViewEventsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='pending_view_events'",
+    ).get();
+
+    if (pendingViewEventsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE pending_view_events (
+          id TEXT NOT NULL PRIMARY KEY,
+          video_id TEXT NOT NULL,
+          video_pubkey TEXT NOT NULL,
+          video_vine_id TEXT,
+          user_pubkey TEXT NOT NULL,
+          watch_duration_ms INTEGER NOT NULL,
+          total_duration_ms INTEGER,
+          loop_count INTEGER,
+          traffic_source TEXT NOT NULL,
+          source_detail TEXT,
+          status TEXT NOT NULL,
+          retry_count INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT,
+          last_attempt_at INTEGER,
+          created_at INTEGER NOT NULL
+        )
+      ''');
+    }
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_pending_view_events_user_status
+      ON pending_view_events (user_pubkey, status)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_pending_view_events_created_at
+      ON pending_view_events (created_at)
     ''');
 
     // Populate new columns from existing JSON data blobs

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -12200,6 +12200,901 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
   }
 }
 
+class $PendingViewEventsTable extends PendingViewEvents
+    with TableInfo<$PendingViewEventsTable, PendingViewEventRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PendingViewEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _videoIdMeta = const VerificationMeta(
+    'videoId',
+  );
+  @override
+  late final GeneratedColumn<String> videoId = GeneratedColumn<String>(
+    'video_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _videoPubkeyMeta = const VerificationMeta(
+    'videoPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> videoPubkey = GeneratedColumn<String>(
+    'video_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _videoVineIdMeta = const VerificationMeta(
+    'videoVineId',
+  );
+  @override
+  late final GeneratedColumn<String> videoVineId = GeneratedColumn<String>(
+    'video_vine_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _userPubkeyMeta = const VerificationMeta(
+    'userPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> userPubkey = GeneratedColumn<String>(
+    'user_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _watchDurationMsMeta = const VerificationMeta(
+    'watchDurationMs',
+  );
+  @override
+  late final GeneratedColumn<int> watchDurationMs = GeneratedColumn<int>(
+    'watch_duration_ms',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _totalDurationMsMeta = const VerificationMeta(
+    'totalDurationMs',
+  );
+  @override
+  late final GeneratedColumn<int> totalDurationMs = GeneratedColumn<int>(
+    'total_duration_ms',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _loopCountMeta = const VerificationMeta(
+    'loopCount',
+  );
+  @override
+  late final GeneratedColumn<int> loopCount = GeneratedColumn<int>(
+    'loop_count',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _trafficSourceMeta = const VerificationMeta(
+    'trafficSource',
+  );
+  @override
+  late final GeneratedColumn<String> trafficSource = GeneratedColumn<String>(
+    'traffic_source',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sourceDetailMeta = const VerificationMeta(
+    'sourceDetail',
+  );
+  @override
+  late final GeneratedColumn<String> sourceDetail = GeneratedColumn<String>(
+    'source_detail',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _retryCountMeta = const VerificationMeta(
+    'retryCount',
+  );
+  @override
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+    'retry_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
+    'lastError',
+  );
+  @override
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lastAttemptAtMeta = const VerificationMeta(
+    'lastAttemptAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastAttemptAt =
+      GeneratedColumn<DateTime>(
+        'last_attempt_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    videoId,
+    videoPubkey,
+    videoVineId,
+    userPubkey,
+    watchDurationMs,
+    totalDurationMs,
+    loopCount,
+    trafficSource,
+    sourceDetail,
+    status,
+    retryCount,
+    lastError,
+    lastAttemptAt,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_view_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PendingViewEventRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('video_id')) {
+      context.handle(
+        _videoIdMeta,
+        videoId.isAcceptableOrUnknown(data['video_id']!, _videoIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_videoIdMeta);
+    }
+    if (data.containsKey('video_pubkey')) {
+      context.handle(
+        _videoPubkeyMeta,
+        videoPubkey.isAcceptableOrUnknown(
+          data['video_pubkey']!,
+          _videoPubkeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_videoPubkeyMeta);
+    }
+    if (data.containsKey('video_vine_id')) {
+      context.handle(
+        _videoVineIdMeta,
+        videoVineId.isAcceptableOrUnknown(
+          data['video_vine_id']!,
+          _videoVineIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('user_pubkey')) {
+      context.handle(
+        _userPubkeyMeta,
+        userPubkey.isAcceptableOrUnknown(data['user_pubkey']!, _userPubkeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_userPubkeyMeta);
+    }
+    if (data.containsKey('watch_duration_ms')) {
+      context.handle(
+        _watchDurationMsMeta,
+        watchDurationMs.isAcceptableOrUnknown(
+          data['watch_duration_ms']!,
+          _watchDurationMsMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_watchDurationMsMeta);
+    }
+    if (data.containsKey('total_duration_ms')) {
+      context.handle(
+        _totalDurationMsMeta,
+        totalDurationMs.isAcceptableOrUnknown(
+          data['total_duration_ms']!,
+          _totalDurationMsMeta,
+        ),
+      );
+    }
+    if (data.containsKey('loop_count')) {
+      context.handle(
+        _loopCountMeta,
+        loopCount.isAcceptableOrUnknown(data['loop_count']!, _loopCountMeta),
+      );
+    }
+    if (data.containsKey('traffic_source')) {
+      context.handle(
+        _trafficSourceMeta,
+        trafficSource.isAcceptableOrUnknown(
+          data['traffic_source']!,
+          _trafficSourceMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_trafficSourceMeta);
+    }
+    if (data.containsKey('source_detail')) {
+      context.handle(
+        _sourceDetailMeta,
+        sourceDetail.isAcceptableOrUnknown(
+          data['source_detail']!,
+          _sourceDetailMeta,
+        ),
+      );
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_statusMeta);
+    }
+    if (data.containsKey('retry_count')) {
+      context.handle(
+        _retryCountMeta,
+        retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
+      );
+    }
+    if (data.containsKey('last_error')) {
+      context.handle(
+        _lastErrorMeta,
+        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+      );
+    }
+    if (data.containsKey('last_attempt_at')) {
+      context.handle(
+        _lastAttemptAtMeta,
+        lastAttemptAt.isAcceptableOrUnknown(
+          data['last_attempt_at']!,
+          _lastAttemptAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PendingViewEventRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PendingViewEventRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      videoId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}video_id'],
+      )!,
+      videoPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}video_pubkey'],
+      )!,
+      videoVineId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}video_vine_id'],
+      ),
+      userPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}user_pubkey'],
+      )!,
+      watchDurationMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}watch_duration_ms'],
+      )!,
+      totalDurationMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}total_duration_ms'],
+      ),
+      loopCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}loop_count'],
+      ),
+      trafficSource: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}traffic_source'],
+      )!,
+      sourceDetail: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}source_detail'],
+      ),
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      retryCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}retry_count'],
+      )!,
+      lastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_error'],
+      ),
+      lastAttemptAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_attempt_at'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $PendingViewEventsTable createAlias(String alias) {
+    return $PendingViewEventsTable(attachedDatabase, alias);
+  }
+}
+
+class PendingViewEventRow extends DataClass
+    implements Insertable<PendingViewEventRow> {
+  final String id;
+  final String videoId;
+  final String videoPubkey;
+  final String? videoVineId;
+  final String userPubkey;
+  final int watchDurationMs;
+  final int? totalDurationMs;
+  final int? loopCount;
+  final String trafficSource;
+  final String? sourceDetail;
+  final String status;
+  final int retryCount;
+  final String? lastError;
+  final DateTime? lastAttemptAt;
+  final DateTime createdAt;
+  const PendingViewEventRow({
+    required this.id,
+    required this.videoId,
+    required this.videoPubkey,
+    this.videoVineId,
+    required this.userPubkey,
+    required this.watchDurationMs,
+    this.totalDurationMs,
+    this.loopCount,
+    required this.trafficSource,
+    this.sourceDetail,
+    required this.status,
+    required this.retryCount,
+    this.lastError,
+    this.lastAttemptAt,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['video_id'] = Variable<String>(videoId);
+    map['video_pubkey'] = Variable<String>(videoPubkey);
+    if (!nullToAbsent || videoVineId != null) {
+      map['video_vine_id'] = Variable<String>(videoVineId);
+    }
+    map['user_pubkey'] = Variable<String>(userPubkey);
+    map['watch_duration_ms'] = Variable<int>(watchDurationMs);
+    if (!nullToAbsent || totalDurationMs != null) {
+      map['total_duration_ms'] = Variable<int>(totalDurationMs);
+    }
+    if (!nullToAbsent || loopCount != null) {
+      map['loop_count'] = Variable<int>(loopCount);
+    }
+    map['traffic_source'] = Variable<String>(trafficSource);
+    if (!nullToAbsent || sourceDetail != null) {
+      map['source_detail'] = Variable<String>(sourceDetail);
+    }
+    map['status'] = Variable<String>(status);
+    map['retry_count'] = Variable<int>(retryCount);
+    if (!nullToAbsent || lastError != null) {
+      map['last_error'] = Variable<String>(lastError);
+    }
+    if (!nullToAbsent || lastAttemptAt != null) {
+      map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  PendingViewEventsCompanion toCompanion(bool nullToAbsent) {
+    return PendingViewEventsCompanion(
+      id: Value(id),
+      videoId: Value(videoId),
+      videoPubkey: Value(videoPubkey),
+      videoVineId: videoVineId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(videoVineId),
+      userPubkey: Value(userPubkey),
+      watchDurationMs: Value(watchDurationMs),
+      totalDurationMs: totalDurationMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(totalDurationMs),
+      loopCount: loopCount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(loopCount),
+      trafficSource: Value(trafficSource),
+      sourceDetail: sourceDetail == null && nullToAbsent
+          ? const Value.absent()
+          : Value(sourceDetail),
+      status: Value(status),
+      retryCount: Value(retryCount),
+      lastError: lastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastError),
+      lastAttemptAt: lastAttemptAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastAttemptAt),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory PendingViewEventRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PendingViewEventRow(
+      id: serializer.fromJson<String>(json['id']),
+      videoId: serializer.fromJson<String>(json['videoId']),
+      videoPubkey: serializer.fromJson<String>(json['videoPubkey']),
+      videoVineId: serializer.fromJson<String?>(json['videoVineId']),
+      userPubkey: serializer.fromJson<String>(json['userPubkey']),
+      watchDurationMs: serializer.fromJson<int>(json['watchDurationMs']),
+      totalDurationMs: serializer.fromJson<int?>(json['totalDurationMs']),
+      loopCount: serializer.fromJson<int?>(json['loopCount']),
+      trafficSource: serializer.fromJson<String>(json['trafficSource']),
+      sourceDetail: serializer.fromJson<String?>(json['sourceDetail']),
+      status: serializer.fromJson<String>(json['status']),
+      retryCount: serializer.fromJson<int>(json['retryCount']),
+      lastError: serializer.fromJson<String?>(json['lastError']),
+      lastAttemptAt: serializer.fromJson<DateTime?>(json['lastAttemptAt']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'videoId': serializer.toJson<String>(videoId),
+      'videoPubkey': serializer.toJson<String>(videoPubkey),
+      'videoVineId': serializer.toJson<String?>(videoVineId),
+      'userPubkey': serializer.toJson<String>(userPubkey),
+      'watchDurationMs': serializer.toJson<int>(watchDurationMs),
+      'totalDurationMs': serializer.toJson<int?>(totalDurationMs),
+      'loopCount': serializer.toJson<int?>(loopCount),
+      'trafficSource': serializer.toJson<String>(trafficSource),
+      'sourceDetail': serializer.toJson<String?>(sourceDetail),
+      'status': serializer.toJson<String>(status),
+      'retryCount': serializer.toJson<int>(retryCount),
+      'lastError': serializer.toJson<String?>(lastError),
+      'lastAttemptAt': serializer.toJson<DateTime?>(lastAttemptAt),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  PendingViewEventRow copyWith({
+    String? id,
+    String? videoId,
+    String? videoPubkey,
+    Value<String?> videoVineId = const Value.absent(),
+    String? userPubkey,
+    int? watchDurationMs,
+    Value<int?> totalDurationMs = const Value.absent(),
+    Value<int?> loopCount = const Value.absent(),
+    String? trafficSource,
+    Value<String?> sourceDetail = const Value.absent(),
+    String? status,
+    int? retryCount,
+    Value<String?> lastError = const Value.absent(),
+    Value<DateTime?> lastAttemptAt = const Value.absent(),
+    DateTime? createdAt,
+  }) => PendingViewEventRow(
+    id: id ?? this.id,
+    videoId: videoId ?? this.videoId,
+    videoPubkey: videoPubkey ?? this.videoPubkey,
+    videoVineId: videoVineId.present ? videoVineId.value : this.videoVineId,
+    userPubkey: userPubkey ?? this.userPubkey,
+    watchDurationMs: watchDurationMs ?? this.watchDurationMs,
+    totalDurationMs: totalDurationMs.present
+        ? totalDurationMs.value
+        : this.totalDurationMs,
+    loopCount: loopCount.present ? loopCount.value : this.loopCount,
+    trafficSource: trafficSource ?? this.trafficSource,
+    sourceDetail: sourceDetail.present ? sourceDetail.value : this.sourceDetail,
+    status: status ?? this.status,
+    retryCount: retryCount ?? this.retryCount,
+    lastError: lastError.present ? lastError.value : this.lastError,
+    lastAttemptAt: lastAttemptAt.present
+        ? lastAttemptAt.value
+        : this.lastAttemptAt,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  PendingViewEventRow copyWithCompanion(PendingViewEventsCompanion data) {
+    return PendingViewEventRow(
+      id: data.id.present ? data.id.value : this.id,
+      videoId: data.videoId.present ? data.videoId.value : this.videoId,
+      videoPubkey: data.videoPubkey.present
+          ? data.videoPubkey.value
+          : this.videoPubkey,
+      videoVineId: data.videoVineId.present
+          ? data.videoVineId.value
+          : this.videoVineId,
+      userPubkey: data.userPubkey.present
+          ? data.userPubkey.value
+          : this.userPubkey,
+      watchDurationMs: data.watchDurationMs.present
+          ? data.watchDurationMs.value
+          : this.watchDurationMs,
+      totalDurationMs: data.totalDurationMs.present
+          ? data.totalDurationMs.value
+          : this.totalDurationMs,
+      loopCount: data.loopCount.present ? data.loopCount.value : this.loopCount,
+      trafficSource: data.trafficSource.present
+          ? data.trafficSource.value
+          : this.trafficSource,
+      sourceDetail: data.sourceDetail.present
+          ? data.sourceDetail.value
+          : this.sourceDetail,
+      status: data.status.present ? data.status.value : this.status,
+      retryCount: data.retryCount.present
+          ? data.retryCount.value
+          : this.retryCount,
+      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+      lastAttemptAt: data.lastAttemptAt.present
+          ? data.lastAttemptAt.value
+          : this.lastAttemptAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingViewEventRow(')
+          ..write('id: $id, ')
+          ..write('videoId: $videoId, ')
+          ..write('videoPubkey: $videoPubkey, ')
+          ..write('videoVineId: $videoVineId, ')
+          ..write('userPubkey: $userPubkey, ')
+          ..write('watchDurationMs: $watchDurationMs, ')
+          ..write('totalDurationMs: $totalDurationMs, ')
+          ..write('loopCount: $loopCount, ')
+          ..write('trafficSource: $trafficSource, ')
+          ..write('sourceDetail: $sourceDetail, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('lastError: $lastError, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    videoId,
+    videoPubkey,
+    videoVineId,
+    userPubkey,
+    watchDurationMs,
+    totalDurationMs,
+    loopCount,
+    trafficSource,
+    sourceDetail,
+    status,
+    retryCount,
+    lastError,
+    lastAttemptAt,
+    createdAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PendingViewEventRow &&
+          other.id == this.id &&
+          other.videoId == this.videoId &&
+          other.videoPubkey == this.videoPubkey &&
+          other.videoVineId == this.videoVineId &&
+          other.userPubkey == this.userPubkey &&
+          other.watchDurationMs == this.watchDurationMs &&
+          other.totalDurationMs == this.totalDurationMs &&
+          other.loopCount == this.loopCount &&
+          other.trafficSource == this.trafficSource &&
+          other.sourceDetail == this.sourceDetail &&
+          other.status == this.status &&
+          other.retryCount == this.retryCount &&
+          other.lastError == this.lastError &&
+          other.lastAttemptAt == this.lastAttemptAt &&
+          other.createdAt == this.createdAt);
+}
+
+class PendingViewEventsCompanion extends UpdateCompanion<PendingViewEventRow> {
+  final Value<String> id;
+  final Value<String> videoId;
+  final Value<String> videoPubkey;
+  final Value<String?> videoVineId;
+  final Value<String> userPubkey;
+  final Value<int> watchDurationMs;
+  final Value<int?> totalDurationMs;
+  final Value<int?> loopCount;
+  final Value<String> trafficSource;
+  final Value<String?> sourceDetail;
+  final Value<String> status;
+  final Value<int> retryCount;
+  final Value<String?> lastError;
+  final Value<DateTime?> lastAttemptAt;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const PendingViewEventsCompanion({
+    this.id = const Value.absent(),
+    this.videoId = const Value.absent(),
+    this.videoPubkey = const Value.absent(),
+    this.videoVineId = const Value.absent(),
+    this.userPubkey = const Value.absent(),
+    this.watchDurationMs = const Value.absent(),
+    this.totalDurationMs = const Value.absent(),
+    this.loopCount = const Value.absent(),
+    this.trafficSource = const Value.absent(),
+    this.sourceDetail = const Value.absent(),
+    this.status = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PendingViewEventsCompanion.insert({
+    required String id,
+    required String videoId,
+    required String videoPubkey,
+    this.videoVineId = const Value.absent(),
+    required String userPubkey,
+    required int watchDurationMs,
+    this.totalDurationMs = const Value.absent(),
+    this.loopCount = const Value.absent(),
+    required String trafficSource,
+    this.sourceDetail = const Value.absent(),
+    required String status,
+    this.retryCount = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    required DateTime createdAt,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       videoId = Value(videoId),
+       videoPubkey = Value(videoPubkey),
+       userPubkey = Value(userPubkey),
+       watchDurationMs = Value(watchDurationMs),
+       trafficSource = Value(trafficSource),
+       status = Value(status),
+       createdAt = Value(createdAt);
+  static Insertable<PendingViewEventRow> custom({
+    Expression<String>? id,
+    Expression<String>? videoId,
+    Expression<String>? videoPubkey,
+    Expression<String>? videoVineId,
+    Expression<String>? userPubkey,
+    Expression<int>? watchDurationMs,
+    Expression<int>? totalDurationMs,
+    Expression<int>? loopCount,
+    Expression<String>? trafficSource,
+    Expression<String>? sourceDetail,
+    Expression<String>? status,
+    Expression<int>? retryCount,
+    Expression<String>? lastError,
+    Expression<DateTime>? lastAttemptAt,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (videoId != null) 'video_id': videoId,
+      if (videoPubkey != null) 'video_pubkey': videoPubkey,
+      if (videoVineId != null) 'video_vine_id': videoVineId,
+      if (userPubkey != null) 'user_pubkey': userPubkey,
+      if (watchDurationMs != null) 'watch_duration_ms': watchDurationMs,
+      if (totalDurationMs != null) 'total_duration_ms': totalDurationMs,
+      if (loopCount != null) 'loop_count': loopCount,
+      if (trafficSource != null) 'traffic_source': trafficSource,
+      if (sourceDetail != null) 'source_detail': sourceDetail,
+      if (status != null) 'status': status,
+      if (retryCount != null) 'retry_count': retryCount,
+      if (lastError != null) 'last_error': lastError,
+      if (lastAttemptAt != null) 'last_attempt_at': lastAttemptAt,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PendingViewEventsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? videoId,
+    Value<String>? videoPubkey,
+    Value<String?>? videoVineId,
+    Value<String>? userPubkey,
+    Value<int>? watchDurationMs,
+    Value<int?>? totalDurationMs,
+    Value<int?>? loopCount,
+    Value<String>? trafficSource,
+    Value<String?>? sourceDetail,
+    Value<String>? status,
+    Value<int>? retryCount,
+    Value<String?>? lastError,
+    Value<DateTime?>? lastAttemptAt,
+    Value<DateTime>? createdAt,
+    Value<int>? rowid,
+  }) {
+    return PendingViewEventsCompanion(
+      id: id ?? this.id,
+      videoId: videoId ?? this.videoId,
+      videoPubkey: videoPubkey ?? this.videoPubkey,
+      videoVineId: videoVineId ?? this.videoVineId,
+      userPubkey: userPubkey ?? this.userPubkey,
+      watchDurationMs: watchDurationMs ?? this.watchDurationMs,
+      totalDurationMs: totalDurationMs ?? this.totalDurationMs,
+      loopCount: loopCount ?? this.loopCount,
+      trafficSource: trafficSource ?? this.trafficSource,
+      sourceDetail: sourceDetail ?? this.sourceDetail,
+      status: status ?? this.status,
+      retryCount: retryCount ?? this.retryCount,
+      lastError: lastError ?? this.lastError,
+      lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (videoId.present) {
+      map['video_id'] = Variable<String>(videoId.value);
+    }
+    if (videoPubkey.present) {
+      map['video_pubkey'] = Variable<String>(videoPubkey.value);
+    }
+    if (videoVineId.present) {
+      map['video_vine_id'] = Variable<String>(videoVineId.value);
+    }
+    if (userPubkey.present) {
+      map['user_pubkey'] = Variable<String>(userPubkey.value);
+    }
+    if (watchDurationMs.present) {
+      map['watch_duration_ms'] = Variable<int>(watchDurationMs.value);
+    }
+    if (totalDurationMs.present) {
+      map['total_duration_ms'] = Variable<int>(totalDurationMs.value);
+    }
+    if (loopCount.present) {
+      map['loop_count'] = Variable<int>(loopCount.value);
+    }
+    if (trafficSource.present) {
+      map['traffic_source'] = Variable<String>(trafficSource.value);
+    }
+    if (sourceDetail.present) {
+      map['source_detail'] = Variable<String>(sourceDetail.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (retryCount.present) {
+      map['retry_count'] = Variable<int>(retryCount.value);
+    }
+    if (lastError.present) {
+      map['last_error'] = Variable<String>(lastError.value);
+    }
+    if (lastAttemptAt.present) {
+      map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingViewEventsCompanion(')
+          ..write('id: $id, ')
+          ..write('videoId: $videoId, ')
+          ..write('videoPubkey: $videoPubkey, ')
+          ..write('videoVineId: $videoVineId, ')
+          ..write('userPubkey: $userPubkey, ')
+          ..write('watchDurationMs: $watchDurationMs, ')
+          ..write('totalDurationMs: $totalDurationMs, ')
+          ..write('loopCount: $loopCount, ')
+          ..write('trafficSource: $trafficSource, ')
+          ..write('sourceDetail: $sourceDetail, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('lastError: $lastError, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -12225,6 +13120,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $DmMessageReactionsTable(this);
   late final $ConversationsTable conversations = $ConversationsTable(this);
   late final $OutgoingDmsTable outgoingDms = $OutgoingDmsTable(this);
+  late final $PendingViewEventsTable pendingViewEvents =
+      $PendingViewEventsTable(this);
   late final UserProfilesDao userProfilesDao = UserProfilesDao(
     this as AppDatabase,
   );
@@ -12271,6 +13168,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final OutgoingDmsDao outgoingDmsDao = OutgoingDmsDao(
     this as AppDatabase,
   );
+  late final PendingViewEventsDao pendingViewEventsDao = PendingViewEventsDao(
+    this as AppDatabase,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -12293,6 +13193,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     dmMessageReactions,
     conversations,
     outgoingDms,
+    pendingViewEvents,
   ];
 }
 
@@ -17937,6 +18838,427 @@ typedef $$OutgoingDmsTableProcessedTableManager =
       OutgoingDmRow,
       PrefetchHooks Function()
     >;
+typedef $$PendingViewEventsTableCreateCompanionBuilder =
+    PendingViewEventsCompanion Function({
+      required String id,
+      required String videoId,
+      required String videoPubkey,
+      Value<String?> videoVineId,
+      required String userPubkey,
+      required int watchDurationMs,
+      Value<int?> totalDurationMs,
+      Value<int?> loopCount,
+      required String trafficSource,
+      Value<String?> sourceDetail,
+      required String status,
+      Value<int> retryCount,
+      Value<String?> lastError,
+      Value<DateTime?> lastAttemptAt,
+      required DateTime createdAt,
+      Value<int> rowid,
+    });
+typedef $$PendingViewEventsTableUpdateCompanionBuilder =
+    PendingViewEventsCompanion Function({
+      Value<String> id,
+      Value<String> videoId,
+      Value<String> videoPubkey,
+      Value<String?> videoVineId,
+      Value<String> userPubkey,
+      Value<int> watchDurationMs,
+      Value<int?> totalDurationMs,
+      Value<int?> loopCount,
+      Value<String> trafficSource,
+      Value<String?> sourceDetail,
+      Value<String> status,
+      Value<int> retryCount,
+      Value<String?> lastError,
+      Value<DateTime?> lastAttemptAt,
+      Value<DateTime> createdAt,
+      Value<int> rowid,
+    });
+
+class $$PendingViewEventsTableFilterComposer
+    extends Composer<_$AppDatabase, $PendingViewEventsTable> {
+  $$PendingViewEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get videoId => $composableBuilder(
+    column: $table.videoId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get videoPubkey => $composableBuilder(
+    column: $table.videoPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get videoVineId => $composableBuilder(
+    column: $table.videoVineId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get userPubkey => $composableBuilder(
+    column: $table.userPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get watchDurationMs => $composableBuilder(
+    column: $table.watchDurationMs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get totalDurationMs => $composableBuilder(
+    column: $table.totalDurationMs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get loopCount => $composableBuilder(
+    column: $table.loopCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get trafficSource => $composableBuilder(
+    column: $table.trafficSource,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get sourceDetail => $composableBuilder(
+    column: $table.sourceDetail,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PendingViewEventsTableOrderingComposer
+    extends Composer<_$AppDatabase, $PendingViewEventsTable> {
+  $$PendingViewEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get videoId => $composableBuilder(
+    column: $table.videoId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get videoPubkey => $composableBuilder(
+    column: $table.videoPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get videoVineId => $composableBuilder(
+    column: $table.videoVineId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get userPubkey => $composableBuilder(
+    column: $table.userPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get watchDurationMs => $composableBuilder(
+    column: $table.watchDurationMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get totalDurationMs => $composableBuilder(
+    column: $table.totalDurationMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get loopCount => $composableBuilder(
+    column: $table.loopCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get trafficSource => $composableBuilder(
+    column: $table.trafficSource,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get sourceDetail => $composableBuilder(
+    column: $table.sourceDetail,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PendingViewEventsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PendingViewEventsTable> {
+  $$PendingViewEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get videoId =>
+      $composableBuilder(column: $table.videoId, builder: (column) => column);
+
+  GeneratedColumn<String> get videoPubkey => $composableBuilder(
+    column: $table.videoPubkey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get videoVineId => $composableBuilder(
+    column: $table.videoVineId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get userPubkey => $composableBuilder(
+    column: $table.userPubkey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get watchDurationMs => $composableBuilder(
+    column: $table.watchDurationMs,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get totalDurationMs => $composableBuilder(
+    column: $table.totalDurationMs,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get loopCount =>
+      $composableBuilder(column: $table.loopCount, builder: (column) => column);
+
+  GeneratedColumn<String> get trafficSource => $composableBuilder(
+    column: $table.trafficSource,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get sourceDetail => $composableBuilder(
+    column: $table.sourceDetail,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get lastError =>
+      $composableBuilder(column: $table.lastError, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$PendingViewEventsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PendingViewEventsTable,
+          PendingViewEventRow,
+          $$PendingViewEventsTableFilterComposer,
+          $$PendingViewEventsTableOrderingComposer,
+          $$PendingViewEventsTableAnnotationComposer,
+          $$PendingViewEventsTableCreateCompanionBuilder,
+          $$PendingViewEventsTableUpdateCompanionBuilder,
+          (
+            PendingViewEventRow,
+            BaseReferences<
+              _$AppDatabase,
+              $PendingViewEventsTable,
+              PendingViewEventRow
+            >,
+          ),
+          PendingViewEventRow,
+          PrefetchHooks Function()
+        > {
+  $$PendingViewEventsTableTableManager(
+    _$AppDatabase db,
+    $PendingViewEventsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PendingViewEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PendingViewEventsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PendingViewEventsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> videoId = const Value.absent(),
+                Value<String> videoPubkey = const Value.absent(),
+                Value<String?> videoVineId = const Value.absent(),
+                Value<String> userPubkey = const Value.absent(),
+                Value<int> watchDurationMs = const Value.absent(),
+                Value<int?> totalDurationMs = const Value.absent(),
+                Value<int?> loopCount = const Value.absent(),
+                Value<String> trafficSource = const Value.absent(),
+                Value<String?> sourceDetail = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<DateTime?> lastAttemptAt = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PendingViewEventsCompanion(
+                id: id,
+                videoId: videoId,
+                videoPubkey: videoPubkey,
+                videoVineId: videoVineId,
+                userPubkey: userPubkey,
+                watchDurationMs: watchDurationMs,
+                totalDurationMs: totalDurationMs,
+                loopCount: loopCount,
+                trafficSource: trafficSource,
+                sourceDetail: sourceDetail,
+                status: status,
+                retryCount: retryCount,
+                lastError: lastError,
+                lastAttemptAt: lastAttemptAt,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String videoId,
+                required String videoPubkey,
+                Value<String?> videoVineId = const Value.absent(),
+                required String userPubkey,
+                required int watchDurationMs,
+                Value<int?> totalDurationMs = const Value.absent(),
+                Value<int?> loopCount = const Value.absent(),
+                required String trafficSource,
+                Value<String?> sourceDetail = const Value.absent(),
+                required String status,
+                Value<int> retryCount = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<DateTime?> lastAttemptAt = const Value.absent(),
+                required DateTime createdAt,
+                Value<int> rowid = const Value.absent(),
+              }) => PendingViewEventsCompanion.insert(
+                id: id,
+                videoId: videoId,
+                videoPubkey: videoPubkey,
+                videoVineId: videoVineId,
+                userPubkey: userPubkey,
+                watchDurationMs: watchDurationMs,
+                totalDurationMs: totalDurationMs,
+                loopCount: loopCount,
+                trafficSource: trafficSource,
+                sourceDetail: sourceDetail,
+                status: status,
+                retryCount: retryCount,
+                lastError: lastError,
+                lastAttemptAt: lastAttemptAt,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PendingViewEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PendingViewEventsTable,
+      PendingViewEventRow,
+      $$PendingViewEventsTableFilterComposer,
+      $$PendingViewEventsTableOrderingComposer,
+      $$PendingViewEventsTableAnnotationComposer,
+      $$PendingViewEventsTableCreateCompanionBuilder,
+      $$PendingViewEventsTableUpdateCompanionBuilder,
+      (
+        PendingViewEventRow,
+        BaseReferences<
+          _$AppDatabase,
+          $PendingViewEventsTable,
+          PendingViewEventRow
+        >,
+      ),
+      PendingViewEventRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -17975,4 +19297,6 @@ class $AppDatabaseManager {
       $$ConversationsTableTableManager(_db, _db.conversations);
   $$OutgoingDmsTableTableManager get outgoingDms =>
       $$OutgoingDmsTableTableManager(_db, _db.outgoingDms);
+  $$PendingViewEventsTableTableManager get pendingViewEvents =>
+      $$PendingViewEventsTableTableManager(_db, _db.pendingViewEvents);
 }

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -10,6 +10,7 @@ export 'notifications_dao.dart';
 export 'outgoing_dms_dao.dart';
 export 'pending_actions_dao.dart';
 export 'pending_uploads_dao.dart';
+export 'pending_view_events_dao.dart';
 export 'personal_reactions_dao.dart';
 export 'personal_reposts_dao.dart';
 export 'profile_stats_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/pending_view_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_view_events_dao.dart
@@ -1,0 +1,242 @@
+// ABOUTME: Data Access Object for the durable video view-event outbox.
+// ABOUTME: Stores finalized views until kind 22236 relay publish succeeds.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
+
+part 'pending_view_events_dao.g.dart';
+
+enum PendingViewEventStatus {
+  pending,
+  publishing,
+  failed,
+}
+
+class UnknownPendingViewEventStatusException implements Exception {
+  const UnknownPendingViewEventStatusException(this.rawValue);
+
+  final String rawValue;
+
+  @override
+  String toString() {
+    final known = PendingViewEventStatus.values.map((e) => e.name).join(', ');
+    return 'UnknownPendingViewEventStatusException: '
+        'unrecognised pending_view_events status "$rawValue"; '
+        'expected one of $known';
+  }
+}
+
+@immutable
+class PendingViewEvent {
+  const PendingViewEvent({
+    required this.id,
+    required this.videoId,
+    required this.videoPubkey,
+    required this.userPubkey,
+    required this.watchDurationMs,
+    required this.trafficSource,
+    required this.status,
+    required this.createdAt,
+    this.videoVineId,
+    this.totalDurationMs,
+    this.loopCount,
+    this.sourceDetail,
+    this.retryCount = 0,
+    this.lastError,
+    this.lastAttemptAt,
+  });
+
+  final String id;
+  final String videoId;
+  final String videoPubkey;
+  final String? videoVineId;
+  final String userPubkey;
+  final int watchDurationMs;
+  final int? totalDurationMs;
+  final int? loopCount;
+  final String trafficSource;
+  final String? sourceDetail;
+  final PendingViewEventStatus status;
+  final int retryCount;
+  final String? lastError;
+  final DateTime? lastAttemptAt;
+  final DateTime createdAt;
+
+  PendingViewEvent copyWith({
+    String? id,
+    String? videoId,
+    String? videoPubkey,
+    String? videoVineId,
+    String? userPubkey,
+    int? watchDurationMs,
+    int? totalDurationMs,
+    int? loopCount,
+    String? trafficSource,
+    String? sourceDetail,
+    PendingViewEventStatus? status,
+    int? retryCount,
+    String? lastError,
+    DateTime? lastAttemptAt,
+    DateTime? createdAt,
+  }) => PendingViewEvent(
+    id: id ?? this.id,
+    videoId: videoId ?? this.videoId,
+    videoPubkey: videoPubkey ?? this.videoPubkey,
+    videoVineId: videoVineId ?? this.videoVineId,
+    userPubkey: userPubkey ?? this.userPubkey,
+    watchDurationMs: watchDurationMs ?? this.watchDurationMs,
+    totalDurationMs: totalDurationMs ?? this.totalDurationMs,
+    loopCount: loopCount ?? this.loopCount,
+    trafficSource: trafficSource ?? this.trafficSource,
+    sourceDetail: sourceDetail ?? this.sourceDetail,
+    status: status ?? this.status,
+    retryCount: retryCount ?? this.retryCount,
+    lastError: lastError ?? this.lastError,
+    lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+    createdAt: createdAt ?? this.createdAt,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PendingViewEvent &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}
+
+@DriftAccessor(tables: [PendingViewEvents])
+class PendingViewEventsDao extends DatabaseAccessor<AppDatabase>
+    with _$PendingViewEventsDaoMixin {
+  PendingViewEventsDao(super.attachedDatabase);
+
+  PendingViewEventsCompanion _modelToCompanion(PendingViewEvent event) {
+    return PendingViewEventsCompanion.insert(
+      id: event.id,
+      videoId: event.videoId,
+      videoPubkey: event.videoPubkey,
+      videoVineId: Value(event.videoVineId),
+      userPubkey: event.userPubkey,
+      watchDurationMs: event.watchDurationMs,
+      totalDurationMs: Value(event.totalDurationMs),
+      loopCount: Value(event.loopCount),
+      trafficSource: event.trafficSource,
+      sourceDetail: Value(event.sourceDetail),
+      status: event.status.name,
+      retryCount: Value(event.retryCount),
+      lastError: Value(event.lastError),
+      lastAttemptAt: Value(event.lastAttemptAt),
+      createdAt: event.createdAt,
+    );
+  }
+
+  PendingViewEvent _rowToModel(PendingViewEventRow row) {
+    return PendingViewEvent(
+      id: row.id,
+      videoId: row.videoId,
+      videoPubkey: row.videoPubkey,
+      videoVineId: row.videoVineId,
+      userPubkey: row.userPubkey,
+      watchDurationMs: row.watchDurationMs,
+      totalDurationMs: row.totalDurationMs,
+      loopCount: row.loopCount,
+      trafficSource: row.trafficSource,
+      sourceDetail: row.sourceDetail,
+      status: _parseStatus(row.status),
+      retryCount: row.retryCount,
+      lastError: row.lastError,
+      lastAttemptAt: row.lastAttemptAt,
+      createdAt: row.createdAt,
+    );
+  }
+
+  PendingViewEventStatus _parseStatus(String raw) {
+    for (final status in PendingViewEventStatus.values) {
+      if (status.name == raw) return status;
+    }
+    throw UnknownPendingViewEventStatusException(raw);
+  }
+
+  Future<void> enqueue(PendingViewEvent event) async {
+    await into(pendingViewEvents).insert(
+      _modelToCompanion(event),
+      mode: InsertMode.insertOrIgnore,
+    );
+  }
+
+  Future<bool> markPublishing(String id) async {
+    final rows =
+        await (update(pendingViewEvents)..where((t) => t.id.equals(id))).write(
+          PendingViewEventsCompanion(
+            status: Value(PendingViewEventStatus.publishing.name),
+            lastAttemptAt: Value(DateTime.now()),
+          ),
+        );
+    return rows > 0;
+  }
+
+  Future<bool> markFailed(String id, String error) async {
+    return transaction(() async {
+      final row = await (select(
+        pendingViewEvents,
+      )..where((t) => t.id.equals(id))).getSingleOrNull();
+      if (row == null) return false;
+
+      final rows =
+          await (update(
+            pendingViewEvents,
+          )..where((t) => t.id.equals(id))).write(
+            PendingViewEventsCompanion(
+              status: Value(PendingViewEventStatus.failed.name),
+              retryCount: Value(row.retryCount + 1),
+              lastError: Value(error),
+              lastAttemptAt: Value(DateTime.now()),
+            ),
+          );
+      return rows > 0;
+    });
+  }
+
+  Future<int> resetPublishingToPending(String userPubkey) {
+    return (update(pendingViewEvents)..where(
+          (t) =>
+              t.userPubkey.equals(userPubkey) &
+              t.status.equals(PendingViewEventStatus.publishing.name),
+        ))
+        .write(
+          PendingViewEventsCompanion(
+            status: Value(PendingViewEventStatus.pending.name),
+          ),
+        );
+  }
+
+  Future<int> deleteById(String id) {
+    return (delete(pendingViewEvents)..where((t) => t.id.equals(id))).go();
+  }
+
+  Future<PendingViewEvent?> getById(String id) async {
+    final row = await (select(
+      pendingViewEvents,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    return row == null ? null : _rowToModel(row);
+  }
+
+  Future<List<PendingViewEvent>> getRetryableForUser({
+    required String userPubkey,
+    required int maxRetries,
+  }) async {
+    final query = select(pendingViewEvents)
+      ..where(
+        (t) =>
+            t.userPubkey.equals(userPubkey) &
+            (t.status.equals(PendingViewEventStatus.pending.name) |
+                t.status.equals(PendingViewEventStatus.failed.name)),
+      )
+      ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/pending_view_events_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_view_events_dao.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_view_events_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$PendingViewEventsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $PendingViewEventsTable get pendingViewEvents =>
+      attachedDatabase.pendingViewEvents;
+  PendingViewEventsDaoManager get managers => PendingViewEventsDaoManager(this);
+}
+
+class PendingViewEventsDaoManager {
+  final _$PendingViewEventsDaoMixin _db;
+  PendingViewEventsDaoManager(this._db);
+  $$PendingViewEventsTableTableManager get pendingViewEvents =>
+      $$PendingViewEventsTableTableManager(
+        _db.attachedDatabase,
+        _db.pendingViewEvents,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1163,3 +1163,59 @@ class OutgoingDms extends Table {
     ),
   ];
 }
+
+/// Durable queue of finalized video view events awaiting relay publish.
+@DataClassName('PendingViewEventRow')
+class PendingViewEvents extends Table {
+  @override
+  String get tableName => 'pending_view_events';
+
+  TextColumn get id => text()();
+
+  TextColumn get videoId => text().named('video_id')();
+
+  TextColumn get videoPubkey => text().named('video_pubkey')();
+
+  TextColumn get videoVineId => text().nullable().named('video_vine_id')();
+
+  TextColumn get userPubkey => text().named('user_pubkey')();
+
+  IntColumn get watchDurationMs => integer().named('watch_duration_ms')();
+
+  IntColumn get totalDurationMs =>
+      integer().nullable().named('total_duration_ms')();
+
+  IntColumn get loopCount => integer().nullable().named('loop_count')();
+
+  TextColumn get trafficSource => text().named('traffic_source')();
+
+  TextColumn get sourceDetail => text().nullable().named('source_detail')();
+
+  TextColumn get status => text()();
+
+  IntColumn get retryCount =>
+      integer().withDefault(const Constant(0)).named('retry_count')();
+
+  TextColumn get lastError => text().nullable().named('last_error')();
+
+  DateTimeColumn get lastAttemptAt =>
+      dateTime().nullable().named('last_attempt_at')();
+
+  DateTimeColumn get createdAt => dateTime().named('created_at')();
+
+  @override
+  Set<Column> get primaryKey => {id};
+
+  List<Index> get indexes => [
+    Index(
+      'idx_pending_view_events_user_status',
+      'CREATE INDEX IF NOT EXISTS idx_pending_view_events_user_status '
+          'ON pending_view_events (user_pubkey, status)',
+    ),
+    Index(
+      'idx_pending_view_events_created_at',
+      'CREATE INDEX IF NOT EXISTS idx_pending_view_events_created_at '
+          'ON pending_view_events (created_at)',
+    ),
+  ];
+}

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -365,6 +365,117 @@ void main() {
         },
       );
 
+      test('upgrade path — recreates pending_view_events when missing', () async {
+        await database.customStatement('DROP TABLE pending_view_events');
+
+        final droppedCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' "
+              "AND name='pending_view_events'",
+            )
+            .get();
+        expect(
+          droppedCheck,
+          isEmpty,
+          reason: 'precondition: pending_view_events must be missing',
+        );
+
+        await database.close();
+        database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+        final tableCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' "
+              "AND name='pending_view_events'",
+            )
+            .get();
+        expect(
+          tableCheck,
+          hasLength(1),
+          reason: 'pending_view_events must be re-created on reopen',
+        );
+
+        final indexNames = await _collectIndexNames(
+          database,
+          'pending_view_events',
+        );
+        expect(
+          indexNames,
+          containsAll(<String>{
+            'idx_pending_view_events_user_status',
+            'idx_pending_view_events_created_at',
+          }),
+        );
+
+        final dao = database.pendingViewEventsDao;
+        await dao.enqueue(
+          PendingViewEvent(
+            id: 'upgrade-view-id',
+            videoId:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            videoPubkey: testPubkey,
+            userPubkey: testPubkey,
+            watchDurationMs: 2500,
+            trafficSource: 'home',
+            status: PendingViewEventStatus.pending,
+            createdAt: DateTime.utc(2026, 5),
+          ),
+        );
+
+        final fetched = await dao.getById('upgrade-view-id');
+        expect(fetched, isNotNull);
+        expect(fetched!.status, PendingViewEventStatus.pending);
+        expect(fetched.watchDurationMs, 2500);
+      });
+
+      test(
+        'schema parity — pending_view_events fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'pending_view_events',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'pending_view_events',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have pending_view_events',
+          );
+
+          await database.customStatement('DROP TABLE pending_view_events');
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_view_events'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'pending_view_events',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'pending_view_events',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+
       test('does not delete non-expired data', () async {
         final eventsDao = database.nostrEventsDao;
         final profileStatsDao = database.profileStatsDao;

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -365,7 +365,7 @@ void main() {
         },
       );
 
-      test('upgrade path — recreates pending_view_events when missing', () async {
+      test('upgrade path recreates pending_view_events when missing', () async {
         await database.customStatement('DROP TABLE pending_view_events');
 
         final droppedCheck = await database
@@ -411,8 +411,7 @@ void main() {
         await dao.enqueue(
           PendingViewEvent(
             id: 'upgrade-view-id',
-            videoId:
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            videoId: testPubkey,
             videoPubkey: testPubkey,
             userPubkey: testPubkey,
             watchDurationMs: 2500,

--- a/mobile/packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart
@@ -18,8 +18,6 @@ void main() {
       'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
   const videoIdA =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-  const videoIdB =
-      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
   const authorPubkey =
       'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 
@@ -162,7 +160,7 @@ void main() {
 
     group('getRetryableForUser', () {
       test(
-        'returns pending and failed rows including exhausted retries oldest first',
+        'returns retryable pending, failed, and exhausted rows oldest first',
         () async {
           await dao.enqueue(
             makeEvent(
@@ -182,7 +180,6 @@ void main() {
           await dao.enqueue(
             makeEvent(
               id: 'pending-new',
-              status: PendingViewEventStatus.pending,
               createdAt: DateTime.utc(2026, 5, 3),
             ),
           );
@@ -198,7 +195,6 @@ void main() {
             makeEvent(
               id: 'other-user',
               userPubkey: userB,
-              status: PendingViewEventStatus.pending,
               createdAt: DateTime.utc(2026, 5, 5),
             ),
           );
@@ -227,9 +223,7 @@ void main() {
               status: PendingViewEventStatus.publishing,
             ),
           );
-          await dao.enqueue(
-            makeEvent(id: 'pending-a', status: PendingViewEventStatus.pending),
-          );
+          await dao.enqueue(makeEvent(id: 'pending-a'));
           await dao.enqueue(
             makeEvent(
               id: 'publishing-b',

--- a/mobile/packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart
@@ -1,0 +1,271 @@
+// ABOUTME: Unit tests for PendingViewEventsDao durable view-event outbox.
+// ABOUTME: Covers enqueue, retry filtering, status transitions, and cleanup.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late PendingViewEventsDao dao;
+  late String tempDbPath;
+
+  const userA =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const userB =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+  const videoIdA =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const videoIdB =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const authorPubkey =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+  PendingViewEvent makeEvent({
+    required String id,
+    String userPubkey = userA,
+    String videoId = videoIdA,
+    PendingViewEventStatus status = PendingViewEventStatus.pending,
+    int retryCount = 0,
+    DateTime? createdAt,
+    DateTime? lastAttemptAt,
+    String? lastError,
+  }) {
+    return PendingViewEvent(
+      id: id,
+      videoId: videoId,
+      videoPubkey: authorPubkey,
+      videoVineId: 'vine-$id',
+      userPubkey: userPubkey,
+      watchDurationMs: 2500,
+      totalDurationMs: 6000,
+      loopCount: 1,
+      trafficSource: 'home',
+      sourceDetail: 'following',
+      status: status,
+      retryCount: retryCount,
+      lastError: lastError,
+      lastAttemptAt: lastAttemptAt,
+      createdAt: createdAt ?? DateTime.utc(2026, 5),
+    );
+  }
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'pending_view_events_test_',
+    );
+    tempDbPath = '${tempDir.path}/test.db';
+
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.pendingViewEventsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final file = File(tempDbPath);
+    if (file.existsSync()) {
+      file.deleteSync();
+    }
+    final dir = Directory(tempDbPath).parent;
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  });
+
+  group('PendingViewEventsDao', () {
+    group('enqueue', () {
+      test('inserts a pending view event with all publish fields', () async {
+        await dao.enqueue(makeEvent(id: 'view-a'));
+
+        final fetched = await dao.getById('view-a');
+
+        expect(fetched, isNotNull);
+        expect(fetched!.status, PendingViewEventStatus.pending);
+        expect(fetched.videoId, videoIdA);
+        expect(fetched.videoPubkey, authorPubkey);
+        expect(fetched.videoVineId, 'vine-view-a');
+        expect(fetched.userPubkey, userA);
+        expect(fetched.watchDurationMs, 2500);
+        expect(fetched.totalDurationMs, 6000);
+        expect(fetched.loopCount, 1);
+        expect(fetched.trafficSource, 'home');
+        expect(fetched.sourceDetail, 'following');
+        expect(fetched.retryCount, 0);
+        expect(fetched.lastError, isNull);
+        expect(fetched.lastAttemptAt, isNull);
+      });
+
+      test('re-enqueueing the same id preserves delivery state', () async {
+        await dao.enqueue(makeEvent(id: 'view-a'));
+        await dao.markPublishing('view-a');
+        await dao.markFailed('view-a', 'relay timeout');
+
+        await dao.enqueue(makeEvent(id: 'view-a'));
+
+        final fetched = await dao.getById('view-a');
+        expect(fetched!.status, PendingViewEventStatus.failed);
+        expect(fetched.retryCount, 1);
+        expect(fetched.lastError, 'relay timeout');
+        expect(fetched.lastAttemptAt, isNotNull);
+      });
+    });
+
+    group('status updates', () {
+      test(
+        'markPublishing moves row to publishing and records attempt time',
+        () async {
+          await dao.enqueue(makeEvent(id: 'view-a'));
+
+          final before = DateTime.now();
+          final updated = await dao.markPublishing('view-a');
+          final after = DateTime.now();
+
+          expect(updated, isTrue);
+          final fetched = await dao.getById('view-a');
+          expect(fetched!.status, PendingViewEventStatus.publishing);
+          expect(fetched.lastAttemptAt, isNotNull);
+          expect(
+            fetched.lastAttemptAt!.isAfter(
+              before.subtract(const Duration(seconds: 2)),
+            ),
+            isTrue,
+          );
+          expect(
+            fetched.lastAttemptAt!.isBefore(
+              after.add(const Duration(seconds: 2)),
+            ),
+            isTrue,
+          );
+        },
+      );
+
+      test('markFailed records error and increments retry count', () async {
+        await dao.enqueue(makeEvent(id: 'view-a'));
+
+        final updated = await dao.markFailed('view-a', 'relay rejected');
+
+        expect(updated, isTrue);
+        final fetched = await dao.getById('view-a');
+        expect(fetched!.status, PendingViewEventStatus.failed);
+        expect(fetched.retryCount, 1);
+        expect(fetched.lastError, 'relay rejected');
+        expect(fetched.lastAttemptAt, isNotNull);
+      });
+
+      test('returns false when updating a missing row', () async {
+        expect(await dao.markPublishing('missing'), isFalse);
+        expect(await dao.markFailed('missing', 'no row'), isFalse);
+      });
+    });
+
+    group('getRetryableForUser', () {
+      test(
+        'returns pending and failed rows including exhausted retries oldest first',
+        () async {
+          await dao.enqueue(
+            makeEvent(
+              id: 'publishing',
+              status: PendingViewEventStatus.publishing,
+              createdAt: DateTime.utc(2026, 5),
+            ),
+          );
+          await dao.enqueue(
+            makeEvent(
+              id: 'failed-old',
+              status: PendingViewEventStatus.failed,
+              retryCount: 2,
+              createdAt: DateTime.utc(2026, 5, 2),
+            ),
+          );
+          await dao.enqueue(
+            makeEvent(
+              id: 'pending-new',
+              status: PendingViewEventStatus.pending,
+              createdAt: DateTime.utc(2026, 5, 3),
+            ),
+          );
+          await dao.enqueue(
+            makeEvent(
+              id: 'exhausted',
+              status: PendingViewEventStatus.failed,
+              retryCount: 5,
+              createdAt: DateTime.utc(2026, 5, 4),
+            ),
+          );
+          await dao.enqueue(
+            makeEvent(
+              id: 'other-user',
+              userPubkey: userB,
+              status: PendingViewEventStatus.pending,
+              createdAt: DateTime.utc(2026, 5, 5),
+            ),
+          );
+
+          final retryable = await dao.getRetryableForUser(
+            userPubkey: userA,
+            maxRetries: 5,
+          );
+
+          expect(retryable.map((event) => event.id), [
+            'failed-old',
+            'pending-new',
+            'exhausted',
+          ]);
+        },
+      );
+    });
+
+    group('resetPublishingToPending', () {
+      test(
+        'resets interrupted publishing rows for the selected user',
+        () async {
+          await dao.enqueue(
+            makeEvent(
+              id: 'publishing-a',
+              status: PendingViewEventStatus.publishing,
+            ),
+          );
+          await dao.enqueue(
+            makeEvent(id: 'pending-a', status: PendingViewEventStatus.pending),
+          );
+          await dao.enqueue(
+            makeEvent(
+              id: 'publishing-b',
+              userPubkey: userB,
+              status: PendingViewEventStatus.publishing,
+            ),
+          );
+
+          final reset = await dao.resetPublishingToPending(userA);
+
+          expect(reset, 1);
+          expect(
+            (await dao.getById('publishing-a'))!.status,
+            PendingViewEventStatus.pending,
+          );
+          expect(
+            (await dao.getById('pending-a'))!.status,
+            PendingViewEventStatus.pending,
+          );
+          expect(
+            (await dao.getById('publishing-b'))!.status,
+            PendingViewEventStatus.publishing,
+          );
+        },
+      );
+    });
+
+    group('deleteById', () {
+      test('removes the row after publish success', () async {
+        await dao.enqueue(makeEvent(id: 'view-a'));
+
+        final deleted = await dao.deleteById('view-a');
+
+        expect(deleted, 1);
+        expect(await dao.getById('view-a'), isNull);
+      });
+    });
+  });
+}

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_metrics_tracker.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart'
     as video_platform;
@@ -124,6 +125,7 @@ void main() {
       await tester.pump();
 
       expect(find.byType(WebVideoFeed), findsOneWidget);
+      expect(find.byType(VideoMetricsTracker), findsOneWidget);
       expect(find.byType(VideoOverlayActions), findsOneWidget);
     }, skip: !kIsWeb);
 

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -27,6 +27,7 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
@@ -767,7 +768,10 @@ void main() {
       );
     }
 
-    void stubControllerForVideo(VideoEvent video) {
+    void stubControllerForVideo(
+      VideoEvent video, {
+      VideoIndexState indexState = const VideoIndexState(),
+    }) {
       when(() => videoFeedController.videoCount).thenReturn(1);
       when(
         () => videoFeedController.videos,
@@ -776,7 +780,7 @@ void main() {
       when(() => videoFeedController.onPageChanged(any())).thenReturn(null);
       when(
         () => videoFeedController.getIndexNotifier(any()),
-      ).thenReturn(ValueNotifier(const VideoIndexState()));
+      ).thenReturn(ValueNotifier(indexState));
     }
 
     testWidgets(
@@ -851,6 +855,34 @@ void main() {
         expect(pooledVideoFeed.physics, isA<AlwaysScrollableScrollPhysics>());
       },
     );
+
+    testWidgets('mounts a metrics tracker for pooled feed playback', (
+      tester,
+    ) async {
+      final positionController = StreamController<Duration>.broadcast();
+      addTearDown(positionController.close);
+      final player = _stubPlayer(positionController.stream);
+      final testVideo = createTestVideoEvent();
+      final state = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: [testVideo],
+      );
+
+      stubControllerForVideo(
+        testVideo,
+        indexState: VideoIndexState(player: player),
+      );
+
+      await tester.pumpWidget(buildSubject(state));
+      await tester.pump();
+
+      final tracker = tester.widget<PooledVideoMetricsTracker>(
+        find.byType(PooledVideoMetricsTracker),
+      );
+
+      expect(tracker.video.id, equals(testVideo.id));
+      expect(tracker.isActive, isTrue);
+    });
   });
 
   group('VideoFeedView native-player branch', () {

--- a/mobile/test/screens/feed/video_feed_page_web_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_web_test.dart
@@ -5,9 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
-import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_metrics_tracker.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart'
     as video_platform;
@@ -19,10 +21,14 @@ import '../../test_data/video_test_data.dart';
 class MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedBlocState>
     implements VideoFeedBloc {}
 
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
+
 void main() {
   group('VideoFeedView web', () {
     late MockVideoFeedBloc mockBloc;
     late MockProfileRepository mockProfileRepository;
+    late _MockVideoVolumeCubit videoVolumeCubit;
     late video_platform.VideoPlayerPlatform originalPlatform;
     late FakeVideoPlayerController webController;
 
@@ -33,17 +39,21 @@ void main() {
     setUp(() {
       mockBloc = MockVideoFeedBloc();
       mockProfileRepository = createMockProfileRepository();
+      videoVolumeCubit = _MockVideoVolumeCubit();
       originalPlatform = video_platform.VideoPlayerPlatform.instance;
       video_platform.VideoPlayerPlatform.instance = FakeVideoPlayerPlatform();
       webController = FakeVideoPlayerController();
       when(() => mockBloc.stream).thenAnswer((_) => const Stream.empty());
+      when(() => videoVolumeCubit.state).thenReturn(const VideoVolumeState());
     });
 
     tearDown(() {
       video_platform.VideoPlayerPlatform.instance = originalPlatform;
     });
 
-    testWidgets('renders Auto action in the home web overlay', (tester) async {
+    testWidgets('renders action column in the home web overlay', (
+      tester,
+    ) async {
       final video = createTestVideoEvent(
         id: 'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234',
         pubkey:
@@ -70,6 +80,7 @@ void main() {
               BlocProvider<VideoPlaybackStatusCubit>(
                 create: (_) => VideoPlaybackStatusCubit(),
               ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
             ],
             child: VideoFeedView(
               webControllerFactory: ({required url, required headers}) =>
@@ -81,7 +92,8 @@ void main() {
       await tester.pump();
 
       expect(find.byType(WebVideoFeed), findsOneWidget);
-      expect(find.byType(AutoActionButton), findsOneWidget);
+      expect(find.byType(VideoMetricsTracker), findsOneWidget);
+      expect(find.byType(VideoOverlayActionColumn), findsOneWidget);
     }, skip: !kIsWeb);
   });
 }

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -1,22 +1,53 @@
 // ABOUTME: Tests for analytics service view tracking and Nostr event publishing
 // ABOUTME: Verifies user preference controls, deduplication, and event flow
 
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/view_event_publisher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class _MockViewEventPublisher extends Mock implements ViewEventPublisher {}
+
+class _MockPendingViewEventsDao extends Mock implements PendingViewEventsDao {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeVideoEvent());
+    registerFallbackValue(_pendingViewEventFallback());
+    registerFallbackValue(ViewTrafficSource.unknown);
+  });
   group('AnalyticsService', () {
     late AnalyticsService analyticsService;
+    AppDatabase? database;
+    String? tempDbPath;
 
     setUp(() {
       SharedPreferences.setMockInitialValues({});
       analyticsService = AnalyticsService(disableNostrPublishing: true);
     });
 
-    tearDown(() {
+    tearDown(() async {
       analyticsService.dispose();
+      await database?.close();
+      final path = tempDbPath;
+      if (path != null) {
+        final file = File(path);
+        if (file.existsSync()) {
+          file.deleteSync();
+        }
+        final dir = Directory(path).parent;
+        if (dir.existsSync()) {
+          dir.deleteSync(recursive: true);
+        }
+      }
     });
 
     test('should initialize with analytics enabled by default', () async {
@@ -96,6 +127,202 @@ void main() {
       expect(true, isTrue);
     });
 
+    test('enqueues eligible view_end before triggering a retry flush', () async {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'analytics_pending_view_test_',
+      );
+      tempDbPath = '${tempDir.path}/test.db';
+      database = AppDatabase.test(NativeDatabase(File(tempDbPath!)));
+      var flushCount = 0;
+      analyticsService.dispose();
+      analyticsService = AnalyticsService(
+        pendingViewEventsDao: database!.pendingViewEventsDao,
+        flushPendingViewEvents: () async {
+          flushCount++;
+        },
+      );
+      await analyticsService.initialize();
+
+      final video = VideoEvent(
+        id: '22e73ca1faedb07dd3e24c1dca52d849aa75c6e4090eb60c532820b782c93da3',
+        pubkey:
+            'ae73ca1faedb07dd3e24c1dca52d849aa75c6e4090eb60c532820b782c93da3',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: 'Test video',
+        timestamp: DateTime.now(),
+        vineId: 'vine-id',
+      );
+
+      await analyticsService.trackDetailedVideoViewWithUser(
+        video,
+        userId:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        source: 'mobile',
+        eventType: 'view_end',
+        watchDuration: const Duration(milliseconds: 2500),
+        totalDuration: const Duration(seconds: 6),
+        loopCount: 1,
+        trafficSource: ViewTrafficSource.home,
+        sourceDetail: 'following',
+      );
+
+      final retryable = await database!.pendingViewEventsDao.getRetryableForUser(
+        userPubkey:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        maxRetries: 5,
+      );
+      expect(retryable, hasLength(1));
+      expect(retryable.single.videoId, video.id);
+      expect(retryable.single.videoPubkey, video.pubkey);
+      expect(retryable.single.videoVineId, 'vine-id');
+      expect(retryable.single.watchDurationMs, 2500);
+      expect(retryable.single.totalDurationMs, 6000);
+      expect(retryable.single.loopCount, 1);
+      expect(retryable.single.trafficSource, 'home');
+      expect(retryable.single.sourceDetail, 'following');
+      expect(flushCount, 1);
+    });
+
+    test('does not enqueue when analytics is disabled', () async {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'analytics_disabled_pending_view_test_',
+      );
+      tempDbPath = '${tempDir.path}/test.db';
+      database = AppDatabase.test(NativeDatabase(File(tempDbPath!)));
+      var flushCount = 0;
+      analyticsService.dispose();
+      analyticsService = AnalyticsService(
+        pendingViewEventsDao: database!.pendingViewEventsDao,
+        flushPendingViewEvents: () async {
+          flushCount++;
+        },
+      );
+      await analyticsService.initialize();
+      await analyticsService.setAnalyticsEnabled(false);
+
+      final video = VideoEvent(
+        id: '22e73ca1faedb07dd3e24c1dca52d849aa75c6e4090eb60c532820b782c93da3',
+        pubkey:
+            'ae73ca1faedb07dd3e24c1dca52d849aa75c6e4090eb60c532820b782c93da3',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: 'Test video',
+        timestamp: DateTime.now(),
+      );
+
+      await analyticsService.trackDetailedVideoViewWithUser(
+        video,
+        userId:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        source: 'mobile',
+        eventType: 'view_end',
+        watchDuration: const Duration(seconds: 2),
+      );
+
+      final retryable = await database!.pendingViewEventsDao.getRetryableForUser(
+        userPubkey:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        maxRetries: 5,
+      );
+      expect(retryable, isEmpty);
+      expect(flushCount, 0);
+    });
+
+    test('falls back to direct publish when pending enqueue fails', () async {
+      final publisher = _MockViewEventPublisher();
+      final dao = _MockPendingViewEventsDao();
+      when(() => dao.enqueue(any())).thenThrow(StateError('enqueue failed'));
+      when(
+        () => publisher.publishViewEvent(
+          video: any(named: 'video'),
+          startSeconds: any(named: 'startSeconds'),
+          endSeconds: any(named: 'endSeconds'),
+          source: any(named: 'source'),
+          sourceDetail: any(named: 'sourceDetail'),
+          loopCount: any(named: 'loopCount'),
+        ),
+      ).thenAnswer((_) async => true);
+      analyticsService.dispose();
+      analyticsService = AnalyticsService(
+        viewEventPublisher: publisher,
+        pendingViewEventsDao: dao,
+      );
+      await analyticsService.initialize();
+      final video = _testVideo();
+
+      await expectLater(
+        analyticsService.trackDetailedVideoViewWithUser(
+          video,
+          userId:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          source: 'mobile',
+          eventType: 'view_end',
+          watchDuration: const Duration(seconds: 2),
+          trafficSource: ViewTrafficSource.home,
+        ),
+        completes,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => publisher.publishViewEvent(
+          video: video,
+          startSeconds: 0,
+          endSeconds: 2,
+          source: ViewTrafficSource.home,
+          sourceDetail: any(named: 'sourceDetail'),
+          loopCount: any(named: 'loopCount'),
+        ),
+      ).called(1);
+    });
+
+    test('keeps queued row when immediate flush fails', () async {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'analytics_flush_failure_test_',
+      );
+      tempDbPath = '${tempDir.path}/test.db';
+      database = AppDatabase.test(NativeDatabase(File(tempDbPath!)));
+      final publisher = _MockViewEventPublisher();
+      analyticsService.dispose();
+      analyticsService = AnalyticsService(
+        viewEventPublisher: publisher,
+        pendingViewEventsDao: database!.pendingViewEventsDao,
+        flushPendingViewEvents: () async => throw StateError('flush failed'),
+      );
+      await analyticsService.initialize();
+      final video = _testVideo();
+      const userPubkey =
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+      await expectLater(
+        analyticsService.trackDetailedVideoViewWithUser(
+          video,
+          userId: userPubkey,
+          source: 'mobile',
+          eventType: 'view_end',
+          watchDuration: const Duration(seconds: 2),
+          trafficSource: ViewTrafficSource.home,
+        ),
+        completes,
+      );
+
+      final retryable = await database!.pendingViewEventsDao
+          .getRetryableForUser(
+            userPubkey: userPubkey,
+            maxRetries: 5,
+          );
+      expect(retryable, hasLength(1));
+      verifyNever(
+        () => publisher.publishViewEvent(
+          video: any(named: 'video'),
+          startSeconds: any(named: 'startSeconds'),
+          endSeconds: any(named: 'endSeconds'),
+          source: any(named: 'source'),
+          sourceDetail: any(named: 'sourceDetail'),
+          loopCount: any(named: 'loopCount'),
+        ),
+      );
+    });
+
     test('should persist analytics preference', () async {
       await analyticsService.initialize();
 
@@ -144,4 +371,30 @@ void main() {
       await expectLater(analyticsService.trackVideoViews(videos), completes);
     });
   });
+}
+
+VideoEvent _testVideo() {
+  return VideoEvent(
+    id: '22e73ca1faedb07dd3e24c1dca52d849aa75c6e4090eb60c532820b782c93da3',
+    pubkey: 'ae73ca1faedb07dd3e24c1dca52d849aa75c6e4090eb60c532820b782c93da3',
+    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    content: 'Test video',
+    timestamp: DateTime.now(),
+    vineId: 'vine-id',
+  );
+}
+
+PendingViewEvent _pendingViewEventFallback() {
+  return PendingViewEvent(
+    id: 'fallback',
+    videoId: 'video-fallback',
+    videoPubkey:
+        'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+    userPubkey:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    watchDurationMs: 1000,
+    trafficSource: 'unknown',
+    status: PendingViewEventStatus.pending,
+    createdAt: DateTime.utc(2026, 5),
+  );
 }

--- a/mobile/test/services/view_event_retry_service_test.dart
+++ b/mobile/test/services/view_event_retry_service_test.dart
@@ -1,0 +1,314 @@
+// ABOUTME: Unit tests for durable view-event retry sweeping.
+// ABOUTME: Verifies queued views publish, fail, back off, and terminally drop.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/services/view_event_retry_service.dart';
+
+class _MockViewEventPublisher extends Mock implements ViewEventPublisher {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeVideoEvent());
+    registerFallbackValue(ViewTrafficSource.unknown);
+  });
+
+  group(ViewEventRetryService, () {
+    late AppDatabase database;
+    late PendingViewEventsDao dao;
+    late _MockViewEventPublisher publisher;
+    late String tempDbPath;
+    late DateTime now;
+
+    const userPubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const videoPubkey =
+        'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+    PendingViewEvent makeEvent({
+      required String id,
+      PendingViewEventStatus status = PendingViewEventStatus.pending,
+      int watchDurationMs = 2500,
+      int retryCount = 0,
+      DateTime? lastAttemptAt,
+      String eventVideoPubkey = videoPubkey,
+    }) {
+      return PendingViewEvent(
+        id: id,
+        videoId: 'video-$id',
+        videoPubkey: eventVideoPubkey,
+        videoVineId: 'vine-$id',
+        userPubkey: userPubkey,
+        watchDurationMs: watchDurationMs,
+        totalDurationMs: 6000,
+        loopCount: 1,
+        trafficSource: 'home',
+        sourceDetail: 'following',
+        status: status,
+        retryCount: retryCount,
+        lastAttemptAt: lastAttemptAt,
+        createdAt: DateTime.utc(2026, 5),
+      );
+    }
+
+    ViewEventRetryService makeService({Stream<bool>? foregroundStream}) {
+      return ViewEventRetryService(
+        viewEventPublisher: publisher,
+        pendingViewEventsDao: dao,
+        userPubkey: userPubkey,
+        appForegroundStream: foregroundStream ?? const Stream<bool>.empty(),
+        now: () => now,
+      );
+    }
+
+    setUp(() {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'view_event_retry_service_test_',
+      );
+      tempDbPath = '${tempDir.path}/test.db';
+      database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+      dao = database.pendingViewEventsDao;
+      publisher = _MockViewEventPublisher();
+      now = DateTime.utc(2026, 5, 23, 12);
+
+      when(
+        () => publisher.publishViewEvent(
+          video: any(named: 'video'),
+          startSeconds: any(named: 'startSeconds'),
+          endSeconds: any(named: 'endSeconds'),
+          source: any(named: 'source'),
+          sourceDetail: any(named: 'sourceDetail'),
+          loopCount: any(named: 'loopCount'),
+        ),
+      ).thenAnswer((_) async => true);
+    });
+
+    tearDown(() async {
+      await database.close();
+      final file = File(tempDbPath);
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
+      final dir = Directory(tempDbPath).parent;
+      if (dir.existsSync()) {
+        dir.deleteSync(recursive: true);
+      }
+    });
+
+    test('publishes retryable view and deletes it after success', () async {
+      await dao.enqueue(makeEvent(id: 'view-a'));
+      final service = makeService();
+
+      await service.sweep();
+
+      expect(await dao.getById('view-a'), isNull);
+      final captured = verify(
+        () => publisher.publishViewEvent(
+          video: captureAny(named: 'video'),
+          startSeconds: captureAny(named: 'startSeconds'),
+          endSeconds: captureAny(named: 'endSeconds'),
+          source: captureAny(named: 'source'),
+          sourceDetail: captureAny(named: 'sourceDetail'),
+          loopCount: captureAny(named: 'loopCount'),
+        ),
+      ).captured;
+      final video = captured[0] as VideoEvent;
+      expect(video.id, 'video-view-a');
+      expect(video.pubkey, videoPubkey);
+      expect(video.vineId, 'vine-view-a');
+      expect(captured[1], 0);
+      expect(captured[2], 2);
+      expect(captured[3], ViewTrafficSource.home);
+      expect(captured[4], 'following');
+      expect(captured[5], 1);
+    });
+
+    test(
+      'marks row failed and increments retry count after publish failure',
+      () async {
+        when(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        ).thenAnswer((_) async => false);
+        await dao.enqueue(makeEvent(id: 'view-a'));
+        final service = makeService();
+
+        await service.sweep();
+
+        final failed = await dao.getById('view-a');
+        expect(failed, isNotNull);
+        expect(failed!.status, PendingViewEventStatus.failed);
+        expect(failed.retryCount, 1);
+        expect(failed.lastError, 'publish returned false');
+        expect(failed.lastAttemptAt, isNotNull);
+      },
+    );
+
+    test('skips failed rows whose retry backoff has not elapsed', () async {
+      await dao.enqueue(
+        makeEvent(
+          id: 'view-a',
+          status: PendingViewEventStatus.failed,
+          retryCount: 2,
+          lastAttemptAt: now.subtract(const Duration(seconds: 1)),
+        ),
+      );
+      final service = makeService();
+
+      await service.sweep();
+
+      verifyNever(
+        () => publisher.publishViewEvent(
+          video: any(named: 'video'),
+          startSeconds: any(named: 'startSeconds'),
+          endSeconds: any(named: 'endSeconds'),
+          source: any(named: 'source'),
+          sourceDetail: any(named: 'sourceDetail'),
+          loopCount: any(named: 'loopCount'),
+        ),
+      );
+      final skipped = await dao.getById('view-a');
+      expect(skipped!.status, PendingViewEventStatus.failed);
+      expect(skipped.retryCount, 2);
+    });
+
+    test(
+      'retries high-retry failed rows after capped backoff elapses',
+      () async {
+        await dao.enqueue(
+          makeEvent(
+            id: 'view-a',
+            status: PendingViewEventStatus.failed,
+            retryCount: 7,
+            lastAttemptAt: now.subtract(const Duration(minutes: 6)),
+          ),
+        );
+        final service = makeService();
+
+        await service.sweep();
+
+        expect(await dao.getById('view-a'), isNull);
+        verify(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'skips high-retry failed rows before capped backoff elapses',
+      () async {
+        await dao.enqueue(
+          makeEvent(
+            id: 'view-a',
+            status: PendingViewEventStatus.failed,
+            retryCount: 7,
+            lastAttemptAt: now.subtract(const Duration(minutes: 4)),
+          ),
+        );
+        final service = makeService();
+
+        await service.sweep();
+
+        verifyNever(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        );
+        final skipped = await dao.getById('view-a');
+        expect(skipped!.retryCount, 7);
+      },
+    );
+
+    test(
+      'deletes terminal self-views and sub-second rows without publishing',
+      () async {
+        await dao.enqueue(
+          makeEvent(
+            id: 'self-view',
+            eventVideoPubkey: userPubkey,
+          ),
+        );
+        await dao.enqueue(
+          makeEvent(
+            id: 'short-view',
+            watchDurationMs: 999,
+          ),
+        );
+        final service = makeService();
+
+        await service.sweep();
+
+        expect(await dao.getById('self-view'), isNull);
+        expect(await dao.getById('short-view'), isNull);
+        verifyNever(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'initialize resets interrupted publishing rows and sweeps on foreground',
+      () async {
+        final foregroundController = StreamController<bool>();
+        addTearDown(foregroundController.close);
+        await dao.enqueue(
+          makeEvent(id: 'view-a', status: PendingViewEventStatus.publishing),
+        );
+        final service = makeService(
+          foregroundStream: foregroundController.stream,
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+        foregroundController.add(true);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(await dao.getById('view-a'), isNull);
+        verify(
+          () => publisher.publishViewEvent(
+            video: any(named: 'video'),
+            startSeconds: any(named: 'startSeconds'),
+            endSeconds: any(named: 'endSeconds'),
+            source: any(named: 'source'),
+            sourceDetail: any(named: 'sourceDetail'),
+            loopCount: any(named: 'loopCount'),
+          ),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/divine_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/divine_video_metrics_tracker_test.dart
@@ -1,0 +1,434 @@
+// ABOUTME: Lifecycle tests for DivineVideoMetricsTracker view analytics
+// ABOUTME: Verifies native player active/inactive, dispose, and video changes
+
+import 'dart:async';
+
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
+import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/widgets/divine_video_metrics_tracker.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockDivineVideoPlayerController extends Mock
+    implements DivineVideoPlayerController {}
+
+class _RecordingAnalyticsService extends AnalyticsService {
+  final events = <_TrackedAnalyticsEvent>[];
+
+  @override
+  Future<void> trackDetailedVideoViewWithUser(
+    VideoEvent video, {
+    required String? userId,
+    required String source,
+    required String eventType,
+    Duration? watchDuration,
+    Duration? totalDuration,
+    int? loopCount,
+    bool? completedVideo,
+    ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
+    String? sourceDetail,
+  }) async {
+    events.add(
+      _TrackedAnalyticsEvent(
+        video: video,
+        userId: userId,
+        source: source,
+        eventType: eventType,
+        watchDuration: watchDuration,
+        totalDuration: totalDuration,
+        loopCount: loopCount,
+        completedVideo: completedVideo,
+        trafficSource: trafficSource,
+        sourceDetail: sourceDetail,
+      ),
+    );
+  }
+}
+
+class _RecordingSeenVideosService extends SeenVideosService {
+  final records = <_SeenVideoRecord>[];
+
+  @override
+  Future<void> recordVideoView(
+    String videoId, {
+    int? loopCount,
+    Duration? watchDuration,
+  }) async {
+    records.add(
+      _SeenVideoRecord(
+        videoId: videoId,
+        loopCount: loopCount,
+        watchDuration: watchDuration,
+      ),
+    );
+  }
+}
+
+class _TrackedAnalyticsEvent {
+  const _TrackedAnalyticsEvent({
+    required this.video,
+    required this.userId,
+    required this.source,
+    required this.eventType,
+    required this.watchDuration,
+    required this.totalDuration,
+    required this.loopCount,
+    required this.completedVideo,
+    required this.trafficSource,
+    required this.sourceDetail,
+  });
+
+  final VideoEvent video;
+  final String? userId;
+  final String source;
+  final String eventType;
+  final Duration? watchDuration;
+  final Duration? totalDuration;
+  final int? loopCount;
+  final bool? completedVideo;
+  final ViewTrafficSource trafficSource;
+  final String? sourceDetail;
+}
+
+class _SeenVideoRecord {
+  const _SeenVideoRecord({
+    required this.videoId,
+    required this.loopCount,
+    required this.watchDuration,
+  });
+
+  final String videoId;
+  final int? loopCount;
+  final Duration? watchDuration;
+}
+
+void main() {
+  group(DivineVideoMetricsTracker, () {
+    late _MockAuthService authService;
+    late _RecordingAnalyticsService analyticsService;
+    late _RecordingSeenVideosService seenVideosService;
+    late DateTime now;
+
+    setUp(() {
+      authService = _MockAuthService();
+      analyticsService = _RecordingAnalyticsService();
+      seenVideosService = _RecordingSeenVideosService();
+      now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+
+      when(() => authService.currentPublicKeyHex).thenReturn('viewer_pubkey');
+    });
+
+    testWidgets('active tracker sends view_start', (tester) async {
+      final controller = _stubController(isPlaying: false);
+
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          isActive: true,
+          clock: () => now,
+        ),
+      );
+
+      expect(
+        analyticsService.events.map((event) => event.eventType),
+        contains('view_start'),
+      );
+
+      await controller.close();
+    });
+
+    testWidgets('active to inactive after one second sends one view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1100));
+      isActive.value = false;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.video.id, equals('video_id'));
+      expect(viewEndEvents.single.userId, equals('viewer_pubkey'));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 1100),
+      );
+      expect(viewEndEvents.single.totalDuration, const Duration(seconds: 5));
+      expect(viewEndEvents.single.trafficSource, ViewTrafficSource.home);
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('active to inactive under one second omits view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 900));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, isEmpty);
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('dispose after one second sends one view_end', (tester) async {
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          isActive: true,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1200));
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 1200),
+      );
+      expect(seenVideosService.records, hasLength(1));
+
+      await controller.close();
+    });
+
+    testWidgets('inactive then dispose does not duplicate view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1100));
+      isActive.value = false;
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(_viewEndEvents(analyticsService), hasLength(1));
+      expect(seenVideosService.records, hasLength(1));
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+
+    testWidgets('video id change finalizes old video and starts new one', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final controller = _stubController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller.controller,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1300));
+      video.value = _secondVideo;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.video.id, equals('video_id'));
+      expect(
+        analyticsService.events.where(
+          (event) => event.eventType == 'view_start',
+        ),
+        hasLength(2),
+      );
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+
+      isActive.dispose();
+      video.dispose();
+      await controller.close();
+    });
+  });
+}
+
+Widget _buildTracker({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required DivineVideoPlayerController controller,
+  required bool isActive,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: DivineVideoMetricsTracker(
+        video: _video,
+        controller: controller,
+        isActive: isActive,
+        trafficSource: ViewTrafficSource.home,
+        clock: clock,
+        child: const SizedBox.shrink(),
+      ),
+    ),
+  );
+}
+
+Widget _buildTrackerHarness({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required DivineVideoPlayerController controller,
+  required ValueListenable<VideoEvent> video,
+  required ValueListenable<bool> isActive,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: ValueListenableBuilder<VideoEvent>(
+        valueListenable: video,
+        builder: (context, currentVideo, _) => ValueListenableBuilder<bool>(
+          valueListenable: isActive,
+          builder: (context, active, _) => DivineVideoMetricsTracker(
+            video: currentVideo,
+            controller: controller,
+            isActive: active,
+            trafficSource: ViewTrafficSource.home,
+            clock: clock,
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+List<_TrackedAnalyticsEvent> _viewEndEvents(
+  _RecordingAnalyticsService analyticsService,
+) => analyticsService.events
+    .where((event) => event.eventType == 'view_end')
+    .toList();
+
+({DivineVideoPlayerController controller, Future<void> Function() close})
+_stubController({
+  required bool isPlaying,
+  Duration duration = const Duration(seconds: 5),
+}) {
+  final controller = _MockDivineVideoPlayerController();
+  final stateController = StreamController<DivineVideoPlayerState>.broadcast();
+  var state = DivineVideoPlayerState(
+    status: isPlaying ? PlaybackStatus.playing : PlaybackStatus.ready,
+    duration: duration,
+    isFirstFrameRendered: true,
+  );
+
+  when(() => controller.isInitialized).thenReturn(true);
+  when(() => controller.state).thenAnswer((_) => state);
+  when(() => controller.stateStream).thenAnswer((_) => stateController.stream);
+
+  return (
+    controller: controller,
+    close: () async {
+      await stateController.close();
+      state = const DivineVideoPlayerState();
+    },
+  );
+}
+
+final _video = VideoEvent(
+  id: 'video_id',
+  pubkey: 'creator_pubkey',
+  createdAt: 1700000000,
+  content: 'test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+);
+
+final _secondVideo = VideoEvent(
+  id: 'second_video_id',
+  pubkey: 'creator_pubkey',
+  createdAt: 1700000001,
+  content: 'second test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+);

--- a/mobile/test/widgets/pooled_video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/pooled_video_metrics_tracker_test.dart
@@ -1,0 +1,420 @@
+// ABOUTME: Lifecycle tests for PooledVideoMetricsTracker view analytics
+// ABOUTME: Verifies active/inactive finalization, dispose behavior, and duplicate prevention
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
+import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockPlayer extends Mock implements Player {}
+
+class _MockPlayerStream extends Mock implements PlayerStream {}
+
+class _MockPlayerState extends Mock implements PlayerState {}
+
+class _RecordingAnalyticsService extends AnalyticsService {
+  final events = <_TrackedAnalyticsEvent>[];
+
+  @override
+  Future<void> trackDetailedVideoViewWithUser(
+    VideoEvent video, {
+    required String? userId,
+    required String source,
+    required String eventType,
+    Duration? watchDuration,
+    Duration? totalDuration,
+    int? loopCount,
+    bool? completedVideo,
+    ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
+    String? sourceDetail,
+  }) async {
+    events.add(
+      _TrackedAnalyticsEvent(
+        video: video,
+        userId: userId,
+        source: source,
+        eventType: eventType,
+        watchDuration: watchDuration,
+        totalDuration: totalDuration,
+        loopCount: loopCount,
+        completedVideo: completedVideo,
+        trafficSource: trafficSource,
+        sourceDetail: sourceDetail,
+      ),
+    );
+  }
+}
+
+class _RecordingSeenVideosService extends SeenVideosService {
+  final records = <_SeenVideoRecord>[];
+
+  @override
+  Future<void> recordVideoView(
+    String videoId, {
+    int? loopCount,
+    Duration? watchDuration,
+  }) async {
+    records.add(
+      _SeenVideoRecord(
+        videoId: videoId,
+        loopCount: loopCount,
+        watchDuration: watchDuration,
+      ),
+    );
+  }
+}
+
+class _TrackedAnalyticsEvent {
+  const _TrackedAnalyticsEvent({
+    required this.video,
+    required this.userId,
+    required this.source,
+    required this.eventType,
+    required this.watchDuration,
+    required this.totalDuration,
+    required this.loopCount,
+    required this.completedVideo,
+    required this.trafficSource,
+    required this.sourceDetail,
+  });
+
+  final VideoEvent video;
+  final String? userId;
+  final String source;
+  final String eventType;
+  final Duration? watchDuration;
+  final Duration? totalDuration;
+  final int? loopCount;
+  final bool? completedVideo;
+  final ViewTrafficSource trafficSource;
+  final String? sourceDetail;
+}
+
+class _SeenVideoRecord {
+  const _SeenVideoRecord({
+    required this.videoId,
+    required this.loopCount,
+    required this.watchDuration,
+  });
+
+  final String videoId;
+  final int? loopCount;
+  final Duration? watchDuration;
+}
+
+void main() {
+  group(PooledVideoMetricsTracker, () {
+    late _MockAuthService authService;
+    late _RecordingAnalyticsService analyticsService;
+    late _RecordingSeenVideosService seenVideosService;
+    late DateTime now;
+
+    setUp(() {
+      authService = _MockAuthService();
+      analyticsService = _RecordingAnalyticsService();
+      seenVideosService = _RecordingSeenVideosService();
+      now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+
+      when(() => authService.currentPublicKeyHex).thenReturn('viewer_pubkey');
+    });
+
+    testWidgets('active tracker sends view_start', (tester) async {
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          player: _stubPlayer(isPlaying: false),
+          isActive: true,
+          clock: () => now,
+        ),
+      );
+
+      expect(
+        analyticsService.events.map((event) => event.eventType),
+        contains('view_start'),
+      );
+    });
+
+    testWidgets('active to inactive after one second sends one view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final player = _stubPlayer(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          player: player,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1100));
+      isActive.value = false;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.video.id, equals('video_id'));
+      expect(viewEndEvents.single.userId, equals('viewer_pubkey'));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 1100),
+      );
+      expect(viewEndEvents.single.totalDuration, const Duration(seconds: 5));
+      expect(viewEndEvents.single.trafficSource, ViewTrafficSource.home);
+      expect(seenVideosService.records, hasLength(1));
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+
+      isActive.dispose();
+      video.dispose();
+    });
+
+    testWidgets('active to inactive under one second omits view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final player = _stubPlayer(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          player: player,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 900));
+      isActive.value = false;
+      await tester.pump();
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, isEmpty);
+
+      isActive.dispose();
+      video.dispose();
+    });
+
+    testWidgets('dispose after one second sends one view_end', (tester) async {
+      final player = _stubPlayer(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          player: player,
+          isActive: true,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1200));
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 1200),
+      );
+      expect(seenVideosService.records, hasLength(1));
+    });
+
+    testWidgets('inactive then dispose does not duplicate view_end', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final player = _stubPlayer(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          player: player,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1100));
+      isActive.value = false;
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(_viewEndEvents(analyticsService), hasLength(1));
+      expect(seenVideosService.records, hasLength(1));
+
+      isActive.dispose();
+      video.dispose();
+    });
+
+    testWidgets('video id change finalizes old video and starts new one', (
+      tester,
+    ) async {
+      final isActive = ValueNotifier(true);
+      final video = ValueNotifier(_video);
+      final player = _stubPlayer(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          player: player,
+          video: video,
+          isActive: isActive,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1300));
+      video.value = _secondVideo;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.video.id, equals('video_id'));
+      expect(
+        analyticsService.events.where(
+          (event) => event.eventType == 'view_start',
+        ),
+        hasLength(2),
+      );
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+
+      isActive.dispose();
+      video.dispose();
+    });
+  });
+}
+
+Widget _buildTracker({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required Player player,
+  required bool isActive,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: PooledVideoMetricsTracker(
+        video: _video,
+        player: player,
+        isActive: isActive,
+        trafficSource: ViewTrafficSource.home,
+        clock: clock,
+        child: const SizedBox.shrink(),
+      ),
+    ),
+  );
+}
+
+Widget _buildTrackerHarness({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required Player player,
+  required ValueListenable<VideoEvent> video,
+  required ValueListenable<bool> isActive,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: ValueListenableBuilder<VideoEvent>(
+        valueListenable: video,
+        builder: (context, currentVideo, _) => ValueListenableBuilder<bool>(
+          valueListenable: isActive,
+          builder: (context, active, _) => PooledVideoMetricsTracker(
+            video: currentVideo,
+            player: player,
+            isActive: active,
+            trafficSource: ViewTrafficSource.home,
+            clock: clock,
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+List<_TrackedAnalyticsEvent> _viewEndEvents(
+  _RecordingAnalyticsService analyticsService,
+) => analyticsService.events
+    .where((event) => event.eventType == 'view_end')
+    .toList();
+
+Player _stubPlayer({
+  required bool isPlaying,
+  Duration duration = const Duration(seconds: 5),
+}) {
+  final player = _MockPlayer();
+  final stream = _MockPlayerStream();
+  final state = _MockPlayerState();
+
+  when(() => player.stream).thenReturn(stream);
+  when(() => player.state).thenReturn(state);
+  when(() => stream.playing).thenAnswer((_) => const Stream<bool>.empty());
+  when(() => stream.position).thenAnswer((_) => const Stream<Duration>.empty());
+  when(() => state.duration).thenReturn(duration);
+  when(() => state.playing).thenReturn(isPlaying);
+
+  return player;
+}
+
+final _video = VideoEvent(
+  id: 'video_id',
+  pubkey: 'creator_pubkey',
+  createdAt: 1700000000,
+  content: 'test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+);
+
+final _secondVideo = VideoEvent(
+  id: 'second_video_id',
+  pubkey: 'creator_pubkey',
+  createdAt: 1700000001,
+  content: 'second test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+);

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -23,8 +23,13 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/connection_status_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
+import 'package:openvine/services/view_event_publisher.dart'
+    show ViewTrafficSource;
+import 'package:openvine/widgets/divine_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
@@ -65,6 +70,31 @@ class _MockLikesRepository extends Mock implements LikesRepository {}
 class _MockCommentsRepository extends Mock implements CommentsRepository {}
 
 class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+class _NoopAnalyticsService extends AnalyticsService {
+  @override
+  Future<void> trackDetailedVideoViewWithUser(
+    VideoEvent video, {
+    required String? userId,
+    required String source,
+    required String eventType,
+    Duration? watchDuration,
+    Duration? totalDuration,
+    int? loopCount,
+    bool? completedVideo,
+    ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
+    String? sourceDetail,
+  }) async {}
+}
+
+class _NoopSeenVideosService extends SeenVideosService {
+  @override
+  Future<void> recordVideoView(
+    String videoId, {
+    int? loopCount,
+    Duration? watchDuration,
+  }) async {}
+}
 
 // ---------------------------------------------------------------------------
 // Test data
@@ -161,7 +191,9 @@ List _buildOverrides({
   RepostsRepository? repostsRepository,
 }) {
   return [
-    ...getStandardTestOverrides(),
+    ...getStandardTestOverrides(mockAuthService: createMockAuthService()),
+    analyticsServiceProvider.overrideWithValue(_NoopAnalyticsService()),
+    seenVideosServiceProvider.overrideWithValue(_NoopSeenVideosService()),
     connectionStatusServiceProvider.overrideWithValue(
       _MockConnectionStatusService(),
     ),
@@ -472,6 +504,21 @@ void main() {
       );
       expect(feed.isActive, isFalse);
     });
+
+    testWidgets(
+      'mounts $DivineVideoMetricsTracker for active native playback',
+      (
+        tester,
+      ) async {
+        InfiniteVideoFeed.debugIsSupportedOverride = true;
+        final video = _makeVideo();
+
+        await _pumpFeedVideos(tester, videos: [video]);
+        await tester.pump(const Duration(seconds: 4));
+
+        expect(find.byType(DivineVideoMetricsTracker), findsOneWidget);
+      },
+    );
 
     testWidgets('route-aware callbacks toggle InfiniteVideoFeed activity', (
       tester,

--- a/mobile/test/widgets/video_metrics_tracker_test.dart
+++ b/mobile/test/widgets/video_metrics_tracker_test.dart
@@ -1,0 +1,454 @@
+// ABOUTME: Lifecycle tests for VideoMetricsTracker view analytics
+// ABOUTME: Verifies video_player finalization, short-view filtering, and video changes
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/seen_videos_service.dart';
+import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/widgets/video_metrics_tracker.dart';
+import 'package:video_player/video_player.dart';
+
+import '../helpers/web_video_player_test_doubles.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _RecordingAnalyticsService extends AnalyticsService {
+  final events = <_TrackedAnalyticsEvent>[];
+
+  @override
+  Future<void> trackDetailedVideoViewWithUser(
+    VideoEvent video, {
+    required String? userId,
+    required String source,
+    required String eventType,
+    Duration? watchDuration,
+    Duration? totalDuration,
+    int? loopCount,
+    bool? completedVideo,
+    ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
+    String? sourceDetail,
+  }) async {
+    events.add(
+      _TrackedAnalyticsEvent(
+        video: video,
+        userId: userId,
+        source: source,
+        eventType: eventType,
+        watchDuration: watchDuration,
+        totalDuration: totalDuration,
+        loopCount: loopCount,
+        completedVideo: completedVideo,
+        trafficSource: trafficSource,
+        sourceDetail: sourceDetail,
+      ),
+    );
+  }
+}
+
+class _RecordingSeenVideosService extends SeenVideosService {
+  final records = <_SeenVideoRecord>[];
+
+  @override
+  Future<void> recordVideoView(
+    String videoId, {
+    int? loopCount,
+    Duration? watchDuration,
+  }) async {
+    records.add(
+      _SeenVideoRecord(
+        videoId: videoId,
+        loopCount: loopCount,
+        watchDuration: watchDuration,
+      ),
+    );
+  }
+}
+
+class _TrackedAnalyticsEvent {
+  const _TrackedAnalyticsEvent({
+    required this.video,
+    required this.userId,
+    required this.source,
+    required this.eventType,
+    required this.watchDuration,
+    required this.totalDuration,
+    required this.loopCount,
+    required this.completedVideo,
+    required this.trafficSource,
+    required this.sourceDetail,
+  });
+
+  final VideoEvent video;
+  final String? userId;
+  final String source;
+  final String eventType;
+  final Duration? watchDuration;
+  final Duration? totalDuration;
+  final int? loopCount;
+  final bool? completedVideo;
+  final ViewTrafficSource trafficSource;
+  final String? sourceDetail;
+}
+
+class _SeenVideoRecord {
+  const _SeenVideoRecord({
+    required this.videoId,
+    required this.loopCount,
+    required this.watchDuration,
+  });
+
+  final String videoId;
+  final int? loopCount;
+  final Duration? watchDuration;
+}
+
+void main() {
+  group(VideoMetricsTracker, () {
+    late _MockAuthService authService;
+    late _RecordingAnalyticsService analyticsService;
+    late _RecordingSeenVideosService seenVideosService;
+    late DateTime now;
+
+    setUp(() {
+      authService = _MockAuthService();
+      analyticsService = _RecordingAnalyticsService();
+      seenVideosService = _RecordingSeenVideosService();
+      now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+
+      when(() => authService.currentPublicKeyHex).thenReturn('viewer_pubkey');
+    });
+
+    testWidgets('active tracker sends view_start', (tester) async {
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: _initializedController(isPlaying: false),
+          video: _video,
+          clock: () => now,
+        ),
+      );
+
+      expect(
+        analyticsService.events.map((event) => event.eventType),
+        contains('view_start'),
+      );
+    });
+
+    testWidgets('dispose after one second sends one view_end', (tester) async {
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: _initializedController(isPlaying: true),
+          video: _video,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1200));
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.video.id, equals('video_id'));
+      expect(viewEndEvents.single.userId, equals('viewer_pubkey'));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 1200),
+      );
+      expect(viewEndEvents.single.totalDuration, const Duration(seconds: 5));
+      expect(viewEndEvents.single.trafficSource, ViewTrafficSource.home);
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+    });
+
+    testWidgets('dispose under one second omits view_end', (tester) async {
+      await tester.pumpWidget(
+        _buildTracker(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: _initializedController(isPlaying: true),
+          video: _video,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 900));
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(_viewEndEvents(analyticsService), isEmpty);
+      expect(seenVideosService.records, isEmpty);
+    });
+
+    testWidgets('controller becoming null finalizes once', (tester) async {
+      final controller = ValueNotifier<FakeVideoPlayerController?>(
+        _initializedController(isPlaying: true),
+      );
+
+      await tester.pumpWidget(
+        _buildControllerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1200));
+      controller.value = null;
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(
+        viewEndEvents.single.watchDuration,
+        const Duration(milliseconds: 1200),
+      );
+      expect(viewEndEvents.single.totalDuration, const Duration(seconds: 5));
+      expect(seenVideosService.records, hasLength(1));
+
+      controller.dispose();
+    });
+
+    testWidgets('controller becoming non-null starts tracking', (tester) async {
+      final controller = ValueNotifier<FakeVideoPlayerController?>(null);
+
+      await tester.pumpWidget(
+        _buildControllerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller,
+          clock: () => now,
+        ),
+      );
+
+      expect(analyticsService.events, isEmpty);
+
+      controller.value = _initializedController(isPlaying: true);
+      await tester.pump();
+
+      expect(
+        analyticsService.events.where(
+          (event) => event.eventType == 'view_start',
+        ),
+        hasLength(1),
+      );
+
+      now = now.add(const Duration(milliseconds: 1300));
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(_viewEndEvents(analyticsService), hasLength(1));
+      controller.dispose();
+    });
+
+    testWidgets('same video active inactive active creates separate sessions', (
+      tester,
+    ) async {
+      final firstController = _initializedController(isPlaying: true);
+      final secondController = _initializedController(isPlaying: true);
+      final controller = ValueNotifier<FakeVideoPlayerController?>(
+        firstController,
+      );
+
+      await tester.pumpWidget(
+        _buildControllerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1200));
+      controller.value = null;
+      await tester.pump();
+      controller.value = secondController;
+      await tester.pump();
+      now = now.add(const Duration(milliseconds: 1400));
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(
+        analyticsService.events.where(
+          (event) => event.eventType == 'view_start',
+        ),
+        hasLength(2),
+      );
+      expect(
+        _viewEndEvents(analyticsService).map((event) => event.watchDuration),
+        [
+          const Duration(milliseconds: 1200),
+          const Duration(milliseconds: 1400),
+        ],
+      );
+
+      controller.dispose();
+    });
+
+    testWidgets('video id change finalizes old video and starts new one', (
+      tester,
+    ) async {
+      final video = ValueNotifier(_video);
+      final controller = _initializedController(isPlaying: true);
+
+      await tester.pumpWidget(
+        _buildTrackerHarness(
+          authService: authService,
+          analyticsService: analyticsService,
+          seenVideosService: seenVideosService,
+          controller: controller,
+          video: video,
+          clock: () => now,
+        ),
+      );
+
+      now = now.add(const Duration(milliseconds: 1300));
+      video.value = _secondVideo;
+      await tester.pump();
+
+      final viewEndEvents = _viewEndEvents(analyticsService);
+      expect(viewEndEvents, hasLength(1));
+      expect(viewEndEvents.single.video.id, equals('video_id'));
+      expect(
+        analyticsService.events.where(
+          (event) => event.eventType == 'view_start',
+        ),
+        hasLength(2),
+      );
+      expect(seenVideosService.records.single.videoId, equals('video_id'));
+
+      video.dispose();
+    });
+  });
+}
+
+Widget _buildTracker({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required FakeVideoPlayerController controller,
+  required VideoEvent video,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: VideoMetricsTracker(
+        video: video,
+        controller: controller,
+        trafficSource: ViewTrafficSource.home,
+        clock: clock,
+        child: const SizedBox.shrink(),
+      ),
+    ),
+  );
+}
+
+Widget _buildTrackerHarness({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required FakeVideoPlayerController controller,
+  required ValueNotifier<VideoEvent> video,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: ValueListenableBuilder<VideoEvent>(
+        valueListenable: video,
+        builder: (context, currentVideo, _) => VideoMetricsTracker(
+          video: currentVideo,
+          controller: controller,
+          trafficSource: ViewTrafficSource.home,
+          clock: clock,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _buildControllerHarness({
+  required AuthService authService,
+  required AnalyticsService analyticsService,
+  required SeenVideosService seenVideosService,
+  required ValueNotifier<FakeVideoPlayerController?> controller,
+  required DateTime Function() clock,
+}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(authService),
+      analyticsServiceProvider.overrideWithValue(analyticsService),
+      seenVideosServiceProvider.overrideWithValue(seenVideosService),
+    ],
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: ValueListenableBuilder<FakeVideoPlayerController?>(
+        valueListenable: controller,
+        builder: (context, currentController, _) => VideoMetricsTracker(
+          video: _video,
+          controller: currentController,
+          trafficSource: ViewTrafficSource.home,
+          clock: clock,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    ),
+  );
+}
+
+List<_TrackedAnalyticsEvent> _viewEndEvents(
+  _RecordingAnalyticsService analyticsService,
+) => analyticsService.events
+    .where((event) => event.eventType == 'view_end')
+    .toList();
+
+FakeVideoPlayerController _initializedController({required bool isPlaying}) {
+  return FakeVideoPlayerController(
+    initialValue: VideoPlayerValue(
+      duration: const Duration(seconds: 5),
+      size: const Size(1080, 1920),
+      isInitialized: true,
+      isPlaying: isPlaying,
+    ),
+  );
+}
+
+final _video = VideoEvent(
+  id: 'video_id',
+  pubkey: 'creator_pubkey',
+  createdAt: 1700000000,
+  content: 'test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+);
+
+final _secondVideo = VideoEvent(
+  id: 'second_video_id',
+  pubkey: 'creator_pubkey',
+  createdAt: 1700000001,
+  content: 'second test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+);


### PR DESCRIPTION
Closes #4678

## Summary
- Queue eligible completed view events in a durable Drift outbox before publishing so UI lifecycle changes do not lose analytics.
- Add a foreground/startup retry service for pending view events with capped backoff and no permanent retry-count exhaustion.
- Fix web/native tracker lifecycle and analytics-service provider refresh handling so finalized views publish exactly once with the current service instance.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed lib test integration_test packages/db_client/lib packages/db_client/test`
- [x] `flutter analyze lib test integration_test`
- [x] `flutter test test/services/analytics_service_test.dart test/services/view_event_retry_service_test.dart packages/db_client/test/src/database/daos/pending_view_events_dao_test.dart test/widgets/video_metrics_tracker_test.dart test/widgets/pooled_video_metrics_tracker_test.dart test/widgets/divine_video_metrics_tracker_test.dart test/widgets/video_feed_item/feed_videos_test.dart test/screens/feed/video_feed_page_test.dart test/screens/feed/video_feed_page_web_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart --reporter expanded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)