### PR TITLE
fix(video-metadata): restore classic post form controls

### DIFF
--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart
@@ -25,14 +25,7 @@ class VideoMetadataClassicStack extends StatelessWidget {
                 spacing: 16,
                 children: [
                   VideoMetadataClassicPreviewThumbnail(),
-                  VideoMetadataFormFields(
-                    enableTags: false,
-                    enableExpiration: false,
-                    enableContentWarning: false,
-                    enableCollaborators: false,
-                    enableInspiredBy: false,
-                    enableVideoReply: false,
-                  ),
+                  VideoMetadataFormFields(),
                 ],
               ),
             ),

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_stack_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_stack_test.dart
@@ -110,7 +110,7 @@ void main() {
     });
 
     testWidgetsWithSurfaceSize(
-      '$VideoMetadataFormFields disables optional sections',
+      '$VideoMetadataFormFields keeps the full post controls available',
       (
         tester,
       ) async {
@@ -119,11 +119,12 @@ void main() {
         final formFields = tester.widget<VideoMetadataFormFields>(
           find.byType(VideoMetadataFormFields),
         );
-        expect(formFields.enableTags, isFalse);
-        expect(formFields.enableExpiration, isFalse);
-        expect(formFields.enableContentWarning, isFalse);
-        expect(formFields.enableCollaborators, isFalse);
-        expect(formFields.enableInspiredBy, isFalse);
+        expect(formFields.enableTags, isTrue);
+        expect(formFields.enableExpiration, isTrue);
+        expect(formFields.enableContentWarning, isTrue);
+        expect(formFields.enableCollaborators, isTrue);
+        expect(formFields.enableInspiredBy, isTrue);
+        expect(formFields.enableVideoReply, isTrue);
       },
     );
   });


### PR DESCRIPTION
Closes #4687

## Summary
- Restore the full metadata form controls on the classic post-details screen.
- Update the classic metadata stack regression test so tags, expiration, content warnings, collaborators, inspiration, and reply visibility remain enabled.

## Test Plan
- flutter test test/widgets/video_metadata/modes/classic/video_metadata_classic_stack_test.dart test/screens/video_metadata_screen_test.dart test/widgets/video_metadata/video_metadata_form_fields_test.dart
- flutter analyze lib test
- git push pre-push checks: changed-file analyzer and classic stack test

## Notes
- Full `flutter analyze` currently exits nonzero on pre-existing `avoid_print` info findings in `integration_test_manual`, `scripts`, and `tools`; the scoped app/test analyzer pass and pre-push analyzer pass are clean.