### PR TITLE
fix(video-editor): preserve clip speed preview position

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -94,15 +94,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   final AudioExtractionService _audioExtractionService;
   final SplitClipFn _splitClip;
 
-  static DivineVideoClip normalizeClipUpdate({
+  static ({double min, double max})? allowedPlaybackSpeedRange({
     required List<DivineVideoClip> clips,
     required int clipIndex,
-    required DivineVideoClip currentClip,
-    required DivineVideoClip proposedClip,
+    required DivineVideoClip clip,
   }) {
-    final nextSpeed = proposedClip.playbackSpeed;
-    if (nextSpeed == null || nextSpeed <= 0) return proposedClip;
-
     var otherPlaybackDuration = Duration.zero;
     for (var i = 0; i < clips.length; i++) {
       if (i == clipIndex) continue;
@@ -112,21 +108,45 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final remainingPlaybackUs =
         (VideoEditorConstants.maxDuration - otherPlaybackDuration)
             .inMicroseconds;
-    final trimmedUs = proposedClip.trimmedDuration.inMicroseconds;
-    if (trimmedUs <= 0) return proposedClip;
-    if (remainingPlaybackUs <= 0) return currentClip;
+    final trimmedUs = clip.trimmedDuration.inMicroseconds;
+    if (trimmedUs <= 0) {
+      return (
+        min: VideoEditorConstants.clipSpeedMin,
+        max: VideoEditorConstants.clipSpeedMax,
+      );
+    }
+    if (remainingPlaybackUs <= 0) return null;
 
     final minAllowedSpeed = trimmedUs / remainingPlaybackUs;
     if (minAllowedSpeed > VideoEditorConstants.clipSpeedMax) {
-      return currentClip;
+      return null;
     }
 
-    final clampedSpeed = nextSpeed.clamp(
-      minAllowedSpeed > VideoEditorConstants.clipSpeedMin
+    return (
+      min: minAllowedSpeed > VideoEditorConstants.clipSpeedMin
           ? minAllowedSpeed
           : VideoEditorConstants.clipSpeedMin,
-      VideoEditorConstants.clipSpeedMax,
+      max: VideoEditorConstants.clipSpeedMax,
     );
+  }
+
+  static DivineVideoClip normalizeClipUpdate({
+    required List<DivineVideoClip> clips,
+    required int clipIndex,
+    required DivineVideoClip currentClip,
+    required DivineVideoClip proposedClip,
+  }) {
+    final nextSpeed = proposedClip.playbackSpeed;
+    if (nextSpeed == null || nextSpeed <= 0) return proposedClip;
+
+    final allowedRange = allowedPlaybackSpeedRange(
+      clips: clips,
+      clipIndex: clipIndex,
+      clip: proposedClip,
+    );
+    if (allowedRange == null) return currentClip;
+
+    final clampedSpeed = nextSpeed.clamp(allowedRange.min, allowedRange.max);
     if (clampedSpeed == nextSpeed) return proposedClip;
     return proposedClip.copyWith(playbackSpeed: clampedSpeed);
   }
@@ -186,13 +206,38 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final index = state.clips.indexWhere((c) => c.id == event.clipId);
     if (index == -1) return;
 
+    final currentClip = state.clips[index];
     final nextClip = normalizeClipUpdate(
       clips: state.clips,
       clipIndex: index,
-      currentClip: state.clips[index],
+      currentClip: currentClip,
       proposedClip: event.clip,
     );
     final newClips = List<DivineVideoClip>.of(state.clips)..[index] = nextClip;
+
+    final previousSpeed = currentClip.playbackSpeed ?? 1.0;
+    final requestedSpeed = event.clip.playbackSpeed;
+    final appliedSpeed = nextClip.playbackSpeed ?? 1.0;
+    if (requestedSpeed != null && requestedSpeed > 0) {
+      if ((requestedSpeed - appliedSpeed).abs() > 1e-9) {
+        Log.info(
+          '⚡ Clip speed constrained: clip=${event.clipId} '
+          'requested=${requestedSpeed.toStringAsFixed(2)} '
+          'applied=${appliedSpeed.toStringAsFixed(2)}',
+          name: 'ClipEditorBloc',
+          category: LogCategory.video,
+        );
+      }
+      if ((previousSpeed - appliedSpeed).abs() > 1e-9) {
+        Log.info(
+          '⚡ Clip speed updated: clip=${event.clipId} '
+          'from=${previousSpeed.toStringAsFixed(2)} '
+          'to=${appliedSpeed.toStringAsFixed(2)}',
+          name: 'ClipEditorBloc',
+          category: LogCategory.video,
+        );
+      }
+    }
 
     emit(state.copyWith(clips: List.unmodifiable(newClips)));
   }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -66,6 +66,115 @@ class VideoEditorCanvas extends StatelessWidget {
     proVideoController.setPlayTime(startPosition);
   }
 
+  @visibleForTesting
+  static Duration clampPlaybackPositionToClips({
+    required Duration position,
+    required List<DivineVideoClip> clips,
+  }) {
+    final totalDuration = clips.fold(
+      Duration.zero,
+      (sum, clip) => sum + clip.playbackDuration,
+    );
+    if (position < Duration.zero) return Duration.zero;
+    if (position > totalDuration) return totalDuration;
+    return position;
+  }
+
+  @visibleForTesting
+  static Duration remapPlaybackPositionForClipUpdate({
+    required List<DivineVideoClip> previousClips,
+    required List<DivineVideoClip> currentClips,
+    required Duration currentPosition,
+  }) {
+    if (currentClips.isEmpty) return Duration.zero;
+    if (previousClips.isEmpty) {
+      return clampPlaybackPositionToClips(
+        position: currentPosition,
+        clips: currentClips,
+      );
+    }
+
+    final previousTotalDuration = previousClips.fold(
+      Duration.zero,
+      (sum, clip) => sum + clip.playbackDuration,
+    );
+    if (previousTotalDuration <= Duration.zero) {
+      return clampPlaybackPositionToClips(
+        position: currentPosition,
+        clips: currentClips,
+      );
+    }
+
+    final normalizedPosition = currentPosition < previousTotalDuration
+        ? currentPosition
+        : previousTotalDuration;
+
+    var previousPrefix = Duration.zero;
+    DivineVideoClip? previousClip;
+    for (var i = 0; i < previousClips.length; i++) {
+      final clip = previousClips[i];
+      final clipEnd = previousPrefix + clip.playbackDuration;
+      if (normalizedPosition < clipEnd || i == previousClips.length - 1) {
+        previousClip = clip;
+        break;
+      }
+      previousPrefix = clipEnd;
+    }
+
+    if (previousClip == null) {
+      return clampPlaybackPositionToClips(
+        position: normalizedPosition,
+        clips: currentClips,
+      );
+    }
+    final resolvedPreviousClip = previousClip;
+
+    final currentClipIndex = currentClips.indexWhere(
+      (clip) => clip.id == resolvedPreviousClip.id,
+    );
+    if (currentClipIndex == -1) {
+      return clampPlaybackPositionToClips(
+        position: normalizedPosition,
+        clips: currentClips,
+      );
+    }
+
+    final relativePlaybackPosition = normalizedPosition - previousPrefix;
+    final previousSpeed = resolvedPreviousClip.playbackSpeed ?? 1.0;
+    final relativeSourceMicroseconds = previousSpeed == 1.0
+        ? relativePlaybackPosition.inMicroseconds
+        : (relativePlaybackPosition.inMicroseconds * previousSpeed).round();
+    final sourcePosition =
+        resolvedPreviousClip.trimStart +
+        Duration(microseconds: relativeSourceMicroseconds);
+
+    final currentClip = currentClips[currentClipIndex];
+    final clampedSourcePosition = sourcePosition < currentClip.trimStart
+        ? currentClip.trimStart
+        : sourcePosition > currentClip.trimStart + currentClip.trimmedDuration
+        ? currentClip.trimStart + currentClip.trimmedDuration
+        : sourcePosition;
+    final relativeSourcePosition =
+        clampedSourcePosition - currentClip.trimStart;
+    final currentSpeed = currentClip.playbackSpeed ?? 1.0;
+    final remappedLocalPlayback = currentSpeed == 1.0
+        ? relativeSourcePosition
+        : Duration(
+            microseconds: (relativeSourcePosition.inMicroseconds / currentSpeed)
+                .round(),
+          );
+
+    var currentPrefix = Duration.zero;
+    for (var i = 0; i < currentClipIndex; i++) {
+      currentPrefix += currentClips[i].playbackDuration;
+    }
+
+    return clampPlaybackPositionToClips(
+      position: currentPrefix + remappedLocalPlayback,
+      clips: currentClips,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -123,6 +232,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
   bool _isInitialized = false;
   bool _isImportingHistory = false;
+  List<DivineVideoClip> _lastAppliedClips = const [];
 
   bool get _isLayerBeingTransformed => _selectedLayer != null;
 
@@ -289,9 +399,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
         final speed = clip.playbackSpeed ?? 1.0;
         final relativePlayback = speed == 1.0
             ? relative
-            : Duration(
-                microseconds: (relative.inMicroseconds / speed).round(),
-              );
+            : Duration(microseconds: (relative.inMicroseconds / speed).round());
         return precedingDuration + relativePlayback;
       }
       // Accumulate in playback time (trimmedDuration ÷ speed) so that
@@ -384,21 +492,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     }
 
     final clips = ref.read(clipManagerProvider).clips;
-    final currentPosition = context
-        .read<VideoEditorMainBloc>()
-        .state
-        .currentPosition;
-    _videoPlayer?.setClips([
-      for (final clip in clips)
-        if (clip.video.file?.path case final path?)
-          VideoClip(
-            uri: path,
-            start: clip.trimStart,
-            end: clip.duration - clip.trimEnd,
-            volume: clip.volume,
-            playbackSpeed: clip.playbackSpeed ?? 1.0,
-          ),
-    ], startPosition: currentPosition);
+    final currentPosition = VideoEditorCanvas.clampPlaybackPositionToClips(
+      position: context.read<VideoEditorMainBloc>().state.currentPosition,
+      clips: clips,
+    );
+    _setPlayerTimelinePosition(currentPosition);
+    unawaited(_applyPlayerClips(clips, startPosition: currentPosition));
   }
 
   /// Creates the [ProVideoController] (only once, not tied to a file).
@@ -459,18 +558,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
     await _videoPlayer!.initialize();
     if (!mounted) return;
-    await _videoPlayer!.setClips(
-      [
-        for (final clip in clips)
-          if (clip.video.file?.path case final path?)
-            VideoClip(
-              uri: path,
-              start: clip.trimStart,
-              end: clip.duration - clip.trimEnd,
-              volume: clip.volume,
-              playbackSpeed: clip.playbackSpeed ?? 1.0,
-            ),
-      ],
+    await _applyPlayerClips(
+      clips,
       startPosition: startPosition != null && startPosition > Duration.zero
           ? startPosition
           : null,
@@ -500,6 +589,42 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
       name: 'VideoEditorCanvas',
       category: LogCategory.video,
     );
+  }
+
+  List<VideoClip> _buildPlayerClips(List<DivineVideoClip> clips) {
+    return [
+      for (final clip in clips)
+        if (clip.video.file?.path case final path?)
+          VideoClip(
+            uri: path,
+            start: clip.trimStart,
+            end: clip.duration - clip.trimEnd,
+            volume: clip.volume,
+            playbackSpeed: clip.playbackSpeed ?? 1.0,
+          ),
+    ];
+  }
+
+  Future<void> _applyPlayerClips(
+    List<DivineVideoClip> clips, {
+    Duration? startPosition,
+  }) async {
+    final player = _videoPlayer;
+    if (player == null || clips.isEmpty) return;
+    await player.setClips(
+      _buildPlayerClips(clips),
+      startPosition: startPosition,
+    );
+    _lastAppliedClips = List<DivineVideoClip>.unmodifiable(clips);
+  }
+
+  void _setPlayerTimelinePosition(Duration position) {
+    final bloc = context.read<VideoEditorMainBloc>();
+    if (bloc.state.currentPosition != position) {
+      bloc.add(VideoEditorPositionChanged(position));
+    }
+    _lastReportedPosition = position;
+    _proVideoController.setPlayTime(position);
   }
 
   /// Syncs native audio overlay tracks from the [TimelineOverlayBloc]
@@ -806,22 +931,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
         // builds a composition with `renderSize == .zero` on iOS,
         // which crashes `AVPlayerItem.setVideoComposition:`.
         if (clips.isEmpty || !_isPlayerInitialized) return;
-        final currentPosition = context
-            .read<VideoEditorMainBloc>()
-            .state
-            .currentPosition;
+        final currentPosition = VideoEditorCanvas.clampPlaybackPositionToClips(
+          position: context.read<VideoEditorMainBloc>().state.currentPosition,
+          clips: clips,
+        );
 
-        _videoPlayer?.setClips([
-          for (final clip in clips)
-            if (clip.video.file?.path case final path?)
-              VideoClip(
-                uri: path,
-                start: clip.trimStart,
-                end: clip.duration - clip.trimEnd,
-                volume: clip.volume,
-                playbackSpeed: clip.playbackSpeed ?? 1.0,
-              ),
-        ], startPosition: currentPosition);
+        _setPlayerTimelinePosition(currentPosition);
+        unawaited(_applyPlayerClips(clips, startPosition: currentPosition));
       },
     );
 
@@ -835,22 +951,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
         final clips = ref.read(clipManagerProvider).clips;
         if (clips.isEmpty || !_isPlayerInitialized) return;
-        final currentPosition = context
-            .read<VideoEditorMainBloc>()
-            .state
-            .currentPosition;
+        final currentPosition = VideoEditorCanvas.clampPlaybackPositionToClips(
+          position: context.read<VideoEditorMainBloc>().state.currentPosition,
+          clips: clips,
+        );
 
-        _videoPlayer?.setClips([
-          for (final clip in clips)
-            if (clip.video.file?.path case final path?)
-              VideoClip(
-                uri: path,
-                start: clip.trimStart,
-                end: clip.duration - clip.trimEnd,
-                volume: clip.volume,
-                playbackSpeed: clip.playbackSpeed ?? 1.0,
-              ),
-        ], startPosition: currentPosition);
+        _setPlayerTimelinePosition(currentPosition);
+        unawaited(_applyPlayerClips(clips, startPosition: currentPosition));
       },
     );
 
@@ -932,14 +1039,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             _seekEpoch++;
             _pendingSeekPosition = null;
             _isSeeking = false;
-            _videoPlayer?.setClips([
-              VideoClip(
-                uri: path,
-                end: clip.duration,
-                volume: clip.volume,
-                playbackSpeed: clip.playbackSpeed ?? 1.0,
-              ),
-            ]);
+            unawaited(
+              _applyPlayerClips([
+                clip.copyWith(trimStart: Duration.zero, trimEnd: Duration.zero),
+              ]),
+            );
           },
         ),
         BlocListener<ClipEditorBloc, ClipEditorState>(
@@ -1051,11 +1155,32 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
             // Seek to the trim handle's release point when restoring the composite.
             final trimEndPosition = _consumeTrimEndStartPosition(state.clips);
-            final startPosition = trimEndPosition ?? bloc.state.currentPosition;
-            // Sync so subsequent re-emits read the post-seek position.
-            if (trimEndPosition != null) {
-              bloc.add(VideoEditorPositionChanged(trimEndPosition));
+            var startPosition = trimEndPosition ?? bloc.state.currentPosition;
+            final previousClips = _lastAppliedClips;
+            if (trimEndPosition == null &&
+                previousClips.isNotEmpty &&
+                previousClips.length == state.clips.length) {
+              final previousIds = previousClips.map((clip) => clip.id).toList();
+              final currentIds = state.clips.map((clip) => clip.id).toList();
+              if (listEquals(previousIds, currentIds)) {
+                startPosition =
+                    VideoEditorCanvas.remapPlaybackPositionForClipUpdate(
+                      previousClips: previousClips,
+                      currentClips: state.clips,
+                      currentPosition: bloc.state.currentPosition,
+                    );
+                if (startPosition != bloc.state.currentPosition) {
+                  Log.info(
+                    '⚡ Clip preview remapped: '
+                    'fromMs=${bloc.state.currentPosition.inMilliseconds} '
+                    'toMs=${startPosition.inMilliseconds}',
+                    name: 'VideoEditorCanvas',
+                    category: LogCategory.video,
+                  );
+                }
+              }
             }
+            _setPlayerTimelinePosition(startPosition);
             // Composition swap back — invalidate in-flight single-clip seeks.
             _seekEpoch++;
             _pendingSeekPosition = null;
@@ -1065,23 +1190,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             final ownerEpoch = _seekEpoch;
 
             try {
-              await _videoPlayer?.setClips([
-                for (final clip in state.clips)
-                  if (clip.video.file?.path case final path?)
-                    VideoClip(
-                      uri: path,
-                      start: clip.trimStart,
-                      end: clip.duration - clip.trimEnd,
-                      volume: clip.volume,
-                      playbackSpeed: clip.playbackSpeed ?? 1.0,
-                    ),
-              ], startPosition: startPosition);
+              await _applyPlayerClips(
+                state.clips,
+                startPosition: startPosition,
+              );
               if (mounted) {
                 VideoEditorCanvas.syncPositionAfterTrimRelease(
                   mainBloc: bloc,
                   proVideoController: _proVideoController,
                   startPosition: startPosition,
-                  trimEndAlreadyDispatched: trimEndPosition != null,
+                  trimEndAlreadyDispatched: true,
                 );
               }
             } catch (e, s) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet.dart
@@ -8,9 +8,16 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 
 class VideoEditorClipSpeedSheet extends StatefulWidget {
-  const VideoEditorClipSpeedSheet({super.key, this.initialSpeed = 1.0});
+  const VideoEditorClipSpeedSheet({
+    super.key,
+    this.initialSpeed = 1.0,
+    this.minSpeed = VideoEditorConstants.clipSpeedMin,
+    this.maxSpeed = VideoEditorConstants.clipSpeedMax,
+  });
 
   final double initialSpeed;
+  final double minSpeed;
+  final double maxSpeed;
 
   @override
   State<VideoEditorClipSpeedSheet> createState() =>
@@ -23,11 +30,11 @@ class _VideoEditorClipSpeedSheetState extends State<VideoEditorClipSpeedSheet> {
   @override
   void initState() {
     super.initState();
+    final minSpeed = widget.minSpeed <= widget.maxSpeed
+        ? widget.minSpeed
+        : widget.maxSpeed;
     _speed = ValueNotifier(
-      widget.initialSpeed.clamp(
-        VideoEditorConstants.clipSpeedMin,
-        VideoEditorConstants.clipSpeedMax,
-      ),
+      widget.initialSpeed.clamp(minSpeed, widget.maxSpeed),
     );
   }
 
@@ -74,7 +81,13 @@ class _VideoEditorClipSpeedSheetState extends State<VideoEditorClipSpeedSheet> {
           color: VineTheme.outlinedDisabled,
         ),
         const SizedBox(height: 16),
-        _SpeedControlBar(speed: _speed),
+        _SpeedControlBar(
+          speed: _speed,
+          minSpeed: widget.minSpeed <= widget.maxSpeed
+              ? widget.minSpeed
+              : widget.maxSpeed,
+          maxSpeed: widget.maxSpeed,
+        ),
         const SizedBox(height: 16),
       ],
     );
@@ -82,9 +95,15 @@ class _VideoEditorClipSpeedSheetState extends State<VideoEditorClipSpeedSheet> {
 }
 
 class _SpeedControlBar extends StatelessWidget {
-  const _SpeedControlBar({required this.speed});
+  const _SpeedControlBar({
+    required this.speed,
+    required this.minSpeed,
+    required this.maxSpeed,
+  });
 
   final ValueNotifier<double> speed;
+  final double minSpeed;
+  final double maxSpeed;
 
   @override
   Widget build(BuildContext context) {
@@ -103,14 +122,13 @@ class _SpeedControlBar extends StatelessWidget {
             valueListenable: speed,
             builder: (_, value, _) => DivineSlider(
               value: value,
-              min: VideoEditorConstants.clipSpeedMin,
-              max: VideoEditorConstants.clipSpeedMax,
-              divisions:
-                  ((VideoEditorConstants.clipSpeedMax -
-                              VideoEditorConstants.clipSpeedMin) /
-                          VideoEditorConstants.clipSpeedStep)
-                      .round(),
-              onChanged: (v) => speed.value = v,
+              min: minSpeed,
+              max: maxSpeed,
+              divisions: maxSpeed > minSpeed
+                  ? ((maxSpeed - minSpeed) / VideoEditorConstants.clipSpeedStep)
+                        .round()
+                  : 1,
+              onChanged: maxSpeed > minSpeed ? (v) => speed.value = v : null,
             ),
           ),
         ],

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -54,40 +55,50 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
 
   Future<void> _setPlaybackSpeed(BuildContext context) async {
     final bloc = context.read<ClipEditorBloc>();
-    final state = bloc.state;
-    if (state.currentClipIndex < 0 ||
-        state.currentClipIndex >= state.clips.length) {
+    final initialState = bloc.state;
+    if (initialState.currentClipIndex < 0 ||
+        initialState.currentClipIndex >= initialState.clips.length) {
       return;
     }
-    final clip = state.clips[state.currentClipIndex];
+    final clip = initialState.clips[initialState.currentClipIndex];
     final editor = VideoEditorScope.of(context).requireEditor;
+    final allowedRange = ClipEditorBloc.allowedPlaybackSpeedRange(
+      clips: initialState.clips,
+      clipIndex: initialState.currentClipIndex,
+      clip: clip,
+    );
 
     final result = await VineBottomSheet.show<double>(
       context: context,
       expanded: false,
       scrollable: false,
       isScrollControlled: true,
-      body: VideoEditorClipSpeedSheet(initialSpeed: clip.playbackSpeed ?? 1.0),
+      body: VideoEditorClipSpeedSheet(
+        initialSpeed: clip.playbackSpeed ?? 1.0,
+        minSpeed: allowedRange?.min ?? VideoEditorConstants.clipSpeedMin,
+        maxSpeed: allowedRange?.max ?? VideoEditorConstants.clipSpeedMax,
+      ),
     );
 
     if (result == null || !mounted) return;
 
+    final state = bloc.state;
+    final clipIndex = state.clips.indexWhere(
+      (candidate) => candidate.id == clip.id,
+    );
+    if (clipIndex == -1) return;
+    final currentClip = state.clips[clipIndex];
     final updated = ClipEditorBloc.normalizeClipUpdate(
       clips: state.clips,
-      clipIndex: state.currentClipIndex,
-      currentClip: clip,
-      proposedClip: clip.copyWith(playbackSpeed: result),
+      clipIndex: clipIndex,
+      currentClip: currentClip,
+      proposedClip: currentClip.copyWith(playbackSpeed: result),
     );
+    final updatedClips = state.clips
+        .map((c) => c.id == clip.id ? updated : c)
+        .toList(growable: false);
     bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: updated));
-
-    editor.addHistory(
-      meta: {
-        ...editor.stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey: state.clips
-            .map((c) => c.id == clip.id ? updated.toJson() : c.toJson())
-            .toList(),
-      },
-    );
+    editor.setClipState(updatedClips);
   }
 
   void _requestExtractAudio(BuildContext context) {

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -351,6 +351,26 @@ void main() {
           );
         },
       );
+
+      test(
+        'reports the effective playback speed range for the selected clip',
+        () {
+          final clips = [
+            _createClip(id: 'a', duration: const Duration(seconds: 2)),
+            _createClip(id: 'b', duration: const Duration(seconds: 6)),
+          ];
+
+          final range = ClipEditorBloc.allowedPlaybackSpeedRange(
+            clips: clips,
+            clipIndex: 1,
+            clip: clips[1],
+          );
+
+          expect(range, isNotNull);
+          expect(range!.min, closeTo(1.3953488372, 1e-9));
+          expect(range.max, VideoEditorConstants.clipSpeedMax);
+        },
+      );
     });
 
     // =========================================================

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -2,13 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/video_editor/draw_editor/video_editor_draw_bloc.dart';
 import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' show ProVideoController;
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
 
 void main() {
   testWidgets('VideoEditorCanvas renders safely with no clips', (tester) async {
@@ -67,53 +70,107 @@ void main() {
       await mainBloc.close();
     });
 
-    test(
-      'dispatches VideoEditorPositionChanged(startPosition) and updates '
-      'playTime when the trim-end position was not pre-dispatched',
-      () {
-        const startPosition = Duration(seconds: 2);
+    test('dispatches VideoEditorPositionChanged(startPosition) and updates '
+        'playTime when the trim-end position was not pre-dispatched', () {
+      const startPosition = Duration(seconds: 2);
 
-        VideoEditorCanvas.syncPositionAfterTrimRelease(
-          mainBloc: mainBloc,
-          proVideoController: controller,
-          startPosition: startPosition,
-          trimEndAlreadyDispatched: false,
-        );
+      VideoEditorCanvas.syncPositionAfterTrimRelease(
+        mainBloc: mainBloc,
+        proVideoController: controller,
+        startPosition: startPosition,
+        trimEndAlreadyDispatched: false,
+      );
 
-        expect(
-          mainBloc.events,
-          contains(
-            isA<VideoEditorPositionChanged>().having(
-              (e) => e.position,
-              'position',
-              startPosition,
-            ),
+      expect(
+        mainBloc.events,
+        contains(
+          isA<VideoEditorPositionChanged>().having(
+            (e) => e.position,
+            'position',
+            startPosition,
           ),
-        );
-        expect(controller.playTimeNotifier.value, equals(startPosition));
-      },
-    );
+        ),
+      );
+      expect(controller.playTimeNotifier.value, equals(startPosition));
+    });
+
+    test('skips the bloc dispatch but still updates playTime when the '
+        'trim-end position was already pushed pre-await', () {
+      const startPosition = Duration(milliseconds: 1500);
+
+      VideoEditorCanvas.syncPositionAfterTrimRelease(
+        mainBloc: mainBloc,
+        proVideoController: controller,
+        startPosition: startPosition,
+        trimEndAlreadyDispatched: true,
+      );
+
+      expect(mainBloc.events.whereType<VideoEditorPositionChanged>(), isEmpty);
+      expect(controller.playTimeNotifier.value, equals(startPosition));
+    });
+  });
+
+  group('VideoEditorCanvas.remapPlaybackPositionForClipUpdate', () {
+    test('preserves the same frame when a single clip is sped up', () {
+      final previousClips = [
+        _createClip(duration: const Duration(seconds: 4), playbackSpeed: 1.0),
+      ];
+      final currentClips = [
+        _createClip(duration: const Duration(seconds: 4), playbackSpeed: 2.0),
+      ];
+
+      final remapped = VideoEditorCanvas.remapPlaybackPositionForClipUpdate(
+        previousClips: previousClips,
+        currentClips: currentClips,
+        currentPosition: const Duration(seconds: 3),
+      );
+
+      expect(remapped, const Duration(milliseconds: 1500));
+    });
 
     test(
-      'skips the bloc dispatch but still updates playTime when the '
-      'trim-end position was already pushed pre-await',
+      'preserves the active clip frame when an earlier clip changes speed',
       () {
-        const startPosition = Duration(milliseconds: 1500);
+        final previousClips = [
+          _createClip(id: 'a', duration: const Duration(seconds: 4)),
+          _createClip(id: 'b', duration: const Duration(seconds: 4)),
+        ];
+        final currentClips = [
+          _createClip(
+            id: 'a',
+            duration: const Duration(seconds: 4),
+            playbackSpeed: 2.0,
+          ),
+          _createClip(id: 'b', duration: const Duration(seconds: 4)),
+        ];
 
-        VideoEditorCanvas.syncPositionAfterTrimRelease(
-          mainBloc: mainBloc,
-          proVideoController: controller,
-          startPosition: startPosition,
-          trimEndAlreadyDispatched: true,
+        final remapped = VideoEditorCanvas.remapPlaybackPositionForClipUpdate(
+          previousClips: previousClips,
+          currentClips: currentClips,
+          currentPosition: const Duration(seconds: 5),
         );
 
-        expect(
-          mainBloc.events.whereType<VideoEditorPositionChanged>(),
-          isEmpty,
-        );
-        expect(controller.playTimeNotifier.value, equals(startPosition));
+        expect(remapped, const Duration(seconds: 3));
       },
     );
+
+    test('clamps to the new composition duration when the clip disappears', () {
+      final previousClips = [
+        _createClip(id: 'a', duration: const Duration(seconds: 6)),
+        _createClip(id: 'b', duration: const Duration(seconds: 4)),
+      ];
+      final currentClips = [
+        _createClip(id: 'b', duration: const Duration(seconds: 4)),
+      ];
+
+      final remapped = VideoEditorCanvas.remapPlaybackPositionForClipUpdate(
+        previousClips: previousClips,
+        currentClips: currentClips,
+        currentPosition: const Duration(seconds: 5),
+      );
+
+      expect(remapped, const Duration(seconds: 4));
+    });
   });
 }
 
@@ -128,4 +185,20 @@ class _SpyVideoEditorMainBloc extends VideoEditorMainBloc {
     events.add(event);
     super.add(event);
   }
+}
+
+DivineVideoClip _createClip({
+  required Duration duration,
+  String id = 'clip',
+  double? playbackSpeed,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/tmp/$id.mp4'),
+    duration: duration,
+    recordedAt: DateTime(2026),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: model.AspectRatio.vertical,
+    playbackSpeed: playbackSpeed,
+  );
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet_test.dart
@@ -18,7 +18,11 @@ class _HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) => const Scaffold(body: Text('home'));
 }
 
-Widget _buildSubject({double initialSpeed = 1.0}) {
+Widget _buildSubject({
+  double initialSpeed = 1.0,
+  double minSpeed = VideoEditorConstants.clipSpeedMin,
+  double maxSpeed = VideoEditorConstants.clipSpeedMax,
+}) {
   return MaterialApp.router(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
@@ -31,7 +35,11 @@ Widget _buildSubject({double initialSpeed = 1.0}) {
             GoRoute(
               path: 'speed',
               builder: (context, state) => Scaffold(
-                body: VideoEditorClipSpeedSheet(initialSpeed: initialSpeed),
+                body: VideoEditorClipSpeedSheet(
+                  initialSpeed: initialSpeed,
+                  minSpeed: minSpeed,
+                  maxSpeed: maxSpeed,
+                ),
               ),
             ),
           ],
@@ -81,6 +89,17 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(DivineSlider), findsOneWidget);
+      });
+
+      testWidgets('uses the provided min and max speeds', (tester) async {
+        await tester.pumpWidget(
+          _buildSubject(initialSpeed: 1.5, minSpeed: 1.4, maxSpeed: 2.5),
+        );
+        await tester.pumpAndSettle();
+
+        final slider = tester.widget<DivineSlider>(find.byType(DivineSlider));
+        expect(slider.min, 1.4);
+        expect(slider.max, 2.5);
       });
 
       testWidgets('shows cancel and confirm buttons', (tester) async {
@@ -144,6 +163,17 @@ void main() {
         final expected =
             '${VideoEditorConstants.clipSpeedMax.toStringAsFixed(2)}×';
         expect(find.text(expected), findsOneWidget);
+      });
+
+      testWidgets('clamps below the provided minSpeed to minSpeed', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _buildSubject(minSpeed: 1.4),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('1.40×'), findsOneWidget);
       });
     });
 


### PR DESCRIPTION
## Summary
Fixes the clip-speed preview feature to preserve playback position and respect user-selected speeds.

## Root Cause Analysis
The editor was passing a stale global playback position to the player after a speed change. When the composition shrank (e.g., 3.0× speed-up), the position could land beyond the new end, causing the player to clamp and loop — making it appear as though the speed was always "fastest."

Additional issues:
- Speed sheet slider offered out-of-range values that the bloc silently rejected (stale UX)
- History write captured pre-sheet state, creating a race condition for multi-clip/concurrent edits
- Zero telemetry for speed application, making future logs unhelpful

## Implementation
1. **Position remapping helper** – converts the current playback position to the equivalent frame in the new composition, preserving the scrubber position on the same source frame
2. **Centralized speed range** – moved `computeAllowedSpeedRange()` to a shared helper, used by both bloc normalization and the speed sheet slider bounds
3. **Fresh state history write** – removed pre-sheet `state` snapshot; now reads bloc state after the sheet closes and writes via `setClipState(...)`
4. **Observability** – added targeted speed-change telemetry for requested/applied speed and position remap

## Testing
- Unit tests for position remap across speed changes (bloc + widget tests)
- Validated slider bounds match actual allowed range (widget tests)
- Full `test/blocs/video_editor/` and `test/widgets/video_editor/` suites green
- `flutter analyze lib test integration_test` clean
- GitHub checks all green

## Manual Verification
- Speed up / speed down on single and multi-clip timelines
- Edge cases: min/max constraints, undo/redo
- Logs show requested speed, normalized speed, and new preview position

Closes #7455.