### PR TITLE
fix(video-editor): resolve buggy speed-feature

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -2,7 +2,6 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' show AudioEvent;
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/observability/reportable_error.dart';
@@ -94,43 +93,6 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   final AudioExtractionService _audioExtractionService;
   final SplitClipFn _splitClip;
 
-  static DivineVideoClip normalizeClipUpdate({
-    required List<DivineVideoClip> clips,
-    required int clipIndex,
-    required DivineVideoClip currentClip,
-    required DivineVideoClip proposedClip,
-  }) {
-    final nextSpeed = proposedClip.playbackSpeed;
-    if (nextSpeed == null || nextSpeed <= 0) return proposedClip;
-
-    var otherPlaybackDuration = Duration.zero;
-    for (var i = 0; i < clips.length; i++) {
-      if (i == clipIndex) continue;
-      otherPlaybackDuration += clips[i].playbackDuration;
-    }
-
-    final remainingPlaybackUs =
-        (VideoEditorConstants.maxDuration - otherPlaybackDuration)
-            .inMicroseconds;
-    final trimmedUs = proposedClip.trimmedDuration.inMicroseconds;
-    if (trimmedUs <= 0) return proposedClip;
-    if (remainingPlaybackUs <= 0) return currentClip;
-
-    final minAllowedSpeed = trimmedUs / remainingPlaybackUs;
-    if (minAllowedSpeed > VideoEditorConstants.clipSpeedMax) {
-      return currentClip;
-    }
-
-    final clampedSpeed = nextSpeed.clamp(
-      minAllowedSpeed > VideoEditorConstants.clipSpeedMin
-          ? minAllowedSpeed
-          : VideoEditorConstants.clipSpeedMin,
-      VideoEditorConstants.clipSpeedMax,
-    );
-    if (clampedSpeed == nextSpeed) return proposedClip;
-    return proposedClip.copyWith(playbackSpeed: clampedSpeed);
-  }
-
   // === CLIP DATA ===
 
   void _onInitialized(
@@ -186,8 +148,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final index = state.clips.indexWhere((c) => c.id == event.clipId);
     if (index == -1) return;
 
-    final nextClip = state.clips[index].copyWith();
-    final newClips = List<DivineVideoClip>.of(state.clips)..[index] = nextClip;
+    final newClips = List<DivineVideoClip>.of(state.clips)
+      ..[index] = event.clip;
 
     emit(state.copyWith(clips: List.unmodifiable(newClips)));
   }

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -186,12 +186,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final index = state.clips.indexWhere((c) => c.id == event.clipId);
     if (index == -1) return;
 
-    final nextClip = normalizeClipUpdate(
-      clips: state.clips,
-      clipIndex: index,
-      currentClip: state.clips[index],
-      proposedClip: event.clip,
-    );
+    final nextClip = state.clips[index].copyWith();
     final newClips = List<DivineVideoClip>.of(state.clips)..[index] = nextClip;
 
     emit(state.copyWith(clips: List.unmodifiable(newClips)));

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -1,7 +1,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -11,17 +10,16 @@ import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_edi
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 
 /// Controls shown when a clip is in editing mode: Delete, Copy, Split, Done.
-class TimelineClipControls extends ConsumerStatefulWidget {
+class TimelineClipControls extends StatefulWidget {
   const TimelineClipControls({required this.playheadPosition, super.key});
 
   final ValueNotifier<Duration> playheadPosition;
 
   @override
-  ConsumerState<TimelineClipControls> createState() =>
-      _TimelineClipControlsState();
+  State<TimelineClipControls> createState() => _TimelineClipControlsState();
 }
 
-class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
+class _TimelineClipControlsState extends State<TimelineClipControls> {
   @override
   Widget build(BuildContext context) {
     final clips = context.select((ClipEditorBloc b) => b.state.clips);
@@ -31,8 +29,8 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
     );
 
     return VideoEditorTimelineControls(
-      onDelete: isLastClip ? null : () => _deleteClip(context, ref),
-      onDuplicated: () => _duplicateClip(context, ref),
+      onDelete: isLastClip ? null : () => _deleteClip(context),
+      onDuplicated: () => _duplicateClip(context),
       onSplit: () => _splitClip(context),
       onSpeed: () => _setPlaybackSpeed(context),
       onExtractAudio: () => _requestExtractAudio(context),
@@ -88,7 +86,7 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
     );
   }
 
-  void _deleteClip(BuildContext context, WidgetRef ref) {
+  void _deleteClip(BuildContext context) {
     final bloc = context.read<ClipEditorBloc>();
     final state = bloc.state;
     final clipId = state.clips[state.currentClipIndex].id;
@@ -106,7 +104,7 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
     );
   }
 
-  void _duplicateClip(BuildContext context, WidgetRef ref) {
+  void _duplicateClip(BuildContext context) {
     final bloc = context.read<ClipEditorBloc>();
     final state = bloc.state;
     final clip = state.clips[state.currentClipIndex];

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -72,21 +72,11 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
 
     if (result == null || !mounted) return;
 
-    final updated = ClipEditorBloc.normalizeClipUpdate(
-      clips: state.clips,
-      clipIndex: state.currentClipIndex,
-      currentClip: clip,
-      proposedClip: clip.copyWith(playbackSpeed: result),
-    );
+    final updated = clip.copyWith(playbackSpeed: result);
     bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: updated));
 
-    editor.addHistory(
-      meta: {
-        ...editor.stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey: state.clips
-            .map((c) => c.id == clip.id ? updated.toJson() : c.toJson())
-            .toList(),
-      },
+    editor.setClipState(
+      state.clips.map((c) => c.id == clip.id ? updated : c).toList(),
     );
   }
 
@@ -111,14 +101,8 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
     }
     bloc.add(const ClipEditorEditingStopped());
 
-    editor.addHistory(
-      meta: {
-        ...editor.stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey: state.clips
-            .where((clip) => clip.id != clipId)
-            .map((e) => e.toJson())
-            .toList(),
-      },
+    editor.setClipState(
+      state.clips.where((clip) => clip.id != clipId).toList(),
     );
   }
 
@@ -138,15 +122,7 @@ class _TimelineClipControlsState extends ConsumerState<TimelineClipControls> {
       ..add(ClipEditorClipInserted(index: state.clips.length, clip: copy))
       ..add(const ClipEditorEditingStopped());
 
-    editor.addHistory(
-      meta: {
-        ...editor.stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey: [
-          ...state.clips,
-          copy,
-        ].map((e) => e.toJson()).toList(),
-      },
-    );
+    editor.setClipState([...state.clips, copy]);
   }
 
   void _splitClip(BuildContext context) {

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -428,7 +428,19 @@ internal class DivineVideoPlayerInstance(
         // time, which is what ExoPlayer.seekTo expects.
         val resolved = resolveGlobalPosition(globalMs)
 
-        exoPlayer.seekTo(resolved.first, resolved.second)
+        val targetIndex = resolved.first
+        exoPlayer.seekTo(targetIndex, resolved.second)
+
+        // Apply the target clip's per-clip speed and volume immediately.
+        // ExoPlayer does not fire onPositionDiscontinuity / onMediaItemTransition
+        // with a speed-update path for manual seeks — only AUTO_TRANSITION is
+        // covered there. Without this, seeking from clip 2 (e.g. 0.25×) back
+        // to clip 1 (e.g. 3×) leaves the player running at 0.25× indefinitely.
+        exoPlayer.volume = (clipVolumes.getOrElse(targetIndex) { 1.0f }) * volume.toFloat()
+        exoPlayer.setPlaybackParameters(
+            PlaybackParameters(clipSpeeds.getOrElse(targetIndex) { 1.0f }),
+        )
+
         syncAudioOverlays()
 
         // Safety timeout — complete after 500ms if the callback never fires.

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -5,6 +5,7 @@ import android.graphics.SurfaceTexture
 import android.os.Handler
 import android.view.Surface
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import io.flutter.plugin.common.BinaryMessenger
@@ -341,5 +342,60 @@ class DivineVideoPlayerInstanceTest {
         instance.dispose()
 
         verify(exactly = 1) { result.success(null) }
+    }
+
+    // -- seekTo per-clip speed --
+
+    /**
+     * Regression test for the seek-backward speed bug:
+     * Clip 0 at 3× (source 3 s → 1 s on the timeline),
+     * clip 1 at 0.25× (source 4 s → 16 s on the timeline).
+     *
+     * After setClips the player is at clip 0.  When the user seeks to a
+     * position inside clip 0 the player must apply clip 0's speed (3×),
+     * NOT whatever speed was last active before the seek.
+     */
+    @Test
+    fun `seekTo applies the target clip speed so seeking backward from slow clip restores fast clip speed`() {
+        capturePlayerListener()
+
+        // Clip 0: 3 s source at 3× → 1 000 ms of playback timeline (offset 0..1000).
+        // Clip 1: 4 s source at 0.25× → 16 000 ms of playback timeline (offset 1000..17000).
+        instance.onMethodCall(
+            MethodCall(
+                "setClips",
+                mapOf(
+                    "clips" to listOf(
+                        mapOf(
+                            "uri" to "file:///a.mp4",
+                            "startMs" to 0,
+                            "endMs" to 3000,
+                            "playbackSpeed" to 3.0,
+                        ),
+                        mapOf(
+                            "uri" to "file:///b.mp4",
+                            "startMs" to 0,
+                            "endMs" to 4000,
+                            "playbackSpeed" to 0.25,
+                        ),
+                    ),
+                ),
+            ),
+            mockk(relaxed = true),
+        )
+
+        // Discard calls made by setClips so only the seekTo invocation is verified.
+        clearMocks(mockPlayer, answers = false, recordedCalls = true)
+
+        // Seek to global 500 ms → resolves to clip 0 (offset range 0–1000 ms).
+        instance.onMethodCall(
+            MethodCall("seekTo", mapOf("positionMs" to 500)),
+            mockk(relaxed = true),
+        )
+
+        // Clip 0's speed (3×) must be applied.
+        verify { mockPlayer.setPlaybackParameters(PlaybackParameters(3.0f)) }
+        // Clip 1's speed must NOT be applied.
+        verify(exactly = 0) { mockPlayer.setPlaybackParameters(PlaybackParameters(0.25f)) }
     }
 }

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -290,67 +290,6 @@ void main() {
         ),
         expect: () => <ClipEditorState>[],
       );
-
-      blocTest<ClipEditorBloc, ClipEditorState>(
-        'clamps playbackSpeed updates to preserve the maxDuration invariant',
-        build: buildBloc,
-        seed: () => ClipEditorState(
-          clips: [
-            _createClip(id: 'a', duration: const Duration(seconds: 2)),
-            _createClip(id: 'b', duration: const Duration(seconds: 6)),
-          ],
-        ),
-        act: (bloc) => bloc.add(
-          ClipEditorClipUpdated(
-            clipId: 'b',
-            clip: _createClip(
-              id: 'b',
-              duration: const Duration(seconds: 6),
-              playbackSpeed: 0.5,
-            ),
-          ),
-        ),
-        verify: (bloc) {
-          expect(
-            bloc.state.totalDuration <= VideoEditorConstants.maxDuration,
-            isTrue,
-          );
-          expect(
-            bloc.state.clips[1].playbackSpeed,
-            closeTo(1.3953488372, 1e-9),
-          );
-        },
-      );
-
-      blocTest<ClipEditorBloc, ClipEditorState>(
-        'rejects playbackSpeed updates when no valid speed can satisfy maxDuration',
-        build: buildBloc,
-        seed: () => ClipEditorState(
-          clips: [
-            _createClip(id: 'a', duration: VideoEditorConstants.maxDuration),
-            _createClip(id: 'b', duration: const Duration(seconds: 1)),
-          ],
-        ),
-        act: (bloc) => bloc.add(
-          ClipEditorClipUpdated(
-            clipId: 'b',
-            clip: _createClip(
-              id: 'b',
-              duration: const Duration(seconds: 1),
-              playbackSpeed: 0.5,
-            ),
-          ),
-        ),
-        verify: (bloc) {
-          expect(bloc.state.clips[1].playbackSpeed, isNull);
-          expect(
-            bloc.state.totalDuration,
-            equals(
-              VideoEditorConstants.maxDuration + const Duration(seconds: 1),
-            ),
-          );
-        },
-      );
     });
 
     // =========================================================

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -7,7 +7,6 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';


### PR DESCRIPTION
Closes #4691

## Description

The speed feature in the editor didn't work as expected because there was a "normalizer" method that changed the user-selected speed. This was a hallucination from Claude that is unnecessary in our scenario.

**Related Issue:** Closes # or Relates to #

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
