### PR TITLE
fix(images): cancel orphaned thumbnail downloads

### DIFF
--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -180,8 +180,8 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
   }
 }
 
-/// Error-safe network image widget that prevents HTTP 404 and other network exceptions
-/// Uses CachedNetworkImage which handles network errors more gracefully than Image.network
+/// Error-safe network image widget that prevents HTTP 404 and other network exceptions.
+/// Uses [VineCachedImage] for shared cache-backed loading where appropriate.
 class _SafeNetworkImage extends StatelessWidget {
   const _SafeNetworkImage({
     required this.url,
@@ -201,8 +201,8 @@ class _SafeNetworkImage extends StatelessWidget {
   final bool showPlayIcon;
   final BorderRadius? borderRadius;
 
-  // Toggle to test with plain Image.network instead of CachedNetworkImage
-  // Set to true to debug if the issue is with flutter_cache_manager
+  // Toggle to test with plain Image.network instead of VineCachedImage.
+  // Set to true to debug cache-manager behavior.
   static const bool _useSimpleImageNetwork = false;
 
   static bool _shouldBypassCacheManager(String url) {
@@ -211,7 +211,7 @@ class _SafeNetworkImage extends StatelessWidget {
 
     // Explore/grid thumbnails are predominantly served from Divine-owned,
     // immutable blob URLs. These load reliably with Image.network, while the
-    // CachedNetworkImage + custom cache manager path has been less reliable
+    // The shared cache-manager path has been less reliable
     // under concurrent grid loads on desktop.
     return host == 'divine.video' || host.endsWith('.divine.video');
   }

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -122,30 +122,16 @@ class _VineCachedImageState extends State<VineCachedImage> {
     _listener = null;
   }
 
-  Widget _buildPlaceholder() {
-    if (widget.placeholder == null) {
-      return SizedBox(width: widget.width, height: widget.height);
-    }
-    return KeyedSubtree(
-      key: const ValueKey('placeholder'),
-      child: widget.placeholder!(context, widget.imageUrl),
-    );
-  }
-
-  Widget _buildErrorWidget(Object error) {
-    if (widget.errorWidget == null) {
-      return SizedBox(width: widget.width, height: widget.height);
-    }
-    return KeyedSubtree(
-      key: const ValueKey('error'),
-      child: widget.errorWidget!(context, widget.imageUrl, error),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     if (_error != null) {
-      return _buildErrorWidget(_error!);
+      return _ErrorWidget(
+        error: _error!,
+        imageUrl: widget.imageUrl,
+        width: widget.width,
+        height: widget.height,
+        errorWidget: widget.errorWidget,
+      );
     }
 
     final image = Image(
@@ -154,7 +140,13 @@ class _VineCachedImageState extends State<VineCachedImage> {
       height: widget.height,
       fit: widget.fit,
       alignment: widget.alignment,
-      errorBuilder: (context, error, stackTrace) => _buildErrorWidget(error),
+      errorBuilder: (context, error, stackTrace) => _ErrorWidget(
+        error: error,
+        imageUrl: widget.imageUrl,
+        width: widget.width,
+        height: widget.height,
+        errorWidget: widget.errorWidget,
+      ),
     );
 
     if (widget.placeholder == null) {
@@ -173,7 +165,12 @@ class _VineCachedImageState extends State<VineCachedImage> {
           child: AnimatedOpacity(
             opacity: _hasImage ? 0 : 1,
             duration: widget.fadeOutDuration,
-            child: _buildPlaceholder(),
+            child: _Placeholder(
+              imageUrl: widget.imageUrl,
+              width: widget.width,
+              height: widget.height,
+              placeholder: widget.placeholder,
+            ),
           ),
         ),
         AnimatedOpacity(
@@ -183,6 +180,58 @@ class _VineCachedImageState extends State<VineCachedImage> {
           child: image,
         ),
       ],
+    );
+  }
+}
+
+class _Placeholder extends StatelessWidget {
+  const _Placeholder({
+    required this.imageUrl,
+    required this.width,
+    required this.height,
+    required this.placeholder,
+  });
+
+  final String imageUrl;
+  final double? width;
+  final double? height;
+  final PlaceholderWidgetBuilder? placeholder;
+
+  @override
+  Widget build(BuildContext context) {
+    if (placeholder == null) {
+      return SizedBox(width: width, height: height);
+    }
+    return KeyedSubtree(
+      key: const ValueKey('placeholder'),
+      child: placeholder!(context, imageUrl),
+    );
+  }
+}
+
+class _ErrorWidget extends StatelessWidget {
+  const _ErrorWidget({
+    required this.error,
+    required this.imageUrl,
+    required this.width,
+    required this.height,
+    required this.errorWidget,
+  });
+
+  final Object error;
+  final String imageUrl;
+  final double? width;
+  final double? height;
+  final LoadingErrorWidgetBuilder? errorWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    if (errorWidget == null) {
+      return SizedBox(width: width, height: height);
+    }
+    return KeyedSubtree(
+      key: const ValueKey('error'),
+      child: errorWidget!(context, imageUrl, error),
     );
   }
 }

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -1,15 +1,21 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/widgets.dart';
 import 'package:media_cache/media_cache.dart';
+
+/// Signature used to build a loading placeholder.
+typedef PlaceholderWidgetBuilder =
+    Widget Function(BuildContext context, String imageUrl);
+
+/// Signature used to build an error widget.
+typedef LoadingErrorWidgetBuilder =
+    Widget Function(BuildContext context, String imageUrl, Object error);
 
 /// Global image cache singleton backed by [MediaCacheManager].
 final openVineImageCache = MediaCacheManager(
   config: const MediaCacheConfig.image(cacheKey: 'openvine_image_cache'),
 );
 
-/// A wrapper around [CachedNetworkImage] that always uses
-/// [openVineImageCache] as the cache manager.
-class VineCachedImage extends StatelessWidget {
+/// A wrapper around [Image] that always uses [openVineImageCache].
+class VineCachedImage extends StatefulWidget {
   const VineCachedImage({
     required this.imageUrl,
     super.key,
@@ -38,20 +44,145 @@ class VineCachedImage extends StatelessWidget {
   final Duration fadeOutDuration;
 
   @override
+  State<VineCachedImage> createState() => _VineCachedImageState();
+}
+
+class _VineCachedImageState extends State<VineCachedImage> {
+  ImageStream? _imageStream;
+  ImageStreamListener? _listener;
+  Object? _error;
+  bool _hasImage = false;
+
+  ImageProvider<Object> get _imageProvider => ResizeImage.resizeIfNeeded(
+    widget.memCacheWidth,
+    widget.memCacheHeight,
+    MediaCacheImageProvider(widget.imageUrl, cacheManager: openVineImageCache),
+  );
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveImageStream();
+  }
+
+  @override
+  void didUpdateWidget(covariant VineCachedImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageUrl != widget.imageUrl ||
+        oldWidget.memCacheWidth != widget.memCacheWidth ||
+        oldWidget.memCacheHeight != widget.memCacheHeight) {
+      _resolveImageStream();
+    }
+  }
+
+  @override
+  void dispose() {
+    _removeImageListener();
+    super.dispose();
+  }
+
+  void _resolveImageStream() {
+    final newStream = _imageProvider.resolve(
+      createLocalImageConfiguration(context),
+    );
+    if (_imageStream?.key == newStream.key) {
+      return;
+    }
+
+    _removeImageListener();
+    _imageStream = newStream;
+    _error = null;
+    _hasImage = false;
+
+    _listener = ImageStreamListener(
+      (image, synchronousCall) {
+        image.dispose();
+        if (!mounted || _hasImage) return;
+        setState(() {
+          _hasImage = true;
+          _error = null;
+        });
+      },
+      onError: (Object error, StackTrace? stackTrace) {
+        if (!mounted) return;
+        setState(() {
+          _error = error;
+          _hasImage = false;
+        });
+      },
+    );
+    _imageStream!.addListener(_listener!);
+  }
+
+  void _removeImageListener() {
+    if (_imageStream != null && _listener != null) {
+      _imageStream!.removeListener(_listener!);
+    }
+    _imageStream = null;
+    _listener = null;
+  }
+
+  Widget _buildPlaceholder() {
+    if (widget.placeholder == null) {
+      return SizedBox(width: widget.width, height: widget.height);
+    }
+    return KeyedSubtree(
+      key: const ValueKey('placeholder'),
+      child: widget.placeholder!(context, widget.imageUrl),
+    );
+  }
+
+  Widget _buildErrorWidget(Object error) {
+    if (widget.errorWidget == null) {
+      return SizedBox(width: widget.width, height: widget.height);
+    }
+    return KeyedSubtree(
+      key: const ValueKey('error'),
+      child: widget.errorWidget!(context, widget.imageUrl, error),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return CachedNetworkImage(
-      imageUrl: imageUrl,
-      width: width,
-      height: height,
-      fit: fit,
-      alignment: alignment,
-      cacheManager: openVineImageCache,
-      placeholder: placeholder,
-      errorWidget: errorWidget,
-      memCacheWidth: memCacheWidth,
-      memCacheHeight: memCacheHeight,
-      fadeInDuration: fadeInDuration,
-      fadeOutDuration: fadeOutDuration,
+    if (_error != null) {
+      return _buildErrorWidget(_error!);
+    }
+
+    final image = Image(
+      image: _imageProvider,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      alignment: widget.alignment,
+      errorBuilder: (context, error, stackTrace) => _buildErrorWidget(error),
+    );
+
+    if (widget.placeholder == null) {
+      return AnimatedOpacity(
+        key: const ValueKey('image'),
+        opacity: _hasImage ? 1 : 0,
+        duration: widget.fadeInDuration,
+        child: image,
+      );
+    }
+
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        IgnorePointer(
+          child: AnimatedOpacity(
+            opacity: _hasImage ? 0 : 1,
+            duration: widget.fadeOutDuration,
+            child: _buildPlaceholder(),
+          ),
+        ),
+        AnimatedOpacity(
+          key: const ValueKey('image'),
+          opacity: _hasImage ? 1 : 0,
+          duration: widget.fadeInDuration,
+          child: image,
+        ),
+      ],
     );
   }
 }

--- a/mobile/packages/media_cache/lib/media_cache.dart
+++ b/mobile/packages/media_cache/lib/media_cache.dart
@@ -35,17 +35,19 @@
 /// }
 /// ```
 ///
-/// ## Image Caching with CachedNetworkImage
+/// ## Image Caching with MediaCacheImageProvider
 ///
 /// ```dart
 /// final imageCache = MediaCacheManager(
 ///   config: MediaCacheConfig.image(cacheKey: 'my_image_cache'),
 /// );
 ///
-/// // Use with CachedNetworkImage widget
-/// CachedNetworkImage(
-///   imageUrl: 'https://example.com/image.jpg',
-///   cacheManager: imageCache,
+/// // Use with Image widget
+/// Image(
+///   image: MediaCacheImageProvider(
+///     'https://example.com/image.jpg',
+///     cacheManager: imageCache,
+///   ),
 /// )
 /// ```
 library;
@@ -53,6 +55,7 @@ library;
 export 'src/cancellable_cache_operation.dart' show CancellableCacheOperation;
 export 'src/cancellable_downloader.dart'
     show CancellableDownload, CancellableDownloader, HttpCancellableDownloader;
+export 'src/media_cache_image_provider.dart' show MediaCacheImageProvider;
 export 'src/media_cache_manager.dart'
     show CacheMetrics, MediaCacheConfig, MediaCacheManager;
 export 'src/safe_cache_info_repository.dart'

--- a/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
@@ -152,7 +152,10 @@ class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
     scale,
     cacheKey,
     Object.hashAllUnordered(
-      authHeaders?.entries ?? const <MapEntry<String, String>>[],
+      authHeaders?.entries.map(
+            (entry) => Object.hash(entry.key, entry.value),
+          ) ??
+          const <int>[],
     ),
   );
 

--- a/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+import 'dart:io' as io;
+import 'dart:ui' as ui;
+
+import 'package:file/file.dart' as fs;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+import 'package:media_cache/src/cancellable_cache_operation.dart';
+import 'package:media_cache/src/media_cache_manager.dart';
+
+typedef _SimpleDecoderCallback =
+    Future<ui.Codec> Function(ui.ImmutableBuffer buffer);
+
+/// Loads images through [MediaCacheManager] with cancellation-aware downloads.
+@immutable
+class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
+  /// Creates a provider that resolves [url] through [cacheManager].
+  const MediaCacheImageProvider(
+    this.url, {
+    required this.cacheManager,
+    this.scale = 1.0,
+    this.cacheKey,
+    this.authHeaders,
+  });
+
+  /// The remote URL to load.
+  final String url;
+
+  /// The cache manager that owns the backing on-disk file.
+  final MediaCacheManager cacheManager;
+
+  /// The scale to report in the resulting [ImageInfo].
+  final double scale;
+
+  /// Optional explicit cache key. Defaults to [url].
+  final String? cacheKey;
+
+  /// Optional request headers.
+  final Map<String, String>? authHeaders;
+
+  String get _resolvedCacheKey => cacheKey ?? url;
+
+  @override
+  Future<MediaCacheImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<MediaCacheImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+    MediaCacheImageProvider key,
+    ImageDecoderCallback decode,
+  ) {
+    final loadHandle = _ImageLoadHandle();
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, loadHandle, decode: decode),
+      scale: key.scale,
+      debugLabel: key.url,
+      informationCollector: () => <DiagnosticsNode>[
+        DiagnosticsProperty<ImageProvider>('Image provider', this),
+        DiagnosticsProperty<MediaCacheImageProvider>('Image key', key),
+      ],
+    )..addOnLastListenerRemovedCallback(loadHandle.cancel);
+  }
+
+  Future<ui.Codec> _loadAsync(
+    MediaCacheImageProvider key,
+    _ImageLoadHandle loadHandle, {
+    required _SimpleDecoderCallback decode,
+  }) async {
+    try {
+      assert(
+        key == this,
+        'MediaCacheImageProvider.loadImage received a mismatched key.',
+      );
+
+      final existing = await cacheManager.getFileFromCache(_resolvedCacheKey);
+      if (existing != null && existing.file.existsSync()) {
+        if (loadHandle.isCancelled) {
+          throw const _ImageLoadCancelledException();
+        }
+        return _decodeFile(existing.file, decode: decode);
+      }
+
+      if (loadHandle.isCancelled) {
+        throw const _ImageLoadCancelledException();
+      }
+
+      final operation = cacheManager.cacheFileCancellable(
+        url,
+        key: _resolvedCacheKey,
+        authHeaders: authHeaders,
+      );
+      loadHandle.attach(operation);
+
+      final file = await operation.file;
+      if (file == null || loadHandle.isCancelled) {
+        throw const _ImageLoadCancelledException();
+      }
+
+      return _decodeFile(file, decode: decode);
+    } catch (error) {
+      scheduleMicrotask(() {
+        PaintingBinding.instance.imageCache.evict(key);
+      });
+      rethrow;
+    }
+  }
+
+  Future<ui.Codec> _decodeFile(
+    Object file, {
+    required _SimpleDecoderCallback decode,
+  }) async {
+    if (file is io.File) {
+      final lengthInBytes = await file.length();
+      if (lengthInBytes == 0) {
+        throw StateError('$file is empty and cannot be loaded as an image.');
+      }
+      return decode(await ui.ImmutableBuffer.fromFilePath(file.path));
+    }
+    if (file is fs.File) {
+      final lengthInBytes = await file.length();
+      if (lengthInBytes == 0) {
+        throw StateError('$file is empty and cannot be loaded as an image.');
+      }
+      return decode(
+        await ui.ImmutableBuffer.fromUint8List(await file.readAsBytes()),
+      );
+    }
+    throw StateError(
+      'Unsupported file type for image decode: ${file.runtimeType}',
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is MediaCacheImageProvider &&
+        other.url == url &&
+        identical(other.cacheManager, cacheManager) &&
+        other.scale == scale &&
+        other.cacheKey == cacheKey &&
+        mapEquals(other.authHeaders, authHeaders);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    url,
+    identityHashCode(cacheManager),
+    scale,
+    cacheKey,
+    Object.hashAllUnordered(
+      authHeaders?.entries ?? const <MapEntry<String, String>>[],
+    ),
+  );
+
+  @override
+  String toString() {
+    return '${objectRuntimeType(this, 'MediaCacheImageProvider')}'
+        '("$url", scale: ${scale.toStringAsFixed(1)})';
+  }
+}
+
+class _ImageLoadHandle {
+  CancellableCacheOperation? _operation;
+  bool _isCancelled = false;
+
+  bool get isCancelled => _isCancelled;
+
+  void attach(CancellableCacheOperation operation) {
+    _operation = operation;
+    if (_isCancelled) {
+      operation.cancel();
+    }
+  }
+
+  void cancel() {
+    if (_isCancelled) return;
+    _isCancelled = true;
+    _operation?.cancel();
+  }
+}
+
+class _ImageLoadCancelledException implements Exception {
+  const _ImageLoadCancelledException();
+
+  @override
+  String toString() => 'MediaCacheImageProvider load cancelled';
+}

--- a/mobile/packages/media_cache/pubspec.yaml
+++ b/mobile/packages/media_cache/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   cronet_http: ^1.8.0
   cupertino_http: ^2.4.0
+  file: ^7.0.0
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.4.1
@@ -22,7 +23,6 @@ dependencies:
     path: ../unified_logger
 
 dev_dependencies:
-  file: ^7.0.0
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -1,0 +1,267 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:file/local.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'helpers/mocks.dart';
+import 'helpers/test_helpers.dart';
+
+const _transparentPng = <int>[
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0xF8,
+  0xCF,
+  0xC0,
+  0x00,
+  0x00,
+  0x03,
+  0x01,
+  0x01,
+  0x00,
+  0x18,
+  0xDD,
+  0x8D,
+  0xB1,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE,
+  0x42,
+  0x60,
+  0x82,
+];
+
+class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MediaCacheImageProvider', () {
+    setUpTestEnvironment();
+
+    setUpAll(() async {
+      await setUpTestDirectories();
+    });
+
+    tearDownAll(() async {
+      await tearDownTestDirectories();
+    });
+
+    test(
+      'cancels in-flight download when the last listener is removed',
+      () async {
+        const url = 'https://example.com/image.jpg';
+        final cacheManager = _MockMediaCacheManager();
+        final download = FakeCancellableDownload(
+          url: url,
+          targetFile: File('$testTempPath/pending.jpg'),
+          headers: null,
+        );
+        final operation = CancellableCacheOperation.fromDownload(download);
+
+        when(
+          () => cacheManager.getFileFromCache(url),
+        ).thenAnswer((_) async => null);
+        when(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).thenReturn(operation);
+
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+        final completer = provider.loadImage(
+          provider,
+          (buffer, {getTargetSize}) => Completer<ui.Codec>().future,
+        );
+        final listener = ImageStreamListener((image, synchronousCall) {
+          image.dispose();
+        });
+
+        completer.addListener(listener);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => cacheManager.getFileFromCache(url)).called(1);
+        verify(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).called(1);
+        expect(download.isCancelled, isFalse);
+
+        completer.removeListener(listener);
+
+        expect(download.isCancelled, isTrue);
+      },
+    );
+
+    test(
+      'keeps a shared in-flight download alive until every listener leaves',
+      () async {
+        const url = 'https://example.com/image.jpg';
+        final cacheManager = _MockMediaCacheManager();
+        final download = FakeCancellableDownload(
+          url: url,
+          targetFile: File('$testTempPath/shared.jpg'),
+          headers: null,
+        );
+        final operation = CancellableCacheOperation.fromDownload(download);
+
+        when(
+          () => cacheManager.getFileFromCache(url),
+        ).thenAnswer((_) async => null);
+        when(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).thenReturn(operation);
+
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+        final completer = provider.loadImage(
+          provider,
+          (buffer, {getTargetSize}) => Completer<ui.Codec>().future,
+        );
+        final firstListener = ImageStreamListener((image, synchronousCall) {
+          image.dispose();
+        });
+        final secondListener = ImageStreamListener((image, synchronousCall) {
+          image.dispose();
+        });
+
+        completer
+          ..addListener(firstListener)
+          ..addListener(secondListener);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => cacheManager.getFileFromCache(url)).called(1);
+        verify(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).called(1);
+
+        completer.removeListener(firstListener);
+        expect(download.isCancelled, isFalse);
+
+        completer.removeListener(secondListener);
+        expect(download.isCancelled, isTrue);
+      },
+    );
+
+    test(
+      'decodes an existing cached file without starting a new download',
+      () async {
+        const url = 'https://example.com/cached-image.jpg';
+        final cacheManager = _MockMediaCacheManager();
+        final imageFile = const LocalFileSystem().file(
+          '$testTempPath/cached-image.png',
+        )..writeAsBytesSync(Uint8List.fromList(_transparentPng));
+
+        final fileInfo = MockFileInfo();
+        when(() => fileInfo.file).thenReturn(imageFile);
+        when(
+          () => cacheManager.getFileFromCache(url),
+        ).thenAnswer((_) async => fileInfo);
+
+        var decodeCalled = false;
+        final decodeAttempted = Completer<void>();
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+        final completer = provider.loadImage(provider, (
+          buffer, {
+          getTargetSize,
+        }) {
+          decodeCalled = true;
+          if (!decodeAttempted.isCompleted) {
+            decodeAttempted.complete();
+          }
+          throw StateError('stop after verifying decode entry');
+        });
+        final listener = ImageStreamListener(
+          (image, synchronousCall) {
+            image.dispose();
+          },
+          onError: (error, stackTrace) {},
+        );
+
+        completer.addListener(listener);
+        await decodeAttempted.future;
+
+        expect(decodeCalled, isTrue);
+        verify(() => cacheManager.getFileFromCache(url)).called(1);
+        verifyNever(
+          () => cacheManager.cacheFileCancellable(
+            any(),
+            key: any(named: 'key'),
+          ),
+        );
+
+        completer.removeListener(listener);
+      },
+    );
+  });
+}

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -100,21 +100,63 @@ void main() {
       await tearDownTestDirectories();
     });
 
+    test('obtainKey returns the provider synchronously', () async {
+      const url = 'https://example.com/image.jpg';
+      final cacheManager = _MockMediaCacheManager();
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+
+      final key = await provider.obtainKey(ImageConfiguration.empty);
+
+      expect(key, same(provider));
+    });
+
     test(
-      'obtainKey returns the provider synchronously',
-      () async {
+      'equal providers with separate but equal authHeaders share a hash code',
+      () {
         const url = 'https://example.com/image.jpg';
         final cacheManager = _MockMediaCacheManager();
-        final provider = MediaCacheImageProvider(
+        final first = MediaCacheImageProvider(
           url,
           cacheManager: cacheManager,
+          authHeaders: const {
+            'Authorization': 'Bearer token',
+            'X-Trace': 'abc123',
+          },
+        );
+        final second = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+          authHeaders: const {
+            'X-Trace': 'abc123',
+            'Authorization': 'Bearer token',
+          },
         );
 
-        final key = await provider.obtainKey(ImageConfiguration.empty);
-
-        expect(key, same(provider));
+        expect(first, equals(second));
+        expect(first.hashCode, equals(second.hashCode));
       },
     );
+
+    test('cacheKey and scale still participate in equality', () {
+      const url = 'https://example.com/image.jpg';
+      final cacheManager = _MockMediaCacheManager();
+      final base = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final customCacheKey = MediaCacheImageProvider(
+        url,
+        cacheManager: cacheManager,
+        cacheKey: 'custom-key',
+      );
+      final customScale = MediaCacheImageProvider(
+        url,
+        cacheManager: cacheManager,
+        scale: 2,
+      );
+
+      expect(base, isNot(equals(customCacheKey)));
+      expect(base.hashCode, isNot(equals(customCacheKey.hashCode)));
+      expect(base, isNot(equals(customScale)));
+      expect(base.hashCode, isNot(equals(customScale.hashCode)));
+    });
 
     test(
       'cancels in-flight download when the last listener is removed',
@@ -132,10 +174,7 @@ void main() {
           () => cacheManager.getFileFromCache(url),
         ).thenAnswer((_) async => null);
         when(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
+          () => cacheManager.cacheFileCancellable(url, key: url),
         ).thenReturn(operation);
 
         final provider = MediaCacheImageProvider(
@@ -155,10 +194,7 @@ void main() {
 
         verify(() => cacheManager.getFileFromCache(url)).called(1);
         verify(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
+          () => cacheManager.cacheFileCancellable(url, key: url),
         ).called(1);
         expect(download.isCancelled, isFalse);
 
@@ -184,10 +220,7 @@ void main() {
           () => cacheManager.getFileFromCache(url),
         ).thenAnswer((_) async => null);
         when(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
+          () => cacheManager.cacheFileCancellable(url, key: url),
         ).thenReturn(operation);
 
         final provider = MediaCacheImageProvider(
@@ -212,10 +245,7 @@ void main() {
 
         verify(() => cacheManager.getFileFromCache(url)).called(1);
         verify(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
+          () => cacheManager.cacheFileCancellable(url, key: url),
         ).called(1);
 
         completer.removeListener(firstListener);
@@ -257,12 +287,9 @@ void main() {
           }
           throw StateError('stop after verifying decode entry');
         });
-        final listener = ImageStreamListener(
-          (image, synchronousCall) {
-            image.dispose();
-          },
-          onError: (error, stackTrace) {},
-        );
+        final listener = ImageStreamListener((image, synchronousCall) {
+          image.dispose();
+        }, onError: (error, stackTrace) {});
 
         completer.addListener(listener);
         await decodeAttempted.future;
@@ -270,189 +297,145 @@ void main() {
         expect(decodeCalled, isTrue);
         verify(() => cacheManager.getFileFromCache(url)).called(1);
         verifyNever(
-          () => cacheManager.cacheFileCancellable(
-            any(),
-            key: any(named: 'key'),
-          ),
+          () =>
+              cacheManager.cacheFileCancellable(any(), key: any(named: 'key')),
         );
 
         completer.removeListener(listener);
       },
     );
 
-    test(
-      'decodes a downloaded dart:io file after cache miss',
-      () async {
-        const url = 'https://example.com/downloaded-image.png';
-        final cacheManager = _MockMediaCacheManager();
-        final imageFile = File(
-          '$testTempPath/downloaded-image.png',
-        )..writeAsBytesSync(Uint8List.fromList(_transparentPng));
-        final download = FakeCancellableDownload(
-          url: url,
-          targetFile: imageFile,
-          headers: null,
-        );
-        final operation = CancellableCacheOperation.fromDownload(download);
+    test('decodes a downloaded dart:io file after cache miss', () async {
+      const url = 'https://example.com/downloaded-image.png';
+      final cacheManager = _MockMediaCacheManager();
+      final imageFile = File('$testTempPath/downloaded-image.png')
+        ..writeAsBytesSync(Uint8List.fromList(_transparentPng));
+      final download = FakeCancellableDownload(
+        url: url,
+        targetFile: imageFile,
+        headers: null,
+      );
+      final operation = CancellableCacheOperation.fromDownload(download);
 
-        when(
-          () => cacheManager.getFileFromCache(url),
-        ).thenAnswer((_) async => null);
-        when(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
-        ).thenReturn(operation);
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => null);
+      when(
+        () => cacheManager.cacheFileCancellable(url, key: url),
+      ).thenReturn(operation);
 
-        var decodeCalled = false;
-        final decodeAttempted = Completer<void>();
-        final provider = MediaCacheImageProvider(
-          url,
-          cacheManager: cacheManager,
-        );
-        final completer = provider.loadImage(provider, (
-          buffer, {
-          getTargetSize,
-        }) {
-          decodeCalled = true;
-          if (!decodeAttempted.isCompleted) {
-            decodeAttempted.complete();
-          }
-          throw StateError('stop after verifying decode entry');
-        });
-        final listener = ImageStreamListener(
-          (image, synchronousCall) {
-            image.dispose();
-          },
-          onError: (error, stackTrace) {},
-        );
+      var decodeCalled = false;
+      final decodeAttempted = Completer<void>();
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final completer = provider.loadImage(provider, (buffer, {getTargetSize}) {
+        decodeCalled = true;
+        if (!decodeAttempted.isCompleted) {
+          decodeAttempted.complete();
+        }
+        throw StateError('stop after verifying decode entry');
+      });
+      final listener = ImageStreamListener((image, synchronousCall) {
+        image.dispose();
+      }, onError: (error, stackTrace) {});
 
-        completer.addListener(listener);
-        await Future<void>.delayed(Duration.zero);
-        download.completeWith(imageFile);
-        await decodeAttempted.future;
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+      download.completeWith(imageFile);
+      await decodeAttempted.future;
 
-        expect(decodeCalled, isTrue);
-        verify(() => cacheManager.getFileFromCache(url)).called(1);
-        verify(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
-        ).called(1);
+      expect(decodeCalled, isTrue);
+      verify(() => cacheManager.getFileFromCache(url)).called(1);
+      verify(() => cacheManager.cacheFileCancellable(url, key: url)).called(1);
 
-        completer.removeListener(listener);
-      },
-    );
+      completer.removeListener(listener);
+    });
 
-    test(
-      'evicts and stops decode when the download resolves null',
-      () async {
-        const url = 'https://example.com/cancelled-image.png';
-        final cacheManager = _MockMediaCacheManager();
-        final download = FakeCancellableDownload(
-          url: url,
-          targetFile: File('$testTempPath/cancelled-image.png'),
-          headers: null,
-        );
-        final operation = CancellableCacheOperation.fromDownload(download);
+    test('evicts and stops decode when the download resolves null', () async {
+      const url = 'https://example.com/cancelled-image.png';
+      final cacheManager = _MockMediaCacheManager();
+      final download = FakeCancellableDownload(
+        url: url,
+        targetFile: File('$testTempPath/cancelled-image.png'),
+        headers: null,
+      );
+      final operation = CancellableCacheOperation.fromDownload(download);
 
-        when(
-          () => cacheManager.getFileFromCache(url),
-        ).thenAnswer((_) async => null);
-        when(
-          () => cacheManager.cacheFileCancellable(
-            url,
-            key: url,
-          ),
-        ).thenReturn(operation);
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => null);
+      when(
+        () => cacheManager.cacheFileCancellable(url, key: url),
+      ).thenReturn(operation);
 
-        final provider = MediaCacheImageProvider(
-          url,
-          cacheManager: cacheManager,
-        );
-        final errors = <Object>[];
-        final completer = provider.loadImage(provider, (
-          buffer, {
-          getTargetSize,
-        }) {
-          throw StateError('decode should not run after null result');
-        });
-        final listener = ImageStreamListener(
-          (image, synchronousCall) {
-            image.dispose();
-          },
-          onError: (error, stackTrace) {
-            errors.add(error);
-          },
-        );
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final errors = <Object>[];
+      final completer = provider.loadImage(provider, (buffer, {getTargetSize}) {
+        throw StateError('decode should not run after null result');
+      });
+      final listener = ImageStreamListener(
+        (image, synchronousCall) {
+          image.dispose();
+        },
+        onError: (error, stackTrace) {
+          errors.add(error);
+        },
+      );
 
-        completer.addListener(listener);
-        await Future<void>.delayed(Duration.zero);
-        download.completeNull();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+      download.completeNull();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
-        expect(errors, hasLength(1));
-        expect(
-          errors.single.toString(),
-          contains('MediaCacheImageProvider load cancelled'),
-        );
-        expect(
-          PaintingBinding.instance.imageCache.containsKey(provider),
-          isFalse,
-        );
+      expect(errors, hasLength(1));
+      expect(
+        errors.single.toString(),
+        contains('MediaCacheImageProvider load cancelled'),
+      );
+      expect(
+        PaintingBinding.instance.imageCache.containsKey(provider),
+        isFalse,
+      );
 
-        completer.removeListener(listener);
-      },
-    );
+      completer.removeListener(listener);
+    });
 
-    test(
-      'throws for an empty cached file',
-      () async {
-        const url = 'https://example.com/empty-image.png';
-        final cacheManager = _MockMediaCacheManager();
-        final imageFile = const LocalFileSystem().file(
-          '$testTempPath/empty-image.png',
-        )..writeAsBytesSync(Uint8List(0));
+    test('throws for an empty cached file', () async {
+      const url = 'https://example.com/empty-image.png';
+      final cacheManager = _MockMediaCacheManager();
+      final imageFile = const LocalFileSystem().file(
+        '$testTempPath/empty-image.png',
+      )..writeAsBytesSync(Uint8List(0));
 
-        final fileInfo = MockFileInfo();
-        when(() => fileInfo.file).thenReturn(imageFile);
-        when(
-          () => cacheManager.getFileFromCache(url),
-        ).thenAnswer((_) async => fileInfo);
+      final fileInfo = MockFileInfo();
+      when(() => fileInfo.file).thenReturn(imageFile);
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => fileInfo);
 
-        final provider = MediaCacheImageProvider(
-          url,
-          cacheManager: cacheManager,
-        );
-        final errors = <Object>[];
-        final completer = provider.loadImage(provider, (
-          buffer, {
-          getTargetSize,
-        }) {
-          throw StateError('decode should not run for an empty file');
-        });
-        final listener = ImageStreamListener(
-          (image, synchronousCall) {
-            image.dispose();
-          },
-          onError: (error, stackTrace) {
-            errors.add(error);
-          },
-        );
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final errors = <Object>[];
+      final completer = provider.loadImage(provider, (buffer, {getTargetSize}) {
+        throw StateError('decode should not run for an empty file');
+      });
+      final listener = ImageStreamListener(
+        (image, synchronousCall) {
+          image.dispose();
+        },
+        onError: (error, stackTrace) {
+          errors.add(error);
+        },
+      );
 
-        completer.addListener(listener);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
-        expect(errors, hasLength(1));
-        expect(errors.single, isA<StateError>());
-        expect(errors.single.toString(), contains('is empty'));
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<StateError>());
+      expect(errors.single.toString(), contains('is empty'));
 
-        completer.removeListener(listener);
-      },
-    );
+      completer.removeListener(listener);
+    });
   });
 }

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -101,6 +101,22 @@ void main() {
     });
 
     test(
+      'obtainKey returns the provider synchronously',
+      () async {
+        const url = 'https://example.com/image.jpg';
+        final cacheManager = _MockMediaCacheManager();
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+
+        final key = await provider.obtainKey(ImageConfiguration.empty);
+
+        expect(key, same(provider));
+      },
+    );
+
+    test(
       'cancels in-flight download when the last listener is removed',
       () async {
         const url = 'https://example.com/image.jpg';
@@ -259,6 +275,181 @@ void main() {
             key: any(named: 'key'),
           ),
         );
+
+        completer.removeListener(listener);
+      },
+    );
+
+    test(
+      'decodes a downloaded dart:io file after cache miss',
+      () async {
+        const url = 'https://example.com/downloaded-image.png';
+        final cacheManager = _MockMediaCacheManager();
+        final imageFile = File(
+          '$testTempPath/downloaded-image.png',
+        )..writeAsBytesSync(Uint8List.fromList(_transparentPng));
+        final download = FakeCancellableDownload(
+          url: url,
+          targetFile: imageFile,
+          headers: null,
+        );
+        final operation = CancellableCacheOperation.fromDownload(download);
+
+        when(
+          () => cacheManager.getFileFromCache(url),
+        ).thenAnswer((_) async => null);
+        when(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).thenReturn(operation);
+
+        var decodeCalled = false;
+        final decodeAttempted = Completer<void>();
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+        final completer = provider.loadImage(provider, (
+          buffer, {
+          getTargetSize,
+        }) {
+          decodeCalled = true;
+          if (!decodeAttempted.isCompleted) {
+            decodeAttempted.complete();
+          }
+          throw StateError('stop after verifying decode entry');
+        });
+        final listener = ImageStreamListener(
+          (image, synchronousCall) {
+            image.dispose();
+          },
+          onError: (error, stackTrace) {},
+        );
+
+        completer.addListener(listener);
+        await Future<void>.delayed(Duration.zero);
+        download.completeWith(imageFile);
+        await decodeAttempted.future;
+
+        expect(decodeCalled, isTrue);
+        verify(() => cacheManager.getFileFromCache(url)).called(1);
+        verify(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).called(1);
+
+        completer.removeListener(listener);
+      },
+    );
+
+    test(
+      'evicts and stops decode when the download resolves null',
+      () async {
+        const url = 'https://example.com/cancelled-image.png';
+        final cacheManager = _MockMediaCacheManager();
+        final download = FakeCancellableDownload(
+          url: url,
+          targetFile: File('$testTempPath/cancelled-image.png'),
+          headers: null,
+        );
+        final operation = CancellableCacheOperation.fromDownload(download);
+
+        when(
+          () => cacheManager.getFileFromCache(url),
+        ).thenAnswer((_) async => null);
+        when(
+          () => cacheManager.cacheFileCancellable(
+            url,
+            key: url,
+          ),
+        ).thenReturn(operation);
+
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+        final errors = <Object>[];
+        final completer = provider.loadImage(provider, (
+          buffer, {
+          getTargetSize,
+        }) {
+          throw StateError('decode should not run after null result');
+        });
+        final listener = ImageStreamListener(
+          (image, synchronousCall) {
+            image.dispose();
+          },
+          onError: (error, stackTrace) {
+            errors.add(error);
+          },
+        );
+
+        completer.addListener(listener);
+        await Future<void>.delayed(Duration.zero);
+        download.completeNull();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(errors, hasLength(1));
+        expect(
+          errors.single.toString(),
+          contains('MediaCacheImageProvider load cancelled'),
+        );
+        expect(
+          PaintingBinding.instance.imageCache.containsKey(provider),
+          isFalse,
+        );
+
+        completer.removeListener(listener);
+      },
+    );
+
+    test(
+      'throws for an empty cached file',
+      () async {
+        const url = 'https://example.com/empty-image.png';
+        final cacheManager = _MockMediaCacheManager();
+        final imageFile = const LocalFileSystem().file(
+          '$testTempPath/empty-image.png',
+        )..writeAsBytesSync(Uint8List(0));
+
+        final fileInfo = MockFileInfo();
+        when(() => fileInfo.file).thenReturn(imageFile);
+        when(
+          () => cacheManager.getFileFromCache(url),
+        ).thenAnswer((_) async => fileInfo);
+
+        final provider = MediaCacheImageProvider(
+          url,
+          cacheManager: cacheManager,
+        );
+        final errors = <Object>[];
+        final completer = provider.loadImage(provider, (
+          buffer, {
+          getTargetSize,
+        }) {
+          throw StateError('decode should not run for an empty file');
+        });
+        final listener = ImageStreamListener(
+          (image, synchronousCall) {
+            image.dispose();
+          },
+          onError: (error, stackTrace) {
+            errors.add(error);
+          },
+        );
+
+        completer.addListener(listener);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(errors, hasLength(1));
+        expect(errors.single, isA<StateError>());
+        expect(errors.single.toString(), contains('is empty'));
 
         completer.removeListener(listener);
       },

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -24,6 +24,11 @@ class _ThrowingCancellableDownloader implements CancellableDownloader {
   Future<void> close() async {}
 }
 
+Future<File?> _cancelAndWait(CancellableCacheOperation operation) async {
+  operation.cancel();
+  return operation.file;
+}
+
 void main() {
   setUpTestEnvironment();
 
@@ -1374,6 +1379,57 @@ void main() {
           expect(opFile, isNotNull);
           expect(cfFile!.path, equals(opFile!.path));
           expect(downloadCallCount, equals(1));
+        },
+      );
+
+      test(
+        'cacheFile in-flight: cancelling the joined cancellable op '
+        'completes it locally without cancelling the shared download',
+        () async {
+          final mockFile = MockFile();
+          final mockFileInfo = MockFileInfo();
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          final downloadCompleter = Completer<FileInfo>();
+          var downloadCallCount = 0;
+
+          when(mockFile.existsSync).thenReturn(true);
+          when(() => mockFile.path).thenReturn('/test/path/shared_cancel.mp4');
+          when(() => mockFileInfo.file).thenReturn(mockFile);
+
+          final fakeDownloader = FakeCancellableDownloader();
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'cross_dedup_cf_cancel_$timestamp',
+              enableSyncManifest: true,
+            ),
+            downloaderOverride: fakeDownloader,
+            mockGetFileFromCache: (key) async => null,
+            mockDownloadFile: (url, {key, authHeaders}) {
+              downloadCallCount++;
+              return downloadCompleter.future;
+            },
+          );
+
+          final cacheFileFuture = cacheManager.cacheFile(
+            'https://example.com/shared_cancel.mp4',
+            key: 'shared_cancel_key',
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+
+          final op = cacheManager.cacheFileCancellable(
+            'https://example.com/shared_cancel.mp4',
+            key: 'shared_cancel_key',
+          );
+          final joinedFile = await _cancelAndWait(op);
+          expect(joinedFile, isNull);
+
+          downloadCompleter.complete(mockFileInfo);
+          final cacheFileResult = await cacheFileFuture;
+
+          expect(cacheFileResult, isNotNull);
+          expect(cacheFileResult!.path, equals(mockFile.path));
+          expect(downloadCallCount, equals(1));
+          expect(fakeDownloader.downloads, isEmpty);
         },
       );
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -281,30 +281,6 @@ packages:
       url: "https://github.com/guardianproject/c2pa-flutter.git"
     source: git
     version: "0.0.3"
-  cached_network_image:
-    dependency: "direct main"
-    description:
-      name: cached_network_image
-      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.1"
-  cached_network_image_platform_interface:
-    dependency: transitive
-    description:
-      name: cached_network_image_platform_interface
-      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.1"
-  cached_network_image_web:
-    dependency: transitive
-    description:
-      name: cached_network_image_web
-      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -1431,10 +1407,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1596,14 +1572,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
-  octo_image:
-    dependency: transitive
-    description:
-      name: octo_image
-      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -2381,26 +2349,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timezone:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1407,10 +1407,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -2349,26 +2349,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -162,7 +162,6 @@ dependencies:
   bech32: ^0.2.2
 
   # UI/UX
-  cached_network_image: ^3.3.1
   flutter_cache_manager: ^3.3.1
   share_plus: ^12.0.0 # Cross-platform sharing
   google_fonts: ^6.3.2 # For using Google Fonts including Pacifico

--- a/mobile/test/notifications/widgets/notification_avatar_stack_test.dart
+++ b/mobile/test/notifications/widgets/notification_avatar_stack_test.dart
@@ -1,11 +1,11 @@
 @Tags(['skip_very_good_optimization'])
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 void main() {
   const actor1 = ActorInfo(
@@ -40,14 +40,14 @@ void main() {
       await tester.pumpWidget(buildSubject(actors: const [actor1]));
       await tester.pump();
 
-      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      expect(find.byType(VineCachedImage), findsOneWidget);
     });
 
     testWidgets('renders two avatars for two actors', (tester) async {
       await tester.pumpWidget(buildSubject(actors: const [actor1, actor2]));
       await tester.pump();
 
-      expect(find.byType(CachedNetworkImage), findsNWidgets(2));
+      expect(find.byType(VineCachedImage), findsNWidgets(2));
     });
 
     testWidgets('renders three avatars for three actors', (tester) async {
@@ -57,8 +57,8 @@ void main() {
       await tester.pump();
 
       expect(find.byType(UserAvatar), findsNWidgets(3));
-      // actor1 and actor2 have URLs => CachedNetworkImage
-      expect(find.byType(CachedNetworkImage), findsNWidgets(2));
+      // actor1 and actor2 have URLs => VineCachedImage.
+      expect(find.byType(VineCachedImage), findsNWidgets(2));
     });
 
     testWidgets('renders overflow circle when overflowCount > 0', (
@@ -95,7 +95,7 @@ void main() {
 
       // Only first 3 actors shown (not 4); actor1 and actor2 have URLs.
       expect(find.byType(UserAvatar), findsNWidgets(3));
-      expect(find.byType(CachedNetworkImage), findsNWidgets(2));
+      expect(find.byType(VineCachedImage), findsNWidgets(2));
     });
   });
 }

--- a/mobile/test/widget/widgets/video_feed_item_test.dart.archived
+++ b/mobile/test/widget/widgets/video_feed_item_test.dart.archived
@@ -115,7 +115,7 @@ void main() {
         await tester.pumpWidget(createTestWidget(videoEvent: videoEventWithThumbnail));
         await tester.pump();
 
-        // Should show thumbnail as background layer (CachedNetworkImage)
+        // Should show thumbnail as background layer.
         expect(find.byType(Image), findsAtLeastNWidgets(1));
         
         // Should show loading indicator over thumbnail
@@ -347,7 +347,7 @@ void main() {
         await tester.pumpWidget(createTestWidget(videoEvent: gifEvent));
         await tester.pump();
 
-        // Should show CachedNetworkImage for GIF, not video player
+        // Should show image thumbnail for GIF, not video player.
         expect(find.byType(Image), findsAtLeastNWidgets(1));
         expect(find.byType(Chewie), findsNothing);
         

--- a/mobile/test/widgets/comprehensive_user_avatar_test.dart
+++ b/mobile/test/widgets/comprehensive_user_avatar_test.dart
@@ -3,13 +3,13 @@
 
 import 'dart:typed_data';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 import '../helpers/golden_test_devices.dart';
 
@@ -166,7 +166,7 @@ void main() {
     });
 
     group('Image Loading States', () {
-      testWidgets('shows CachedNetworkImage when imageUrl is provided', (
+      testWidgets('shows VineCachedImage when imageUrl is provided', (
         tester,
       ) async {
         const testImageUrl = 'https://example.com/avatar.jpg';
@@ -179,13 +179,13 @@ void main() {
           ),
         );
 
-        expect(find.byType(CachedNetworkImage), findsOneWidget);
+        expect(find.byType(VineCachedImage), findsOneWidget);
 
-        final cachedImage = tester.widget<CachedNetworkImage>(
-          find.byType(CachedNetworkImage),
+        final image = tester.widget<VineCachedImage>(
+          find.byType(VineCachedImage),
         );
-        expect(cachedImage.imageUrl, testImageUrl);
-        expect(cachedImage.fit, BoxFit.cover);
+        expect(image.imageUrl, testImageUrl);
+        expect(image.fit, BoxFit.cover);
         expect(_clipSize(tester), const Size.square(44));
       });
 
@@ -200,7 +200,7 @@ void main() {
           ),
         );
 
-        expect(find.byType(CachedNetworkImage), findsNothing);
+        expect(find.byType(VineCachedImage), findsNothing);
         expect(find.byType(Image), findsNothing);
         expect(_gradientFinder(), findsAtLeastNWidgets(1));
       });
@@ -218,7 +218,7 @@ void main() {
           ),
         );
 
-        expect(find.byType(CachedNetworkImage), findsNothing);
+        expect(find.byType(VineCachedImage), findsNothing);
         expect(find.byType(Image), findsNothing);
         expect(_gradientFinder(), findsAtLeastNWidgets(1));
       });
@@ -238,7 +238,7 @@ void main() {
           ),
         );
 
-        expect(find.byType(CachedNetworkImage), findsNothing);
+        expect(find.byType(VineCachedImage), findsNothing);
         expect(find.byType(Image), findsOneWidget);
         final image = tester.widget<Image>(find.byType(Image));
         expect(image.image, same(provider));
@@ -290,10 +290,10 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        final cachedImage = tester.widget<CachedNetworkImage>(
-          find.byType(CachedNetworkImage),
+        final image = tester.widget<VineCachedImage>(
+          find.byType(VineCachedImage),
         );
-        expect(cachedImage.errorWidget, isNotNull);
+        expect(image.errorWidget, isNotNull);
       });
 
       testWidgets('shows placeholder while image is loading', (tester) async {
@@ -309,10 +309,10 @@ void main() {
           ),
         );
 
-        final cachedImage = tester.widget<CachedNetworkImage>(
-          find.byType(CachedNetworkImage),
+        final image = tester.widget<VineCachedImage>(
+          find.byType(VineCachedImage),
         );
-        expect(cachedImage.placeholder, isNotNull);
+        expect(image.placeholder, isNotNull);
       });
     });
 
@@ -590,7 +590,7 @@ void main() {
         );
 
         expect(find.byType(UserAvatar), findsNWidgets(3));
-        expect(find.byType(CachedNetworkImage), findsOneWidget);
+        expect(find.byType(VineCachedImage), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/ios_network_image_deadlock_test.dart
+++ b/mobile/test/widgets/ios_network_image_deadlock_test.dart
@@ -1,21 +1,17 @@
 @Tags(['skip_very_good_optimization', 'integration'])
-// ABOUTME: Test to reproduce and verify iOS network image loading deadlock issues
-// ABOUTME: Ensures network images load properly on iOS without causing hangs or timeouts
-import 'package:cached_network_image/cached_network_image.dart';
+// ABOUTME: Regression coverage for concurrent thumbnail loading through VineCachedImage
+// ABOUTME: Ensures placeholders and transport settings stay stable under load
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 void main() {
-  group('iOS Network Image Deadlock Prevention', () {
+  group('VineCachedImage concurrency regression', () {
     testWidgets(
-      'Multiple concurrent network images should load without hanging (iOS regression test)',
+      'multiple concurrent image widgets should build without hanging',
       (tester) async {
-        // This test reproduces the iOS hang issue where multiple CachedNetworkImages
-        // loading simultaneously can cause a deadlock in the image loading pipeline
-
-        // Simulate the scenario from the crash logs: multiple avatar and thumbnail images
-        // loading at the same time during app startup
         const testImageUrls = [
           'https://api.openvine.co/avatar1.jpg',
           'https://api.openvine.co/avatar2.jpg',
@@ -36,9 +32,8 @@ void main() {
                       (url) => SizedBox(
                         width: 100,
                         height: 100,
-                        child: CachedNetworkImage(
+                        child: VineCachedImage(
                           imageUrl: url,
-                          fit: BoxFit.cover,
                           placeholder: (context, url) =>
                               Container(color: Colors.grey),
                           errorWidget: (context, url, error) =>
@@ -52,37 +47,27 @@ void main() {
           ),
         );
 
-        // Allow initial frame to render
         await tester.pump();
 
-        // This should complete within reasonable time without hanging
-        // If there's a deadlock, this test will timeout
         final stopwatch = Stopwatch()..start();
-
-        // Wait for network images to start loading (multiple pump cycles)
         for (int i = 0; i < 10; i++) {
           await tester.pump(const Duration(milliseconds: 100));
         }
-
         stopwatch.stop();
 
-        // Test should complete quickly - if it takes too long, there's likely a deadlock
         expect(
           stopwatch.elapsedMilliseconds,
           lessThan(5000),
           reason:
-              'Network image loading took too long, possible deadlock detected',
+              'Concurrent image loading took too long, possible stall detected',
         );
-
-        // Verify that placeholder/error widgets are shown (images will fail to load in test env)
         expect(find.byType(Container), findsAtLeast(testImageUrls.length));
       },
     );
 
-    testWidgets('Single network image should have proper timeout handling', (
+    testWidgets('single image shows placeholder before load resolves', (
       tester,
     ) async {
-      // Test individual network image timeout behavior
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -91,9 +76,8 @@ void main() {
             body: SizedBox(
               width: 100,
               height: 100,
-              child: CachedNetworkImage(
+              child: VineCachedImage(
                 imageUrl: 'https://api.openvine.co/nonexistent-image.jpg',
-                fit: BoxFit.cover,
                 placeholder: (context, url) => const ColoredBox(
                   color: Colors.grey,
                   child: Text('Loading'),
@@ -108,32 +92,24 @@ void main() {
 
       await tester.pump();
 
-      // Should show placeholder initially
       expect(find.text('Loading'), findsOneWidget);
 
-      // After some time, should show error widget or still loading
       await tester.pump(const Duration(milliseconds: 100));
 
-      // Note: In test environment, network requests might fail immediately or show loading
-      // We just verify the app doesn't hang
       expect(find.byType(ColoredBox), findsAtLeast(1));
     });
 
-    test('CachedNetworkImage should have reasonable connection timeout configured', () {
-      // This test verifies that our custom cache manager has proper timeout configuration
-
-      // Based on iOS crash logs, we ensure:
-      // 1. Connection timeout is set to 10 seconds (prevents hanging on slow connections)
-      // 2. Idle timeout is set to 30 seconds (prevents keeping connections open too long)
-      // 3. Maximum concurrent connections is limited to 6 (prevents resource exhaustion)
-
-      // The implementation is in ImageCacheManager
+    test('openVineImageCache keeps the image preset transport limits', () {
+      expect(openVineImageCache.mediaConfig, isA<MediaCacheConfig>());
       expect(
-        true,
-        isTrue,
-        reason:
-            'Network image timeout configuration implemented in ImageCacheManager',
+        openVineImageCache.mediaConfig.connectionTimeout,
+        const Duration(seconds: 10),
       );
+      expect(
+        openVineImageCache.mediaConfig.idleTimeout,
+        const Duration(seconds: 30),
+      );
+      expect(openVineImageCache.mediaConfig.maxConnectionsPerHost, 20);
     });
   });
 }

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1,5 +1,4 @@
 import 'package:blurhash_service/blurhash_service.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,6 +6,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 import '../test_data/video_test_data.dart';
 
@@ -64,8 +64,8 @@ void main() {
       // Widget should build without error
       expect(find.byType(VideoThumbnailWidget), findsOneWidget);
 
-      // Should create a CachedNetworkImage widget when thumbnail URL exists
-      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      // Should create a VineCachedImage widget when thumbnail URL exists.
+      expect(find.byType(VineCachedImage), findsOneWidget);
     });
 
     testWidgets(
@@ -92,7 +92,7 @@ void main() {
         );
 
         expect(find.byType(Image), findsOneWidget);
-        expect(find.byType(CachedNetworkImage), findsNothing);
+        expect(find.byType(VineCachedImage), findsNothing);
       },
     );
 
@@ -119,8 +119,8 @@ void main() {
       // (current implementation uses flat color instead of blurhash)
       expect(find.byType(Container), findsWidgets);
 
-      // Should not show CachedNetworkImage since no thumbnail URL
-      expect(find.byType(CachedNetworkImage), findsNothing);
+      // Should not show VineCachedImage since no thumbnail URL.
+      expect(find.byType(VineCachedImage), findsNothing);
     });
 
     testWidgets('displays thumbnail with flat background when both exist', (
@@ -140,8 +140,8 @@ void main() {
         ),
       );
 
-      // Should show CachedNetworkImage for thumbnail
-      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      // Should show VineCachedImage for thumbnail.
+      expect(find.byType(VineCachedImage), findsOneWidget);
       expect(find.byType(Stack), findsAtLeastNWidgets(1));
     });
 
@@ -167,8 +167,8 @@ void main() {
         // Should show Container with surfaceContainer color as placeholder
         expect(find.byType(Container), findsWidgets);
 
-        // Should not show CachedNetworkImage since no thumbnail URL
-        expect(find.byType(CachedNetworkImage), findsNothing);
+        // Should not show VineCachedImage since no thumbnail URL.
+        expect(find.byType(VineCachedImage), findsNothing);
       },
     );
 
@@ -232,8 +232,8 @@ void main() {
         ),
       );
 
-      // Initially shows CachedNetworkImage for thumbnail
-      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      // Initially shows VineCachedImage for thumbnail.
+      expect(find.byType(VineCachedImage), findsOneWidget);
 
       // Update to video with only blurhash (no thumbnail)
       await tester.pumpWidget(
@@ -252,8 +252,8 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // Should now show flat placeholder (no CachedNetworkImage)
-      expect(find.byType(CachedNetworkImage), findsNothing);
+      // Should now show flat placeholder (no VineCachedImage).
+      expect(find.byType(VineCachedImage), findsNothing);
       expect(find.byType(Container), findsWidgets);
     });
 
@@ -402,7 +402,7 @@ void main() {
 
       // Should show flat placeholder, not loading indicator or image
       expect(find.byType(Container), findsWidgets);
-      expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(find.byType(VineCachedImage), findsNothing);
     });
 
     testWidgets('handles empty thumbnail URL as null', (tester) async {
@@ -430,7 +430,7 @@ void main() {
 
       // Should treat empty URL as null and show flat placeholder
       expect(find.byType(Container), findsWidgets);
-      expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(find.byType(VineCachedImage), findsNothing);
     });
   });
 }

--- a/mobile/test/widgets/vine_cached_image_test.dart
+++ b/mobile/test/widgets/vine_cached_image_test.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
@@ -32,36 +31,41 @@ void main() {
   group(VineCachedImage, () {
     const testUrl = 'https://example.com/image.jpg';
 
-    testWidgets('renders $CachedNetworkImage with correct imageUrl', (
+    testWidgets('renders Image with a MediaCacheImageProvider', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: testUrl),
+        ),
+      );
+
+      expect(find.byType(Image), findsOneWidget);
+
+      final image = tester.widget<Image>(find.byType(Image));
+      final provider = image.image as MediaCacheImageProvider;
+      expect(provider.url, equals(testUrl));
+      expect(provider.cacheManager, same(openVineImageCache));
+    });
+
+    testWidgets('uses ResizeImage when memCache sizing is provided', (
       tester,
     ) async {
       await tester.pumpWidget(
         const Directionality(
           textDirection: TextDirection.ltr,
-          child: VineCachedImage(imageUrl: testUrl),
+          child: VineCachedImage(
+            imageUrl: testUrl,
+            memCacheWidth: 256,
+            memCacheHeight: 512,
+          ),
         ),
       );
 
-      expect(find.byType(CachedNetworkImage), findsOneWidget);
-
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.imageUrl, equals(testUrl));
-    });
-
-    testWidgets('uses openVineImageCache as cacheManager', (tester) async {
-      await tester.pumpWidget(
-        const Directionality(
-          textDirection: TextDirection.ltr,
-          child: VineCachedImage(imageUrl: testUrl),
-        ),
-      );
-
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.cacheManager, equals(openVineImageCache));
+      final image = tester.widget<Image>(find.byType(Image));
+      final resized = image.image as ResizeImage;
+      expect(resized.width, 256);
+      expect(resized.height, 512);
+      expect(resized.imageProvider, isA<MediaCacheImageProvider>());
     });
 
     testWidgets('defaults fit to BoxFit.cover', (tester) async {
@@ -72,10 +76,8 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.fit, equals(BoxFit.cover));
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.fit, equals(BoxFit.cover));
     });
 
     testWidgets('defaults alignment to Alignment.center', (tester) async {
@@ -86,10 +88,8 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.alignment, equals(Alignment.center));
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.alignment, equals(Alignment.center));
     });
 
     testWidgets('passes width and height through', (tester) async {
@@ -100,11 +100,9 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.width, equals(100));
-      expect(cached.height, equals(200));
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.width, equals(100));
+      expect(image.height, equals(200));
     });
 
     testWidgets('passes fit and alignment through', (tester) async {
@@ -119,32 +117,9 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.fit, equals(BoxFit.contain));
-      expect(cached.alignment, equals(Alignment.topCenter));
-    });
-
-    testWidgets('passes memCacheWidth and memCacheHeight through', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        const Directionality(
-          textDirection: TextDirection.ltr,
-          child: VineCachedImage(
-            imageUrl: testUrl,
-            memCacheWidth: 256,
-            memCacheHeight: 512,
-          ),
-        ),
-      );
-
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
-      );
-      expect(cached.memCacheWidth, equals(256));
-      expect(cached.memCacheHeight, equals(512));
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.fit, equals(BoxFit.contain));
+      expect(image.alignment, equals(Alignment.topCenter));
     });
 
     testWidgets('defaults fadeInDuration to 500ms', (tester) async {
@@ -155,10 +130,10 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
       );
-      expect(cached.fadeInDuration, equals(const Duration(milliseconds: 500)));
+      expect(image.fadeInDuration, equals(const Duration(milliseconds: 500)));
     });
 
     testWidgets('defaults fadeOutDuration to 1000ms', (tester) async {
@@ -169,13 +144,10 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
       );
-      expect(
-        cached.fadeOutDuration,
-        equals(const Duration(milliseconds: 1000)),
-      );
+      expect(image.fadeOutDuration, equals(const Duration(milliseconds: 1000)));
     });
 
     testWidgets('passes fadeInDuration and fadeOutDuration through', (
@@ -192,11 +164,11 @@ void main() {
         ),
       );
 
-      final cached = tester.widget<CachedNetworkImage>(
-        find.byType(CachedNetworkImage),
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
       );
-      expect(cached.fadeInDuration, equals(Duration.zero));
-      expect(cached.fadeOutDuration, equals(const Duration(milliseconds: 200)));
+      expect(image.fadeInDuration, equals(Duration.zero));
+      expect(image.fadeOutDuration, equals(const Duration(milliseconds: 200)));
     });
   });
 }


### PR DESCRIPTION
Closes #4692
Closes #4696

## Summary
- replace the last cached_network_image usage with a repo-owned MediaCacheImageProvider backed by MediaCacheManager.cacheFileCancellable
- cancel in-flight thumbnail downloads when the last image listener is removed while preserving VineCachedImage's public API
- drop the cached_network_image dependency and refresh regression coverage around avatars, thumbnails, and concurrent image loading

## Verification
- flutter test test/src/media_cache_image_provider_test.dart (from mobile/packages/media_cache)
- flutter test --no-pub test/widgets/vine_cached_image_test.dart
- flutter test --no-pub test/widgets/video_thumbnail_widget_test.dart
- flutter test --no-pub test/widgets/comprehensive_user_avatar_test.dart
- flutter test --no-pub test/notifications/widgets/notification_avatar_stack_test.dart
- flutter test --no-pub test/widgets/ios_network_image_deadlock_test.dart
- flutter test --no-pub test/widgets/profile/profile_tab_thumbnail_test.dart
- flutter test --no-pub test/widgets/user_avatar_svg_test.dart
- flutter analyze --no-pub lib/widgets/vine_cached_image.dart packages/media_cache/lib/src/media_cache_image_provider.dart packages/media_cache/test/src/media_cache_image_provider_test.dart test/widgets/ios_network_image_deadlock_test.dart test/widgets/video_thumbnail_widget_test.dart test/widgets/comprehensive_user_avatar_test.dart test/notifications/widgets/notification_avatar_stack_test.dart test/widgets/vine_cached_image_test.dart test/widgets/profile/profile_tab_thumbnail_test.dart

## Notes
- full-repo flutter analyze still reports pre-existing infos in unrelated manual/integration scripts outside this diff; the changed files above analyze cleanly
- flutter test / flutter analyze without --no-pub can crash in this worktree because Flutter tries to delete ios/Flutter/ephemeral/Packages/.packages; verification used the already-resolved dependency graph to avoid that tooling bug
