### PR TITLE
ci: reduce GitHub Actions runner size

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   generated-files:
     name: Generated Files
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     defaults:
       run:
         working-directory: mobile/
@@ -83,7 +83,7 @@ jobs:
           fi
   format:
     name: Format
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     defaults:
       run:
         working-directory: mobile/
@@ -101,7 +101,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed lib test integration_test
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     defaults:
       run:
         working-directory: mobile/
@@ -119,7 +119,7 @@ jobs:
         run: flutter analyze lib test integration_test
   tests:
     name: Tests
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     defaults:
       run:
         working-directory: mobile/
@@ -145,7 +145,7 @@ jobs:
         run: very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed random
   vgv-tag-gate:
     name: VGV Tag Gate
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     defaults:
       run:
         working-directory: mobile/
@@ -184,7 +184,7 @@ jobs:
       - analyze
       - tests
       - vgv-tag-gate
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     steps:
       - name: Verify upstream jobs
         env:

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   generated-files:
     name: Generated Files
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: mobile/
@@ -83,7 +83,7 @@ jobs:
           fi
   format:
     name: Format
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: mobile/
@@ -101,7 +101,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed lib test integration_test
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: mobile/
@@ -119,7 +119,7 @@ jobs:
         run: flutter analyze lib test integration_test
   tests:
     name: Tests
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: mobile/
@@ -145,7 +145,7 @@ jobs:
         run: very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed random
   vgv-tag-gate:
     name: VGV Tag Gate
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: mobile/
@@ -184,7 +184,7 @@ jobs:
       - analyze
       - tests
       - vgv-tag-gate
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     steps:
       - name: Verify upstream jobs
         env:

--- a/.github/workflows/mobile_pr_preview_build.yml
+++ b/.github/workflows/mobile_pr_preview_build.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-preview:
     name: Build Flutter Web Preview
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
 

--- a/.github/workflows/mobile_pr_preview_build.yml
+++ b/.github/workflows/mobile_pr_preview_build.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-preview:
     name: Build Flutter Web Preview
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 

--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -16,7 +16,7 @@ jobs:
   deploy-preview:
     name: Deploy PR Preview To Cloudflare
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -16,7 +16,7 @@ jobs:
   deploy-preview:
     name: Deploy PR Preview To Cloudflare
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   service-tests:
     name: Integration Tests (services)
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: mobile/

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   service-tests:
     name: Integration Tests (services)
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     defaults:
       run:
         working-directory: mobile/

--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-and-deploy:
     name: Build & Deploy to app.divine.video
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 

--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-and-deploy:
     name: Build & Deploy to app.divine.video
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
 

--- a/.github/workflows/pr_issue_link.yml
+++ b/.github/workflows/pr_issue_link.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   ensure-issue:
     name: ensure-linked-issue
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Ensure PR has a linked tracking issue

--- a/.github/workflows/pr_issue_link.yml
+++ b/.github/workflows/pr_issue_link.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   ensure-issue:
     name: ensure-linked-issue
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Ensure PR has a linked tracking issue

--- a/mobile/scripts/baseline/ui_service_imports.txt
+++ b/mobile/scripts/baseline/ui_service_imports.txt
@@ -68,7 +68,6 @@ lib/widgets/global_upload_indicator.dart
 lib/widgets/hashtag_search_view.dart
 lib/widgets/library/sounds_tab.dart
 lib/widgets/new_videos_tab.dart
-lib/widgets/pooled_video_metrics_tracker.dart
 lib/widgets/popular_videos_tab.dart
 lib/widgets/profile/profile_collabs_grid.dart
 lib/widgets/profile/profile_header_widget.dart


### PR DESCRIPTION
## Summary
- replace `ubuntu-24.04-16core` GitHub larger runner labels with `ubuntu-24.04-4core`
- reduce Actions spend while keeping larger-than-standard Linux runner capacity

## Motivation
The Divine org has used 90% of its May 2026 Actions budget. 4-core Linux larger runners are materially cheaper than 16-core runners while still giving build/test jobs more CPU than the default runner.

## Linked issue
None.

## Manual validation
- Verified changed workflow files no longer contain `ubuntu-24.04-16core`.
- Verified changed workflow files now use `ubuntu-24.04-4core`.
