### PR TITLE
fix(feed): reuse username badges in author overlay

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_author_info_section.dart
+++ b/mobile/lib/widgets/video_feed_item/video_author_info_section.dart
@@ -13,6 +13,7 @@ import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
@@ -110,8 +111,9 @@ class VideoAuthorInfoSection extends ConsumerWidget {
                       container: true,
                       explicitChildNodes: true,
                       label: context.l10n.videoAuthorSemanticLabel(displayName),
-                      child: Text(
-                        displayName,
+                      child: UserName.fromPubKey(
+                        video.pubkey,
+                        embeddedName: video.authorName,
                         style: VineTheme.titleSmallFont(),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,

--- a/mobile/test/widgets/video_feed_item/video_author_info_section_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_author_info_section_test.dart
@@ -1,11 +1,15 @@
 // ABOUTME: Semantics regressions for shared author overlay metadata.
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/services/og_viner_cache_service.dart';
 import 'package:openvine/widgets/video_feed_item/video_author_info_section.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
@@ -70,6 +74,51 @@ void main() {
       );
       expect(
         find.bySemanticsLabel(enL10n.videoAuthorAvatarSemanticLabel),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'author row uses shared username badge rendering for OG Viners',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({
+        ogVinerPubkeysCacheKey: jsonEncode([testPubkey]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final mockNostr = createMockNostrService();
+      when(() => mockNostr.publicKey).thenReturn(testPubkey);
+
+      await tester.pumpWidget(
+        testProviderScope(
+          mockNostrService: mockNostr,
+          mockSharedPreferences: prefs,
+          additionalOverrides: [
+            userProfileReactiveProvider(testPubkey).overrideWith(
+              (ref) => Stream<UserProfile?>.value(null),
+            ),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoAuthorInfoSection(
+                video: video,
+                hasTextContent: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(video.authorName!), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics && widget.properties.label == 'OG Viner',
+        ),
         findsOneWidget,
       );
     },


### PR DESCRIPTION
Closes #4701

## Summary
- render feed overlay author names through the shared UserName widget
- preserve embedded author-name fallback while enabling special profile checks and OG Viner badges
- add a widget regression test for OG Viner badge rendering in the author row

## Tests
- flutter test test/widgets/video_feed_item/video_author_info_section_test.dart --plain-name 'author row uses shared username badge rendering for OG Viners' (red before fix, pass after)
- flutter analyze lib/widgets/video_feed_item/video_author_info_section.dart test/widgets/video_feed_item/video_author_info_section_test.dart
- flutter test test/widgets/video_feed_item/video_author_info_section_test.dart
- pre-push analyzer and changed-file tests