### PR TITLE
fix(feed): preserve payload engagement counts

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -20,10 +20,10 @@ part 'video_interactions_state.dart';
 ///
 /// This bloc is created per-VideoFeedItem and manages:
 /// - Like status (from LikesRepository)
-/// - Like count (from relays via LikesRepository)
+/// - Like count (from seeded feed payload, or relay fallback when unseeded)
 /// - Repost status (from RepostsRepository)
-/// - Repost count (from video metadata)
-/// - Comment count (from relays via CommentsRepository)
+/// - Repost count (from seeded feed payload, or relay fallback when unseeded)
+/// - Comment count (from seeded feed payload, or relay fallback when unseeded)
 ///
 /// The bloc subscribes to the repository's liked/reposted IDs streams to stay
 /// in sync when interactions change from other sources (e.g., profile grids).
@@ -37,6 +37,8 @@ class VideoInteractionsBloc
     required RepostsRepository repostsRepository,
     String? addressableId,
     int? initialLikeCount,
+    int? initialCommentCount,
+    int? initialRepostCount,
     bool includeVideoReplies = false,
   }) : _eventId = eventId,
        _authorPubkey = authorPubkey,
@@ -45,7 +47,13 @@ class VideoInteractionsBloc
        _repostsRepository = repostsRepository,
        _addressableId = addressableId,
        _includeVideoReplies = includeVideoReplies,
-       super(VideoInteractionsState(likeCount: initialLikeCount)) {
+       super(
+         VideoInteractionsState(
+           likeCount: initialLikeCount,
+           repostCount: initialRepostCount,
+           commentCount: initialCommentCount,
+         ),
+       ) {
     on<VideoInteractionsFetchRequested>(_onFetchRequested);
     // Toggle handlers fire-and-forget the publish (see _onLikeToggled),
     // so they return in microseconds and do not benefit from a
@@ -136,6 +144,7 @@ class VideoInteractionsBloc
     final preFetchLikeCount = state.likeCount;
     final preFetchIsReposted = state.isReposted;
     final preFetchRepostCount = state.repostCount;
+    final preFetchCommentCount = state.commentCount;
 
     emit(state.copyWith(status: VideoInteractionsStatus.loading));
 
@@ -156,11 +165,9 @@ class VideoInteractionsBloc
           ? _repostsRepository.getRepostCount(_addressableId)
           : _repostsRepository.getRepostCountByEventId(_eventId);
 
-      // Always fetch a fresh count from relay. When initialLikeCount was
-      // seeded from Funnelcake REST (e.g. notification tap), the cached REST
-      // value may lag behind real-time relay data and show a stale (lower)
-      // count. The initial state already shows the seeded value immediately;
-      // this round-trip updates it to the accurate relay count once it arrives.
+      // Fetch a relay count for blocs that were not seeded from the feed
+      // payload. Seeded counts stay authoritative below because relay COUNT
+      // results can include unrelated historical reactions.
       final likeCountFuture = _likesRepository.getLikeCount(
         _eventId,
         addressableId: _addressableId,
@@ -177,22 +184,16 @@ class VideoInteractionsBloc
       ]);
 
       final fetchedLikeCount = results[0];
-      final commentCount = results[1];
-      final repostCount = results[2];
+      final fetchedCommentCount = results[1];
+      final fetchedRepostCount = results[2];
 
-      // For addressable videos, treat a relay-fetched 0 as "no fresh info"
-      // when we already have a non-zero pre-fetch count. After a metadata
-      // edit the new event_id has no #e reactions yet, and the #a COUNT on
-      // the divine relay for kind 7 is unreliable — letting that 0 stomp
-      // the carried-forward nostrLikeCount (or Vine originalLikes portion)
-      // surfaces as #4432 ("likes went to zero after editing"). Mirrors the
-      // skip-zero guard in VideoEventService._executeLikeCountBatchFetch.
-      final likeCount =
-          (_addressableId != null &&
-              fetchedLikeCount == 0 &&
-              (preFetchLikeCount ?? 0) > 0)
-          ? preFetchLikeCount!
-          : fetchedLikeCount;
+      // Feed/Funnelcake counts are the display baseline. Relay COUNT queries
+      // are still useful when a bloc has no seeded count, but they must not
+      // replace counts we already rendered from the video payload: the relay
+      // can aggregate unrelated historical reactions and surface bogus spikes.
+      final likeCount = preFetchLikeCount ?? fetchedLikeCount;
+      final commentCount = preFetchCommentCount ?? fetchedCommentCount;
+      final repostCount = preFetchRepostCount ?? fetchedRepostCount;
 
       emit(
         state.copyWith(
@@ -205,7 +206,9 @@ class VideoInteractionsBloc
           repostCount: state.repostCount == preFetchRepostCount
               ? repostCount
               : null,
-          commentCount: commentCount,
+          commentCount: state.commentCount == preFetchCommentCount
+              ? commentCount
+              : null,
         ),
       );
     } catch (e, stackTrace) {

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1130,9 +1130,11 @@ class _PooledFullscreenItem extends ConsumerWidget {
               repostsRepository: repostsRepository,
               addressableId: addressableId,
               includeVideoReplies: showVideoReplies,
-              initialLikeCount: video.nostrLikeCount != null
-                  ? video.totalLikes
-                  : null,
+              initialLikeCount: video.totalLikes,
+              initialCommentCount: video.originalComments ?? 0,
+              initialRepostCount:
+                  (video.reposterPubkeys?.length ?? 0) +
+                  (video.originalReposts ?? 0),
             )
             ..add(const VideoInteractionsSubscriptionRequested())
             ..add(const VideoInteractionsFetchRequested()),
@@ -1208,9 +1210,11 @@ class _WebFullscreenItem extends ConsumerWidget {
                   commentsRepository: commentsRepository,
                   repostsRepository: repostsRepository,
                   addressableId: addressableId,
-                  initialLikeCount: video.nostrLikeCount != null
-                      ? video.totalLikes
-                      : null,
+                  initialLikeCount: video.totalLikes,
+                  initialCommentCount: video.originalComments ?? 0,
+                  initialRepostCount:
+                      (video.reposterPubkeys?.length ?? 0) +
+                      (video.originalReposts ?? 0),
                 )
                 ..add(const VideoInteractionsSubscriptionRequested())
                 ..add(const VideoInteractionsFetchRequested()),

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -1083,9 +1083,11 @@ class _PooledVideoFeedItem extends ConsumerWidget {
               repostsRepository: repostsRepository,
               addressableId: addressableId,
               includeVideoReplies: showVideoReplies,
-              initialLikeCount: video.nostrLikeCount != null
-                  ? video.totalLikes
-                  : null,
+              initialLikeCount: video.totalLikes,
+              initialCommentCount: video.originalComments ?? 0,
+              initialRepostCount:
+                  (video.reposterPubkeys?.length ?? 0) +
+                  (video.originalReposts ?? 0),
             )
             ..add(const VideoInteractionsSubscriptionRequested())
             ..add(const VideoInteractionsFetchRequested()),
@@ -1148,9 +1150,11 @@ class _WebVideoFeedItem extends ConsumerWidget {
               commentsRepository: commentsRepository,
               repostsRepository: repostsRepository,
               addressableId: addressableId,
-              initialLikeCount: video.nostrLikeCount != null
-                  ? video.totalLikes
-                  : null,
+              initialLikeCount: video.totalLikes,
+              initialCommentCount: video.originalComments ?? 0,
+              initialRepostCount:
+                  (video.reposterPubkeys?.length ?? 0) +
+                  (video.originalReposts ?? 0),
             )
             ..add(const VideoInteractionsSubscriptionRequested())
             ..add(const VideoInteractionsFetchRequested()),

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -571,9 +571,11 @@ class __OverlayState extends ConsumerState<_Overlay> {
                     commentsRepository: commentsRepository,
                     repostsRepository: repostsRepository,
                     addressableId: addressableId,
-                    initialLikeCount: video.nostrLikeCount != null
-                        ? video.totalLikes
-                        : null,
+                    initialLikeCount: video.totalLikes,
+                    initialCommentCount: video.originalComments ?? 0,
+                    initialRepostCount:
+                        (video.reposterPubkeys?.length ?? 0) +
+                        (video.originalReposts ?? 0),
                   )
                   ..add(const VideoInteractionsSubscriptionRequested())
                   ..add(const VideoInteractionsFetchRequested()),

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -72,6 +72,8 @@ void main() {
     VideoInteractionsBloc createBloc({
       String? addressableId,
       int? initialLikeCount,
+      int? initialCommentCount,
+      int? initialRepostCount,
     }) => VideoInteractionsBloc(
       eventId: testEventId,
       authorPubkey: testAuthorPubkey,
@@ -80,6 +82,8 @@ void main() {
       repostsRepository: mockRepostsRepository,
       addressableId: addressableId,
       initialLikeCount: initialLikeCount,
+      initialCommentCount: initialCommentCount,
+      initialRepostCount: initialRepostCount,
     );
 
     test('initial state is initial with default values', () {
@@ -93,9 +97,15 @@ void main() {
       bloc.close();
     });
 
-    test('initial state seeds likeCount from initialLikeCount', () {
-      final bloc = createBloc(initialLikeCount: 42);
+    test('initial state seeds engagement counts from initial counts', () {
+      final bloc = createBloc(
+        initialLikeCount: 42,
+        initialCommentCount: 3,
+        initialRepostCount: 7,
+      );
       expect(bloc.state.likeCount, equals(42));
+      expect(bloc.state.commentCount, equals(3));
+      expect(bloc.state.repostCount, equals(7));
       bloc.close();
     });
 
@@ -131,12 +141,59 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        // Regression for #4159: the relay must always be queried for a fresh
-        // count even when initialLikeCount was seeded from the Funnelcake REST
-        // API (e.g. notification tap). REST counts are indexed asynchronously
-        // and may lag behind real-time relay data, causing the like count to
-        // appear stale until the user navigates away and back.
-        'always fetches relay like count even when seeded with initialLikeCount',
+        'does not overwrite seeded engagement counts with relay counts',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 100);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 7);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 32);
+        },
+        build: () => createBloc(addressableId: testAddressableId),
+        seed: () => const VideoInteractionsState(
+          likeCount: 1,
+          commentCount: 0,
+          repostCount: 0,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 1,
+            commentCount: 0,
+            repostCount: 0,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 1,
+            commentCount: 0,
+            repostCount: 0,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // The relay is still queried so unseeded blocs can use live counts,
+        // but a seeded display count from the feed payload must not be
+        // replaced by relay COUNT results, which can aggregate unrelated
+        // historical reactions.
+        'fetches relay like count but preserves seeded initialLikeCount',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
@@ -163,7 +220,7 @@ void main() {
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isLiked: true,
-            likeCount: 120, // Updated to relay count, not the stale REST seed.
+            likeCount: 100,
             repostCount: 5,
             commentCount: 10,
           ),
@@ -176,12 +233,12 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        // Companion to the non-addressable case above: production notification
-        // taps for Kind 34236 videos pass both eventId and addressableId to
-        // getLikeCount(), so the relay query must still fire even when the
-        // count was pre-seeded and an addressableId is present.
-        'always fetches relay like count when seeded with initialLikeCount '
-        'and addressableId',
+        // Companion to the non-addressable case above: production feed items
+        // for Kind 34236 videos pass both eventId and addressableId to
+        // getLikeCount(), so the relay query still fires but the pre-seeded
+        // count remains the display source of truth.
+        'fetches relay like count with addressableId but preserves seeded '
+        'initialLikeCount',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
@@ -217,7 +274,7 @@ void main() {
           ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            likeCount: 75, // Updated to relay count, not the stale REST seed.
+            likeCount: 50,
             repostCount: 2,
             commentCount: 3,
           ),
@@ -285,13 +342,11 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        // Companion to the addressable case above: for non-addressable
-        // videos (kind 22) the event_id never changes, so a relay 0 is
-        // authoritative and must still overwrite a stale seed. This pins
-        // the PR #4253 contract — relay is the source of truth — for the
-        // case where the #4432 guard does not apply.
-        'still overwrites a seeded likeCount with a relay 0 for '
-        'non-addressable videos (preserves #4253 contract)',
+        // Even for non-addressable videos, seeded feed counts are the display
+        // baseline. A relay 0 should not erase a count the feed payload
+        // already rendered.
+        'preserves a seeded likeCount over a relay 0 for non-addressable '
+        'videos',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
@@ -315,7 +370,7 @@ void main() {
           ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            likeCount: 0, // Relay 0 wins — no addressable id to gate on.
+            likeCount: 5,
             repostCount: 0,
             commentCount: 0,
           ),


### PR DESCRIPTION
Closes #4704

## Summary
- seed feed interaction blocs with payload engagement counts for likes, comments, and reposts
- keep seeded counts authoritative when relay COUNT fetches return conflicting values
- add a regression test for seeded 1/0/0 counts being overwritten by bogus relay counts

## Testing
- flutter test test/blocs/video_interactions/video_interactions_bloc_test.dart --plain-name "does not overwrite seeded engagement counts with relay counts"
- flutter test test/blocs/video_interactions/video_interactions_bloc_test.dart
- flutter analyze lib/blocs/video_interactions/video_interactions_bloc.dart lib/screens/feed/video_feed_page.dart lib/screens/feed/pooled_fullscreen_video_feed_screen.dart lib/widgets/video_feed_item/feed_videos.dart test/blocs/video_interactions/video_interactions_bloc_test.dart
- flutter test test/widgets/video_feed_item/actions/like_action_button_test.dart test/widgets/video_feed_item/actions/comment_action_button_test.dart test/widgets/video_feed_item/actions/repost_action_button_test.dart test/widgets/video_feed_item/feed_videos_repo_swap_test.dart test/screens/feed/pooled_video_feed_item_repo_swap_test.dart test/widgets/video_feed_item/video_interactions_bloc_key_test.dart
- git push pre-push checks