### PR TITLE
fix(comments): restore rounded corners on inline video player

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -150,17 +150,20 @@ class _CommentItemState extends ConsumerState<CommentItem> {
                             alignment: Alignment.centerLeft,
                             child: ConstrainedBox(
                               constraints: const BoxConstraints(maxWidth: 248),
-                              child: VideoCommentPlayer(
-                                videoUrl: widget.comment.videoUrl!,
-                                thumbnailUrl: widget.comment.thumbnailUrl,
-                                blurhash: widget.comment.videoBlurhash,
-                                onOpenVideo: () => context.push(
-                                  VideoDetailScreen.pathForId(
-                                    widget.comment.id,
-                                  ),
-                                  extra: VideoDetailRouteExtra(
-                                    initialVideo: widget.comment
-                                        .toSyntheticVideoEvent(),
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(12),
+                                child: VideoCommentPlayer(
+                                  videoUrl: widget.comment.videoUrl!,
+                                  thumbnailUrl: widget.comment.thumbnailUrl,
+                                  blurhash: widget.comment.videoBlurhash,
+                                  onOpenVideo: () => context.push(
+                                    VideoDetailScreen.pathForId(
+                                      widget.comment.id,
+                                    ),
+                                    extra: VideoDetailRouteExtra(
+                                      initialVideo: widget.comment
+                                          .toSyntheticVideoEvent(),
+                                    ),
                                   ),
                                 ),
                               ),

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -105,55 +105,52 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer> {
     return VisibilityDetector(
       key: Key('video-comment-${widget.videoUrl}'),
       onVisibilityChanged: _onVisibilityChanged,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: AspectRatio(
-          aspectRatio: 9 / 16,
-          child: DecoratedBox(
-            decoration: const BoxDecoration(color: VineTheme.containerLow),
-            child: GestureDetector(
-              onTap: _togglePlay,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  if (_controller?.value.isInitialized ?? false)
-                    VideoPlayer(_controller!)
-                  else if (widget.thumbnailUrl?.isNotEmpty ?? false)
-                    VineCachedImage(
-                      imageUrl: widget.thumbnailUrl!,
-                      errorWidget: (_, _, _) => const _VideoPlaceholder(),
-                    )
-                  else
-                    const _VideoPlaceholder(),
-                  if (_isInitializing)
-                    const Center(
-                      child: SizedBox.square(
-                        dimension: 28,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: VineTheme.onSurface,
-                        ),
-                      ),
-                    )
-                  else if (!_isPlaying)
-                    const _PlayOverlay(),
-                  if (_controller?.value.isInitialized ?? false)
-                    Positioned(
-                      right: 8,
-                      bottom: 8,
-                      child: _MuteButton(
-                        isMuted: _isMuted,
-                        onTap: _toggleMute,
+      child: AspectRatio(
+        aspectRatio: 9 / 16,
+        child: DecoratedBox(
+          decoration: const BoxDecoration(color: VineTheme.containerLow),
+          child: GestureDetector(
+            onTap: _togglePlay,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (_controller?.value.isInitialized ?? false)
+                  VideoPlayer(_controller!)
+                else if (widget.thumbnailUrl?.isNotEmpty ?? false)
+                  VineCachedImage(
+                    imageUrl: widget.thumbnailUrl!,
+                    errorWidget: (_, _, _) => const _VideoPlaceholder(),
+                  )
+                else
+                  const _VideoPlaceholder(),
+                if (_isInitializing)
+                  const Center(
+                    child: SizedBox.square(
+                      dimension: 28,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: VineTheme.onSurface,
                       ),
                     ),
-                  if (widget.onOpenVideo != null)
-                    Positioned(
-                      right: 8,
-                      top: 8,
-                      child: _OpenVideoButton(onTap: widget.onOpenVideo!),
+                  )
+                else if (!_isPlaying)
+                  const _PlayOverlay(),
+                if (_controller?.value.isInitialized ?? false)
+                  Positioned(
+                    right: 8,
+                    bottom: 8,
+                    child: _MuteButton(
+                      isMuted: _isMuted,
+                      onTap: _toggleMute,
                     ),
-                ],
-              ),
+                  ),
+                if (widget.onOpenVideo != null)
+                  Positioned(
+                    right: 8,
+                    top: 8,
+                    child: _OpenVideoButton(onTap: widget.onOpenVideo!),
+                  ),
+              ],
             ),
           ),
         ),

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -157,6 +157,9 @@ class _CardChrome extends ConsumerWidget {
           ),
           decoration: BoxDecoration(
             color: VineTheme.surfaceContainerHigh,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          foregroundDecoration: BoxDecoration(
             border: Border.all(color: VineTheme.outlineMuted),
             borderRadius: BorderRadius.circular(16),
           ),
@@ -270,9 +273,9 @@ class _InvitePreviewSurface extends StatelessWidget {
             thumbnailUrl: thumbnailUrl,
           ),
           PositionedDirectional(
-            start: 12,
-            end: 12,
-            bottom: 12,
+            start: 0,
+            end: 0,
+            bottom: 0,
             child: IgnorePointer(
               child: _InviteGradientCopy(
                 title: title,
@@ -432,7 +435,7 @@ class _InviteGradientCopy extends StatelessWidget {
         ),
       ),
       child: Padding(
-        padding: const EdgeInsets.only(top: 48),
+        padding: const EdgeInsetsGeometry.fromSTEB(12, 48, 12, 12),
         child: _InviteCopy(
           previewTitle: previewTitle,
           title: title,

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -435,7 +435,7 @@ class _InviteGradientCopy extends StatelessWidget {
         ),
       ),
       child: Padding(
-        padding: const EdgeInsetsGeometry.fromSTEB(12, 48, 12, 12),
+        padding: const EdgeInsetsDirectional.fromSTEB(12, 48, 12, 12),
         child: _InviteCopy(
           previewTitle: previewTitle,
           title: title,

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -17,9 +17,11 @@ import 'package:openvine/blocs/comments/comment_reactions/comment_reactions_bloc
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/comments/widgets/comment_item.dart';
+import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../builders/comment_builder.dart';
 
@@ -50,6 +52,7 @@ const _testRootAuthorPubkey =
 
 void main() {
   setUpAll(() {
+    VisibilityDetectorController.instance.updateInterval = Duration.zero;
     registerFallbackValue(const CommentReplyToggled(''));
     registerFallbackValue(
       const CommentReactionsErrorCleared(),
@@ -226,6 +229,63 @@ void main() {
     expect(capturedExtra?.initialVideo?.title, comment.content);
     expect(capturedExtra?.initialVideo?.isVideoReply, isTrue);
     expect(capturedExtra?.initialVideo?.replyRootRouteId, _testRootEventId);
+  });
+
+  testWidgets('wraps the inline video player with rounded corners', (
+    tester,
+  ) async {
+    final mocks = buildMocks();
+    final comment = CommentBuilder()
+        .withAuthorPubkey(_testHexPubkey)
+        .withRootEventId(_testRootEventId)
+        .withRootAuthorPubkey(_testRootAuthorPubkey)
+        .withContent('Ferns')
+        .build()
+        .copyWith(
+          videoUrl: 'https://media.divine.video/some-video.mp4',
+          thumbnailUrl: 'https://media.divine.video/some-thumb.jpg',
+          videoDimensions: '1080x1920',
+          videoDuration: 6,
+        );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          nostrServiceProvider.overrideWithValue(const _FakeNostrClient()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MultiBlocProvider(
+              providers: [
+                BlocProvider<CommentComposerBloc>.value(value: mocks.composer),
+                BlocProvider<CommentReactionsBloc>.value(
+                  value: mocks.reactions,
+                ),
+              ],
+              child: SingleChildScrollView(
+                child: CommentItem(comment: comment),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final clipRRect = tester.widget<ClipRRect>(
+      find.ancestor(
+        of: find.byType(VideoCommentPlayer),
+        matching: find.byType(ClipRRect),
+      ),
+    );
+    expect(clipRRect.borderRadius, BorderRadius.circular(12));
+
+    // Drain VisibilityDetector's 500ms debounce and the identity skeleton's
+    // 7s fallthrough so no pending timers leak into the next test.
+    await tester.pump(const Duration(seconds: 8));
+    await tester.pumpAndSettle();
   });
 
   group('Identity skeleton (#4163 follow-up)', () {

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -274,12 +274,12 @@ void main() {
     );
     await tester.pump();
 
-    final clipRRect = tester.widget<ClipRRect>(
-      find.ancestor(
-        of: find.byType(VideoCommentPlayer),
-        matching: find.byType(ClipRRect),
-      ),
+    final clipFinder = find.ancestor(
+      of: find.byType(VideoCommentPlayer),
+      matching: find.byType(ClipRRect),
     );
+    expect(clipFinder, findsOneWidget);
+    final clipRRect = tester.widget<ClipRRect>(clipFinder);
     expect(clipRRect.borderRadius, BorderRadius.circular(12));
 
     // Drain VisibilityDetector's 500ms debounce and the identity skeleton's

--- a/mobile/test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart
@@ -1,0 +1,184 @@
+// ABOUTME: Widget tests for CollaboratorInviteCard.
+// ABOUTME: Regression tests for the visual redesign: foreground border paints
+// ABOUTME: over content and the container clips video to rounded corners.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/collaborator_invite.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/screens/inbox/conversation/widgets/collaborator_invite_card.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+import '../../../../helpers/test_provider_overrides.dart';
+
+class _MockCollaboratorInviteActionsCubit
+    extends MockCubit<CollaboratorInviteActionsState>
+    implements CollaboratorInviteActionsCubit {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+const _creatorPubkey =
+    '1122334411223344112233441122334411223344112233441122334411223344';
+
+const _testInvite = CollaboratorInvite(
+  messageId: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+  videoAddress:
+      '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
+  videoKind: 34236,
+  creatorPubkey: _creatorPubkey,
+  videoDTag: 'skate-loop',
+  role: 'Collaborator',
+  title: 'Skate loop',
+);
+
+void main() {
+  late _MockCollaboratorInviteActionsCubit mockCubit;
+  late _MockVideoEventService mockVideoEventService;
+  late MockNostrClient mockNostrClient;
+
+  setUp(() {
+    mockCubit = _MockCollaboratorInviteActionsCubit();
+    mockVideoEventService = _MockVideoEventService();
+    mockNostrClient = createMockNostrService();
+
+    when(() => mockCubit.state).thenReturn(
+      const CollaboratorInviteActionsState(),
+    );
+    when(
+      () => mockCubit.loadInvites(any()),
+    ).thenReturn(null);
+    when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+    when(
+      () => mockVideoEventService.getVideoEventByVineId(any()),
+    ).thenReturn(null);
+  });
+
+  Widget buildSubject({bool isSent = false}) {
+    return ProviderScope(
+      overrides: [
+        nostrServiceProvider.overrideWithValue(mockNostrClient),
+        videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: BlocProvider<CollaboratorInviteActionsCubit>.value(
+            value: mockCubit,
+            child: CollaboratorInviteCard(
+              invite: _testInvite,
+              isSent: isSent,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group(CollaboratorInviteCard, () {
+    group('card chrome', () {
+      testWidgets(
+        'clips content to rounded corners via Clip.antiAlias on the container',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byType(CollaboratorInviteCard),
+              matching: find.byWidgetPredicate(
+                (w) =>
+                    w is Container &&
+                    w.clipBehavior == Clip.antiAlias &&
+                    w.decoration is BoxDecoration,
+              ),
+            ),
+          );
+
+          expect(container.clipBehavior, Clip.antiAlias);
+
+          final decoration = container.decoration! as BoxDecoration;
+          expect(
+            decoration.borderRadius,
+            BorderRadius.circular(16),
+          );
+        },
+      );
+
+      testWidgets(
+        'foregroundDecoration has a border that paints over the video content',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byType(CollaboratorInviteCard),
+              matching: find.byWidgetPredicate(
+                (w) =>
+                    w is Container &&
+                    w.foregroundDecoration is BoxDecoration &&
+                    (w.foregroundDecoration! as BoxDecoration).border != null,
+              ),
+            ),
+          );
+
+          final foreground = container.foregroundDecoration! as BoxDecoration;
+          expect(foreground.border, isNotNull);
+          expect(
+            foreground.borderRadius,
+            BorderRadius.circular(16),
+          );
+        },
+      );
+
+      testWidgets(
+        'sent card aligns to end of row',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(isSent: true));
+          await tester.pump();
+
+          final align = tester.widget<Align>(
+            find.descendant(
+              of: find.byType(CollaboratorInviteCard),
+              matching: find.byWidgetPredicate(
+                (w) =>
+                    w is Align && w.alignment == AlignmentDirectional.centerEnd,
+              ),
+            ),
+          );
+
+          expect(align.alignment, AlignmentDirectional.centerEnd);
+        },
+      );
+
+      testWidgets(
+        'received card aligns to start of row',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
+
+          final align = tester.widget<Align>(
+            find.descendant(
+              of: find.byType(CollaboratorInviteCard),
+              matching: find.byWidgetPredicate(
+                (w) =>
+                    w is Align &&
+                    w.alignment == AlignmentDirectional.centerStart,
+              ),
+            ),
+          );
+
+          expect(align.alignment, AlignmentDirectional.centerStart);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #4707

## Description

A previous refactor of `VideoCommentPlayer` removed its outer `ClipRRect`, which inadvertently dropped the rounded corners on inline video previews inside comment items. This PR restores the rounded corners at the caller side and includes a visual redesign of `CollaboratorInviteCard._CardChrome`.

- `comment_item.dart`: wrap `VideoCommentPlayer` in `ClipRRect(borderRadius: BorderRadius.circular(12))` inside the existing `Align` + `ConstrainedBox(maxWidth: 248)`, restoring the previous visual.
- `collaborator_invite_card.dart`:
  - Background `BoxDecoration` now includes `borderRadius: BorderRadius.circular(16)` so the fill is rounded.
  - Border moved from `decoration` to `foregroundDecoration` — it now paints **on top of** the content, which means the border is never obscured by video content bleeding to the edge.
  - Added `clipBehavior: Clip.antiAlias` on the outer `Container` — clips the video player (and all other children) to the 16 px rounded corners so no content overflows the card boundary.
  - Switched `EdgeInsetsGeometry.fromSTEB` to `EdgeInsetsDirectional.fromSTEB(12, 48, 12, 12)` so padding mirrors correctly in RTL locales.
- `comment_item_test.dart`: add a regression test (`wraps the inline video player with rounded corners`) that asserts the `ClipRRect` ancestor and its 12 px radius. Sets `VisibilityDetectorController.instance.updateInterval = Duration.zero` in `setUpAll` to prevent the visibility_detector timer from leaking into other tests (matches the existing pattern in `video_comment_player_test.dart` and `visibility_aware_video_test.dart`).
- `collaborator_invite_card_test.dart`: add regression tests for the `_CardChrome` visual redesign — asserts `Clip.antiAlias` is set, `foregroundDecoration` has a border, and sent/received cards align to the correct end of the row.

| Before | After |
| ------ | ------ |
|      <img width="322" alt="before" src="https://github.com/user-attachments/assets/bf240c4a-29bc-4f6d-9502-7da10b930c5b"/>    |    <img width="322" alt="after" src="https://github.com/user-attachments/assets/e79cf751-955c-4da2-bfb9-a1372df915ec"/>          |

**Related Issue:** N/A — follow-up to commit `a95b8d78` on this branch.

## Out of Scope

None.

## Verification

- `flutter test test/screens/comments/comment_item_test.dart` → 7/7 pass
- `flutter test test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart` → 4/4 pass
- `flutter analyze lib test integration_test`

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)