### PR TITLE
feat(dm): multi-line message composer (auto-grow up to 5 lines)

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -77,33 +77,37 @@ class _MessageInputBarState extends State<MessageInputBar> {
       child: SafeArea(
         top: false,
         child: Container(
-          height: 48,
+          constraints: const BoxConstraints(minHeight: 48),
           decoration: BoxDecoration(
             color: VineTheme.surfaceContainer,
             borderRadius: BorderRadius.circular(20),
           ),
           child: Row(
+            // Anchor send button to pill bottom as the field grows.
+            crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               // Text input
               Expanded(
-                child: MediaQuery.withNoTextScaling(
-                  child: TextField(
-                    controller: _controller,
-                    style: VineTheme.bodyLargeFont(),
-                    cursorColor: VineTheme.primary,
-                    textInputAction: TextInputAction.send,
-                    onSubmitted: (_) => _handleSend(),
-                    contextMenuBuilder: _buildContextMenu,
-                    decoration: InputDecoration(
-                      hintText: context.l10n.dmMessageInputHint,
-                      hintStyle: VineTheme.bodyLargeFont(
-                        color: VineTheme.onSurfaceMuted,
-                      ),
-                      border: InputBorder.none,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
+                // Field honours font scaling (#4620): no withNoTextScaling.
+                child: TextField(
+                  controller: _controller,
+                  style: VineTheme.bodyLargeFont(),
+                  cursorColor: VineTheme.primary,
+                  keyboardType: TextInputType.multiline,
+                  // Return = newline; send via button only (#4620).
+                  textInputAction: TextInputAction.newline,
+                  minLines: 1,
+                  maxLines: 5,
+                  contextMenuBuilder: _buildContextMenu,
+                  decoration: InputDecoration(
+                    hintText: context.l10n.dmMessageInputHint,
+                    hintStyle: VineTheme.bodyLargeFont(
+                      color: VineTheme.onSurfaceMuted,
+                    ),
+                    border: InputBorder.none,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
                     ),
                   ),
                 ),
@@ -111,7 +115,7 @@ class _MessageInputBarState extends State<MessageInputBar> {
               // Send button
               if (_hasText)
                 Padding(
-                  padding: const EdgeInsetsDirectional.only(end: 4),
+                  padding: const EdgeInsetsDirectional.only(end: 4, bottom: 4),
                   child: GestureDetector(
                     onTap: _handleSend,
                     child: Container(

--- a/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
@@ -125,6 +125,65 @@ void main() {
       });
     });
 
+    group('multiline composition', () {
+      testWidgets('grows from 1 to 5 lines and uses the multiline keyboard', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: MessageInputBar(onSend: (_) {})),
+          ),
+        );
+
+        final field = tester.widget<TextField>(find.byType(TextField));
+        expect(field.minLines, 1);
+        expect(field.maxLines, 5);
+        expect(field.keyboardType, TextInputType.multiline);
+      });
+
+      testWidgets('Return inserts a newline instead of sending', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: MessageInputBar(onSend: (_) {})),
+          ),
+        );
+
+        final field = tester.widget<TextField>(find.byType(TextField));
+        expect(field.textInputAction, TextInputAction.newline);
+        expect(field.onSubmitted, isNull);
+      });
+
+      testWidgets('preserves internal newlines in the sent message', (
+        tester,
+      ) async {
+        String? sentText;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageInputBar(onSend: (text) => sentText = text),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'line one\nline two');
+        await tester.pump();
+
+        await tester.tap(find.byType(DivineIcon));
+        await tester.pump();
+
+        expect(sentText, equals('line one\nline two'));
+      });
+    });
+
     group('selection toolbar', () {
       /// Pumps the input bar, enters [seedText], selects the range
       /// `[selStart, selEnd]`, and invokes the TextField's
@@ -274,46 +333,44 @@ void main() {
         expect(harness.controller.text, equals('use `foo()` here'));
       });
 
-      testWidgets(
-        'Bold on already-bold selection unwraps the surrounding **',
-        (tester) async {
-          // `**hi**` — select just the inner `hi` so the surrounding
-          // `**` markers can be detected and stripped.
-          final harness = await pumpAndBuildToolbar(
-            tester,
-            seedText: 'say **hi** please',
-            selStart: 6,
-            selEnd: 8,
-          );
-          final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
-          toolbar.buttonItems!.first.onPressed!();
-          await tester.pump();
-          expect(harness.controller.text, equals('say hi please'));
-        },
-      );
+      testWidgets('Bold on already-bold selection unwraps the surrounding **', (
+        tester,
+      ) async {
+        // `**hi**` — select just the inner `hi` so the surrounding
+        // `**` markers can be detected and stripped.
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'say **hi** please',
+          selStart: 6,
+          selEnd: 8,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        toolbar.buttonItems!.first.onPressed!();
+        await tester.pump();
+        expect(harness.controller.text, equals('say hi please'));
+      });
 
-      testWidgets(
-        'selection labels resolve from l10n, not hardcoded English',
-        (tester) async {
-          // Sanity guard against accidentally hardcoding the label —
-          // if the widget ever stops reading from context.l10n, this
-          // test breaks loudly.
-          final harness = await pumpAndBuildToolbar(
-            tester,
-            seedText: 'hello',
-            selStart: 0,
-            selEnd: 5,
-          );
-          final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
-          final labels = toolbar.buttonItems!.take(4).map((b) => b.label);
-          expect(labels, [
-            lookupAppLocalizations(const Locale('en')).dmFormatBold,
-            lookupAppLocalizations(const Locale('en')).dmFormatItalic,
-            lookupAppLocalizations(const Locale('en')).dmFormatStrikethrough,
-            lookupAppLocalizations(const Locale('en')).dmFormatCode,
-          ]);
-        },
-      );
+      testWidgets('selection labels resolve from l10n, not hardcoded English', (
+        tester,
+      ) async {
+        // Sanity guard against accidentally hardcoding the label —
+        // if the widget ever stops reading from context.l10n, this
+        // test breaks loudly.
+        final harness = await pumpAndBuildToolbar(
+          tester,
+          seedText: 'hello',
+          selStart: 0,
+          selEnd: 5,
+        );
+        final toolbar = harness.toolbar as AdaptiveTextSelectionToolbar;
+        final labels = toolbar.buttonItems!.take(4).map((b) => b.label);
+        expect(labels, [
+          lookupAppLocalizations(const Locale('en')).dmFormatBold,
+          lookupAppLocalizations(const Locale('en')).dmFormatItalic,
+          lookupAppLocalizations(const Locale('en')).dmFormatStrikethrough,
+          lookupAppLocalizations(const Locale('en')).dmFormatCode,
+        ]);
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

The DM message composer was locked to a single line inside a fixed-height
(48&nbsp;px) pill: long messages scrolled horizontally on one line, you
couldn't review what you were about to send, and there was no way to insert
a line break.

This makes the composer behave like a standard messenger input — it grows
from 1 line up to 5 as the text wraps, then scrolls internally; **Return
inserts a newline**; sending is the explicit up-arrow button; the send
button stays anchored to the bottom of the (now taller) pill; and the field
honours system font scaling.

It is a **presentation-only** change. The send path already preserved
newlines end-to-end (`MessageInputBar` trims only leading/trailing
whitespace → `ConversationMessageSent(content)` → `DmRepository.sendMessage`
→ NIP-17 rumor), so no BLoC / repository / client changes were needed. The
implementation mirrors the existing comments-sheet (`comment_input.dart`)
and inline (`inline_comment_composer_bar.dart`) composers.

**Related Issue:** Closes #4620

### What changed (`mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart`)
- Fixed `height: 48` → `constraints: BoxConstraints(minHeight: 48)` so the pill grows with content.
- `TextField`: added `keyboardType: TextInputType.multiline`, `minLines: 1`, `maxLines: 5`.
- `textInputAction: TextInputAction.send` → `TextInputAction.newline` and removed `onSubmitted` — Return inserts a newline; sending is the button only.
- `Row` → `crossAxisAlignment: CrossAxisAlignment.end` and send-button padding `bottom: 4` so it stays bottom-anchored as the field grows.
- Removed `MediaQuery.withNoTextScaling` so the field honours system font scaling (that wrapper was a single-line fixed-height workaround).

### ⚠️ Intended behavior change
Previously **Return sent** the message. Now **Return inserts a newline** and sending is the up-arrow button only. This is required by the issue and matches iMessage / WhatsApp / Signal / Telegram — worth a release note for muscle memory.

### Reproducing the original limitation (before this PR)
1. Open a DM conversation (Inbox → a 1:1 or group thread).
2. Type or paste a long, multi-sentence message into the composer.
3. **Problem:** the text scrolls horizontally on a single line — you can't see the whole message — and pressing Return sends instead of adding a line break.

### Verifying the new behavior (after this PR) — mapped to acceptance criteria
1. Type a long message → the pill **grows line by line up to 5 lines**. _(AC 1)_
2. Keep typing past 5 lines → height **caps at 5**, content **scrolls inside** the field, layout above doesn't jump. _(AC 2)_
3. Press **Return** → inserts a **newline**; the only way to send is the **up-arrow button**. _(AC 3)_
4. As the field grows, the send button stays pinned to the **bottom-right**. _(AC 4)_
5. Set the system font to **largest** → text scales and the field grows with no clipping. _(AC 5)_
6. Send a 3-line message → line breaks are preserved in the sent/received bubble; the field clears to one line. _(AC 6 / messenger parity)_

## Out of Scope
- **Attach / emoji affordances** — the DM composer has only a send button today; the issue's AC lists attach/emoji generically, but those don't exist here and are not added.
- **Markdown formatting (#4621)** — unchanged; the selection toolbar (bold / italic / strikethrough / code) is preserved and its 8 tests still pass.
- **Send-button semantic label** — the send button is a bare `GestureDetector` without a `Semantics` wrapper (a pre-existing a11y gap, not introduced here); left for a small separate follow-up to avoid scope creep.
- **Draft persistence** — unchanged; the draft still lives in the widget's `TextEditingController`.

## Verification
- `dart format` — clean (0 changed).
- `flutter analyze` (changed files) — **No issues found**.
- `flutter test test/screens/inbox/conversation/widgets/message_input_bar_test.dart` — **17/17 pass**: 6 existing behavior tests (send-via-button still works after dropping `onSubmitted`), 8 markdown-toolbar regression tests, and 3 new (1→5 grow + multiline keyboard; Return=newline / `onSubmitted` null; internal-newline preservation on send).
- Flutter 3.41.9 (pinned via `mise`).
- 📱 **On-device pass pending** — checklist below; a screen recording will be attached after the device run.

<details>
<summary>Device QA checklist (iOS + Android, portrait + landscape, keyboard shown)</summary>

- [ ] Grows 1→5 lines as text wraps
- [ ] Caps at 5 lines, scrolls internally, no layout jump
- [ ] Return inserts newline; send only via button
- [ ] Send button stays bottom-anchored while growing
- [ ] Multi-line send preserves line breaks (sender + recipient)
- [ ] Field clears to 1 line after send
- [ ] iOS portrait/landscape, Android portrait/landscape — OK with keyboard up
- [ ] Largest system font: grows, no clipping
- [ ] Markdown toolbar (bold / italic / strike / code, wrap + unwrap) still works
- [ ] Send hidden for empty / whitespace-only input
- [ ] Keyboard dismiss on outer tap; no focus flicker on input tap
</details>

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
