### PR TITLE
fix(auth): keep publish flow alive during expired-session recovery

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -77,7 +77,12 @@ class BackgroundPublishBloc
           .where((upload) => upload.draft.id != event.draft.id)
           .toList();
 
-      emit(state.copyWith(uploads: updatedUploads));
+      emit(
+        state.copyWith(
+          uploads: updatedUploads,
+          recentlySucceededIds: {event.draft.id},
+        ),
+      );
 
       // Draft is no longer needed after successful publish
       unawaited(_draftStorageService.deleteDraft(event.draft.id));

--- a/mobile/lib/blocs/background_publish/background_publish_state.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_state.dart
@@ -28,18 +28,34 @@ class BackgroundUpload extends Equatable {
 }
 
 class BackgroundPublishState extends Equatable {
-  const BackgroundPublishState({this.uploads = const []});
+  const BackgroundPublishState({
+    this.uploads = const [],
+    this.recentlySucceededIds = const {},
+  });
 
   final List<BackgroundUpload> uploads;
+
+  /// Draft IDs that completed with [PublishSuccess] in the most recent
+  /// state transition. Cleared on the next emission that does not add new
+  /// successes. Used by [UploadFailureListener] to distinguish true publish
+  /// success from [BackgroundPublishVanished], which also removes an upload
+  /// without a success result.
+  final Set<String> recentlySucceededIds;
 
   /// Returns true if there is any upload in progress (no result yet).
   bool get hasUploadInProgress =>
       uploads.any((upload) => upload.result == null);
 
-  BackgroundPublishState copyWith({List<BackgroundUpload>? uploads}) {
-    return BackgroundPublishState(uploads: uploads ?? this.uploads);
+  BackgroundPublishState copyWith({
+    List<BackgroundUpload>? uploads,
+    Set<String>? recentlySucceededIds,
+  }) {
+    return BackgroundPublishState(
+      uploads: uploads ?? this.uploads,
+      recentlySucceededIds: recentlySucceededIds ?? const {},
+    );
   }
 
   @override
-  List<Object?> get props => [uploads];
+  List<Object?> get props => [uploads, recentlySucceededIds];
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2114,7 +2114,7 @@
     "uploadProcessingMessage": "ቪዲዮን በመስራት ላይ - ይህ ጥቂት ደቂቃዎችን ሊወስድ ይችላል።",
     "uploadReadyToPublishMessage": "ቪዲዮው በተሳካ ሁኔታ ተከናውኗል እና ለመታተም ዝግጁ ነው።",
     "uploadPublishedMessage": "ቪዲዮ ወደ መገለጫዎ ታትሟል",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{ቪዲዮ ወደ መገለጫዎ ታትሟል} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "ሰቀላው አልተሳካም - እባክዎ እንደገና ይሞክሩ",
     "uploadRetryingMessage": "ሰቀላን እንደገና በመሞከር ላይ...",
     "uploadPausedMessage": "ሰቀላው ባለበት ቆሟል",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2114,6 +2114,7 @@
     "uploadProcessingMessage": "ቪዲዮን በመስራት ላይ - ይህ ጥቂት ደቂቃዎችን ሊወስድ ይችላል።",
     "uploadReadyToPublishMessage": "ቪዲዮው በተሳካ ሁኔታ ተከናውኗል እና ለመታተም ዝግጁ ነው።",
     "uploadPublishedMessage": "ቪዲዮ ወደ መገለጫዎ ታትሟል",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "ሰቀላው አልተሳካም - እባክዎ እንደገና ይሞክሩ",
     "uploadRetryingMessage": "ሰቀላን እንደገና በመሞከር ላይ...",
     "uploadPausedMessage": "ሰቀላው ባለበት ቆሟል",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2114,7 +2114,7 @@
     "uploadProcessingMessage": "ቪዲዮን በመስራት ላይ - ይህ ጥቂት ደቂቃዎችን ሊወስድ ይችላል።",
     "uploadReadyToPublishMessage": "ቪዲዮው በተሳካ ሁኔታ ተከናውኗል እና ለመታተም ዝግጁ ነው።",
     "uploadPublishedMessage": "ቪዲዮ ወደ መገለጫዎ ታትሟል",
-  "uploadPublishedCountMessage": "{count, plural, =1{ቪዲዮ ወደ መገለጫዎ ታትሟል} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{ቪዲዮ ወደ መገለጫዎ ታትሟል} other{{count} ቪዲዮዎች ወደ መገለጫዎ ታትሟቸዋል}}",
     "uploadFailedMessage": "ሰቀላው አልተሳካም - እባክዎ እንደገና ይሞክሩ",
     "uploadRetryingMessage": "ሰቀላን እንደገና በመሞከር ላይ...",
     "uploadPausedMessage": "ሰቀላው ባለበት ቆሟል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1794,7 +1794,7 @@
     "uploadProcessingMessage": "جارٍ معالجة الفيديو - قد يستغرق هذا بضع دقائق",
     "uploadReadyToPublishMessage": "تمت معالجة الفيديو بنجاح وهو جاهز للنشر",
     "uploadPublishedMessage": "تم نشر الفيديو في ملفك الشخصي",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{تم نشر الفيديو في ملفك الشخصي} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "فشل الرفع - يُرجى المحاولة مرة أخرى",
     "uploadRetryingMessage": "جارٍ إعادة محاولة الرفع...",
     "uploadPausedMessage": "أوقف المستخدم الرفع مؤقتًا",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1794,6 +1794,7 @@
     "uploadProcessingMessage": "جارٍ معالجة الفيديو - قد يستغرق هذا بضع دقائق",
     "uploadReadyToPublishMessage": "تمت معالجة الفيديو بنجاح وهو جاهز للنشر",
     "uploadPublishedMessage": "تم نشر الفيديو في ملفك الشخصي",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "فشل الرفع - يُرجى المحاولة مرة أخرى",
     "uploadRetryingMessage": "جارٍ إعادة محاولة الرفع...",
     "uploadPausedMessage": "أوقف المستخدم الرفع مؤقتًا",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1794,7 +1794,7 @@
     "uploadProcessingMessage": "جارٍ معالجة الفيديو - قد يستغرق هذا بضع دقائق",
     "uploadReadyToPublishMessage": "تمت معالجة الفيديو بنجاح وهو جاهز للنشر",
     "uploadPublishedMessage": "تم نشر الفيديو في ملفك الشخصي",
-  "uploadPublishedCountMessage": "{count, plural, =1{تم نشر الفيديو في ملفك الشخصي} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{تم نشر الفيديو في ملفك الشخصي} other{تم نشر {count} مقاطع فيديو في ملفك الشخصي}}",
     "uploadFailedMessage": "فشل الرفع - يُرجى المحاولة مرة أخرى",
     "uploadRetryingMessage": "جارٍ إعادة محاولة الرفع...",
     "uploadPausedMessage": "أوقف المستخدم الرفع مؤقتًا",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2003,7 +2003,7 @@
     "uploadProcessingMessage": "Обработваме видеото - може да отнеме няколко минути",
     "uploadReadyToPublishMessage": "Видеото е обработено и готово за публикуване",
     "uploadPublishedMessage": "Видеото е публикувано в профила ти",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Видеото е публикувано в профила ти} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Качването не мина - опитай пак",
     "uploadRetryingMessage": "Опитваме качването пак...",
     "uploadPausedMessage": "Качването е спряно от теб",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2003,6 +2003,7 @@
     "uploadProcessingMessage": "Обработваме видеото - може да отнеме няколко минути",
     "uploadReadyToPublishMessage": "Видеото е обработено и готово за публикуване",
     "uploadPublishedMessage": "Видеото е публикувано в профила ти",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Качването не мина - опитай пак",
     "uploadRetryingMessage": "Опитваме качването пак...",
     "uploadPausedMessage": "Качването е спряно от теб",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2003,7 +2003,7 @@
     "uploadProcessingMessage": "Обработваме видеото - може да отнеме няколко минути",
     "uploadReadyToPublishMessage": "Видеото е обработено и готово за публикуване",
     "uploadPublishedMessage": "Видеото е публикувано в профила ти",
-  "uploadPublishedCountMessage": "{count, plural, =1{Видеото е публикувано в профила ти} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Видеото е публикувано в профила ти} other{{count} видеа са публикувани в профила ти}}",
     "uploadFailedMessage": "Качването не мина - опитай пак",
     "uploadRetryingMessage": "Опитваме качването пак...",
     "uploadPausedMessage": "Качването е спряно от теб",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Video wird verarbeitet — das kann ein paar Minuten dauern",
     "uploadReadyToPublishMessage": "Video erfolgreich verarbeitet und bereit zur Veröffentlichung",
     "uploadPublishedMessage": "Video in deinem Profil veröffentlicht",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Upload fehlgeschlagen — bitte versuch es nochmal",
     "uploadRetryingMessage": "Upload wird erneut versucht...",
     "uploadPausedMessage": "Upload vom Nutzer pausiert",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Video wird verarbeitet — das kann ein paar Minuten dauern",
     "uploadReadyToPublishMessage": "Video erfolgreich verarbeitet und bereit zur Veröffentlichung",
     "uploadPublishedMessage": "Video in deinem Profil veröffentlicht",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video in deinem Profil veröffentlicht} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Upload fehlgeschlagen — bitte versuch es nochmal",
     "uploadRetryingMessage": "Upload wird erneut versucht...",
     "uploadPausedMessage": "Upload vom Nutzer pausiert",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Video wird verarbeitet — das kann ein paar Minuten dauern",
     "uploadReadyToPublishMessage": "Video erfolgreich verarbeitet und bereit zur Veröffentlichung",
     "uploadPublishedMessage": "Video in deinem Profil veröffentlicht",
-  "uploadPublishedCountMessage": "{count, plural, =1{Video in deinem Profil veröffentlicht} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video in deinem Profil veröffentlicht} other{{count} Videos in deinem Profil veröffentlicht}}",
     "uploadFailedMessage": "Upload fehlgeschlagen — bitte versuch es nochmal",
     "uploadRetryingMessage": "Upload wird erneut versucht...",
     "uploadPausedMessage": "Upload vom Nutzer pausiert",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2332,9 +2332,9 @@
   "uploadProcessingMessage": "Processing video - this may take a few minutes",
   "uploadReadyToPublishMessage": "Video processed successfully and ready to publish",
   "uploadPublishedMessage": "Video published to your profile",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
-  "@uploadPublishedMultipleMessage": {
-    "description": "Snackbar shown after multiple background uploads succeed, e.g. after a re-auth redirect during which several publishes completed.",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video published to your profile} other{{count} videos published to your profile}}",
+  "@uploadPublishedCountMessage": {
+    "description": "Snackbar shown after one or more background uploads succeed, e.g. after a re-auth redirect during which uploads completed.",
     "placeholders": {
       "count": {
         "type": "int",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2332,6 +2332,16 @@
   "uploadProcessingMessage": "Processing video - this may take a few minutes",
   "uploadReadyToPublishMessage": "Video processed successfully and ready to publish",
   "uploadPublishedMessage": "Video published to your profile",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "@uploadPublishedMultipleMessage": {
+    "description": "Snackbar shown after multiple background uploads succeed, e.g. after a re-auth redirect during which several publishes completed.",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
   "uploadFailedMessage": "Upload failed - please try again",
   "uploadRetryingMessage": "Retrying upload...",
   "uploadPausedMessage": "Upload paused by user",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1808,6 +1808,7 @@
     "uploadProcessingMessage": "Procesando video — esto puede tardar unos minutos",
     "uploadReadyToPublishMessage": "Video procesado con éxito y listo para publicar",
     "uploadPublishedMessage": "Video publicado en tu perfil",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Falló la subida — probá de nuevo",
     "uploadRetryingMessage": "Reintentando la subida...",
     "uploadPausedMessage": "Subida pausada por el usuario",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1808,7 +1808,7 @@
     "uploadProcessingMessage": "Procesando video — esto puede tardar unos minutos",
     "uploadReadyToPublishMessage": "Video procesado con éxito y listo para publicar",
     "uploadPublishedMessage": "Video publicado en tu perfil",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video publicado en tu perfil} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Falló la subida — probá de nuevo",
     "uploadRetryingMessage": "Reintentando la subida...",
     "uploadPausedMessage": "Subida pausada por el usuario",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1808,7 +1808,7 @@
     "uploadProcessingMessage": "Procesando video — esto puede tardar unos minutos",
     "uploadReadyToPublishMessage": "Video procesado con éxito y listo para publicar",
     "uploadPublishedMessage": "Video publicado en tu perfil",
-  "uploadPublishedCountMessage": "{count, plural, =1{Video publicado en tu perfil} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video publicado en tu perfil} other{{count} videos publicados en tu perfil}}",
     "uploadFailedMessage": "Falló la subida — probá de nuevo",
     "uploadRetryingMessage": "Reintentando la subida...",
     "uploadPausedMessage": "Subida pausada por el usuario",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1109,7 +1109,7 @@
     "uploadProcessingMessage": "Pino-process ang video - maaaring tumagal ng ilang minuto",
     "uploadReadyToPublishMessage": "Matagumpay na na-process ang video at handa nang i-publish",
     "uploadPublishedMessage": "Na-publish na ang video sa profile mo",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Na-publish na ang video sa profile mo} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Hindi nag-upload - subukan ulit",
     "uploadRetryingMessage": "Sinusubukan ulit i-upload...",
     "uploadPausedMessage": "Naka-pause ang upload ng user",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1109,7 +1109,7 @@
     "uploadProcessingMessage": "Pino-process ang video - maaaring tumagal ng ilang minuto",
     "uploadReadyToPublishMessage": "Matagumpay na na-process ang video at handa nang i-publish",
     "uploadPublishedMessage": "Na-publish na ang video sa profile mo",
-  "uploadPublishedCountMessage": "{count, plural, =1{Na-publish na ang video sa profile mo} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Na-publish na ang video sa profile mo} other{Na-publish na ang {count} na video sa profile mo}}",
     "uploadFailedMessage": "Hindi nag-upload - subukan ulit",
     "uploadRetryingMessage": "Sinusubukan ulit i-upload...",
     "uploadPausedMessage": "Naka-pause ang upload ng user",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1109,6 +1109,7 @@
     "uploadProcessingMessage": "Pino-process ang video - maaaring tumagal ng ilang minuto",
     "uploadReadyToPublishMessage": "Matagumpay na na-process ang video at handa nang i-publish",
     "uploadPublishedMessage": "Na-publish na ang video sa profile mo",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Hindi nag-upload - subukan ulit",
     "uploadRetryingMessage": "Sinusubukan ulit i-upload...",
     "uploadPausedMessage": "Naka-pause ang upload ng user",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Traitement de la vidéo - ça peut prendre quelques minutes",
     "uploadReadyToPublishMessage": "Vidéo traitée avec succès et prête à publier",
     "uploadPublishedMessage": "Vidéo publiée sur ton profil",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Échec de l'envoi - réessaie",
     "uploadRetryingMessage": "Nouvelle tentative d'envoi...",
     "uploadPausedMessage": "Envoi mis en pause par l'utilisateur",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Traitement de la vidéo - ça peut prendre quelques minutes",
     "uploadReadyToPublishMessage": "Vidéo traitée avec succès et prête à publier",
     "uploadPublishedMessage": "Vidéo publiée sur ton profil",
-  "uploadPublishedCountMessage": "{count, plural, =1{Vidéo publiée sur ton profil} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Vidéo publiée sur ton profil} other{{count} vidéos publiées sur ton profil}}",
     "uploadFailedMessage": "Échec de l'envoi - réessaie",
     "uploadRetryingMessage": "Nouvelle tentative d'envoi...",
     "uploadPausedMessage": "Envoi mis en pause par l'utilisateur",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Traitement de la vidéo - ça peut prendre quelques minutes",
     "uploadReadyToPublishMessage": "Vidéo traitée avec succès et prête à publier",
     "uploadPublishedMessage": "Vidéo publiée sur ton profil",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Vidéo publiée sur ton profil} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Échec de l'envoi - réessaie",
     "uploadRetryingMessage": "Nouvelle tentative d'envoi...",
     "uploadPausedMessage": "Envoi mis en pause par l'utilisateur",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1801,7 +1801,7 @@
     "uploadProcessingMessage": "Memproses video - ini mungkin butuh beberapa menit",
     "uploadReadyToPublishMessage": "Video berhasil diproses dan siap dipublikasikan",
     "uploadPublishedMessage": "Video dipublikasikan ke profilmu",
-  "uploadPublishedCountMessage": "{count, plural, =1{Video dipublikasikan ke profilmu} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video dipublikasikan ke profilmu} other{{count} video dipublikasikan ke profilmu}}",
     "uploadFailedMessage": "Unggah gagal - silakan coba lagi",
     "uploadRetryingMessage": "Mencoba unggah lagi...",
     "uploadPausedMessage": "Unggahan dijeda oleh pengguna",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1801,7 +1801,7 @@
     "uploadProcessingMessage": "Memproses video - ini mungkin butuh beberapa menit",
     "uploadReadyToPublishMessage": "Video berhasil diproses dan siap dipublikasikan",
     "uploadPublishedMessage": "Video dipublikasikan ke profilmu",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video dipublikasikan ke profilmu} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Unggah gagal - silakan coba lagi",
     "uploadRetryingMessage": "Mencoba unggah lagi...",
     "uploadPausedMessage": "Unggahan dijeda oleh pengguna",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1801,6 +1801,7 @@
     "uploadProcessingMessage": "Memproses video - ini mungkin butuh beberapa menit",
     "uploadReadyToPublishMessage": "Video berhasil diproses dan siap dipublikasikan",
     "uploadPublishedMessage": "Video dipublikasikan ke profilmu",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Unggah gagal - silakan coba lagi",
     "uploadRetryingMessage": "Mencoba unggah lagi...",
     "uploadPausedMessage": "Unggahan dijeda oleh pengguna",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Elaborazione del video - potrebbe volerci qualche minuto",
     "uploadReadyToPublishMessage": "Video elaborato con successo e pronto per la pubblicazione",
     "uploadPublishedMessage": "Video pubblicato sul tuo profilo",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video pubblicato sul tuo profilo} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Caricamento fallito - riprova",
     "uploadRetryingMessage": "Nuovo tentativo di caricamento...",
     "uploadPausedMessage": "Caricamento messo in pausa dall'utente",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Elaborazione del video - potrebbe volerci qualche minuto",
     "uploadReadyToPublishMessage": "Video elaborato con successo e pronto per la pubblicazione",
     "uploadPublishedMessage": "Video pubblicato sul tuo profilo",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Caricamento fallito - riprova",
     "uploadRetryingMessage": "Nuovo tentativo di caricamento...",
     "uploadPausedMessage": "Caricamento messo in pausa dall'utente",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Elaborazione del video - potrebbe volerci qualche minuto",
     "uploadReadyToPublishMessage": "Video elaborato con successo e pronto per la pubblicazione",
     "uploadPublishedMessage": "Video pubblicato sul tuo profilo",
-  "uploadPublishedCountMessage": "{count, plural, =1{Video pubblicato sul tuo profilo} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video pubblicato sul tuo profilo} other{{count} video pubblicati sul tuo profilo}}",
     "uploadFailedMessage": "Caricamento fallito - riprova",
     "uploadRetryingMessage": "Nuovo tentativo di caricamento...",
     "uploadPausedMessage": "Caricamento messo in pausa dall'utente",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1794,6 +1794,7 @@
     "uploadProcessingMessage": "動画を処理中 - 数分かかるかも",
     "uploadReadyToPublishMessage": "動画の処理が完了、公開の準備OKだよ",
     "uploadPublishedMessage": "動画をプロフィールに公開したよ",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "アップロードがうまくいかなかった - もう一回試してみて",
     "uploadRetryingMessage": "アップロードを再試行中...",
     "uploadPausedMessage": "アップロードを一時停止したよ",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1794,7 +1794,7 @@
     "uploadProcessingMessage": "動画を処理中 - 数分かかるかも",
     "uploadReadyToPublishMessage": "動画の処理が完了、公開の準備OKだよ",
     "uploadPublishedMessage": "動画をプロフィールに公開したよ",
-  "uploadPublishedCountMessage": "{count, plural, =1{動画をプロフィールに公開したよ} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{動画をプロフィールに公開したよ} other{{count}本の動画をプロフィールに公開したよ}}",
     "uploadFailedMessage": "アップロードがうまくいかなかった - もう一回試してみて",
     "uploadRetryingMessage": "アップロードを再試行中...",
     "uploadPausedMessage": "アップロードを一時停止したよ",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1794,7 +1794,7 @@
     "uploadProcessingMessage": "動画を処理中 - 数分かかるかも",
     "uploadReadyToPublishMessage": "動画の処理が完了、公開の準備OKだよ",
     "uploadPublishedMessage": "動画をプロフィールに公開したよ",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{動画をプロフィールに公開したよ} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "アップロードがうまくいかなかった - もう一回試してみて",
     "uploadRetryingMessage": "アップロードを再試行中...",
     "uploadPausedMessage": "アップロードを一時停止したよ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1090,7 +1090,7 @@
     "uploadProcessingMessage": "영상을 처리하는 중 - 몇 분이 걸릴 수 있어요",
     "uploadReadyToPublishMessage": "영상을 성공적으로 처리했고 게시할 준비가 됐어요",
     "uploadPublishedMessage": "프로필에 영상을 게시했어요",
-  "uploadPublishedCountMessage": "{count, plural, =1{프로필에 영상을 게시했어요} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{프로필에 영상을 게시했어요} other{프로필에 영상 {count}개를 게시했어요}}",
     "uploadFailedMessage": "업로드에 실패했어요 - 다시 시도해 주세요",
     "uploadRetryingMessage": "업로드를 다시 시도하는 중...",
     "uploadPausedMessage": "사용자가 업로드를 일시 중지했어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1090,7 +1090,7 @@
     "uploadProcessingMessage": "영상을 처리하는 중 - 몇 분이 걸릴 수 있어요",
     "uploadReadyToPublishMessage": "영상을 성공적으로 처리했고 게시할 준비가 됐어요",
     "uploadPublishedMessage": "프로필에 영상을 게시했어요",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{프로필에 영상을 게시했어요} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "업로드에 실패했어요 - 다시 시도해 주세요",
     "uploadRetryingMessage": "업로드를 다시 시도하는 중...",
     "uploadPausedMessage": "사용자가 업로드를 일시 중지했어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1090,6 +1090,7 @@
     "uploadProcessingMessage": "영상을 처리하는 중 - 몇 분이 걸릴 수 있어요",
     "uploadReadyToPublishMessage": "영상을 성공적으로 처리했고 게시할 준비가 됐어요",
     "uploadPublishedMessage": "프로필에 영상을 게시했어요",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "업로드에 실패했어요 - 다시 시도해 주세요",
     "uploadRetryingMessage": "업로드를 다시 시도하는 중...",
     "uploadPausedMessage": "사용자가 업로드를 일시 중지했어요",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Video verwerken — dit kan een paar minuten duren",
     "uploadReadyToPublishMessage": "Video succesvol verwerkt en klaar om te publiceren",
     "uploadPublishedMessage": "Video gepubliceerd op je profiel",
-  "uploadPublishedCountMessage": "{count, plural, =1{Video gepubliceerd op je profiel} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video gepubliceerd op je profiel} other{{count} videos gepubliceerd op je profiel}}",
     "uploadFailedMessage": "Upload mislukt — probeer het opnieuw",
     "uploadRetryingMessage": "Upload opnieuw proberen...",
     "uploadPausedMessage": "Upload gepauzeerd door gebruiker",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Video verwerken — dit kan een paar minuten duren",
     "uploadReadyToPublishMessage": "Video succesvol verwerkt en klaar om te publiceren",
     "uploadPublishedMessage": "Video gepubliceerd op je profiel",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video gepubliceerd op je profiel} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Upload mislukt — probeer het opnieuw",
     "uploadRetryingMessage": "Upload opnieuw proberen...",
     "uploadPausedMessage": "Upload gepauzeerd door gebruiker",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Video verwerken — dit kan een paar minuten duren",
     "uploadReadyToPublishMessage": "Video succesvol verwerkt en klaar om te publiceren",
     "uploadPublishedMessage": "Video gepubliceerd op je profiel",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Upload mislukt — probeer het opnieuw",
     "uploadRetryingMessage": "Upload opnieuw proberen...",
     "uploadPausedMessage": "Upload gepauzeerd door gebruiker",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Przetwarzanie filmu - to może potrwać kilka minut",
     "uploadReadyToPublishMessage": "Film przetworzony pomyślnie i gotowy do publikacji",
     "uploadPublishedMessage": "Film opublikowany na twoim profilu",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Film opublikowany na twoim profilu} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Przesyłanie nieudane - spróbuj ponownie",
     "uploadRetryingMessage": "Ponawianie przesyłania...",
     "uploadPausedMessage": "Przesyłanie wstrzymane przez użytkownika",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Przetwarzanie filmu - to może potrwać kilka minut",
     "uploadReadyToPublishMessage": "Film przetworzony pomyślnie i gotowy do publikacji",
     "uploadPublishedMessage": "Film opublikowany na twoim profilu",
-  "uploadPublishedCountMessage": "{count, plural, =1{Film opublikowany na twoim profilu} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Film opublikowany na twoim profilu} few{{count} filmy opublikowane na twoim profilu} many{{count} filmów opublikowanych na twoim profilu} other{{count} filmów opublikowanych na twoim profilu}}",
     "uploadFailedMessage": "Przesyłanie nieudane - spróbuj ponownie",
     "uploadRetryingMessage": "Ponawianie przesyłania...",
     "uploadPausedMessage": "Przesyłanie wstrzymane przez użytkownika",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Przetwarzanie filmu - to może potrwać kilka minut",
     "uploadReadyToPublishMessage": "Film przetworzony pomyślnie i gotowy do publikacji",
     "uploadPublishedMessage": "Film opublikowany na twoim profilu",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Przesyłanie nieudane - spróbuj ponownie",
     "uploadRetryingMessage": "Ponawianie przesyłania...",
     "uploadPausedMessage": "Przesyłanie wstrzymane przez użytkownika",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Processando vídeo - isso pode levar alguns minutos",
     "uploadReadyToPublishMessage": "Vídeo processado com sucesso e pronto para publicar",
     "uploadPublishedMessage": "Vídeo publicado no seu perfil",
-  "uploadPublishedCountMessage": "{count, plural, =1{Vídeo publicado no seu perfil} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Vídeo publicado no seu perfil} other{{count} vídeos publicados no seu perfil}}",
     "uploadFailedMessage": "Falha no envio - tente novamente",
     "uploadRetryingMessage": "Tentando enviar novamente...",
     "uploadPausedMessage": "Envio pausado pelo usuário",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Processando vídeo - isso pode levar alguns minutos",
     "uploadReadyToPublishMessage": "Vídeo processado com sucesso e pronto para publicar",
     "uploadPublishedMessage": "Vídeo publicado no seu perfil",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Falha no envio - tente novamente",
     "uploadRetryingMessage": "Tentando enviar novamente...",
     "uploadPausedMessage": "Envio pausado pelo usuário",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Processando vídeo - isso pode levar alguns minutos",
     "uploadReadyToPublishMessage": "Vídeo processado com sucesso e pronto para publicar",
     "uploadPublishedMessage": "Vídeo publicado no seu perfil",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Vídeo publicado no seu perfil} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Falha no envio - tente novamente",
     "uploadRetryingMessage": "Tentando enviar novamente...",
     "uploadPausedMessage": "Envio pausado pelo usuário",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Se procesează videoclipul - poate dura câteva minute",
     "uploadReadyToPublishMessage": "Videoclip procesat cu succes și gata de publicare",
     "uploadPublishedMessage": "Videoclip publicat pe profilul tău",
-  "uploadPublishedCountMessage": "{count, plural, =1{Videoclip publicat pe profilul tău} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Videoclip publicat pe profilul tău} few{{count} videoclipuri publicate pe profilul tău} other{{count} de videoclipuri publicate pe profilul tău}}",
     "uploadFailedMessage": "Încărcarea a eșuat - încearcă din nou",
     "uploadRetryingMessage": "Se reîncearcă încărcarea...",
     "uploadPausedMessage": "Încărcare oprită de utilizator",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Se procesează videoclipul - poate dura câteva minute",
     "uploadReadyToPublishMessage": "Videoclip procesat cu succes și gata de publicare",
     "uploadPublishedMessage": "Videoclip publicat pe profilul tău",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Videoclip publicat pe profilul tău} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Încărcarea a eșuat - încearcă din nou",
     "uploadRetryingMessage": "Se reîncearcă încărcarea...",
     "uploadPausedMessage": "Încărcare oprită de utilizator",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Se procesează videoclipul - poate dura câteva minute",
     "uploadReadyToPublishMessage": "Videoclip procesat cu succes și gata de publicare",
     "uploadPublishedMessage": "Videoclip publicat pe profilul tău",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Încărcarea a eșuat - încearcă din nou",
     "uploadRetryingMessage": "Se reîncearcă încărcarea...",
     "uploadPausedMessage": "Încărcare oprită de utilizator",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Bearbetar video – det här kan ta några minuter",
     "uploadReadyToPublishMessage": "Videon bearbetades och är redo att publiceras",
     "uploadPublishedMessage": "Videon publicerad till din profil",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Videon publicerad till din profil} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Uppladdning misslyckades – försök igen",
     "uploadRetryingMessage": "Försöker ladda upp igen...",
     "uploadPausedMessage": "Uppladdning pausad av användaren",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1804,7 +1804,7 @@
     "uploadProcessingMessage": "Bearbetar video – det här kan ta några minuter",
     "uploadReadyToPublishMessage": "Videon bearbetades och är redo att publiceras",
     "uploadPublishedMessage": "Videon publicerad till din profil",
-  "uploadPublishedCountMessage": "{count, plural, =1{Videon publicerad till din profil} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Videon publicerad till din profil} other{{count} videor publicerade till din profil}}",
     "uploadFailedMessage": "Uppladdning misslyckades – försök igen",
     "uploadRetryingMessage": "Försöker ladda upp igen...",
     "uploadPausedMessage": "Uppladdning pausad av användaren",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1804,6 +1804,7 @@
     "uploadProcessingMessage": "Bearbetar video – det här kan ta några minuter",
     "uploadReadyToPublishMessage": "Videon bearbetades och är redo att publiceras",
     "uploadPublishedMessage": "Videon publicerad till din profil",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Uppladdning misslyckades – försök igen",
     "uploadRetryingMessage": "Försöker ladda upp igen...",
     "uploadPausedMessage": "Uppladdning pausad av användaren",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1801,6 +1801,7 @@
     "uploadProcessingMessage": "Video işleniyor - bu birkaç dakika sürebilir",
     "uploadReadyToPublishMessage": "Video başarıyla işlendi ve yayınlamaya hazır",
     "uploadPublishedMessage": "Video profiline yayınlandı",
+  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
     "uploadFailedMessage": "Yükleme başarısız - lütfen tekrar dene",
     "uploadRetryingMessage": "Yükleme yeniden deneniyor...",
     "uploadPausedMessage": "Yükleme kullanıcı tarafından duraklatıldı",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1801,7 +1801,7 @@
     "uploadProcessingMessage": "Video işleniyor - bu birkaç dakika sürebilir",
     "uploadReadyToPublishMessage": "Video başarıyla işlendi ve yayınlamaya hazır",
     "uploadPublishedMessage": "Video profiline yayınlandı",
-  "uploadPublishedCountMessage": "{count, plural, =1{Video profiline yayınlandı} other{{count} videos published to your profile}}",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video profiline yayınlandı} other{{count} video profiline yayınlandı}}",
     "uploadFailedMessage": "Yükleme başarısız - lütfen tekrar dene",
     "uploadRetryingMessage": "Yükleme yeniden deneniyor...",
     "uploadPausedMessage": "Yükleme kullanıcı tarafından duraklatıldı",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1801,7 +1801,7 @@
     "uploadProcessingMessage": "Video işleniyor - bu birkaç dakika sürebilir",
     "uploadReadyToPublishMessage": "Video başarıyla işlendi ve yayınlamaya hazır",
     "uploadPublishedMessage": "Video profiline yayınlandı",
-  "uploadPublishedMultipleMessage": "{count} videos published to your profile",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video profiline yayınlandı} other{{count} videos published to your profile}}",
     "uploadFailedMessage": "Yükleme başarısız - lütfen tekrar dene",
     "uploadRetryingMessage": "Yükleme yeniden deneniyor...",
     "uploadPausedMessage": "Yükleme kullanıcı tarafından duraklatıldı",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7406,11 +7406,11 @@ abstract class AppLocalizations {
   /// **'Video published to your profile'**
   String get uploadPublishedMessage;
 
-  /// Snackbar shown after multiple background uploads succeed, e.g. after a re-auth redirect during which several publishes completed.
+  /// Snackbar shown after one or more background uploads succeed, e.g. after a re-auth redirect during which uploads completed.
   ///
   /// In en, this message translates to:
-  /// **'{count} videos published to your profile'**
-  String uploadPublishedMultipleMessage(int count);
+  /// **'{count, plural, =1{Video published to your profile} other{{count} videos published to your profile}}'**
+  String uploadPublishedCountMessage(int count);
 
   /// No description provided for @uploadFailedMessage.
   ///

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7406,6 +7406,12 @@ abstract class AppLocalizations {
   /// **'Video published to your profile'**
   String get uploadPublishedMessage;
 
+  /// Snackbar shown after multiple background uploads succeed, e.g. after a re-auth redirect during which several publishes completed.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} videos published to your profile'**
+  String uploadPublishedMultipleMessage(int count);
+
   /// No description provided for @uploadFailedMessage.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4166,7 +4166,7 @@ class AppLocalizationsAm extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count ቪዲዮዎች ወደ መገለጫዎ ታትሟቸዋል',
       one: 'ቪዲዮ ወደ መገለጫዎ ታትሟል',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4162,6 +4162,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get uploadPublishedMessage => 'ቪዲዮ ወደ መገለጫዎ ታትሟል';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count ቪዲዮዎች ወደ መገለጫዎ ታትሟቸዋል';
+  }
+
+  @override
   String get uploadFailedMessage => 'ሰቀላው አልተሳካም - እባክዎ እንደገና ይሞክሩ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4163,7 +4163,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count ቪዲዮዎች ወደ መገለጫዎ ታትሟቸዋል';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4162,8 +4162,14 @@ class AppLocalizationsAm extends AppLocalizations {
   String get uploadPublishedMessage => 'ቪዲዮ ወደ መገለጫዎ ታትሟል';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'ቪዲዮ ወደ መገለጫዎ ታትሟል',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4208,6 +4208,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get uploadPublishedMessage => 'تم نشر الفيديو في ملفك الشخصي';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return 'تم نشر $count مقاطع فيديو في ملفك الشخصي';
+  }
+
+  @override
   String get uploadFailedMessage => 'فشل الرفع - يُرجى المحاولة مرة أخرى';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4212,7 +4212,7 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: 'تم نشر $count مقاطع فيديو في ملفك الشخصي',
       one: 'تم نشر الفيديو في ملفك الشخصي',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4209,7 +4209,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return 'تم نشر $count مقاطع فيديو في ملفك الشخصي';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4208,8 +4208,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get uploadPublishedMessage => 'تم نشر الفيديو في ملفك الشخصي';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'تم نشر الفيديو في ملفك الشخصي',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4298,6 +4298,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get uploadPublishedMessage => 'Видеото е публикувано в профила ти';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count видеа са публикувани в профила ти';
+  }
+
+  @override
   String get uploadFailedMessage => 'Качването не мина - опитай пак';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4298,8 +4298,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get uploadPublishedMessage => 'Видеото е публикувано в профила ти';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Видеото е публикувано в профила ти',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4299,7 +4299,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count видеа са публикувани в профила ти';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4302,7 +4302,7 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count видеа са публикувани в профила ти',
       one: 'Видеото е публикувано в профила ти',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4304,6 +4304,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get uploadPublishedMessage => 'Video in deinem Profil veröffentlicht';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count Videos in deinem Profil veröffentlicht';
+  }
+
+  @override
   String get uploadFailedMessage =>
       'Upload fehlgeschlagen — bitte versuch es nochmal';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4304,8 +4304,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get uploadPublishedMessage => 'Video in deinem Profil veröffentlicht';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video in deinem Profil veröffentlicht',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4308,7 +4308,7 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count Videos in deinem Profil veröffentlicht',
       one: 'Video in deinem Profil veröffentlicht',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4305,7 +4305,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count Videos in deinem Profil veröffentlicht';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4253,8 +4253,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get uploadPublishedMessage => 'Video published to your profile';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video published to your profile',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4253,6 +4253,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get uploadPublishedMessage => 'Video published to your profile';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count videos published to your profile';
+  }
+
+  @override
   String get uploadFailedMessage => 'Upload failed - please try again';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4299,8 +4299,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get uploadPublishedMessage => 'Video publicado en tu perfil';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video publicado en tu perfil',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4300,7 +4300,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count videos publicados en tu perfil';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4303,7 +4303,7 @@ class AppLocalizationsEs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count videos publicados en tu perfil',
       one: 'Video publicado en tu perfil',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4299,6 +4299,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get uploadPublishedMessage => 'Video publicado en tu perfil';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count videos publicados en tu perfil';
+  }
+
+  @override
   String get uploadFailedMessage => 'Falló la subida — probá de nuevo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4311,8 +4311,14 @@ class AppLocalizationsFil extends AppLocalizations {
   String get uploadPublishedMessage => 'Na-publish na ang video sa profile mo';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Na-publish na ang video sa profile mo',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4312,7 +4312,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count videos na-publish sa profile mo';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4311,6 +4311,11 @@ class AppLocalizationsFil extends AppLocalizations {
   String get uploadPublishedMessage => 'Na-publish na ang video sa profile mo';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count videos na-publish sa profile mo';
+  }
+
+  @override
   String get uploadFailedMessage => 'Hindi nag-upload - subukan ulit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4315,7 +4315,7 @@ class AppLocalizationsFil extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: 'Na-publish na ang $count na video sa profile mo',
       one: 'Na-publish na ang video sa profile mo',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4317,7 +4317,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count vidéos publiées sur ton profil';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4316,8 +4316,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get uploadPublishedMessage => 'Vidéo publiée sur ton profil';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Vidéo publiée sur ton profil',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4316,6 +4316,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get uploadPublishedMessage => 'Vidéo publiée sur ton profil';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count vidéos publiées sur ton profil';
+  }
+
+  @override
   String get uploadFailedMessage => 'Échec de l\'envoi - réessaie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4320,7 +4320,7 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count vidéos publiées sur ton profil',
       one: 'Vidéo publiée sur ton profil',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4224,6 +4224,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get uploadPublishedMessage => 'Video dipublikasikan ke profilmu';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count video dipublikasikan ke profilmu';
+  }
+
+  @override
   String get uploadFailedMessage => 'Unggah gagal - silakan coba lagi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4228,7 +4228,7 @@ class AppLocalizationsId extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count video dipublikasikan ke profilmu',
       one: 'Video dipublikasikan ke profilmu',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4225,7 +4225,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count video dipublikasikan ke profilmu';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4224,8 +4224,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get uploadPublishedMessage => 'Video dipublikasikan ke profilmu';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video dipublikasikan ke profilmu',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4297,6 +4297,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get uploadPublishedMessage => 'Video pubblicato sul tuo profilo';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count video pubblicati sul tuo profilo';
+  }
+
+  @override
   String get uploadFailedMessage => 'Caricamento fallito - riprova';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4301,7 +4301,7 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count video pubblicati sul tuo profilo',
       one: 'Video pubblicato sul tuo profilo',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4297,8 +4297,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get uploadPublishedMessage => 'Video pubblicato sul tuo profilo';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video pubblicato sul tuo profilo',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4298,7 +4298,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count video pubblicati sul tuo profilo';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4050,8 +4050,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get uploadPublishedMessage => '動画をプロフィールに公開したよ';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: '動画をプロフィールに公開したよ',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4054,7 +4054,7 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count本の動画をプロフィールに公開したよ',
       one: '動画をプロフィールに公開したよ',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4050,6 +4050,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get uploadPublishedMessage => '動画をプロフィールに公開したよ';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count本の動画をプロフィールに公開したよ';
+  }
+
+  @override
   String get uploadFailedMessage => 'アップロードがうまくいかなかった - もう一回試してみて';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4051,7 +4051,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count本の動画をプロフィールに公開したよ';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4069,7 +4069,7 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '프로필에 영상 $count개를 게시했어요',
       one: '프로필에 영상을 게시했어요',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4066,7 +4066,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '프로필에 영상 $count개를 게시했어요';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4065,8 +4065,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get uploadPublishedMessage => '프로필에 영상을 게시했어요';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: '프로필에 영상을 게시했어요',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4065,6 +4065,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get uploadPublishedMessage => '프로필에 영상을 게시했어요';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '프로필에 영상 $count개를 게시했어요';
+  }
+
+  @override
   String get uploadFailedMessage => '업로드에 실패했어요 - 다시 시도해 주세요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4272,7 +4272,7 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count videos gepubliceerd op je profiel',
       one: 'Video gepubliceerd op je profiel',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4268,8 +4268,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get uploadPublishedMessage => 'Video gepubliceerd op je profiel';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video gepubliceerd op je profiel',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4268,6 +4268,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get uploadPublishedMessage => 'Video gepubliceerd op je profiel';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count video\'s gepubliceerd op je profiel';
+  }
+
+  @override
   String get uploadFailedMessage => 'Upload mislukt — probeer het opnieuw';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4269,7 +4269,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count video\'s gepubliceerd op je profiel';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4360,6 +4360,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get uploadPublishedMessage => 'Film opublikowany na twoim profilu';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count filmy opublikowane na twoim profilu';
+  }
+
+  @override
   String get uploadFailedMessage => 'Przesyłanie nieudane - spróbuj ponownie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4360,8 +4360,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get uploadPublishedMessage => 'Film opublikowany na twoim profilu';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Film opublikowany na twoim profilu',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4361,7 +4361,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count filmy opublikowane na twoim profilu';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4364,7 +4364,9 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count filmów opublikowanych na twoim profilu',
+      many: '$count filmów opublikowanych na twoim profilu',
+      few: '$count filmy opublikowane na twoim profilu',
       one: 'Film opublikowany na twoim profilu',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4282,7 +4282,7 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count vídeos publicados no seu perfil',
       one: 'Vídeo publicado no seu perfil',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4279,7 +4279,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count vídeos publicados no seu perfil';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4278,8 +4278,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get uploadPublishedMessage => 'Vídeo publicado no seu perfil';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Vídeo publicado no seu perfil',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4278,6 +4278,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get uploadPublishedMessage => 'Vídeo publicado no seu perfil';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count vídeos publicados no seu perfil';
+  }
+
+  @override
   String get uploadFailedMessage => 'Falha no envio - tente novamente';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4378,7 +4378,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count videoclipuri publicate pe profilul tău';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4377,8 +4377,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get uploadPublishedMessage => 'Videoclip publicat pe profilul tău';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Videoclip publicat pe profilul tău',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4381,7 +4381,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count de videoclipuri publicate pe profilul tău',
+      few: '$count videoclipuri publicate pe profilul tău',
       one: 'Videoclip publicat pe profilul tău',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4377,6 +4377,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get uploadPublishedMessage => 'Videoclip publicat pe profilul tău';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count videoclipuri publicate pe profilul tău';
+  }
+
+  @override
   String get uploadFailedMessage => 'Încărcarea a eșuat - încearcă din nou';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4250,8 +4250,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get uploadPublishedMessage => 'Videon publicerad till din profil';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Videon publicerad till din profil',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4250,6 +4250,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get uploadPublishedMessage => 'Videon publicerad till din profil';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count videor publicerade till din profil';
+  }
+
+  @override
   String get uploadFailedMessage => 'Uppladdning misslyckades – försök igen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4254,7 +4254,7 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count videor publicerade till din profil',
       one: 'Videon publicerad till din profil',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4251,7 +4251,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count videor publicerade till din profil';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4238,7 +4238,7 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count videos published to your profile',
+      other: '$count video profiline yayınlandı',
       one: 'Video profiline yayınlandı',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4234,6 +4234,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get uploadPublishedMessage => 'Video profiline yayınlandı';
 
   @override
+  String uploadPublishedMultipleMessage(int count) {
+    return '$count video profiline yayınlandı';
+  }
+
+  @override
   String get uploadFailedMessage => 'Yükleme başarısız - lütfen tekrar dene';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4235,7 +4235,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String uploadPublishedMultipleMessage(int count) {
-    return '$count video profiline yayınlandı';
+    return '$count videos published to your profile';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4234,8 +4234,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get uploadPublishedMessage => 'Video profiline yayınlandı';
 
   @override
-  String uploadPublishedMultipleMessage(int count) {
-    return '$count videos published to your profile';
+  String uploadPublishedCountMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count videos published to your profile',
+      one: 'Video profiline yayınlandı',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2082,8 +2082,8 @@ class _DivineAppState extends ConsumerState<DivineApp> {
               );
             }
           },
-          child: UpdateDialogListener(
-            child: _UploadFailureListener(
+            child: UpdateDialogListener(
+            child: UploadFailureListener(
               child: GeoBlockingGate(
                 child: AppLifecycleHandler(
                   child: BlocBuilder<LocaleCubit, LocaleState>(
@@ -2135,19 +2135,22 @@ class _DivineAppState extends ConsumerState<DivineApp> {
 /// through re-auth after an expired-session redirect — the success count is
 /// buffered and a confirmation snackbar is shown the moment authentication is
 /// restored.
-class _UploadFailureListener extends StatefulWidget {
-  const _UploadFailureListener({required this.child});
+@visibleForTesting
+class UploadFailureListener extends StatefulWidget {
+  const UploadFailureListener({required this.child, super.key});
 
   final Widget child;
 
   @override
-  State<_UploadFailureListener> createState() => _UploadFailureListenerState();
+  State<UploadFailureListener> createState() => UploadFailureListenerState();
 }
 
-class _UploadFailureListenerState extends State<_UploadFailureListener> {
-  var _lastKnownFailedIds = <String>{};
-  var _lastKnownInProgressIds = <String>{};
-  var _pendingSuccessCount = 0;
+/// State for [UploadFailureListener]. Public for testing.
+@visibleForTesting
+class UploadFailureListenerState extends State<UploadFailureListener> {
+  var lastKnownFailedIds = <String>{};
+  var lastKnownInProgressIds = <String>{};
+  var pendingSuccessCount = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -2169,11 +2172,11 @@ class _UploadFailureListenerState extends State<_UploadFailureListener> {
 
         // IDs that were in-progress and are now gone from state entirely
         // (not in progress, not in failures) → they succeeded.
-        final succeededIds = _lastKnownInProgressIds
+        final succeededIds = lastKnownInProgressIds
             .difference(currentInProgressIds)
             .difference(currentFailedIds);
 
-        _lastKnownInProgressIds = currentInProgressIds;
+        lastKnownInProgressIds = currentInProgressIds;
 
         if (succeededIds.isNotEmpty) {
           if (authService.isAuthenticated) {
@@ -2181,13 +2184,13 @@ class _UploadFailureListenerState extends State<_UploadFailureListener> {
             _showPublishSuccessSnackbar(context, succeededIds.length);
           } else {
             // Buffer for when auth is restored after re-auth redirect.
-            _pendingSuccessCount += succeededIds.length;
+            pendingSuccessCount += succeededIds.length;
           }
         }
 
         // Don't show failure sheets while the user is not authenticated
         // (e.g. still on the login screen after a cold start).
-        // Also don't update _lastKnownFailedIds so these failures are
+        // Also don't update lastKnownFailedIds so these failures are
         // detected as "new" once the user eventually authenticates.
         if (!authService.isAuthenticated) {
           // Flush any buffered successes once auth is restored.
@@ -2195,13 +2198,13 @@ class _UploadFailureListenerState extends State<_UploadFailureListener> {
         }
 
         // Auth is now confirmed — flush buffered successes from re-auth window.
-        if (_pendingSuccessCount > 0) {
-          _showPublishSuccessSnackbar(context, _pendingSuccessCount);
-          _pendingSuccessCount = 0;
+        if (pendingSuccessCount > 0) {
+          _showPublishSuccessSnackbar(context, pendingSuccessCount);
+          pendingSuccessCount = 0;
         }
 
-        final newFailedIds = currentFailedIds.difference(_lastKnownFailedIds);
-        _lastKnownFailedIds = currentFailedIds;
+        final newFailedIds = currentFailedIds.difference(lastKnownFailedIds);
+        lastKnownFailedIds = currentFailedIds;
 
         if (newFailedIds.isEmpty) return;
 
@@ -2221,18 +2224,19 @@ class _UploadFailureListenerState extends State<_UploadFailureListener> {
 
 /// Shows a snackbar confirming that [count] background uploads completed.
 ///
-/// Uses [ScaffoldMessenger] via [NavigatorKeys.root] so it works from any
-/// route, including the welcome/login screen during a re-auth redirect.
+/// Uses [ScaffoldMessenger] via [NavigatorKeys.root] to reach the root
+/// [Scaffold] — this is required because the listener's [BuildContext] may
+/// not have a [Scaffold] ancestor when the snackbar fires during a re-auth
+/// redirect. The l10n strings are resolved from the passed-in [context]
+/// (the BlocListener's context), which always has localisation ancestors.
 void _showPublishSuccessSnackbar(BuildContext context, int count) {
   final navContext = NavigatorKeys.root.currentContext;
   if (navContext == null || !navContext.mounted) return;
-  final l10n = navContext.l10n;
+  final l10n = context.l10n;
   ScaffoldMessenger.of(navContext).showSnackBar(
     SnackBar(
       content: Text(
-        count == 1
-            ? l10n.uploadPublishedMessage
-            : l10n.uploadPublishedMultipleMessage(count),
+        l10n.uploadPublishedCountMessage(count),
         style: VineTheme.bodyMediumFont(),
       ),
       backgroundColor: VineTheme.navGreen,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2118,14 +2118,23 @@ class _DivineAppState extends ConsumerState<DivineApp> {
   }
 }
 
-/// Listens for background upload failures and shows a bottom sheet.
+/// Listens for background upload completions and shows the appropriate UI.
 ///
 /// Uses [NavigatorKeys.root] to obtain a [BuildContext] inside the
-/// [Navigator] tree, which [showModalBottomSheet] requires.
+/// [Navigator] tree, which [showModalBottomSheet] and [ScaffoldMessenger]
+/// require.
 ///
-/// Tracks the set of currently-failed draft IDs so that only **new**
-/// failures trigger a sheet. When a draft is retried or dismissed its ID
-/// leaves the failed set, so a subsequent failure is detected as new again.
+/// **Failure tracking:** Tracks the set of currently-failed draft IDs so that
+/// only *new* failures trigger a sheet. When a draft is retried or dismissed
+/// its ID leaves the failed set, so a subsequent failure is detected as new.
+///
+/// **Success tracking (publish-flow continuity, #4626):** Tracks in-progress
+/// draft IDs. When an ID disappears from state without appearing in the
+/// failure set it succeeded silently (the bloc removes it immediately). If the
+/// user is not yet authenticated at that moment — because they are mid-way
+/// through re-auth after an expired-session redirect — the success count is
+/// buffered and a confirmation snackbar is shown the moment authentication is
+/// restored.
 class _UploadFailureListener extends StatefulWidget {
   const _UploadFailureListener({required this.child});
 
@@ -2137,24 +2146,59 @@ class _UploadFailureListener extends StatefulWidget {
 
 class _UploadFailureListenerState extends State<_UploadFailureListener> {
   var _lastKnownFailedIds = <String>{};
+  var _lastKnownInProgressIds = <String>{};
+  var _pendingSuccessCount = 0;
 
   @override
   Widget build(BuildContext context) {
     return BlocListener<BackgroundPublishBloc, BackgroundPublishState>(
       listener: (context, state) {
-        // Don't show failure sheets while the user is not authenticated
-        // (e.g. still on the login screen after a cold start).
-        // Also don't update _lastKnownFailedIds so these failures are
-        // detected as "new" once the user eventually authenticates.
         final authService = ProviderScope.containerOf(
           context,
         ).read(authServiceProvider);
-        if (!authService.isAuthenticated) return;
+
+        final currentInProgressIds = state.uploads
+            .where((u) => u.result == null)
+            .map((u) => u.draft.id)
+            .toSet();
 
         final currentFailedIds = state.uploads
             .where((u) => u.result is PublishError)
             .map((u) => u.draft.id)
             .toSet();
+
+        // IDs that were in-progress and are now gone from state entirely
+        // (not in progress, not in failures) → they succeeded.
+        final succeededIds = _lastKnownInProgressIds
+            .difference(currentInProgressIds)
+            .difference(currentFailedIds);
+
+        _lastKnownInProgressIds = currentInProgressIds;
+
+        if (succeededIds.isNotEmpty) {
+          if (authService.isAuthenticated) {
+            // Show immediately — user is still in-app.
+            _showPublishSuccessSnackbar(context, succeededIds.length);
+          } else {
+            // Buffer for when auth is restored after re-auth redirect.
+            _pendingSuccessCount += succeededIds.length;
+          }
+        }
+
+        // Don't show failure sheets while the user is not authenticated
+        // (e.g. still on the login screen after a cold start).
+        // Also don't update _lastKnownFailedIds so these failures are
+        // detected as "new" once the user eventually authenticates.
+        if (!authService.isAuthenticated) {
+          // Flush any buffered successes once auth is restored.
+          return;
+        }
+
+        // Auth is now confirmed — flush buffered successes from re-auth window.
+        if (_pendingSuccessCount > 0) {
+          _showPublishSuccessSnackbar(context, _pendingSuccessCount);
+          _pendingSuccessCount = 0;
+        }
 
         final newFailedIds = currentFailedIds.difference(_lastKnownFailedIds);
         _lastKnownFailedIds = currentFailedIds;
@@ -2173,6 +2217,28 @@ class _UploadFailureListenerState extends State<_UploadFailureListener> {
       child: widget.child,
     );
   }
+}
+
+/// Shows a snackbar confirming that [count] background uploads completed.
+///
+/// Uses [ScaffoldMessenger] via [NavigatorKeys.root] so it works from any
+/// route, including the welcome/login screen during a re-auth redirect.
+void _showPublishSuccessSnackbar(BuildContext context, int count) {
+  final navContext = NavigatorKeys.root.currentContext;
+  if (navContext == null || !navContext.mounted) return;
+  final l10n = navContext.l10n;
+  ScaffoldMessenger.of(navContext).showSnackBar(
+    SnackBar(
+      content: Text(
+        count == 1
+            ? l10n.uploadPublishedMessage
+            : l10n.uploadPublishedMultipleMessage(count),
+        style: VineTheme.bodyMediumFont(),
+      ),
+      backgroundColor: VineTheme.navGreen,
+      behavior: SnackBarBehavior.floating,
+    ),
+  );
 }
 
 /// Shows failure bottom sheets one after another for each failed upload.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2128,13 +2128,12 @@ class _DivineAppState extends ConsumerState<DivineApp> {
 /// only *new* failures trigger a sheet. When a draft is retried or dismissed
 /// its ID leaves the failed set, so a subsequent failure is detected as new.
 ///
-/// **Success tracking (publish-flow continuity, #4626):** Tracks in-progress
-/// draft IDs. When an ID disappears from state without appearing in the
-/// failure set it succeeded silently (the bloc removes it immediately). If the
-/// user is not yet authenticated at that moment — because they are mid-way
-/// through re-auth after an expired-session redirect — the success count is
-/// buffered and a confirmation snackbar is shown the moment authentication is
-/// restored.
+/// **Success tracking (publish-flow continuity, #4626):** Reads
+/// [BackgroundPublishState.recentlySucceededIds] — populated by the bloc only
+/// on a true [PublishSuccess], never on [BackgroundPublishVanished] — so a
+/// vanished upload cannot produce a false "published" snackbar. If the user is
+/// not yet authenticated at the moment of success (mid re-auth redirect), the
+/// count is buffered and shown once authentication is restored.
 @visibleForTesting
 class UploadFailureListener extends StatefulWidget {
   const UploadFailureListener({required this.child, super.key});
@@ -2142,15 +2141,12 @@ class UploadFailureListener extends StatefulWidget {
   final Widget child;
 
   @override
-  State<UploadFailureListener> createState() => UploadFailureListenerState();
+  State<UploadFailureListener> createState() => _UploadFailureListenerState();
 }
 
-/// State for [UploadFailureListener]. Public for testing.
-@visibleForTesting
-class UploadFailureListenerState extends State<UploadFailureListener> {
-  var lastKnownFailedIds = <String>{};
-  var lastKnownInProgressIds = <String>{};
-  var pendingSuccessCount = 0;
+class _UploadFailureListenerState extends State<UploadFailureListener> {
+  var _lastKnownFailedIds = <String>{};
+  var _pendingSuccessCount = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -2160,51 +2156,41 @@ class UploadFailureListenerState extends State<UploadFailureListener> {
           context,
         ).read(authServiceProvider);
 
-        final currentInProgressIds = state.uploads
-            .where((u) => u.result == null)
-            .map((u) => u.draft.id)
-            .toSet();
+        // Use the bloc's own recentlySucceededIds so we never confuse a
+        // BackgroundPublishVanished removal with a true publish success.
+        final succeededCount = state.recentlySucceededIds.length;
+
+        if (succeededCount > 0) {
+          if (authService.isAuthenticated) {
+            // Show immediately — user is still in-app.
+            _showPublishSuccessSnackbar(context, succeededCount);
+          } else {
+            // Buffer for when auth is restored after re-auth redirect.
+            _pendingSuccessCount += succeededCount;
+          }
+        }
 
         final currentFailedIds = state.uploads
             .where((u) => u.result is PublishError)
             .map((u) => u.draft.id)
             .toSet();
 
-        // IDs that were in-progress and are now gone from state entirely
-        // (not in progress, not in failures) → they succeeded.
-        final succeededIds = lastKnownInProgressIds
-            .difference(currentInProgressIds)
-            .difference(currentFailedIds);
-
-        lastKnownInProgressIds = currentInProgressIds;
-
-        if (succeededIds.isNotEmpty) {
-          if (authService.isAuthenticated) {
-            // Show immediately — user is still in-app.
-            _showPublishSuccessSnackbar(context, succeededIds.length);
-          } else {
-            // Buffer for when auth is restored after re-auth redirect.
-            pendingSuccessCount += succeededIds.length;
-          }
-        }
-
         // Don't show failure sheets while the user is not authenticated
         // (e.g. still on the login screen after a cold start).
-        // Also don't update lastKnownFailedIds so these failures are
+        // Also don't update _lastKnownFailedIds so these failures are
         // detected as "new" once the user eventually authenticates.
         if (!authService.isAuthenticated) {
-          // Flush any buffered successes once auth is restored.
           return;
         }
 
         // Auth is now confirmed — flush buffered successes from re-auth window.
-        if (pendingSuccessCount > 0) {
-          _showPublishSuccessSnackbar(context, pendingSuccessCount);
-          pendingSuccessCount = 0;
+        if (_pendingSuccessCount > 0) {
+          _showPublishSuccessSnackbar(context, _pendingSuccessCount);
+          _pendingSuccessCount = 0;
         }
 
-        final newFailedIds = currentFailedIds.difference(lastKnownFailedIds);
-        lastKnownFailedIds = currentFailedIds;
+        final newFailedIds = currentFailedIds.difference(_lastKnownFailedIds);
+        _lastKnownFailedIds = currentFailedIds;
 
         if (newFailedIds.isEmpty) return;
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2082,7 +2082,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
               );
             }
           },
-            child: UpdateDialogListener(
+          child: UpdateDialogListener(
             child: UploadFailureListener(
               child: GeoBlockingGate(
                 child: AppLifecycleHandler(

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -95,19 +95,28 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     // Refresh definitively failed. If a background upload is in progress,
     // do not interrupt it by navigating now. Instead, wait for the upload
     // to finish and then route to login-options automatically.
+    //
+    // Subscribe BEFORE checking current state to close the window where the
+    // last upload could complete between the check and the listen call.
+    // After subscribing, immediately re-check; if already clear, navigate now
+    // and cancel — no further emission is needed.
     final publishBloc = context.read<BackgroundPublishBloc>();
-    if (publishBloc.state.hasUploadInProgress) {
-      _deferredNavSubscription?.cancel();
-      _deferredNavSubscription = publishBloc.stream.listen((state) {
-        if (!state.hasUploadInProgress) {
-          _deferredNavSubscription?.cancel();
-          _deferredNavSubscription = null;
-          if (mounted) {
-            GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
-          }
+    _deferredNavSubscription?.cancel();
+    _deferredNavSubscription = publishBloc.stream.listen((state) {
+      if (!state.hasUploadInProgress) {
+        _deferredNavSubscription?.cancel();
+        _deferredNavSubscription = null;
+        if (mounted) {
+          GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
         }
-      });
-    } else {
+      }
+    });
+    // Re-check current state now that the listener is attached. If the last
+    // upload already finished before we subscribed, no further emission will
+    // arrive and we must navigate immediately.
+    if (!publishBloc.state.hasUploadInProgress) {
+      _deferredNavSubscription?.cancel();
+      _deferredNavSubscription = null;
       GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
     }
   }

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -9,7 +9,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
-import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/settings_account/settings_account_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -25,7 +24,6 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/apps/apps_directory_screen.dart';
 import 'package:openvine/screens/apps/apps_permissions_screen.dart';
 import 'package:openvine/screens/auth/secure_account_screen.dart';
-import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/screens/creator_analytics_screen.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
@@ -37,6 +35,7 @@ import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/nip05_verification_service.dart';
+import 'package:openvine/utils/deferred_login_options_navigator.dart';
 import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -56,10 +55,7 @@ class SettingsScreen extends ConsumerStatefulWidget {
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   String _appVersion = '';
   late final SettingsAccountCubit _accountCubit;
-
-  /// Subscription used to defer login-options navigation until a background
-  /// video upload finishes when a session-expiry refresh fails mid-publish.
-  StreamSubscription<BackgroundPublishState>? _deferredNavSubscription;
+  final _deferredLoginOptionsNavigator = DeferredLoginOptionsNavigator();
 
   @override
   void initState() {
@@ -74,7 +70,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   @override
   void dispose() {
-    _deferredNavSubscription?.cancel();
+    _deferredLoginOptionsNavigator.dispose();
     _accountCubit.close();
     super.dispose();
   }
@@ -92,33 +88,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     if (!mounted) return;
     if (refreshed) return;
 
-    // Refresh definitively failed. If a background upload is in progress,
-    // do not interrupt it by navigating now. Instead, wait for the upload
-    // to finish and then route to login-options automatically.
-    //
-    // Subscribe BEFORE checking current state to close the window where the
-    // last upload could complete between the check and the listen call.
-    // After subscribing, immediately re-check; if already clear, navigate now
-    // and cancel — no further emission is needed.
-    final publishBloc = context.read<BackgroundPublishBloc>();
-    _deferredNavSubscription?.cancel();
-    _deferredNavSubscription = publishBloc.stream.listen((state) {
-      if (!state.hasUploadInProgress) {
-        _deferredNavSubscription?.cancel();
-        _deferredNavSubscription = null;
-        if (mounted) {
-          GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
-        }
-      }
-    });
-    // Re-check current state now that the listener is attached. If the last
-    // upload already finished before we subscribed, no further emission will
-    // arrive and we must navigate immediately.
-    if (!publishBloc.state.hasUploadInProgress) {
-      _deferredNavSubscription?.cancel();
-      _deferredNavSubscription = null;
-      GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
-    }
+    _deferredLoginOptionsNavigator.goAfterUploadsComplete(
+      context: context,
+      publishBloc: context.read(),
+    );
   }
 
   Future<void> _handleSwitchAccount() async {

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/settings_account/settings_account_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -56,6 +57,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   String _appVersion = '';
   late final SettingsAccountCubit _accountCubit;
 
+  /// Subscription used to defer login-options navigation until a background
+  /// video upload finishes when a session-expiry refresh fails mid-publish.
+  StreamSubscription<BackgroundPublishState>? _deferredNavSubscription;
+
   @override
   void initState() {
     super.initState();
@@ -69,6 +74,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   @override
   void dispose() {
+    _deferredNavSubscription?.cancel();
     _accountCubit.close();
     super.dispose();
   }
@@ -82,11 +88,27 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   Future<void> _handleSessionExpired() async {
     final authService = ref.read(authServiceProvider);
-    final router = GoRouter.of(context);
     final refreshed = await authService.tryRefreshExpiredSession();
     if (!mounted) return;
-    if (!refreshed) {
-      router.go(WelcomeScreen.loginOptionsPath);
+    if (refreshed) return;
+
+    // Refresh definitively failed. If a background upload is in progress,
+    // do not interrupt it by navigating now. Instead, wait for the upload
+    // to finish and then route to login-options automatically.
+    final publishBloc = context.read<BackgroundPublishBloc>();
+    if (publishBloc.state.hasUploadInProgress) {
+      _deferredNavSubscription?.cancel();
+      _deferredNavSubscription = publishBloc.stream.listen((state) {
+        if (!state.hasUploadInProgress) {
+          _deferredNavSubscription?.cancel();
+          _deferredNavSubscription = null;
+          if (mounted) {
+            GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
+          }
+        }
+      });
+    } else {
+      GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
     }
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -229,6 +229,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   String? _lastError;
   bool _storageErrorOccurred = false;
   bool _hasExpiredOAuthSession = false;
+  bool _isRpcUpgradeInProgress = false;
   Future<bool>? _pendingRefresh;
   Future<KeycastSession?>? _pendingOAuthRefresh;
   KeycastRpc? _keycastSigner;
@@ -402,6 +403,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// The user's identity is intact but remote signing is unavailable.
   /// UI should prompt re-login instead of "Secure Your Account".
   bool get hasExpiredOAuthSession => _hasExpiredOAuthSession;
+
+  /// True while a background OAuth RPC upgrade is in progress during startup.
+  /// The session-expired sheet should be suppressed until this resolves so the
+  /// UI does not prompt re-login before the silent refresh has definitively failed.
+  bool get isRpcUpgradeInProgress => _isRpcUpgradeInProgress;
+
+  /// True while a [tryRefreshExpiredSession] call is in flight.
+  /// Callers can use this to avoid redundant UI prompts while refresh is pending.
+  bool get isRefreshInProgress => _pendingRefresh != null;
 
   /// Timeout for background RPC refresh during local-first startup.
   @visibleForTesting
@@ -579,6 +589,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
 
+    _isRpcUpgradeInProgress = true;
     try {
       if (_oauthClient == null) {
         _setRpcCapability(AuthRpcCapability.unavailable);
@@ -618,6 +629,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         name: 'AuthService',
         category: LogCategory.auth,
       );
+    } finally {
+      _isRpcUpgradeInProgress = false;
+      // Nudge the auth stream so widgets re-evaluate whether the
+      // session-expired sheet should be shown now that the upgrade has resolved.
+      _authStateController.add(_authState);
     }
 
     _setRpcCapability(AuthRpcCapability.unavailable);

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -409,10 +409,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// UI does not prompt re-login before the silent refresh has definitively failed.
   bool get isRpcUpgradeInProgress => _isRpcUpgradeInProgress;
 
-  /// True while a [tryRefreshExpiredSession] call is in flight.
-  /// Callers can use this to avoid redundant UI prompts while refresh is pending.
-  bool get isRefreshInProgress => _pendingRefresh != null;
-
   /// Timeout for background RPC refresh during local-first startup.
   @visibleForTesting
   static const rpcRefreshTimeout = Duration(seconds: 10);

--- a/mobile/lib/utils/deferred_login_options_navigator.dart
+++ b/mobile/lib/utils/deferred_login_options_navigator.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+
+/// Defers login-options navigation until in-flight background uploads finish.
+class DeferredLoginOptionsNavigator {
+  StreamSubscription<BackgroundPublishState>? _subscription;
+  var _isDisposed = false;
+
+  void dispose() {
+    _isDisposed = true;
+    _subscription?.cancel();
+    _subscription = null;
+  }
+
+  void goAfterUploadsComplete({
+    required BuildContext context,
+    required BackgroundPublishBloc publishBloc,
+  }) {
+    if (_isDisposed) return;
+    final router = GoRouter.of(context);
+
+    _subscription?.cancel();
+    _subscription = publishBloc.stream.listen((state) {
+      if (!state.hasUploadInProgress) {
+        _navigateNow(router);
+      }
+    });
+
+    // Re-check current state now that the listener is attached. If the last
+    // upload already finished before we subscribed, no further emission will
+    // arrive and we must navigate immediately.
+    if (!publishBloc.state.hasUploadInProgress) {
+      _navigateNow(router);
+    }
+  }
+
+  void _navigateNow(GoRouter router) {
+    if (_isDisposed) return;
+    _subscription?.cancel();
+    _subscription = null;
+    router.go(WelcomeScreen.loginOptionsPath);
+  }
+}

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -10,7 +10,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
-import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/other_profile/other_profile_bloc.dart';
 import 'package:openvine/features/people_lists/view/people_list_membership_indicator.dart';
@@ -21,10 +20,10 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/widgets/followers_screen_router.dart';
 import 'package:openvine/router/widgets/following_screen_router.dart';
-import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
+import 'package:openvine/utils/deferred_login_options_navigator.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
@@ -122,15 +121,12 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
   Timer? _identitySkeletonTimer;
   bool _identityTimeoutExpired = false;
   bool? _wasLoadingIdentity;
-
-  /// Subscription used to defer login-options navigation until a background
-  /// video upload finishes when a session-expiry refresh fails mid-publish.
-  StreamSubscription<BackgroundPublishState>? _deferredNavSubscription;
+  final _deferredLoginOptionsNavigator = DeferredLoginOptionsNavigator();
 
   @override
   void dispose() {
     _identitySkeletonTimer?.cancel();
-    _deferredNavSubscription?.cancel();
+    _deferredLoginOptionsNavigator.dispose();
     super.dispose();
   }
 
@@ -160,21 +156,19 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
           .select<
             MyProfileBloc,
             ({UserProfile? profile, bool isInitialOrLoading})
-          >(
-            (bloc) {
-              final state = bloc.state;
-              return (
-                profile: switch (state) {
-                  MyProfileUpdated(:final profile) => profile,
-                  MyProfileLoaded(:final profile) => profile,
-                  MyProfileLoading(:final profile) => profile,
-                  _ => null,
-                },
-                isInitialOrLoading:
-                    state is MyProfileInitial || state is MyProfileLoading,
-              );
-            },
-          );
+          >((bloc) {
+            final state = bloc.state;
+            return (
+              profile: switch (state) {
+                MyProfileUpdated(:final profile) => profile,
+                MyProfileLoaded(:final profile) => profile,
+                MyProfileLoading(:final profile) => profile,
+                _ => null,
+              },
+              isInitialOrLoading:
+                  state is MyProfileInitial || state is MyProfileLoading,
+            );
+          });
       effectiveProfile = selection.profile ?? widget.profile;
       // Skeleton on the user's own profile is appropriate only while we
       // genuinely have nothing to show. As soon as a cached profile is
@@ -395,10 +389,10 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         if (!context.mounted) return;
         if (refreshed) return;
 
-        // Refresh definitively failed. Route to login-options, deferring
-        // until any in-flight background upload finishes.
-        final publishBloc = context.read<BackgroundPublishBloc>();
-        _navigateToLoginOptionsAfterUpload(context, publishBloc);
+        _deferredLoginOptionsNavigator.goAfterUploadsComplete(
+          context: context,
+          publishBloc: context.read(),
+        );
       },
       secondaryButtonText: l10n.profileMaybeLaterLabel,
       onSecondaryPressed: () async {
@@ -407,40 +401,6 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         if (context.mounted) Navigator.of(context).pop();
       },
     );
-  }
-
-  /// Subscribes to [BackgroundPublishBloc] and navigates to login-options the
-  /// moment the last in-flight upload finishes. Cancels any previous deferred
-  /// nav subscription so only one listener is ever registered at a time.
-  ///
-  /// Subscribes BEFORE checking current state to close the window where the
-  /// last upload could complete between the check and the listen call.
-  /// After subscribing, immediately re-checks; if already clear, navigates now
-  /// and cancels — no further emission is needed.
-  void _navigateToLoginOptionsAfterUpload(
-    BuildContext context,
-    BackgroundPublishBloc publishBloc,
-  ) {
-    _deferredNavSubscription?.cancel();
-    _deferredNavSubscription = publishBloc.stream.listen((state) {
-      if (!state.hasUploadInProgress) {
-        _deferredNavSubscription?.cancel();
-        _deferredNavSubscription = null;
-        if (context.mounted) {
-          GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
-        }
-      }
-    });
-    // Re-check current state now that the listener is attached. If the last
-    // upload already finished before we subscribed, no further emission will
-    // arrive and we must navigate immediately.
-    if (!publishBloc.state.hasUploadInProgress) {
-      _deferredNavSubscription?.cancel();
-      _deferredNavSubscription = null;
-      if (context.mounted) {
-        GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
-      }
-    }
   }
 
   void _showActionsSheet(

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/other_profile/other_profile_bloc.dart';
 import 'package:openvine/features/people_lists/view/people_list_membership_indicator.dart';
@@ -122,9 +123,14 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
   bool _identityTimeoutExpired = false;
   bool? _wasLoadingIdentity;
 
+  /// Subscription used to defer login-options navigation until a background
+  /// video upload finishes when a session-expiry refresh fails mid-publish.
+  StreamSubscription<BackgroundPublishState>? _deferredNavSubscription;
+
   @override
   void dispose() {
     _identitySkeletonTimer?.cancel();
+    _deferredNavSubscription?.cancel();
     super.dispose();
   }
 
@@ -216,20 +222,26 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     final authService = ref.watch(authServiceProvider);
 
     // Watch auth state to rebuild when auth state changes
-    // (e.g., after email verification completes)
+    // (e.g., after email verification completes, or after background RPC
+    // upgrade resolves — the auth stream emits a nudge in both cases)
     ref.watch(currentAuthStateProvider);
     final isAnonymous = authService.isAnonymous;
     final hasExpiredSession = authService.hasExpiredOAuthSession;
+    final isRpcUpgradeInProgress = authService.isRpcUpgradeInProgress;
     final prefs = ref.watch(sharedPreferencesProvider);
     final isDivineLoginBannerHidden = isDivineLoginBannerDismissed(
       prefs,
       widget.userIdHex,
     );
 
-    // Show session expired bottom sheet for non-anonymous users
+    // Show session expired bottom sheet for non-anonymous users, but only
+    // after the background RPC upgrade has definitively resolved. Showing the
+    // sheet while the silent refresh is still in flight would send the user
+    // to the login screen even when the refresh ultimately succeeds.
     if (widget.isOwnProfile &&
         !isAnonymous &&
         hasExpiredSession &&
+        !isRpcUpgradeInProgress &&
         !isDivineLoginBannerHidden) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (context.mounted) {
@@ -380,7 +392,16 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         Navigator.of(context).pop();
         final authService = ref.read(authServiceProvider);
         final refreshed = await authService.tryRefreshExpiredSession();
-        if (context.mounted && !refreshed) {
+        if (!context.mounted) return;
+        if (refreshed) return;
+
+        // Refresh definitively failed. If a background upload is in progress,
+        // do not interrupt it by navigating now. Instead, wait for the upload
+        // to finish and then route to login-options automatically.
+        final publishBloc = context.read<BackgroundPublishBloc>();
+        if (publishBloc.state.hasUploadInProgress) {
+          _navigateToLoginOptionsAfterUpload(context, publishBloc);
+        } else {
           GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
         }
       },
@@ -391,6 +412,25 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         if (context.mounted) Navigator.of(context).pop();
       },
     );
+  }
+
+  /// Subscribes to [BackgroundPublishBloc] and navigates to login-options the
+  /// moment the last in-flight upload finishes. Cancels any previous deferred
+  /// nav subscription so only one listener is ever registered at a time.
+  void _navigateToLoginOptionsAfterUpload(
+    BuildContext context,
+    BackgroundPublishBloc publishBloc,
+  ) {
+    _deferredNavSubscription?.cancel();
+    _deferredNavSubscription = publishBloc.stream.listen((state) {
+      if (!state.hasUploadInProgress) {
+        _deferredNavSubscription?.cancel();
+        _deferredNavSubscription = null;
+        if (context.mounted) {
+          GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
+        }
+      }
+    });
   }
 
   void _showActionsSheet(

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -395,15 +395,10 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         if (!context.mounted) return;
         if (refreshed) return;
 
-        // Refresh definitively failed. If a background upload is in progress,
-        // do not interrupt it by navigating now. Instead, wait for the upload
-        // to finish and then route to login-options automatically.
+        // Refresh definitively failed. Route to login-options, deferring
+        // until any in-flight background upload finishes.
         final publishBloc = context.read<BackgroundPublishBloc>();
-        if (publishBloc.state.hasUploadInProgress) {
-          _navigateToLoginOptionsAfterUpload(context, publishBloc);
-        } else {
-          GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
-        }
+        _navigateToLoginOptionsAfterUpload(context, publishBloc);
       },
       secondaryButtonText: l10n.profileMaybeLaterLabel,
       onSecondaryPressed: () async {
@@ -417,6 +412,11 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
   /// Subscribes to [BackgroundPublishBloc] and navigates to login-options the
   /// moment the last in-flight upload finishes. Cancels any previous deferred
   /// nav subscription so only one listener is ever registered at a time.
+  ///
+  /// Subscribes BEFORE checking current state to close the window where the
+  /// last upload could complete between the check and the listen call.
+  /// After subscribing, immediately re-checks; if already clear, navigates now
+  /// and cancels — no further emission is needed.
   void _navigateToLoginOptionsAfterUpload(
     BuildContext context,
     BackgroundPublishBloc publishBloc,
@@ -431,6 +431,16 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         }
       }
     });
+    // Re-check current state now that the listener is attached. If the last
+    // upload already finished before we subscribed, no further emission will
+    // arrive and we must navigate immediately.
+    if (!publishBloc.state.hasUploadInProgress) {
+      _deferredNavSubscription?.cancel();
+      _deferredNavSubscription = null;
+      if (context.mounted) {
+        GoRouter.of(context).go(WelcomeScreen.loginOptionsPath);
+      }
+    }
   }
 
   void _showActionsSheet(

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -132,7 +132,8 @@ void main() {
                 BackgroundUpload(draft: draft, result: null, progress: 0),
               ],
             ),
-            const BackgroundPublishState(),
+            // Success: upload removed and recentlySucceededIds populated.
+            BackgroundPublishState(recentlySucceededIds: {draftId}),
           ],
           verify: (_) {
             verify(
@@ -240,8 +241,10 @@ void main() {
             ),
           ),
           expect: () => [
-            // Only emits the final state after success, no duplicate added
-            const BackgroundPublishState(),
+            // Only emits the final state after success, no duplicate added.
+            // recentlySucceededIds is populated so UploadFailureListener can
+            // distinguish a true success from BackgroundPublishVanished.
+            BackgroundPublishState(recentlySucceededIds: {draftId}),
           ],
         );
       });
@@ -379,6 +382,26 @@ void main() {
           ).called(1);
         },
       );
+
+      blocTest(
+        'does NOT populate recentlySucceededIds — '
+        'regression: vanished upload must not trigger a success snackbar',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 1.0),
+          ],
+        ),
+        act: (bloc) => bloc.add(BackgroundPublishVanished(draftId: draftId)),
+        verify: (bloc) {
+          // recentlySucceededIds must be empty — Vanished is not a publish
+          // success and must never trigger a success snackbar.
+          expect(bloc.state.recentlySucceededIds, isEmpty);
+        },
+      );
     });
 
     group('BackgroundPublishFailed', () {
@@ -486,8 +509,9 @@ void main() {
               BackgroundUpload(draft: draft, result: null, progress: 0),
             ],
           ),
-          // Finally: successful retry removes the upload
-          const BackgroundPublishState(),
+          // Finally: successful retry removes the upload, recentlySucceededIds
+          // is populated so UploadFailureListener shows a success snackbar.
+          BackgroundPublishState(recentlySucceededIds: {draftId}),
         ],
         verify: (_) {
           verify(() => mockPublishService.publishVideo(draft: draft)).called(1);

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -133,7 +133,7 @@ void main() {
               ],
             ),
             // Success: upload removed and recentlySucceededIds populated.
-            BackgroundPublishState(recentlySucceededIds: {draftId}),
+            const BackgroundPublishState(recentlySucceededIds: {draftId}),
           ],
           verify: (_) {
             verify(
@@ -244,7 +244,7 @@ void main() {
             // Only emits the final state after success, no duplicate added.
             // recentlySucceededIds is populated so UploadFailureListener can
             // distinguish a true success from BackgroundPublishVanished.
-            BackgroundPublishState(recentlySucceededIds: {draftId}),
+            const BackgroundPublishState(recentlySucceededIds: {draftId}),
           ],
         );
       });
@@ -511,7 +511,7 @@ void main() {
           ),
           // Finally: successful retry removes the upload, recentlySucceededIds
           // is populated so UploadFailureListener shows a success snackbar.
-          BackgroundPublishState(recentlySucceededIds: {draftId}),
+          const BackgroundPublishState(recentlySucceededIds: {draftId}),
         ],
         verify: (_) {
           verify(() => mockPublishService.publishVideo(draft: draft)).called(1);

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -334,10 +334,8 @@ void main() {
             // refreshSession returns immediately. Pump the event queue until
             // the upgrade finishes — it should complete well within 1 second.
             final deadline = DateTime.now().add(const Duration(seconds: 3));
-            while (
-              authService.isRpcUpgradeInProgress &&
-              DateTime.now().isBefore(deadline)
-            ) {
+            while (authService.isRpcUpgradeInProgress &&
+                DateTime.now().isBefore(deadline)) {
               await Future<void>.delayed(const Duration(milliseconds: 10));
             }
 
@@ -391,10 +389,8 @@ void main() {
             // _pendingOAuthRefresh single-flight slot being held by the
             // background upgrade, which would conflate call counts.
             final deadline = DateTime.now().add(const Duration(seconds: 5));
-            while (
-              authService.isRpcUpgradeInProgress &&
-              DateTime.now().isBefore(deadline)
-            ) {
+            while (authService.isRpcUpgradeInProgress &&
+                DateTime.now().isBefore(deadline)) {
               await Future<void>.delayed(const Duration(milliseconds: 10));
             }
 

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -302,5 +302,130 @@ void main() {
         );
       },
     );
+
+    test(
+      'isRpcUpgradeInProgress is false after upgrade completes',
+      () async {
+        // Regression for #4626: isRpcUpgradeInProgress must be false after
+        // _upgradeDivineRpcInBackground finishes so the session-expired sheet
+        // is no longer suppressed once the silent refresh has definitively
+        // resolved.
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        arrangeExpiredSessionWithLocalKeys();
+
+        // Refresh fails immediately.
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final authService = createAuthService();
+
+        await runZonedGuarded(
+          () async {
+            await authService.initialize();
+
+            // The background upgrade is unawaited but resolves quickly since
+            // refreshSession returns immediately. Pump the event queue until
+            // the upgrade finishes — it should complete well within 1 second.
+            final deadline = DateTime.now().add(const Duration(seconds: 3));
+            while (
+              authService.isRpcUpgradeInProgress &&
+              DateTime.now().isBefore(deadline)
+            ) {
+              await Future<void>.delayed(const Duration(milliseconds: 10));
+            }
+
+            expect(
+              authService.isRpcUpgradeInProgress,
+              isFalse,
+              reason:
+                  'isRpcUpgradeInProgress must be false after the upgrade '
+                  'completes (failure path)',
+            );
+
+            // Session is still flagged as expired (refresh failed).
+            expect(authService.hasExpiredOAuthSession, isTrue);
+          },
+          (error, stack) {
+            // Ignore background relay/RPC errors
+          },
+        );
+      },
+    );
+
+    test(
+      'concurrent tryRefreshExpiredSession calls share one in-flight future '
+      '(single-flight guard)',
+      () async {
+        // Regression for #4626: if multiple UI surfaces call
+        // tryRefreshExpiredSession concurrently (e.g. profile header + settings
+        // tile both visible), only one token refresh should be attempted.
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        arrangeExpiredSessionWithLocalKeys();
+
+        // Refresh always returns null (failure).
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final authService = createAuthService();
+
+        await runZonedGuarded(
+          () async {
+            await authService.initialize();
+
+            // Wait for the background upgrade to finish before testing
+            // tryRefreshExpiredSession in isolation. This avoids the
+            // _pendingOAuthRefresh single-flight slot being held by the
+            // background upgrade, which would conflate call counts.
+            final deadline = DateTime.now().add(const Duration(seconds: 5));
+            while (
+              authService.isRpcUpgradeInProgress &&
+              DateTime.now().isBefore(deadline)
+            ) {
+              await Future<void>.delayed(const Duration(milliseconds: 10));
+            }
+
+            // Session should be expired after init with failed refresh.
+            expect(authService.hasExpiredOAuthSession, isTrue);
+
+            // Reset interaction tracking after init's refresh calls.
+            clearInteractions(mockOAuthClient);
+
+            // Two concurrent callers.
+            final results = await Future.wait([
+              authService.tryRefreshExpiredSession(),
+              authService.tryRefreshExpiredSession(),
+            ]);
+
+            // Both callers receive the same result (false — refresh failed).
+            expect(results, equals([false, false]));
+
+            // refreshSession was only called ONCE despite two concurrent
+            // tryRefreshExpiredSession calls (single-flight _pendingRefresh).
+            verify(
+              () => mockOAuthClient.refreshSession(
+                userPubkey: any(named: 'userPubkey'),
+              ),
+            ).called(1);
+          },
+          (error, stack) {
+            // Ignore background errors
+          },
+        );
+      },
+    );
   });
 }

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -1272,6 +1272,111 @@ void main() {
           ).called(1);
         },
       );
+
+      testWidgets(
+        'navigates immediately when upload finishes before stream listener '
+        'attaches — regression for check/listen race',
+        (tester) async {
+          // Regression: the upload completes between the state read and the
+          // stream.listen() call. With the old code (check-then-listen), no
+          // further emission would arrive and navigation would be silently lost.
+          // With the fix (listen-then-recheck), the recheck fires navigation.
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          // Bloc already has no upload in progress — simulates upload having
+          // finished just before _navigateToLoginOptionsAfterUpload attaches.
+          final mockPublishBloc = _MockBackgroundPublishBloc();
+          when(() => mockPublishBloc.state).thenReturn(
+            const BackgroundPublishState(),
+          );
+          // Stream produces no further emissions — the critical race condition.
+          whenListen(
+            mockPublishBloc,
+            const Stream<BackgroundPublishState>.empty(),
+            initialState: const BackgroundPublishState(),
+          );
+
+          final authService = MockAuthService(
+            hasExpiredOAuthSessionValue: true,
+            // tryRefreshResult defaults to false — refresh will fail.
+          );
+
+          final mockGoRouter = MockGoRouter();
+          when(() => mockGoRouter.go(any())).thenReturn(null);
+
+          await tester.pumpWidget(
+            MockGoRouterProvider(
+              goRouter: mockGoRouter,
+              child: ProviderScope(
+                overrides: [
+                  ...getStandardTestOverrides(
+                    mockNostrService: mockNostrClient,
+                    mockSharedPreferences: prefs,
+                    mockNip05VerificationService:
+                        createMockNip05VerificationService(),
+                    mockFollowRepository: mockFollowRepository,
+                  ),
+                  fetchUserProfileProvider(testUserHex).overrideWith(
+                    (ref) async => testProfile,
+                  ),
+                  userProfileStatsReactiveProvider(testUserHex).overrideWith(
+                    (ref) => const Stream.empty(),
+                  ),
+                  authServiceProvider.overrideWithValue(authService),
+                  currentAuthStateProvider.overrideWith(
+                    (ref) => AuthState.authenticated,
+                  ),
+                  isFeatureEnabledProvider(
+                    FeatureFlag.curatedLists,
+                  ).overrideWith((ref) => false),
+                ],
+                child: MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockPublishBloc,
+                    child: BlocProvider<MyProfileBloc>(
+                      create: (_) {
+                        final bloc = _MockMyProfileBloc();
+                        when(() => bloc.state).thenReturn(
+                          MyProfileUpdated(profile: testProfile),
+                        );
+                        return bloc;
+                      },
+                      child: const Scaffold(
+                        body: SingleChildScrollView(
+                          child: ProfileHeaderWidget(
+                            userIdHex: testUserHex,
+                            isOwnProfile: true,
+                            videoCount: 0,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileSessionExpired), findsWidgets);
+
+          // Tap "Sign in" — triggers the deferred-nav helper.
+          await tester.tap(find.text(l10n.profileSignInButton).last);
+          await tester.pumpAndSettle();
+
+          // Navigation must have fired immediately — re-check after subscribe
+          // detected no upload in progress (no stream emission needed).
+          verify(
+            () => mockGoRouter.go(any(that: contains('login-options'))),
+          ).called(1);
+        },
+      );
     });
 
     group('MyProfile state fallbacks (own profile)', () {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -1027,7 +1027,12 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          expect(find.text(lookupAppLocalizations(const Locale('en')).profileSessionExpired), findsNothing);
+          expect(
+            find.text(
+              lookupAppLocalizations(const Locale('en')).profileSessionExpired,
+            ),
+            findsNothing,
+          );
         },
       );
 
@@ -1114,7 +1119,9 @@ void main() {
           );
           await tester.pumpAndSettle();
           expect(
-            find.text(lookupAppLocalizations(const Locale('en')).profileSessionExpired),
+            find.text(
+              lookupAppLocalizations(const Locale('en')).profileSessionExpired,
+            ),
             findsNothing,
           );
 
@@ -1133,7 +1140,9 @@ void main() {
 
           // Sheet must not appear — session is no longer expired.
           expect(
-            find.text(lookupAppLocalizations(const Locale('en')).profileSessionExpired),
+            find.text(
+              lookupAppLocalizations(const Locale('en')).profileSessionExpired,
+            ),
             findsNothing,
           );
         },

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -13,6 +13,7 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -20,6 +21,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/features/people_lists/view/people_list_membership_indicator.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
@@ -30,6 +32,7 @@ import 'package:openvine/widgets/user_avatar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
+import '../../helpers/go_router.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
@@ -41,6 +44,10 @@ class _MockOthersFollowersBloc
 
 class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
     implements PeopleListsBloc {}
+
+class _MockBackgroundPublishBloc
+    extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
+    implements BackgroundPublishBloc {}
 
 // Mock classes
 class MockFollowRepository extends Mock implements FollowRepository {
@@ -132,10 +139,14 @@ class MockAuthService extends Mock implements AuthService {
   MockAuthService({
     this.isAnonymousValue = false,
     this.hasExpiredOAuthSessionValue = false,
+    this.isRpcUpgradeInProgressValue = false,
+    this.tryRefreshResult = false,
   });
 
   final bool isAnonymousValue;
   final bool hasExpiredOAuthSessionValue;
+  final bool isRpcUpgradeInProgressValue;
+  final bool tryRefreshResult;
 
   @override
   bool get isAnonymous => isAnonymousValue;
@@ -152,11 +163,23 @@ class MockAuthService extends Mock implements AuthService {
 
   @override
   bool get hasExpiredOAuthSession => hasExpiredOAuthSessionValue;
+
+  @override
+  bool get isRpcUpgradeInProgress => isRpcUpgradeInProgressValue;
+
+  @override
+  Future<bool> tryRefreshExpiredSession() async => tryRefreshResult;
 }
 
 const testUserHex =
     '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
 const _dismissedDivineLoginBannerPrefix = 'dismissed_divine_login_banner_';
+
+/// Minimal fake [DivineVideoDraft] for use in [BackgroundUpload] test fixtures.
+class _FakeDraft extends Fake implements DivineVideoDraft {
+  @override
+  String get id => 'fake-draft-id';
+}
 
 void main() {
   group('ProfileHeaderWidget', () {
@@ -209,16 +232,32 @@ void main() {
       bool profileIsLoading = false,
       bool isAnonymous = false,
       bool hasExpiredSession = false,
+      bool isRpcUpgradeInProgress = false,
+      bool tryRefreshResult = false,
       SharedPreferences? sharedPreferences,
       String? displayNameHint,
       String? avatarUrlHint,
       MyProfileState? myProfileState,
       bool curatedListsEnabled = false,
       PeopleListsState? peopleListsState,
+      BackgroundPublishState? backgroundPublishState,
+      Stream<BackgroundPublishState>? backgroundPublishStream,
     }) {
       final authService = MockAuthService(
         isAnonymousValue: isAnonymous,
         hasExpiredOAuthSessionValue: hasExpiredSession,
+        isRpcUpgradeInProgressValue: isRpcUpgradeInProgress,
+        tryRefreshResult: tryRefreshResult,
+      );
+
+      final mockPublishBloc = _MockBackgroundPublishBloc();
+      final publishState =
+          backgroundPublishState ?? const BackgroundPublishState();
+      when(() => mockPublishBloc.state).thenReturn(publishState);
+      whenListen(
+        mockPublishBloc,
+        backgroundPublishStream ?? const Stream<BackgroundPublishState>.empty(),
+        initialState: publishState,
       );
 
       Widget header = ProfileHeaderWidget(
@@ -264,6 +303,13 @@ void main() {
           child: header,
         );
       }
+
+      // Wrap with BackgroundPublishBloc — available everywhere in the real app
+      // tree and required by the session-expired nav deferral logic.
+      header = BlocProvider<BackgroundPublishBloc>.value(
+        value: mockPublishBloc,
+        child: header,
+      );
 
       return ProviderScope(
         overrides: [
@@ -1006,6 +1052,205 @@ void main() {
           // Anonymous users see the action label pill, not session expired
           expect(find.text('Secure your account'), findsOneWidget);
           expect(find.text('Session Expired'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'does not show session expired sheet while RPC upgrade is in progress',
+        (tester) async {
+          // Regression for #4626: the sheet must be suppressed while a
+          // background OAuth upgrade is still in flight to avoid routing the
+          // user to /welcome/login-options before the silent refresh has had a
+          // chance to complete.
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              hasExpiredSession: true,
+              isRpcUpgradeInProgress: true,
+              sharedPreferences: prefs,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Sheet must NOT appear while upgrade is running.
+          expect(find.text('Session Expired'), findsNothing);
+          expect(find.text('Sign in'), findsNothing);
+          expect(find.text('Maybe Later'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'sheet does not appear after successful RPC upgrade clears the '
+        'expired-session flag',
+        (tester) async {
+          // Regression for #4626: when the background upgrade succeeds the
+          // session-expired flag is cleared. The widget must not show the sheet
+          // at any point — neither while the upgrade is running (suppressed by
+          // isRpcUpgradeInProgress) nor after it succeeds (hasExpiredOAuthSession
+          // is false).
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          // Phase 1: session expired, upgrade in progress → sheet suppressed.
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              hasExpiredSession: true,
+              isRpcUpgradeInProgress: true,
+              sharedPreferences: prefs,
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(find.text('Session Expired'), findsNothing);
+
+          // Phase 2: upgrade succeeds — session flag cleared.
+          // Rebuild with hasExpiredSession: false to simulate what happens
+          // after a successful upgrade nudges the widget to re-evaluate.
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              sharedPreferences: prefs,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Sheet must not appear — session is no longer expired.
+          expect(find.text('Session Expired'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'defers nav to login-options until background upload finishes '
+        'when refresh fails and upload is in progress',
+        (tester) async {
+          // Regression for #4626: tapping "Sign in" when an upload is active
+          // must not navigate immediately. Navigation is deferred until the
+          // BackgroundPublishBloc's hasUploadInProgress becomes false.
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          // Simulate an in-flight upload followed by completion.
+          final publishStreamController =
+              StreamController<BackgroundPublishState>();
+          addTearDown(publishStreamController.close);
+
+          final mockPublishBloc = _MockBackgroundPublishBloc();
+          // Upload is in progress initially.
+          final inProgressState = BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(
+                draft: _FakeDraft(),
+                result: null,
+                progress: 0.5,
+              ),
+            ],
+          );
+          when(() => mockPublishBloc.state).thenReturn(inProgressState);
+          whenListen(
+            mockPublishBloc,
+            publishStreamController.stream,
+            initialState: inProgressState,
+          );
+
+          final authService = MockAuthService(
+            hasExpiredOAuthSessionValue: true,
+            // tryRefreshResult defaults to false — refresh will fail
+          );
+
+          // Use a mock GoRouter so go() calls are verifiable, not errors.
+          final mockGoRouter = MockGoRouter();
+          when(() => mockGoRouter.go(any())).thenReturn(null);
+
+          await tester.pumpWidget(
+            MockGoRouterProvider(
+              goRouter: mockGoRouter,
+              child: ProviderScope(
+                overrides: [
+                  ...getStandardTestOverrides(
+                    mockNostrService: mockNostrClient,
+                    mockSharedPreferences: prefs,
+                    mockNip05VerificationService:
+                        createMockNip05VerificationService(),
+                    mockFollowRepository: mockFollowRepository,
+                  ),
+                  fetchUserProfileProvider(testUserHex).overrideWith(
+                    (ref) async => testProfile,
+                  ),
+                  userProfileStatsReactiveProvider(testUserHex).overrideWith(
+                    (ref) => const Stream.empty(),
+                  ),
+                  authServiceProvider.overrideWithValue(authService),
+                  currentAuthStateProvider.overrideWith(
+                    (ref) => AuthState.authenticated,
+                  ),
+                  isFeatureEnabledProvider(
+                    FeatureFlag.curatedLists,
+                  ).overrideWith((ref) => false),
+                ],
+                child: MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockPublishBloc,
+                    child: BlocProvider<MyProfileBloc>(
+                      create: (_) {
+                        final bloc = _MockMyProfileBloc();
+                        when(() => bloc.state).thenReturn(
+                          MyProfileUpdated(profile: testProfile),
+                        );
+                        return bloc;
+                      },
+                      child: const Scaffold(
+                        body: SingleChildScrollView(
+                          child: ProfileHeaderWidget(
+                            userIdHex: testUserHex,
+                            isOwnProfile: true,
+                            videoCount: 0,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Session expired sheet should be visible.
+          expect(find.text('Session Expired'), findsWidgets);
+
+          // Tap "Sign in" — triggers tryRefreshExpiredSession (returns false)
+          // and the upload-in-progress guard should subscribe for deferred nav.
+          await tester.tap(find.text('Sign in').last);
+          await tester.pumpAndSettle();
+
+          // Navigation must NOT have fired yet — upload is still active.
+          verifyNever(() => mockGoRouter.go(any()));
+
+          // Simulate upload completing.
+          publishStreamController.add(const BackgroundPublishState());
+          await tester.pump();
+
+          // Navigation must now have fired exactly once to login-options.
+          verify(
+            () => mockGoRouter.go(
+              any(that: contains('login-options')),
+            ),
+          ).called(1);
         },
       );
     });

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -996,9 +996,10 @@ void main() {
           // Expired" / "Sign in" / "Maybe Later" via the actions list, so
           // assert at least one of each — finding all three at the same time
           // confirms the sheet itself opened.
-          expect(find.text('Session Expired'), findsWidgets);
-          expect(find.text('Sign in'), findsWidgets);
-          expect(find.text('Maybe Later'), findsWidgets);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileSessionExpired), findsWidgets);
+          expect(find.text(l10n.profileSignInButton), findsWidgets);
+          expect(find.text(l10n.profileMaybeLaterLabel), findsWidgets);
         },
       );
 
@@ -1026,7 +1027,7 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          expect(find.text('Session Expired'), findsNothing);
+          expect(find.text(lookupAppLocalizations(const Locale('en')).profileSessionExpired), findsNothing);
         },
       );
 
@@ -1050,8 +1051,9 @@ void main() {
           await tester.pumpAndSettle();
 
           // Anonymous users see the action label pill, not session expired
+          final l10n = lookupAppLocalizations(const Locale('en'));
           expect(find.text('Secure your account'), findsOneWidget);
-          expect(find.text('Session Expired'), findsNothing);
+          expect(find.text(l10n.profileSessionExpired), findsNothing);
         },
       );
 
@@ -1079,9 +1081,10 @@ void main() {
           await tester.pumpAndSettle();
 
           // Sheet must NOT appear while upgrade is running.
-          expect(find.text('Session Expired'), findsNothing);
-          expect(find.text('Sign in'), findsNothing);
-          expect(find.text('Maybe Later'), findsNothing);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileSessionExpired), findsNothing);
+          expect(find.text(l10n.profileSignInButton), findsNothing);
+          expect(find.text(l10n.profileMaybeLaterLabel), findsNothing);
         },
       );
 
@@ -1110,7 +1113,10 @@ void main() {
             ),
           );
           await tester.pumpAndSettle();
-          expect(find.text('Session Expired'), findsNothing);
+          expect(
+            find.text(lookupAppLocalizations(const Locale('en')).profileSessionExpired),
+            findsNothing,
+          );
 
           // Phase 2: upgrade succeeds — session flag cleared.
           // Rebuild with hasExpiredSession: false to simulate what happens
@@ -1126,7 +1132,10 @@ void main() {
           await tester.pumpAndSettle();
 
           // Sheet must not appear — session is no longer expired.
-          expect(find.text('Session Expired'), findsNothing);
+          expect(
+            find.text(lookupAppLocalizations(const Locale('en')).profileSessionExpired),
+            findsNothing,
+          );
         },
       );
 
@@ -1231,11 +1240,12 @@ void main() {
           await tester.pumpAndSettle();
 
           // Session expired sheet should be visible.
-          expect(find.text('Session Expired'), findsWidgets);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileSessionExpired), findsWidgets);
 
           // Tap "Sign in" — triggers tryRefreshExpiredSession (returns false)
           // and the upload-in-progress guard should subscribe for deferred nav.
-          await tester.tap(find.text('Sign in').last);
+          await tester.tap(find.text(l10n.profileSignInButton).last);
           await tester.pumpAndSettle();
 
           // Navigation must NOT have fired yet — upload is still active.

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -43,6 +43,7 @@ class _FakeDraft extends Fake implements DivineVideoDraft {
   @override
   String get id => 'settings-fake-draft';
 }
+
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -666,5 +666,57 @@ void main() {
         await tester.pump();
       },
     );
+
+    testWidgets(
+      'navigates immediately when upload finishes before stream listener '
+      'attaches — regression for check/listen race',
+      (tester) async {
+        // Regression for the subscribe/re-check race: the upload completes
+        // between the state read and the stream.listen() call. With the old
+        // code (check-then-listen), no further emission would ever arrive and
+        // navigation would be silently lost. With the fix (listen-then-recheck),
+        // the recheck immediately fires navigation.
+        //
+        // We model this by giving the bloc a state that already has no upload
+        // in progress before _handleSessionExpired even runs. The stream emits
+        // nothing further. Navigation must still fire exactly once.
+        final emptyState = const BackgroundPublishState();
+        final mockPublishBloc = _MockBackgroundPublishBloc();
+        when(() => mockPublishBloc.state).thenReturn(emptyState);
+        // Stream produces no further emissions after subscribe — simulating
+        // the race where the last upload completed just before listen().
+        whenListen(
+          mockPublishBloc,
+          const Stream<BackgroundPublishState>.empty(),
+          initialState: emptyState,
+        );
+
+        when(() => mockAuthService.hasExpiredOAuthSession).thenReturn(true);
+        when(
+          () => mockAuthService.tryRefreshExpiredSession(),
+        ).thenAnswer((_) async => false);
+
+        final mockGoRouter = MockGoRouter();
+        when(() => mockGoRouter.go(any())).thenReturn(null);
+
+        await tester.pumpWidget(
+          buildSubject(goRouter: mockGoRouter, publishBloc: mockPublishBloc),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap Session Expired tile — triggers _handleSessionExpired.
+        await tester.tap(find.text(l10n.settingsSessionExpired));
+        await tester.pumpAndSettle();
+
+        // Navigation must have fired immediately because re-check after
+        // subscribe detected no upload in progress.
+        verify(
+          () => mockGoRouter.go(any(that: contains('login-options'))),
+        ).called(1);
+
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
   });
 }

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -445,7 +445,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.text('Secure Your Account'), findsOneWidget);
+      expect(find.text(l10n.settingsSecureAccount), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
@@ -459,7 +459,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.text('Session Expired'), findsOneWidget);
+      expect(find.text(l10n.settingsSessionExpired), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
@@ -501,8 +501,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsOneWidget);
-        expect(find.text('Session Expired'), findsNothing);
+        expect(find.text(l10n.settingsSecureAccount), findsOneWidget);
+        expect(find.text(l10n.settingsSessionExpired), findsNothing);
 
         await tester.pumpWidget(const SizedBox());
         await tester.pump();
@@ -517,7 +517,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.text('Secure Your Account'), findsNothing);
+      expect(find.text(l10n.settingsSecureAccount), findsNothing);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
@@ -640,10 +640,10 @@ void main() {
         await tester.pumpAndSettle();
 
         // Session Expired tile is present.
-        expect(find.text('Session Expired'), findsOneWidget);
+      expect(find.text(l10n.settingsSessionExpired), findsOneWidget);
 
         // Tap the tile — triggers _handleSessionExpired.
-        await tester.tap(find.text('Session Expired'));
+        await tester.tap(find.text(l10n.settingsSessionExpired));
         await tester.pumpAndSettle();
 
         // Navigation must NOT have fired yet — upload is still in progress.

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -680,7 +680,7 @@ void main() {
         // We model this by giving the bloc a state that already has no upload
         // in progress before _handleSessionExpired even runs. The stream emits
         // nothing further. Navigation must still fire exactly once.
-        final emptyState = const BackgroundPublishState();
+        const emptyState = BackgroundPublishState();
         final mockPublishBloc = _MockBackgroundPublishBloc();
         when(() => mockPublishBloc.state).thenReturn(emptyState);
         // Stream produces no further emissions after subscribe — simulating

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -640,7 +640,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Session Expired tile is present.
-      expect(find.text(l10n.settingsSessionExpired), findsOneWidget);
+        expect(find.text(l10n.settingsSessionExpired), findsOneWidget);
 
         // Tap the tile — triggers _handleSessionExpired.
         await tester.tap(find.text(l10n.settingsSessionExpired));

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Widget test for settings hub screen
 // ABOUTME: Verifies account header, auth-state tiles, and navigation structure
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -8,11 +10,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/locale/locale_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -31,6 +35,14 @@ import '../helpers/go_router.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
+class _MockBackgroundPublishBloc
+    extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
+    implements BackgroundPublishBloc {}
+
+class _FakeDraft extends Fake implements DivineVideoDraft {
+  @override
+  String get id => 'settings-fake-draft';
+}
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
@@ -100,12 +112,26 @@ void main() {
       MockGoRouter? goRouter,
       List<KnownAccount> knownAccounts = const [],
       _MockInviteStatusCubit? inviteCubit,
+      _MockBackgroundPublishBloc? publishBloc,
     }) {
       when(
         () => mockAuthService.getKnownAccounts(),
       ).thenAnswer((_) async => knownAccounts);
 
       final mockInviteCubit = inviteCubit ?? _createMockInviteCubit();
+
+      // Default publish bloc has no uploads in progress.
+      final effectivePublishBloc = publishBloc ?? _MockBackgroundPublishBloc();
+      if (publishBloc == null) {
+        when(() => effectivePublishBloc.state).thenReturn(
+          const BackgroundPublishState(),
+        );
+        whenListen(
+          effectivePublishBloc,
+          const Stream<BackgroundPublishState>.empty(),
+          initialState: const BackgroundPublishState(),
+        );
+      }
 
       final app = ProviderScope(
         overrides: [
@@ -127,6 +153,9 @@ void main() {
             providers: [
               BlocProvider<InviteStatusCubit>.value(value: mockInviteCubit),
               BlocProvider<LocaleCubit>.value(value: mockLocaleCubit),
+              BlocProvider<BackgroundPublishBloc>.value(
+                value: effectivePublishBloc,
+              ),
             ],
             child: const SettingsScreen(),
           ),
@@ -560,6 +589,77 @@ void main() {
 
         expect(find.text(l10n.settingsGeneralTitle), findsOneWidget);
         expect(find.text('Bluesky Publishing'), findsNothing);
+
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'defers nav to login-options until background upload finishes '
+      'when Session Expired tile is tapped and refresh fails',
+      (tester) async {
+        // Regression for #4626: tapping the Session Expired tile while a
+        // background upload is active must not navigate immediately.
+        // Navigation is deferred until BackgroundPublishBloc.hasUploadInProgress
+        // becomes false.
+        final publishStreamController =
+            StreamController<BackgroundPublishState>();
+        addTearDown(publishStreamController.close);
+
+        final mockPublishBloc = _MockBackgroundPublishBloc();
+        final inProgressState = BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: _FakeDraft(),
+              result: null,
+              progress: 0.5,
+            ),
+          ],
+        );
+        when(() => mockPublishBloc.state).thenReturn(inProgressState);
+        whenListen(
+          mockPublishBloc,
+          publishStreamController.stream,
+          initialState: inProgressState,
+        );
+
+        // Session is expired, refresh will fail.
+        when(() => mockAuthService.hasExpiredOAuthSession).thenReturn(true);
+        when(
+          () => mockAuthService.tryRefreshExpiredSession(),
+        ).thenAnswer((_) async => false);
+
+        final mockGoRouter = MockGoRouter();
+        when(() => mockGoRouter.go(any())).thenReturn(null);
+
+        await tester.pumpWidget(
+          buildSubject(goRouter: mockGoRouter, publishBloc: mockPublishBloc),
+        );
+        await tester.pumpAndSettle();
+
+        // Session Expired tile is present.
+        expect(find.text('Session Expired'), findsOneWidget);
+
+        // Tap the tile — triggers _handleSessionExpired.
+        await tester.tap(find.text('Session Expired'));
+        await tester.pumpAndSettle();
+
+        // Navigation must NOT have fired yet — upload is still in progress.
+        verifyNever(() => mockGoRouter.go(any()));
+
+        // Simulate upload completing.
+        publishStreamController.add(const BackgroundPublishState());
+        await tester.pump();
+
+        // Now navigation must have fired exactly once to login-options.
+        verify(
+          () => mockGoRouter.go(
+            any(
+              that: contains('login-options'),
+            ),
+          ),
+        ).called(1);
 
         await tester.pumpWidget(const SizedBox());
         await tester.pump();

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -1,0 +1,234 @@
+// ABOUTME: Widget tests for the UploadFailureListener success-tracking state machine.
+// ABOUTME: Covers: success while authenticated, success buffered during re-auth then
+// ABOUTME: flushed on restore, and a vanished failed upload not miscounted as success.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/navigator_keys.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/video_publish/video_publish_service.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class _MockBackgroundPublishBloc
+    extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
+    implements BackgroundPublishBloc {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _FakeDraft extends Fake implements DivineVideoDraft {
+  _FakeDraft(this._id);
+
+  final String _id;
+
+  @override
+  String get id => _id;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a minimal harness that wraps [UploadFailureListener] inside a
+/// [ProviderScope] (with [authServiceProvider] overridden) and a
+/// [BlocProvider] for [BackgroundPublishBloc].
+///
+/// The [MaterialApp] is keyed to [NavigatorKeys.root] so that
+/// [_showPublishSuccessSnackbar] can resolve its [ScaffoldMessenger] via
+/// the same key the production code uses.
+Widget _buildHarness({
+  required _MockBackgroundPublishBloc publishBloc,
+  required _MockAuthService authService,
+}) {
+  return ProviderScope(
+    overrides: [authServiceProvider.overrideWithValue(authService)],
+    child: MaterialApp(
+      // Wire the real NavigatorKeys.root so the snackbar helper can find the
+      // ScaffoldMessenger ancestor from NavigatorKeys.root.currentContext.
+      navigatorKey: NavigatorKeys.root,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: BlocProvider<BackgroundPublishBloc>.value(
+        value: publishBloc,
+        child: app.UploadFailureListener(
+          child: const Scaffold(body: SizedBox.shrink()),
+        ),
+      ),
+    ),
+  );
+}
+
+/// Creates a [BackgroundUpload] with result == null (in-progress).
+BackgroundUpload _inProgress(String id) => BackgroundUpload(
+  draft: _FakeDraft(id),
+  result: null,
+  progress: 0.5,
+);
+
+/// Creates a [BackgroundUpload] with a [PublishError] result.
+BackgroundUpload _failed(String id) => BackgroundUpload(
+  draft: _FakeDraft(id),
+  result: const PublishError('Upload failed'),
+  progress: 1.0,
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late _MockBackgroundPublishBloc publishBloc;
+  late _MockAuthService authService;
+  late StreamController<BackgroundPublishState> publishStream;
+
+  setUp(() {
+    publishBloc = _MockBackgroundPublishBloc();
+    authService = _MockAuthService();
+    publishStream = StreamController<BackgroundPublishState>.broadcast();
+  });
+
+  tearDown(() {
+    publishStream.close();
+  });
+
+  /// Stubs [publishBloc] with the given initial state and stream.
+  void stubPublishBloc(BackgroundPublishState initial) {
+    when(() => publishBloc.state).thenReturn(initial);
+    whenListen(publishBloc, publishStream.stream, initialState: initial);
+  }
+
+  group('UploadFailureListener success tracking', () {
+    testWidgets(
+      'shows snackbar immediately when upload succeeds while authenticated',
+      (tester) async {
+        // Start with an empty state (no uploads), then add an in-progress
+        // upload, then mark it as complete — mirroring the real app lifecycle.
+        stubPublishBloc(const BackgroundPublishState());
+
+        when(() => authService.isAuthenticated).thenReturn(true);
+
+        await tester.pumpWidget(
+          _buildHarness(publishBloc: publishBloc, authService: authService),
+        );
+
+        // Step 1: Upload starts (in-progress) — listener records the ID.
+        publishStream.add(
+          BackgroundPublishState(uploads: [_inProgress('draft-1')]),
+        );
+        await tester.pump();
+
+        // Step 2: Upload completes — draft-1 disappears from state entirely
+        // (neither in-progress nor failed).
+        publishStream.add(const BackgroundPublishState());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // A success snackbar must be visible.
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.uploadPublishedCountMessage(1)),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'buffers success while unauthenticated then flushes on re-auth',
+      (tester) async {
+        // Start empty, then add in-progress upload.
+        stubPublishBloc(const BackgroundPublishState());
+
+        when(() => authService.isAuthenticated).thenReturn(false);
+
+        await tester.pumpWidget(
+          _buildHarness(publishBloc: publishBloc, authService: authService),
+        );
+
+        // Upload starts while user is NOT authenticated.
+        publishStream.add(
+          BackgroundPublishState(uploads: [_inProgress('draft-2')]),
+        );
+        await tester.pump();
+
+        // Upload succeeds while still unauthenticated: draft-2 disappears.
+        publishStream.add(const BackgroundPublishState());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // No snackbar yet — auth is not restored.
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+
+        // Auth is now restored. Emit a new state to trigger the listener
+        // again, this time with isAuthenticated == true.
+        when(() => authService.isAuthenticated).thenReturn(true);
+        publishStream.add(const BackgroundPublishState());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Buffered success must now be flushed.
+        expect(
+          find.text(l10n.uploadPublishedCountMessage(1)),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'does not count a vanished failed upload as a success',
+      (tester) async {
+        // Start empty, user is NOT authenticated yet (prevents failure sheets
+        // from showing, keeping the test focused on success counting).
+        stubPublishBloc(const BackgroundPublishState());
+        when(() => authService.isAuthenticated).thenReturn(false);
+
+        await tester.pumpWidget(
+          _buildHarness(publishBloc: publishBloc, authService: authService),
+        );
+
+        // Both the in-progress and the pre-existing failed upload appear
+        // together. With auth=false the failure sheet is suppressed, and the
+        // listener records draft-3 as in-progress and draft-fail as failed.
+        publishStream.add(
+          BackgroundPublishState(
+            uploads: [_inProgress('draft-3'), _failed('draft-fail')],
+          ),
+        );
+        await tester.pump();
+
+        // Now auth is restored. The failed upload is dismissed (removed from
+        // state) and the in-progress upload also disappears (succeeds). Only
+        // draft-3 was ever in-progress, so success count must be 1, not 2.
+        when(() => authService.isAuthenticated).thenReturn(true);
+        publishStream.add(const BackgroundPublishState());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // Must show exactly 1 success.
+        expect(
+          find.text(l10n.uploadPublishedCountMessage(1)),
+          findsOneWidget,
+        );
+        // The plural "2 videos …" form must not appear.
+        expect(
+          find.text(l10n.uploadPublishedCountMessage(2)),
+          findsNothing,
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -79,13 +79,6 @@ BackgroundUpload _inProgress(String id) => BackgroundUpload(
   progress: 0.5,
 );
 
-/// Creates a [BackgroundUpload] with a [PublishError] result.
-BackgroundUpload _failed(String id) => BackgroundUpload(
-  draft: _FakeDraft(id),
-  result: const PublishError('Upload failed'),
-  progress: 1.0,
-);
-
 /// A [BackgroundPublishState] that carries a success signal for [id], with no
 /// remaining uploads — mirrors what the bloc emits on [PublishSuccess].
 BackgroundPublishState _succeededState(String id) => BackgroundPublishState(

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for the UploadFailureListener success-tracking state machine.
 // ABOUTME: Covers: success while authenticated, success buffered during re-auth then
-// ABOUTME: flushed on restore, and a vanished failed upload not miscounted as success.
+// ABOUTME: flushed on restore, BackgroundPublishVanished not miscounted as success,
+// ABOUTME: and BackgroundPublishBloc state-test coverage for recentlySucceededIds.
 
 import 'dart:async';
 
@@ -85,6 +86,16 @@ BackgroundUpload _failed(String id) => BackgroundUpload(
   progress: 1.0,
 );
 
+/// A [BackgroundPublishState] that carries a success signal for [id], with no
+/// remaining uploads — mirrors what the bloc emits on [PublishSuccess].
+BackgroundPublishState _succeededState(String id) => BackgroundPublishState(
+  recentlySucceededIds: {id},
+);
+
+/// A [BackgroundPublishState] where upload [id] disappeared without a success
+/// signal — mirrors what the bloc emits on [BackgroundPublishVanished].
+BackgroundPublishState _vanishedState() => const BackgroundPublishState();
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -114,29 +125,18 @@ void main() {
     testWidgets(
       'shows snackbar immediately when upload succeeds while authenticated',
       (tester) async {
-        // Start with an empty state (no uploads), then add an in-progress
-        // upload, then mark it as complete — mirroring the real app lifecycle.
         stubPublishBloc(const BackgroundPublishState());
-
         when(() => authService.isAuthenticated).thenReturn(true);
 
         await tester.pumpWidget(
           _buildHarness(publishBloc: publishBloc, authService: authService),
         );
 
-        // Step 1: Upload starts (in-progress) — listener records the ID.
-        publishStream.add(
-          BackgroundPublishState(uploads: [_inProgress('draft-1')]),
-        );
-        await tester.pump();
-
-        // Step 2: Upload completes — draft-1 disappears from state entirely
-        // (neither in-progress nor failed).
-        publishStream.add(const BackgroundPublishState());
+        // Bloc emits a state with recentlySucceededIds populated (true success).
+        publishStream.add(_succeededState('draft-1'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
-        // A success snackbar must be visible.
         final l10n = lookupAppLocalizations(const Locale('en'));
         expect(
           find.text(l10n.uploadPublishedCountMessage(1)),
@@ -148,32 +148,23 @@ void main() {
     testWidgets(
       'buffers success while unauthenticated then flushes on re-auth',
       (tester) async {
-        // Start empty, then add in-progress upload.
         stubPublishBloc(const BackgroundPublishState());
-
         when(() => authService.isAuthenticated).thenReturn(false);
 
         await tester.pumpWidget(
           _buildHarness(publishBloc: publishBloc, authService: authService),
         );
 
-        // Upload starts while user is NOT authenticated.
-        publishStream.add(
-          BackgroundPublishState(uploads: [_inProgress('draft-2')]),
-        );
-        await tester.pump();
-
-        // Upload succeeds while still unauthenticated: draft-2 disappears.
-        publishStream.add(const BackgroundPublishState());
+        // Upload succeeds while user is NOT authenticated.
+        publishStream.add(_succeededState('draft-2'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
-        // No snackbar yet — auth is not restored.
         final l10n = lookupAppLocalizations(const Locale('en'));
+        // No snackbar yet — auth is not restored.
         expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
 
-        // Auth is now restored. Emit a new state to trigger the listener
-        // again, this time with isAuthenticated == true.
+        // Auth is now restored. Emit another state to trigger the listener.
         when(() => authService.isAuthenticated).thenReturn(true);
         publishStream.add(const BackgroundPublishState());
         await tester.pump();
@@ -188,46 +179,28 @@ void main() {
     );
 
     testWidgets(
-      'does not count a vanished failed upload as a success',
+      'does not show snackbar when upload vanishes via BackgroundPublishVanished',
       (tester) async {
-        // Start empty, user is NOT authenticated yet (prevents failure sheets
-        // from showing, keeping the test focused on success counting).
-        stubPublishBloc(const BackgroundPublishState());
-        when(() => authService.isAuthenticated).thenReturn(false);
+        // BackgroundPublishVanished emits a state with an empty
+        // recentlySucceededIds — no success signal should be shown.
+        stubPublishBloc(
+          BackgroundPublishState(uploads: [_inProgress('draft-vanish')]),
+        );
+        when(() => authService.isAuthenticated).thenReturn(true);
 
         await tester.pumpWidget(
           _buildHarness(publishBloc: publishBloc, authService: authService),
         );
 
-        // Both the in-progress and the pre-existing failed upload appear
-        // together. With auth=false the failure sheet is suppressed, and the
-        // listener records draft-3 as in-progress and draft-fail as failed.
-        publishStream.add(
-          BackgroundPublishState(
-            uploads: [_inProgress('draft-3'), _failed('draft-fail')],
-          ),
-        );
-        await tester.pump();
-
-        // Now auth is restored. The failed upload is dismissed (removed from
-        // state) and the in-progress upload also disappears (succeeds). Only
-        // draft-3 was ever in-progress, so success count must be 1, not 2.
-        when(() => authService.isAuthenticated).thenReturn(true);
-        publishStream.add(const BackgroundPublishState());
+        // Upload vanishes — draft removed from state but no success signal.
+        publishStream.add(_vanishedState());
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
+        // No snackbar must appear for a vanished upload.
         final l10n = lookupAppLocalizations(const Locale('en'));
-        // Must show exactly 1 success.
-        expect(
-          find.text(l10n.uploadPublishedCountMessage(1)),
-          findsOneWidget,
-        );
-        // The plural "2 videos …" form must not appear.
-        expect(
-          find.text(l10n.uploadPublishedCountMessage(2)),
-          findsNothing,
-        );
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+        expect(find.text(l10n.uploadPublishedCountMessage(2)), findsNothing);
       },
     );
   });

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -63,8 +63,8 @@ Widget _buildHarness({
       supportedLocales: AppLocalizations.supportedLocales,
       home: BlocProvider<BackgroundPublishBloc>.value(
         value: publishBloc,
-        child: app.UploadFailureListener(
-          child: const Scaffold(body: SizedBox.shrink()),
+        child: const app.UploadFailureListener(
+          child: Scaffold(body: SizedBox.shrink()),
         ),
       ),
     ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
An in-progress publish flow could be interrupted by the session-expired recovery UI routing the user to `/welcome/login-options` before the silent refresh had definitively failed. This happened because `ProfileHeaderWidget` and `SettingsScreen` navigated immediately when `tryRefreshExpiredSession()` returned false, with no awareness of either an in-flight background RPC upgrade or an active background upload.
Three coordinated fixes:
1. **`AuthService`** gains `isRpcUpgradeInProgress` (true while `_upgradeDivineRpcInBackground` runs) and `isRefreshInProgress` (true while `tryRefreshExpiredSession` is in flight). The upgrade's `finally` block nudges `authStateStream` so dependent widgets rebuild once the result is known.
2. **`ProfileHeaderWidget`** suppresses the session-expired sheet while `isRpcUpgradeInProgress` is true. If the sheet is shown and refresh fails while an upload is active, navigation to login-options is deferred via a `BackgroundPublishBloc` stream subscription until `hasUploadInProgress` becomes false. `SettingsScreen._handleSessionExpired` applies the same deferral pattern.
3. **`_UploadFailureListener`** (app-level) is extended to also track successful publishes. Successes that complete while the user is mid-reauth are buffered and surfaced as a "Video published to your profile" snackbar the moment authentication is restored — closing the "what happened to my video?" gap after a re-auth redirect.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4626 

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
