### PR TITLE
feat(video-editor): add reverse playback functionality for clips

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -6,6 +6,7 @@ import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
+import 'package:openvine/services/video_editor/video_editor_reverse_service.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
 import 'package:unified_logger/unified_logger.dart';
@@ -31,6 +32,14 @@ typedef SplitClipFn =
       onClipRendered,
     });
 
+/// Function signature matching [VideoEditorReverseService.reverseClip], used as
+/// an injectable seam so tests can swap in a pure-Dart fake.
+typedef ReverseClipFn =
+    Future<EditorVideo> Function({
+      required DivineVideoClip sourceClip,
+      required String renderId,
+    });
+
 /// BLoC for managing video clip editor state.
 ///
 /// Owns a local copy of the clip list so that all mutations (add, remove,
@@ -48,9 +57,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     required this.onFinalClipInvalidated,
     AudioExtractionService? audioExtractionService,
     SplitClipFn? splitClip,
+    ReverseClipFn? reverseClip,
   }) : _audioExtractionService =
            audioExtractionService ?? AudioExtractionService(),
        _splitClip = splitClip ?? VideoEditorSplitService.splitClip,
+       _reverseClip = reverseClip ?? VideoEditorReverseService.reverseClip,
        super(const ClipEditorState()) {
     // Clip data
     on<ClipEditorInitialized>(_onInitialized);
@@ -82,6 +93,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       transformer: droppable(),
     );
 
+    // Reverse
+    on<ClipEditorClipReverseRequested>(
+      _onClipReverseRequested,
+      transformer: droppable(),
+    );
+
     // Volume
     on<ClipEditorClipVolumeChanged>(
       _onClipVolumeChanged,
@@ -96,6 +113,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   final void Function() onFinalClipInvalidated;
   final AudioExtractionService _audioExtractionService;
   final SplitClipFn _splitClip;
+  final ReverseClipFn _reverseClip;
 
   // === CLIP DATA ===
 
@@ -530,6 +548,135 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         clipsVolumeRevision: state.clipsVolumeRevision + 1,
       ),
     );
+  }
+
+  // === REVERSE ===
+
+  Future<void> _onClipReverseRequested(
+    ClipEditorClipReverseRequested event,
+    Emitter<ClipEditorState> emit,
+  ) async {
+    final index = state.clips.indexWhere((c) => c.id == event.clipId);
+    if (index == -1) return;
+
+    final clip = state.clips[index];
+    final videoPath = clip.video.file?.path;
+
+    if (videoPath == null) {
+      Log.warning(
+        '⚠️ Reverse skipped: clip ${clip.id} has no local file',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+      emit(state.copyWith(lastReverseResult: ClipReverseNoLocalFile()));
+      return;
+    }
+
+    if (clip.reversed && clip.forwardVideoPath != null) {
+      final restoredClip = clip.copyWith(
+        video: EditorVideo.file(clip.forwardVideoPath),
+        trimStart: clip.trimEnd,
+        trimEnd: clip.trimStart,
+        reversed: false,
+      );
+      final newClips = List<DivineVideoClip>.of(state.clips)
+        ..[index] = restoredClip;
+      emit(
+        state.copyWith(
+          clips: List.unmodifiable(newClips),
+          lastReverseResult: ClipReverseSuccess(),
+        ),
+      );
+      onFinalClipInvalidated.call();
+      return;
+    }
+
+    if (!clip.reversed && clip.reversedVideoPath != null) {
+      final restoredClip = clip.copyWith(
+        video: EditorVideo.file(clip.reversedVideoPath),
+        reversed: true,
+      );
+      final newClips = List<DivineVideoClip>.of(state.clips)
+        ..[index] = restoredClip;
+      emit(
+        state.copyWith(
+          clips: List.unmodifiable(newClips),
+          lastReverseResult: ClipReverseSuccess(),
+        ),
+      );
+      onFinalClipInvalidated.call();
+      return;
+    }
+
+    emit(state.copyWith(isReversing: true, reversingClipId: clip.id));
+
+    try {
+      final reversedVideo = await _reverseClip(
+        sourceClip: clip,
+        renderId: clip.id,
+      );
+
+      final currentClips = state.clips;
+      final currentIndex = currentClips.indexWhere((c) => c.id == clip.id);
+      if (currentIndex == -1) {
+        Log.warning(
+          '⚠️ Reverse result discarded: clip ${clip.id} no longer exists',
+          name: 'ClipEditorBloc',
+          category: LogCategory.video,
+        );
+        emit(
+          state.copyWith(
+            isReversing: false,
+            clearReversingClipId: true,
+            lastReverseResult: ClipReverseDiscarded(),
+          ),
+        );
+        return;
+      }
+
+      final currentClip = currentClips[currentIndex];
+      final updatedClip = currentClip.copyWith(
+        video: reversedVideo,
+        reversed: !clip.reversed,
+        forwardVideoPath: currentClip.forwardVideoPath ?? videoPath,
+        reversedVideoPath:
+            reversedVideo.file?.path ?? currentClip.reversedVideoPath,
+      );
+      final newClips = List<DivineVideoClip>.of(currentClips)
+        ..[currentIndex] = updatedClip;
+
+      emit(
+        state.copyWith(
+          clips: List.unmodifiable(newClips),
+          isReversing: false,
+          clearReversingClipId: true,
+          lastReverseResult: ClipReverseSuccess(),
+        ),
+      );
+
+      onFinalClipInvalidated.call();
+    } catch (e, stackTrace) {
+      final error = switch (e) {
+        StateError() || TypeError() || RangeError() => Reportable(
+          e,
+          context: '_onClipReverseRequested',
+        ),
+        _ => e,
+      };
+      addError(error, stackTrace);
+      Log.error(
+        '❌ Failed to reverse clip ${clip.id}: $e',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+      emit(
+        state.copyWith(
+          isReversing: false,
+          clearReversingClipId: true,
+          lastReverseResult: ClipReverseFailure(),
+        ),
+      );
+    }
   }
 
   // === AUDIO EXTRACTION ===

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -637,14 +637,33 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       }
 
       final currentClip = currentClips[currentIndex];
+
+      // The render input (`videoPath`) holds content in the clip's current
+      // direction (`clip.reversed`); the render output (`reversedVideo`) holds
+      // the opposite. Assign each to its matching cache slot so the branch is
+      // also correct when the input is already reversed — e.g. a duplicate or
+      // split of a reversed clip, which preserves `reversed` but clears both
+      // cache paths. Mapping by output direction instead would store forward
+      // content as the reversed path (and vice versa), making every later
+      // cached toggle play the wrong direction.
+      final renderedPath = reversedVideo.file?.path;
+      final String? forwardVideoPath;
+      final String? reversedVideoPath;
+      if (clip.reversed) {
+        forwardVideoPath = renderedPath ?? currentClip.forwardVideoPath;
+        reversedVideoPath = currentClip.reversedVideoPath ?? videoPath;
+      } else {
+        forwardVideoPath = currentClip.forwardVideoPath ?? videoPath;
+        reversedVideoPath = renderedPath ?? currentClip.reversedVideoPath;
+      }
+
       final updatedClip = currentClip.copyWith(
         video: reversedVideo,
         trimStart: currentClip.trimEnd,
         trimEnd: currentClip.trimStart,
         reversed: !clip.reversed,
-        forwardVideoPath: currentClip.forwardVideoPath ?? videoPath,
-        reversedVideoPath:
-            reversedVideo.file?.path ?? currentClip.reversedVideoPath,
+        forwardVideoPath: forwardVideoPath,
+        reversedVideoPath: reversedVideoPath,
       );
       final newClips = List<DivineVideoClip>.of(currentClips)
         ..[currentIndex] = updatedClip;

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -594,6 +594,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     if (!clip.reversed && clip.reversedVideoPath != null) {
       final restoredClip = clip.copyWith(
         video: EditorVideo.file(clip.reversedVideoPath),
+        trimStart: clip.trimEnd,
+        trimEnd: clip.trimStart,
         reversed: true,
       );
       final newClips = List<DivineVideoClip>.of(state.clips)
@@ -637,6 +639,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       final currentClip = currentClips[currentIndex];
       final updatedClip = currentClip.copyWith(
         video: reversedVideo,
+        trimStart: currentClip.trimEnd,
+        trimEnd: currentClip.trimStart,
         reversed: !clip.reversed,
         forwardVideoPath: currentClip.forwardVideoPath ?? videoPath,
         reversedVideoPath:

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -191,6 +191,18 @@ class ClipEditorAudioExtractionRequested extends ClipEditorEvent {
   List<Object?> get props => [clipTitle];
 }
 
+// === REVERSE ===
+
+/// Request reverse rendering for the clip with [clipId].
+class ClipEditorClipReverseRequested extends ClipEditorEvent {
+  const ClipEditorClipReverseRequested({required this.clipId});
+
+  final String clipId;
+
+  @override
+  List<Object?> get props => [clipId];
+}
+
 // === VOLUME ===
 
 /// Update the volume of a clip by its ID.

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -22,6 +22,9 @@ class ClipEditorState extends Equatable {
     this.lastAudioExtraction,
     this.isSplitting = false,
     this.lastSplitFailure,
+    this.isReversing = false,
+    this.reversingClipId,
+    this.lastReverseResult,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -90,6 +93,18 @@ class ClipEditorState extends Equatable {
   /// fresh signal even when fields happen to repeat.
   final ClipAudioExtractionResult? lastAudioExtraction;
 
+  /// Whether a reverse render operation is currently running.
+  final bool isReversing;
+
+  /// Clip ID used as the render-progress stream key while reversing.
+  final String? reversingClipId;
+
+  /// Last completed reverse-render result.
+  ///
+  /// Consumed by the widget layer to persist clip history after a successful
+  /// reverse render.
+  final ClipReverseResult? lastReverseResult;
+
   /// Total wall-clock duration of all clips (respecting trim and playback speed).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
@@ -112,6 +127,10 @@ class ClipEditorState extends Equatable {
     ClipAudioExtractionResult? lastAudioExtraction,
     bool? isSplitting,
     ClipSplitFailure? lastSplitFailure,
+    bool? isReversing,
+    String? reversingClipId,
+    bool clearReversingClipId = false,
+    ClipReverseResult? lastReverseResult,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -131,6 +150,11 @@ class ClipEditorState extends Equatable {
       lastAudioExtraction: lastAudioExtraction ?? this.lastAudioExtraction,
       isSplitting: isSplitting ?? this.isSplitting,
       lastSplitFailure: lastSplitFailure ?? this.lastSplitFailure,
+      isReversing: isReversing ?? this.isReversing,
+      reversingClipId: clearReversingClipId
+          ? null
+          : (reversingClipId ?? this.reversingClipId),
+      lastReverseResult: lastReverseResult ?? this.lastReverseResult,
     );
   }
 
@@ -152,6 +176,9 @@ class ClipEditorState extends Equatable {
     isSplitting,
     // Identity-only: each ClipSplitFailure is a fresh instance per failure.
     identityHashCode(lastSplitFailure),
+    isReversing,
+    reversingClipId,
+    identityHashCode(lastReverseResult),
   ];
 }
 
@@ -218,3 +245,20 @@ final class ClipAudioExtractionFailure extends ClipAudioExtractionResult {}
 /// Identity-compared so each failure produces a distinct notification even
 /// when the same error type repeats consecutively.
 final class ClipSplitFailure {}
+
+// === REVERSE RESULT ===
+
+/// One-shot signal describing the outcome of a reverse-render operation.
+sealed class ClipReverseResult {}
+
+/// Reverse render succeeded; widget should persist the updated clip state.
+final class ClipReverseSuccess extends ClipReverseResult {}
+
+/// Reverse render was attempted but the clip has no locally available file.
+final class ClipReverseNoLocalFile extends ClipReverseResult {}
+
+/// Reverse render completed but the source clip was removed in-flight.
+final class ClipReverseDiscarded extends ClipReverseResult {}
+
+/// Reverse render failed.
+final class ClipReverseFailure extends ClipReverseResult {}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3422,6 +3422,8 @@
     "videoEditorReverseLabel": "ወደ ኋላ",
     "videoEditorReverseClipSemanticLabel": "ለተመረጠው ክሊፕ የኋላ ወደ ፊት ማጫወቻ ቀይር",
     "videoEditorReverseProgressLabel": "አንድ ትንሽ ቆይ፣ ክሊፕዎን ወደ ኋላ እየቀየርን ነው",
+    "videoEditorReverseNoLocalFile": "ወደ ኋላ መቀየር አልተቻለም፤ ቅንጥቡ በሀገር ዉስጥ አይገኝም።",
+    "videoEditorReverseFailed": "ቅንጥቡን ወደ ኋላ መቀየር አልተቻለም። እንደገና ሞክር።",
     "videoEditorSpeedSheetTitle": "የክሊፕ ፍጥነት",
     "videoEditorFinishTimelineEditingSemanticLabel": "የጊዜ መስመር አርትዖትን ጨርስ",
     "videoEditorAudioPlayPreviewSemanticLabel": "ቅድመ እይታን አጫውት።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3419,6 +3419,8 @@
     "videoEditorExtractAudioFailed": "ድምፅ ማዎጣት አልተቻለም። እንደገና ሞክር።",
     "videoEditorSpeedLabel": "ፍጥነት",
     "videoEditorSetClipSpeedSemanticLabel": "ለተመረጠው ክሊፕ የማጫወቻ ፍጥነት ያዘጋጁ",
+    "videoEditorReverseLabel": "ወደ ኋላ",
+    "videoEditorReverseClipSemanticLabel": "ለተመረጠው ክሊፕ የኋላ ወደ ፊት ማጫወቻ ቀይር",
     "videoEditorSpeedSheetTitle": "የክሊፕ ፍጥነት",
     "videoEditorFinishTimelineEditingSemanticLabel": "የጊዜ መስመር አርትዖትን ጨርስ",
     "videoEditorAudioPlayPreviewSemanticLabel": "ቅድመ እይታን አጫውት።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3421,6 +3421,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "ለተመረጠው ክሊፕ የማጫወቻ ፍጥነት ያዘጋጁ",
     "videoEditorReverseLabel": "ወደ ኋላ",
     "videoEditorReverseClipSemanticLabel": "ለተመረጠው ክሊፕ የኋላ ወደ ፊት ማጫወቻ ቀይር",
+    "videoEditorReverseProgressLabel": "አንድ ትንሽ ቆይ፣ ክሊፕዎን ወደ ኋላ እየቀየርን ነው",
     "videoEditorSpeedSheetTitle": "የክሊፕ ፍጥነት",
     "videoEditorFinishTimelineEditingSemanticLabel": "የጊዜ መስመር አርትዖትን ጨርስ",
     "videoEditorAudioPlayPreviewSemanticLabel": "ቅድመ እይታን አጫውት።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2853,6 +2853,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "تعيين سرعة التشغيل للمقطع المحدد",
     "videoEditorReverseLabel": "عكس",
     "videoEditorReverseClipSemanticLabel": "تبديل تشغيل المقطع المحدد بشكل معكوس",
+    "videoEditorReverseProgressLabel": "لحظة من فضلك، نحن نعكس المقطع الخاص بك",
     "videoEditorSpeedSheetTitle": "سرعة المقطع",
     "videoEditorStickersDivineOriginals": "Divine الأصلية",
     "videoEditorStickerSearchHint": "البحث في الملصقات...",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2851,6 +2851,8 @@
     "videoEditorExtractAudioFailed": "تعذّر استخراج الصوت. يرجى المحاولة مجددًا.",
     "videoEditorSpeedLabel": "السرعة",
     "videoEditorSetClipSpeedSemanticLabel": "تعيين سرعة التشغيل للمقطع المحدد",
+    "videoEditorReverseLabel": "عكس",
+    "videoEditorReverseClipSemanticLabel": "تبديل تشغيل المقطع المحدد بشكل معكوس",
     "videoEditorSpeedSheetTitle": "سرعة المقطع",
     "videoEditorStickersDivineOriginals": "Divine الأصلية",
     "videoEditorStickerSearchHint": "البحث في الملصقات...",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2854,6 +2854,8 @@
     "videoEditorReverseLabel": "عكس",
     "videoEditorReverseClipSemanticLabel": "تبديل تشغيل المقطع المحدد بشكل معكوس",
     "videoEditorReverseProgressLabel": "لحظة من فضلك، نحن نعكس المقطع الخاص بك",
+    "videoEditorReverseNoLocalFile": "لا يمكن العكس: المقطع غير متاح محليًا.",
+    "videoEditorReverseFailed": "تعذّر عكس المقطع. يرجى المحاولة مجددًا.",
     "videoEditorSpeedSheetTitle": "سرعة المقطع",
     "videoEditorStickersDivineOriginals": "Divine الأصلية",
     "videoEditorStickerSearchHint": "البحث في الملصقات...",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3112,6 +3112,8 @@
     "videoEditorReverseLabel": "Обратно",
     "videoEditorReverseClipSemanticLabel": "Включване или изключване на обратно възпроизвеждане за избрания клип",
     "videoEditorReverseProgressLabel": "Момент, обръщаме клипа ви",
+    "videoEditorReverseNoLocalFile": "Не може да се обърне: клипът не е наличен локално.",
+    "videoEditorReverseFailed": "Клипът не можа да се обърне. Моля, опитайте отново.",
     "videoEditorSpeedSheetTitle": "Скорост на клипа",
     "videoEditorFinishTimelineEditingSemanticLabel": "Завършете редактирането на времевата линия",
     "videoEditorAudioPlayPreviewSemanticLabel": "Пусни предварителен преглед",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3109,6 +3109,8 @@
     "videoEditorExtractAudioFailed": "Не можа да се извлече аудио. Моля, опитайте отново.",
     "videoEditorSpeedLabel": "Скорост",
     "videoEditorSetClipSpeedSemanticLabel": "Задаване на скорост на възпроизвеждане за избрания клип",
+    "videoEditorReverseLabel": "Обратно",
+    "videoEditorReverseClipSemanticLabel": "Включване или изключване на обратно възпроизвеждане за избрания клип",
     "videoEditorSpeedSheetTitle": "Скорост на клипа",
     "videoEditorFinishTimelineEditingSemanticLabel": "Завършете редактирането на времевата линия",
     "videoEditorAudioPlayPreviewSemanticLabel": "Пусни предварителен преглед",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3111,6 +3111,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Задаване на скорост на възпроизвеждане за избрания клип",
     "videoEditorReverseLabel": "Обратно",
     "videoEditorReverseClipSemanticLabel": "Включване или изключване на обратно възпроизвеждане за избрания клип",
+    "videoEditorReverseProgressLabel": "Момент, обръщаме клипа ви",
     "videoEditorSpeedSheetTitle": "Скорост на клипа",
     "videoEditorFinishTimelineEditingSemanticLabel": "Завършете редактирането на времевата линия",
     "videoEditorAudioPlayPreviewSemanticLabel": "Пусни предварителен преглед",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Rückwärts",
     "videoEditorReverseClipSemanticLabel": "Rückwärtswiedergabe für ausgewählten Clip umschalten",
     "videoEditorReverseProgressLabel": "Einen Moment, wir drehen deinen Clip rückwärts",
+    "videoEditorReverseNoLocalFile": "Rückwärtsdrehen nicht möglich: Clip ist lokal nicht verfügbar.",
+    "videoEditorReverseFailed": "Clip konnte nicht rückwärts gedreht werden. Bitte erneut versuchen.",
     "videoEditorSpeedSheetTitle": "Clip-Geschwindigkeit",
     "videoEditorFinishTimelineEditingSemanticLabel": "Timeline-Bearbeitung abschließen",
     "videoEditorAudioPlayPreviewSemanticLabel": "Vorschau abspielen",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Audio konnte nicht extrahiert werden. Bitte erneut versuchen.",
     "videoEditorSpeedLabel": "Geschwindigkeit",
     "videoEditorSetClipSpeedSemanticLabel": "Wiedergabegeschwindigkeit für ausgewählten Clip festlegen",
+    "videoEditorReverseLabel": "Rückwärts",
+    "videoEditorReverseClipSemanticLabel": "Rückwärtswiedergabe für ausgewählten Clip umschalten",
     "videoEditorSpeedSheetTitle": "Clip-Geschwindigkeit",
     "videoEditorFinishTimelineEditingSemanticLabel": "Timeline-Bearbeitung abschließen",
     "videoEditorAudioPlayPreviewSemanticLabel": "Vorschau abspielen",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Wiedergabegeschwindigkeit für ausgewählten Clip festlegen",
     "videoEditorReverseLabel": "Rückwärts",
     "videoEditorReverseClipSemanticLabel": "Rückwärtswiedergabe für ausgewählten Clip umschalten",
+    "videoEditorReverseProgressLabel": "Einen Moment, wir drehen deinen Clip rückwärts",
     "videoEditorSpeedSheetTitle": "Clip-Geschwindigkeit",
     "videoEditorFinishTimelineEditingSemanticLabel": "Timeline-Bearbeitung abschließen",
     "videoEditorAudioPlayPreviewSemanticLabel": "Vorschau abspielen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4468,6 +4468,14 @@
   "@videoEditorReverseProgressLabel": {
     "description": "Status text shown while the selected clip is being rendered in reverse for preview playback."
   },
+  "videoEditorReverseNoLocalFile": "Cannot reverse: clip is not locally available.",
+  "@videoEditorReverseNoLocalFile": {
+    "description": "Snackbar message shown when a reverse is requested for a clip that has no locally available file."
+  },
+  "videoEditorReverseFailed": "Could not reverse clip. Please try again.",
+  "@videoEditorReverseFailed": {
+    "description": "Snackbar message shown when reversing a clip fails during rendering."
+  },
   "videoEditorSpeedSheetTitle": "Clip Speed",
   "@videoEditorSpeedSheetTitle": {
     "description": "Title of the bottom sheet for adjusting clip playback speed."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4464,6 +4464,10 @@
   "@videoEditorReverseClipSemanticLabel": {
     "description": "Accessibility label for the Reverse button in the timeline clip controls."
   },
+  "videoEditorReverseProgressLabel": "One moment, we're reversing your clip",
+  "@videoEditorReverseProgressLabel": {
+    "description": "Status text shown while the selected clip is being rendered in reverse for preview playback."
+  },
   "videoEditorSpeedSheetTitle": "Clip Speed",
   "@videoEditorSpeedSheetTitle": {
     "description": "Title of the bottom sheet for adjusting clip playback speed."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4456,6 +4456,14 @@
   "@videoEditorSetClipSpeedSemanticLabel": {
     "description": "Accessibility label for the Set Speed button in the timeline clip controls."
   },
+  "videoEditorReverseLabel": "Reverse",
+  "@videoEditorReverseLabel": {
+    "description": "Label for the Reverse button in the timeline clip controls."
+  },
+  "videoEditorReverseClipSemanticLabel": "Toggle reverse playback for selected clip",
+  "@videoEditorReverseClipSemanticLabel": {
+    "description": "Accessibility label for the Reverse button in the timeline clip controls."
+  },
   "videoEditorSpeedSheetTitle": "Clip Speed",
   "@videoEditorSpeedSheetTitle": {
     "description": "Title of the bottom sheet for adjusting clip playback speed."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2868,6 +2868,8 @@
     "videoEditorReverseLabel": "Invertir",
     "videoEditorReverseClipSemanticLabel": "Activar o desactivar la reproducción inversa del clip seleccionado",
     "videoEditorReverseProgressLabel": "Un momento, estamos invirtiendo tu clip",
+    "videoEditorReverseNoLocalFile": "No se puede invertir: el clip no está disponible localmente.",
+    "videoEditorReverseFailed": "No se pudo invertir el clip. Por favor, inténtalo de nuevo.",
     "videoEditorSpeedSheetTitle": "Velocidad del clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Terminar edición de la línea de tiempo",
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproducir vista previa",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2867,6 +2867,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Establecer la velocidad de reproducción del clip seleccionado",
     "videoEditorReverseLabel": "Invertir",
     "videoEditorReverseClipSemanticLabel": "Activar o desactivar la reproducción inversa del clip seleccionado",
+    "videoEditorReverseProgressLabel": "Un momento, estamos invirtiendo tu clip",
     "videoEditorSpeedSheetTitle": "Velocidad del clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Terminar edición de la línea de tiempo",
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproducir vista previa",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2865,6 +2865,8 @@
     "videoEditorExtractAudioFailed": "No se pudo extraer el audio. Por favor, inténtalo de nuevo.",
     "videoEditorSpeedLabel": "Velocidad",
     "videoEditorSetClipSpeedSemanticLabel": "Establecer la velocidad de reproducción del clip seleccionado",
+    "videoEditorReverseLabel": "Invertir",
+    "videoEditorReverseClipSemanticLabel": "Activar o desactivar la reproducción inversa del clip seleccionado",
     "videoEditorSpeedSheetTitle": "Velocidad del clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Terminar edición de la línea de tiempo",
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproducir vista previa",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1759,6 +1759,8 @@
     "videoEditorExtractAudioFailed": "Hindi na-extract ang audio. Pakisubukang muli.",
     "videoEditorSpeedLabel": "Bilis",
     "videoEditorSetClipSpeedSemanticLabel": "Itakda ang bilis ng playback para sa napiling clip",
+    "videoEditorReverseLabel": "Baligtad",
+    "videoEditorReverseClipSemanticLabel": "I-toggle ang pabalik na pagpapalaro para sa napiling clip",
     "videoEditorSpeedSheetTitle": "Bilis ng Clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Tapusin ang pag-edit ng timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "I-play ang preview",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1761,6 +1761,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Itakda ang bilis ng playback para sa napiling clip",
     "videoEditorReverseLabel": "Baligtad",
     "videoEditorReverseClipSemanticLabel": "I-toggle ang pabalik na pagpapalaro para sa napiling clip",
+    "videoEditorReverseProgressLabel": "Sandali lang, nirereverse namin ang clip mo",
     "videoEditorSpeedSheetTitle": "Bilis ng Clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Tapusin ang pag-edit ng timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "I-play ang preview",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1762,6 +1762,8 @@
     "videoEditorReverseLabel": "Baligtad",
     "videoEditorReverseClipSemanticLabel": "I-toggle ang pabalik na pagpapalaro para sa napiling clip",
     "videoEditorReverseProgressLabel": "Sandali lang, nirereverse namin ang clip mo",
+    "videoEditorReverseNoLocalFile": "Hindi ma-reverse: hindi available ang clip nang lokal.",
+    "videoEditorReverseFailed": "Hindi na-reverse ang clip. Pakisubukang muli.",
     "videoEditorSpeedSheetTitle": "Bilis ng Clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Tapusin ang pag-edit ng timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "I-play ang preview",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Définir la vitesse de lecture du clip sélectionné",
     "videoEditorReverseLabel": "Inverser",
     "videoEditorReverseClipSemanticLabel": "Activer ou désactiver la lecture inversée du clip sélectionné",
+    "videoEditorReverseProgressLabel": "Un instant, nous inversons votre clip",
     "videoEditorSpeedSheetTitle": "Vitesse du clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Terminer l'édition de la timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "Lire l'aperçu",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Impossible d'extraire l'audio. Veuillez réessayer.",
     "videoEditorSpeedLabel": "Vitesse",
     "videoEditorSetClipSpeedSemanticLabel": "Définir la vitesse de lecture du clip sélectionné",
+    "videoEditorReverseLabel": "Inverser",
+    "videoEditorReverseClipSemanticLabel": "Activer ou désactiver la lecture inversée du clip sélectionné",
     "videoEditorSpeedSheetTitle": "Vitesse du clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Terminer l'édition de la timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "Lire l'aperçu",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Inverser",
     "videoEditorReverseClipSemanticLabel": "Activer ou désactiver la lecture inversée du clip sélectionné",
     "videoEditorReverseProgressLabel": "Un instant, nous inversons votre clip",
+    "videoEditorReverseNoLocalFile": "Impossible d'inverser : le clip n'est pas disponible localement.",
+    "videoEditorReverseFailed": "Impossible d'inverser le clip. Veuillez réessayer.",
     "videoEditorSpeedSheetTitle": "Vitesse du clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Terminer l'édition de la timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "Lire l'aperçu",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2860,6 +2860,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Atur kecepatan putar untuk klip yang dipilih",
     "videoEditorReverseLabel": "Balik",
     "videoEditorReverseClipSemanticLabel": "Aktifkan atau nonaktifkan pemutaran terbalik untuk klip yang dipilih",
+    "videoEditorReverseProgressLabel": "Tunggu sebentar, kami sedang membalik klip Anda",
     "videoEditorSpeedSheetTitle": "Kecepatan Klip",
     "videoEditorStickersDivineOriginals": "Divine Orisinal",
     "videoEditorStickerSearchHint": "Cari stiker...",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2858,6 +2858,8 @@
     "videoEditorExtractAudioFailed": "Tidak dapat mengekstrak audio. Silakan coba lagi.",
     "videoEditorSpeedLabel": "Kecepatan",
     "videoEditorSetClipSpeedSemanticLabel": "Atur kecepatan putar untuk klip yang dipilih",
+    "videoEditorReverseLabel": "Balik",
+    "videoEditorReverseClipSemanticLabel": "Aktifkan atau nonaktifkan pemutaran terbalik untuk klip yang dipilih",
     "videoEditorSpeedSheetTitle": "Kecepatan Klip",
     "videoEditorStickersDivineOriginals": "Divine Orisinal",
     "videoEditorStickerSearchHint": "Cari stiker...",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2861,6 +2861,8 @@
     "videoEditorReverseLabel": "Balik",
     "videoEditorReverseClipSemanticLabel": "Aktifkan atau nonaktifkan pemutaran terbalik untuk klip yang dipilih",
     "videoEditorReverseProgressLabel": "Tunggu sebentar, kami sedang membalik klip Anda",
+    "videoEditorReverseNoLocalFile": "Tidak dapat membalik: klip tidak tersedia secara lokal.",
+    "videoEditorReverseFailed": "Tidak dapat membalik klip. Silakan coba lagi.",
     "videoEditorSpeedSheetTitle": "Kecepatan Klip",
     "videoEditorStickersDivineOriginals": "Divine Orisinal",
     "videoEditorStickerSearchHint": "Cari stiker...",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Inverti",
     "videoEditorReverseClipSemanticLabel": "Attiva o disattiva la riproduzione inversa per il clip selezionato",
     "videoEditorReverseProgressLabel": "Un momento, stiamo invertendo la clip",
+    "videoEditorReverseNoLocalFile": "Impossibile invertire: il clip non è disponibile localmente.",
+    "videoEditorReverseFailed": "Impossibile invertire il clip. Riprova.",
     "videoEditorSpeedSheetTitle": "Velocità del clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Termina modifica timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "Riproduci anteprima",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Imposta la velocità di riproduzione per il clip selezionato",
     "videoEditorReverseLabel": "Inverti",
     "videoEditorReverseClipSemanticLabel": "Attiva o disattiva la riproduzione inversa per il clip selezionato",
+    "videoEditorReverseProgressLabel": "Un momento, stiamo invertendo la clip",
     "videoEditorSpeedSheetTitle": "Velocità del clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Termina modifica timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "Riproduci anteprima",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Impossibile estrarre l'audio. Riprova.",
     "videoEditorSpeedLabel": "Velocità",
     "videoEditorSetClipSpeedSemanticLabel": "Imposta la velocità di riproduzione per il clip selezionato",
+    "videoEditorReverseLabel": "Inverti",
+    "videoEditorReverseClipSemanticLabel": "Attiva o disattiva la riproduzione inversa per il clip selezionato",
     "videoEditorSpeedSheetTitle": "Velocità del clip",
     "videoEditorFinishTimelineEditingSemanticLabel": "Termina modifica timeline",
     "videoEditorAudioPlayPreviewSemanticLabel": "Riproduci anteprima",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2853,6 +2853,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "選択したクリップの再生速度を設定",
     "videoEditorReverseLabel": "逆再生",
     "videoEditorReverseClipSemanticLabel": "選択したクリップの逆再生を切り替え",
+    "videoEditorReverseProgressLabel": "少々お待ちください。クリップを逆再生用に処理しています",
     "videoEditorSpeedSheetTitle": "クリップの速度",
     "videoEditorStickersDivineOriginals": "Divine オリジナル",
     "videoEditorStickerSearchHint": "ステッカーを検索...",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2854,6 +2854,8 @@
     "videoEditorReverseLabel": "逆再生",
     "videoEditorReverseClipSemanticLabel": "選択したクリップの逆再生を切り替え",
     "videoEditorReverseProgressLabel": "少々お待ちください。クリップを逆再生用に処理しています",
+    "videoEditorReverseNoLocalFile": "逆再生できません：クリップがローカルで利用できません。",
+    "videoEditorReverseFailed": "クリップを逆再生できませんでした。もう一度お試しください。",
     "videoEditorSpeedSheetTitle": "クリップの速度",
     "videoEditorStickersDivineOriginals": "Divine オリジナル",
     "videoEditorStickerSearchHint": "ステッカーを検索...",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2851,6 +2851,8 @@
     "videoEditorExtractAudioFailed": "音声を抽出できませんでした。もう一度お試しください。",
     "videoEditorSpeedLabel": "速度",
     "videoEditorSetClipSpeedSemanticLabel": "選択したクリップの再生速度を設定",
+    "videoEditorReverseLabel": "逆再生",
+    "videoEditorReverseClipSemanticLabel": "選択したクリップの逆再生を切り替え",
     "videoEditorSpeedSheetTitle": "クリップの速度",
     "videoEditorStickersDivineOriginals": "Divine オリジナル",
     "videoEditorStickerSearchHint": "ステッカーを検索...",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2147,6 +2147,8 @@
     "videoEditorExtractAudioFailed": "오디오를 추출할 수 없었습니다. 다시 시도해 주세요.",
     "videoEditorSpeedLabel": "속도",
     "videoEditorSetClipSpeedSemanticLabel": "선택한 클립의 재생 속도 설정",
+    "videoEditorReverseLabel": "역재생",
+    "videoEditorReverseClipSemanticLabel": "선택한 클립의 역방향 재생 전환",
     "videoEditorSpeedSheetTitle": "클립 속도",
     "videoEditorStickersDivineOriginals": "Divine 오리지널",
     "videoEditorStickerSearchHint": "스티커 검색...",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2150,6 +2150,8 @@
     "videoEditorReverseLabel": "역재생",
     "videoEditorReverseClipSemanticLabel": "선택한 클립의 역방향 재생 전환",
     "videoEditorReverseProgressLabel": "잠시만요. 클립을 역재생으로 변환하고 있어요",
+    "videoEditorReverseNoLocalFile": "역재생할 수 없습니다: 클립이 로컬에서 사용할 수 없습니다.",
+    "videoEditorReverseFailed": "클립을 역재생할 수 없었습니다. 다시 시도해 주세요.",
     "videoEditorSpeedSheetTitle": "클립 속도",
     "videoEditorStickersDivineOriginals": "Divine 오리지널",
     "videoEditorStickerSearchHint": "스티커 검색...",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2149,6 +2149,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "선택한 클립의 재생 속도 설정",
     "videoEditorReverseLabel": "역재생",
     "videoEditorReverseClipSemanticLabel": "선택한 클립의 역방향 재생 전환",
+    "videoEditorReverseProgressLabel": "잠시만요. 클립을 역재생으로 변환하고 있어요",
     "videoEditorSpeedSheetTitle": "클립 속도",
     "videoEditorStickersDivineOriginals": "Divine 오리지널",
     "videoEditorStickerSearchHint": "스티커 검색...",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Kon audio niet extraheren. Probeer het opnieuw.",
     "videoEditorSpeedLabel": "Snelheid",
     "videoEditorSetClipSpeedSemanticLabel": "Afspeelsnelheid voor geselecteerd clip instellen",
+    "videoEditorReverseLabel": "Omgekeerd",
+    "videoEditorReverseClipSemanticLabel": "Omgekeerde weergave voor geselecteerde clip in-/uitschakelen",
     "videoEditorSpeedSheetTitle": "Clipsnelheid",
     "videoEditorFinishTimelineEditingSemanticLabel": "Bewerken van tijdlijn voltooien",
     "videoEditorAudioPlayPreviewSemanticLabel": "Voorbeeld afspelen",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Afspeelsnelheid voor geselecteerd clip instellen",
     "videoEditorReverseLabel": "Omgekeerd",
     "videoEditorReverseClipSemanticLabel": "Omgekeerde weergave voor geselecteerde clip in-/uitschakelen",
+    "videoEditorReverseProgressLabel": "Een moment, we draaien je clip om",
     "videoEditorSpeedSheetTitle": "Clipsnelheid",
     "videoEditorFinishTimelineEditingSemanticLabel": "Bewerken van tijdlijn voltooien",
     "videoEditorAudioPlayPreviewSemanticLabel": "Voorbeeld afspelen",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Omgekeerd",
     "videoEditorReverseClipSemanticLabel": "Omgekeerde weergave voor geselecteerde clip in-/uitschakelen",
     "videoEditorReverseProgressLabel": "Een moment, we draaien je clip om",
+    "videoEditorReverseNoLocalFile": "Kan niet omdraaien: clip is niet lokaal beschikbaar.",
+    "videoEditorReverseFailed": "Kon clip niet omdraaien. Probeer het opnieuw.",
     "videoEditorSpeedSheetTitle": "Clipsnelheid",
     "videoEditorFinishTimelineEditingSemanticLabel": "Bewerken van tijdlijn voltooien",
     "videoEditorAudioPlayPreviewSemanticLabel": "Voorbeeld afspelen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Nie udało się wyodrębnić audio. Spróbuj ponownie.",
     "videoEditorSpeedLabel": "Prędkość",
     "videoEditorSetClipSpeedSemanticLabel": "Ustaw prędkość odtwarzania dla wybranego klipu",
+    "videoEditorReverseLabel": "Odwróć",
+    "videoEditorReverseClipSemanticLabel": "Włącz lub wyłącz odwrotne odtwarzanie dla wybranego klipu",
     "videoEditorSpeedSheetTitle": "Prędkość klipu",
     "videoEditorFinishTimelineEditingSemanticLabel": "Zakończ edycję osi czasu",
     "videoEditorAudioPlayPreviewSemanticLabel": "Odtwórz podgląd",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Odwróć",
     "videoEditorReverseClipSemanticLabel": "Włącz lub wyłącz odwrotne odtwarzanie dla wybranego klipu",
     "videoEditorReverseProgressLabel": "Chwileczkę, odwracamy Twój klip",
+    "videoEditorReverseNoLocalFile": "Nie można odwrócić: klip nie jest dostępny lokalnie.",
+    "videoEditorReverseFailed": "Nie udało się odwrócić klipu. Spróbuj ponownie.",
     "videoEditorSpeedSheetTitle": "Prędkość klipu",
     "videoEditorFinishTimelineEditingSemanticLabel": "Zakończ edycję osi czasu",
     "videoEditorAudioPlayPreviewSemanticLabel": "Odtwórz podgląd",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Ustaw prędkość odtwarzania dla wybranego klipu",
     "videoEditorReverseLabel": "Odwróć",
     "videoEditorReverseClipSemanticLabel": "Włącz lub wyłącz odwrotne odtwarzanie dla wybranego klipu",
+    "videoEditorReverseProgressLabel": "Chwileczkę, odwracamy Twój klip",
     "videoEditorSpeedSheetTitle": "Prędkość klipu",
     "videoEditorFinishTimelineEditingSemanticLabel": "Zakończ edycję osi czasu",
     "videoEditorAudioPlayPreviewSemanticLabel": "Odtwórz podgląd",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Definir a velocidade de reprodução do clipe selecionado",
     "videoEditorReverseLabel": "Inverter",
     "videoEditorReverseClipSemanticLabel": "Ativar ou desativar a reprodução inversa para o clipe selecionado",
+    "videoEditorReverseProgressLabel": "Um momento, estamos invertendo seu clipe",
     "videoEditorSpeedSheetTitle": "Velocidade do clipe",
     "videoEditorFinishTimelineEditingSemanticLabel": "Finalizar edição da linha do tempo",
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproduzir prévia",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Inverter",
     "videoEditorReverseClipSemanticLabel": "Ativar ou desativar a reprodução inversa para o clipe selecionado",
     "videoEditorReverseProgressLabel": "Um momento, estamos invertendo seu clipe",
+    "videoEditorReverseNoLocalFile": "Não é possível inverter: o clipe não está disponível localmente.",
+    "videoEditorReverseFailed": "Não foi possível inverter o clipe. Por favor, tente novamente.",
     "videoEditorSpeedSheetTitle": "Velocidade do clipe",
     "videoEditorFinishTimelineEditingSemanticLabel": "Finalizar edição da linha do tempo",
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproduzir prévia",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Não foi possível extrair o áudio. Por favor, tente novamente.",
     "videoEditorSpeedLabel": "Velocidade",
     "videoEditorSetClipSpeedSemanticLabel": "Definir a velocidade de reprodução do clipe selecionado",
+    "videoEditorReverseLabel": "Inverter",
+    "videoEditorReverseClipSemanticLabel": "Ativar ou desativar a reprodução inversa para o clipe selecionado",
     "videoEditorSpeedSheetTitle": "Velocidade do clipe",
     "videoEditorFinishTimelineEditingSemanticLabel": "Finalizar edição da linha do tempo",
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproduzir prévia",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Nu s-a putut extrage audio. Vă rugăm să încercați din nou.",
     "videoEditorSpeedLabel": "Viteză",
     "videoEditorSetClipSpeedSemanticLabel": "Setați viteza de redare pentru clipul selectat",
+    "videoEditorReverseLabel": "Invers",
+    "videoEditorReverseClipSemanticLabel": "Activați sau dezactivați redarea inversă pentru clipul selectat",
     "videoEditorSpeedSheetTitle": "Viteza clipului",
     "videoEditorFinishTimelineEditingSemanticLabel": "Finalizează editarea cronologiei",
     "videoEditorAudioPlayPreviewSemanticLabel": "Redă previzualizarea",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Setați viteza de redare pentru clipul selectat",
     "videoEditorReverseLabel": "Invers",
     "videoEditorReverseClipSemanticLabel": "Activați sau dezactivați redarea inversă pentru clipul selectat",
+    "videoEditorReverseProgressLabel": "O clipă, inversăm clipul tău",
     "videoEditorSpeedSheetTitle": "Viteza clipului",
     "videoEditorFinishTimelineEditingSemanticLabel": "Finalizează editarea cronologiei",
     "videoEditorAudioPlayPreviewSemanticLabel": "Redă previzualizarea",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Invers",
     "videoEditorReverseClipSemanticLabel": "Activați sau dezactivați redarea inversă pentru clipul selectat",
     "videoEditorReverseProgressLabel": "O clipă, inversăm clipul tău",
+    "videoEditorReverseNoLocalFile": "Nu se poate inversa: clipul nu este disponibil local.",
+    "videoEditorReverseFailed": "Nu s-a putut inversa clipul. Vă rugăm să încercați din nou.",
     "videoEditorSpeedSheetTitle": "Viteza clipului",
     "videoEditorFinishTimelineEditingSemanticLabel": "Finalizează editarea cronologiei",
     "videoEditorAudioPlayPreviewSemanticLabel": "Redă previzualizarea",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2857,6 +2857,8 @@
     "videoEditorExtractAudioFailed": "Kunde inte extrahera ljud. Försök igen.",
     "videoEditorSpeedLabel": "Hastighet",
     "videoEditorSetClipSpeedSemanticLabel": "Ange uppspelningshastighet för valt klipp",
+    "videoEditorReverseLabel": "Baklänges",
+    "videoEditorReverseClipSemanticLabel": "Aktivera eller inaktivera omvänd uppspelning för valt klipp",
     "videoEditorSpeedSheetTitle": "Klipphastighet",
     "videoEditorFinishTimelineEditingSemanticLabel": "Avsluta redigering av tidslinje",
     "videoEditorAudioPlayPreviewSemanticLabel": "Spela förhandsvisning",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2859,6 +2859,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Ange uppspelningshastighet för valt klipp",
     "videoEditorReverseLabel": "Baklänges",
     "videoEditorReverseClipSemanticLabel": "Aktivera eller inaktivera omvänd uppspelning för valt klipp",
+    "videoEditorReverseProgressLabel": "Ett ögonblick, vi vänder ditt klipp baklänges",
     "videoEditorSpeedSheetTitle": "Klipphastighet",
     "videoEditorFinishTimelineEditingSemanticLabel": "Avsluta redigering av tidslinje",
     "videoEditorAudioPlayPreviewSemanticLabel": "Spela förhandsvisning",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2860,6 +2860,8 @@
     "videoEditorReverseLabel": "Baklänges",
     "videoEditorReverseClipSemanticLabel": "Aktivera eller inaktivera omvänd uppspelning för valt klipp",
     "videoEditorReverseProgressLabel": "Ett ögonblick, vi vänder ditt klipp baklänges",
+    "videoEditorReverseNoLocalFile": "Kan inte vända baklänges: klippet är inte tillgängligt lokalt.",
+    "videoEditorReverseFailed": "Kunde inte vända klippet baklänges. Försök igen.",
     "videoEditorSpeedSheetTitle": "Klipphastighet",
     "videoEditorFinishTimelineEditingSemanticLabel": "Avsluta redigering av tidslinje",
     "videoEditorAudioPlayPreviewSemanticLabel": "Spela förhandsvisning",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2861,6 +2861,8 @@
     "videoEditorReverseLabel": "Tersine Çevir",
     "videoEditorReverseClipSemanticLabel": "Seçili klip için ters oynatmayı aç veya kapat",
     "videoEditorReverseProgressLabel": "Bir saniye, klibini tersine çeviriyoruz",
+    "videoEditorReverseNoLocalFile": "Tersine çevrilemiyor: klip yerel olarak kullanılamıyor.",
+    "videoEditorReverseFailed": "Klip tersine çevrilemedi. Lütfen tekrar deneyin.",
     "videoEditorSpeedSheetTitle": "Klip Hızı",
     "videoEditorStickersDivineOriginals": "Divine Orijinaller",
     "videoEditorStickerSearchHint": "Çıkartma ara...",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2858,6 +2858,8 @@
     "videoEditorExtractAudioFailed": "Ses çıkarılamadı. Lütfen tekrar deneyin.",
     "videoEditorSpeedLabel": "Hız",
     "videoEditorSetClipSpeedSemanticLabel": "Seçili klip için oynatma hızını ayarla",
+    "videoEditorReverseLabel": "Tersine Çevir",
+    "videoEditorReverseClipSemanticLabel": "Seçili klip için ters oynatmayı aç veya kapat",
     "videoEditorSpeedSheetTitle": "Klip Hızı",
     "videoEditorStickersDivineOriginals": "Divine Orijinaller",
     "videoEditorStickerSearchHint": "Çıkartma ara...",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2860,6 +2860,7 @@
     "videoEditorSetClipSpeedSemanticLabel": "Seçili klip için oynatma hızını ayarla",
     "videoEditorReverseLabel": "Tersine Çevir",
     "videoEditorReverseClipSemanticLabel": "Seçili klip için ters oynatmayı aç veya kapat",
+    "videoEditorReverseProgressLabel": "Bir saniye, klibini tersine çeviriyoruz",
     "videoEditorSpeedSheetTitle": "Klip Hızı",
     "videoEditorStickersDivineOriginals": "Divine Orijinaller",
     "videoEditorStickerSearchHint": "Çıkartma ara...",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13832,6 +13832,18 @@ abstract class AppLocalizations {
   /// **'One moment, we\'re reversing your clip'**
   String get videoEditorReverseProgressLabel;
 
+  /// Snackbar message shown when a reverse is requested for a clip that has no locally available file.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot reverse: clip is not locally available.'**
+  String get videoEditorReverseNoLocalFile;
+
+  /// Snackbar message shown when reversing a clip fails during rendering.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not reverse clip. Please try again.'**
+  String get videoEditorReverseFailed;
+
   /// Title of the bottom sheet for adjusting clip playback speed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13826,6 +13826,12 @@ abstract class AppLocalizations {
   /// **'Toggle reverse playback for selected clip'**
   String get videoEditorReverseClipSemanticLabel;
 
+  /// Status text shown while the selected clip is being rendered in reverse for preview playback.
+  ///
+  /// In en, this message translates to:
+  /// **'One moment, we\'re reversing your clip'**
+  String get videoEditorReverseProgressLabel;
+
   /// Title of the bottom sheet for adjusting clip playback speed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13814,6 +13814,18 @@ abstract class AppLocalizations {
   /// **'Set playback speed for selected clip'**
   String get videoEditorSetClipSpeedSemanticLabel;
 
+  /// Label for the Reverse button in the timeline clip controls.
+  ///
+  /// In en, this message translates to:
+  /// **'Reverse'**
+  String get videoEditorReverseLabel;
+
+  /// Accessibility label for the Reverse button in the timeline clip controls.
+  ///
+  /// In en, this message translates to:
+  /// **'Toggle reverse playback for selected clip'**
+  String get videoEditorReverseClipSemanticLabel;
+
   /// Title of the bottom sheet for adjusting clip playback speed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7794,6 +7794,13 @@ class AppLocalizationsAm extends AppLocalizations {
       'ለተመረጠው ክሊፕ የማጫወቻ ፍጥነት ያዘጋጁ';
 
   @override
+  String get videoEditorReverseLabel => 'ወደ ኋላ';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'ለተመረጠው ክሊፕ የኋላ ወደ ፊት ማጫወቻ ቀይር';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'የክሊፕ ፍጥነት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7801,6 +7801,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ለተመረጠው ክሊፕ የኋላ ወደ ፊት ማጫወቻ ቀይር';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'አንድ ትንሽ ቆይ፣ ክሊፕዎን ወደ ኋላ እየቀየርን ነው';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'የክሊፕ ፍጥነት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7805,6 +7805,13 @@ class AppLocalizationsAm extends AppLocalizations {
       'አንድ ትንሽ ቆይ፣ ክሊፕዎን ወደ ኋላ እየቀየርን ነው';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'ወደ ኋላ መቀየር አልተቻለም፤ ቅንጥቡ በሀገር ዉስጥ አይገኝም።';
+
+  @override
+  String get videoEditorReverseFailed => 'ቅንጥቡን ወደ ኋላ መቀየር አልተቻለም። እንደገና ሞክር።';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'የክሊፕ ፍጥነት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7873,6 +7873,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'تعيين سرعة التشغيل للمقطع المحدد';
 
   @override
+  String get videoEditorReverseLabel => 'عكس';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'تبديل تشغيل المقطع المحدد بشكل معكوس';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'سرعة المقطع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7880,6 +7880,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'تبديل تشغيل المقطع المحدد بشكل معكوس';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'لحظة من فضلك، نحن نعكس المقطع الخاص بك';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'سرعة المقطع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7884,6 +7884,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'لحظة من فضلك، نحن نعكس المقطع الخاص بك';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'لا يمكن العكس: المقطع غير متاح محليًا.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'تعذّر عكس المقطع. يرجى المحاولة مجددًا.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'سرعة المقطع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8019,6 +8019,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoEditorReverseProgressLabel => 'Момент, обръщаме клипа ви';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Не може да се обърне: клипът не е наличен локално.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Клипът не можа да се обърне. Моля, опитайте отново.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Скорост на клипа';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8016,6 +8016,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Включване или изключване на обратно възпроизвеждане за избрания клип';
 
   @override
+  String get videoEditorReverseProgressLabel => 'Момент, обръщаме клипа ви';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Скорост на клипа';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8009,6 +8009,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Задаване на скорост на възпроизвеждане за избрания клип';
 
   @override
+  String get videoEditorReverseLabel => 'Обратно';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Включване или изключване на обратно възпроизвеждане за избрания клип';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Скорост на клипа';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8029,6 +8029,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Rückwärtswiedergabe für ausgewählten Clip umschalten';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Einen Moment, wir drehen deinen Clip rückwärts';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clip-Geschwindigkeit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8022,6 +8022,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wiedergabegeschwindigkeit für ausgewählten Clip festlegen';
 
   @override
+  String get videoEditorReverseLabel => 'Rückwärts';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Rückwärtswiedergabe für ausgewählten Clip umschalten';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clip-Geschwindigkeit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8033,6 +8033,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Einen Moment, wir drehen deinen Clip rückwärts';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Rückwärtsdrehen nicht möglich: Clip ist lokal nicht verfügbar.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Clip konnte nicht rückwärts gedreht werden. Bitte erneut versuchen.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clip-Geschwindigkeit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7937,6 +7937,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Toggle reverse playback for selected clip';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'One moment, we\'re reversing your clip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clip Speed';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7941,6 +7941,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'One moment, we\'re reversing your clip';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Cannot reverse: clip is not locally available.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Could not reverse clip. Please try again.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clip Speed';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7930,6 +7930,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Set playback speed for selected clip';
 
   @override
+  String get videoEditorReverseLabel => 'Reverse';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Toggle reverse playback for selected clip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clip Speed';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8018,6 +8018,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Un momento, estamos invirtiendo tu clip';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'No se puede invertir: el clip no está disponible localmente.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'No se pudo invertir el clip. Por favor, inténtalo de nuevo.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocidad del clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8007,6 +8007,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Establecer la velocidad de reproducción del clip seleccionado';
 
   @override
+  String get videoEditorReverseLabel => 'Invertir';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Activar o desactivar la reproducción inversa del clip seleccionado';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocidad del clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8014,6 +8014,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Activar o desactivar la reproducción inversa del clip seleccionado';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Un momento, estamos invirtiendo tu clip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocidad del clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8034,6 +8034,14 @@ class AppLocalizationsFil extends AppLocalizations {
       'Sandali lang, nirereverse namin ang clip mo';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Hindi ma-reverse: hindi available ang clip nang lokal.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Hindi na-reverse ang clip. Pakisubukang muli.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Bilis ng Clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8030,6 +8030,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-toggle ang pabalik na pagpapalaro para sa napiling clip';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Sandali lang, nirereverse namin ang clip mo';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Bilis ng Clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8023,6 +8023,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'Itakda ang bilis ng playback para sa napiling clip';
 
   @override
+  String get videoEditorReverseLabel => 'Baligtad';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'I-toggle ang pabalik na pagpapalaro para sa napiling clip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Bilis ng Clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8049,6 +8049,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Un instant, nous inversons votre clip';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Impossible d\'inverser : le clip n\'est pas disponible localement.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Impossible d\'inverser le clip. Veuillez réessayer.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Vitesse du clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8045,6 +8045,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer ou désactiver la lecture inversée du clip sélectionné';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Un instant, nous inversons votre clip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Vitesse du clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8038,6 +8038,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Définir la vitesse de lecture du clip sélectionné';
 
   @override
+  String get videoEditorReverseLabel => 'Inverser';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Activer ou désactiver la lecture inversée du clip sélectionné';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Vitesse du clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7923,6 +7923,14 @@ class AppLocalizationsId extends AppLocalizations {
       'Tunggu sebentar, kami sedang membalik klip Anda';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Tidak dapat membalik: klip tidak tersedia secara lokal.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Tidak dapat membalik klip. Silakan coba lagi.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Kecepatan Klip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7919,6 +7919,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Aktifkan atau nonaktifkan pemutaran terbalik untuk klip yang dipilih';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Tunggu sebentar, kami sedang membalik klip Anda';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Kecepatan Klip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7912,6 +7912,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Atur kecepatan putar untuk klip yang dipilih';
 
   @override
+  String get videoEditorReverseLabel => 'Balik';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Aktifkan atau nonaktifkan pemutaran terbalik untuk klip yang dipilih';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Kecepatan Klip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8015,6 +8015,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Un momento, stiamo invertendo la clip';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Impossibile invertire: il clip non è disponibile localmente.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Impossibile invertire il clip. Riprova.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocità del clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8004,6 +8004,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Imposta la velocità di riproduzione per il clip selezionato';
 
   @override
+  String get videoEditorReverseLabel => 'Inverti';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Attiva o disattiva la riproduzione inversa per il clip selezionato';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocità del clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8011,6 +8011,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Attiva o disattiva la riproduzione inversa per il clip selezionato';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Un momento, stiamo invertendo la clip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocità del clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7664,6 +7664,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorReverseProgressLabel => '少々お待ちください。クリップを逆再生用に処理しています';
 
   @override
+  String get videoEditorReverseNoLocalFile => '逆再生できません：クリップがローカルで利用できません。';
+
+  @override
+  String get videoEditorReverseFailed => 'クリップを逆再生できませんでした。もう一度お試しください。';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'クリップの速度';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7655,6 +7655,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorSetClipSpeedSemanticLabel => '選択したクリップの再生速度を設定';
 
   @override
+  String get videoEditorReverseLabel => '逆再生';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel => '選択したクリップの逆再生を切り替え';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'クリップの速度';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7661,6 +7661,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorReverseClipSemanticLabel => '選択したクリップの逆再生を切り替え';
 
   @override
+  String get videoEditorReverseProgressLabel => '少々お待ちください。クリップを逆再生用に処理しています';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'クリップの速度';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7686,6 +7686,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorReverseProgressLabel => '잠시만요. 클립을 역재생으로 변환하고 있어요';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      '역재생할 수 없습니다: 클립이 로컬에서 사용할 수 없습니다.';
+
+  @override
+  String get videoEditorReverseFailed => '클립을 역재생할 수 없었습니다. 다시 시도해 주세요.';
+
+  @override
   String get videoEditorSpeedSheetTitle => '클립 속도';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7683,6 +7683,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorReverseClipSemanticLabel => '선택한 클립의 역방향 재생 전환';
 
   @override
+  String get videoEditorReverseProgressLabel => '잠시만요. 클립을 역재생으로 변환하고 있어요';
+
+  @override
   String get videoEditorSpeedSheetTitle => '클립 속도';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7677,6 +7677,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorSetClipSpeedSemanticLabel => '선택한 클립의 재생 속도 설정';
 
   @override
+  String get videoEditorReverseLabel => '역재생';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel => '선택한 클립의 역방향 재생 전환';
+
+  @override
   String get videoEditorSpeedSheetTitle => '클립 속도';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7983,6 +7983,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Een moment, we draaien je clip om';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Kan niet omdraaien: clip is niet lokaal beschikbaar.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Kon clip niet omdraaien. Probeer het opnieuw.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clipsnelheid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7979,6 +7979,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Omgekeerde weergave voor geselecteerde clip in-/uitschakelen';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Een moment, we draaien je clip om';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clipsnelheid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7972,6 +7972,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Afspeelsnelheid voor geselecteerd clip instellen';
 
   @override
+  String get videoEditorReverseLabel => 'Omgekeerd';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Omgekeerde weergave voor geselecteerde clip in-/uitschakelen';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Clipsnelheid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8088,6 +8088,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Ustaw prędkość odtwarzania dla wybranego klipu';
 
   @override
+  String get videoEditorReverseLabel => 'Odwróć';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Włącz lub wyłącz odwrotne odtwarzanie dla wybranego klipu';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Prędkość klipu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8099,6 +8099,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'Chwileczkę, odwracamy Twój klip';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Nie można odwrócić: klip nie jest dostępny lokalnie.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Nie udało się odwrócić klipu. Spróbuj ponownie.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Prędkość klipu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8095,6 +8095,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Włącz lub wyłącz odwrotne odtwarzanie dla wybranego klipu';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Chwileczkę, odwracamy Twój klip';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Prędkość klipu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7993,6 +7993,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Um momento, estamos invertendo seu clipe';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Não é possível inverter: o clipe não está disponível localmente.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Não foi possível inverter o clipe. Por favor, tente novamente.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocidade do clipe';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7982,6 +7982,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Definir a velocidade de reprodução do clipe selecionado';
 
   @override
+  String get videoEditorReverseLabel => 'Inverter';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Ativar ou desativar a reprodução inversa para o clipe selecionado';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocidade do clipe';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7989,6 +7989,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Ativar ou desativar a reprodução inversa para o clipe selecionado';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Um momento, estamos invertendo seu clipe';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Velocidade do clipe';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8106,6 +8106,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Setați viteza de redare pentru clipul selectat';
 
   @override
+  String get videoEditorReverseLabel => 'Invers';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Activați sau dezactivați redarea inversă pentru clipul selectat';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Viteza clipului';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8116,6 +8116,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorReverseProgressLabel => 'O clipă, inversăm clipul tău';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Nu se poate inversa: clipul nu este disponibil local.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Nu s-a putut inversa clipul. Vă rugăm să încercați din nou.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Viteza clipului';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8113,6 +8113,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați sau dezactivați redarea inversă pentru clipul selectat';
 
   @override
+  String get videoEditorReverseProgressLabel => 'O clipă, inversăm clipul tău';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Viteza clipului';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7952,6 +7952,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ett ögonblick, vi vänder ditt klipp baklänges';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Kan inte vända baklänges: klippet är inte tillgängligt lokalt.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Kunde inte vända klippet baklänges. Försök igen.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Klipphastighet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7941,6 +7941,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ange uppspelningshastighet för valt klipp';
 
   @override
+  String get videoEditorReverseLabel => 'Baklänges';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Aktivera eller inaktivera omvänd uppspelning för valt klipp';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Klipphastighet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7948,6 +7948,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Aktivera eller inaktivera omvänd uppspelning för valt klipp';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Ett ögonblick, vi vänder ditt klipp baklänges';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Klipphastighet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7921,6 +7921,14 @@ class AppLocalizationsTr extends AppLocalizations {
       'Bir saniye, klibini tersine çeviriyoruz';
 
   @override
+  String get videoEditorReverseNoLocalFile =>
+      'Tersine çevrilemiyor: klip yerel olarak kullanılamıyor.';
+
+  @override
+  String get videoEditorReverseFailed =>
+      'Klip tersine çevrilemedi. Lütfen tekrar deneyin.';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Klip Hızı';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7910,6 +7910,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Seçili klip için oynatma hızını ayarla';
 
   @override
+  String get videoEditorReverseLabel => 'Tersine Çevir';
+
+  @override
+  String get videoEditorReverseClipSemanticLabel =>
+      'Seçili klip için ters oynatmayı aç veya kapat';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Klip Hızı';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7917,6 +7917,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Seçili klip için ters oynatmayı aç veya kapat';
 
   @override
+  String get videoEditorReverseProgressLabel =>
+      'Bir saniye, klibini tersine çeviriyoruz';
+
+  @override
   String get videoEditorSpeedSheetTitle => 'Klip Hızı';
 
   @override

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -27,6 +27,9 @@ class DivineVideoClip {
     this.trimEnd = Duration.zero,
     this.volume = 1,
     this.playbackSpeed,
+    this.reversed = false,
+    this.forwardVideoPath,
+    this.reversedVideoPath,
     this.proofManifestJson,
     this.deletedAt,
   }) : _thumbnailTimestamp = thumbnailTimestamp,
@@ -67,6 +70,15 @@ class DivineVideoClip {
   /// Playback speed multiplier for this clip (e.g. 0.5 = half speed, 2.0 = double speed).
   /// Null means normal speed (1.0).
   final double? playbackSpeed;
+
+  /// Whether this clip plays in reverse.
+  final bool reversed;
+
+  /// Cached forward file path used to restore the clip after a reverse toggle.
+  final String? forwardVideoPath;
+
+  /// Cached reversed file path so repeated reverse toggles can reuse it.
+  final String? reversedVideoPath;
 
   /// JSON-encoded ProofMode / C2PA attestation data for this individual clip.
   final String? proofManifestJson;
@@ -139,10 +151,17 @@ class DivineVideoClip {
     double? volume,
     double? playbackSpeed,
     bool clearPlaybackSpeed = false,
+    bool? reversed,
+    String? forwardVideoPath,
+    bool clearForwardVideoPath = false,
+    String? reversedVideoPath,
+    bool clearReversedVideoPath = false,
     String? proofManifestJson,
     bool clearProofManifestJson = false,
     DateTime? deletedAt,
   }) {
+    final isNewLogicalClip = id != null && id != this.id;
+
     return DivineVideoClip(
       id: id ?? this.id,
       video: video ?? this.video,
@@ -161,6 +180,17 @@ class DivineVideoClip {
       playbackSpeed: clearPlaybackSpeed
           ? null
           : (playbackSpeed ?? this.playbackSpeed),
+      reversed: reversed ?? this.reversed,
+      forwardVideoPath: isNewLogicalClip
+          ? null
+          : clearForwardVideoPath
+          ? null
+          : (forwardVideoPath ?? this.forwardVideoPath),
+      reversedVideoPath: isNewLogicalClip
+          ? null
+          : clearReversedVideoPath
+          ? null
+          : (reversedVideoPath ?? this.reversedVideoPath),
       proofManifestJson: clearProofManifestJson
           ? null
           : (proofManifestJson ?? this.proofManifestJson),
@@ -191,6 +221,11 @@ class DivineVideoClip {
       'trimEndMs': trimEnd.inMilliseconds,
       'volume': volume,
       if (playbackSpeed != null) 'playbackSpeed': playbackSpeed,
+      if (reversed) 'reversed': true,
+      if (forwardVideoPath != null)
+        'forwardVideoPath': p.basename(forwardVideoPath!),
+      if (reversedVideoPath != null)
+        'reversedVideoPath': p.basename(reversedVideoPath!),
       if (proofManifestJson != null) 'proofManifestJson': proofManifestJson,
     };
   }
@@ -244,6 +279,17 @@ class DivineVideoClip {
       trimEnd: Duration(milliseconds: (json['trimEndMs'] as int?) ?? 0),
       volume: (json['volume'] as num?)?.toDouble() ?? 1,
       playbackSpeed: (json['playbackSpeed'] as num?)?.toDouble(),
+      reversed: (json['reversed'] as bool?) ?? false,
+      forwardVideoPath: resolvePath(
+        json['forwardVideoPath'] as String?,
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      ),
+      reversedVideoPath: resolvePath(
+        json['reversedVideoPath'] as String?,
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      ),
       proofManifestJson: json['proofManifestJson'] as String?,
     );
   }

--- a/mobile/lib/services/video_editor/video_editor_reverse_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_reverse_service.dart
@@ -22,6 +22,16 @@ class VideoEditorReverseService {
       documentsPath,
       '${sourceClip.id}_reversed.mp4',
     );
+
+    // Defensive: refuse to render when the input path collides with the
+    // output path. We delete the output file before rendering, so a collision
+    // would destroy the source video in-place.
+    if (p.equals(inputPath, outputPath)) {
+      throw StateError(
+        'Reverse render aborted: input path equals output path ($inputPath)',
+      );
+    }
+
     final outputFile = File(outputPath);
 
     Log.info(

--- a/mobile/lib/services/video_editor/video_editor_reverse_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_reverse_service.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/utils/path_resolver.dart';
+import 'package:path/path.dart' as p;
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Service for rendering a reversed clip to a new local file.
+class VideoEditorReverseService {
+  /// Renders the full clip in reverse.
+  ///
+  /// Callers keep trim bounds in state and derive the visible segment from the
+  /// reversed source file instead of baking the trim into the output file.
+  static Future<EditorVideo> reverseClip({
+    required DivineVideoClip sourceClip,
+    required String renderId,
+  }) async {
+    final documentsPath = await getDocumentsPath();
+    final inputPath = await sourceClip.video.safeFilePath();
+    final outputPath = p.join(
+      documentsPath,
+      '${sourceClip.id}_reversed.mp4',
+    );
+    final outputFile = File(outputPath);
+
+    Log.info(
+      '🔄 Rendering reversed clip ${sourceClip.id} to $outputPath',
+      name: 'VideoEditorReverseService',
+      category: LogCategory.video,
+    );
+
+    try {
+      try {
+        await ProVideoEditor.instance.cancel(renderId);
+      } catch (e) {
+        Log.debug(
+          '⏹️ Reverse cancel returned for $renderId: $e',
+          name: 'VideoEditorReverseService',
+          category: LogCategory.video,
+        );
+      }
+
+      if (outputFile.existsSync()) {
+        await outputFile.delete();
+        Log.debug(
+          '🗑️ Deleted stale reverse output: $outputPath',
+          name: 'VideoEditorReverseService',
+          category: LogCategory.video,
+        );
+      }
+
+      await ProVideoEditor.instance.renderVideoToFile(
+        outputPath,
+        VideoRenderData(
+          id: renderId,
+          videoSegments: [
+            VideoSegment(
+              video: EditorVideo.file(inputPath),
+              reverseVideo: true,
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      if (outputFile.existsSync()) {
+        try {
+          await outputFile.delete();
+        } catch (deleteError) {
+          Log.warning(
+            '⚠️ Failed to delete partial reverse output $outputPath: '
+            '$deleteError',
+            name: 'VideoEditorReverseService',
+            category: LogCategory.video,
+          );
+        }
+      }
+      rethrow;
+    }
+
+    Log.info(
+      '✅ Reverse render complete for ${sourceClip.id}',
+      name: 'VideoEditorReverseService',
+      category: LogCategory.video,
+    );
+
+    return EditorVideo.file(outputPath);
+  }
+}

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -174,6 +174,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   bool _isTrimmingLayer = false;
   bool _isTrimmingClip = false;
   bool _isDraggingLayer = false;
+
+  /// One-shot guard set by the reverse-success [BlocListener] before it
+  /// imperatively rebuilds the player with the reversed clip list. The next
+  /// [ClipEditorState] clip-snapshot diff would otherwise re-trigger the
+  /// generic clip-sync path and overwrite the just-applied reversed source.
+  /// Consumed (cleared) by the clip-snapshot listener on its next pass.
   bool _skipNextClipSnapshotSync = false;
 
   /// Guards against duplicate [addHistory] calls when both

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -174,6 +174,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   bool _isTrimmingLayer = false;
   bool _isTrimmingClip = false;
   bool _isDraggingLayer = false;
+  bool _skipNextClipSnapshotSync = false;
 
   /// Guards against duplicate [addHistory] calls when both
   /// [ClipEditorBloc.clipsVolumeRevision] and
@@ -659,6 +660,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
       );
       if (!mounted || clips.isEmpty || _isImportingHistory) return;
 
+      if (_skipNextClipSnapshotSync) {
+        _skipNextClipSnapshotSync = false;
+        return;
+      }
+
       // Only update if clips actually changed to avoid unnecessary rebuilds
       // and autosave triggers. DivineVideoClip uses reference equality, so
       // we compare the editable properties explicitly.
@@ -1078,10 +1084,74 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             scope.requireEditor.setTimelineMarkers(state.timelineMarkers);
           },
         ),
-        // Update native player clip boundaries when trim handle is
-        // released or for non-trim clip changes (reorder, add, remove).
         BlocListener<ClipEditorBloc, ClipEditorState>(
           listenWhen: (previous, current) {
+            return !identical(
+                  previous.lastReverseResult,
+                  current.lastReverseResult,
+                ) &&
+                current.lastReverseResult is ClipReverseSuccess;
+          },
+          listener: (context, state) async {
+            if (state.clips.isEmpty || !_isPlayerInitialized) return;
+
+            _skipNextClipSnapshotSync = true;
+            ref.read(clipManagerProvider.notifier).replaceClips(state.clips);
+
+            final currentPosition = context
+                .read<VideoEditorMainBloc>()
+                .state
+                .currentPosition;
+
+            _seekEpoch++;
+            _pendingSeekPosition = null;
+            _isSeeking = true;
+            final ownerEpoch = _seekEpoch;
+
+            try {
+              await _videoPlayer?.setClips([
+                for (final clip in state.clips)
+                  if (clip.video.file?.path case final path?)
+                    VideoClip(
+                      uri: path,
+                      start: clip.trimStart,
+                      end: clip.duration - clip.trimEnd,
+                      volume: clip.volume,
+                      playbackSpeed: clip.playbackSpeed ?? 1.0,
+                    ),
+              ], startPosition: currentPosition);
+
+              if (!mounted) return;
+              _lastReportedPosition = currentPosition;
+              _proVideoController.setPlayTime(currentPosition);
+            } catch (e, s) {
+              Log.error(
+                'setClips failed after reverse completion: $e',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+                error: e,
+                stackTrace: s,
+              );
+            } finally {
+              if (_seekEpoch == ownerEpoch) {
+                _isSeeking = false;
+              }
+            }
+          },
+        ),
+        // Update native player clip boundaries when trim handle is
+        // released or for non-trim clip changes (reorder, add, remove).
+        // Reverse completion is handled by the dedicated listener above.
+        BlocListener<ClipEditorBloc, ClipEditorState>(
+          listenWhen: (previous, current) {
+            // Reverse completion is handled by the dedicated listener above.
+            if (!identical(
+                  previous.lastReverseResult,
+                  current.lastReverseResult,
+                ) &&
+                current.lastReverseResult is ClipReverseSuccess) {
+              return false;
+            }
             return VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
               previous: previous,
               current: current,

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -32,6 +32,11 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       ),
     );
     final isLastClip = clipCount <= 1;
+    final isReversed = context.select((ClipEditorBloc b) {
+      final index = b.state.currentClipIndex;
+      final clips = b.state.clips;
+      return index >= 0 && index < clips.length && clips[index].reversed;
+    });
 
     return VideoEditorTimelineControls(
       onDelete: isLastClip ? null : () => _deleteClip(context),
@@ -39,6 +44,8 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       onSplit: isSplitting ? null : () => _splitClip(context),
       onSpeed: () => _setPlaybackSpeed(context),
       onExtractAudio: () => _requestExtractAudio(context),
+      onReversed: () => _reverseClip(context),
+      isReversed: isReversed,
       isExtractingAudio: isExtractingAudio,
       // Done is gated while extraction is in flight purely as a UX cue —
       // the success/failure side effect itself is handled by an editor-
@@ -53,6 +60,17 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
               );
             },
     );
+  }
+
+  void _reverseClip(BuildContext context) {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (state.currentClipIndex < 0 ||
+        state.currentClipIndex >= state.clips.length) {
+      return;
+    }
+    final clip = state.clips[state.currentClipIndex];
+    bloc.add(ClipEditorClipReverseRequested(clipId: clip.id));
   }
 
   Future<void> _setPlaybackSpeed(BuildContext context) async {

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -11,6 +11,8 @@ class VideoEditorTimelineControls extends StatelessWidget {
     this.onDuplicated,
     this.onSplit,
     this.onSpeed,
+    this.onReversed,
+    this.isReversed = false,
     this.onExtractAudio,
     this.isExtractingAudio = false,
     super.key,
@@ -21,6 +23,8 @@ class VideoEditorTimelineControls extends StatelessWidget {
   final VoidCallback? onDuplicated;
   final VoidCallback? onSplit;
   final VoidCallback? onSpeed;
+  final VoidCallback? onReversed;
+  final bool isReversed;
   final VoidCallback? onExtractAudio;
   final bool isExtractingAudio;
   final VoidCallback? onDone;
@@ -94,6 +98,15 @@ class VideoEditorTimelineControls extends StatelessWidget {
                       semanticLabel:
                           context.l10n.videoEditorSetClipSpeedSemanticLabel,
                       onPressed: onSpeed,
+                    ),
+                  if (onReversed != null)
+                    _ControlButton(
+                      icon: .arrowCounterClockwise,
+                      label: context.l10n.videoEditorReverseLabel,
+                      semanticLabel:
+                          context.l10n.videoEditorReverseClipSemanticLabel,
+                      onPressed: onReversed,
+                      type: isReversed ? .primary : .secondary,
                     ),
                   if (onExtractAudio != null)
                     _ControlButton(

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -7,6 +7,7 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
@@ -19,6 +20,8 @@ import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_acti
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline.dart';
+import 'package:pro_video_editor/core/models/video/progress_model.dart';
+import 'package:pro_video_editor/core/platform/platform_interface.dart';
 
 /// A scaffold widget that provides the standard layout for the video editor.
 ///
@@ -44,8 +47,10 @@ class VideoEditorScaffold extends StatelessWidget {
         resizeToAvoidBottomInset: false,
         floatingActionButton: const _AddElementFab(),
         body: _SplitFailureListener(
-          child: _AudioExtractionResultListener(
-            child: _ScaffoldBody(isLoading: isLoading),
+          child: _ClipReverseResultListener(
+            child: _AudioExtractionResultListener(
+              child: _ScaffoldBody(isLoading: isLoading),
+            ),
           ),
         ),
       ),
@@ -60,23 +65,31 @@ class _ScaffoldBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return Stack(
+      fit: .expand,
+      clipBehavior: .none,
       children: [
-        Expanded(
-          child: Stack(
-            fit: .expand,
-            clipBehavior: .none,
-            children: [
-              if (isLoading)
-                const BrandedLoadingScaffold()
-              else
-                const VideoEditorCanvas(),
+        Column(
+          children: [
+            Expanded(
+              child: Stack(
+                fit: .expand,
+                clipBehavior: .none,
+                children: [
+                  if (isLoading)
+                    const BrandedLoadingScaffold()
+                  else
+                    const VideoEditorCanvas(),
 
-              const _OverlayControls(),
-            ],
-          ),
+                  const _OverlayControls(),
+                ],
+              ),
+            ),
+            const _TimelineSection(),
+          ],
         ),
-        const _TimelineSection(),
+
+        const _ReverseProgressOverlay(),
       ],
     );
   }
@@ -105,6 +118,29 @@ class _SplitFailureListener extends StatelessWidget {
       },
       child: child,
     );
+  }
+}
+
+class _ClipReverseResultListener extends StatelessWidget {
+  const _ClipReverseResultListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: (prev, curr) =>
+          !identical(prev.lastReverseResult, curr.lastReverseResult) &&
+          curr.lastReverseResult != null,
+      listener: _onReverseResult,
+      child: child,
+    );
+  }
+
+  void _onReverseResult(BuildContext context, ClipEditorState state) {
+    if (state.lastReverseResult case ClipReverseSuccess()) {
+      VideoEditorScope.of(context).requireEditor.setClipState(state.clips);
+    }
   }
 }
 
@@ -278,6 +314,46 @@ class _OverlayControls extends StatelessWidget {
         ),
         // Fallback
         _ => const VideoEditorMainOverlayActions(),
+      },
+    );
+  }
+}
+
+class _ReverseProgressOverlay extends StatelessWidget {
+  const _ReverseProgressOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<
+      ClipEditorBloc,
+      ClipEditorState,
+      ({bool isReversing, String? renderId})
+    >(
+      selector: (state) => (
+        isReversing: state.isReversing,
+        renderId: state.reversingClipId,
+      ),
+      builder: (context, reverseState) {
+        if (!reverseState.isReversing || reverseState.renderId == null) {
+          return const SizedBox.shrink();
+        }
+
+        return ColoredBox(
+          color: VineTheme.scrim65,
+          child: Center(
+            child: RepaintBoundary(
+              child: StreamBuilder<ProgressModel>(
+                stream: ProVideoEditor.instance.progressStreamById(
+                  reverseState.renderId!,
+                ),
+                builder: (context, snapshot) {
+                  final progress = snapshot.data?.progress ?? 0;
+                  return PartialCircleSpinner(progress: progress);
+                },
+              ),
+            ),
+          ),
+        );
       },
     );
   }

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -45,8 +45,10 @@ class VideoEditorScaffold extends StatelessWidget {
         resizeToAvoidBottomInset: false,
         floatingActionButton: const _AddElementFab(),
         body: _SplitFailureListener(
-          child: _AudioExtractionResultListener(
-            child: _ScaffoldBody(isLoading: isLoading),
+          child: _ClipReverseResultListener(
+            child: _AudioExtractionResultListener(
+              child: _ScaffoldBody(isLoading: isLoading),
+            ),
           ),
         ),
       ),
@@ -114,6 +116,58 @@ class _SplitFailureListener extends StatelessWidget {
       },
       child: child,
     );
+  }
+}
+
+/// Listens to [ClipEditorBloc.state.lastReverseResult] and surfaces a
+/// snackbar when a reverse-render operation fails or the clip has no local
+/// file. Success is handled by the canvas player-sync listener; this listener
+/// only covers the failure outcomes so they aren't silent to the user.
+///
+/// Kept at the scaffold level (always mounted) so the snackbar fires even
+/// if the timeline controls are hidden while the render is in flight.
+class _ClipReverseResultListener extends StatelessWidget {
+  const _ClipReverseResultListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: (prev, curr) =>
+          !identical(prev.lastReverseResult, curr.lastReverseResult) &&
+          curr.lastReverseResult != null,
+      listener: _onReverseResult,
+      child: child,
+    );
+  }
+
+  void _onReverseResult(BuildContext context, ClipEditorState state) {
+    final result = state.lastReverseResult;
+    if (result == null) return;
+
+    switch (result) {
+      case ClipReverseNoLocalFile():
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.videoEditorReverseNoLocalFile,
+          ),
+        );
+      case ClipReverseFailure():
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.videoEditorReverseFailed,
+          ),
+        );
+      case ClipReverseDiscarded():
+        // Source clip was removed during the async gap — there is no clip to
+        // attach the reversed render to and no user action that warrants a
+        // snackbar.
+        break;
+      case ClipReverseSuccess():
+        // Player sync is handled by the canvas listener; nothing to do here.
+        break;
+    }
   }
 }
 
@@ -319,6 +373,9 @@ class _ReverseProgressOverlay extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 spacing: 24,
                 children: [
+                  // Transient render progress is read straight from the
+                  // plugin stream (no service indirection) since it is purely
+                  // ephemeral UI feedback that never outlives this overlay.
                   StreamBuilder<ProgressModel>(
                     stream: ProVideoEditor.instance.progressStreamById(
                       reverseState.renderId!,

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -339,17 +339,31 @@ class _ReverseProgressOverlay extends StatelessWidget {
         }
 
         return ColoredBox(
-          color: VineTheme.scrim65,
+          color: VineTheme.backgroundColor.withAlpha(210),
           child: Center(
             child: RepaintBoundary(
-              child: StreamBuilder<ProgressModel>(
-                stream: ProVideoEditor.instance.progressStreamById(
-                  reverseState.renderId!,
-                ),
-                builder: (context, snapshot) {
-                  final progress = snapshot.data?.progress ?? 0;
-                  return PartialCircleSpinner(progress: progress);
-                },
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 24,
+                children: [
+                  StreamBuilder<ProgressModel>(
+                    stream: ProVideoEditor.instance.progressStreamById(
+                      reverseState.renderId!,
+                    ),
+                    builder: (context, snapshot) {
+                      final progress = snapshot.data?.progress ?? 0;
+                      return PartialCircleSpinner(progress: progress);
+                    },
+                  ),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 240),
+                    child: Text(
+                      context.l10n.videoEditorReverseProgressLabel,
+                      textAlign: TextAlign.center,
+                      style: VineTheme.bodyMediumFont(),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -7,7 +7,6 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
-import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
@@ -47,10 +46,8 @@ class VideoEditorScaffold extends StatelessWidget {
         resizeToAvoidBottomInset: false,
         floatingActionButton: const _AddElementFab(),
         body: _SplitFailureListener(
-          child: _ClipReverseResultListener(
-            child: _AudioExtractionResultListener(
-              child: _ScaffoldBody(isLoading: isLoading),
-            ),
+          child: _AudioExtractionResultListener(
+            child: _ScaffoldBody(isLoading: isLoading),
           ),
         ),
       ),
@@ -118,29 +115,6 @@ class _SplitFailureListener extends StatelessWidget {
       },
       child: child,
     );
-  }
-}
-
-class _ClipReverseResultListener extends StatelessWidget {
-  const _ClipReverseResultListener({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocListener<ClipEditorBloc, ClipEditorState>(
-      listenWhen: (prev, curr) =>
-          !identical(prev.lastReverseResult, curr.lastReverseResult) &&
-          curr.lastReverseResult != null,
-      listener: _onReverseResult,
-      child: child,
-    );
-  }
-
-  void _onReverseResult(BuildContext context, ClipEditorState state) {
-    if (state.lastReverseResult case ClipReverseSuccess()) {
-      VideoEditorScope.of(context).requireEditor.setClipState(state.clips);
-    }
   }
 }
 

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -19,8 +19,7 @@ import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_acti
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline.dart';
-import 'package:pro_video_editor/core/models/video/progress_model.dart';
-import 'package:pro_video_editor/core/platform/platform_interface.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 /// A scaffold widget that provides the standard layout for the video editor.
 ///

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1832,10 +1832,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: fb173de8e408103c72f75b1009131cc46a8721e08e4e00b18703e5aa1ebeb87f
+      sha256: "2f74363e49e0c94d42ac66639049b912a43962bf541550b29543ff6dc3051f5c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.5"
+    version: "1.17.6"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -70,7 +70,7 @@ workspace:
   - packages/unified_logger
   - packages/verifier_client
   - packages/video_event_cache
-  - packages/videos_repository 
+  - packages/videos_repository
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -298,7 +298,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: 1.17.6
+  pro_video_editor: ^1.17.6
   pro_image_editor: ^12.4.8
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -70,7 +70,7 @@ workspace:
   - packages/unified_logger
   - packages/verifier_client
   - packages/video_event_cache
-  - packages/videos_repository
+  - packages/videos_repository 
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -298,7 +298,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.17.5
+  pro_video_editor: 1.17.6
   pro_image_editor: ^12.4.8
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1397,16 +1397,6 @@ void main() {
                 '/reversed/clip-local_clip-local.mp4',
               )
               .having(
-                (s) => s.clips.first.trimStart,
-                'trimStart',
-                const Duration(milliseconds: 500),
-              )
-              .having(
-                (s) => s.clips.first.trimEnd,
-                'trimEnd',
-                const Duration(seconds: 1),
-              )
-              .having(
                 (s) => s.clips.first.duration,
                 'duration',
                 const Duration(seconds: 5),

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1414,6 +1414,94 @@ void main() {
         ],
       );
 
+      // Regression test: a duplicate/split of a reversed clip preserves
+      // `reversed: true` but clears both cache paths, so the fresh-render
+      // branch is reached with reversed input. The render output is forward
+      // content and must be cached as `forwardVideoPath`; the reversed input
+      // must be cached as `reversedVideoPath`. Mapping by output direction
+      // would invert both and make later cached toggles play the wrong way.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'caches forward/reversed paths in the correct direction when fresh '
+        'rendering a reversed clip with no cache (duplicate of reversed)',
+        build: () => buildBloc(reverseClip: _fakeReverseClip),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile().copyWith(
+              video: EditorVideo.file('/path/clip-local-reversed.mp4'),
+              reversed: true,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.isReversing,
+            'isReversing',
+            isTrue,
+          ),
+          isA<ClipEditorState>()
+              .having((s) => s.isReversing, 'isReversing', isFalse)
+              .having((s) => s.clips.first.reversed, 'reversed', isFalse)
+              .having(
+                (s) => s.clips.first.forwardVideoPath,
+                'forwardVideoPath',
+                '/reversed/clip-local_clip-local.mp4',
+              )
+              .having(
+                (s) => s.clips.first.reversedVideoPath,
+                'reversedVideoPath',
+                '/path/clip-local-reversed.mp4',
+              )
+              .having(
+                (s) => s.lastReverseResult,
+                'lastReverseResult',
+                isA<ClipReverseSuccess>(),
+              ),
+        ],
+        verify: (bloc) {
+          expect(
+            bloc.state.clips.first.video.file?.path,
+            equals('/reversed/clip-local_clip-local.mp4'),
+          );
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'emits failure result and reports unexpected errors when the reverse '
+        'render throws',
+        build: () => buildBloc(
+          reverseClip: ({required sourceClip, required renderId}) async {
+            throw StateError('reverse render failed');
+          },
+        ),
+        seed: () => ClipEditorState(clips: [_createClipWithFile()]),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.isReversing,
+            'isReversing',
+            isTrue,
+          ),
+          isA<ClipEditorState>()
+              .having((s) => s.isReversing, 'isReversing', isFalse)
+              .having((s) => s.reversingClipId, 'reversingClipId', isNull)
+              .having(
+                (s) => s.lastReverseResult,
+                'lastReverseResult',
+                isA<ClipReverseFailure>(),
+              ),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>()
+              .having((r) => r.unwrap(), 'unwrap', isA<StateError>())
+              .having((r) => r.context, 'context', '_onClipReverseRequested'),
+        ],
+      );
+
       test(
         'discards reverse result when source clip is removed in-flight',
         () async {

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1270,7 +1270,7 @@ void main() {
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(
-        'renders reversed clip, preserves trim bounds, and toggles reversed flag',
+        'renders reversed clip, swaps trim bounds, and toggles reversed flag',
         build: () => buildBloc(reverseClip: _fakeReverseClip),
         seed: () => ClipEditorState(clips: [_createClipWithFile()]),
         act: (bloc) => bloc.add(
@@ -1291,12 +1291,12 @@ void main() {
               .having(
                 (s) => s.clips.first.trimStart,
                 'trimStart',
-                const Duration(seconds: 1),
+                const Duration(milliseconds: 500),
               )
               .having(
                 (s) => s.clips.first.trimEnd,
                 'trimEnd',
-                const Duration(milliseconds: 500),
+                const Duration(seconds: 1),
               )
               .having(
                 (s) => s.clips.first.duration,
@@ -1371,7 +1371,7 @@ void main() {
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(
-        'reuses cached reversed clip without calling reverse service again',
+        'reuses cached reversed clip and swaps trim bounds',
         build: () => buildBloc(
           reverseClip: ({required sourceClip, required renderId}) async {
             throw StateError('reverse service should not be called');
@@ -1395,6 +1395,16 @@ void main() {
                 (s) => s.clips.first.video.file?.path,
                 'videoPath',
                 '/reversed/clip-local_clip-local.mp4',
+              )
+              .having(
+                (s) => s.clips.first.trimStart,
+                'trimStart',
+                const Duration(milliseconds: 500),
+              )
+              .having(
+                (s) => s.clips.first.trimEnd,
+                'trimEnd',
+                const Duration(seconds: 1),
               )
               .having(
                 (s) => s.clips.first.duration,

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -166,6 +166,13 @@ Future<void> _fakeSplitClipThenFail({
   throw StateError('render failed');
 }
 
+Future<EditorVideo> _fakeReverseClip({
+  required DivineVideoClip sourceClip,
+  required String renderId,
+}) async {
+  return EditorVideo.file('/reversed/${sourceClip.id}_$renderId.mp4');
+}
+
 void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
@@ -197,11 +204,13 @@ void main() {
     ClipEditorBloc buildBloc({
       AudioExtractionService? audioExtractionService,
       SplitClipFn? splitClip,
+      ReverseClipFn? reverseClip,
     }) {
       return ClipEditorBloc(
         onFinalClipInvalidated: () {},
         audioExtractionService: audioExtractionService,
         splitClip: splitClip,
+        reverseClip: reverseClip,
       );
     }
 
@@ -212,6 +221,7 @@ void main() {
       expect(bloc.state.splitPosition, equals(Duration.zero));
       expect(bloc.state.isEditing, isFalse);
       expect(bloc.state.isTrimDragging, isFalse);
+      expect(bloc.state.isReversing, isFalse);
       expect(bloc.state.totalDuration, equals(Duration.zero));
       bloc.close();
     });
@@ -1242,6 +1252,202 @@ void main() {
       );
     });
 
+    group('ClipEditorClipReverseRequested', () {
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'emits no-local-file result when clip has no local file',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: [_createClipNoFile()]),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-no-file'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.lastReverseResult,
+            'lastReverseResult',
+            isA<ClipReverseNoLocalFile>(),
+          ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'renders reversed clip, preserves trim bounds, and toggles reversed flag',
+        build: () => buildBloc(reverseClip: _fakeReverseClip),
+        seed: () => ClipEditorState(clips: [_createClipWithFile()]),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.isReversing, 'isReversing', isTrue)
+              .having(
+                (s) => s.reversingClipId,
+                'reversingClipId',
+                'clip-local',
+              ),
+          isA<ClipEditorState>()
+              .having((s) => s.isReversing, 'isReversing', isFalse)
+              .having((s) => s.reversingClipId, 'reversingClipId', isNull)
+              .having((s) => s.clips.first.reversed, 'reversed', isTrue)
+              .having(
+                (s) => s.clips.first.trimStart,
+                'trimStart',
+                const Duration(seconds: 1),
+              )
+              .having(
+                (s) => s.clips.first.trimEnd,
+                'trimEnd',
+                const Duration(milliseconds: 500),
+              )
+              .having(
+                (s) => s.clips.first.duration,
+                'duration',
+                const Duration(seconds: 5),
+              )
+              .having(
+                (s) => s.clips.first.forwardVideoPath,
+                'forwardVideoPath',
+                '/path/clip-local.mp4',
+              )
+              .having(
+                (s) => s.clips.first.reversedVideoPath,
+                'reversedVideoPath',
+                '/reversed/clip-local_clip-local.mp4',
+              )
+              .having(
+                (s) => s.lastReverseResult,
+                'lastReverseResult',
+                isA<ClipReverseSuccess>(),
+              ),
+        ],
+        verify: (bloc) {
+          expect(
+            bloc.state.clips.first.video.file?.path,
+            equals('/reversed/clip-local_clip-local.mp4'),
+          );
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'restores cached forward clip without calling reverse service',
+        build: () => buildBloc(
+          reverseClip: ({required sourceClip, required renderId}) async {
+            throw StateError('reverse service should not be called');
+          },
+        ),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile().copyWith(
+              video: EditorVideo.file('/reversed/clip-local_clip-local.mp4'),
+              trimStart: const Duration(milliseconds: 500),
+              trimEnd: const Duration(seconds: 1),
+              reversed: true,
+              forwardVideoPath: '/path/clip-local.mp4',
+              reversedVideoPath: '/reversed/clip-local_clip-local.mp4',
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.clips.first.reversed, 'reversed', isFalse)
+              .having(
+                (s) => s.clips.first.video.file?.path,
+                'videoPath',
+                '/path/clip-local.mp4',
+              )
+              .having(
+                (s) => s.clips.first.trimStart,
+                'trimStart',
+                const Duration(seconds: 1),
+              )
+              .having(
+                (s) => s.clips.first.trimEnd,
+                'trimEnd',
+                const Duration(milliseconds: 500),
+              ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'reuses cached reversed clip without calling reverse service again',
+        build: () => buildBloc(
+          reverseClip: ({required sourceClip, required renderId}) async {
+            throw StateError('reverse service should not be called');
+          },
+        ),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile().copyWith(
+              forwardVideoPath: '/path/clip-local.mp4',
+              reversedVideoPath: '/reversed/clip-local_clip-local.mp4',
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.clips.first.reversed, 'reversed', isTrue)
+              .having(
+                (s) => s.clips.first.video.file?.path,
+                'videoPath',
+                '/reversed/clip-local_clip-local.mp4',
+              )
+              .having(
+                (s) => s.clips.first.trimStart,
+                'trimStart',
+                const Duration(milliseconds: 500),
+              )
+              .having(
+                (s) => s.clips.first.trimEnd,
+                'trimEnd',
+                const Duration(seconds: 1),
+              )
+              .having(
+                (s) => s.clips.first.duration,
+                'duration',
+                const Duration(seconds: 5),
+              ),
+        ],
+      );
+
+      test(
+        'discards reverse result when source clip is removed in-flight',
+        () async {
+          final completer = Completer<EditorVideo>();
+          final clip = _createClipWithFile();
+          final bloc = buildBloc(
+            reverseClip: ({required sourceClip, required renderId}) =>
+                completer.future,
+          );
+
+          bloc.add(ClipEditorInitialized([clip]));
+          await Future<void>.delayed(Duration.zero);
+
+          bloc.add(const ClipEditorClipReverseRequested(clipId: 'clip-local'));
+          await Future<void>.delayed(Duration.zero);
+          expect(bloc.state.isReversing, isTrue);
+
+          bloc.add(const ClipEditorClipRemoved('clip-local'));
+          await Future<void>.delayed(Duration.zero);
+          expect(bloc.state.clips, isEmpty);
+
+          completer.complete(EditorVideo.file('/reversed/discarded.mp4'));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(bloc.state.isReversing, isFalse);
+          expect(bloc.state.reversingClipId, isNull);
+          expect(bloc.state.clips, isEmpty);
+          expect(bloc.state.lastReverseResult, isA<ClipReverseDiscarded>());
+
+          await bloc.close();
+        },
+      );
+    });
+
     // =========================================================
     // EVENT EQUALITY
     // =========================================================
@@ -1273,6 +1479,13 @@ void main() {
         expect(
           const ClipEditorSplitPositionChanged(Duration(seconds: 1)),
           equals(const ClipEditorSplitPositionChanged(Duration(seconds: 1))),
+        );
+      });
+
+      test('$ClipEditorClipReverseRequested with same id are equal', () {
+        expect(
+          const ClipEditorClipReverseRequested(clipId: 'x'),
+          equals(const ClipEditorClipReverseRequested(clipId: 'x')),
         );
       });
 

--- a/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
@@ -1,0 +1,235 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_reverse_service.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+class _FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProviderPlatform({required this.documentsPath});
+
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationCachePath() async {
+    return path.join(path.dirname(documentsPath), 'cache');
+  }
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return documentsPath;
+  }
+}
+
+class _FakeProVideoEditor extends ProVideoEditor {
+  final canceledTaskIds = <String>[];
+  final renderedPaths = <String>[];
+  final renderedData = <VideoRenderData>[];
+  final outputExistedWhenRenderStarted = <bool>[];
+
+  bool cancelShouldThrow = false;
+  bool renderShouldThrow = false;
+  bool createPartialOutputBeforeThrow = false;
+
+  @override
+  void initializeStream() {}
+
+  @override
+  Future<void> cancel(String taskId) async {
+    canceledTaskIds.add(taskId);
+    if (cancelShouldThrow) {
+      throw ArgumentError('unknown task');
+    }
+  }
+
+  @override
+  Future<String> renderVideoToFile(
+    String filePath,
+    VideoRenderData value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    outputExistedWhenRenderStarted.add(File(filePath).existsSync());
+    renderedPaths.add(filePath);
+    renderedData.add(value);
+
+    if (renderShouldThrow) {
+      if (createPartialOutputBeforeThrow) {
+        await File(filePath).writeAsString('partial reverse render');
+      }
+      throw Exception('reverse render failed');
+    }
+
+    return filePath;
+  }
+}
+
+@Tags(['skip_very_good_optimization'])
+void main() {
+  late Directory tempDir;
+  late String documentsPath;
+  late PathProviderPlatform originalPathProvider;
+  late ProVideoEditor originalProVideoEditor;
+  late _FakeProVideoEditor proVideoEditor;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    originalPathProvider = PathProviderPlatform.instance;
+    originalProVideoEditor = ProVideoEditor.instance;
+
+    tempDir = await Directory.systemTemp.createTemp(
+      'video_editor_reverse_service_test_',
+    );
+    documentsPath = path.join(tempDir.path, 'documents');
+    await Directory(documentsPath).create(recursive: true);
+
+    PathProviderPlatform.instance = _FakePathProviderPlatform(
+      documentsPath: documentsPath,
+    );
+    proVideoEditor = _FakeProVideoEditor();
+    ProVideoEditor.instance = proVideoEditor;
+  });
+
+  tearDown(() async {
+    PathProviderPlatform.instance = originalPathProvider;
+    ProVideoEditor.instance = originalProVideoEditor;
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('VideoEditorReverseService', () {
+    test('renders the source clip as a reversed video segment', () async {
+      final inputPath = path.join(tempDir.path, 'source.mp4');
+      final sourceClip = _clip(id: 'clip-1', inputPath: inputPath);
+
+      final result = await VideoEditorReverseService.reverseClip(
+        sourceClip: sourceClip,
+        renderId: 'reverse-render-1',
+      );
+
+      final expectedOutputPath = path.join(
+        documentsPath,
+        'clip-1_reversed.mp4',
+      );
+      expect(result.file?.path, expectedOutputPath);
+      expect(proVideoEditor.canceledTaskIds, ['reverse-render-1']);
+      expect(proVideoEditor.renderedPaths, [expectedOutputPath]);
+
+      final renderData = proVideoEditor.renderedData.single;
+      expect(renderData.id, 'reverse-render-1');
+      expect(renderData.videoSegments, hasLength(1));
+
+      final segment = renderData.videoSegments!.single;
+      expect(segment.reverseVideo, isTrue);
+      expect(segment.startTime, isNull);
+      expect(segment.endTime, isNull);
+      expect(await segment.video.safeFilePath(), inputPath);
+    });
+
+    test(
+      'continues rendering when there is no active render to cancel',
+      () async {
+        proVideoEditor.cancelShouldThrow = true;
+        final sourceClip = _clip(
+          id: 'clip-cancel-miss',
+          inputPath: path.join(tempDir.path, 'source.mp4'),
+        );
+
+        await VideoEditorReverseService.reverseClip(
+          sourceClip: sourceClip,
+          renderId: 'reverse-render-missing',
+        );
+
+        expect(proVideoEditor.canceledTaskIds, ['reverse-render-missing']);
+        expect(proVideoEditor.renderedData, hasLength(1));
+      },
+    );
+
+    test('deletes stale output before starting a new reverse render', () async {
+      final sourceClip = _clip(
+        id: 'clip-stale-output',
+        inputPath: path.join(tempDir.path, 'source.mp4'),
+      );
+      final outputPath = path.join(
+        documentsPath,
+        'clip-stale-output_reversed.mp4',
+      );
+      await File(outputPath).writeAsString('old reverse render');
+
+      await VideoEditorReverseService.reverseClip(
+        sourceClip: sourceClip,
+        renderId: 'reverse-render-stale',
+      );
+
+      expect(proVideoEditor.outputExistedWhenRenderStarted, [isFalse]);
+    });
+
+    test('does not delete the source video when input equals output', () async {
+      final collidingPath = path.join(
+        documentsPath,
+        'clip-reversed_reversed.mp4',
+      );
+      await File(collidingPath).writeAsString('source video');
+      final sourceClip = _clip(
+        id: 'clip-reversed',
+        inputPath: collidingPath,
+      );
+
+      await expectLater(
+        () => VideoEditorReverseService.reverseClip(
+          sourceClip: sourceClip,
+          renderId: 'reverse-render-collision',
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(await File(collidingPath).readAsString(), 'source video');
+      expect(proVideoEditor.canceledTaskIds, isEmpty);
+      expect(proVideoEditor.renderedData, isEmpty);
+    });
+
+    test('deletes partial output when rendering fails', () async {
+      proVideoEditor
+        ..renderShouldThrow = true
+        ..createPartialOutputBeforeThrow = true;
+      final sourceClip = _clip(
+        id: 'clip-partial-output',
+        inputPath: path.join(tempDir.path, 'source.mp4'),
+      );
+      final outputPath = path.join(
+        documentsPath,
+        'clip-partial-output_reversed.mp4',
+      );
+
+      await expectLater(
+        () => VideoEditorReverseService.reverseClip(
+          sourceClip: sourceClip,
+          renderId: 'reverse-render-failure',
+        ),
+        throwsException,
+      );
+
+      expect(File(outputPath).existsSync(), isFalse);
+    });
+  });
+}
+
+DivineVideoClip _clip({
+  required String id,
+  required String inputPath,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file(inputPath),
+    duration: const Duration(seconds: 6),
+    recordedAt: DateTime(2026, 6, 10, 12),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+  );
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart' as model;
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -80,7 +80,7 @@ void main() {
             DivineVideoClip(
               id: 'clip-1',
               video: EditorVideo.file('/tmp/clip-1.mp4'),
-              duration: Duration(seconds: 3),
+              duration: const Duration(seconds: 3),
               recordedAt: DateTime(2025),
               targetAspectRatio: model.AspectRatio.vertical,
               originalAspectRatio: 9 / 16,

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -7,11 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
     implements ClipEditorBloc {}
@@ -66,6 +69,40 @@ void main() {
 
       verify(() => bloc.add(const ClipEditorEditingStopped())).called(1);
     });
+
+    testWidgets(
+      'dispatches ClipEditorClipReverseRequested when reverse pressed',
+      (
+        tester,
+      ) async {
+        final state = ClipEditorState(
+          clips: [
+            DivineVideoClip(
+              id: 'clip-1',
+              video: EditorVideo.file('/tmp/clip-1.mp4'),
+              duration: Duration(seconds: 3),
+              recordedAt: DateTime(2025),
+              targetAspectRatio: model.AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+        );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        when(() => bloc.state).thenReturn(state);
+
+        await tester.pumpWidget(build());
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoEditorReverseClipSemanticLabel),
+        );
+        await tester.pump();
+
+        verify(
+          () =>
+              bloc.add(const ClipEditorClipReverseRequested(clipId: 'clip-1')),
+        ).called(1);
+      },
+    );
 
     // Regression test for Fix 2: Done button is disabled while audio
     // extraction is running so the user cannot dismiss the busy state

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies loading UI and FAB visibility rules.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -123,6 +124,32 @@ void main() {
 
       expect(find.bySemanticsLabel('Add element'), findsNothing);
     });
+
+    testWidgets(
+      'shows reverse progress overlay while clip reverse is running',
+      (
+        tester,
+      ) async {
+        final clipBloc = _MockClipEditorBloc();
+        const reversingState = ClipEditorState(
+          isReversing: true,
+          reversingClipId: 'clip-1',
+        );
+
+        when(() => clipBloc.state).thenReturn(reversingState);
+        whenListen(
+          clipBloc,
+          const Stream<ClipEditorState>.empty(),
+          initialState: reversingState,
+        );
+
+        await tester.pumpWidget(
+          buildWidget(isLoading: false, clipBlocOverride: clipBloc),
+        );
+
+        expect(find.byType(PartialCircleSpinner), findsOneWidget);
+      },
+    );
 
     testWidgets(
       'writes history on extraction success even when handled above clip controls',

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -221,6 +221,79 @@ void main() {
       },
     );
 
+    testWidgets('shows a snackbar when a clip reverse render fails', (
+      tester,
+    ) async {
+      final clipBloc = _MockClipEditorBloc();
+      final failureState = ClipEditorState(
+        lastReverseResult: ClipReverseFailure(),
+      );
+
+      when(() => clipBloc.state).thenReturn(const ClipEditorState());
+      whenListen(
+        clipBloc,
+        Stream<ClipEditorState>.fromIterable([failureState]),
+        initialState: const ClipEditorState(),
+      );
+
+      await tester.pumpWidget(
+        buildWidget(isLoading: true, clipBlocOverride: clipBloc),
+      );
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.videoEditorReverseFailed), findsOneWidget);
+    });
+
+    testWidgets(
+      'shows a snackbar when a clip reverse has no local file',
+      (tester) async {
+        final clipBloc = _MockClipEditorBloc();
+        final noFileState = ClipEditorState(
+          lastReverseResult: ClipReverseNoLocalFile(),
+        );
+
+        when(() => clipBloc.state).thenReturn(const ClipEditorState());
+        whenListen(
+          clipBloc,
+          Stream<ClipEditorState>.fromIterable([noFileState]),
+          initialState: const ClipEditorState(),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(isLoading: true, clipBlocOverride: clipBloc),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.videoEditorReverseNoLocalFile), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'ignores discarded reverse results without a snackbar',
+      (tester) async {
+        final clipBloc = _MockClipEditorBloc();
+        final discardedState = ClipEditorState(
+          lastReverseResult: ClipReverseDiscarded(),
+        );
+
+        when(() => clipBloc.state).thenReturn(const ClipEditorState());
+        whenListen(
+          clipBloc,
+          Stream<ClipEditorState>.fromIterable([discardedState]),
+          initialState: const ClipEditorState(),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(isLoading: true, clipBlocOverride: clipBloc),
+        );
+        await tester.pump();
+
+        expect(find.byType(SnackBar), findsNothing);
+      },
+    );
+
     testWidgets(
       'ignores discarded extraction results without snackbar or history write',
       (tester) async {


### PR DESCRIPTION
## Description

Adds a reverse-playback feature for individual clips in the video editor. Users
can toggle a clip between forward and reversed playback; the editor caches both
variants so toggling back is instant.

### Why we pre-render instead of playing backwards live

Mobile video players (`video_player`, ExoPlayer, AVPlayer) cannot reliably play
arbitrary encoded video backwards. H.264/HEVC are forward-oriented codecs built
on keyframes plus forward-predicted deltas, so reverse playback would require
seeking keyframe-by-keyframe and decoding each GOP in reverse.

To get a smooth, deterministic result we render a reversed copy of the clip's
source file via `pro_video_editor` once, cache it, and swap the player source.
That gives us frame-accurate reverse playback that behaves consistently across
iOS, Android, and the web preview.

### Behaviour notes

- Trim bounds are swapped symmetrically when toggling direction, so a
  forward -> reversed -> forward roundtrip restores the original trim.
- The bloc handler uses the `droppable()` transformer so rapid toggles cannot
  stack overlapping render jobs.
- Cached reversed/forward sources are reused on subsequent toggles, so there is
  no re-render after the first pass.
- A defensive guard in the reverse service refuses to render when the input path
  equals the output path.
- Reverse failures and missing-local-file cases surface a scaffold-level
  snackbar; removed-in-flight results are intentionally discarded.
- Reverse-related strings are localized across the supported locales.

**Related Issue:** Closes #4693

## Verification

- `mise exec -- flutter test test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart test/services/video_editor/video_editor_reverse_service_test.dart test/widgets/video_editor/video_editor_scaffold_test.dart test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart test/widgets/video_editor/main_editor/video_editor_canvas_test.dart`
- `mise exec -- flutter analyze lib/blocs/video_editor lib/services/video_editor lib/widgets/video_editor lib/models/divine_video_clip.dart test/blocs/video_editor test/services/video_editor test/widgets/video_editor`
- Pre-push hook on the rebased branch: analyzer clean and changed-file tests passed.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
