### PR TITLE
fix(engagement): pre-fetch profiles on who-liked/reposted list load

### DIFF
--- a/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
+++ b/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
@@ -6,6 +6,8 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
+import 'package:models/models.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
 part 'video_engagement_event.dart';
@@ -16,6 +18,13 @@ part 'video_engagement_state.dart';
 /// Reads the relevant fetch method on [LikesRepository] /
 /// [RepostsRepository] based on [type], and emits the resulting pubkey
 /// list to the UI.
+///
+/// After fetching pubkeys, calls [ProfileRepository.fetchBatchProfiles] with a
+/// 2-second timeout to pre-warm the local Drift cache before the UI renders.
+/// This ensures [UserProfileTile] widgets can immediately display real names
+/// instead of the generated fallback placeholder. The timeout is best-effort —
+/// a failure or timeout does not block the list from appearing; per-tile
+/// [userProfileReactiveProvider] fetches serve as the fallback.
 class VideoEngagementBloc
     extends Bloc<VideoEngagementEvent, VideoEngagementState> {
   VideoEngagementBloc({
@@ -24,8 +33,10 @@ class VideoEngagementBloc
     required LikesRepository likesRepository,
     required RepostsRepository repostsRepository,
     this.addressableId,
+    ProfileRepository? profileRepository,
   }) : _likesRepository = likesRepository,
        _repostsRepository = repostsRepository,
+       _profileRepository = profileRepository,
        super(VideoEngagementState(type: type)) {
     on<VideoEngagementLoadRequested>(
       _onLoadRequested,
@@ -45,6 +56,13 @@ class VideoEngagementBloc
   final LikesRepository _likesRepository;
   final RepostsRepository _repostsRepository;
 
+  /// Optional — omitted only in tests that don't exercise profile hydration.
+  /// When present, profiles for the returned pubkeys are batch-fetched into
+  /// the local cache before the success state is emitted.
+  final ProfileRepository? _profileRepository;
+
+  static const _profilePrefetchTimeout = Duration(seconds: 2);
+
   Future<void> _onLoadRequested(
     VideoEngagementLoadRequested event,
     Emitter<VideoEngagementState> emit,
@@ -52,6 +70,17 @@ class VideoEngagementBloc
     emit(state.copyWith(status: VideoEngagementStatus.loading));
     try {
       final pubkeys = await _fetch();
+
+      // Pre-warm the profile cache so UserProfileTile widgets render real
+      // names immediately. Errors (including TimeoutException) are swallowed
+      // — the per-tile userProfileReactiveProvider fetch acts as fallback.
+      if (pubkeys.isNotEmpty) {
+        await _profileRepository
+            ?.fetchBatchProfiles(pubkeys: pubkeys)
+            .timeout(_profilePrefetchTimeout)
+            .catchError((_) => <String, UserProfile>{});
+      }
+
       emit(
         state.copyWith(
           status: VideoEngagementStatus.success,

--- a/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
+++ b/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
@@ -21,10 +21,10 @@ part 'video_engagement_state.dart';
 ///
 /// After fetching pubkeys, calls [ProfileRepository.fetchBatchProfiles] with a
 /// 2-second timeout to pre-warm the local Drift cache before the UI renders.
-/// This ensures [UserProfileTile] widgets can immediately display real names
-/// instead of the generated fallback placeholder. The timeout is best-effort —
-/// a failure or timeout does not block the list from appearing; per-tile
-/// [userProfileReactiveProvider] fetches serve as the fallback.
+/// This holds the loading state for up to 2 seconds so [UserProfileTile]
+/// widgets can display real names on first paint instead of the generated
+/// fallback placeholder. On timeout or error the list is still emitted as
+/// success — per-tile [userProfileReactiveProvider] fetches serve as fallback.
 class VideoEngagementBloc
     extends Bloc<VideoEngagementEvent, VideoEngagementState> {
   VideoEngagementBloc({
@@ -32,8 +32,8 @@ class VideoEngagementBloc
     required this.type,
     required LikesRepository likesRepository,
     required RepostsRepository repostsRepository,
+    required ProfileRepository? profileRepository,
     this.addressableId,
-    ProfileRepository? profileRepository,
   }) : _likesRepository = likesRepository,
        _repostsRepository = repostsRepository,
        _profileRepository = profileRepository,
@@ -56,9 +56,9 @@ class VideoEngagementBloc
   final LikesRepository _likesRepository;
   final RepostsRepository _repostsRepository;
 
-  /// Optional — omitted only in tests that don't exercise profile hydration.
-  /// When present, profiles for the returned pubkeys are batch-fetched into
-  /// the local cache before the success state is emitted.
+  /// Nullable because [profileRepositoryProvider] legitimately returns `null`
+  /// before authentication. When non-null, profiles for the returned pubkeys
+  /// are batch-fetched into the local cache before the success state is emitted.
   final ProfileRepository? _profileRepository;
 
   static const _profilePrefetchTimeout = Duration(seconds: 2);
@@ -72,8 +72,10 @@ class VideoEngagementBloc
       final pubkeys = await _fetch();
 
       // Pre-warm the profile cache so UserProfileTile widgets render real
-      // names immediately. Errors (including TimeoutException) are swallowed
-      // — the per-tile userProfileReactiveProvider fetch acts as fallback.
+      // names on first paint. This awaits the batch fetch (bounded to
+      // _profilePrefetchTimeout = 2 s), so the loading state is held for up
+      // to that duration. On timeout or error the list still appears — the
+      // per-tile userProfileReactiveProvider fetch acts as fallback.
       if (pubkeys.isNotEmpty) {
         await _profileRepository
             ?.fetchBatchProfiles(pubkeys: pubkeys)

--- a/mobile/lib/screens/video_engagement/video_engagement_list_screen.dart
+++ b/mobile/lib/screens/video_engagement/video_engagement_list_screen.dart
@@ -61,7 +61,14 @@ class VideoEngagementListScreen extends ConsumerWidget {
 
     return BlocProvider<VideoEngagementBloc>(
       key: ValueKey(
-        (likesRepository, repostsRepository, profileRepository, eventId, type),
+        (
+          likesRepository,
+          repostsRepository,
+          profileRepository,
+          eventId,
+          type,
+          addressableId,
+        ),
       ),
       create: (_) => VideoEngagementBloc(
         eventId: eventId,

--- a/mobile/lib/screens/video_engagement/video_engagement_list_screen.dart
+++ b/mobile/lib/screens/video_engagement/video_engagement_list_screen.dart
@@ -57,14 +57,18 @@ class VideoEngagementListScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final likesRepository = ref.watch(likesRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
+    final profileRepository = ref.watch(profileRepositoryProvider);
 
     return BlocProvider<VideoEngagementBloc>(
-      key: ValueKey((likesRepository, repostsRepository, eventId, type)),
+      key: ValueKey(
+        (likesRepository, repostsRepository, profileRepository, eventId, type),
+      ),
       create: (_) => VideoEngagementBloc(
         eventId: eventId,
         type: type,
         likesRepository: likesRepository,
         repostsRepository: repostsRepository,
+        profileRepository: profileRepository,
         addressableId: addressableId,
       )..add(const VideoEngagementLoadRequested()),
       child: const VideoEngagementListView(),

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -377,7 +377,10 @@ class NotificationRepository {
       row.timestamp * 1000,
       isUtc: true,
     ).toLocal();
-    final actor = ActorInfo(pubkey: row.fromPubkey, displayName: 'Loading…');
+    final actor = ActorInfo(
+      pubkey: row.fromPubkey,
+      displayName: UserProfile.defaultDisplayNameFor(row.fromPubkey),
+    );
 
     // Video-anchored kinds — reconstruct VideoNotification using the cached
     // targetEventId (which `_itemToCacheRow` writes as videoEventId).

--- a/mobile/test/blocs/video_engagement/video_engagement_bloc_test.dart
+++ b/mobile/test/blocs/video_engagement/video_engagement_bloc_test.dart
@@ -1,20 +1,26 @@
 // ABOUTME: Tests for VideoEngagementBloc — likers / reposters list loading.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
 class _MockRepostsRepository extends Mock implements RepostsRepository {}
 
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
 void main() {
   group(VideoEngagementBloc, () {
     late _MockLikesRepository likesRepository;
     late _MockRepostsRepository repostsRepository;
+    late _MockProfileRepository profileRepository;
 
     const testEventId = 'event-id-1';
     const testAddressableId = '34236:authorpubkey:dtag';
@@ -25,6 +31,14 @@ void main() {
     setUp(() {
       likesRepository = _MockLikesRepository();
       repostsRepository = _MockRepostsRepository();
+      profileRepository = _MockProfileRepository();
+
+      // Default stub — batch fetch returns empty map (cache miss is fine).
+      when(
+        () => profileRepository.fetchBatchProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => {});
     });
 
     VideoEngagementBloc createBloc({
@@ -35,6 +49,7 @@ void main() {
       type: type,
       likesRepository: likesRepository,
       repostsRepository: repostsRepository,
+      profileRepository: profileRepository,
       addressableId: addressableId,
     );
 
@@ -181,6 +196,64 @@ void main() {
           ),
         ],
         errors: () => [isA<FetchRepostersFailedException>()],
+      );
+    });
+
+    group('profile batch prefetch', () {
+      blocTest<VideoEngagementBloc, VideoEngagementState>(
+        'calls fetchBatchProfiles with likers pubkeys after successful fetch',
+        setUp: () {
+          when(
+            () => likesRepository.fetchEventLikers(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => const [liker1, liker2]);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const VideoEngagementLoadRequested()),
+        verify: (_) {
+          verify(
+            () => profileRepository.fetchBatchProfiles(
+              pubkeys: [liker1, liker2],
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoEngagementBloc, VideoEngagementState>(
+        'emits success even when fetchBatchProfiles times out',
+        setUp: () {
+          when(
+            () => likesRepository.fetchEventLikers(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => const [liker1]);
+          // Simulate the TimeoutException that .timeout(2s) throws when the
+          // profile fetch exceeds the deadline. The catchError in the bloc must
+          // swallow it so success is still emitted.
+          when(
+            () => profileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer(
+            (_) => Future.error(TimeoutException('profile prefetch timed out')),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const VideoEngagementLoadRequested()),
+        expect: () => [
+          const VideoEngagementState(
+            type: VideoEngagementType.likers,
+            status: VideoEngagementStatus.loading,
+          ),
+          const VideoEngagementState(
+            type: VideoEngagementType.likers,
+            status: VideoEngagementStatus.success,
+            pubkeys: [liker1],
+          ),
+        ],
       );
     });
 

--- a/mobile/test/screens/video_engagement/video_engagement_list_screen_test.dart
+++ b/mobile/test/screens/video_engagement/video_engagement_list_screen_test.dart
@@ -192,6 +192,7 @@ void main() {
                 type: VideoEngagementType.likers,
                 likesRepository: likesRepository,
                 repostsRepository: repostsRepository,
+                profileRepository: null,
               ),
               child: const VideoEngagementListView(),
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
VideoEngagementBloc now batch-fetches Kind 0 profiles (2s timeout, best-effort) immediately after resolving likers/reposters pubkeys. This pre-warms the Drift cache so UserProfileTile widgets render real names on first paint instead of generated placeholder names.

Also replaces the hardcoded English 'Loading\u2026' string used for cold-start notification placeholders with UserProfile.defaultDisplayNameFor, keeping fallbacks consistent across the codebase and locale-safe.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4016

<!--- Note any intentionally excluded follow-up work or confirm "None". -->


<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
