### PR TITLE
refactor(notifications): remove legacy bare-string payload fallback

### DIFF
--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -507,14 +507,14 @@ class NotificationService {
           ),
         );
       }
-    } catch (_) {
-      // Legacy payloads were bare event IDs (plain strings, not JSON).
-      // Treat the whole payload as a referencedEventId with unknown type.
-      // TODO(#4329): Remove this fallback once all clients have been emitting
-      // JSON payloads (referencedEventId + notificationType) for at least one
-      // full app-store release cycle and telemetry confirms this path is
-      // never reached. See issue for the full removal plan.
-      _emitNotificationTap(NotificationTapEvent(referencedEventId: payload));
+    } catch (e) {
+      // Malformed payload (non-JSON, non-object, or unexpected shape).
+      // Log a warning and discard — do not propagate to the Flutter error path.
+      Log.warning(
+        'Notification tap payload could not be parsed, ignoring: $e',
+        name: 'NotificationService',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -282,19 +282,61 @@ void main() {
       expect(events.single.notificationType, isNull);
     });
 
-    test('handles legacy bare event-ID payload (non-JSON)', () async {
+    test('does not emit and does not throw on non-JSON payload', () async {
       final events = <NotificationTapEvent>[];
       final sub = service.notificationTapStream.listen(events.add);
       addTearDown(sub.cancel);
 
-      service.handleNotificationTapPayload('legacyEventId999');
+      expect(
+        () => service.handleNotificationTapPayload('not-json-at-all'),
+        returnsNormally,
+      );
 
       await Future<void>.delayed(Duration.zero);
 
-      expect(events, hasLength(1));
-      expect(events.single.referencedEventId, equals('legacyEventId999'));
-      expect(events.single.notificationType, isNull);
+      expect(events, isEmpty);
     });
+
+    test(
+      'does not emit and does not throw when JSON is not an object',
+      () async {
+        final events = <NotificationTapEvent>[];
+        final sub = service.notificationTapStream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        // A JSON array is valid JSON but not a Map<String, dynamic>.
+        expect(
+          () => service.handleNotificationTapPayload('[1,2,3]'),
+          returnsNormally,
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(events, isEmpty);
+      },
+    );
+
+    test(
+      'does not emit and does not throw when referencedEventId is not a string',
+      () async {
+        final events = <NotificationTapEvent>[];
+        final sub = service.notificationTapStream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        // referencedEventId is a number, not a String — field() returns null,
+        // and the emit guard should suppress without throwing.
+        expect(
+          () => service.handleNotificationTapPayload(
+            jsonEncode({'referencedEventId': 12345}),
+          ),
+          returnsNormally,
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(events, isEmpty);
+      },
+    );
 
     test('does not emit when payload is null', () async {
       final events = <NotificationTapEvent>[];


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
The catch block in _handleNotificationTapPayload that handled pre-JSON bare event-ID payloads has been dormant since all notification clients switched to emitting JSON with referencedEventId + notificationType.

Removes the catch(_) block and its corresponding test.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #4329 

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
