### PR TITLE
test(notifications): stabilize flaky large-text overflow tests on CI (#4719)

### DIFF
--- a/mobile/test/notifications/widgets/actor_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/actor_notification_row_test.dart
@@ -48,6 +48,12 @@ Future<void> _pump(
   Locale? locale,
   double textScaleFactor = 1,
 }) async {
+  // Pin a tall, deterministic surface: the 2× stacked layout needs the
+  // vertical room production's scrollable list gives it, and pinning makes
+  // the file immune to surface-size leaks under the shared-isolate CI run
+  // (`very_good test --optimization`). Reset after each test. See #4719.
+  await tester.binding.setSurfaceSize(const Size(420, 1200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(
     MaterialApp(
       locale: locale,
@@ -355,7 +361,7 @@ void main() {
           ),
           textScaleFactor: 2,
         );
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);
       });

--- a/mobile/test/notifications/widgets/video_notification_row_test.dart
+++ b/mobile/test/notifications/widgets/video_notification_row_test.dart
@@ -64,6 +64,12 @@ Future<void> _pump(
   Locale? locale,
   double textScaleFactor = 1,
 }) async {
+  // Pin a tall, deterministic surface: the 2× stacked layout needs the
+  // vertical room production's scrollable list gives it, and pinning makes
+  // the file immune to surface-size leaks under the shared-isolate CI run
+  // (`very_good test --optimization`). Reset after each test. See #4719.
+  await tester.binding.setSurfaceSize(const Size(420, 1200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(
     MaterialApp(
       locale: locale,
@@ -340,7 +346,7 @@ void main() {
           ),
           textScaleFactor: 2,
         );
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);
       });


### PR DESCRIPTION
## Summary

Fixes #4719.

`test/notifications/widgets/video_notification_row_test.dart` →
**`VideoNotificationRow interactions does not overflow at large text sizes`**
was failing ~50–60% of Linux CI runs while passing 18/18 in isolation on
macOS — a silent tax on unrelated PRs (any branch whose CI hit a failing roll
got a red `Tests` / `Mobile CI` gate for a reason unrelated to its diff).

This is a **test-harness determinism** fix. No production code changes — the
`VideoNotificationRow` layout is correct and already handles large text via
`largeTextStackThreshold` + thumbnail stacking.

## Root cause (confirmed locally)

The overflow is **vertical**, and the test's available **height** was
nondeterministic:

- `_pump` mounted the row at `textScaler 2.0` in `SizedBox(width: 320)` but
  **never pinned a surface size**, so the row inherited whatever height was
  ambient.
- CI runs `very_good test --optimization --concurrency=2
  --test-randomize-ordering-seed random` → every test file shares **one
  isolate** in **randomized order**, so the ambient surface height is either
  the default *or* a height **leaked** by whatever file ran first (the exact
  leak vector documented in #4412's commit body for `web_video_player_test`).
- The 2× stacked content is **~672 px** tall and the default test surface
  clears it by only single-digit pixels. Linux font metrics (or a shorter
  leaked surface) nudge the content past that razor-thin margin → a transient
  `RenderFlex overflowed … on the bottom` that `takeException()` captures.

Proven on macOS by temporarily forcing a short surface, which reproduced
`A RenderFlex overflowed by 336 pixels on the bottom` — confirming the axis
(vertical) and the lever (height). Horizontal overflow is structurally
impossible here: the outer `Row`'s text child is `Expanded`, `_MessageText`
soft-wraps, `NotificationCommentQuote` is `maxLines: 2` + ellipsis, and the
avatar (32 px) + thumbnail (56 px) are fixed and fit within 320 px.

## Fix

In each test's `_pump`, pin a tall deterministic surface and reset it:

```dart
await tester.binding.setSurfaceSize(const Size(420, 1200));
addTearDown(() => tester.binding.setSurfaceSize(null));
```

This mirrors the already-stable `notification_rows_golden_test.dart`
(`Size(420, 1200)` + `pumpAndSettle`), which pumps the same widget at 2× and
does not flake. The single `pump()` is switched to `pumpAndSettle()` for
parity.

Why it's robust:

- **~500 px of vertical headroom** over the ~672 px content — the boundary is
  gone regardless of font metrics.
- The file becomes **immune to** inbound leaked surface sizes **and** stops
  leaking its own (the `addTearDown` reset).
- **Width stays pinned at 320**, so the test still guards the real production
  risk (horizontal fit) and still catches a layout that genuinely overflows
  1200 px.
- Faithful to production, where the row lives in a scrollable list with
  effectively unbounded height.

## Commits

1. `test(notifications):` video row test — the issue's direct subject.
2. `test(notifications):` actor row test — identical unpinned `_pump` pattern
   and its own 2× "does not overflow" test, i.e. the same latent flake;
   hardened preemptively so it can't become the next #4719.

## Testing

- ✅ `flutter test test/notifications/widgets/video_notification_row_test.dart` → 18/18
- ✅ `flutter test test/notifications/widgets/actor_notification_row_test.dart` → 21/21
- ✅ `flutter test test/notifications/` → 160/160
- ✅ `dart format` (no changes) · `flutter analyze lib test` → No issues found
- ⏳ **CI acceptance gate**: the flake cannot reproduce on macOS, so this PR's
  `Tests` job is being re-run multiple times across random seeds to confirm
  the flake is gone. (See PR checks.)

## Notes

- Focused, dedicated PR — not scope-crept into a feature branch, per the
  issue's guidance.
- No `pubspec.yaml` / `pubspec.lock` changes.
