### PR TITLE
fix(dm): add accessible label to composer send button

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2658,6 +2658,8 @@
     "dmStatusFailed": "መላክ አልተሳካም",
     "dmStatusDeliveredSelfFailed": "ተልኳል። ወደ ሌሎች መሣሪያዎችህ አይመሳሰልም።",
     "dmConversationLoadError": "መልዕክቶችን መጫን አልተቻለም",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "ሰርዝ",
     "reportDialogReport": "ሪፖርት አድርግ",
     "exploreVideoId": "ID: {id}",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2480,6 +2480,8 @@
     "dmStatusFailed": "فشل الإرسال",
     "dmStatusDeliveredSelfFailed": "تم التسليم. لن تتم المزامنة مع أجهزتك الأخرى.",
     "dmConversationLoadError": "تعذّر تحميل الرسائل",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "إلغاء",
     "reportDialogReport": "إبلاغ",
     "routerInvalidCreator": "منشئ غير صالح",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2520,6 +2520,8 @@
     "dmStatusFailed": "Изпращането не успя",
     "dmStatusDeliveredSelfFailed": "Доставено. Няма да се синхронизира с другите ти устройства.",
     "dmConversationLoadError": "Съобщенията не се заредиха",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Отказ",
     "reportDialogReport": "Докладвай",
     "exploreVideoId": "ID: {id}",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Senden fehlgeschlagen",
     "dmStatusDeliveredSelfFailed": "Zugestellt. Wird nicht mit deinen anderen Geräten synchronisiert.",
     "dmConversationLoadError": "Nachrichten konnten nicht geladen werden",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Abbrechen",
     "reportDialogReport": "Melden",
     "routerInvalidCreator": "Ungültiger Ersteller",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3019,6 +3019,10 @@
   "@dmMessageInputHint": {
     "description": "Placeholder text shown inside the compose field at the bottom of a DM conversation when the user hasn't typed anything yet."
   },
+  "dmMessageSendLabel": "Send message",
+  "@dmMessageSendLabel": {
+    "description": "Screen-reader label for the send button at the bottom of a DM conversation."
+  },
   "dmMessageBubbleSentHint": "Sent message",
   "@dmMessageBubbleSentHint": {
     "description": "Accessibility hint announcing that a direct message bubble was sent by the current user"

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2496,6 +2496,8 @@
     "dmStatusFailed": "No se pudo enviar",
     "dmStatusDeliveredSelfFailed": "Entregado. No se sincronizará con tus otros dispositivos.",
     "dmConversationLoadError": "No se pudieron cargar los mensajes",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Reportar",
     "routerInvalidCreator": "Creador no válido",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1427,6 +1427,8 @@
     "dmStatusFailed": "Nabigong ipadala",
     "dmStatusDeliveredSelfFailed": "Naipadala. Hindi mag-sync sa iba mong device.",
     "dmConversationLoadError": "Hindi na-load ang mga message",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "inboxReportedUser": "Na-report si {displayName}",
     "inboxBlockedUser": "Na-block si {displayName}",
     "inboxUnblockedUser": "Na-unblock si {displayName}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Échec de l’envoi",
     "dmStatusDeliveredSelfFailed": "Livré. Ne se synchronisera pas avec tes autres appareils.",
     "dmConversationLoadError": "Impossible de charger les messages",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Annuler",
     "reportDialogReport": "Signaler",
     "routerInvalidCreator": "Créateur non valide",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2487,6 +2487,8 @@
     "dmStatusFailed": "Gagal mengirim",
     "dmStatusDeliveredSelfFailed": "Terkirim. Tidak akan tersinkron ke perangkat lainmu.",
     "dmConversationLoadError": "Pesan tidak dapat dimuat",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Batal",
     "reportDialogReport": "Laporkan",
     "routerInvalidCreator": "Kreator tidak valid",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Invio non riuscito",
     "dmStatusDeliveredSelfFailed": "Consegnato. Non si sincronizzerà con i tuoi altri dispositivi.",
     "dmConversationLoadError": "Impossibile caricare i messaggi",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Annulla",
     "reportDialogReport": "Segnala",
     "routerInvalidCreator": "Creatore non valido",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2480,6 +2480,8 @@
     "dmStatusFailed": "送信できなかった",
     "dmStatusDeliveredSelfFailed": "配信済み。ほかのデバイスには同期されない。",
     "dmConversationLoadError": "メッセージを読み込めなかった",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "キャンセル",
     "reportDialogReport": "報告",
     "routerInvalidCreator": "無効なクリエイター",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1776,6 +1776,8 @@
     "dmStatusFailed": "보내지 못했어요",
     "dmStatusDeliveredSelfFailed": "전달됐어요. 다른 기기에는 동기화되지 않아요.",
     "dmConversationLoadError": "메시지를 불러오지 못했어요",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "취소",
     "reportDialogReport": "신고",
     "routerInvalidCreator": "유효하지 않은 크리에이터",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Versturen mislukt",
     "dmStatusDeliveredSelfFailed": "Bezorgd. Wordt niet gesynchroniseerd met je andere apparaten.",
     "dmConversationLoadError": "Berichten konden niet worden geladen",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Annuleren",
     "reportDialogReport": "Rapporteren",
     "routerInvalidCreator": "Ongeldige maker",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Nie udało się wysłać",
     "dmStatusDeliveredSelfFailed": "Dostarczone. Nie zsynchronizuje się z twoimi innymi urządzeniami.",
     "dmConversationLoadError": "Nie udało się wczytać wiadomości",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Anuluj",
     "reportDialogReport": "Zgłoś",
     "routerInvalidCreator": "Nieprawidłowy twórca",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Falha ao enviar",
     "dmStatusDeliveredSelfFailed": "Entregue. Não será sincronizado com seus outros dispositivos.",
     "dmConversationLoadError": "Não foi possível carregar as mensagens",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Denunciar",
     "routerInvalidCreator": "Criador inválido",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "N-am putut trimite",
     "dmStatusDeliveredSelfFailed": "Livrat. Nu se va sincroniza cu celelalte dispozitive.",
     "dmConversationLoadError": "Mesajele nu au putut fi încărcate",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Anulează",
     "reportDialogReport": "Raportează",
     "routerInvalidCreator": "Creator invalid",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2488,6 +2488,8 @@
     "dmStatusFailed": "Kunde inte skicka",
     "dmStatusDeliveredSelfFailed": "Levererat. Synkas inte till dina andra enheter.",
     "dmConversationLoadError": "Det gick inte att läsa in meddelandena",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "Avbryt",
     "reportDialogReport": "Rapportera",
     "routerInvalidCreator": "Ogiltig skapare",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2487,6 +2487,8 @@
     "dmStatusFailed": "Gönderilemedi",
     "dmStatusDeliveredSelfFailed": "Teslim edildi. Diğer cihazlarınla eşitlenmeyecek.",
     "dmConversationLoadError": "Mesajlar yüklenemedi",
+    "dmMessageInputHint": "Say something…",
+    "dmMessageSendLabel": "Send message",
     "reportDialogCancel": "İptal",
     "reportDialogReport": "Bildir",
     "routerInvalidCreator": "Geçersiz içerik üretici",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9656,6 +9656,12 @@ abstract class AppLocalizations {
   /// **'Say something…'**
   String get dmMessageInputHint;
 
+  /// Screen-reader label for the send button at the bottom of a DM conversation.
+  ///
+  /// In en, this message translates to:
+  /// **'Send message'**
+  String get dmMessageSendLabel;
+
   /// Accessibility hint announcing that a direct message bubble was sent by the current user
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5381,6 +5381,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5442,6 +5442,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5546,6 +5546,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5560,6 +5560,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5494,6 +5494,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5542,6 +5542,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5562,6 +5562,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5565,6 +5565,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5468,6 +5468,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5541,6 +5541,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5266,6 +5266,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5283,6 +5283,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5516,6 +5516,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5628,6 +5628,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5526,6 +5526,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5641,6 +5641,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5493,6 +5493,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5474,6 +5474,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmMessageInputHint => 'Say something…';
 
   @override
+  String get dmMessageSendLabel => 'Send message';
+
+  @override
   String get dmMessageBubbleSentHint => 'Sent message';
 
   @override

--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -116,33 +116,38 @@ class _MessageInputBarState extends State<MessageInputBar> {
               if (_hasText)
                 Padding(
                   padding: const EdgeInsetsDirectional.only(end: 4, bottom: 4),
-                  child: GestureDetector(
-                    onTap: _handleSend,
-                    child: Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: VineTheme.primary,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: widget.isSending
-                          ? const Center(
-                              child: SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
+                  child: Semantics(
+                    identifier: 'dm_message_send_button',
+                    button: true,
+                    label: context.l10n.dmMessageSendLabel,
+                    child: SizedBox.square(
+                      dimension: 40,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: VineTheme.primary,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: widget.isSending
+                            ? const Center(
+                                child: SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    color: VineTheme.surfaceBackground,
+                                    strokeWidth: 2,
+                                  ),
+                                ),
+                              )
+                            : IconButton(
+                                onPressed: _handleSend,
+                                padding: EdgeInsets.zero,
+                                icon: const DivineIcon(
+                                  icon: DivineIconName.arrowUp,
                                   color: VineTheme.surfaceBackground,
-                                  strokeWidth: 2,
+                                  size: 20,
                                 ),
                               ),
-                            )
-                          : const Center(
-                              child: DivineIcon(
-                                icon: DivineIconName.arrowUp,
-                                color: VineTheme.surfaceBackground,
-                                size: 20,
-                              ),
-                            ),
+                      ),
                     ),
                   ),
                 ),

--- a/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
@@ -182,6 +182,22 @@ void main() {
 
         expect(sentText, equals('line one\nline two'));
       });
+
+      testWidgets('send button exposes an accessible label', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: MessageInputBar(onSend: (_) {})),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'Hello');
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.bySemanticsLabel(l10n.dmMessageSendLabel), findsOneWidget);
+      });
     });
 
     group('selection toolbar', () {

--- a/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_input_bar_test.dart
@@ -10,6 +10,9 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/message_input_bar.dart';
 
 void main() {
+  Finder findSendButton(AppLocalizations l10n) =>
+      find.bySemanticsLabel(l10n.dmMessageSendLabel);
+
   group(MessageInputBar, () {
     group('renders', () {
       testWidgets('renders $TextField with hint text', (tester) async {
@@ -75,7 +78,8 @@ void main() {
         await tester.enterText(find.byType(TextField), '  Hello  ');
         await tester.pump();
 
-        await tester.tap(find.byType(DivineIcon));
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(findSendButton(l10n));
         await tester.pump();
 
         expect(sentText, equals('Hello'));
@@ -93,7 +97,8 @@ void main() {
         await tester.enterText(find.byType(TextField), 'Hello');
         await tester.pump();
 
-        await tester.tap(find.byType(DivineIcon));
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(findSendButton(l10n));
         await tester.pump();
 
         final textField = tester.widget<TextField>(find.byType(TextField));
@@ -177,7 +182,8 @@ void main() {
         await tester.enterText(find.byType(TextField), 'line one\nline two');
         await tester.pump();
 
-        await tester.tap(find.byType(DivineIcon));
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(findSendButton(l10n));
         await tester.pump();
 
         expect(sentText, equals('line one\nline two'));


### PR DESCRIPTION
Closes #4724

## Summary
- add a localized screen-reader label for the DM composer send button
- replace the raw tap target with an IconButton inside Semantics to preserve the existing visuals while exposing button semantics
- cover the new accessibility contract with a widget test

## Verification
- flutter analyze lib/screens/inbox/conversation/widgets/message_input_bar.dart test/screens/inbox/conversation/widgets/message_input_bar_test.dart
- flutter test test/screens/inbox/conversation/widgets/message_input_bar_test.dart