### PR TITLE
refactor(comments): move inline video corner radius into player

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -150,20 +150,18 @@ class _CommentItemState extends ConsumerState<CommentItem> {
                             alignment: Alignment.centerLeft,
                             child: ConstrainedBox(
                               constraints: const BoxConstraints(maxWidth: 248),
-                              child: ClipRRect(
+                              child: VideoCommentPlayer(
+                                videoUrl: widget.comment.videoUrl!,
+                                thumbnailUrl: widget.comment.thumbnailUrl,
+                                blurhash: widget.comment.videoBlurhash,
                                 borderRadius: BorderRadius.circular(12),
-                                child: VideoCommentPlayer(
-                                  videoUrl: widget.comment.videoUrl!,
-                                  thumbnailUrl: widget.comment.thumbnailUrl,
-                                  blurhash: widget.comment.videoBlurhash,
-                                  onOpenVideo: () => context.push(
-                                    VideoDetailScreen.pathForId(
-                                      widget.comment.id,
-                                    ),
-                                    extra: VideoDetailRouteExtra(
-                                      initialVideo: widget.comment
-                                          .toSyntheticVideoEvent(),
-                                    ),
+                                onOpenVideo: () => context.push(
+                                  VideoDetailScreen.pathForId(
+                                    widget.comment.id,
+                                  ),
+                                  extra: VideoDetailRouteExtra(
+                                    initialVideo: widget.comment
+                                        .toSyntheticVideoEvent(),
                                   ),
                                 ),
                               ),

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -13,6 +13,7 @@ class VideoCommentPlayer extends StatefulWidget {
     required this.videoUrl,
     this.thumbnailUrl,
     this.blurhash,
+    this.borderRadius,
     this.onOpenVideo,
     super.key,
   });
@@ -20,6 +21,7 @@ class VideoCommentPlayer extends StatefulWidget {
   final String videoUrl;
   final String? thumbnailUrl;
   final String? blurhash;
+  final BorderRadiusGeometry? borderRadius;
   final VoidCallback? onOpenVideo;
 
   @override
@@ -102,7 +104,7 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer> {
 
   @override
   Widget build(BuildContext context) {
-    return VisibilityDetector(
+    final player = VisibilityDetector(
       key: Key('video-comment-${widget.videoUrl}'),
       onVisibilityChanged: _onVisibilityChanged,
       child: AspectRatio(
@@ -155,6 +157,16 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer> {
           ),
         ),
       ),
+    );
+
+    final borderRadius = widget.borderRadius;
+    if (borderRadius == null) {
+      return player;
+    }
+
+    return ClipRRect(
+      borderRadius: borderRadius,
+      child: player,
     );
   }
 }

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -274,13 +274,10 @@ void main() {
     );
     await tester.pump();
 
-    final clipFinder = find.ancestor(
-      of: find.byType(VideoCommentPlayer),
-      matching: find.byType(ClipRRect),
+    final player = tester.widget<VideoCommentPlayer>(
+      find.byType(VideoCommentPlayer),
     );
-    expect(clipFinder, findsOneWidget);
-    final clipRRect = tester.widget<ClipRRect>(clipFinder);
-    expect(clipRRect.borderRadius, BorderRadius.circular(12));
+    expect(player.borderRadius, BorderRadius.circular(12));
 
     // Drain VisibilityDetector's 500ms debounce and the identity skeleton's
     // 7s fallthrough so no pending timers leak into the next test.

--- a/mobile/test/screens/comments/widgets/video_comment_player_test.dart
+++ b/mobile/test/screens/comments/widgets/video_comment_player_test.dart
@@ -10,6 +10,31 @@ void main() {
     VisibilityDetectorController.instance.updateInterval = Duration.zero;
   });
 
+  testWidgets('clips to the provided border radius', (tester) async {
+    const borderRadius = BorderRadius.all(Radius.circular(12));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: VideoCommentPlayer(
+            videoUrl: 'https://media.divine.video/comment-video.mp4',
+            borderRadius: borderRadius,
+          ),
+        ),
+      ),
+    );
+
+    final clip = tester.widget<ClipRRect>(
+      find.ancestor(
+        of: find.byType(VisibilityDetector),
+        matching: find.byType(ClipRRect),
+      ),
+    );
+    expect(clip.borderRadius, borderRadius);
+  });
+
   testWidgets('opens the full video page from the inline comment player', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- move rounded-corner ownership into `VideoCommentPlayer` with an explicit `borderRadius` API
- keep `CommentItem` responsible only for passing the desired radius, not wrapping the player
- move the rounded-corner regression coverage to the player test and keep the parent test focused on wiring

## Why
PR #4706 fixed the visible regression, but it left the styling contract owned by the parent widget and coupled the regression test to that wrapper detail. This follow-up removes that new debt and restores a cleaner component boundary.

Closes #4723

## Verification
- `flutter test test/screens/comments/widgets/video_comment_player_test.dart`
- `flutter test test/screens/comments/comment_item_test.dart`
- `flutter test test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart`
- `flutter analyze lib/screens/comments/widgets/comment_item.dart lib/screens/comments/widgets/video_comment_player.dart lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart test/screens/comments/comment_item_test.dart test/screens/comments/widgets/video_comment_player_test.dart test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart`