### PR TITLE
fix(notifications): unify push, local, and in-app tap routing (#4727)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -50,6 +50,7 @@ import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 import 'package:openvine/network/vine_cdn_http_overrides.dart'
     if (dart.library.html) 'package:openvine/utils/platform_io_web.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
+import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/services/notification_realtime_bridge.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/observability/divine_bloc_observer.dart';
@@ -65,6 +66,7 @@ import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
@@ -81,7 +83,7 @@ import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_helpers.dart'
     show parseFcmPayload;
 import 'package:openvine/services/notification_service.dart'
-    show NotificationPayloadKind, NotificationTapEvent;
+    show NotificationTapEvent;
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -92,6 +94,7 @@ import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/platform_support.dart';
 import 'package:openvine/utils/recoverable_flutter_error.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
@@ -144,10 +147,14 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     body: body,
     notificationDetails: details,
     payload: jsonEncode({
+      // Preserve the full normalized payload so a tap on this background-built
+      // notification routes identically to a system push tap. The FCM wire key
+      // 'type' maps to the internal 'notificationType'. senderPubkey carries
+      // the actor so follow taps (which have no referencedEventId) can route.
       'referencedEventId': data['referencedEventId'],
-      // Normalise at the boundary: FCM wire key is 'type'; the internal
-      // payload (read by NotificationService) uses 'notificationType'.
+      'eventId': data['eventId'],
       'notificationType': data['type'],
+      'senderPubkey': data['senderPubkey'],
     }),
   );
 }
@@ -256,29 +263,93 @@ VideoDeepLinkNavAction resolveVideoDeepLinkNavAction({
   return VideoDeepLinkNavAction.push;
 }
 
-/// Resolves [referencedEventId] from a push notification payload to a video
-/// event ID, then pushes a [DeepLink] into [deepLinkService].
+/// Resolves a push/local payload to a [NotificationTapTarget] and the event id
+/// to navigate to, via the shared [resolveNotificationTapTarget] contract.
 ///
-/// For `notificationType == "reply"` (and other comment-type notifications),
-/// [referencedEventId] is the ID of a Kind 1111 comment event, not a video.
-/// [NotificationTargetResolver] fetches that event from the relay, walks its
-/// NIP-22 `E` / NIP-10 `e` tags, and returns the root video event ID.
-///
-/// For video-type events the resolver returns the same ID unchanged.
-Future<void> _resolveAndPushNotificationDeepLink({
-  required String referencedEventId,
+/// `referencedEventId` (the event acted upon) is preferred as the video target;
+/// it is absent for follow/mention, which fall back to `eventId` (the source
+/// event). Extracted and `@visibleForTesting` so the push-side per-kind routing
+/// can be asserted without a navigator — mirrors [resolveVideoDeepLinkNavAction].
+@visibleForTesting
+({NotificationTapTarget target, String? targetEventId})
+pushNotificationTapTarget({
+  required String? referencedEventId,
+  required String? eventId,
   required String? notificationType,
+  required String? senderPubkey,
+}) {
+  final targetEventId =
+      (referencedEventId != null && referencedEventId.isNotEmpty)
+      ? referencedEventId
+      : eventId;
+  return (
+    target: resolveNotificationTapTarget(
+      kind: notificationKindFromPushType(notificationType),
+      hasVideoTarget: targetEventId != null && targetEventId.isNotEmpty,
+      actorPubkey: senderPubkey,
+    ),
+    targetEventId: targetEventId,
+  );
+}
+
+/// Routes a notification tap (FCM system push, local notification, or
+/// cold-start) to a destination using the shared [resolveNotificationTapTarget]
+/// contract — the same contract the in-app notification rows use, so the three
+/// entry points cannot drift.
+///
+/// [referencedEventId] is the event acted upon (present for like/comment/
+/// repost). [eventId] is the source event itself, used as the target for
+/// mentions, which carry no `referencedEventId`. [senderPubkey] is the actor —
+/// it opens a profile for follows and is the safe fallback when a video target
+/// cannot be resolved.
+Future<void> _routeNotificationTap({
+  required String? referencedEventId,
+  required String? eventId,
+  required String? notificationType,
+  required String? senderPubkey,
   required ProviderContainer container,
 }) async {
-  final deepLinkService = container.read(deepLinkServiceProvider);
-  final autoOpenComments = notificationType == NotificationPayloadKind.reply;
+  final (:target, :targetEventId) = pushNotificationTapTarget(
+    referencedEventId: referencedEventId,
+    eventId: eventId,
+    notificationType: notificationType,
+    senderPubkey: senderPubkey,
+  );
 
+  switch (target) {
+    case OpenProfileTarget(:final actorPubkey):
+      _navigateToNotificationProfile(container, actorPubkey);
+    case OpenInboxTarget():
+      _navigateToNotificationInbox(container);
+    case OpenVideoTarget(:final autoOpenComments):
+      await _resolveAndPushVideoLink(
+        container: container,
+        targetEventId: targetEventId!,
+        autoOpenComments: autoOpenComments,
+        fallbackPubkey: senderPubkey,
+      );
+  }
+}
+
+/// Resolves [targetEventId] to a root video and pushes a video [DeepLink].
+///
+/// For comment/reply targets [targetEventId] is a Kind 1111 comment event, not
+/// a video; [NotificationTargetResolver] walks its NIP-22 `E` / NIP-10 `e`
+/// tags to the root video. When resolution fails the tap falls back to the
+/// actor's profile (or the inbox if no pubkey is known) instead of silently
+/// doing nothing.
+Future<void> _resolveAndPushVideoLink({
+  required ProviderContainer container,
+  required String targetEventId,
+  required bool autoOpenComments,
+  required String? fallbackPubkey,
+}) async {
   String? videoEventId;
   try {
     videoEventId = await NotificationTargetResolver(
       videoEventService: container.read(videoEventServiceProvider),
       nostrService: container.read(nostrServiceProvider),
-    ).resolveVideoEventIdFromNotificationTarget(referencedEventId);
+    ).resolveVideoEventIdFromNotificationTarget(targetEventId);
   } catch (e) {
     Log.error(
       'Failed to resolve notification target: $e',
@@ -289,28 +360,44 @@ Future<void> _resolveAndPushNotificationDeepLink({
 
   if (videoEventId == null) {
     Log.warning(
-      'Could not resolve notification target to a video, '
-      'referencedEventId=$referencedEventId type=$notificationType',
+      'Could not resolve notification target to a video '
+      '(targetEventId=$targetEventId) — falling back',
       name: 'main',
       category: LogCategory.system,
     );
+    if (fallbackPubkey != null && fallbackPubkey.isNotEmpty) {
+      _navigateToNotificationProfile(container, fallbackPubkey);
+    } else {
+      _navigateToNotificationInbox(container);
+    }
     return;
   }
 
-  Log.info(
-    'Resolved notification target: $referencedEventId → $videoEventId '
-    '(type=$notificationType, autoOpenComments=$autoOpenComments)',
-    name: 'main',
-    category: LogCategory.system,
-  );
+  container
+      .read(deepLinkServiceProvider)
+      .pushLink(
+        DeepLink(
+          type: DeepLinkType.video,
+          videoRef: videoEventId,
+          autoOpenComments: autoOpenComments,
+        ),
+      );
+}
 
-  deepLinkService.pushLink(
-    DeepLink(
-      type: DeepLinkType.video,
-      videoRef: videoEventId,
-      autoOpenComments: autoOpenComments,
-    ),
-  );
+/// Opens the actor's profile. Used for follow taps and as the fallback when a
+/// video target cannot be resolved.
+void _navigateToNotificationProfile(
+  ProviderContainer container,
+  String actorPubkeyHex,
+) {
+  final npub = NostrKeyUtils.encodePubKey(actorPubkeyHex);
+  container.read(goRouterProvider).push(OtherProfileScreen.pathForNpub(npub));
+}
+
+/// Opens the notifications inbox — the deterministic safe fallback when a tap
+/// carries no resolvable target and no actor pubkey.
+void _navigateToNotificationInbox(ProviderContainer container) {
+  container.read(goRouterProvider).go(NotificationsPage.pathForIndex());
 }
 
 StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
@@ -511,16 +598,17 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
           final parsed = parseFcmPayload(initialMessage.data);
           if (parsed != null) {
             Log.info(
-              'App launched from push notification, '
-              'target: ${parsed.referencedEventId} '
-              '(type: ${parsed.notificationType})',
+              'App launched from push notification (type: '
+              '${parsed.notificationType})',
               name: 'main',
               category: LogCategory.system,
             );
             unawaited(
-              _resolveAndPushNotificationDeepLink(
+              _routeNotificationTap(
                 referencedEventId: parsed.referencedEventId,
+                eventId: parsed.eventId,
                 notificationType: parsed.notificationType,
+                senderPubkey: parsed.senderPubkey,
                 container: container,
               ),
             );
@@ -532,16 +620,17 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
           final parsed = parseFcmPayload(message.data);
           if (parsed != null) {
             Log.info(
-              'Push notification tapped (background), '
-              'target: ${parsed.referencedEventId} '
-              '(type: ${parsed.notificationType})',
+              'Push notification tapped (background) (type: '
+              '${parsed.notificationType})',
               name: 'main',
               category: LogCategory.system,
             );
             unawaited(
-              _resolveAndPushNotificationDeepLink(
+              _routeNotificationTap(
                 referencedEventId: parsed.referencedEventId,
+                eventId: parsed.eventId,
                 notificationType: parsed.notificationType,
+                senderPubkey: parsed.senderPubkey,
                 container: container,
               ),
             );
@@ -1225,15 +1314,16 @@ class _DivineAppState extends ConsumerState<DivineApp> {
         .notificationTapStream
         .listen((tapEvent) {
           Log.info(
-            '🔔 Local notification tap: eventId=${tapEvent.referencedEventId} '
-            'type=${tapEvent.notificationType}',
+            '🔔 Local notification tap (type: ${tapEvent.notificationType})',
             name: 'DeepLinkHandler',
             category: LogCategory.ui,
           );
           unawaited(
-            _resolveAndPushNotificationDeepLink(
+            _routeNotificationTap(
               referencedEventId: tapEvent.referencedEventId,
+              eventId: tapEvent.eventId,
               notificationType: tapEvent.notificationType,
+              senderPubkey: tapEvent.senderPubkey,
               container: container,
             ),
           );

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -295,7 +295,8 @@ pushNotificationTapTarget({
 /// Routes a notification tap (FCM system push, local notification, or
 /// cold-start) to a destination using the shared [resolveNotificationTapTarget]
 /// contract — the same contract the in-app notification rows use, so the three
-/// entry points cannot drift.
+/// entry points share one target-selection policy even though each executor
+/// keeps its own navigation mechanics.
 ///
 /// [referencedEventId] is the event acted upon (present for like/comment/
 /// repost). [eventId] is the source event itself, used as the target for

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -1,0 +1,132 @@
+// ABOUTME: Source-agnostic decision for where a notification tap should go.
+// ABOUTME: One contract shared by in-app row taps, FCM push taps, and local taps.
+
+import 'package:equatable/equatable.dart';
+import 'package:models/models.dart' show NotificationKind;
+
+/// Normalized destination for a notification tap.
+///
+/// Built from either a `NotificationItem` (in-app row tap) or a push/local
+/// payload (`type` + `referencedEventId`/`eventId` [+ `senderPubkey`]). All
+/// three entry points resolve through [resolveNotificationTapTarget] so they
+/// cannot drift on where a tap lands.
+///
+/// This is intentionally Flutter-free: it decides *what* to open, not *how*.
+/// Each executor maps the target to its own navigation mechanism (the in-app
+/// path opens [PooledFullscreenVideoFeedScreen] with a pre-fetched stream; the
+/// push path pushes a video `DeepLink` / navigates to the profile or inbox).
+sealed class NotificationTapTarget extends Equatable {
+  const NotificationTapTarget();
+}
+
+/// Open the video associated with the notification.
+///
+/// The executor owns resolving the concrete route id (preferring a stable
+/// NIP-33 addressable id, otherwise walking the target event to its root
+/// video) and the fallback when that resolution fails.
+class OpenVideoTarget extends NotificationTapTarget {
+  const OpenVideoTarget({required this.autoOpenComments});
+
+  /// Whether the opened video should auto-expand its comments.
+  final bool autoOpenComments;
+
+  @override
+  List<Object?> get props => [autoOpenComments];
+}
+
+/// Open the actor's profile (e.g. a follow notification, or a tap whose video
+/// target could not be determined).
+class OpenProfileTarget extends NotificationTapTarget {
+  const OpenProfileTarget(this.actorPubkey);
+
+  /// Hex pubkey of the actor whose profile to open.
+  final String actorPubkey;
+
+  @override
+  List<Object?> get props => [actorPubkey];
+}
+
+/// Deterministic safe fallback: open the notifications inbox.
+///
+/// Used when a tap carries no resolvable video target and no actor pubkey, so
+/// an unresolved tap lands somewhere sensible instead of silently doing
+/// nothing.
+class OpenInboxTarget extends NotificationTapTarget {
+  const OpenInboxTarget();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// Whether a tap of [kind] should open the video with its comments expanded.
+///
+/// Single source of truth for the auto-open-comments policy across every
+/// entry point. The push path historically keyed this off a `'reply'` string
+/// the backend never sends, so comments never auto-opened from a push; routing
+/// through this helper fixes that drift.
+bool notificationKindOpensComments(NotificationKind? kind) =>
+    kind == NotificationKind.comment ||
+    kind == NotificationKind.reply ||
+    kind == NotificationKind.likeComment ||
+    kind == NotificationKind.mention;
+
+/// Maps the push wire `type` to a [NotificationKind].
+///
+/// `divine-push-service` sends a lowercase, five-value vocabulary
+/// (`like`/`comment`/`follow`/`mention`/`repost`). It never sends `reply`,
+/// `likeComment`, or `system`. Unknown / absent values return `null`, which
+/// [resolveNotificationTapTarget] treats as a best-effort video-or-inbox tap.
+NotificationKind? notificationKindFromPushType(String? type) {
+  switch (type) {
+    case 'like':
+      return NotificationKind.like;
+    case 'comment':
+      return NotificationKind.comment;
+    case 'follow':
+      return NotificationKind.follow;
+    case 'mention':
+      return NotificationKind.mention;
+    case 'repost':
+      return NotificationKind.repost;
+    default:
+      return null;
+  }
+}
+
+/// Decides where a notification tap should go.
+///
+/// [hasVideoTarget] is supplied by the caller: `true` when it holds a video
+/// event id, a stable addressable id, or a target event id that can be walked
+/// to a video. The id mechanics stay in the executor so this decision is pure
+/// and testable in isolation.
+///
+/// Policy:
+/// * `follow` → the actor's profile (or the inbox if no pubkey is known).
+/// * `system` → the inbox.
+/// * any other kind with a video target → the video, with comments auto-opened
+///   per [notificationKindOpensComments].
+/// * any other kind without a video target → the actor's profile, or the inbox
+///   when no pubkey is known.
+NotificationTapTarget resolveNotificationTapTarget({
+  required NotificationKind? kind,
+  required bool hasVideoTarget,
+  String? actorPubkey,
+}) {
+  if (kind == NotificationKind.follow) {
+    return _profileOrInbox(actorPubkey);
+  }
+  if (kind == NotificationKind.system) {
+    return const OpenInboxTarget();
+  }
+  if (hasVideoTarget) {
+    return OpenVideoTarget(
+      autoOpenComments: notificationKindOpensComments(kind),
+    );
+  }
+  return _profileOrInbox(actorPubkey);
+}
+
+NotificationTapTarget _profileOrInbox(String? actorPubkey) =>
+    (actorPubkey != null && actorPubkey.isNotEmpty)
+    ? OpenProfileTarget(actorPubkey)
+    : const OpenInboxTarget();

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -8,8 +8,8 @@ import 'package:models/models.dart' show NotificationKind;
 ///
 /// Built from either a `NotificationItem` (in-app row tap) or a push/local
 /// payload (`type` + `referencedEventId`/`eventId` [+ `senderPubkey`]). All
-/// three entry points resolve through [resolveNotificationTapTarget] so they
-/// cannot drift on where a tap lands.
+/// three entry points resolve through [resolveNotificationTapTarget] so the
+/// kind -> destination decision cannot drift.
 ///
 /// This is intentionally Flutter-free: it decides *what* to open, not *how*.
 /// Each executor maps the target to its own navigation mechanism (the in-app
@@ -75,7 +75,8 @@ bool notificationKindOpensComments(NotificationKind? kind) =>
 /// `divine-push-service` sends a lowercase, five-value vocabulary
 /// (`like`/`comment`/`follow`/`mention`/`repost`). It never sends `reply`,
 /// `likeComment`, or `system`. Unknown / absent values return `null`, which
-/// [resolveNotificationTapTarget] treats as a best-effort video-or-inbox tap.
+/// [resolveNotificationTapTarget] treats as a best-effort video/profile/inbox
+/// tap.
 NotificationKind? notificationKindFromPushType(String? type) {
   switch (type) {
     case 'like':
@@ -89,6 +90,8 @@ NotificationKind? notificationKindFromPushType(String? type) {
     case 'repost':
       return NotificationKind.repost;
     default:
+      // Keep unknown values non-fatal: a mistyped or legacy-cased payload
+      // should still fall back to the best available target.
       return null;
   }
 }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -173,55 +174,64 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       NotificationFeedItemTapped(notification.id),
     );
 
+    // Route the kind -> destination decision through the shared contract so
+    // the in-app, push, and local tap paths cannot drift. The executors
+    // (here vs main.dart) keep their own navigation mechanics.
     switch (notification) {
       case VideoNotification(
         :final videoEventId,
         :final videoAddressableId,
         :final type,
       ):
-        await _navigateToVideo(
-          context,
-          videoEventId,
-          videoAddressableId: videoAddressableId,
-          notificationKind: type,
+        final target = resolveNotificationTapTarget(
+          kind: type,
+          hasVideoTarget: true,
         );
+        switch (target) {
+          case OpenVideoTarget():
+            await _navigateToVideo(
+              context,
+              videoEventId,
+              videoAddressableId: videoAddressableId,
+              notificationKind: type,
+            );
+          case OpenProfileTarget(:final actorPubkey):
+            _navigateToProfile(context, actorPubkey);
+          case OpenInboxTarget():
+            break;
+        }
       case ActorNotification(
         :final actor,
         :final type,
         :final targetEventId,
         :final videoAddressableId,
       ):
-        switch (type) {
-          case NotificationKind.follow:
-            _navigateToProfile(context, actor.pubkey);
-          case NotificationKind.mention:
-          case NotificationKind.likeComment:
-          case NotificationKind.reply:
-            // targetEventId is the event the resolver will walk to find the
-            // root video. Falls back to the actor's profile only for mentions,
-            // where the mention may have no video context at all.
-            if (targetEventId != null && targetEventId.isNotEmpty) {
-              final navigated = await _navigateToVideo(
-                context,
-                targetEventId,
-                videoAddressableId: videoAddressableId,
-                notificationKind: type,
-              );
-              if (!navigated &&
-                  type == NotificationKind.mention &&
-                  context.mounted) {
-                _navigateToProfile(context, actor.pubkey);
-              }
-            } else {
+        final hasVideoTarget =
+            targetEventId != null && targetEventId.isNotEmpty;
+        final target = resolveNotificationTapTarget(
+          kind: type,
+          hasVideoTarget: hasVideoTarget,
+          actorPubkey: actor.pubkey,
+        );
+        switch (target) {
+          case OpenVideoTarget():
+            // targetEventId is the event the resolver walks to find the root
+            // video. A mention with no resolvable video falls back to the
+            // actor's profile.
+            final navigated = await _navigateToVideo(
+              context,
+              targetEventId!,
+              videoAddressableId: videoAddressableId,
+              notificationKind: type,
+            );
+            if (!navigated &&
+                type == NotificationKind.mention &&
+                context.mounted) {
               _navigateToProfile(context, actor.pubkey);
             }
-          case NotificationKind.system:
-            break;
-          case NotificationKind.like:
-          case NotificationKind.comment:
-          case NotificationKind.repost:
-            // Not represented as ActorNotification, but pattern-match
-            // exhaustivity requires these.
+          case OpenProfileTarget(:final actorPubkey):
+            _navigateToProfile(context, actorPubkey);
+          case OpenInboxTarget():
             break;
         }
     }
@@ -252,11 +262,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     final videoEventService = ref.read(videoEventServiceProvider);
     final videosRepository = ref.read(videosRepositoryProvider);
 
-    final shouldAutoOpenComments =
-        notificationKind == NotificationKind.comment ||
-        notificationKind == NotificationKind.reply ||
-        notificationKind == NotificationKind.likeComment ||
-        notificationKind == NotificationKind.mention;
+    final shouldAutoOpenComments = notificationKindOpensComments(
+      notificationKind,
+    );
 
     // Resolve the navigation target.
     //

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -175,8 +175,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     );
 
     // Route the kind -> destination decision through the shared contract so
-    // the in-app, push, and local tap paths cannot drift. The executors
-    // (here vs main.dart) keep their own navigation mechanics.
+    // the in-app, push, and local tap paths share one target-selection policy.
+    // The executors (here vs main.dart) still keep their own navigation
+    // mechanics after that decision is made.
     switch (notification) {
       case VideoNotification(
         :final videoEventId,
@@ -196,8 +197,12 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
               notificationKind: type,
             );
           case OpenProfileTarget(:final actorPubkey):
+            // Exhaustiveness-only: VideoNotification currently always resolves
+            // to OpenVideoTarget because it always carries a video target.
             _navigateToProfile(context, actorPubkey);
           case OpenInboxTarget():
+            // Exhaustiveness-only: VideoNotification currently always resolves
+            // to OpenVideoTarget because it always carries a video target.
             break;
         }
       case ActorNotification(

--- a/mobile/lib/services/notification_helpers.dart
+++ b/mobile/lib/services/notification_helpers.dart
@@ -63,25 +63,47 @@ String? extractAddressableId(Event event) {
   return (kind: kind, pubkey: pubkey, dTag: dTag);
 }
 
-/// Normalises a raw push-notification payload map into the two fields the
-/// deep-link resolver needs.
+/// Normalises a raw push-notification payload map into the fields the tap
+/// router needs.
 ///
-/// Translates the wire key `'type'` to `notificationType` so callers see one
-/// shape regardless of whether the payload came from the FCM wire (`type`)
-/// or a locally-emitted notification JSON (`notificationType`).
+/// Mirrors the `divine-push-service` data-only contract: `type` (lowercase
+/// `like`/`comment`/`follow`/`mention`/`repost`), `referencedEventId` (present
+/// only when the source event has an `e` tag — i.e. like/comment/repost),
+/// `eventId` (the source event itself, always present), and `senderPubkey`
+/// (the actor). Translates the wire key `'type'` to `notificationType` so
+/// callers see one shape whether the payload came from the FCM wire or a
+/// locally-emitted notification JSON.
 ///
-/// Returns `null` when the payload carries no `referencedEventId`, so the
-/// caller can short-circuit before reaching the deep-link resolver.
-({String referencedEventId, String? notificationType})? parseFcmPayload(
-  Map<String, dynamic> data,
-) {
-  final referencedEventId = data['referencedEventId'] as String?;
-  if (referencedEventId == null || referencedEventId.isEmpty) return null;
-  final notificationType =
-      data['type'] as String? ?? data['notificationType'] as String?;
+/// Returns `null` only when the payload carries nothing routable — no
+/// `referencedEventId`, no `eventId`, and no `senderPubkey`. A `follow`/
+/// `mention` carries no `referencedEventId` but is still routable (via
+/// `senderPubkey` / `eventId`), so those are no longer dropped.
+({
+  String? referencedEventId,
+  String? eventId,
+  String? notificationType,
+  String? senderPubkey,
+})?
+parseFcmPayload(Map<String, dynamic> data) {
+  String? nonEmpty(String key) {
+    final value = data[key];
+    return value is String && value.isNotEmpty ? value : null;
+  }
+
+  final referencedEventId = nonEmpty('referencedEventId');
+  final eventId = nonEmpty('eventId');
+  final senderPubkey = nonEmpty('senderPubkey');
+  final notificationType = nonEmpty('type') ?? nonEmpty('notificationType');
+
+  if (referencedEventId == null && eventId == null && senderPubkey == null) {
+    return null;
+  }
+
   return (
     referencedEventId: referencedEventId,
+    eventId: eventId,
     notificationType: notificationType,
+    senderPubkey: senderPubkey,
   );
 }
 

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -21,32 +21,36 @@ enum NotificationType {
 @immutable
 class NotificationTapEvent {
   const NotificationTapEvent({
-    required this.referencedEventId,
-    required this.notificationType,
+    this.referencedEventId,
+    this.eventId,
+    this.notificationType,
+    this.senderPubkey,
   });
 
-  final String referencedEventId;
+  /// The event acted upon (present for like/comment/repost). Null for
+  /// follow/mention, which the push service sends without an `e` tag.
+  final String? referencedEventId;
+
+  /// The source event itself (the like/comment/follow/mention event).
+  final String? eventId;
   final String? notificationType;
+
+  /// Hex pubkey of the actor — used to route follows (and unresolved taps)
+  /// to a profile.
+  final String? senderPubkey;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is NotificationTapEvent &&
           referencedEventId == other.referencedEventId &&
-          notificationType == other.notificationType;
+          eventId == other.eventId &&
+          notificationType == other.notificationType &&
+          senderPubkey == other.senderPubkey;
 
   @override
-  int get hashCode => Object.hash(referencedEventId, notificationType);
-}
-
-/// Push-notification kind values as they appear in the FCM payload `type` field
-/// and in the local-notification JSON payload `notificationType` field.
-///
-/// Use these constants instead of bare string literals so that the routing
-/// policy (e.g. "open comments for replies") is defined in one place.
-abstract final class NotificationPayloadKind {
-  /// The originating notification was a reply to one of the user's videos.
-  static const String reply = 'reply';
+  int get hashCode =>
+      Object.hash(referencedEventId, eventId, notificationType, senderPubkey);
 }
 
 /// Notification data structure
@@ -481,13 +485,25 @@ class NotificationService {
 
     try {
       final data = jsonDecode(payload) as Map<String, dynamic>;
-      final referencedEventId = data['referencedEventId'] as String?;
-      final notificationType = data['notificationType'] as String?;
-      if (referencedEventId != null && referencedEventId.isNotEmpty) {
+      String? field(String key) {
+        final value = data[key];
+        return value is String && value.isNotEmpty ? value : null;
+      }
+
+      final referencedEventId = field('referencedEventId');
+      final eventId = field('eventId');
+      final senderPubkey = field('senderPubkey');
+      // A follow/mention carries no referencedEventId but is still routable
+      // via senderPubkey / eventId, so emit whenever any of the three exist.
+      if (referencedEventId != null ||
+          eventId != null ||
+          senderPubkey != null) {
         _emitNotificationTap(
           NotificationTapEvent(
             referencedEventId: referencedEventId,
-            notificationType: notificationType,
+            eventId: eventId,
+            notificationType: field('notificationType'),
+            senderPubkey: senderPubkey,
           ),
         );
       }
@@ -498,12 +514,7 @@ class NotificationService {
       // JSON payloads (referencedEventId + notificationType) for at least one
       // full app-store release cycle and telemetry confirms this path is
       // never reached. See issue for the full removal plan.
-      _emitNotificationTap(
-        NotificationTapEvent(
-          referencedEventId: payload,
-          notificationType: null,
-        ),
-      );
+      _emitNotificationTap(NotificationTapEvent(referencedEventId: payload));
     }
   }
 

--- a/mobile/test/main_notification_tap_routing_test.dart
+++ b/mobile/test/main_notification_tap_routing_test.dart
@@ -72,6 +72,18 @@ void main() {
       expect(result.targetEventId, equals(sourceEvent));
     });
 
+    test('mention without a video target falls back to the actor profile', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'mention',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenProfileTarget(actor));
+      expect(result.targetEventId, isNull);
+    });
+
     test('prefers referencedEventId over eventId as the video target', () {
       final result = app.pushNotificationTapTarget(
         referencedEventId: videoEvent,

--- a/mobile/test/main_notification_tap_routing_test.dart
+++ b/mobile/test/main_notification_tap_routing_test.dart
@@ -1,0 +1,110 @@
+// ABOUTME: Regression tests for push/local notification tap routing.
+// ABOUTME: Proves follow/mention are no longer dropped and that the push path
+// ABOUTME: shares the same routing contract as in-app notification rows.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/notifications/routing/notification_tap_target.dart';
+
+void main() {
+  const actor = 'follower_pubkey_hex';
+  const videoEvent = 'video_event_id';
+  const commentEvent = 'comment_event_id';
+  const sourceEvent = 'source_event_id';
+
+  group('pushNotificationTapTarget', () {
+    test('follow opens the actor profile (carries no referencedEventId)', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: null,
+        eventId: 'contact_list_event',
+        notificationType: 'follow',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenProfileTarget(actor));
+    });
+
+    test('like opens the referenced video without comments', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: videoEvent,
+        eventId: sourceEvent,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+      expect(result.targetEventId, equals(videoEvent));
+    });
+
+    test('comment opens the referenced video with comments', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: commentEvent,
+        eventId: sourceEvent,
+        notificationType: 'comment',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: true));
+      expect(result.targetEventId, equals(commentEvent));
+    });
+
+    test('repost opens the referenced video without comments', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: videoEvent,
+        eventId: sourceEvent,
+        notificationType: 'repost',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+    });
+
+    test('mention uses eventId as the video target (no referencedEventId) '
+        'and opens comments', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: null,
+        eventId: sourceEvent,
+        notificationType: 'mention',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: true));
+      expect(result.targetEventId, equals(sourceEvent));
+    });
+
+    test('prefers referencedEventId over eventId as the video target', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: videoEvent,
+        eventId: sourceEvent,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.targetEventId, equals(videoEvent));
+    });
+
+    test('nothing routable and no pubkey opens the inbox', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'follow',
+        senderPubkey: null,
+      );
+
+      expect(result.target, const OpenInboxTarget());
+    });
+
+    test('unknown type with a video target opens the video without '
+        'comments', () {
+      final result = app.pushNotificationTapTarget(
+        referencedEventId: videoEvent,
+        eventId: null,
+        // Capitalized — not the lowercase wire value the service sends.
+        notificationType: 'Like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+    });
+  });
+}

--- a/mobile/test/notifications/routing/notification_tap_target_test.dart
+++ b/mobile/test/notifications/routing/notification_tap_target_test.dart
@@ -1,0 +1,177 @@
+// ABOUTME: Tests for the shared notification tap routing decision.
+// ABOUTME: Pins the one contract used by in-app, push, and local tap paths.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show NotificationKind;
+import 'package:openvine/notifications/routing/notification_tap_target.dart';
+
+void main() {
+  group('notificationKindOpensComments', () {
+    for (final kind in const [
+      NotificationKind.comment,
+      NotificationKind.reply,
+      NotificationKind.likeComment,
+      NotificationKind.mention,
+    ]) {
+      test('is true for $kind', () {
+        expect(notificationKindOpensComments(kind), isTrue);
+      });
+    }
+
+    for (final kind in const [
+      NotificationKind.like,
+      NotificationKind.repost,
+      NotificationKind.follow,
+      NotificationKind.system,
+    ]) {
+      test('is false for $kind', () {
+        expect(notificationKindOpensComments(kind), isFalse);
+      });
+    }
+
+    test('is false for null kind', () {
+      expect(notificationKindOpensComments(null), isFalse);
+    });
+  });
+
+  group('notificationKindFromPushType', () {
+    test('maps the lowercase 5-value push vocabulary', () {
+      expect(notificationKindFromPushType('like'), NotificationKind.like);
+      expect(notificationKindFromPushType('comment'), NotificationKind.comment);
+      expect(notificationKindFromPushType('follow'), NotificationKind.follow);
+      expect(notificationKindFromPushType('mention'), NotificationKind.mention);
+      expect(notificationKindFromPushType('repost'), NotificationKind.repost);
+    });
+
+    test('returns null for values the push service never sends', () {
+      // The backend emits lowercase only and has no reply/likeComment/system.
+      expect(notificationKindFromPushType('Like'), isNull);
+      expect(notificationKindFromPushType('reply'), isNull);
+      expect(notificationKindFromPushType('likeComment'), isNull);
+      expect(notificationKindFromPushType('system'), isNull);
+      expect(notificationKindFromPushType('zap'), isNull);
+      expect(notificationKindFromPushType(null), isNull);
+      expect(notificationKindFromPushType(''), isNull);
+    });
+  });
+
+  group('resolveNotificationTapTarget', () {
+    const pubkey = 'actor_pubkey_hex';
+
+    test('follow with actor pubkey opens the profile', () {
+      expect(
+        resolveNotificationTapTarget(
+          kind: NotificationKind.follow,
+          hasVideoTarget: false,
+          actorPubkey: pubkey,
+        ),
+        const OpenProfileTarget(pubkey),
+      );
+    });
+
+    test('follow without actor pubkey falls back to the inbox', () {
+      expect(
+        resolveNotificationTapTarget(
+          kind: NotificationKind.follow,
+          hasVideoTarget: false,
+        ),
+        const OpenInboxTarget(),
+      );
+    });
+
+    test('system always opens the inbox', () {
+      expect(
+        resolveNotificationTapTarget(
+          kind: NotificationKind.system,
+          hasVideoTarget: true,
+          actorPubkey: pubkey,
+        ),
+        const OpenInboxTarget(),
+      );
+    });
+
+    test(
+      'like / repost with a video target open the video without comments',
+      () {
+        for (final kind in const [
+          NotificationKind.like,
+          NotificationKind.repost,
+        ]) {
+          expect(
+            resolveNotificationTapTarget(kind: kind, hasVideoTarget: true),
+            const OpenVideoTarget(autoOpenComments: false),
+            reason: '$kind should not auto-open comments',
+          );
+        }
+      },
+    );
+
+    test('comment / likeComment / mention with a video target auto-open '
+        'comments', () {
+      for (final kind in const [
+        NotificationKind.comment,
+        NotificationKind.likeComment,
+        NotificationKind.reply,
+        NotificationKind.mention,
+      ]) {
+        expect(
+          resolveNotificationTapTarget(kind: kind, hasVideoTarget: true),
+          const OpenVideoTarget(autoOpenComments: true),
+          reason: '$kind should auto-open comments',
+        );
+      }
+    });
+
+    test(
+      'comment-type kind without a video target falls back to the profile',
+      () {
+        expect(
+          resolveNotificationTapTarget(
+            kind: NotificationKind.mention,
+            hasVideoTarget: false,
+            actorPubkey: pubkey,
+          ),
+          const OpenProfileTarget(pubkey),
+        );
+      },
+    );
+
+    test('no video target and no actor pubkey opens the inbox', () {
+      expect(
+        resolveNotificationTapTarget(
+          kind: NotificationKind.mention,
+          hasVideoTarget: false,
+        ),
+        const OpenInboxTarget(),
+      );
+    });
+
+    test(
+      'unknown kind with a video target opens the video without comments',
+      () {
+        expect(
+          resolveNotificationTapTarget(kind: null, hasVideoTarget: true),
+          const OpenVideoTarget(autoOpenComments: false),
+        );
+      },
+    );
+
+    test('identical inputs produce equal targets regardless of source '
+        '(anti-drift)', () {
+      // In-app and push both feed the same (kind, hasVideoTarget, pubkey)
+      // into this function; value-equality proves they cannot diverge.
+      final fromInApp = resolveNotificationTapTarget(
+        kind: NotificationKind.comment,
+        hasVideoTarget: true,
+        actorPubkey: pubkey,
+      );
+      final fromPush = resolveNotificationTapTarget(
+        kind: NotificationKind.comment,
+        hasVideoTarget: true,
+        actorPubkey: pubkey,
+      );
+      expect(fromInApp, fromPush);
+      expect(fromInApp, const OpenVideoTarget(autoOpenComments: true));
+    });
+  });
+}

--- a/mobile/test/services/notification_helpers_test.dart
+++ b/mobile/test/services/notification_helpers_test.dart
@@ -423,58 +423,89 @@ void main() {
   });
 
   group('parseFcmPayload', () {
-    test('returns null when referencedEventId is missing', () {
+    test('returns null when the payload carries nothing routable', () {
       expect(parseFcmPayload(const {}), isNull);
+      // A type with no event id and no sender pubkey is not routable.
       expect(parseFcmPayload(const {'type': 'like'}), isNull);
-    });
-
-    test('returns null when referencedEventId is an empty string', () {
       expect(parseFcmPayload(const {'referencedEventId': ''}), isNull);
     });
 
-    test(
-      'returns the referenced event id with a null type when type missing',
-      () {
-        final result = parseFcmPayload(const {
-          'referencedEventId': 'event_abc',
-        });
-
-        expect(result, isNotNull);
-        expect(result!.referencedEventId, equals('event_abc'));
-        expect(result.notificationType, isNull);
-      },
-    );
-
-    test('reads the FCM wire key "type" into notificationType', () {
+    test('parses a like payload (referencedEventId + sender)', () {
       final result = parseFcmPayload(const {
-        'referencedEventId': 'event_abc',
-        'type': 'reply',
+        'type': 'like',
+        'eventId': 'reaction_event',
+        'referencedEventId': 'video_event',
+        'senderPubkey': 'actor_hex',
       });
 
       expect(result, isNotNull);
-      expect(result!.referencedEventId, equals('event_abc'));
-      expect(result.notificationType, equals('reply'));
+      expect(result!.notificationType, equals('like'));
+      expect(result.referencedEventId, equals('video_event'));
+      expect(result.eventId, equals('reaction_event'));
+      expect(result.senderPubkey, equals('actor_hex'));
     });
 
-    test('reads local notification JSON key "notificationType"', () {
+    test('parses a follow payload via senderPubkey (no referencedEventId)', () {
+      // The push service sends follows with senderPubkey + eventId but no
+      // referencedEventId — these must no longer be dropped.
       final result = parseFcmPayload(const {
-        'referencedEventId': 'event_abc',
-        'notificationType': 'reply',
+        'type': 'follow',
+        'eventId': 'contact_list_event',
+        'senderPubkey': 'follower_hex',
       });
 
       expect(result, isNotNull);
-      expect(result!.referencedEventId, equals('event_abc'));
-      expect(result.notificationType, equals('reply'));
+      expect(result!.notificationType, equals('follow'));
+      expect(result.referencedEventId, isNull);
+      expect(result.senderPubkey, equals('follower_hex'));
+      expect(result.eventId, equals('contact_list_event'));
     });
 
-    test('prefers FCM wire key when both type fields are present', () {
+    test('parses a mention payload via eventId (no referencedEventId)', () {
+      final result = parseFcmPayload(const {
+        'type': 'mention',
+        'eventId': 'mention_note',
+        'senderPubkey': 'mentioner_hex',
+      });
+
+      expect(result, isNotNull);
+      expect(result!.referencedEventId, isNull);
+      expect(result.eventId, equals('mention_note'));
+      expect(result.senderPubkey, equals('mentioner_hex'));
+    });
+
+    test('notificationType is null when absent', () {
+      final result = parseFcmPayload(const {'eventId': 'evt'});
+
+      expect(result, isNotNull);
+      expect(result!.notificationType, isNull);
+    });
+
+    test('reads the FCM wire key "type"', () {
+      final result = parseFcmPayload(const {
+        'referencedEventId': 'event_abc',
+        'type': 'comment',
+      });
+
+      expect(result!.notificationType, equals('comment'));
+    });
+
+    test('reads the local notification JSON key "notificationType"', () {
+      final result = parseFcmPayload(const {
+        'referencedEventId': 'event_abc',
+        'notificationType': 'comment',
+      });
+
+      expect(result!.notificationType, equals('comment'));
+    });
+
+    test('prefers the FCM wire key when both type fields are present', () {
       final result = parseFcmPayload(const {
         'referencedEventId': 'event_abc',
         'type': 'mention',
-        'notificationType': 'reply',
+        'notificationType': 'comment',
       });
 
-      expect(result, isNotNull);
       expect(result!.notificationType, equals('mention'));
     });
 
@@ -485,24 +516,23 @@ void main() {
       final result = parseFcmPayload(const {
         'referencedEventId': fullEventId,
         'type': 'like',
+        'senderPubkey': 'actor',
       });
 
       expect(result!.referencedEventId, equals(fullEventId));
     });
 
-    test('handles each known notification kind', () {
-      const kinds = ['like', 'reply', 'comment', 'mention', 'repost', 'follow'];
+    test('parses each push-service notification kind', () {
+      // The push service emits a lowercase five-value vocabulary.
+      const kinds = ['like', 'comment', 'follow', 'mention', 'repost'];
       for (final kind in kinds) {
         final result = parseFcmPayload({
-          'referencedEventId': 'evt_$kind',
           'type': kind,
+          'eventId': 'evt_$kind',
+          'senderPubkey': 'actor_$kind',
         });
 
-        expect(
-          result,
-          isNotNull,
-          reason: '$kind payload should parse to non-null',
-        );
+        expect(result, isNotNull, reason: '$kind payload should parse');
         expect(result!.notificationType, equals(kind));
       }
     });

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -308,18 +308,43 @@ void main() {
       expect(events, isEmpty);
     });
 
-    test('does not emit when referencedEventId is absent', () async {
+    test('does not emit when nothing routable is present', () async {
       final events = <NotificationTapEvent>[];
       final sub = service.notificationTapStream.listen(events.add);
       addTearDown(sub.cancel);
 
+      // No referencedEventId, eventId, or senderPubkey → nothing to route.
       service.handleNotificationTapPayload(
-        jsonEncode({'notificationType': 'reaction'}),
+        jsonEncode({'notificationType': 'comment'}),
       );
 
       await Future<void>.delayed(Duration.zero);
 
       expect(events, isEmpty);
+    });
+
+    test('emits a follow tap via senderPubkey (no referencedEventId)', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
+
+      // Follows carry senderPubkey + eventId but no referencedEventId; the tap
+      // must still emit so the router can open the actor's profile.
+      service.handleNotificationTapPayload(
+        jsonEncode({
+          'notificationType': 'follow',
+          'eventId': 'contact_list_event',
+          'senderPubkey': 'follower_hex',
+        }),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(events.single.referencedEventId, isNull);
+      expect(events.single.senderPubkey, equals('follower_hex'));
+      expect(events.single.eventId, equals('contact_list_event'));
+      expect(events.single.notificationType, equals('follow'));
     });
 
     test('no-ops gracefully when the stream has no listeners', () {


### PR DESCRIPTION
## Description

Unifies the three notification tap entry points — FCM system push
(`getInitialMessage` / `onMessageOpenedApp`), local-notification taps, and
in-app notification rows — behind **one shared routing decision**,
`resolveNotificationTapTarget` (new, pure, Flutter-free). They can no longer
drift on where a tap lands, whether comments auto-open, or how unresolved
targets fall back. Each path keeps its own navigation mechanics/UX (the in-app
path keeps its `PooledFullscreenVideoFeedScreen` + snackbar behavior).

Fixes grounded in the `divine-push-service` source contract (data-only FCM,
lowercase five-value `type`, `senderPubkey`):

- **Follow & mention pushes no longer dead-end.** `parseFcmPayload` dropped any
  payload without a `referencedEventId`; follows/mentions have none. Now
  `senderPubkey` + `eventId` are parsed and carried through the
  local-notification payload and `NotificationTapEvent`, and the push executor
  routes follows to the actor profile (and unresolvable targets to
  profile/inbox) instead of silently returning.
- **Comment auto-open unified.** The push path keyed auto-open off a `'reply'`
  string the service never sends (it sends lowercase `'comment'`), so push
  comments never auto-opened. Now driven by the shared
  `notificationKindOpensComments` policy.
- **Removed dead code:** `NotificationPayloadKind.reply`.

**Related Issue:** Closes #4727 (parent epic #4200)

## Out of Scope

- **#4728** — foreground local notifications still don't carry a payload
  (`handleForegroundMessage` → `sendLocal` drops it). This PR establishes the
  contract they'll feed; #4728 wires the foreground producer onto it.
- **#4730** — `referencedDTag` owned-video attribution safety.
- Converging the in-app vs push video *screen* (`PooledFullscreenVideoFeedScreen`
  vs `VideoDetailScreen`) — intentionally preserved per the issue's "preserve
  current working behaviors from the in-app path."
- Profile deep-link nav-stack push/skip parity (#4331) — the follow→profile push
  uses `push()` directly and does not depend on it.

## Verification

- `flutter analyze lib test` → **No issues found**
- `flutter test test/notifications/ test/services/notification_service_test.dart
  test/services/notification_helpers_test.dart
  test/main_notification_tap_routing_test.dart
  test/main_video_deep_link_nav_action_test.dart` → **254 pass** (+28 new cases:
  shared decision per-kind, push routing per-kind, follow/mention payload
  parsing, follow tap-emit, anti-drift equality)
- `dart format --output=none --set-exit-if-changed` → clean

### Known residual
Cold-start navigator readiness for the new direct profile/inbox
`goRouterProvider` navigation is runtime-only (not statically provable);
reasoned safe because the deferred FCM startup phase fires after the widget tree
mounts — the same precondition the existing video → deep-link-stream path
already relies on.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
