### PR TITLE
refactor(models): extract URL resolution out of VideoEvent

### DIFF
--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -51,5 +51,6 @@ export 'src/video_event_filters.dart';
 export 'src/video_reply_visibility.dart';
 export 'src/video_state.dart';
 export 'src/video_stats.dart';
+export 'src/video_url_resolver.dart';
 export 'src/video_views_response.dart';
 export 'src/vine_sound.dart';

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -264,16 +264,7 @@ class VideoEvent {
           // Check if this is a valid video URL
           if (tagValue.isNotEmpty &&
               VideoUrlResolver.isValidVideoUrl(tagValue)) {
-            if (tagValue.contains('apt.openvine.co')) {
-              // Fix typo: apt.openvine.co -> api.openvine.co
-              final fixedUrl = tagValue.replaceAll(
-                'apt.openvine.co',
-                'api.openvine.co',
-              );
-              videoUrlCandidates.add(fixedUrl);
-            } else {
-              videoUrlCandidates.add(tagValue);
-            }
+            videoUrlCandidates.add(VideoUrlResolver.fixOpenvineTypo(tagValue));
           }
         case 'streaming':
           // Handle streaming tag with HLS/DASH URLs
@@ -292,16 +283,9 @@ class VideoEvent {
                 // Check if this is a valid video URL and add to candidates
                 if (value.isNotEmpty &&
                     VideoUrlResolver.isValidVideoUrl(value)) {
-                  if (value.contains('apt.openvine.co')) {
-                    // Fix typo: apt.openvine.co -> api.openvine.co
-                    final fixedUrl = value.replaceAll(
-                      'apt.openvine.co',
-                      'api.openvine.co',
-                    );
-                    videoUrlCandidates.add(fixedUrl);
-                  } else {
-                    videoUrlCandidates.add(value);
-                  }
+                  videoUrlCandidates.add(
+                    VideoUrlResolver.fixOpenvineTypo(value),
+                  );
                 }
               // POSTEL'S LAW: Accept various video URL keys that
               // different clients may use
@@ -564,11 +548,7 @@ class VideoEvent {
 
     // If we still have a broken apt.openvine.co URL, fix it
     if (videoUrl?.contains('apt.openvine.co') ?? false) {
-      final fixedUrl = videoUrl!.replaceAll(
-        'apt.openvine.co',
-        'api.openvine.co',
-      );
-      videoUrl = fixedUrl;
+      videoUrl = VideoUrlResolver.fixOpenvineTypo(videoUrl!);
     }
 
     // Use 'd' tag if available, otherwise fallback to event ID

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:models/src/nip71_video_kinds.dart';
 import 'package:models/src/video_attribution.dart';
+import 'package:models/src/video_url_resolver.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:text_sanitizer/text_sanitizer.dart';
 
@@ -261,7 +262,8 @@ class VideoEvent {
       switch (tagName) {
         case 'url':
           // Check if this is a valid video URL
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             if (tagValue.contains('apt.openvine.co')) {
               // Fix typo: apt.openvine.co -> api.openvine.co
               final fixedUrl = tagValue.replaceAll(
@@ -276,7 +278,8 @@ class VideoEvent {
         case 'streaming':
           // Handle streaming tag with HLS/DASH URLs
           // Format: ["streaming", "url", "format"] e.g., ["streaming", "https://cdn.divine.video/.../video.m3u8", "hls"]
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             videoUrlCandidates.add(tagValue);
           }
         case 'imeta':
@@ -287,7 +290,8 @@ class VideoEvent {
             switch (key) {
               case 'url':
                 // Check if this is a valid video URL and add to candidates
-                if (value.isNotEmpty && _isValidVideoUrl(value)) {
+                if (value.isNotEmpty &&
+                    VideoUrlResolver.isValidVideoUrl(value)) {
                   if (value.contains('apt.openvine.co')) {
                     // Fix typo: apt.openvine.co -> api.openvine.co
                     final fixedUrl = value.replaceAll(
@@ -309,7 +313,8 @@ class VideoEvent {
               case 'mp4':
               case 'video':
                 // Alternative video URL keys - add as candidates if valid
-                if (value.isNotEmpty && _isValidVideoUrl(value)) {
+                if (value.isNotEmpty &&
+                    VideoUrlResolver.isValidVideoUrl(value)) {
                   videoUrlCandidates.add(value);
                 }
               case 'm':
@@ -322,12 +327,14 @@ class VideoEvent {
                 dimensions ??= value;
               case 'thumb':
                 // Thumbnail URL
-                if (value.isNotEmpty && _isValidVideoUrl(value)) {
+                if (value.isNotEmpty &&
+                    VideoUrlResolver.isValidVideoUrl(value)) {
                   thumbnailUrl ??= value;
                 }
               case 'image':
                 // NIP-92 uses 'image' for thumbnail in imeta
-                if (value.isNotEmpty && _isValidVideoUrl(value)) {
+                if (value.isNotEmpty &&
+                    VideoUrlResolver.isValidVideoUrl(value)) {
                   thumbnailUrl ??= value;
                 }
               case 'blurhash':
@@ -356,7 +363,8 @@ class VideoEvent {
           fileSize = int.tryParse(tagValue);
         case 'thumb':
           // Thumbnail URL - prefer static thumbnails for grid display
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             thumbnailUrl = tagValue;
           }
         case 'preview':
@@ -369,7 +377,8 @@ class VideoEvent {
           }
         case 'image':
           // Alternative to 'thumb' tag - some clients use 'image' instead
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             thumbnailUrl ??= tagValue;
           }
         case 'd':
@@ -413,15 +422,18 @@ class VideoEvent {
             final url = tagValue;
             final type = tag[2];
 
-            if (type == 'video' && url.isNotEmpty && _isValidVideoUrl(url)) {
+            if (type == 'video' &&
+                url.isNotEmpty &&
+                VideoUrlResolver.isValidVideoUrl(url)) {
               videoUrl ??= url;
             } else if (type == 'thumbnail' &&
                 url.isNotEmpty &&
-                _isValidVideoUrl(url) &&
+                VideoUrlResolver.isValidVideoUrl(url) &&
                 !url.contains('picsum.photos')) {
               thumbnailUrl ??= url;
             }
-          } else if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          } else if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             // Fallback: if no type annotation, treat as video URL
             videoUrlCandidates.add(tagValue);
           }
@@ -451,12 +463,14 @@ class VideoEvent {
             }
           }
           // Also check if it's a media URL in disguise (legacy behavior)
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             videoUrlCandidates.add(tagValue);
           }
         case 'i':
           // External identity - sometimes used for media
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             videoUrlCandidates.add(tagValue);
           }
         case 'p':
@@ -505,7 +519,8 @@ class VideoEvent {
           }
         default:
           // POSTEL'S LAW: Check if any unknown tag contains a valid video URL
-          if (tagValue.isNotEmpty && _isValidVideoUrl(tagValue)) {
+          if (tagValue.isNotEmpty &&
+              VideoUrlResolver.isValidVideoUrl(tagValue)) {
             videoUrlCandidates.add(tagValue);
           }
       }
@@ -532,15 +547,15 @@ class VideoEvent {
     // POSTEL'S LAW: Be liberal in what you accept
     // Apply comprehensive fallback logic to find video URLs
     if (videoUrl == null || videoUrl.isEmpty) {
-      videoUrl = _extractVideoUrlFromContent(event.content);
+      videoUrl = VideoUrlResolver.extractVideoUrlFromContent(event.content);
     }
 
     // Select best video URL from all candidates
     if (videoUrlCandidates.isNotEmpty) {
-      videoUrl = _selectBestVideoUrl(videoUrlCandidates);
+      videoUrl = VideoUrlResolver.selectBestVideoUrl(videoUrlCandidates);
     } else {
       // If no candidates found, use the old fallback method
-      videoUrl = _findAnyVideoUrlInTags(event.tags);
+      videoUrl = VideoUrlResolver.findAnyVideoUrlInTags(event.tags);
     }
 
     // Note: Removed Classic Vine hardening that was forcing api.openvine.co
@@ -1466,166 +1481,6 @@ class VideoEvent {
         reposterPubkeys ?? [reposterPubkey], // Default to single reposter
     repostedAt: repostedAt,
   );
-
-  /// Check if a URL is a valid video URL
-  static bool _isValidVideoUrl(String url) {
-    if (url.isEmpty) return false;
-
-    // Fix common typo: apt.openvine.co -> api.openvine.co
-    var correctedUrl = url;
-    if (url.contains('apt.openvine.co')) {
-      correctedUrl = url.replaceAll('apt.openvine.co', 'api.openvine.co');
-    }
-
-    try {
-      final uri = Uri.parse(correctedUrl);
-
-      // Must be HTTP or HTTPS
-      if (!['http', 'https'].contains(uri.scheme.toLowerCase())) {
-        return false;
-      }
-
-      // Must have a valid host
-      if (uri.host.isEmpty) return false;
-
-      // Accept any valid HTTP/HTTPS URL
-      // This is an open protocol - people can host videos anywhere
-      // The video player will determine if it can actually play the content
-      return true;
-    } on FormatException {
-      return false;
-    }
-  }
-
-  /// Score video URL by format preference
-  /// Higher scores = better format preference
-  /// For short videos (6 seconds): MP4 is ALWAYS better than HLS
-  /// - MP4: Single file, fast download, universal support
-  /// - HLS: Manifest + segments, slower, overkill for short videos
-  static int _scoreVideoUrl(String url) {
-    final urlLower = url.toLowerCase();
-
-    // Reject broken vine.co URLs immediately (but NOT openvine.co,
-    // divine.video, etc.). Only reject URLs from the dead vine.co domain
-    if (urlLower.contains('//vine.co/') ||
-        urlLower.contains('//www.vine.co/') ||
-        urlLower.startsWith('vine.co/')) {
-      return -1;
-    }
-
-    // POSTEL'S LAW: Deprioritize known broken URL patterns
-    // The cdn.divine.video/*/manifest/video.m3u8 pattern is often broken
-    // Prefer stream.divine.video HLS or direct MP4 files
-    if (urlLower.contains('cdn.divine.video') &&
-        urlLower.contains('/manifest/')) {
-      return 5;
-    }
-
-    // ALWAYS prefer MP4 over HLS for short videos (6 seconds)
-    // HLS adaptive bitrate is pointless for content this short
-    // MP4 is simpler, faster (single file vs manifest + segments)
-
-    // Direct MP4 from cdn.divine.video (blob storage) - highest priority
-    if (urlLower.contains('.mp4') && urlLower.contains('cdn.divine.video')) {
-      return 115;
-    }
-
-    // Any other MP4 - still preferred
-    if (urlLower.contains('.mp4')) return 110;
-
-    // BunnyStream HLS (stream.divine.video) - reliable streaming
-    if (urlLower.contains('.m3u8') &&
-        urlLower.contains('stream.divine.video')) {
-      return 105;
-    }
-
-    // Generic HLS fallback
-    if (urlLower.contains('.m3u8') || urlLower.contains('hls')) return 100;
-
-    // WebM is good for web
-    if (urlLower.contains('.webm')) return 90;
-
-    // MOV is decent but large
-    if (urlLower.contains('.mov')) return 70;
-
-    // AVI is supported but not optimal
-    if (urlLower.contains('.avi')) return 60;
-
-    // DASH can be problematic
-    if (urlLower.contains('.mpd') || urlLower.contains('dash')) return 10;
-
-    // Generic URLs get medium priority
-    return 50;
-  }
-
-  /// Select the best video URL from multiple candidates
-  static String? _selectBestVideoUrl(List<String> candidates) {
-    if (candidates.isEmpty) return null;
-
-    // Score all candidates and pick the highest scoring one
-    String? bestUrl;
-    var bestScore = -1;
-
-    for (final url in candidates) {
-      final isValid = _isValidVideoUrl(url);
-      if (isValid) {
-        final score = _scoreVideoUrl(url);
-        if (score > bestScore) {
-          bestScore = score;
-          bestUrl = url;
-        }
-      }
-    }
-
-    return bestUrl;
-  }
-
-  /// Extract video URL from event content text (fallback strategy)
-  static String? _extractVideoUrlFromContent(String content) {
-    // Look for URLs in the content using regex
-    final urlRegex = RegExp(r'https?://[^\s]+');
-    final matches = urlRegex.allMatches(content);
-
-    for (final match in matches) {
-      var url = match.group(0);
-      if (url != null) {
-        // Fix common typo: apt.openvine.co -> api.openvine.co
-        if (url.contains('apt.openvine.co')) {
-          url = url.replaceAll('apt.openvine.co', 'api.openvine.co');
-        }
-        if (_isValidVideoUrl(url)) {
-          return url;
-        }
-      }
-    }
-
-    return null;
-  }
-
-  /// Find any potential video URL in all tags (aggressive fallback)
-  static String? _findAnyVideoUrlInTags(List<dynamic> tags) {
-    for (final tagRaw in tags) {
-      if (tagRaw is! List || tagRaw.isEmpty) continue;
-
-      final tag = tagRaw.map((e) => e.toString()).toList();
-
-      // Check all tag values for potential URLs
-      for (var i = 1; i < tag.length; i++) {
-        var value = tag[i];
-        if (value.isNotEmpty) {
-          // Fix common typo: apt.openvine.co -> api.openvine.co
-          if (value.contains('apt.openvine.co')) {
-            value = value.replaceAll('apt.openvine.co', 'api.openvine.co');
-          }
-          if (_isValidVideoUrl(value)) {
-            return value;
-          }
-        }
-      }
-    }
-
-    return null;
-  }
 }
 
 /// Exception thrown when parsing video events

--- a/mobile/packages/models/lib/src/video_url_resolver.dart
+++ b/mobile/packages/models/lib/src/video_url_resolver.dart
@@ -1,0 +1,163 @@
+/// Resolves and scores candidate video URLs extracted from Nostr event tags
+/// and content.
+///
+/// Extracted from `VideoEvent` (#4740) so that URL selection — which is
+/// business logic, not data — lives outside the data model. All methods are
+/// pure: no I/O, no state.
+class VideoUrlResolver {
+  VideoUrlResolver._();
+
+  /// Corrects the common `apt.openvine.co` typo to `api.openvine.co`.
+  static String _fixOpenvineTypo(String url) {
+    if (url.contains('apt.openvine.co')) {
+      return url.replaceAll('apt.openvine.co', 'api.openvine.co');
+    }
+    return url;
+  }
+
+  /// Whether [url] is a usable video URL (a well-formed HTTP/HTTPS URL).
+  ///
+  /// Divine is an open protocol — videos can be hosted anywhere — so any valid
+  /// HTTP/HTTPS URL with a host is accepted; the player decides playability.
+  static bool isValidVideoUrl(String url) {
+    if (url.isEmpty) return false;
+
+    final correctedUrl = _fixOpenvineTypo(url);
+
+    try {
+      final uri = Uri.parse(correctedUrl);
+
+      // Must be HTTP or HTTPS.
+      if (!['http', 'https'].contains(uri.scheme.toLowerCase())) {
+        return false;
+      }
+
+      // Must have a valid host.
+      if (uri.host.isEmpty) return false;
+
+      return true;
+    } on FormatException {
+      return false;
+    }
+  }
+
+  /// Scores [url] by format preference (higher = better).
+  ///
+  /// For short videos MP4 is always preferred over HLS (single file, fast,
+  /// universal). Dead `vine.co` URLs and the often-broken
+  /// `cdn.divine.video/*/manifest/*.m3u8` pattern are deprioritized.
+  static int scoreVideoUrl(String url) {
+    final urlLower = url.toLowerCase();
+
+    // Reject broken vine.co URLs immediately (but NOT openvine.co,
+    // divine.video, etc.). Only reject URLs from the dead vine.co domain.
+    if (urlLower.contains('//vine.co/') ||
+        urlLower.contains('//www.vine.co/') ||
+        urlLower.startsWith('vine.co/')) {
+      return -1;
+    }
+
+    // POSTEL'S LAW: Deprioritize known broken URL patterns.
+    // The cdn.divine.video/*/manifest/video.m3u8 pattern is often broken;
+    // prefer stream.divine.video HLS or direct MP4 files.
+    if (urlLower.contains('cdn.divine.video') &&
+        urlLower.contains('/manifest/')) {
+      return 5;
+    }
+
+    // ALWAYS prefer MP4 over HLS for short videos (6 seconds).
+    // HLS adaptive bitrate is pointless for content this short; MP4 is simpler
+    // and faster (single file vs manifest + segments).
+
+    // Direct MP4 from cdn.divine.video (blob storage) - highest priority.
+    if (urlLower.contains('.mp4') && urlLower.contains('cdn.divine.video')) {
+      return 115;
+    }
+
+    // Any other MP4 - still preferred.
+    if (urlLower.contains('.mp4')) return 110;
+
+    // BunnyStream HLS (stream.divine.video) - reliable streaming.
+    if (urlLower.contains('.m3u8') &&
+        urlLower.contains('stream.divine.video')) {
+      return 105;
+    }
+
+    // Generic HLS fallback.
+    if (urlLower.contains('.m3u8') || urlLower.contains('hls')) return 100;
+
+    // WebM is good for web.
+    if (urlLower.contains('.webm')) return 90;
+
+    // MOV is decent but large.
+    if (urlLower.contains('.mov')) return 70;
+
+    // AVI is supported but not optimal.
+    if (urlLower.contains('.avi')) return 60;
+
+    // DASH can be problematic.
+    if (urlLower.contains('.mpd') || urlLower.contains('dash')) return 10;
+
+    // Generic URLs get medium priority.
+    return 50;
+  }
+
+  /// Selects the highest-scoring valid URL from [candidates], or `null`.
+  static String? selectBestVideoUrl(List<String> candidates) {
+    if (candidates.isEmpty) return null;
+
+    String? bestUrl;
+    var bestScore = -1;
+
+    for (final url in candidates) {
+      if (isValidVideoUrl(url)) {
+        final score = scoreVideoUrl(url);
+        if (score > bestScore) {
+          bestScore = score;
+          bestUrl = url;
+        }
+      }
+    }
+
+    return bestUrl;
+  }
+
+  /// Extracts the first valid video URL from free-text [content] (fallback).
+  static String? extractVideoUrlFromContent(String content) {
+    final urlRegex = RegExp(r'https?://[^\s]+');
+    final matches = urlRegex.allMatches(content);
+
+    for (final match in matches) {
+      var url = match.group(0);
+      if (url != null) {
+        url = _fixOpenvineTypo(url);
+        if (isValidVideoUrl(url)) {
+          return url;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /// Finds any valid video URL across all [tags] (aggressive fallback).
+  static String? findAnyVideoUrlInTags(List<dynamic> tags) {
+    for (final tagRaw in tags) {
+      if (tagRaw is! List || tagRaw.isEmpty) continue;
+
+      final tag = tagRaw.map((e) => e.toString()).toList();
+
+      for (var i = 1; i < tag.length; i++) {
+        var value = tag[i];
+        if (value.isNotEmpty) {
+          value = _fixOpenvineTypo(value);
+          if (isValidVideoUrl(value)) {
+            return value;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/mobile/packages/models/lib/src/video_url_resolver.dart
+++ b/mobile/packages/models/lib/src/video_url_resolver.dart
@@ -8,7 +8,7 @@ class VideoUrlResolver {
   VideoUrlResolver._();
 
   /// Corrects the common `apt.openvine.co` typo to `api.openvine.co`.
-  static String _fixOpenvineTypo(String url) {
+  static String fixOpenvineTypo(String url) {
     if (url.contains('apt.openvine.co')) {
       return url.replaceAll('apt.openvine.co', 'api.openvine.co');
     }
@@ -22,7 +22,7 @@ class VideoUrlResolver {
   static bool isValidVideoUrl(String url) {
     if (url.isEmpty) return false;
 
-    final correctedUrl = _fixOpenvineTypo(url);
+    final correctedUrl = fixOpenvineTypo(url);
 
     try {
       final uri = Uri.parse(correctedUrl);
@@ -130,7 +130,7 @@ class VideoUrlResolver {
     for (final match in matches) {
       var url = match.group(0);
       if (url != null) {
-        url = _fixOpenvineTypo(url);
+        url = fixOpenvineTypo(url);
         if (isValidVideoUrl(url)) {
           return url;
         }
@@ -150,7 +150,7 @@ class VideoUrlResolver {
       for (var i = 1; i < tag.length; i++) {
         var value = tag[i];
         if (value.isNotEmpty) {
-          value = _fixOpenvineTypo(value);
+          value = fixOpenvineTypo(value);
           if (isValidVideoUrl(value)) {
             return value;
           }

--- a/mobile/packages/models/test/src/video_url_resolver_test.dart
+++ b/mobile/packages/models/test/src/video_url_resolver_test.dart
@@ -3,6 +3,22 @@ import 'package:test/test.dart';
 
 void main() {
   group('VideoUrlResolver', () {
+    group('fixOpenvineTypo', () {
+      test('corrects the apt.openvine.co typo when present', () {
+        expect(
+          VideoUrlResolver.fixOpenvineTypo('https://apt.openvine.co/v.mp4'),
+          equals('https://api.openvine.co/v.mp4'),
+        );
+      });
+
+      test('returns the original URL when no typo is present', () {
+        expect(
+          VideoUrlResolver.fixOpenvineTypo('https://api.openvine.co/v.mp4'),
+          equals('https://api.openvine.co/v.mp4'),
+        );
+      });
+    });
+
     group('isValidVideoUrl', () {
       test('accepts well-formed http and https URLs with a host', () {
         expect(
@@ -24,10 +40,7 @@ void main() {
           VideoUrlResolver.isValidVideoUrl('ftp://example.com/v.mp4'),
           isFalse,
         );
-        expect(
-          VideoUrlResolver.isValidVideoUrl('file:///tmp/v.mp4'),
-          isFalse,
-        );
+        expect(VideoUrlResolver.isValidVideoUrl('file:///tmp/v.mp4'), isFalse);
       });
 
       test('rejects a string with no host', () {
@@ -64,9 +77,7 @@ void main() {
 
       test('ranks stream.divine.video HLS above generic HLS', () {
         expect(
-          VideoUrlResolver.scoreVideoUrl(
-            'https://stream.divine.video/v.m3u8',
-          ),
+          VideoUrlResolver.scoreVideoUrl('https://stream.divine.video/v.m3u8'),
           equals(105),
         );
         expect(
@@ -119,10 +130,7 @@ void main() {
           VideoUrlResolver.scoreVideoUrl('https://e.com/v.mpd'),
           equals(10),
         );
-        expect(
-          VideoUrlResolver.scoreVideoUrl('https://e.com/v'),
-          equals(50),
-        );
+        expect(VideoUrlResolver.scoreVideoUrl('https://e.com/v'), equals(50));
       });
     });
 

--- a/mobile/packages/models/test/src/video_url_resolver_test.dart
+++ b/mobile/packages/models/test/src/video_url_resolver_test.dart
@@ -1,0 +1,242 @@
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VideoUrlResolver', () {
+    group('isValidVideoUrl', () {
+      test('accepts well-formed http and https URLs with a host', () {
+        expect(
+          VideoUrlResolver.isValidVideoUrl('https://cdn.divine.video/v.mp4'),
+          isTrue,
+        );
+        expect(
+          VideoUrlResolver.isValidVideoUrl('http://example.com/v.mp4'),
+          isTrue,
+        );
+      });
+
+      test('rejects an empty string', () {
+        expect(VideoUrlResolver.isValidVideoUrl(''), isFalse);
+      });
+
+      test('rejects non-http(s) schemes', () {
+        expect(
+          VideoUrlResolver.isValidVideoUrl('ftp://example.com/v.mp4'),
+          isFalse,
+        );
+        expect(
+          VideoUrlResolver.isValidVideoUrl('file:///tmp/v.mp4'),
+          isFalse,
+        );
+      });
+
+      test('rejects a string with no host', () {
+        expect(VideoUrlResolver.isValidVideoUrl('https://'), isFalse);
+        expect(VideoUrlResolver.isValidVideoUrl('not-a-url'), isFalse);
+      });
+
+      test('rejects a malformed URI (FormatException path)', () {
+        expect(VideoUrlResolver.isValidVideoUrl('http://[::1'), isFalse);
+      });
+
+      test('corrects the apt.openvine.co typo before validating', () {
+        expect(
+          VideoUrlResolver.isValidVideoUrl('https://apt.openvine.co/v.mp4'),
+          isTrue,
+        );
+      });
+    });
+
+    group('scoreVideoUrl', () {
+      test('ranks MP4 on cdn.divine.video highest', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://cdn.divine.video/v.mp4'),
+          equals(115),
+        );
+      });
+
+      test('ranks generic MP4 above HLS', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://example.com/v.mp4'),
+          equals(110),
+        );
+      });
+
+      test('ranks stream.divine.video HLS above generic HLS', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl(
+            'https://stream.divine.video/v.m3u8',
+          ),
+          equals(105),
+        );
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://example.com/v.m3u8'),
+          equals(100),
+        );
+      });
+
+      test('deprioritizes the broken cdn.divine.video /manifest/ pattern', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl(
+            'https://cdn.divine.video/abc/manifest/video.m3u8',
+          ),
+          equals(5),
+        );
+      });
+
+      test('rejects dead vine.co URLs with a negative score', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://vine.co/v/abc'),
+          equals(-1),
+        );
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://www.vine.co/v/abc'),
+          equals(-1),
+        );
+      });
+
+      test('does not reject openvine.co (only dead vine.co)', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://openvine.co/v'),
+          equals(50),
+        );
+      });
+
+      test('scores other formats by preference', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://e.com/v.webm'),
+          equals(90),
+        );
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://e.com/v.mov'),
+          equals(70),
+        );
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://e.com/v.avi'),
+          equals(60),
+        );
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://e.com/v.mpd'),
+          equals(10),
+        );
+        expect(
+          VideoUrlResolver.scoreVideoUrl('https://e.com/v'),
+          equals(50),
+        );
+      });
+    });
+
+    group('selectBestVideoUrl', () {
+      test('returns null for an empty candidate list', () {
+        expect(VideoUrlResolver.selectBestVideoUrl([]), isNull);
+      });
+
+      test('picks the highest-scoring valid candidate', () {
+        final best = VideoUrlResolver.selectBestVideoUrl([
+          'https://example.com/v.m3u8', // 100
+          'https://cdn.divine.video/v.mp4', // 115
+          'https://example.com/v.webm', // 90
+        ]);
+        expect(best, equals('https://cdn.divine.video/v.mp4'));
+      });
+
+      test('returns null when every candidate is invalid', () {
+        expect(
+          VideoUrlResolver.selectBestVideoUrl(['', 'ftp://x/v.mp4']),
+          isNull,
+        );
+      });
+
+      test('does not select dead vine.co URLs (negative score)', () {
+        expect(
+          VideoUrlResolver.selectBestVideoUrl(['https://vine.co/v/abc']),
+          isNull,
+        );
+      });
+
+      test('skips invalid candidates and selects the valid one', () {
+        final best = VideoUrlResolver.selectBestVideoUrl([
+          'not-a-url',
+          'https://example.com/v.mp4',
+        ]);
+        expect(best, equals('https://example.com/v.mp4'));
+      });
+    });
+
+    group('extractVideoUrlFromContent', () {
+      test('returns the first valid URL found in free text', () {
+        expect(
+          VideoUrlResolver.extractVideoUrlFromContent(
+            'watch this https://example.com/v.mp4 now',
+          ),
+          equals('https://example.com/v.mp4'),
+        );
+      });
+
+      test('corrects the apt.openvine.co typo in the returned URL', () {
+        expect(
+          VideoUrlResolver.extractVideoUrlFromContent(
+            'see https://apt.openvine.co/v.mp4',
+          ),
+          equals('https://api.openvine.co/v.mp4'),
+        );
+      });
+
+      test('returns null when there is no URL', () {
+        expect(
+          VideoUrlResolver.extractVideoUrlFromContent('no links here'),
+          isNull,
+        );
+      });
+    });
+
+    group('findAnyVideoUrlInTags', () {
+      test('returns a valid URL from a tag value', () {
+        expect(
+          VideoUrlResolver.findAnyVideoUrlInTags([
+            ['url', 'https://example.com/v.mp4'],
+          ]),
+          equals('https://example.com/v.mp4'),
+        );
+      });
+
+      test('ignores the tag name at index 0', () {
+        expect(
+          VideoUrlResolver.findAnyVideoUrlInTags([
+            ['https://example.com/v.mp4'],
+          ]),
+          isNull,
+        );
+      });
+
+      test('skips non-list and empty tags', () {
+        expect(
+          VideoUrlResolver.findAnyVideoUrlInTags([
+            'not-a-list',
+            <dynamic>[],
+            ['x', 'https://example.com/v.mp4'],
+          ]),
+          equals('https://example.com/v.mp4'),
+        );
+      });
+
+      test('corrects the apt.openvine.co typo in the returned URL', () {
+        expect(
+          VideoUrlResolver.findAnyVideoUrlInTags([
+            ['x', 'https://apt.openvine.co/v.mp4'],
+          ]),
+          equals('https://api.openvine.co/v.mp4'),
+        );
+      });
+
+      test('returns null when no tag holds a valid URL', () {
+        expect(
+          VideoUrlResolver.findAnyVideoUrlInTags([
+            ['x', 'not-a-url'],
+          ]),
+          isNull,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

First **Wave 2** slice of architecture epic #4338 (state/layering decomposition).

Moves the 5 URL-resolution methods out of the `VideoEvent` **data model** into a dedicated, tested `VideoUrlResolver` utility in the same `models` package — URL scoring/selection is business logic, not data, so it shouldn't live on the model.

- **New:** `mobile/packages/models/lib/src/video_url_resolver.dart` — `VideoUrlResolver` with public statics `isValidVideoUrl`, `scoreVideoUrl`, `selectBestVideoUrl`, `extractVideoUrlFromContent`, `findAnyVideoUrlInTags`, plus a private `_fixOpenvineTypo` that consolidates the `apt.openvine.co → api.openvine.co` fix previously duplicated across 3 methods.
- **`video_event.dart`:** removed the 5 private methods (−~144 lines), rewired its 17 call sites to the resolver, added the import.
- **Barrel:** exported the resolver.

**Behavior-preserving.** Methods moved verbatim; the typo-fix consolidation keeps the exact string op. Follows the existing `NostrHexUtils` / `engagement_count_parser` utility precedent in this package.

**Related Issue:** Closes #4740 · Part of #4338 (Wave 2) · addresses audit context #3617.

## Out of Scope

- Other `services/` god-file extractions (#4741 / #4742) and the rest of Wave 2.
- Any behavior/scoring change — this is a pure extraction.

## Verification

- `flutter analyze lib test` (models) → No issues found.
- `dart format` → clean.
- New `video_url_resolver_test.dart`: **26 tests** covering every method + branch (mp4>hls, `cdn.divine.video` 115, vine.co `-1` not selected, `/manifest/` deprioritization, apt-typo correction, tag index-0 skip, empty/invalid handling).
- Existing `video_event_*` tests (parsing/json/filters/reply-metadata) — the factory now delegates to the resolver — stay green.
- **Full `models` package suite: 655 tests green.**

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
