### PR TITLE
refactor(state): migrate NotificationSettingsScreen to a Cubit

### DIFF
--- a/mobile/lib/blocs/notification_settings/notification_settings_cubit.dart
+++ b/mobile/lib/blocs/notification_settings/notification_settings_cubit.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Screen-scoped Cubit for the notification settings screen.
+// ABOUTME: Owns the notification preferences and the local push/sound/vibration
+// ABOUTME: toggles, persisting preference changes via NotificationPreferencesService.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
+import 'package:openvine/models/notification_preferences.dart';
+import 'package:openvine/services/notification_preferences_service.dart';
+
+/// Cubit backing `NotificationSettingsScreen`.
+///
+/// Holds the notification [NotificationSettingsState.preferences] (persisted)
+/// and the local-only push/sound/vibration toggles. Preference mutations are
+/// written through [NotificationPreferencesService]; the local toggles are not
+/// persisted (matching the pre-migration behavior).
+class NotificationSettingsCubit extends Cubit<NotificationSettingsState> {
+  NotificationSettingsCubit({
+    required NotificationPreferencesService preferencesService,
+  }) : _preferencesService = preferencesService,
+       super(const NotificationSettingsState());
+
+  final NotificationPreferencesService _preferencesService;
+
+  /// Loads the persisted preferences. `loadPreferences` is itself defensive
+  /// (returns defaults on storage/decoding errors), so this does not throw.
+  Future<void> load() async {
+    emit(state.copyWith(status: NotificationSettingsStatus.loading));
+    final preferences = await _preferencesService.loadPreferences();
+    emit(
+      state.copyWith(
+        status: NotificationSettingsStatus.ready,
+        preferences: preferences,
+      ),
+    );
+  }
+
+  /// Applies [preferences] optimistically, then persists them.
+  Future<void> setPreferences(NotificationPreferences preferences) async {
+    emit(state.copyWith(preferences: preferences));
+    await _preferencesService.updatePreferences(preferences);
+  }
+
+  void setSystemEnabled(bool value) =>
+      emit(state.copyWith(systemEnabled: value));
+
+  void setPushNotificationsEnabled(bool value) =>
+      emit(state.copyWith(pushNotificationsEnabled: value));
+
+  void setSoundEnabled(bool value) => emit(state.copyWith(soundEnabled: value));
+
+  void setVibrationEnabled(bool value) =>
+      emit(state.copyWith(vibrationEnabled: value));
+
+  /// Resets preferences and local toggles to their defaults and persists.
+  Future<void> resetToDefaults() async {
+    const defaults = NotificationPreferences();
+    emit(
+      state.copyWith(
+        preferences: defaults,
+        systemEnabled: true,
+        pushNotificationsEnabled: true,
+        soundEnabled: true,
+        vibrationEnabled: true,
+      ),
+    );
+    await _preferencesService.updatePreferences(defaults);
+  }
+}

--- a/mobile/lib/blocs/notification_settings/notification_settings_state.dart
+++ b/mobile/lib/blocs/notification_settings/notification_settings_state.dart
@@ -1,0 +1,60 @@
+// ABOUTME: State for NotificationSettingsCubit — the persisted notification
+// ABOUTME: preferences plus the local-only push/sound/vibration UI toggles.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/models/notification_preferences.dart';
+
+/// Load lifecycle of the notification settings screen.
+enum NotificationSettingsStatus { initial, loading, ready }
+
+/// State for [NotificationSettingsCubit].
+///
+/// [preferences] is persisted via `NotificationPreferencesService`. The four
+/// booleans are local-only UI toggles with no service backing (they mirror the
+/// pre-migration `setState`-only fields).
+class NotificationSettingsState extends Equatable {
+  const NotificationSettingsState({
+    this.status = NotificationSettingsStatus.initial,
+    this.preferences = const NotificationPreferences(),
+    this.systemEnabled = true,
+    this.pushNotificationsEnabled = true,
+    this.soundEnabled = true,
+    this.vibrationEnabled = true,
+  });
+
+  final NotificationSettingsStatus status;
+  final NotificationPreferences preferences;
+  final bool systemEnabled;
+  final bool pushNotificationsEnabled;
+  final bool soundEnabled;
+  final bool vibrationEnabled;
+
+  NotificationSettingsState copyWith({
+    NotificationSettingsStatus? status,
+    NotificationPreferences? preferences,
+    bool? systemEnabled,
+    bool? pushNotificationsEnabled,
+    bool? soundEnabled,
+    bool? vibrationEnabled,
+  }) {
+    return NotificationSettingsState(
+      status: status ?? this.status,
+      preferences: preferences ?? this.preferences,
+      systemEnabled: systemEnabled ?? this.systemEnabled,
+      pushNotificationsEnabled:
+          pushNotificationsEnabled ?? this.pushNotificationsEnabled,
+      soundEnabled: soundEnabled ?? this.soundEnabled,
+      vibrationEnabled: vibrationEnabled ?? this.vibrationEnabled,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    status,
+    preferences,
+    systemEnabled,
+    pushNotificationsEnabled,
+    soundEnabled,
+    vibrationEnabled,
+  ];
+}

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -3,109 +3,70 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/notification_settings/notification_settings_cubit.dart';
+import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 
-class NotificationSettingsScreen extends ConsumerStatefulWidget {
+/// Page: bridges Riverpod-provided dependencies into [NotificationSettingsCubit].
+class NotificationSettingsScreen extends ConsumerWidget {
+  const NotificationSettingsScreen({super.key});
+
   /// Route name for this screen.
   static const routeName = 'notification-settings';
 
   /// Path for this route.
   static const path = '/notification-settings';
 
-  const NotificationSettingsScreen({super.key});
-
   @override
-  ConsumerState<NotificationSettingsScreen> createState() =>
-      _NotificationSettingsScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final preferencesService = ref.watch(
+      notificationPreferencesServiceProvider,
+    );
+    final repository = ref.watch(notificationRepositoryProvider);
 
-class _NotificationSettingsScreenState
-    extends ConsumerState<NotificationSettingsScreen> {
-  NotificationPreferences _preferences = const NotificationPreferences();
-  bool _systemEnabled = true;
-  bool _pushNotificationsEnabled = true;
-  bool _soundEnabled = true;
-  bool _vibrationEnabled = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadPreferences();
-  }
-
-  Future<void> _loadPreferences() async {
-    final prefs = await ref
-        .read(notificationPreferencesServiceProvider)
-        .loadPreferences();
-    if (!mounted) return;
-
-    setState(() {
-      _preferences = prefs;
-    });
-  }
-
-  Future<void> _applyPreferences(NotificationPreferences newPrefs) async {
-    setState(() {
-      _preferences = newPrefs;
-    });
-
-    await ref
-        .read(notificationPreferencesServiceProvider)
-        .updatePreferences(newPrefs);
-  }
-
-  Future<void> _resetToDefaults() async {
-    await _applyPreferences(const NotificationPreferences());
-    if (!mounted) return;
-
-    setState(() {
-      _systemEnabled = true;
-      _pushNotificationsEnabled = true;
-      _soundEnabled = true;
-      _vibrationEnabled = true;
-    });
-  }
-
-  Future<void> _markAllAsRead() async {
-    final repo = ref.read(notificationRepositoryProvider);
-    if (repo == null) return;
-
-    try {
-      await repo.markAllAsRead();
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.notificationSettingsAllMarkedAsRead),
-          duration: const Duration(seconds: 2),
-          backgroundColor: VineTheme.vineGreen,
-        ),
-      );
-    } catch (_) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.notificationSettingsMarkAllAsReadFailed),
-          duration: const Duration(seconds: 2),
-          backgroundColor: VineTheme.error,
-        ),
-      );
-    }
-  }
-
-  void _showResetSnackBar() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(context.l10n.notificationSettingsResetToDefaults),
-        duration: const Duration(seconds: 2),
-        backgroundColor: VineTheme.vineGreen,
+    return BlocProvider(
+      // notificationPreferencesServiceProvider watches authServiceProvider, so
+      // its identity can change on auth flip; re-key so the Cubit reloads with
+      // the fresh service instead of operating on a stale one.
+      key: ValueKey(preferencesService),
+      create: (_) =>
+          NotificationSettingsCubit(preferencesService: preferencesService)
+            ..load(),
+      child: NotificationSettingsView(
+        onMarkAllAsRead: repository == null
+            ? null
+            : () => _markAllAsRead(repository),
       ),
     );
   }
+
+  Future<bool> _markAllAsRead(NotificationRepository repository) async {
+    try {
+      await repository.markAllAsRead();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+/// View: renders the notification settings UI from the Cubit state.
+///
+/// [onMarkAllAsRead] performs the bridge-level repository call and resolves to
+/// whether it succeeded; `null` disables the mark-all-as-read action. That
+/// action stays out of the Cubit because it uses a separate, auth-nullable
+/// notification repository (see #4744 scope decision).
+class NotificationSettingsView extends StatelessWidget {
+  @visibleForTesting
+  const NotificationSettingsView({required this.onMarkAllAsRead, super.key});
+
+  final Future<bool> Function()? onMarkAllAsRead;
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -118,11 +79,7 @@ class _NotificationSettingsScreenState
         DiVineAppBarAction(
           icon: const MaterialIconSource(Icons.refresh),
           tooltip: context.l10n.notificationSettingsResetTooltip,
-          onPressed: () async {
-            await _resetToDefaults();
-            if (!mounted) return;
-            _showResetSnackBar();
-          },
+          onPressed: () => _onResetPressed(context),
         ),
       ],
     ),
@@ -130,134 +87,179 @@ class _NotificationSettingsScreenState
       alignment: Alignment.topCenter,
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 600),
-        child: ListView(
-          padding: .fromLTRB(
-            16,
-            16,
-            16,
-            16 + MediaQuery.viewPaddingOf(context).bottom,
-          ),
-          children: [
-            // Notification Types Section
-            _buildSectionHeader(context.l10n.notificationSettingsTypes),
-            const SizedBox(height: 8),
-            _buildNotificationCard(
-              icon: Icons.favorite,
-              iconColor: VineTheme.likeRed,
-              title: context.l10n.notificationSettingsLikes,
-              subtitle: context.l10n.notificationSettingsLikesSubtitle,
-              value: _preferences.likesEnabled,
-              onChanged: (value) =>
-                  _applyPreferences(_preferences.copyWith(likesEnabled: value)),
-            ),
-            _buildNotificationCard(
-              icon: Icons.chat_bubble,
-              iconColor: VineTheme.commentBlue,
-              title: context.l10n.notificationSettingsComments,
-              subtitle: context.l10n.notificationSettingsCommentsSubtitle,
-              value: _preferences.commentsEnabled,
-              onChanged: (value) => _applyPreferences(
-                _preferences.copyWith(commentsEnabled: value),
-              ),
-            ),
-            _buildNotificationCard(
-              icon: Icons.person_add,
-              iconColor: VineTheme.vineGreen,
-              title: context.l10n.notificationSettingsFollows,
-              subtitle: context.l10n.notificationSettingsFollowsSubtitle,
-              value: _preferences.followsEnabled,
-              onChanged: (value) => _applyPreferences(
-                _preferences.copyWith(followsEnabled: value),
-              ),
-            ),
-            _buildNotificationCard(
-              icon: Icons.alternate_email,
-              iconColor: VineTheme.warning,
-              title: context.l10n.notificationSettingsMentions,
-              subtitle: context.l10n.notificationSettingsMentionsSubtitle,
-              value: _preferences.mentionsEnabled,
-              onChanged: (value) => _applyPreferences(
-                _preferences.copyWith(mentionsEnabled: value),
-              ),
-            ),
-            _buildNotificationCard(
-              icon: Icons.repeat,
-              iconColor: VineTheme.vineGreenLight,
-              title: context.l10n.notificationSettingsReposts,
-              subtitle: context.l10n.notificationSettingsRepostsSubtitle,
-              value: _preferences.repostsEnabled,
-              onChanged: (value) => _applyPreferences(
-                _preferences.copyWith(repostsEnabled: value),
-              ),
-            ),
-            _buildNotificationCard(
-              icon: Icons.phone_android,
-              iconColor: VineTheme.lightText,
-              title: context.l10n.notificationSettingsSystem,
-              subtitle: context.l10n.notificationSettingsSystemSubtitle,
-              value: _systemEnabled,
-              onChanged: (value) => setState(() => _systemEnabled = value),
-            ),
+        child:
+            BlocBuilder<NotificationSettingsCubit, NotificationSettingsState>(
+              builder: (context, state) {
+                final cubit = context.read<NotificationSettingsCubit>();
+                final prefs = state.preferences;
+                return ListView(
+                  padding: .fromLTRB(
+                    16,
+                    16,
+                    16,
+                    16 + MediaQuery.viewPaddingOf(context).bottom,
+                  ),
+                  children: [
+                    // Notification Types Section
+                    _buildSectionHeader(context.l10n.notificationSettingsTypes),
+                    const SizedBox(height: 8),
+                    _buildNotificationCard(
+                      icon: Icons.favorite,
+                      iconColor: VineTheme.likeRed,
+                      title: context.l10n.notificationSettingsLikes,
+                      subtitle: context.l10n.notificationSettingsLikesSubtitle,
+                      value: prefs.likesEnabled,
+                      onChanged: (value) => cubit.setPreferences(
+                        prefs.copyWith(likesEnabled: value),
+                      ),
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.chat_bubble,
+                      iconColor: VineTheme.commentBlue,
+                      title: context.l10n.notificationSettingsComments,
+                      subtitle:
+                          context.l10n.notificationSettingsCommentsSubtitle,
+                      value: prefs.commentsEnabled,
+                      onChanged: (value) => cubit.setPreferences(
+                        prefs.copyWith(commentsEnabled: value),
+                      ),
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.person_add,
+                      iconColor: VineTheme.vineGreen,
+                      title: context.l10n.notificationSettingsFollows,
+                      subtitle:
+                          context.l10n.notificationSettingsFollowsSubtitle,
+                      value: prefs.followsEnabled,
+                      onChanged: (value) => cubit.setPreferences(
+                        prefs.copyWith(followsEnabled: value),
+                      ),
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.alternate_email,
+                      iconColor: VineTheme.warning,
+                      title: context.l10n.notificationSettingsMentions,
+                      subtitle:
+                          context.l10n.notificationSettingsMentionsSubtitle,
+                      value: prefs.mentionsEnabled,
+                      onChanged: (value) => cubit.setPreferences(
+                        prefs.copyWith(mentionsEnabled: value),
+                      ),
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.repeat,
+                      iconColor: VineTheme.vineGreenLight,
+                      title: context.l10n.notificationSettingsReposts,
+                      subtitle:
+                          context.l10n.notificationSettingsRepostsSubtitle,
+                      value: prefs.repostsEnabled,
+                      onChanged: (value) => cubit.setPreferences(
+                        prefs.copyWith(repostsEnabled: value),
+                      ),
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.phone_android,
+                      iconColor: VineTheme.lightText,
+                      title: context.l10n.notificationSettingsSystem,
+                      subtitle: context.l10n.notificationSettingsSystemSubtitle,
+                      value: state.systemEnabled,
+                      onChanged: cubit.setSystemEnabled,
+                    ),
 
-            const SizedBox(height: 24),
+                    const SizedBox(height: 24),
 
-            // Push Notification Settings
-            _buildSectionHeader(
-              context.l10n.notificationSettingsPushNotificationsSection,
+                    // Push Notification Settings
+                    _buildSectionHeader(
+                      context.l10n.notificationSettingsPushNotificationsSection,
+                    ),
+                    const SizedBox(height: 8),
+                    _buildNotificationCard(
+                      icon: Icons.notifications,
+                      iconColor: VineTheme.vineGreen,
+                      title: context.l10n.notificationSettingsPushNotifications,
+                      subtitle: context
+                          .l10n
+                          .notificationSettingsPushNotificationsSubtitle,
+                      value: state.pushNotificationsEnabled,
+                      onChanged: cubit.setPushNotificationsEnabled,
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.volume_up,
+                      iconColor: VineTheme.commentBlue,
+                      title: context.l10n.notificationSettingsSound,
+                      subtitle: context.l10n.notificationSettingsSoundSubtitle,
+                      value: state.soundEnabled,
+                      onChanged: cubit.setSoundEnabled,
+                    ),
+                    _buildNotificationCard(
+                      icon: Icons.vibration,
+                      iconColor: VineTheme.vineGreen,
+                      title: context.l10n.notificationSettingsVibration,
+                      subtitle:
+                          context.l10n.notificationSettingsVibrationSubtitle,
+                      value: state.vibrationEnabled,
+                      onChanged: cubit.setVibrationEnabled,
+                    ),
+
+                    const SizedBox(height: 24),
+
+                    // Actions
+                    _buildSectionHeader(
+                      context.l10n.notificationSettingsActions,
+                    ),
+                    const SizedBox(height: 8),
+
+                    _buildActionCard(
+                      icon: Icons.check_circle,
+                      iconColor: VineTheme.vineGreenLight,
+                      title: context.l10n.notificationSettingsMarkAllAsRead,
+                      subtitle: context
+                          .l10n
+                          .notificationSettingsMarkAllAsReadSubtitle,
+                      onTap: onMarkAllAsRead == null
+                          ? null
+                          : () => _onMarkAllAsReadPressed(context),
+                    ),
+
+                    const SizedBox(height: 24),
+
+                    // Info Section
+                    _buildInfoCard(context),
+                  ],
+                );
+              },
             ),
-            const SizedBox(height: 8),
-            _buildNotificationCard(
-              icon: Icons.notifications,
-              iconColor: VineTheme.vineGreen,
-              title: context.l10n.notificationSettingsPushNotifications,
-              subtitle:
-                  context.l10n.notificationSettingsPushNotificationsSubtitle,
-              value: _pushNotificationsEnabled,
-              onChanged: (value) =>
-                  setState(() => _pushNotificationsEnabled = value),
-            ),
-            _buildNotificationCard(
-              icon: Icons.volume_up,
-              iconColor: VineTheme.commentBlue,
-              title: context.l10n.notificationSettingsSound,
-              subtitle: context.l10n.notificationSettingsSoundSubtitle,
-              value: _soundEnabled,
-              onChanged: (value) => setState(() => _soundEnabled = value),
-            ),
-            _buildNotificationCard(
-              icon: Icons.vibration,
-              iconColor: VineTheme.vineGreen,
-              title: context.l10n.notificationSettingsVibration,
-              subtitle: context.l10n.notificationSettingsVibrationSubtitle,
-              value: _vibrationEnabled,
-              onChanged: (value) => setState(() => _vibrationEnabled = value),
-            ),
-
-            const SizedBox(height: 24),
-
-            // Actions
-            _buildSectionHeader(context.l10n.notificationSettingsActions),
-            const SizedBox(height: 8),
-
-            _buildActionCard(
-              icon: Icons.check_circle,
-              iconColor: VineTheme.vineGreenLight,
-              title: context.l10n.notificationSettingsMarkAllAsRead,
-              subtitle: context.l10n.notificationSettingsMarkAllAsReadSubtitle,
-              onTap: ref.watch(notificationRepositoryProvider) == null
-                  ? null
-                  : _markAllAsRead,
-            ),
-
-            const SizedBox(height: 24),
-
-            // Info Section
-            _buildInfoCard(),
-          ],
-        ),
       ),
     ),
   );
+
+  Future<void> _onResetPressed(BuildContext context) async {
+    await context.read<NotificationSettingsCubit>().resetToDefaults();
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.notificationSettingsResetToDefaults),
+        duration: const Duration(seconds: 2),
+        backgroundColor: VineTheme.vineGreen,
+      ),
+    );
+  }
+
+  Future<void> _onMarkAllAsReadPressed(BuildContext context) async {
+    final success = await onMarkAllAsRead!();
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          success
+              ? context.l10n.notificationSettingsAllMarkedAsRead
+              : context.l10n.notificationSettingsMarkAllAsReadFailed,
+        ),
+        duration: const Duration(seconds: 2),
+        backgroundColor: success ? VineTheme.vineGreen : VineTheme.error,
+      ),
+    );
+  }
 
   Widget _buildSectionHeader(String title) => Text(
     title,
@@ -344,7 +346,7 @@ class _NotificationSettingsScreenState
     ),
   );
 
-  Widget _buildInfoCard() => Card(
+  Widget _buildInfoCard(BuildContext context) => Card(
     color: VineTheme.cardBackground,
     child: Padding(
       padding: const EdgeInsets.all(16),

--- a/mobile/test/blocs/notification_settings/notification_settings_cubit_test.dart
+++ b/mobile/test/blocs/notification_settings/notification_settings_cubit_test.dart
@@ -1,0 +1,125 @@
+// ABOUTME: Unit tests for NotificationSettingsCubit — load, preference
+// ABOUTME: persistence, local-only toggles, and reset-to-defaults.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/notification_settings/notification_settings_cubit.dart';
+import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
+import 'package:openvine/models/notification_preferences.dart';
+import 'package:openvine/services/notification_preferences_service.dart';
+
+class _MockNotificationPreferencesService extends Mock
+    implements NotificationPreferencesService {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const NotificationPreferences());
+  });
+
+  group(NotificationSettingsCubit, () {
+    late _MockNotificationPreferencesService service;
+
+    setUp(() {
+      service = _MockNotificationPreferencesService();
+      when(
+        service.loadPreferences,
+      ).thenAnswer((_) async => const NotificationPreferences());
+      when(() => service.updatePreferences(any())).thenAnswer((_) async {});
+    });
+
+    NotificationSettingsCubit buildCubit() =>
+        NotificationSettingsCubit(preferencesService: service);
+
+    blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+      'load emits loading then ready with the loaded preferences',
+      setUp: () {
+        when(service.loadPreferences).thenAnswer(
+          (_) async => const NotificationPreferences(likesEnabled: false),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => const [
+        NotificationSettingsState(status: NotificationSettingsStatus.loading),
+        NotificationSettingsState(
+          status: NotificationSettingsStatus.ready,
+          preferences: NotificationPreferences(likesEnabled: false),
+        ),
+      ],
+    );
+
+    blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+      'setPreferences emits the new preferences and persists them',
+      build: buildCubit,
+      act: (cubit) => cubit.setPreferences(
+        const NotificationPreferences(commentsEnabled: false),
+      ),
+      expect: () => const [
+        NotificationSettingsState(
+          preferences: NotificationPreferences(commentsEnabled: false),
+        ),
+      ],
+      verify: (_) {
+        verify(
+          () => service.updatePreferences(
+            const NotificationPreferences(commentsEnabled: false),
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+      'local system/push/sound/vibration toggles update state only',
+      build: buildCubit,
+      act: (cubit) => cubit
+        ..setSystemEnabled(false)
+        ..setPushNotificationsEnabled(false)
+        ..setSoundEnabled(false)
+        ..setVibrationEnabled(false),
+      expect: () => const [
+        NotificationSettingsState(systemEnabled: false),
+        NotificationSettingsState(
+          systemEnabled: false,
+          pushNotificationsEnabled: false,
+        ),
+        NotificationSettingsState(
+          systemEnabled: false,
+          pushNotificationsEnabled: false,
+          soundEnabled: false,
+        ),
+        NotificationSettingsState(
+          systemEnabled: false,
+          pushNotificationsEnabled: false,
+          soundEnabled: false,
+          vibrationEnabled: false,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(() => service.updatePreferences(any()));
+      },
+    );
+
+    blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+      'resetToDefaults restores defaults and persists them',
+      seed: () => const NotificationSettingsState(
+        status: NotificationSettingsStatus.ready,
+        preferences: NotificationPreferences(likesEnabled: false),
+        systemEnabled: false,
+        pushNotificationsEnabled: false,
+        soundEnabled: false,
+        vibrationEnabled: false,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.resetToDefaults(),
+      expect: () => const [
+        NotificationSettingsState(status: NotificationSettingsStatus.ready),
+      ],
+      verify: (_) {
+        verify(
+          () => service.updatePreferences(const NotificationPreferences()),
+        ).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

First **Wave 2 / state-lane** slice of architecture epic #4338, opening the Riverpod→BLoC migration tracked by #4744.

Migrates `NotificationSettingsScreen` off `ConsumerStatefulWidget` + `setState` onto a `NotificationSettingsCubit`, using the canonical **Page/View** split:
- **Cubit** (`lib/blocs/notification_settings/`) owns the persisted `NotificationPreferences` + the local push/sound/vibration toggles, and `load` / `setPreferences` / per-toggle setters / `resetToDefaults`.
- **Page** (`ConsumerWidget`) bridges `notificationPreferencesServiceProvider` into the `BlocProvider`. The provider internally `ref.watch`es `authServiceProvider`, so its identity can flip on auth — the `BlocProvider` is re-keyed on the service per the bridging rule (`docs/BLOC_UI_MIGRATION_PRD.md`).
- **View** (`StatelessWidget`) renders from Cubit state via `BlocBuilder`.

**Scope decision** (agreed up front): `markAllAsRead` stays a bridge-level action — it uses the separate, auth-nullable `notificationRepositoryProvider`, not the settings service — so its success/failure snackbars and disabled-when-null behavior are unchanged. Pulling it into the Cubit (with the transient action-signal + nullable-auth-repo `ValueKey`) is a deliberate follow-up.

**Related Issue:** Part of #4744 · Part of #4338 (Wave 2)

## Out of Scope

- `markAllAsRead` → Cubit (kept bridge-level, see above).
- Extracting the `_build*` helper methods into widget classes — unrelated composition refactor; the PRD says not to bundle it with a state migration.
- Co-locating the screen under `lib/features/` (that's #4745).
- The rest of #4744 (the three ~1.4k-line providers + the ChangeNotifier migrations).

## Verification

- `flutter analyze` (cubit, state, screen, tests) → No issues found.
- `dart format` → clean.
- New `notification_settings_cubit_test.dart`: 4 `bloc_test`s (load→loading/ready, setPreferences persists, local toggles update state only, resetToDefaults restores+persists).
- **Existing `notification_settings_screen_test.dart` passes unmodified** — behavior parity for the markAllAsRead success/failure snackbars and disabled-when-repo-null action card.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
