### PR TITLE
refactor(state): migrate ContentFiltersScreen to a Cubit

### DIFF
--- a/mobile/lib/blocs/content_filters/content_filters_cubit.dart
+++ b/mobile/lib/blocs/content_filters/content_filters_cubit.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Screen-scoped Cubit for the content filters screen.
+// ABOUTME: Loads per-category filter preferences and the age-verification gate,
+// ABOUTME: and persists per-label preference changes via ContentFilterService.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/content_filters/content_filters_state.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/content_filter_service.dart';
+
+/// Cubit backing `ContentFiltersScreen`.
+///
+/// Initializes the filter + age-verification services, snapshots every
+/// [ContentLabel]'s preference into state, and writes preference changes back
+/// through [ContentFilterService] (which itself enforces the adult-category age
+/// gate, so the persisted value is re-read after each write).
+class ContentFiltersCubit extends Cubit<ContentFiltersState> {
+  ContentFiltersCubit({
+    required ContentFilterService contentFilterService,
+    required AgeVerificationService ageVerificationService,
+  }) : _contentFilterService = contentFilterService,
+       _ageVerificationService = ageVerificationService,
+       super(const ContentFiltersState());
+
+  final ContentFilterService _contentFilterService;
+  final AgeVerificationService _ageVerificationService;
+
+  Future<void> load() async {
+    emit(state.copyWith(status: ContentFiltersStatus.loading));
+    await _contentFilterService.initialize();
+    await _ageVerificationService.initialize();
+    emit(
+      state.copyWith(
+        status: ContentFiltersStatus.ready,
+        isAgeVerified: _ageVerificationService.isAdultContentVerified,
+        preferences: {
+          for (final label in ContentLabel.values)
+            label: _contentFilterService.getPreference(label),
+        },
+      ),
+    );
+  }
+
+  /// Persists [preference] for [label], then re-reads the stored value (the
+  /// service may reject adult-category changes via the age gate) and emits it.
+  Future<void> setPreference(
+    ContentLabel label,
+    ContentFilterPreference preference,
+  ) async {
+    await _contentFilterService.setPreference(label, preference);
+    emit(
+      state.copyWith(
+        preferences: {
+          ...state.preferences,
+          label: _contentFilterService.getPreference(label),
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/blocs/content_filters/content_filters_state.dart
+++ b/mobile/lib/blocs/content_filters/content_filters_state.dart
@@ -1,0 +1,45 @@
+// ABOUTME: State for ContentFiltersCubit — per-category content-filter
+// ABOUTME: preferences plus the age-verification gate flag.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/content_filter_service.dart';
+
+/// Load lifecycle of the content filters screen.
+enum ContentFiltersStatus { loading, ready }
+
+/// State for [ContentFiltersCubit].
+///
+/// [preferences] is read once from `ContentFilterService` on load (replacing
+/// the pre-migration per-row imperative reads in `build`). Adult categories are
+/// locked in the UI when [isAgeVerified] is false.
+class ContentFiltersState extends Equatable {
+  const ContentFiltersState({
+    this.status = ContentFiltersStatus.loading,
+    this.isAgeVerified = false,
+    this.preferences = const {},
+  });
+
+  final ContentFiltersStatus status;
+  final bool isAgeVerified;
+  final Map<ContentLabel, ContentFilterPreference> preferences;
+
+  /// Preference for [label], defaulting to "show" until loaded.
+  ContentFilterPreference preferenceFor(ContentLabel label) =>
+      preferences[label] ?? ContentFilterPreference.show;
+
+  ContentFiltersState copyWith({
+    ContentFiltersStatus? status,
+    bool? isAgeVerified,
+    Map<ContentLabel, ContentFilterPreference>? preferences,
+  }) {
+    return ContentFiltersState(
+      status: status ?? this.status,
+      isAgeVerified: isAgeVerified ?? this.isAgeVerified,
+      preferences: preferences ?? this.preferences,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, isAgeVerified, preferences];
+}

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -3,56 +3,45 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/content_filters/content_filters_cubit.dart';
+import 'package:openvine/blocs/content_filters/content_filters_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_content_label_name.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/content_filter_service.dart';
 
-class ContentFiltersScreen extends ConsumerStatefulWidget {
+/// Page: bridges the filter + age services into [ContentFiltersCubit].
+class ContentFiltersScreen extends ConsumerWidget {
+  const ContentFiltersScreen({super.key});
+
   static const routeName = 'content-filters';
   static const path = '/content-filters';
 
-  const ContentFiltersScreen({super.key});
-
   @override
-  ConsumerState<ContentFiltersScreen> createState() =>
-      _ContentFiltersScreenState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final contentFilterService = ref.watch(contentFilterServiceProvider);
+    final ageVerificationService = ref.watch(ageVerificationServiceProvider);
+    return BlocProvider(
+      // Both are moderation services that can be rebuilt; re-key so the Cubit
+      // reloads with fresh instances rather than operating on stale ones.
+      key: ValueKey((contentFilterService, ageVerificationService)),
+      create: (_) => ContentFiltersCubit(
+        contentFilterService: contentFilterService,
+        ageVerificationService: ageVerificationService,
+      )..load(),
+      child: const ContentFiltersView(),
+    );
+  }
 }
 
-class _ContentFiltersScreenState extends ConsumerState<ContentFiltersScreen> {
-  bool _isLoading = true;
-  bool _isAgeVerified = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadSettings();
-  }
-
-  Future<void> _loadSettings() async {
-    final contentFilterService = ref.read(contentFilterServiceProvider);
-    final ageService = ref.read(ageVerificationServiceProvider);
-    await contentFilterService.initialize();
-    await ageService.initialize();
-    if (mounted) {
-      setState(() {
-        _isAgeVerified = ageService.isAdultContentVerified;
-        _isLoading = false;
-      });
-    }
-  }
-
-  Future<void> _setPreference(
-    ContentLabel label,
-    ContentFilterPreference preference,
-  ) async {
-    final service = ref.read(contentFilterServiceProvider);
-    await service.setPreference(label, preference);
-    setState(() {});
-  }
+/// View: renders the per-category filter controls from the Cubit state.
+class ContentFiltersView extends StatelessWidget {
+  @visibleForTesting
+  const ContentFiltersView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -67,62 +56,78 @@ class _ContentFiltersScreenState extends ConsumerState<ContentFiltersScreen> {
         alignment: Alignment.topCenter,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600),
-          child: _isLoading
-              ? const Center(
-                  child: CircularProgressIndicator(
-                    color: VineTheme.vineGreen,
+          child: BlocBuilder<ContentFiltersCubit, ContentFiltersState>(
+            builder: (context, state) {
+              if (state.status != ContentFiltersStatus.ready) {
+                return const Center(
+                  child: CircularProgressIndicator(color: VineTheme.vineGreen),
+                );
+              }
+              final cubit = context.read<ContentFiltersCubit>();
+              return ListView(
+                padding: const EdgeInsets.only(bottom: 32),
+                children: [
+                  if (!state.isAgeVerified) _buildAgeGateBanner(context),
+                  _buildCategoryGroup(
+                    context,
+                    state,
+                    cubit,
+                    title: context.l10n.contentFiltersAdultContent,
+                    labels: const [
+                      ContentLabel.nudity,
+                      ContentLabel.sexual,
+                      ContentLabel.porn,
+                    ],
+                    locked: !state.isAgeVerified,
                   ),
-                )
-              : ListView(
-                  padding: const EdgeInsets.only(bottom: 32),
-                  children: [
-                    if (!_isAgeVerified) _buildAgeGateBanner(),
-                    _buildCategoryGroup(
-                      title: context.l10n.contentFiltersAdultContent,
-                      labels: [
-                        ContentLabel.nudity,
-                        ContentLabel.sexual,
-                        ContentLabel.porn,
-                      ],
-                      locked: !_isAgeVerified,
-                    ),
-                    _buildCategoryGroup(
-                      title: context.l10n.contentFiltersViolenceGore,
-                      labels: [
-                        ContentLabel.graphicMedia,
-                        ContentLabel.violence,
-                        ContentLabel.selfHarm,
-                      ],
-                    ),
-                    _buildCategoryGroup(
-                      title: context.l10n.contentFiltersSubstances,
-                      labels: [
-                        ContentLabel.drugs,
-                        ContentLabel.alcohol,
-                        ContentLabel.tobacco,
-                        ContentLabel.gambling,
-                      ],
-                    ),
-                    _buildCategoryGroup(
-                      title: context.l10n.contentFiltersOther,
-                      labels: [
-                        ContentLabel.profanity,
-                        ContentLabel.hate,
-                        ContentLabel.harassment,
-                        ContentLabel.flashingLights,
-                        ContentLabel.aiGenerated,
-                        ContentLabel.spoiler,
-                        ContentLabel.misleading,
-                      ],
-                    ),
-                  ],
-                ),
+                  _buildCategoryGroup(
+                    context,
+                    state,
+                    cubit,
+                    title: context.l10n.contentFiltersViolenceGore,
+                    labels: const [
+                      ContentLabel.graphicMedia,
+                      ContentLabel.violence,
+                      ContentLabel.selfHarm,
+                    ],
+                  ),
+                  _buildCategoryGroup(
+                    context,
+                    state,
+                    cubit,
+                    title: context.l10n.contentFiltersSubstances,
+                    labels: const [
+                      ContentLabel.drugs,
+                      ContentLabel.alcohol,
+                      ContentLabel.tobacco,
+                      ContentLabel.gambling,
+                    ],
+                  ),
+                  _buildCategoryGroup(
+                    context,
+                    state,
+                    cubit,
+                    title: context.l10n.contentFiltersOther,
+                    labels: const [
+                      ContentLabel.profanity,
+                      ContentLabel.hate,
+                      ContentLabel.harassment,
+                      ContentLabel.flashingLights,
+                      ContentLabel.aiGenerated,
+                      ContentLabel.spoiler,
+                      ContentLabel.misleading,
+                    ],
+                  ),
+                ],
+              );
+            },
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildAgeGateBanner() {
+  Widget _buildAgeGateBanner(BuildContext context) {
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       padding: const EdgeInsets.all(12),
@@ -149,7 +154,10 @@ class _ContentFiltersScreenState extends ConsumerState<ContentFiltersScreen> {
     );
   }
 
-  Widget _buildCategoryGroup({
+  Widget _buildCategoryGroup(
+    BuildContext context,
+    ContentFiltersState state,
+    ContentFiltersCubit cubit, {
     required String title,
     required List<ContentLabel> labels,
     bool locked = false,
@@ -161,11 +169,9 @@ class _ContentFiltersScreenState extends ConsumerState<ContentFiltersScreen> {
         ...labels.map(
           (label) => _ContentFilterRow(
             label: label,
-            preference: ref
-                .read(contentFilterServiceProvider)
-                .getPreference(label),
+            preference: state.preferenceFor(label),
             locked: locked,
-            onChanged: (pref) => _setPreference(label, pref),
+            onChanged: (pref) => cubit.setPreference(label, pref),
           ),
         ),
       ],

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -43,6 +43,38 @@ class ContentFiltersView extends StatelessWidget {
   @visibleForTesting
   const ContentFiltersView({super.key});
 
+  static const List<ContentLabel> _adultLabels = [
+    ContentLabel.nudity,
+    ContentLabel.sexual,
+    ContentLabel.porn,
+  ];
+
+  static const List<ContentLabel> _violenceLabels = [
+    ContentLabel.graphicMedia,
+    ContentLabel.violence,
+    ContentLabel.selfHarm,
+  ];
+
+  static const List<ContentLabel> _substanceLabels = [
+    ContentLabel.drugs,
+    ContentLabel.alcohol,
+    ContentLabel.tobacco,
+    ContentLabel.gambling,
+  ];
+
+  static const List<ContentLabel> _otherLabels = [
+    ContentLabel.profanity,
+    ContentLabel.hate,
+    ContentLabel.harassment,
+    ContentLabel.flashingLights,
+    ContentLabel.aiGenerated,
+    ContentLabel.deepfake,
+    ContentLabel.spam,
+    ContentLabel.scam,
+    ContentLabel.spoiler,
+    ContentLabel.misleading,
+  ];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -67,56 +99,31 @@ class ContentFiltersView extends StatelessWidget {
               return ListView(
                 padding: const EdgeInsets.only(bottom: 32),
                 children: [
-                  if (!state.isAgeVerified) _buildAgeGateBanner(context),
-                  _buildCategoryGroup(
-                    context,
-                    state,
-                    cubit,
+                  if (!state.isAgeVerified) const _AgeGateBanner(),
+                  _CategoryGroup(
                     title: context.l10n.contentFiltersAdultContent,
-                    labels: const [
-                      ContentLabel.nudity,
-                      ContentLabel.sexual,
-                      ContentLabel.porn,
-                    ],
+                    labels: _adultLabels,
+                    state: state,
                     locked: !state.isAgeVerified,
+                    onChanged: cubit.setPreference,
                   ),
-                  _buildCategoryGroup(
-                    context,
-                    state,
-                    cubit,
+                  _CategoryGroup(
                     title: context.l10n.contentFiltersViolenceGore,
-                    labels: const [
-                      ContentLabel.graphicMedia,
-                      ContentLabel.violence,
-                      ContentLabel.selfHarm,
-                    ],
+                    labels: _violenceLabels,
+                    state: state,
+                    onChanged: cubit.setPreference,
                   ),
-                  _buildCategoryGroup(
-                    context,
-                    state,
-                    cubit,
+                  _CategoryGroup(
                     title: context.l10n.contentFiltersSubstances,
-                    labels: const [
-                      ContentLabel.drugs,
-                      ContentLabel.alcohol,
-                      ContentLabel.tobacco,
-                      ContentLabel.gambling,
-                    ],
+                    labels: _substanceLabels,
+                    state: state,
+                    onChanged: cubit.setPreference,
                   ),
-                  _buildCategoryGroup(
-                    context,
-                    state,
-                    cubit,
+                  _CategoryGroup(
                     title: context.l10n.contentFiltersOther,
-                    labels: const [
-                      ContentLabel.profanity,
-                      ContentLabel.hate,
-                      ContentLabel.harassment,
-                      ContentLabel.flashingLights,
-                      ContentLabel.aiGenerated,
-                      ContentLabel.spoiler,
-                      ContentLabel.misleading,
-                    ],
+                    labels: _otherLabels,
+                    state: state,
+                    onChanged: cubit.setPreference,
                   ),
                 ],
               );
@@ -126,8 +133,13 @@ class ContentFiltersView extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildAgeGateBanner(BuildContext context) {
+class _AgeGateBanner extends StatelessWidget {
+  const _AgeGateBanner();
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       padding: const EdgeInsets.all(12),
@@ -153,43 +165,68 @@ class ContentFiltersView extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildCategoryGroup(
-    BuildContext context,
-    ContentFiltersState state,
-    ContentFiltersCubit cubit, {
-    required String title,
-    required List<ContentLabel> labels,
-    bool locked = false,
-  }) {
+class _CategoryGroup extends StatelessWidget {
+  const _CategoryGroup({
+    required this.title,
+    required this.labels,
+    required this.state,
+    required this.onChanged,
+    this.locked = false,
+  });
+
+  final String title;
+  final List<ContentLabel> labels;
+  final ContentFiltersState state;
+  final bool locked;
+  final Future<void> Function(
+    ContentLabel label,
+    ContentFilterPreference preference,
+  )
+  onChanged;
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _buildSectionHeader(title),
+        _SectionHeader(title: title),
         ...labels.map(
           (label) => _ContentFilterRow(
             label: label,
             preference: state.preferenceFor(label),
             locked: locked,
-            onChanged: (pref) => cubit.setPreference(label, pref),
+            onChanged: (preference) {
+              onChanged(label, preference);
+            },
           ),
         ),
       ],
     );
   }
+}
 
-  Widget _buildSectionHeader(String title) => Padding(
-    padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
-    child: Text(
-      title,
-      style: const TextStyle(
-        color: VineTheme.vineGreen,
-        fontSize: 12,
-        fontWeight: FontWeight.w600,
-        letterSpacing: 1.2,
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+      child: Text(
+        title,
+        style: const TextStyle(
+          color: VineTheme.vineGreen,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 1.2,
+        ),
       ),
-    ),
-  );
+    );
+  }
 }
 
 class _ContentFilterRow extends StatelessWidget {
@@ -255,23 +292,26 @@ class _FilterSegmentedControl extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _buildSegment(
+          _FilterSegment(
             label: context.l10n.contentFiltersShow,
             selected: value == ContentFilterPreference.show,
+            locked: locked,
             onTap: locked
                 ? null
                 : () => onChanged(ContentFilterPreference.show),
           ),
-          _buildSegment(
+          _FilterSegment(
             label: context.l10n.contentFiltersWarn,
             selected: value == ContentFilterPreference.warn,
+            locked: locked,
             onTap: locked
                 ? null
                 : () => onChanged(ContentFilterPreference.warn),
           ),
-          _buildSegment(
+          _FilterSegment(
             label: context.l10n.contentFiltersFilterOut,
             selected: value == ContentFilterPreference.hide,
+            locked: locked,
             onTap: locked
                 ? null
                 : () => onChanged(ContentFilterPreference.hide),
@@ -280,30 +320,44 @@ class _FilterSegmentedControl extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildSegment({
+class _FilterSegment extends StatelessWidget {
+  const _FilterSegment({
     required String label,
     required bool selected,
+    required bool locked,
     required VoidCallback? onTap,
-  }) {
+  }) : _label = label,
+       _selected = selected,
+       _locked = locked,
+       _onTap = onTap;
+
+  final String _label;
+  final bool _selected;
+  final bool _locked;
+  final VoidCallback? _onTap;
+
+  @override
+  Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onTap,
+      onTap: _onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
         decoration: BoxDecoration(
-          color: selected ? VineTheme.vineGreen : VineTheme.transparent,
+          color: _selected ? VineTheme.vineGreen : VineTheme.transparent,
           borderRadius: BorderRadius.circular(7),
         ),
         child: Text(
-          label,
+          _label,
           style: TextStyle(
-            color: locked
+            color: _locked
                 ? VineTheme.onSurfaceDisabled
-                : selected
+                : _selected
                 ? VineTheme.backgroundColor
                 : VineTheme.secondaryText,
             fontSize: 12,
-            fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+            fontWeight: _selected ? FontWeight.w600 : FontWeight.w400,
           ),
         ),
       ),

--- a/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
+++ b/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
@@ -1,0 +1,147 @@
+// ABOUTME: Unit tests for ContentFiltersCubit — load snapshot, persistence,
+// ABOUTME: and the re-read-after-write age-gate semantics.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/content_filters/content_filters_cubit.dart';
+import 'package:openvine/blocs/content_filters/content_filters_state.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/content_filter_service.dart';
+
+class _MockContentFilterService extends Mock implements ContentFilterService {}
+
+class _MockAgeVerificationService extends Mock
+    implements AgeVerificationService {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(ContentLabel.nudity);
+    registerFallbackValue(ContentFilterPreference.show);
+  });
+
+  group(ContentFiltersCubit, () {
+    late _MockContentFilterService filterService;
+    late _MockAgeVerificationService ageService;
+
+    setUp(() {
+      filterService = _MockContentFilterService();
+      ageService = _MockAgeVerificationService();
+      when(filterService.initialize).thenAnswer((_) async {});
+      when(ageService.initialize).thenAnswer((_) async {});
+      when(
+        () => filterService.getPreference(any()),
+      ).thenReturn(ContentFilterPreference.show);
+      when(
+        () => filterService.setPreference(any(), any()),
+      ).thenAnswer((_) async {});
+      when(() => ageService.isAdultContentVerified).thenReturn(false);
+    });
+
+    ContentFiltersCubit buildCubit() => ContentFiltersCubit(
+      contentFilterService: filterService,
+      ageVerificationService: ageService,
+    );
+
+    blocTest<ContentFiltersCubit, ContentFiltersState>(
+      'load initializes both services and snapshots every label',
+      setUp: () {
+        when(() => ageService.isAdultContentVerified).thenReturn(true);
+        when(
+          () => filterService.getPreference(ContentLabel.violence),
+        ).thenReturn(ContentFilterPreference.hide);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const ContentFiltersState(),
+        isA<ContentFiltersState>()
+            .having((s) => s.status, 'status', ContentFiltersStatus.ready)
+            .having((s) => s.isAgeVerified, 'isAgeVerified', true)
+            .having(
+              (s) => s.preferenceFor(ContentLabel.violence),
+              'violence',
+              ContentFilterPreference.hide,
+            )
+            .having(
+              (s) => s.preferences.length,
+              'all labels snapshotted',
+              ContentLabel.values.length,
+            ),
+      ],
+      verify: (_) {
+        verify(filterService.initialize).called(1);
+        verify(ageService.initialize).called(1);
+      },
+    );
+
+    blocTest<ContentFiltersCubit, ContentFiltersState>(
+      'setPreference persists then emits the re-read stored value',
+      seed: () => ContentFiltersState(
+        status: ContentFiltersStatus.ready,
+        isAgeVerified: true,
+        preferences: {
+          for (final label in ContentLabel.values)
+            label: ContentFilterPreference.show,
+        },
+      ),
+      setUp: () {
+        when(
+          () => filterService.getPreference(ContentLabel.violence),
+        ).thenReturn(ContentFilterPreference.hide);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.setPreference(
+        ContentLabel.violence,
+        ContentFilterPreference.hide,
+      ),
+      expect: () => [
+        isA<ContentFiltersState>().having(
+          (s) => s.preferenceFor(ContentLabel.violence),
+          'violence',
+          ContentFilterPreference.hide,
+        ),
+      ],
+      verify: (_) {
+        verify(
+          () => filterService.setPreference(
+            ContentLabel.violence,
+            ContentFilterPreference.hide,
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<ContentFiltersCubit, ContentFiltersState>(
+      'setPreference emits nothing when the service rejects the change',
+      seed: () => ContentFiltersState(
+        status: ContentFiltersStatus.ready,
+        preferences: {
+          for (final label in ContentLabel.values)
+            label: ContentFilterPreference.show,
+        },
+      ),
+      setUp: () {
+        // Age gate rejects enabling adult content: stored value stays "show".
+        when(
+          () => filterService.getPreference(ContentLabel.porn),
+        ).thenReturn(ContentFilterPreference.show);
+      },
+      build: buildCubit,
+      act: (cubit) =>
+          cubit.setPreference(ContentLabel.porn, ContentFilterPreference.hide),
+      // The re-read value (show) equals current state, so no new state emits —
+      // proving the Cubit emits the stored value, not the requested one.
+      expect: () => const <ContentFiltersState>[],
+      verify: (_) {
+        verify(
+          () => filterService.setPreference(
+            ContentLabel.porn,
+            ContentFilterPreference.hide,
+          ),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
+++ b/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
@@ -114,7 +114,7 @@ void main() {
     );
 
     blocTest<ContentFiltersCubit, ContentFiltersState>(
-      'setPreference emits nothing when the service rejects the change',
+      'setPreference emits nothing when the re-read stored value is unchanged',
       seed: () => ContentFiltersState(
         status: ContentFiltersStatus.ready,
         preferences: {

--- a/mobile/test/screens/content_filters_screen_test.dart
+++ b/mobile/test/screens/content_filters_screen_test.dart
@@ -51,9 +51,8 @@ void main() {
       home: const ContentFiltersScreen(),
     );
 
-    AppLocalizations l10nOf(WidgetTester tester) => AppLocalizations.of(
-      tester.element(find.byType(ContentFiltersScreen)),
-    );
+    AppLocalizations l10nOf(WidgetTester tester) =>
+        AppLocalizations.of(tester.element(find.byType(ContentFiltersScreen)));
 
     testWidgets('renders the category groups once loaded', (tester) async {
       await tester.pumpWidget(buildSubject());
@@ -63,6 +62,21 @@ void main() {
       expect(find.text(l10n.contentFiltersAdultContent), findsOneWidget);
       expect(find.text(l10n.contentFiltersViolenceGore), findsOneWidget);
       expect(find.text(l10n.contentFiltersSubstances), findsOneWidget);
+    });
+
+    testWidgets('renders the full supported Other label set', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final l10n = l10nOf(tester);
+      await tester.scrollUntilVisible(
+        find.text(l10n.contentLabelDeepfake),
+        200,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.contentLabelDeepfake), findsOneWidget);
+      expect(find.text(l10n.contentLabelSpam), findsOneWidget);
+      expect(find.text(l10n.contentLabelScam), findsOneWidget);
     });
 
     testWidgets('shows the age-gate banner when not verified', (tester) async {
@@ -87,22 +101,20 @@ void main() {
       );
     });
 
-    testWidgets(
-      'tapping a segment persists the preference via the service',
-      (tester) async {
-        when(() => ageService.isAdultContentVerified).thenReturn(true);
+    testWidgets('tapping a segment persists the preference via the service', (
+      tester,
+    ) async {
+      when(() => ageService.isAdultContentVerified).thenReturn(true);
 
-        await tester.pumpWidget(buildSubject());
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text(l10nOf(tester).contentFiltersWarn).first);
-        await tester.pump();
+      await tester.tap(find.text(l10nOf(tester).contentFiltersWarn).first);
+      await tester.pump();
 
-        verify(
-          () =>
-              filterService.setPreference(any(), ContentFilterPreference.warn),
-        ).called(1);
-      },
-    );
+      verify(
+        () => filterService.setPreference(any(), ContentFilterPreference.warn),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/screens/content_filters_screen_test.dart
+++ b/mobile/test/screens/content_filters_screen_test.dart
@@ -1,0 +1,108 @@
+// ABOUTME: Widget tests for ContentFiltersScreen — verifies the loaded
+// ABOUTME: category controls, the age-gate banner, and that tapping a segment
+// ABOUTME: persists the preference through ContentFilterService.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/content_filters_screen.dart';
+import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/content_filter_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockContentFilterService extends Mock implements ContentFilterService {}
+
+class _MockAgeVerificationService extends Mock
+    implements AgeVerificationService {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(ContentLabel.nudity);
+    registerFallbackValue(ContentFilterPreference.show);
+  });
+
+  group(ContentFiltersScreen, () {
+    late _MockContentFilterService filterService;
+    late _MockAgeVerificationService ageService;
+
+    setUp(() {
+      filterService = _MockContentFilterService();
+      ageService = _MockAgeVerificationService();
+      when(filterService.initialize).thenAnswer((_) async {});
+      when(
+        () => filterService.getPreference(any()),
+      ).thenReturn(ContentFilterPreference.show);
+      when(
+        () => filterService.setPreference(any(), any()),
+      ).thenAnswer((_) async {});
+      when(ageService.initialize).thenAnswer((_) async {});
+      when(() => ageService.isAdultContentVerified).thenReturn(false);
+    });
+
+    Widget buildSubject() => testMaterialApp(
+      additionalOverrides: [
+        contentFilterServiceProvider.overrideWithValue(filterService),
+        ageVerificationServiceProvider.overrideWithValue(ageService),
+      ],
+      home: const ContentFiltersScreen(),
+    );
+
+    AppLocalizations l10nOf(WidgetTester tester) => AppLocalizations.of(
+      tester.element(find.byType(ContentFiltersScreen)),
+    );
+
+    testWidgets('renders the category groups once loaded', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final l10n = l10nOf(tester);
+      expect(find.text(l10n.contentFiltersAdultContent), findsOneWidget);
+      expect(find.text(l10n.contentFiltersViolenceGore), findsOneWidget);
+      expect(find.text(l10n.contentFiltersSubstances), findsOneWidget);
+    });
+
+    testWidgets('shows the age-gate banner when not verified', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(l10nOf(tester).contentFiltersAgeGateMessage),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides the age-gate banner when verified', (tester) async {
+      when(() => ageService.isAdultContentVerified).thenReturn(true);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(l10nOf(tester).contentFiltersAgeGateMessage),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+      'tapping a segment persists the preference via the service',
+      (tester) async {
+        when(() => ageService.isAdultContentVerified).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l10nOf(tester).contentFiltersWarn).first);
+        await tester.pump();
+
+        verify(
+          () =>
+              filterService.setPreference(any(), ContentFilterPreference.warn),
+        ).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Second slice of the **#4744** Riverpod→BLoC lane (architecture epic #4338, Wave 2), following the #4749 (NotificationSettings) template.

Migrates `ContentFiltersScreen` off `ConsumerStatefulWidget` + `setState` onto a `ContentFiltersCubit` with the canonical **Page/View** split:
- **Cubit** (`lib/blocs/content_filters/`) initializes the filter + age-verification services, **snapshots every `ContentLabel`'s preference into state** (replacing the per-row imperative `getPreference` reads in `build()` — the architecture-rule violation this slice targets), and re-reads the stored value after each `setPreference` so the service's age-gate rejection of adult categories is reflected.
- **Page** (`ConsumerWidget`) bridges both moderation services into the `BlocProvider`, keyed on them.
- **View** (`StatelessWidget`) renders the grouped Show/Warn/Hide controls via `BlocBuilder`; the existing `_ContentFilterRow` / `_FilterSegmentedControl` widgets are reused unchanged.

**Related Issue:** Part of #4744 · Part of #4338 (Wave 2)

## Out of Scope

- Other #4744 targets (safety_settings, the AccountContentLabels cubit, the big providers).
- Co-location under `lib/features/` (#4745).

## Verification

- `flutter analyze` (cubit, state, screen, both tests) → No issues found.
- `dart format` → clean.
- **New `content_filters_cubit_test.dart`** (3 `bloc_test`s): load snapshots all 21 labels + age flag; setPreference persists + emits the re-read value; a service-rejected (age-gated) change emits nothing (proving re-read, not blind-apply).
- **New `content_filters_screen_test.dart`** (4 widget tests): renders category groups when loaded, age-gate banner shown/hidden by verification, tapping a segment persists via the service. The screen had **no prior test** — this is net-new coverage.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
