### PR TITLE
fix(crashlytics): guard OtherProfileBloc emits/adds after close

### DIFF
--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -44,6 +44,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     final cachedProfile = await _profileRepository.getCachedProfile(
       pubkey: pubkey,
     );
+    if (isClosed) return;
     emit(
       MyProfileLoading(
         profile: cachedProfile,
@@ -57,6 +58,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       final freshProfile = await _profileRepository.fetchFreshProfile(
         pubkey: pubkey,
       );
+      if (isClosed) return;
 
       if (freshProfile != null) {
         emit(
@@ -82,6 +84,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         emit(const MyProfileError(errorType: MyProfileErrorType.notFound));
       }
     } on Exception {
+      if (isClosed) return;
       if (cachedProfile != null) {
         emit(
           MyProfileLoaded(
@@ -109,6 +112,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     final cachedProfile = await _profileRepository.getCachedProfile(
       pubkey: pubkey,
     );
+    if (isClosed) return;
     emit(
       MyProfileLoading(
         profile: cachedProfile,
@@ -120,6 +124,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     await emit.forEach<UserProfile?>(
       _profileRepository.watchProfile(pubkey: pubkey),
       onData: (profile) {
+        if (isClosed) return state;
         if (profile != null) {
           add(const VerifiedClaimsRequested());
           return MyProfileUpdated(
@@ -170,6 +175,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         pubkey: profile.pubkey,
         tags: profile.rawTags,
       );
+      if (isClosed) return;
       // State may have changed mid-await; re-check before emitting.
       final latest = state;
       if (latest is MyProfileLoaded &&
@@ -184,6 +190,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       // .claude/rules/error_handling.md they are NOT Reportable. Surface as
       // empty list rather than blocking the UI.
       addError(e, stackTrace);
+      if (isClosed) return;
       final latest = state;
       if (latest is MyProfileLoaded &&
           latest.profile.pubkey == profile.pubkey) {

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -68,12 +68,14 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     final cachedProfile = await _profileRepository.getCachedProfile(
       pubkey: pubkey,
     );
+    if (isClosed) return;
     emit(OtherProfileLoading(profile: cachedProfile));
 
     try {
       final freshProfile = await _profileRepository.fetchFreshProfile(
         pubkey: pubkey,
       );
+      if (isClosed) return;
       if (freshProfile != null) {
         emit(OtherProfileLoaded(profile: freshProfile, isFresh: true));
         add(const VerifiedClaimsRequested());
@@ -86,6 +88,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
         );
       }
     } catch (e) {
+      if (isClosed) return;
       if (cachedProfile != null) {
         emit(OtherProfileLoaded(profile: cachedProfile, isFresh: false));
         add(const VerifiedClaimsRequested());
@@ -115,6 +118,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       final freshProfile = await _profileRepository.fetchFreshProfile(
         pubkey: pubkey,
       );
+      if (isClosed) return;
       if (freshProfile != null) {
         emit(OtherProfileLoaded(profile: freshProfile, isFresh: true));
         add(const VerifiedClaimsRequested());
@@ -127,6 +131,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
         );
       }
     } catch (e) {
+      if (isClosed) return;
       if (currentProfile != null) {
         emit(OtherProfileLoaded(profile: currentProfile, isFresh: false));
         add(const VerifiedClaimsRequested());
@@ -156,6 +161,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
         pubkey: profile.pubkey,
         tags: profile.rawTags,
       );
+      if (isClosed) return;
       final latest = state;
       if (latest is OtherProfileLoaded &&
           latest.profile.pubkey == profile.pubkey) {
@@ -165,6 +171,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       // Verifier failures are expected (network/4xx/5xx/timeout). Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
+      if (isClosed) return;
       final latest = state;
       if (latest is OtherProfileLoaded &&
           latest.profile.pubkey == profile.pubkey) {

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -11,6 +12,18 @@ import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+/// Captures errors routed through [Bloc.onError] so a test can assert that a
+/// bloc closed mid-flight records no error when its awaited work resumes.
+class _ErrorCapturingObserver extends BlocObserver {
+  final List<Object> errors = <Object>[];
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    errors.add(error);
+    super.onError(bloc, error, stackTrace);
+  }
+}
 
 void main() {
   group(MyProfileBloc, () {
@@ -48,6 +61,14 @@ void main() {
 
     MyProfileBloc createBloc({String pubkey = testPubkey}) =>
         MyProfileBloc(profileRepository: mockProfileRepository, pubkey: pubkey);
+
+    _ErrorCapturingObserver captureBlocErrors() {
+      final observer = _ErrorCapturingObserver();
+      final previousObserver = Bloc.observer;
+      Bloc.observer = observer;
+      addTearDown(() => Bloc.observer = previousObserver);
+      return observer;
+    }
 
     test('initial state is $MyProfileInitial', () {
       final bloc = createBloc();
@@ -992,6 +1013,79 @@ void main() {
           verify(
             () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
           ).called(1);
+        },
+      );
+    });
+
+    group('after close (lifecycle regression)', () {
+      test(
+        'records no error when closed before the fresh profile resolves on load',
+        () async {
+          final observer = captureBlocErrors();
+          final freshCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => freshCompleter.future);
+
+          final bloc = createBloc()..add(const MyProfileLoadRequested());
+
+          await pumpEventQueue();
+          await bloc.close();
+          freshCompleter.complete(createTestProfile());
+          await pumpEventQueue();
+
+          expect(observer.errors, isEmpty);
+        },
+      );
+
+      test(
+        'records no error when closed before the fresh fetch throws on load',
+        () async {
+          final observer = captureBlocErrors();
+          final freshCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => freshCompleter.future);
+
+          final bloc = createBloc()..add(const MyProfileLoadRequested());
+
+          await pumpEventQueue();
+          await bloc.close();
+          freshCompleter.completeError(Exception('network error'));
+          await pumpEventQueue();
+
+          expect(observer.errors, isEmpty);
+        },
+      );
+
+      test(
+        'records no error when closed before the profile stream emits',
+        () async {
+          final observer = captureBlocErrors();
+          final streamController = StreamController<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => streamController.stream);
+
+          final bloc = createBloc()
+            ..add(const MyProfileSubscriptionRequested());
+
+          await pumpEventQueue();
+          await bloc.close();
+          streamController.add(createTestProfile());
+          await pumpEventQueue();
+          await streamController.close();
+
+          expect(observer.errors, isEmpty);
         },
       );
     });

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -626,15 +626,23 @@ void main() {
     });
 
     group('after close (lifecycle, regression for #4393)', () {
+      // Installs an observer that records every error routed through
+      // [Bloc.onError] for the running test, restoring the previous observer
+      // on teardown. A closed bloc that resumes an awaited handler must not
+      // surface any error.
+      _ErrorCapturingObserver captureBlocErrors() {
+        final observer = _ErrorCapturingObserver();
+        final previousObserver = Bloc.observer;
+        Bloc.observer = observer;
+        addTearDown(() => Bloc.observer = previousObserver);
+        return observer;
+      }
+
       test(
         'records no error when closed before the fresh profile resolves '
         'on load',
         () async {
-          final observer = _ErrorCapturingObserver();
-          final previousObserver = Bloc.observer;
-          Bloc.observer = observer;
-          addTearDown(() => Bloc.observer = previousObserver);
-
+          final observer = captureBlocErrors();
           final freshCompleter = Completer<UserProfile?>();
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
@@ -647,12 +655,35 @@ void main() {
 
           // Let the handler emit loading and park on fetchFreshProfile.
           await pumpEventQueue();
-
           // The profile screen is disposed while the fetch is in flight.
           await bloc.close();
-
           // The awaited fetch now resolves after close.
           freshCompleter.complete(createTestProfile());
+          await pumpEventQueue();
+
+          expect(observer.errors, isEmpty);
+        },
+      );
+
+      test(
+        'records no error when closed before the fresh fetch throws on load',
+        () async {
+          final observer = captureBlocErrors();
+          final freshCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => freshCompleter.future);
+
+          final bloc = createBloc()..add(const OtherProfileLoadRequested());
+
+          await pumpEventQueue();
+          await bloc.close();
+          // The fetch fails after close: the catch block must not add
+          // VerifiedClaimsRequested to the now-closed bloc.
+          freshCompleter.completeError(Exception('network error'));
           await pumpEventQueue();
 
           expect(observer.errors, isEmpty);
@@ -663,11 +694,7 @@ void main() {
         'records no error when closed before the fresh profile resolves '
         'on refresh',
         () async {
-          final observer = _ErrorCapturingObserver();
-          final previousObserver = Bloc.observer;
-          Bloc.observer = observer;
-          addTearDown(() => Bloc.observer = previousObserver);
-
+          final observer = captureBlocErrors();
           final freshCompleter = Completer<UserProfile?>();
           when(
             () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
@@ -678,6 +705,36 @@ void main() {
           await pumpEventQueue();
           await bloc.close();
           freshCompleter.complete(createTestProfile());
+          await pumpEventQueue();
+
+          expect(observer.errors, isEmpty);
+        },
+      );
+
+      test(
+        'records no error when closed before a seeded refresh fetch throws',
+        () async {
+          // Drive the bloc to a loaded state first so the refresh catch
+          // block takes the branch that re-adds VerifiedClaimsRequested.
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          final bloc = createBloc()..add(const OtherProfileLoadRequested());
+          await pumpEventQueue();
+
+          final observer = captureBlocErrors();
+          final refreshCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => refreshCompleter.future);
+
+          bloc.add(const OtherProfileRefreshRequested());
+          await pumpEventQueue();
+          await bloc.close();
+          refreshCompleter.completeError(Exception('network error'));
           await pumpEventQueue();
 
           expect(observer.errors, isEmpty);

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -1,8 +1,11 @@
 // ABOUTME: Unit tests for OtherProfileBloc
 // ABOUTME: Tests cache+fresh pattern for viewing another user's profile
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,6 +19,18 @@ class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+/// Captures errors routed through [Bloc.onError] so a test can assert that a
+/// bloc closed mid-flight records no error when its awaited work completes.
+class _ErrorCapturingObserver extends BlocObserver {
+  final List<Object> errors = <Object>[];
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    errors.add(error);
+    super.onError(bloc, error, stackTrace);
+  }
+}
 
 void main() {
   group('OtherProfileBloc', () {
@@ -606,6 +621,66 @@ void main() {
           verify(
             () => mockBlocklistRepository.unblockUser(testPubkey),
           ).called(1);
+        },
+      );
+    });
+
+    group('after close (lifecycle, regression for #4393)', () {
+      test(
+        'records no error when closed before the fresh profile resolves '
+        'on load',
+        () async {
+          final observer = _ErrorCapturingObserver();
+          final previousObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = previousObserver);
+
+          final freshCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => freshCompleter.future);
+
+          final bloc = createBloc()..add(const OtherProfileLoadRequested());
+
+          // Let the handler emit loading and park on fetchFreshProfile.
+          await pumpEventQueue();
+
+          // The profile screen is disposed while the fetch is in flight.
+          await bloc.close();
+
+          // The awaited fetch now resolves after close.
+          freshCompleter.complete(createTestProfile());
+          await pumpEventQueue();
+
+          expect(observer.errors, isEmpty);
+        },
+      );
+
+      test(
+        'records no error when closed before the fresh profile resolves '
+        'on refresh',
+        () async {
+          final observer = _ErrorCapturingObserver();
+          final previousObserver = Bloc.observer;
+          Bloc.observer = observer;
+          addTearDown(() => Bloc.observer = previousObserver);
+
+          final freshCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => freshCompleter.future);
+
+          final bloc = createBloc()..add(const OtherProfileRefreshRequested());
+
+          await pumpEventQueue();
+          await bloc.close();
+          freshCompleter.complete(createTestProfile());
+          await pumpEventQueue();
+
+          expect(observer.errors, isEmpty);
         },
       );
     });


### PR DESCRIPTION
## Description

`OtherProfileBloc` dispatched `add(VerifiedClaimsRequested())` and emitted state after awaiting profile fetches without checking `isClosed`. When the profile screen is disposed while a fetch is in flight, the resumed handler calls `add` on the now-closed bloc, throwing **`Bad state: Cannot add new events after calling close`** — Crashlytics `b06311065575782602a6b48f40dae7b8`: **100 nonfatal events / 19 users**.

This is the `OtherProfileBloc` half of #4393. #4648 fixed only the `InviteStatusCubit` half, and #4393 auto-closed one second after that merge, leaving this larger crash live.

The fix adds `if (isClosed) return;` after every `await` in all three async handlers (`_onLoadRequested`, `_onRefreshRequested`, `_onVerifiedClaimsRequested`), so the resumed handler never `emit`s or `add`s on a closed bloc. The genuine verifier `addError` is preserved — no repository errors are suppressed.

No UI change.

**Related Issue:** Closes #4393

## Out of Scope

- The `InviteStatusCubit` half of #4393 (already shipped in #4648).
- Other reliability-epic (#4336) Crashlytics blockers tracked separately: #4394 (list-cache init), #4400 (iOS player teardown), and the LocalKeySigner typed-exception migration.

## Verification

- `flutter analyze lib test integration_test` — No issues found.
- `flutter test test/blocs/other_profile/other_profile_bloc_test.dart` — 36/36 pass.
- 4 regression tests close the bloc before the awaited fetch **resolves** and before it **throws**, on both load and refresh — covering all four `add`-after-close guard sites. Each was verified to **fail without the fix** with the exact production error (`Cannot add new events after calling close`) and pass with it.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)