### PR TITLE
fix(notifications): preserve normalized payload on foreground local notification taps (#4728)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -81,7 +81,7 @@ import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_helpers.dart'
-    show parseFcmPayload;
+    show localNotificationTapPayload, parseFcmPayload;
 import 'package:openvine/services/notification_service.dart'
     show NotificationTapEvent;
 import 'package:openvine/services/notification_target_resolver.dart';
@@ -146,16 +146,10 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     title: title,
     body: body,
     notificationDetails: details,
-    payload: jsonEncode({
-      // Preserve the full normalized payload so a tap on this background-built
-      // notification routes identically to a system push tap. The FCM wire key
-      // 'type' maps to the internal 'notificationType'. senderPubkey carries
-      // the actor so follow taps (which have no referencedEventId) can route.
-      'referencedEventId': data['referencedEventId'],
-      'eventId': data['eventId'],
-      'notificationType': data['type'],
-      'senderPubkey': data['senderPubkey'],
-    }),
+    // Carry the normalized tap payload (shared with the foreground path via
+    // localNotificationTapPayload) so a tap on this background-built
+    // notification routes identically to a system push tap.
+    payload: jsonEncode(localNotificationTapPayload(data)),
   );
 }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -610,6 +610,31 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
           }
         }
 
+        // Local-notification cold-start: Android pushes are data-only and
+        // rendered by flutter_local_notifications, so a tap that launches the
+        // app from a terminated state arrives here — not via getInitialMessage,
+        // which only covers OS-rendered pushes (iOS).
+        final launchTap = await container
+            .read(notificationServiceProvider)
+            .takeLaunchNotificationTap();
+        if (launchTap != null) {
+          Log.info(
+            'App launched from local notification (type: '
+            '${launchTap.notificationType})',
+            name: 'main',
+            category: LogCategory.system,
+          );
+          unawaited(
+            _routeNotificationTap(
+              referencedEventId: launchTap.referencedEventId,
+              eventId: launchTap.eventId,
+              notificationType: launchTap.notificationType,
+              senderPubkey: launchTap.senderPubkey,
+              container: container,
+            ),
+          );
+        }
+
         // Handle taps on notifications while app is in background
         FirebaseMessaging.onMessageOpenedApp.listen((message) {
           final parsed = parseFcmPayload(message.data);

--- a/mobile/lib/services/notification_helpers.dart
+++ b/mobile/lib/services/notification_helpers.dart
@@ -107,6 +107,24 @@ parseFcmPayload(Map<String, dynamic> data) {
   );
 }
 
+/// Builds the normalized local-notification tap payload from an FCM [data] map.
+///
+/// Single source of truth for the JSON shape carried on a locally-displayed
+/// notification, so the background/system-push path and the foreground path
+/// cannot drift. The FCM wire key `type` is stored as `notificationType`;
+/// `senderPubkey` is preserved so follow/mention taps (which carry no
+/// `referencedEventId`) can still route. The shape is the inverse of what
+/// [parseFcmPayload] / `NotificationService.handleNotificationTapPayload`
+/// consume on tap.
+Map<String, dynamic> localNotificationTapPayload(Map<String, dynamic> data) {
+  return {
+    'referencedEventId': data['referencedEventId'],
+    'eventId': data['eventId'],
+    'notificationType': data['type'],
+    'senderPubkey': data['senderPubkey'],
+  };
+}
+
 /// Resolves the actor name from a user profile with fallback priority:
 /// 1. name field
 /// 2. displayName field

--- a/mobile/lib/services/notification_helpers.dart
+++ b/mobile/lib/services/notification_helpers.dart
@@ -63,6 +63,30 @@ String? extractAddressableId(Event event) {
   return (kind: kind, pubkey: pubkey, dTag: dTag);
 }
 
+/// Field names shared between the writer of the local-notification tap payload
+/// ([localNotificationTapPayload]) and its readers ([parseFcmPayload] and
+/// `NotificationService.handleNotificationTapPayload`). Centralised so the
+/// three sites cannot drift apart when a routing field is added or renamed.
+abstract class NotificationPayloadKeys {
+  /// FCM wire key for the notification type (lowercase
+  /// `like`/`comment`/`follow`/`mention`/`repost`). Stored on a locally-emitted
+  /// payload under [notificationType].
+  static const String wireType = 'type';
+
+  /// The event acted upon (present for like/comment/repost; absent for
+  /// follow/mention, which carry no `e` tag).
+  static const String referencedEventId = 'referencedEventId';
+
+  /// The source event itself (the like/comment/follow/mention event).
+  static const String eventId = 'eventId';
+
+  /// Normalised notification type carried on a locally-emitted payload.
+  static const String notificationType = 'notificationType';
+
+  /// Hex pubkey of the actor — used to route follows and unresolved taps.
+  static const String senderPubkey = 'senderPubkey';
+}
+
 /// Normalises a raw push-notification payload map into the fields the tap
 /// router needs.
 ///
@@ -90,10 +114,12 @@ parseFcmPayload(Map<String, dynamic> data) {
     return value is String && value.isNotEmpty ? value : null;
   }
 
-  final referencedEventId = nonEmpty('referencedEventId');
-  final eventId = nonEmpty('eventId');
-  final senderPubkey = nonEmpty('senderPubkey');
-  final notificationType = nonEmpty('type') ?? nonEmpty('notificationType');
+  final referencedEventId = nonEmpty(NotificationPayloadKeys.referencedEventId);
+  final eventId = nonEmpty(NotificationPayloadKeys.eventId);
+  final senderPubkey = nonEmpty(NotificationPayloadKeys.senderPubkey);
+  final notificationType =
+      nonEmpty(NotificationPayloadKeys.wireType) ??
+      nonEmpty(NotificationPayloadKeys.notificationType);
 
   if (referencedEventId == null && eventId == null && senderPubkey == null) {
     return null;
@@ -110,18 +136,24 @@ parseFcmPayload(Map<String, dynamic> data) {
 /// Builds the normalized local-notification tap payload from an FCM [data] map.
 ///
 /// Single source of truth for the JSON shape carried on a locally-displayed
-/// notification, so the background/system-push path and the foreground path
-/// cannot drift. The FCM wire key `type` is stored as `notificationType`;
-/// `senderPubkey` is preserved so follow/mention taps (which carry no
-/// `referencedEventId`) can still route. The shape is the inverse of what
-/// [parseFcmPayload] / `NotificationService.handleNotificationTapPayload`
-/// consume on tap.
+/// notification, so the background and foreground paths cannot drift. Built by
+/// running [data] through [parseFcmPayload] and re-keying the result, so the
+/// writer shares the readers' empty-string normalization through one point
+/// rather than re-deriving it.
+///
+/// The FCM wire key `type` is stored under [NotificationPayloadKeys.
+/// notificationType]; `senderPubkey` is preserved so follow/mention taps (which
+/// carry no `referencedEventId`) can still route. Consumed on tap by
+/// `NotificationService.handleNotificationTapPayload`. Always returns a map
+/// (all-null when nothing routable is present) — the notification still shows
+/// and the tap simply no-ops.
 Map<String, dynamic> localNotificationTapPayload(Map<String, dynamic> data) {
+  final parsed = parseFcmPayload(data);
   return {
-    'referencedEventId': data['referencedEventId'],
-    'eventId': data['eventId'],
-    'notificationType': data['type'],
-    'senderPubkey': data['senderPubkey'],
+    NotificationPayloadKeys.referencedEventId: parsed?.referencedEventId,
+    NotificationPayloadKeys.eventId: parsed?.eventId,
+    NotificationPayloadKeys.notificationType: parsed?.notificationType,
+    NotificationPayloadKeys.senderPubkey: parsed?.senderPubkey,
   };
 }
 

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -524,8 +524,18 @@ class NotificationService {
     controller.add(event);
   }
 
-  /// Send a local notification with title and body
-  Future<void> sendLocal({required String title, required String body}) async {
+  /// Send a local notification with [title], [body], and an optional tap
+  /// [payload].
+  ///
+  /// [payload] is the normalized JSON string consumed by
+  /// [_handleNotificationTapPayload] on tap; pass it (built via
+  /// `localNotificationTapPayload`) so foreground-displayed notifications route
+  /// the same way as background/system-push ones.
+  Future<void> sendLocal({
+    required String title,
+    required String body,
+    String? payload,
+  }) async {
     Log.debug(
       '📱 Sending local notification: $title',
       name: 'NotificationService',
@@ -604,6 +614,7 @@ class NotificationService {
         title: title,
         body: body,
         notificationDetails: notificationDetails,
+        payload: payload,
       );
 
       Log.debug(

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:openvine/services/notification_helpers.dart'
+    show NotificationPayloadKeys;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Types of notifications
@@ -145,7 +147,7 @@ class NotificationService {
   bool _disposed = false;
 
   // Flutter local notifications plugin instance
-  final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
+  FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
   bool _pluginInitialized = false;
   StreamController<NotificationTapEvent>? _notificationTapController;
@@ -161,6 +163,19 @@ class NotificationService {
       (_notificationTapController ??=
               StreamController<NotificationTapEvent>.broadcast())
           .stream;
+
+  /// Test seam: swap in a mock [plugin] and mark the service ready so
+  /// [sendLocal] and [takeLaunchNotificationTap] exercise the plugin directly
+  /// without touching real platform channels.
+  @visibleForTesting
+  void debugConfigurePlugin(
+    FlutterLocalNotificationsPlugin plugin, {
+    bool permissionsGranted = true,
+  }) {
+    _flutterLocalNotificationsPlugin = plugin;
+    _pluginInitialized = true;
+    _permissionsGranted = permissionsGranted;
+  }
 
   /// Initialize notification service
   ///
@@ -481,7 +496,16 @@ class NotificationService {
       category: LogCategory.system,
     );
 
-    if (payload == null || payload.isEmpty) return;
+    final event = _parseTapPayload(payload);
+    if (event != null) _emitNotificationTap(event);
+  }
+
+  /// Parses a local-notification tap [payload] into a [NotificationTapEvent],
+  /// or null when nothing routable is present. Shared by the live-tap path
+  /// ([_handleNotificationTapPayload]) and the cold-start path
+  /// ([takeLaunchNotificationTap]) so the two cannot diverge.
+  NotificationTapEvent? _parseTapPayload(String? payload) {
+    if (payload == null || payload.isEmpty) return null;
 
     try {
       final data = jsonDecode(payload) as Map<String, dynamic>;
@@ -490,23 +514,24 @@ class NotificationService {
         return value is String && value.isNotEmpty ? value : null;
       }
 
-      final referencedEventId = field('referencedEventId');
-      final eventId = field('eventId');
-      final senderPubkey = field('senderPubkey');
+      final referencedEventId = field(
+        NotificationPayloadKeys.referencedEventId,
+      );
+      final eventId = field(NotificationPayloadKeys.eventId);
+      final senderPubkey = field(NotificationPayloadKeys.senderPubkey);
       // A follow/mention carries no referencedEventId but is still routable
-      // via senderPubkey / eventId, so emit whenever any of the three exist.
-      if (referencedEventId != null ||
-          eventId != null ||
-          senderPubkey != null) {
-        _emitNotificationTap(
-          NotificationTapEvent(
-            referencedEventId: referencedEventId,
-            eventId: eventId,
-            notificationType: field('notificationType'),
-            senderPubkey: senderPubkey,
-          ),
-        );
+      // via senderPubkey / eventId, so route whenever any of the three exist.
+      if (referencedEventId == null &&
+          eventId == null &&
+          senderPubkey == null) {
+        return null;
       }
+      return NotificationTapEvent(
+        referencedEventId: referencedEventId,
+        eventId: eventId,
+        notificationType: field(NotificationPayloadKeys.notificationType),
+        senderPubkey: senderPubkey,
+      );
     } catch (e) {
       // Malformed payload (non-JSON, non-object, or unexpected shape).
       // Log a warning and discard — do not propagate to the Flutter error path.
@@ -515,6 +540,37 @@ class NotificationService {
         name: 'NotificationService',
         category: LogCategory.system,
       );
+      return null;
+    }
+  }
+
+  /// Returns the tap event for a locally-displayed notification that launched
+  /// the app from a *terminated* state, or null when the app was not launched
+  /// by such a tap. One-shot — consult once during startup.
+  ///
+  /// Complements FCM's `getInitialMessage`, which only covers OS-rendered
+  /// pushes (iOS, where the push service's APNS alert is shown by the OS). On
+  /// Android the push is data-only and rendered by this plugin, so a
+  /// terminated-app tap is delivered only through
+  /// `getNotificationAppLaunchDetails` — never via [notificationTapStream],
+  /// whose callback requires a live isolate.
+  Future<NotificationTapEvent?> takeLaunchNotificationTap() async {
+    if (kIsWeb) return null;
+    try {
+      if (!_pluginInitialized) {
+        await _initializePlugin();
+      }
+      final details = await _flutterLocalNotificationsPlugin
+          .getNotificationAppLaunchDetails();
+      if (details == null || !details.didNotificationLaunchApp) return null;
+      return _parseTapPayload(details.notificationResponse?.payload);
+    } catch (e) {
+      Log.error(
+        'Failed to read launch notification details: $e',
+        name: 'NotificationService',
+        category: LogCategory.system,
+      );
+      return null;
     }
   }
 

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -13,6 +13,8 @@ import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/notification_helpers.dart'
+    show localNotificationTapPayload;
 import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/utils/nostr_timestamp.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -305,7 +307,15 @@ class PushNotificationService {
 
     final title = (data['title'] as String?) ?? 'diVine';
 
-    await _notificationService.sendLocal(title: title, body: body);
+    // Carry the normalized tap payload so a tap on this foreground-displayed
+    // notification routes through the shared contract exactly like a
+    // background/system-push tap (previously the payload was dropped here, so
+    // foreground taps could not deep-link).
+    await _notificationService.sendLocal(
+      title: title,
+      body: body,
+      payload: jsonEncode(localNotificationTapPayload(data)),
+    );
   }
 
   /// Releases resources held by this service.

--- a/mobile/test/services/notification_helpers_test.dart
+++ b/mobile/test/services/notification_helpers_test.dart
@@ -581,5 +581,22 @@ void main() {
       expect(payload['eventId'], equals('contact_event'));
       expect(payload['referencedEventId'], isNull);
     });
+
+    test('normalizes empty-string routing fields to null', () {
+      final payload = localNotificationTapPayload(const {
+        'type': 'like',
+        'eventId': 'like_event',
+        // An empty referencedEventId on the wire must not survive as '' on the
+        // local payload; the writer shares parseFcmPayload's normalization, so
+        // empty and absent are treated identically.
+        'referencedEventId': '',
+        'senderPubkey': 'actor_hex',
+      });
+
+      expect(payload['referencedEventId'], isNull);
+      expect(payload['eventId'], equals('like_event'));
+      expect(payload['notificationType'], equals('like'));
+      expect(payload['senderPubkey'], equals('actor_hex'));
+    });
   });
 }

--- a/mobile/test/services/notification_helpers_test.dart
+++ b/mobile/test/services/notification_helpers_test.dart
@@ -549,4 +549,37 @@ void main() {
       expect(result.notificationType, equals('like'));
     });
   });
+
+  group('localNotificationTapPayload', () {
+    test('maps FCM type to notificationType and preserves routing fields', () {
+      final payload = localNotificationTapPayload(const {
+        'type': 'comment',
+        'eventId': 'comment_event',
+        'referencedEventId': 'video_event',
+        'senderPubkey': 'actor_hex',
+        'title': 'New comment',
+        'body': 'ignored for routing',
+      });
+
+      expect(payload, {
+        'referencedEventId': 'video_event',
+        'eventId': 'comment_event',
+        'notificationType': 'comment',
+        'senderPubkey': 'actor_hex',
+      });
+    });
+
+    test('preserves senderPubkey for a follow with no referencedEventId', () {
+      final payload = localNotificationTapPayload(const {
+        'type': 'follow',
+        'eventId': 'contact_event',
+        'senderPubkey': 'follower_hex',
+      });
+
+      expect(payload['notificationType'], equals('follow'));
+      expect(payload['senderPubkey'], equals('follower_hex'));
+      expect(payload['eventId'], equals('contact_event'));
+      expect(payload['referencedEventId'], isNull);
+    });
+  });
 }

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -3,10 +3,15 @@
 
 import 'dart:convert';
 
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/notification_helpers.dart'
     show localNotificationTapPayload;
 import 'package:openvine/services/notification_service.dart';
+
+class _MockFlutterLocalNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
 
 void main() {
   group('NotificationService Permission Tests', () {
@@ -426,6 +431,162 @@ void main() {
         ),
         returnsNormally,
       );
+    });
+  });
+
+  group('sendLocal payload forwarding', () {
+    late NotificationService service;
+    late _MockFlutterLocalNotificationsPlugin plugin;
+
+    setUp(() {
+      service = NotificationService();
+      plugin = _MockFlutterLocalNotificationsPlugin();
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('forwards the tap payload to the plugin show() call', () async {
+      when(
+        () => plugin.show(
+          id: any(named: 'id'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          notificationDetails: any(named: 'notificationDetails'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      service.debugConfigurePlugin(plugin);
+
+      final payload = jsonEncode(
+        localNotificationTapPayload(const {
+          'type': 'comment',
+          'eventId': 'comment_event',
+          'referencedEventId': 'video_event',
+          'senderPubkey': 'actor_hex',
+        }),
+      );
+
+      await service.sendLocal(
+        title: 'New comment',
+        body: 'alice commented',
+        payload: payload,
+      );
+
+      // The exact payload reaches the plugin's show(payload:) — the seam this
+      // change adds. The round-trip test above proves the payload then parses
+      // back to a routable tap event.
+      final captured = verify(
+        () => plugin.show(
+          id: any(named: 'id'),
+          title: 'New comment',
+          body: 'alice commented',
+          notificationDetails: any(named: 'notificationDetails'),
+          payload: captureAny(named: 'payload'),
+        ),
+      ).captured;
+      expect(captured.single, equals(payload));
+    });
+
+    test(
+      'omits the payload (null) when sendLocal is called without one',
+      () async {
+        when(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async {});
+
+        service.debugConfigurePlugin(plugin);
+
+        await service.sendLocal(title: 'Upload complete', body: 'done');
+
+        final captured = verify(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: captureAny(named: 'payload'),
+          ),
+        ).captured;
+        expect(captured.single, isNull);
+      },
+    );
+  });
+
+  group('takeLaunchNotificationTap', () {
+    late NotificationService service;
+    late _MockFlutterLocalNotificationsPlugin plugin;
+
+    setUp(() {
+      service = NotificationService();
+      plugin = _MockFlutterLocalNotificationsPlugin();
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test(
+      'routes a local notification that launched the app (cold start)',
+      () async {
+        when(() => plugin.getNotificationAppLaunchDetails()).thenAnswer(
+          (_) async => NotificationAppLaunchDetails(
+            true,
+            notificationResponse: NotificationResponse(
+              notificationResponseType:
+                  NotificationResponseType.selectedNotification,
+              payload: jsonEncode(
+                localNotificationTapPayload(const {
+                  'type': 'follow',
+                  'eventId': 'contact_event',
+                  'senderPubkey': 'follower_hex',
+                }),
+              ),
+            ),
+          ),
+        );
+
+        service.debugConfigurePlugin(plugin);
+
+        final tap = await service.takeLaunchNotificationTap();
+
+        expect(tap, isNotNull);
+        expect(tap!.notificationType, equals('follow'));
+        expect(tap.senderPubkey, equals('follower_hex'));
+        expect(tap.eventId, equals('contact_event'));
+        expect(tap.referencedEventId, isNull);
+      },
+    );
+
+    test(
+      'returns null when the app was not launched by a notification',
+      () async {
+        when(() => plugin.getNotificationAppLaunchDetails()).thenAnswer(
+          (_) async => const NotificationAppLaunchDetails(false),
+        );
+
+        service.debugConfigurePlugin(plugin);
+
+        expect(await service.takeLaunchNotificationTap(), isNull);
+      },
+    );
+
+    test('returns null when there are no launch details', () async {
+      when(
+        () => plugin.getNotificationAppLaunchDetails(),
+      ).thenAnswer((_) async => null);
+
+      service.debugConfigurePlugin(plugin);
+
+      expect(await service.takeLaunchNotificationTap(), isNull);
     });
   });
 

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -4,6 +4,8 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/notification_helpers.dart'
+    show localNotificationTapPayload;
 import 'package:openvine/services/notification_service.dart';
 
 void main() {
@@ -387,6 +389,31 @@ void main() {
       expect(events.single.senderPubkey, equals('follower_hex'));
       expect(events.single.eventId, equals('contact_list_event'));
       expect(events.single.notificationType, equals('follow'));
+    });
+
+    test('a foreground-built local payload round-trips to a routable tap '
+        'event', () async {
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
+
+      // The exact payload the foreground path now attaches (built from FCM
+      // data via the shared helper); tapping it must yield a routable event.
+      final payload = jsonEncode(
+        localNotificationTapPayload(const {
+          'type': 'follow',
+          'eventId': 'contact_event',
+          'senderPubkey': 'follower_hex',
+        }),
+      );
+      service.handleNotificationTapPayload(payload);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(events.single.notificationType, equals('follow'));
+      expect(events.single.senderPubkey, equals('follower_hex'));
+      expect(events.single.eventId, equals('contact_event'));
+      expect(events.single.referencedEventId, isNull);
     });
 
     test('no-ops gracefully when the stream has no listeners', () {

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: deregistration, preference updates, and foreground message handling.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,6 +14,8 @@ import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/notification_helpers.dart'
+    show localNotificationTapPayload;
 import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/services/push_notification_service.dart';
 
@@ -930,28 +933,78 @@ void main() {
     });
 
     group('handleForegroundMessage', () {
+      test('displays a local notification carrying the normalized tap '
+          'payload', () async {
+        when(
+          () => mockNotificationService.sendLocal(
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async {});
+
+        const data = {
+          'title': 'New comment',
+          'body': 'alice commented',
+          'type': 'comment',
+          'eventId': 'comment_event',
+          'referencedEventId': 'video_event',
+          'senderPubkey': 'alice_hex',
+        };
+
+        final service = buildService();
+        await service.handleForegroundMessage(data);
+
+        final payload =
+            verify(
+                  () => mockNotificationService.sendLocal(
+                    title: 'New comment',
+                    body: 'alice commented',
+                    payload: captureAny(named: 'payload'),
+                  ),
+                ).captured.single
+                as String;
+        // The foreground banner attaches exactly the shared payload shape.
+        expect(jsonDecode(payload), equals(localNotificationTapPayload(data)));
+        expect((jsonDecode(payload) as Map)['notificationType'], 'comment');
+        service.dispose();
+      });
+
       test(
-        'sends local notification with title and body from message',
+        'preserves senderPubkey for a follow (no referencedEventId)',
         () async {
           when(
             () => mockNotificationService.sendLocal(
               title: any(named: 'title'),
               body: any(named: 'body'),
+              payload: any(named: 'payload'),
             ),
           ).thenAnswer((_) async {});
 
-          final service = buildService();
-          await service.handleForegroundMessage({
-            'title': 'New Like',
-            'body': 'Someone liked your video',
-          });
+          const data = {
+            'title': 'New follower',
+            'body': 'bob started following you',
+            'type': 'follow',
+            'eventId': 'contact_event',
+            'senderPubkey': 'bob_hex',
+          };
 
-          verify(
-            () => mockNotificationService.sendLocal(
-              title: 'New Like',
-              body: 'Someone liked your video',
-            ),
-          ).called(1);
+          final service = buildService();
+          await service.handleForegroundMessage(data);
+
+          final payload =
+              verify(
+                    () => mockNotificationService.sendLocal(
+                      title: any(named: 'title'),
+                      body: any(named: 'body'),
+                      payload: captureAny(named: 'payload'),
+                    ),
+                  ).captured.single
+                  as String;
+          final decoded = jsonDecode(payload) as Map<String, dynamic>;
+          expect(decoded['notificationType'], 'follow');
+          expect(decoded['senderPubkey'], 'bob_hex');
+          expect(decoded['referencedEventId'], isNull);
           service.dispose();
         },
       );
@@ -961,6 +1014,7 @@ void main() {
           () => mockNotificationService.sendLocal(
             title: any(named: 'title'),
             body: any(named: 'body'),
+            payload: any(named: 'payload'),
           ),
         ).thenAnswer((_) async {});
 
@@ -973,6 +1027,7 @@ void main() {
           () => mockNotificationService.sendLocal(
             title: 'diVine',
             body: 'Someone liked your video',
+            payload: any(named: 'payload'),
           ),
         ).called(1);
         service.dispose();
@@ -986,6 +1041,7 @@ void main() {
           () => mockNotificationService.sendLocal(
             title: any(named: 'title'),
             body: any(named: 'body'),
+            payload: any(named: 'payload'),
           ),
         );
         service.dispose();


### PR DESCRIPTION
## Description

Foreground FCM banners displayed a local notification via `sendLocal()` **without a tap payload**, so tapping a foreground-generated notification did nothing — the shared router (#4727) had no context to route with. This PR closes the foreground payload gap **and** the local-notification cold-start gap that #4728's acceptance criteria call out.

### Payload production (foreground)
- **Extract `localNotificationTapPayload()`** (`notification_helpers.dart`) as the single source of truth for the local-notification tap payload shape — `referencedEventId`, `eventId`, `notificationType` (from the FCM wire `type`), `senderPubkey`. The background/system-push handler (`main.dart`) and the foreground handler now **both build it**.
- **`sendLocal()`** gains an optional `payload` param, threaded to the plugin's `show(payload:)`.
- **`handleForegroundMessage()`** attaches the normalized payload, so foreground taps — including follow/mention, which carry no `referencedEventId` — route through the same contract as background/system-push taps.

### Payload consumption on cold start (new)
`divine-push-service` sends **data-only** FCM messages (`notification: None`, `android: None`; an APNS `aps.alert` is synthesized only for iOS). So on **Android every push is rendered locally** by `flutter_local_notifications`, and a tap that launches the app from a **terminated** state arrives via `getNotificationAppLaunchDetails()` — **not** `getInitialMessage()` (which only covers OS-rendered iOS pushes). That launch path was never consulted, so Android terminated-app taps were silently dropped even with a valid payload attached.
- **`NotificationService.takeLaunchNotificationTap()`** consults `getNotificationAppLaunchDetails()` once at startup (next to `getInitialMessage`) and routes any launch payload through the shared `_routeNotificationTap`.
- **`_parseTapPayload`** extracted so the live-tap and cold-start paths share one parser.

### Review hardening
- **`NotificationPayloadKeys`** centralizes the payload field names previously hand-mirrored across the writer and the two readers; `localNotificationTapPayload` is now derived from `parseFcmPayload`, sharing its empty-string normalization rather than re-deriving it.
- **Plugin injection seam** (`debugConfigurePlugin`, `@visibleForTesting`) so `sendLocal(payload:) → show(payload:)` forwarding and the cold-start path are unit-tested — the prior round-trip test bypassed both.

**Related Issue:** Closes #4728 (parent epic #4200). Builds on #4727 (merged in #4736).

## Out of Scope
- **#4730** — `referencedDTag` owned-video attribution safety.
- **#4731** — duplicate push rendering. Note: #4760 (#4731) edits the same `_firebaseMessagingBackgroundHandler` this PR touches — whichever merges first, the other rebases.
- The routing contract itself (shipped in #4727); this PR makes the foreground path *produce* and the cold-start path *consume* the payload the contract relies on.

## Verification
- `flutter analyze lib test` → **No issues found**
- `flutter test` notifications surface (`test/services/*notification*`, `test/notifications/`, `test/main_notification_tap_routing_test.dart`) → **295 pass**, incl. new `sendLocal` payload-forwarding, `takeLaunchNotificationTap` cold-start (routable / not-launched / no-details), and empty-string normalization.
- `dart format --output=none --set-exit-if-changed` → clean
- No `pubspec.lock` churn.

## Type of Change
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
