### PR TITLE
fix(notifications): gate owned-video addressable on authoritative ownership (#4730)

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1072,7 +1072,10 @@ class NotificationRepository {
       final dTag = group
           .map((n) => n.referencedDTag)
           .firstWhere((d) => d != null, orElse: () => null);
-      final addressableId = _buildRecipientOwnedVideoAddressableId(dTag);
+      final addressableId = _recipientOwnedVideoAddressableId(
+        dTag: dTag,
+        video: video,
+      );
       // Prefer thumbnail from the notification payload — it comes directly from
       // the server and is stable even after a metadata update (unlike the stats
       // lookup which uses the mutable event ID and may 404 post-edit).
@@ -1206,8 +1209,9 @@ class NotificationRepository {
         );
         return null;
       }
-      final addressableId = _buildRecipientOwnedVideoAddressableId(
-        raw.referencedDTag,
+      final addressableId = _recipientOwnedVideoAddressableId(
+        dTag: raw.referencedDTag,
+        video: video,
       );
       return VideoNotification(
         id: raw.dedupeKey,
@@ -1287,15 +1291,23 @@ class NotificationRepository {
     _ => null,
   };
 
-  /// Builds the stable NIP-33 addressable ID for a video owned by the
-  /// current notification recipient.
+  /// Builds the stable NIP-33 addressable ID for a video the current
+  /// recipient *authoritatively* owns, or null when ownership is unknown.
   ///
-  /// Video-anchored notifications are already validated against the current
-  /// user when Funnelcake can resolve ownership. Using [_userPubkey] keeps
-  /// route construction stable when the referenced event ID is stale and the
-  /// metadata lookup misses.
-  String? _buildRecipientOwnedVideoAddressableId(String? dTag) {
+  /// Synthesizing a recipient-owned route is only safe when [video] confirms
+  /// the referenced video's owner is the recipient. When the metadata lookup
+  /// missed — a stale/edited event id, a fetch failure, or a comment whose
+  /// `referenced_event_id` is empty — ownership is unknown, so we return null
+  /// and let navigation fall back to the canonical `referencedEventId` rather
+  /// than guess the recipient owns it and point at another creator's video.
+  /// An empty owner pubkey is treated as unknown for the same reason. See
+  /// #4730.
+  String? _recipientOwnedVideoAddressableId({
+    required String? dTag,
+    required VideoStats? video,
+  }) {
     if (dTag == null || dTag.isEmpty) return null;
+    if (video == null || video.pubkey != _userPubkey) return null;
     return '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag';
   }
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1294,21 +1294,33 @@ class NotificationRepository {
   /// Builds the stable NIP-33 addressable ID for a video the current
   /// recipient *authoritatively* owns, or null when ownership is unknown.
   ///
-  /// Synthesizing a recipient-owned route is only safe when [video] confirms
-  /// the referenced video's owner is the recipient. When the metadata lookup
-  /// missed — a stale/edited event id, a fetch failure, or a comment whose
-  /// `referenced_event_id` is empty — ownership is unknown, so we return null
-  /// and let navigation fall back to the canonical `referencedEventId` rather
-  /// than guess the recipient owns it and point at another creator's video.
-  /// An empty owner pubkey is treated as unknown for the same reason. See
-  /// #4730.
+  /// Only safe when [video] confirms the referenced video's owner is the
+  /// recipient. On a metadata miss — a stale/edited event id, a fetch failure,
+  /// or a comment whose `referenced_event_id` is empty — ownership is unknown,
+  /// so we return null and let navigation fall back to the canonical
+  /// `referencedEventId`. The synthesized id is always scoped to [_userPubkey],
+  /// so a wrong guess would surface the recipient's *own* (or a non-existent)
+  /// video — never another creator's — and failing safe avoids that. An empty
+  /// owner pubkey is treated as unknown for the same reason.
+  ///
+  /// The d-tag comes from the authoritative [video], falling back to the
+  /// payload [dTag] only when `VideoStats` omits one, so a `referenced_video`
+  /// block that disagrees with `referenced_event_id` can't build a mismatched
+  /// route.
+  ///
+  /// Known gaps (deferred, see #4730): the stable route is lost on a metadata
+  /// miss for the recipient's own *edited* video; and the page-load path
+  /// fetches only `referenced_event_id` metadata, so `root_event_id`-anchored
+  /// comments confirm ownership on the realtime path only.
   String? _recipientOwnedVideoAddressableId({
     required String? dTag,
     required VideoStats? video,
   }) {
-    if (dTag == null || dTag.isEmpty) return null;
     if (video == null || video.pubkey != _userPubkey) return null;
-    return '${NIP71VideoKinds.addressableShortVideo}:$_userPubkey:$dTag';
+    final resolvedDTag = _nonEmpty(video.dTag) ?? _nonEmpty(dTag);
+    if (resolvedDTag == null) return null;
+    return '${NIP71VideoKinds.addressableShortVideo}'
+        ':$_userPubkey:$resolvedDTag';
   }
 
   /// Returns the stable NIP-33 addressable ID for an actor-anchored

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -782,8 +782,8 @@ void main() {
         expect(item.actors.first.displayName, equals('Sally Strawberry'));
       });
 
-      test('grouped video notifications build addressable id from '
-          'the current user pubkey and d-tag', () async {
+      test('grouped video notifications build addressable id when the '
+          'recipient authoritatively owns the referenced video', () async {
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -802,6 +802,9 @@ void main() {
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
+        // Authoritative ownership: video stats resolve and the owner is the
+        // recipient (makeVideoStats defaults pubkey == userPubkey).
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
 
         final page = await repository.getNotifications();
 
@@ -816,8 +819,12 @@ void main() {
         );
       });
 
-      test('grouped video notifications still build addressable id when '
-          'video stats miss for a stale referenced event id', () async {
+      test('grouped video notifications leave addressable id null when the '
+          'referenced video owner is unknown (#4730)', () async {
+        // No video stats stubbed → ownership cannot be confirmed (e.g. a
+        // stale/edited event id). Synthesizing a recipient-owned addressable
+        // here could point at the wrong creator's video, so we leave it null
+        // and fall back to the canonical referencedEventId for navigation.
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -841,13 +848,37 @@ void main() {
 
         expect(page.items, hasLength(1));
         final item = page.items.single as VideoNotification;
-        expect(
-          item.videoAddressableId,
-          equals(
-            '${NIP71VideoKinds.addressableShortVideo}:'
-            '$userPubkey:vine-id',
+        expect(item.videoAddressableId, isNull);
+        // Canonical navigation target is preserved for the resolver fallback.
+        expect(item.videoEventId, equals('video_x'));
+      });
+
+      test('comment with empty referencedEventId leaves addressable id null '
+          'and keeps the root video event id (#4730)', () async {
+        // NIP-22 comment whose referenced_event_id is empty carries the video
+        // via rootEventId. Metadata is fetched by referencedEventId, so the
+        // owner is unknown here — the addressable must not be synthesized.
+        stubNotifications([
+          makeNotification(
+            id: 'c1',
+            sourcePubkey: 'pub_a',
+            sourceKind: 1111,
+            notificationType: 'comment',
+            referencedEventId: '',
+            rootEventId: 'video_root',
+            referencedDTag: 'vine-id',
+            content: 'nice one',
           ),
-        );
+        ]);
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.comment));
+        expect(item.videoAddressableId, isNull);
+        expect(item.videoEventId, equals('video_root'));
       });
 
       test('grouped video notifications leave addressable id null when d-tag '
@@ -2345,9 +2376,10 @@ void main() {
         },
       );
 
-      test('builds addressable id from the current user pubkey and d-tag '
-          'for realtime video notifications', () async {
+      test('builds addressable id for realtime video notifications when the '
+          'recipient authoritatively owns the referenced video', () async {
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
 
         final result = await repository.enrichOne(
           raw(referencedDTag: 'vine-id'),
@@ -2364,8 +2396,10 @@ void main() {
         );
       });
 
-      test('builds addressable id for realtime video notifications when '
-          'video stats miss for a stale referenced event id', () async {
+      test('leaves realtime addressable id null when the referenced video '
+          'owner is unknown (#4730)', () async {
+        // No video stats stubbed → ownership unconfirmed; fall back to the
+        // canonical referencedEventId rather than guess recipient ownership.
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
 
         final result = await repository.enrichOne(
@@ -2374,13 +2408,8 @@ void main() {
 
         expect(result, isA<VideoNotification>());
         final video = result! as VideoNotification;
-        expect(
-          video.videoAddressableId,
-          equals(
-            '${NIP71VideoKinds.addressableShortVideo}:'
-            '$userPubkey:vine-id',
-          ),
-        );
+        expect(video.videoAddressableId, isNull);
+        expect(video.videoEventId, equals('video_x'));
       });
 
       test('leaves addressable id null when realtime d-tag is empty', () async {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -199,13 +199,14 @@ void main() {
     String pubkey = userPubkey,
     String? thumbnail,
     String? title,
+    String? dTag,
   }) {
     return VideoStats(
       id: id,
       pubkey: pubkey,
       createdAt: DateTime(2025),
       kind: 34236,
-      dTag: 'd_$id',
+      dTag: dTag ?? 'd_$id',
       title: title ?? '',
       thumbnail: thumbnail ?? '',
       videoUrl: 'https://example.com/$id.mp4',
@@ -782,20 +783,21 @@ void main() {
         expect(item.actors.first.displayName, equals('Sally Strawberry'));
       });
 
-      test('grouped video notifications build addressable id when the '
-          'recipient authoritatively owns the referenced video', () async {
+      test('grouped video notifications build the addressable id from the '
+          'authoritative VideoStats d-tag when the recipient owns the '
+          'referenced video (#4730)', () async {
         stubNotifications([
           makeNotification(
             id: 'l1',
             sourcePubkey: 'pub_a',
             referencedEventId: 'video_x',
-            referencedDTag: 'vine-id',
+            referencedDTag: 'payload-dtag',
           ),
           makeNotification(
             id: 'l2',
             sourcePubkey: 'pub_b',
             referencedEventId: 'video_x',
-            referencedDTag: 'vine-id',
+            referencedDTag: 'payload-dtag',
           ),
         ]);
         stubProfiles({
@@ -803,8 +805,40 @@ void main() {
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
         // Authoritative ownership: video stats resolve and the owner is the
-        // recipient (makeVideoStats defaults pubkey == userPubkey).
+        // recipient (makeVideoStats defaults pubkey == userPubkey, d-tag
+        // 'd_video_x'). The payload referencedDTag intentionally DIFFERS so the
+        // assertion proves the route uses the authoritative VideoStats d-tag,
+        // not the payload — a mismatched referenced_video block can't poison
+        // the route.
         stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(
+          item.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:d_video_x',
+          ),
+        );
+      });
+
+      test('grouped video notifications fall back to the payload d-tag when '
+          'the authoritative VideoStats omits one (#4730)', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'l1',
+            sourcePubkey: 'pub_a',
+            referencedEventId: 'video_x',
+            referencedDTag: 'vine-id',
+          ),
+        ]);
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        // Owner confirmed, but VideoStats carries no d-tag → use the payload
+        // d-tag rather than drop the stable route.
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x', dTag: ''));
 
         final page = await repository.getNotifications();
 
@@ -856,8 +890,10 @@ void main() {
       test('comment with empty referencedEventId leaves addressable id null '
           'and keeps the root video event id (#4730)', () async {
         // NIP-22 comment whose referenced_event_id is empty carries the video
-        // via rootEventId. Metadata is fetched by referencedEventId, so the
-        // owner is unknown here — the addressable must not be synthesized.
+        // via rootEventId. The page-load path fetches metadata by
+        // referenced_event_id only (not rootEventId), so ownership of the root
+        // video is unconfirmed here and the addressable must not be
+        // synthesized — navigation falls back to the rootEventId resolver.
         stubNotifications([
           makeNotification(
             id: 'c1',
@@ -881,8 +917,8 @@ void main() {
         expect(item.videoEventId, equals('video_root'));
       });
 
-      test('grouped video notifications leave addressable id null when d-tag '
-          'is null or empty', () async {
+      test('grouped video notifications leave addressable id null when neither '
+          'VideoStats nor the payload carries a usable d-tag', () async {
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -900,6 +936,10 @@ void main() {
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
+        // Owner confirmed, but no d-tag from either source → cannot synthesize.
+        // (Without this stub the row would be null for the unrelated
+        // ownership-unknown reason, masking the d-tag branch under test.)
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x', dTag: ''));
 
         final page = await repository.getNotifications();
 
@@ -2376,13 +2416,17 @@ void main() {
         },
       );
 
-      test('builds addressable id for realtime video notifications when the '
-          'recipient authoritatively owns the referenced video', () async {
+      test('builds the realtime addressable id from the authoritative '
+          'VideoStats d-tag when the recipient owns the referenced video '
+          '(#4730)', () async {
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        // Owner == recipient, VideoStats d-tag 'd_video_x'. The payload
+        // referencedDTag DIFFERS so the route is proven to come from the
+        // authoritative VideoStats d-tag, not the payload.
         stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
 
         final result = await repository.enrichOne(
-          raw(referencedDTag: 'vine-id'),
+          raw(referencedDTag: 'payload-dtag'),
         );
 
         expect(result, isA<VideoNotification>());
@@ -2391,7 +2435,7 @@ void main() {
           video.videoAddressableId,
           equals(
             '${NIP71VideoKinds.addressableShortVideo}:'
-            '$userPubkey:vine-id',
+            '$userPubkey:d_video_x',
           ),
         );
       });


### PR DESCRIPTION
## Description

Video-anchored notification rows synthesized a **recipient-owned** NIP-33 addressable id (`34236:<recipient_pubkey>:<d-tag>`) from `referencedDTag` even when the referenced video's owner was **unknown** — a metadata miss from a stale/edited event id, a fetch failure, or a NIP-22 comment whose `referenced_event_id` is empty. On the unproven assumption that the recipient owns the video, a tap could open the recipient's own (or a non-existent) video instead of the real target.

- Gate `_recipientOwnedVideoAddressableId` on **authoritative** ownership: synthesize only when the resolved `VideoStats` confirms `video.pubkey == recipient`. When ownership is unknown, return `null` and let navigation fall back to the canonical `referencedEventId` via the resolver.
- Source the synthesized id's **d-tag from the authoritative `VideoStats`** (`video.dTag`), falling back to the payload `referencedDTag` only when `VideoStats` omits one. Confirming ownership via `VideoStats` but still building the route from the payload d-tag let a mismatched `referenced_video` block point at the wrong addressable even with confirmed ownership; sourcing the d-tag from the same authoritative event closes that gap (#4730 "harden row construction against mismatched `referenced_video` metadata vs `referenced_event_id`").
- The existing **known-owner-mismatch drop** (`_hasKnownReferencedVideoOwnerMismatch`) is unchanged; the actor-anchored path (`likeComment`/`reply`) was already null-safe. This closes the remaining video-anchored gap.

**Related Issue:** Closes #4730 (parent epic #4200). Related report: #4694 — note this PR does **not** resolve #4694's "liked my comment shows as liked my video" / unread-count symptom (that is `_mapNotificationKind` / `isReferencedVideo` + read-state, separate work). Independent of #4727 (merged) / #4728 (#4757) / #4729 (#4758) — repository-mapping only; parallel PR.

## Known trade-offs (documented in code)

- On a metadata miss for the recipient's **own *edited* video**, the stable addressable route is lost and navigation falls back to the (possibly stale) `referencedEventId` → resolver. This is the deliberate safety-over-stability trade-off; an authoritative owner field in the payload would shrink this window.
- The **page-load path fetches metadata by `referenced_event_id` only**, so `root_event_id`-anchored NIP-22 comments confirm ownership on the **realtime (`enrichOne`) path only**. Broadening that fetch is deferred (see Out of Scope).

## Out of Scope

- Re-enabling synthesis for *non-recipient* videos would require an authoritative owner field in the payload (upstream/`divine-push-service`) — deliberately not done; mobile fails safe.
- Fetching `rootEventId` in `_fetchVideoMetadata` on the page-load path (would let ownership be confirmed for more comments, removing the page-load vs realtime asymmetry above) — separate enrichment, not required for the safety fix.

## Verification

- `flutter analyze packages/notification_repository/lib packages/notification_repository/test` → **No issues found**
- `flutter test` (notification_repository package) → **120 pass**
- `flutter test test/notifications/` (app downstream) → **180 pass** — the null-addressable → raw-`referencedEventId` navigation fallback is covered by `notifications_view_test.dart` ("like tap falls back to raw eventId when no addressable id is set"), confirming the safety claim end-to-end.
- `dart format --set-exit-if-changed` → clean. Discarded incidental `pubspec.lock` churn.

### Test changes (note for reviewers)

This **intentionally reverses a previously-pinned behavior**: the old tests "build addressable id when video stats miss for a stale referenced event id" (page-load + realtime) asserted the unsafe synthesis. They're inverted to expect `videoAddressableId == null` with `videoEventId` preserved for the resolver fallback. Authoritative-ownership tests now stub video stats (owner = recipient) and keep asserting synthesis. Added an empty-`referencedEventId` comment case. The known-owner-mismatch **drop** test is unchanged.

**Follow-up (commit `f7595f8`, self-review pass):** the two authoritative-ownership tests now assert the route uses the **authoritative `VideoStats` d-tag** (`d_video_x`) over a *differing* payload `referencedDTag`, proving a mismatched payload can't poison the route. Added a payload-d-tag **fallback** test (owner confirmed, `VideoStats` omits d-tag → payload d-tag used). The "no usable d-tag" test now stubs a confirmed owner so it isolates the d-tag branch instead of passing for the unrelated ownership-unknown reason. **Behavior note:** an empty payload `referencedDTag` with a present `VideoStats` d-tag now **synthesizes** (was `null`).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
