### PR TITLE
fix(notifications): suppress duplicate local push render on iOS alert pushes (#4731)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -108,6 +108,22 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:window_manager/window_manager.dart';
 
+/// Whether the background isolate should render a local notification for
+/// [message].
+///
+/// iOS alert pushes (the push service sets `aps.alert` + `content_available`)
+/// are presented by the OS *and* wake this handler — building our own local
+/// notification on top would double-render (#4731). FlutterFire surfaces the
+/// OS-presented alert as [RemoteMessage.notification], so we render only for
+/// data-only messages that carry a body (Android, and iOS silent/data pushes)
+/// and let the OS own presentation whenever it already has it.
+@visibleForTesting
+bool shouldRenderLocalPushNotification(RemoteMessage message) {
+  if (message.notification != null) return false;
+  final body = message.data['body'];
+  return body is String && body.isNotEmpty;
+}
+
 /// Top-level background message handler required by Firebase.
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
@@ -117,7 +133,9 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final title = data['title'] as String? ?? 'diVine';
   final body = data['body'] as String? ?? '';
 
-  if (body.isEmpty) return;
+  // The OS already presents iOS alert pushes (aps.alert); only render a local
+  // notification for data-only messages so we don't double-render (#4731).
+  if (!shouldRenderLocalPushNotification(message)) return;
 
   final plugin = FlutterLocalNotificationsPlugin();
   const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -114,9 +114,11 @@ import 'package:window_manager/window_manager.dart';
 /// iOS alert pushes (the push service sets `aps.alert` + `content_available`)
 /// are presented by the OS *and* wake this handler — building our own local
 /// notification on top would double-render (#4731). FlutterFire surfaces the
-/// OS-presented alert as [RemoteMessage.notification], so we render only for
-/// data-only messages that carry a body (Android, and iOS silent/data pushes)
-/// and let the OS own presentation whenever it already has it.
+/// OS-presented alert as [RemoteMessage.notification], so we render only when
+/// the OS has not already presented it: a data-only message that carries a
+/// body. Today that is Android (the service stays data-only there); the
+/// data-only iOS branch is defensive, for a future silent push the OS would
+/// not surface.
 @visibleForTesting
 bool shouldRenderLocalPushNotification(RemoteMessage message) {
   if (message.notification != null) return false;
@@ -129,13 +131,13 @@ bool shouldRenderLocalPushNotification(RemoteMessage message) {
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
 
-  final data = message.data;
-  final title = data['title'] as String? ?? 'diVine';
-  final body = data['body'] as String? ?? '';
-
   // The OS already presents iOS alert pushes (aps.alert); only render a local
   // notification for data-only messages so we don't double-render (#4731).
   if (!shouldRenderLocalPushNotification(message)) return;
+
+  final data = message.data;
+  final title = data['title'] as String? ?? 'diVine';
+  final body = data['body'] as String? ?? '';
 
   final plugin = FlutterLocalNotificationsPlugin();
   const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');

--- a/mobile/test/main_push_duplicate_render_test.dart
+++ b/mobile/test/main_push_duplicate_render_test.dart
@@ -7,6 +7,10 @@ import 'package:openvine/main.dart' as app;
 
 void main() {
   group('shouldRenderLocalPushNotification', () {
+    // Unit-tests the pure decision predicate only. The background handler that
+    // consumes it (_firebaseMessagingBackgroundHandler) calls
+    // Firebase.initializeApp() and the local-notifications plugin, so its
+    // early-return is verified on-device, not here (#4731).
     test('does not render when the OS already presents the notification — an '
         'iOS alert push surfaces RemoteMessage.notification', () {
       const message = RemoteMessage(
@@ -40,6 +44,31 @@ void main() {
       const message = RemoteMessage(
         notification: RemoteNotification(title: 't', body: 'b'),
         data: {'body': 'b'},
+      );
+
+      expect(app.shouldRenderLocalPushNotification(message), isFalse);
+    });
+
+    test(
+      'does not render a data-only message whose body is an empty string',
+      () {
+        const message = RemoteMessage(data: {'body': '', 'type': 'like'});
+
+        expect(app.shouldRenderLocalPushNotification(message), isFalse);
+      },
+    );
+
+    test('does not render when the data body is not a string', () {
+      const message = RemoteMessage(data: <String, dynamic>{'body': 1});
+
+      expect(app.shouldRenderLocalPushNotification(message), isFalse);
+    });
+
+    test('does not render when the OS presents the alert and the data '
+        'carries no body', () {
+      const message = RemoteMessage(
+        notification: RemoteNotification(title: 'New follower', body: 'bob'),
+        data: {'type': 'follow'},
       );
 
       expect(app.shouldRenderLocalPushNotification(message), isFalse);

--- a/mobile/test/main_push_duplicate_render_test.dart
+++ b/mobile/test/main_push_duplicate_render_test.dart
@@ -1,0 +1,48 @@
+// ABOUTME: Tests the background push de-duplication guard — the app must not
+// ABOUTME: render a local notification when the OS already presents one (#4731).
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+
+void main() {
+  group('shouldRenderLocalPushNotification', () {
+    test('does not render when the OS already presents the notification — an '
+        'iOS alert push surfaces RemoteMessage.notification', () {
+      const message = RemoteMessage(
+        notification: RemoteNotification(
+          title: 'New like',
+          body: 'alice liked your video',
+        ),
+        data: {'body': 'alice liked your video', 'type': 'like'},
+      );
+
+      expect(app.shouldRenderLocalPushNotification(message), isFalse);
+    });
+
+    test('renders for a data-only message that carries a body '
+        '(Android / iOS data push)', () {
+      const message = RemoteMessage(
+        data: {'title': 'New like', 'body': 'alice liked your video'},
+      );
+
+      expect(app.shouldRenderLocalPushNotification(message), isTrue);
+    });
+
+    test('does not render a data-only message with no body', () {
+      const message = RemoteMessage(data: {'type': 'like'});
+
+      expect(app.shouldRenderLocalPushNotification(message), isFalse);
+    });
+
+    test('OS presentation wins even when the data payload also carries a '
+        'body', () {
+      const message = RemoteMessage(
+        notification: RemoteNotification(title: 't', body: 'b'),
+        data: {'body': 'b'},
+      );
+
+      expect(app.shouldRenderLocalPushNotification(message), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Users see **two banners for one push** on iOS. Root cause was traced through `divinevideo/divine-push-service`:

- `build_apns_config` (`src/fcm_sender.rs:136–189`, added by merged push-service **#17** `dfc4359`) synthesizes an **`aps.alert`** (title/body) **+ `content_available` + `mutable_content`**, push-type `Alert`, for **every** notification (all 5 types carry title/body).
- On **iOS background/terminated**: the OS presents the `aps.alert` banner (the `NotificationServiceExtension` only *enriches* that single alert — it never creates a second one) **and** `content_available` wakes `_firebaseMessagingBackgroundHandler`, which built a **second, local** notification → duplicate.
- **Android** stays data-only (`notification: None`, `android: None`) → app renders once. **Foreground** is single (no `setForegroundNotificationPresentationOptions`, and `AppDelegate` never overrides `willPresent` → iOS doesn't OS-present in foreground; the app renders via `handleForegroundMessage`).

**Fix (client-side, defense-in-depth):** FlutterFire surfaces the OS-presented `aps.alert` as `RemoteMessage.notification`. Guard the background isolate to render a local notification **only for data-only messages**:

```dart
@visibleForTesting
bool shouldRenderLocalPushNotification(RemoteMessage message) {
  if (message.notification != null) return false; // OS already presents it
  final body = message.data['body'];
  return body is String && body.isNotEmpty;
}
```

Tapping the OS-presented banner still routes via `onMessageOpenedApp` / `getInitialMessage` → `_routeNotificationTap` (#4727), unchanged. (On iOS the local-notification cold-start tap never routed anyway — there is no `getNotificationAppLaunchDetails()` path — so removing the local banner only leaves the already-correct OS path.) Foreground is intentionally not guarded (the app is the sole renderer there).

**Related Issue:** Closes #4731 (parent epic #4200). Related report: #4708. Backend contract tracked in `divinevideo/divine-push-service#20`.

## Backend coordination (durable fix lives server-side)

This client guard is **defense-in-depth**, not the canonical fix. The duplicate's actual trigger is `content_available` on an **alert** push:

- An `aps.alert` push **is** reliably delivered to a terminated iOS app *without* `content_available` — alert delivery does not depend on the background-fetch wake. (`content_available` is for *silent* pushes, which are the ones iOS throttles when terminated.)
- So `content_available` here buys no delivery reliability for an alert push; it only adds the background-isolate wake that renders banner #2.
- **Recommended source-level fix (push-service #20): drop `content_available` from alert pushes.** That removes the duplicate at the source with no loss of terminated-delivery reliability. The client guard then remains as a safety net per #4731's "defend itself even if the server payload regresses."

## Out of Scope

- **No backend change in this PR.** The client guard is shipped now as the defensive layer #4731 asks for; the server-side `content_available` change is tracked in push-service #20 (see above).
- Independent of #4728 (#4757) and #4729 (#4758)/#4730 (#4759): the fix lives in `_firebaseMessagingBackgroundHandler` (background guard line + a new helper); #4757 touches the foreground handler + the background **payload** line (different line). Parallel PR, safe in any merge order.

## Verification

### Automated
- `flutter analyze lib test integration_test` → **No issues found**
- `flutter test test/main_push_duplicate_render_test.dart` → **7 pass** (iOS-alert → skip; Android data+body → render; no-body → skip; OS-presence wins over data body; empty-string body → skip; non-String body → skip; OS-alert + no data body → skip)
- `dart format --output=none --set-exit-if-changed` → clean

### Manual verification on a real iOS device — required before merge
The guard relies on FlutterFire surfacing the OS `aps.alert` as `RemoteMessage.notification` inside the background isolate. That FlutterFire behavior **cannot be exercised by a unit test** (the unit tests validate the predicate, not the framework), and push is not delivered to the iOS simulator — so confirm on a physical device:

1. **iOS background** — background the app, send a `like`/`comment` push → exactly **one** banner.
2. **iOS terminated (cold start)** — force-quit the app, send a push → **one** banner; tap it → app opens and routes to the correct target (video / profile / inbox).
3. **iOS foreground** — keep the app foregrounded, send a push → **one** banner (rendered by the app, not the OS).
4. **All 5 types** — `like`, `comment`, `follow`, `mention`, `repost`: one banner each; taps route correctly (in particular `follow` / `mention` open a profile / event rather than being dropped).
5. **Android regression** — background and foreground, send a push → still exactly **one** banner.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
