### PR TITLE
fix(e2e): move emulator launch and stack setup into scripts

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,181 +1,111 @@
 ---
 name: e2e-test
 description: |
-  Run and debug E2E integration tests against the local Docker stack.
-  Covers emulator setup, stack management, test execution, log capture,
-  and common failure patterns. Use when running E2E tests, debugging
-  test failures, or setting up the local test infrastructure.
+  Run and debug Flutter E2E integration tests that exercise the real
+  app against a local Docker backend (no mocks). Use when running
+  E2E tests, debugging failures, or working on the local harness.
 author: Claude Code
-version: 1.0.0
+version: 1.1.0
 ---
 
 # E2E Integration Testing
 
-End-to-end tests run the full app against a local Docker backend stack.
-They exercise real OAuth flows, relay subscriptions, and media uploads
-with no mocks.
+Goal: run the real app against a real local backend, end-to-end.
+OAuth, relay subscriptions, and media uploads all hit local Docker
+services — no mocks anywhere. Tests live in
+`mobile/integration_test/`, backend in `local_stack/`.
 
-## Quick Start
+## Run a test
+
+Two terminals, from `mobile/`:
 
 ```bash
-cd mobile/
-mise run local_up        # Start Docker stack
-mise run e2e_test        # Run all E2E tests with profiling
-mise run e2e_test integration_test/auth/auth_journey_test.dart  # Single test
-mise run local_down      # Stop Docker stack
-mise run local_reset     # Wipe data and restart
-mise run local_status    # Check service health
+# Terminal 1 — emulator
+mise run emulator
+
+# Terminal 2 — tests
+mise run e2e_test                                              # All auth tests
+mise run e2e_test integration_test/auth/auth_journey_test.dart # Single test
 ```
 
-**Always use `mise run e2e_test`** — it handles `local_up`, log profiling,
-and merged timeline reports. Never call `patrol test` directly.
+`e2e_test` brings up the Docker stack, runs patrol, captures a
+merged docker+logcat+app timeline at `test_reports/*.jsonl`, and
+prints the native test XML path + failure excerpts when the APK
+fails to install. **Never call `patrol test` directly** — you'll
+lose the timeline and the diagnostics.
 
-## Local Docker Stack
+## Stack
 
-Located in `local_stack/`. Services:
-
-| Service | Host Port | Purpose |
-|---------|-----------|---------|
+| Service | Port | Purpose |
+|---|---|---|
 | Keycast | 43000 | OAuth + NIP-46 signer |
-| FunnelCake Relay | 47777 | Nostr relay (WebSocket) |
+| FunnelCake Relay | 47777 | Nostr relay |
 | FunnelCake API | 43001 | REST API |
 | Blossom | 43003 | Media server |
-| Postgres | 15432 | Keycast database |
-
-All GHCR images are **public** — no Docker login needed. If pulls fail with
-`denied`, check if you have a stale `docker login ghcr.io` session. A stale
-token causes Docker to send bad credentials instead of falling back to
-anonymous access. Fix: `docker logout ghcr.io`.
-
-### Stack Won't Start
-
-If `mise run local_up` fails on image pulls:
-```bash
-# Use cached images, skip pulling
-COMPOSE_FILE=../local_stack/docker-compose.yml docker compose up -d --pull=missing
-```
-
-Then run the test script directly:
-```bash
-bash ../local_stack/profile.sh integration_test/auth/
-```
-
-## Android Emulator
-
-### Setup
-
-The emulator reaches the host via `10.0.2.2`. Port constants are in
-`lib/models/environment_config.dart` and re-exported by
-`integration_test/helpers/constants.dart`.
-
-### Linux / Hyprland Launch
+| Postgres | 15432 | Keycast DB |
 
 ```bash
-DISPLAY=:1 ANDROID_AVD_HOME=/home/daniel/.config/.android/avd \
-  emulator -avd Medium_Phone_API_36.1 -gpu host -no-snapshot-load
+mise run local_up         # Start (auto-runs local_setup on fresh worktrees)
+mise run local_up_cached  # Same, but reuse cached images (offline / rate-limited)
+mise run local_down       # Stop
+mise run local_reset      # Wipe data + restart
+mise run local_status     # Health
 ```
 
-Always use `-gpu host` for video rendering (swiftshader can't render
-media_kit frames).
-
-### Storage Issues
-
-Repeated APK installs fill `/data`. Symptoms: `INSTALL_FAILED_INSUFFICIENT_STORAGE`
-or 0 tests discovered with Gradle exit code 1.
+If `local_up` fails only at `e2e-seed` and the services your test
+actually needs are healthy (auth tests don't need the indexer),
+bypass the seed:
 
 ```bash
-# Check space
-adb shell df -h /data
-
-# Free space
-adb shell pm trim-caches 1G
-
-# Nuclear option: wipe emulator
-emulator -avd <name> -gpu host -wipe-data
+bash ../local_stack/profile.sh integration_test/<your_test>.dart
 ```
 
-### Logcat Buffer
-
-Default 256KB is too small — auth flow logs rotate before critical phases.
+## Emulator
 
 ```bash
-adb logcat -G 16M          # Increase to 16MB
-adb logcat -c              # Clear before test run
-adb logcat -d | grep 'flutter.*\[AUTH\]'  # Capture auth flow
+mise run emulator           # Normal launch (auto-detects DISPLAY)
+mise run emulator_headless  # Offscreen, no window
+mise run emulator_wipe      # -wipe-data (storage exhausted)
 ```
 
-Filter by PID to isolate test cases (each patrolTest runs in a new process):
-```bash
-adb logcat -d | grep '<PID>.*flutter.*\[AUTH\]' | grep -v 'Router redirect'
-```
+Override AVD: `AVD_NAME=<name> mise run emulator`. Always uses
+`-gpu host` — swiftshader can't render media_kit frames.
 
-## Test Framework
+Skip the per-run reinstall with `PATROL_NO_UNINSTALL=true mise run
+e2e_test ...` when iterating fast and the APK hasn't changed.
+Stale-state debugging cost is yours.
 
-### Patrol
+Buffer auth-flow logs: `adb logcat -G 16M` (default 256 KB rotates
+mid-flow).
 
-Tests use Patrol for native UI automation. Patrol wraps Flutter's
-`integration_test` with the ability to handle permission dialogs,
-system back button, notifications, and share sheets.
+## Patterns
 
-```dart
-patrolTest('my test', ($) async {
-  final tester = $.tester;
-  // Use tester for Flutter widget interactions
-  // Use $ for native interactions (permissions, system UI)
-});
-```
+### Launching the app
 
-### Patrol Test Bundling (False Positives)
-
-Patrol bundles ALL test files in a directory into one APK. Each test file
-runs in a separate instrumentation process. When test B runs, test A's
-code is in the bundle but "not requested" — Patrol marks it `[E]`.
-
-**These are false positives, not real failures.** Only trust the `✅`/`❌`
-final status lines from the test runner. The logcat will show:
-```
-registered test "foo_test ..." was not matched by requested test "bar_test ..."
-```
-
-### App Launch Pattern
-
-Use `launchAppGuarded` from `test_setup.dart` to catch async relay errors:
+`pumpAndSettle` hangs because of persistent polling timers. Use
+`launchAppGuarded` (from `test_setup.dart`) with error suppression
+and a manual pump loop:
 
 ```dart
 final originalOnError = suppressSetStateErrors();
 final originalErrorBuilder = saveErrorWidgetBuilder();
-
 launchAppGuarded(app.main);
-await tester.pumpAndSettle(const Duration(seconds: 3));
 
-// ... test body ...
+for (var i = 0; i < 60; i++) {
+  await tester.pump(const Duration(milliseconds: 250));
+  if (find.text('Welcome').evaluate().isNotEmpty) break;
+}
 
 restoreErrorWidgetBuilder(originalErrorBuilder);
 restoreErrorHandler(originalOnError);
 drainAsyncErrors(tester);
 ```
 
-### Polling Instead of pumpAndSettle
+### Async publish → relay query
 
-The app has persistent polling timers that prevent `pumpAndSettle` from
-settling. Use manual pump loops:
-
-```dart
-for (var i = 0; i < 60; i++) {
-  await tester.pump(const Duration(milliseconds: 250));
-  if (find.text('Welcome').evaluate().isNotEmpty) break;
-}
-```
-
-## Common Pitfalls
-
-### Async Publish → Relay Query
-
-Video publishing is async — the UI navigates to profile before the blossom
-upload and relay publish complete. Always poll the relay:
+UI navigates before publish/upload completes. Poll the relay:
 
 ```dart
-var events = <Event>[];
 for (var i = 0; i < 120; i++) {
   await tester.pump(const Duration(milliseconds: 500));
   events = await queryRelay(filter);
@@ -183,10 +113,9 @@ for (var i = 0; i < 120; i++) {
 }
 ```
 
-### Onboarding Sheets Blocking UI
+### Onboarding sheets blocking UI
 
-New features may add bottom sheets that cover buttons the test needs.
-Dismiss them before proceeding:
+New bottom sheets may cover the target widget:
 
 ```dart
 for (var i = 0; i < 20; i++) {
@@ -194,63 +123,57 @@ for (var i = 0; i < 20; i++) {
   final gotIt = find.text('Got it!');
   if (gotIt.evaluate().isNotEmpty) {
     await tester.tap(gotIt);
-    await tester.pump(const Duration(milliseconds: 500));
     break;
   }
 }
 ```
 
-### Riverpod Provider Init Crashes
+### Patrol false positives
 
-If a provider uses `requireIdentity` or similar non-nullable getters, it
-crashes during cold start (before auth) and Riverpod caches the error
-permanently. Use nullable access (`currentIdentity`) in providers and
-handle null. The error looks like:
+Patrol bundles every file in a target dir into one APK. When file B
+runs, file A shows up as "not requested" `[E]` markers in logcat.
+Trust only the final `✅`/`❌` lines.
 
-```
-ProviderException: Tried to use a provider that is in error state.
-Bad state: requireIdentity called with no active NostrIdentity.
-```
+### Provider error caching
 
-### Material Widget Ancestor
+Providers using `requireIdentity` (or similar non-nullable getters)
+crash during cold start and Riverpod caches the error forever. Use
+the nullable accessor (`currentIdentity`) and handle null.
 
-`TextField` requires a `Material` ancestor. If a widget is used in an
-overlay or transition context without `Scaffold`, wrap it:
+### Material ancestor
+
+`TextField` in an overlay/transition without `Scaffold` needs:
 
 ```dart
-Material(
-  color: Colors.transparent,
-  child: TextField(...),
-)
+Material(color: Colors.transparent, child: TextField(...))
 ```
 
-## Test Helpers
+## Helpers
 
-All helpers are in `integration_test/helpers/`:
+`integration_test/helpers/`:
 
-| File | Purpose |
-|------|---------|
-| `constants.dart` | Port constants + `pgPort`, `appPackage` |
-| `db_helpers.dart` | Postgres queries: verification tokens, refresh tokens |
-| `http_helpers.dart` | Keycast API: verify email, forgot password |
-| `navigation_helpers.dart` | UI interactions: register, login, tap tabs, wait for widgets |
-| `relay_helpers.dart` | Publish Nostr events: kind 34236 videos, kind 0 profiles |
-| `test_setup.dart` | Error suppression, app launch, async error draining |
+- `test_setup.dart` — `launchAppGuarded`, error suppression, async-error drain
+- `navigation_helpers.dart` — register, login, tap tabs, wait for widgets
+- `relay_helpers.dart` — publish/query Nostr events
+- `db_helpers.dart` — Postgres (verification tokens, refresh tokens)
+- `http_helpers.dart` — Keycast API (verify email, forgot password)
+- `constants.dart` — ports + `appPackage`
 
 ## Debugging
 
 ```bash
 # Service logs
 docker compose -f local_stack/docker-compose.yml logs keycast --tail=50
-docker compose -f local_stack/docker-compose.yml logs funnelcake-relay --tail=50
-docker compose -f local_stack/docker-compose.yml logs blossom --tail=50
-
-# Check blossom for actual uploads (not just health checks)
 docker compose -f local_stack/docker-compose.yml logs blossom | grep -v 'path=/'
 
-# Auth flow trace
+# Auth trace
 adb logcat -d | grep 'flutter.*\[AUTH\]' | grep -v 'Router redirect'
 
-# Test reports (merged Docker + logcat timeline)
+# Last merged timeline
 ls mobile/test_reports/*.jsonl
 ```
+
+If patrol reports `Total: 0` with Gradle exit 1, the runner
+auto-prints the native test XML path + failure excerpts — that's
+an APK install failure, not a missing test. Free space with
+`adb shell pm trim-caches 1G` or `mise run emulator_wipe`.

--- a/local_stack/android_sdk.sh
+++ b/local_stack/android_sdk.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# android_sdk.sh — ensure Android SDK binaries (adb, emulator) are on PATH.
+#
+# Source this from any local_stack script that shells out to adb or emulator.
+# Scripts invoked outside an interactive shell (ouija-spawned tmux panes, CI
+# runners, mise subprocesses) do not source ~/.zshrc or ~/.bashrc, so any
+# PATH amendments the developer keeps there are missing. This searches the
+# standard Android SDK locations and exports PATH + ANDROID_HOME idempotently.
+
+if ! command -v emulator >/dev/null 2>&1 || ! command -v adb >/dev/null 2>&1; then
+    for _candidate in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" \
+                      "$HOME/Android/Sdk" "$HOME/Library/Android/sdk"; do
+        if [[ -n "$_candidate" && -d "$_candidate/platform-tools" ]]; then
+            export ANDROID_HOME="$_candidate"
+            export PATH="$_candidate/emulator:$_candidate/platform-tools:$PATH"
+            break
+        fi
+    done
+    unset _candidate
+fi
+
+x11_socket_dir() {
+    printf '%s\n' "${X11_SOCKET_DIR:-/tmp/.X11-unix}"
+}
+
+x11_display_number() {
+    local display="${1:-}"
+    display="${display#*:}"
+    display="${display%%.*}"
+    printf '%s\n' "$display"
+}
+
+x11_socket_path() {
+    local display_number
+    display_number="$(x11_display_number "${1:-}")"
+    if [[ -z "$display_number" ]]; then
+        return 1
+    fi
+    printf '%s/X%s\n' "$(x11_socket_dir)" "$display_number"
+}
+
+detect_x11_display() {
+    local candidate="${DISPLAY:-}"
+    local display_number
+    local socket_path
+
+    if [[ -n "$candidate" ]]; then
+        display_number="$(x11_display_number "$candidate")"
+        socket_path="$(x11_socket_path "$candidate")"
+        if [[ -S "$socket_path" ]]; then
+            printf ':%s\n' "$display_number"
+            return
+        fi
+    fi
+
+    for socket_path in "$(x11_socket_dir)"/X*; do
+        if [[ -S "$socket_path" ]]; then
+            printf ':%s\n' "${socket_path##*/X}"
+            return
+        fi
+    done
+
+    printf '\n'
+}
+
+first_available_avd_name() {
+    emulator -list-avds 2>/dev/null | sed -n '1p'
+}

--- a/local_stack/docker-compose.yml
+++ b/local_stack/docker-compose.yml
@@ -248,6 +248,7 @@ services:
   # ---------------------------------------------------------------------------
   e2e-seed:
     build: ./seed
+    profiles: ["seed"]
     depends_on:
       funnelcake-relay:
         condition: service_started

--- a/local_stack/emulator.sh
+++ b/local_stack/emulator.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Android Emulator Launcher
+#
+# Handles display/AVD path/Wayland-vs-XWayland detection so the SKILL.md
+# documentation can stay short.
+#
+# Usage:
+#   local_stack/emulator.sh                 # Normal launch (windowed)
+#   local_stack/emulator.sh --headless      # Offscreen + -no-window
+#   local_stack/emulator.sh --wipe          # -wipe-data (storage reset)
+#
+# Env overrides:
+#   AVD_NAME            (default: first emulator -list-avds entry)
+#   ANDROID_AVD_HOME    (default: $HOME/.android/avd)
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=android_sdk.sh
+source "$SCRIPT_DIR/android_sdk.sh"
+
+MODE="normal"
+case "${1:-}" in
+    --headless) MODE="headless" ;;
+    --wipe)     MODE="wipe" ;;
+    "")         ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        echo "Usage: $0 [--headless|--wipe]" >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v emulator >/dev/null 2>&1; then
+    echo "ERROR: 'emulator' not on PATH and Android SDK not found." >&2
+    echo "Set ANDROID_HOME or install the SDK at \$HOME/Android/Sdk (Linux) / \$HOME/Library/Android/sdk (macOS)." >&2
+    exit 1
+fi
+
+AVD_NAME="${AVD_NAME:-$(first_available_avd_name)}"
+export ANDROID_AVD_HOME="${ANDROID_AVD_HOME:-$HOME/.android/avd}"
+
+if [[ -z "$AVD_NAME" ]]; then
+    echo "ERROR: No Android AVD found. Create one in Android Studio or pass AVD_NAME=<name>." >&2
+    exit 1
+fi
+
+EMULATOR_ARGS=(-avd "$AVD_NAME" -gpu host -no-snapshot-load)
+
+configure_windowed_display() {
+    local missing_display_message="$1"
+    local display_to_use
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        return
+    fi
+
+    display_to_use="$(detect_x11_display)"
+    if [[ -z "$display_to_use" ]]; then
+        echo "ERROR: No X11 socket found at /tmp/.X11-unix/X*." >&2
+        echo "$missing_display_message" >&2
+        exit 1
+    fi
+    export DISPLAY="$display_to_use"
+    export QT_QPA_PLATFORM=xcb
+}
+
+case "$MODE" in
+    headless)
+        export QT_QPA_PLATFORM=offscreen
+        EMULATOR_ARGS+=(-no-window)
+        echo "Launching headless: $AVD_NAME" >&2
+        ;;
+    wipe)
+        # -wipe-data needs a window so caller can confirm the boot — same path as normal.
+        configure_windowed_display "On Hyprland/Wayland, ensure XWayland is running."
+        EMULATOR_ARGS+=(-wipe-data)
+        echo "Launching with -wipe-data: $AVD_NAME" >&2
+        ;;
+    normal)
+        configure_windowed_display "On Hyprland/Wayland, ensure XWayland is running, or use --headless."
+        echo "Launching: $AVD_NAME" >&2
+        ;;
+esac
+
+exec emulator "${EMULATOR_ARGS[@]}"

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -18,14 +18,13 @@ MOBILE_DIR="$(cd "${SCRIPT_DIR}/../mobile" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 MERGE_SCRIPT="${SCRIPT_DIR}/merge_logs.py"
 
+# shellcheck source=android_sdk.sh
+source "${SCRIPT_DIR}/android_sdk.sh"
+
 # --- Ensure DISPLAY is set for emulator (Hyprland/XWayland) ---
-if [[ -z "${DISPLAY:-}" ]]; then
-    if [[ -S /tmp/.X11-unix/X1 ]]; then
-        export DISPLAY=:1
-        echo "Note: Set DISPLAY=:1 (XWayland) for emulator camera support." >&2
-    elif [[ -S /tmp/.X11-unix/X0 ]]; then
-        export DISPLAY=:0
-    fi
+DISPLAY_TO_USE="$(detect_x11_display)"
+if [[ -n "$DISPLAY_TO_USE" ]]; then
+    export DISPLAY="$DISPLAY_TO_USE"
 fi
 
 TEST_PATH="${1:-integration_test/auth/}"
@@ -77,6 +76,11 @@ if [[ -z "$DEVICE" ]]; then
 fi
 echo "Device:     ${DEVICE}" >&2
 
+PATROL_EXTRA_ARGS=()
+if [[ "${PATROL_NO_UNINSTALL:-}" == "true" ]]; then
+    PATROL_EXTRA_ARGS+=(--no-uninstall)
+fi
+
 # --- Start logcat capture (background, flutter/app logs with timestamps) ---
 echo "Starting logcat capture..." >&2
 adb -s "$DEVICE" logcat -c 2>/dev/null || true
@@ -92,6 +96,7 @@ PATH="$HOME/.pub-cache/bin:$PATH" patrol test \
     --target "$TEST_PATH" \
     --dart-define=DEFAULT_ENV=LOCAL \
     --dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004 \
+    "${PATROL_EXTRA_ARGS[@]}" \
     2>&1 | tee "$APP_LOG"
 TEST_EXIT="${PIPESTATUS[0]}"
 set -e
@@ -116,6 +121,20 @@ if [[ $TEST_EXIT -eq 0 ]]; then
     echo "Tests PASSED." >&2
 else
     echo "Tests FAILED (exit ${TEST_EXIT})." >&2
+
+    # Auto-surface install failures: patrol reports "Total: 0" with Gradle exit 1
+    # when the APK install failed (e.g. INSTALL_FAILED_INSUFFICIENT_STORAGE), not
+    # when a test is missing. The native test report has the real failure.
+    if grep -qE 'Total:[[:space:]]+0([^0-9]|$)' "$APP_LOG" 2>/dev/null; then
+        echo "" >&2
+        echo "Patrol reported Total: 0 with non-zero exit — likely APK install failure, not a missing Dart test." >&2
+        while IFS= read -r -d '' f; do
+            if grep -q "<failure\|<error" "$f" 2>/dev/null; then
+                echo "--- $(basename "$f") ---" >&2
+                grep -A 2 "<failure\|<error" "$f" | head -12 >&2 || true
+            fi
+        done < <(find "${MOBILE_DIR}/build" -path '*androidTest-results*' -name 'TEST-*.xml' -print0 2>/dev/null)
+    fi
 fi
 echo "" >&2
 echo "Report: ${REPORT_FILE} (${ENTRY_COUNT} entries)" >&2

--- a/local_stack/setup.sh
+++ b/local_stack/setup.sh
@@ -5,9 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/.env"
 ENV_EXAMPLE="$SCRIPT_DIR/.env.example"
 
-# ── Prerequisites ────────────────────────────────────────────────────────────
+# shellcheck source=android_sdk.sh
+source "$SCRIPT_DIR/android_sdk.sh"
 
-echo "Checking prerequisites..."
+# Track whether we actually performed setup work (used to suppress the summary
+# on no-op runs, since local_up now runs setup.sh on every invocation).
+DID_WORK=false
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
 
 has_errors=false
 
@@ -48,13 +53,12 @@ if [ "$has_errors" = true ]; then
   exit 1
 fi
 
-echo "All prerequisites found."
-
 # ── .env file ────────────────────────────────────────────────────────────────
 
 if [ ! -f "$ENV_FILE" ]; then
   cp "$ENV_EXAMPLE" "$ENV_FILE"
   echo "Created $ENV_FILE from template."
+  DID_WORK=true
 fi
 
 # shellcheck source=/dev/null
@@ -75,23 +79,37 @@ if [ -z "${SERVER_NSEC:-}" ]; then
     echo "SERVER_NSEC=$nsec" >> "$ENV_FILE"
   fi
   echo "Generated SERVER_NSEC and wrote to .env"
+  DID_WORK=true
 fi
 
 # ── Keycast master.key ───────────────────────────────────────────────────────
+
+# Docker creates master.key as a directory when the host path is missing at
+# container start (bind-mount race). Detect and remove so the file path is free.
+if [ -d "$SCRIPT_DIR/master.key" ]; then
+  echo "Removing stray master.key/ directory (Docker bind-mount race)..."
+  rmdir "$SCRIPT_DIR/master.key" 2>/dev/null || {
+    echo "master.key/ is non-empty — inspect manually before deleting it." >&2
+    exit 1
+  }
+  echo "Next 'mise run local_up' will recreate the keycast container with the file mount."
+  DID_WORK=true
+fi
 
 if [ ! -f "$SCRIPT_DIR/master.key" ]; then
   echo "Generating keycast master.key..."
   openssl rand 32 | base64 > "$SCRIPT_DIR/master.key"
   echo "master.key generated at $SCRIPT_DIR/master.key"
-else
-  echo "master.key already exists."
+  DID_WORK=true
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 
-echo ""
-echo "Setup complete. Next steps:"
-echo "  cd mobile"
-echo "  mise run local_up       # start all services"
-echo "  mise run local_status   # verify health"
-echo "  mise run local_logs     # inspect startup"
+if [ "$DID_WORK" = true ]; then
+  echo ""
+  echo "Setup complete. Next steps:"
+  echo "  cd mobile"
+  echo "  mise run local_up       # start all services"
+  echo "  mise run local_status   # verify health"
+  echo "  mise run local_logs     # inspect startup"
+fi

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=android_sdk.sh
+source "${SCRIPT_DIR}/android_sdk.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: ${message}" >&2
+    echo "  expected: ${expected}" >&2
+    echo "  actual:   ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local needle="$1"
+  local file="$2"
+  local message="$3"
+
+  if ! grep -qF "$needle" "$file"; then
+    echo "FAIL: ${message}" >&2
+    echo "  missing: ${needle}" >&2
+    echo "  file:    ${file}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local file="$2"
+  local message="$3"
+
+  if grep -qF "$needle" "$file"; then
+    echo "FAIL: ${message}" >&2
+    echo "  unexpected: ${needle}" >&2
+    echo "  file:       ${file}" >&2
+    exit 1
+  fi
+}
+
+extract_mise_task() {
+  local task_name="$1"
+  local file="$2"
+
+  awk -v task="[tasks.${task_name}]" '
+    $0 == task { in_task = 1 }
+    in_task && $0 ~ /^\[tasks\./ && $0 != task { exit }
+    in_task { print }
+  ' "$file"
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+local_reset_task="${tmp_dir}/local_reset.mise-task"
+extract_mise_task local_reset "${REPO_ROOT}/mobile/mise.toml" > "$local_reset_task"
+
+mkdir -p "${tmp_dir}/home"
+set +e
+env -u ANDROID_HOME -u ANDROID_SDK_ROOT HOME="${tmp_dir}/home" PATH="/usr/bin:/bin" \
+  bash "${SCRIPT_DIR}/emulator.sh" --bogus >/dev/null 2>&1
+bogus_exit=$?
+set -e
+assert_eq "2" "$bogus_exit" \
+  "emulator.sh should reject unknown arguments before checking emulator availability"
+
+assert_eq "/tmp/.X11-unix/X1" "$(x11_socket_path ':1.0')" \
+  "DISPLAY screen suffix should map to the base X socket"
+assert_eq "/tmp/.X11-unix/X10" "$(x11_socket_path ':10')" \
+  "SSH-forwarded DISPLAY values should map to their X socket"
+
+mkdir -p "${tmp_dir}/bin"
+cat > "${tmp_dir}/bin/emulator" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-list-avds" ]]; then
+  printf '%s\n' Pixel_API_35 Medium_Phone_API_36
+fi
+STUB
+chmod +x "${tmp_dir}/bin/emulator"
+
+PATH="${tmp_dir}/bin:${PATH}"
+assert_eq "Pixel_API_35" "$(first_available_avd_name)" \
+  "default AVD should come from emulator -list-avds"
+
+assert_contains 'bash ../local_stack/up.sh' "${REPO_ROOT}/mobile/mise.toml" \
+  "mise local_up tasks should delegate to the shared stack launcher"
+assert_contains 'docker compose -f ../local_stack/docker-compose.yml down -v' "$local_reset_task" \
+  "mise local_reset should wipe local stack volumes before restart"
+assert_contains 'bash ../local_stack/up.sh' "$local_reset_task" \
+  "mise local_reset should delegate restart to the shared stack launcher"
+assert_not_contains 'rm -rf "$SCRIPT_DIR/master.key"' "${SCRIPT_DIR}/setup.sh" \
+  "setup should not recursively delete a non-empty master.key directory"
+assert_not_contains 'docker compose -f "$COMPOSE_FILE" up -d "${PULL_ARGS[@]}"' "${SCRIPT_DIR}/up.sh" \
+  "up.sh should not start one-shot seed containers during default stack startup"
+assert_contains 'docker compose -f "$COMPOSE_FILE" run --rm e2e-seed' "${SCRIPT_DIR}/up.sh" \
+  "up.sh should run e2e-seed as an explicit lifecycle step"
+assert_contains 'profiles: ["seed"]' "${SCRIPT_DIR}/docker-compose.yml" \
+  "e2e-seed should be excluded from default compose up"
+
+cat > "${tmp_dir}/bin/uname" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' Darwin
+STUB
+chmod +x "${tmp_dir}/bin/uname"
+
+set +e
+env -u DISPLAY AVD_NAME=Pixel_API_35 X11_SOCKET_DIR="${tmp_dir}/missing-x11" \
+  PATH="${tmp_dir}/bin:${PATH}" HOME="${tmp_dir}/home" \
+  bash "${SCRIPT_DIR}/emulator.sh" >/dev/null 2>"${tmp_dir}/darwin-emulator.err"
+darwin_emulator_exit=$?
+set -e
+assert_eq "0" "$darwin_emulator_exit" \
+  "Darwin emulator launch should not require Linux X11 socket discovery"
+
+echo "android script checks passed"

--- a/local_stack/up.sh
+++ b/local_stack/up.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+
+PULL_ARGS=()
+case "${1:-}" in
+  --pull=missing)
+    PULL_ARGS+=(--pull=missing)
+    ;;
+  "")
+    ;;
+  *)
+    echo "Unknown argument: $1" >&2
+    echo "Usage: $0 [--pull=missing]" >&2
+    exit 2
+    ;;
+esac
+
+SERVICES=(
+  keycast keycast-postgres keycast-redis
+  funnelcake-relay funnelcake-api funnelcake-proxy funnelcake-redis funnelcake-clickhouse
+  minio blossom blossom-proxy invite
+)
+
+docker compose -f "$COMPOSE_FILE" up -d --wait "${PULL_ARGS[@]}" "${SERVICES[@]}"
+docker compose -f "$COMPOSE_FILE" run --rm e2e-seed

--- a/mobile/integration_test/auth/auth_journey_test.dart
+++ b/mobile/integration_test/auth/auth_journey_test.dart
@@ -3,7 +3,6 @@
 // ABOUTME: Requires: local Docker stack running (mise run local_up)
 // ABOUTME: Run with: mise run e2e_test (passes --dart-define=DEFAULT_ENV=LOCAL automatically)
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -233,32 +232,9 @@ void main() {
         ).clearSnackBars();
         await tester.pump(const Duration(milliseconds: 500));
 
-        // Enter both password fields on the reset screen using the field labels
-        // so stale route-transition widgets cannot be matched accidentally.
-        final newPasswordField = find.descendant(
-          of: find.widgetWithText(
-            DivineAuthTextField,
-            l10n.authNewPasswordLabel,
-          ),
-          matching: find.byType(TextField),
-        );
-        final confirmNewPasswordField = find.descendant(
-          of: find.widgetWithText(
-            DivineAuthTextField,
-            l10n.authConfirmNewPasswordLabel,
-          ),
-          matching: find.byType(TextField),
-        );
-        expect(newPasswordField, findsOneWidget);
-        expect(confirmNewPasswordField, findsOneWidget);
-        await tester.enterText(newPasswordField, newPassword);
-        await tester.pumpAndSettle();
-        await tester.enterText(confirmNewPasswordField, newPassword);
-        await tester.pumpAndSettle();
-
-        // Dismiss keyboard
-        await tester.tapAt(const Offset(10, 100));
-        await tester.pumpAndSettle();
+        // Enter new password and submit. The reset screen requires both the
+        // password and confirmation fields before it calls the reset API.
+        await enterResetPassword(tester, newPassword);
 
         final resetButton = find.text(l10n.authUpdatePassword);
         expect(resetButton, findsOneWidget);

--- a/mobile/integration_test/helpers/navigation_helpers.dart
+++ b/mobile/integration_test/helpers/navigation_helpers.dart
@@ -123,6 +123,36 @@ Future<void> loginWithCredentials(
   await tester.tap(submitButton);
 }
 
+/// Fill the reset password form's new-password and confirmation fields.
+Future<void> enterResetPassword(
+  WidgetTester tester,
+  String password,
+) async {
+  final newPasswordField = find.descendant(
+    of: find.widgetWithText(DivineAuthTextField, _en.authNewPasswordLabel),
+    matching: find.byType(TextField),
+  );
+  final confirmPasswordField = find.descendant(
+    of: find.widgetWithText(
+      DivineAuthTextField,
+      _en.authConfirmNewPasswordLabel,
+    ),
+    matching: find.byType(TextField),
+  );
+
+  expect(newPasswordField, findsOneWidget);
+  expect(confirmPasswordField, findsOneWidget);
+
+  await tester.enterText(newPasswordField, password);
+  await tester.pumpAndSettle();
+  await tester.enterText(confirmPasswordField, password);
+  await tester.pumpAndSettle();
+
+  // Dismiss keyboard before tapping the pinned submit button.
+  await tester.tapAt(const Offset(10, 100));
+  await tester.pumpAndSettle();
+}
+
 /// Wait for a widget with the given text to appear, using pump loops.
 ///
 /// Cannot use pumpAndSettle when polling timers are active (e.g.

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -3,13 +3,16 @@ flutter = "3.41.9"
 
 [tasks.local_up]
 description = "Start all local E2E services"
+depends = ["local_setup"]
 run = """
-docker compose -f ../local_stack/docker-compose.yml up -d
-docker compose -f ../local_stack/docker-compose.yml up -d --wait \
-  keycast keycast-postgres keycast-redis \
-  funnelcake-relay funnelcake-api funnelcake-proxy funnelcake-redis funnelcake-clickhouse \
-  minio blossom blossom-proxy invite
-docker compose -f ../local_stack/docker-compose.yml run --rm e2e-seed
+bash ../local_stack/up.sh
+"""
+
+[tasks.local_up_cached]
+description = "Start stack using cached images (offline / rate-limited / image-pull failures)"
+depends = ["local_setup"]
+run = """
+bash ../local_stack/up.sh --pull=missing
 """
 
 [tasks.local_down]
@@ -35,9 +38,10 @@ run = "docker compose -f ../local_stack/docker-compose.yml ps"
 
 [tasks.local_reset]
 description = "Wipe all local data (relay, DB, blossom) and restart fresh"
+depends = ["local_setup"]
 run = """
 docker compose -f ../local_stack/docker-compose.yml down -v
-docker compose -f ../local_stack/docker-compose.yml up -d --wait
+bash ../local_stack/up.sh
 """
 
 [tasks.local_setup]
@@ -68,3 +72,15 @@ run = "bash ../scripts/install-hooks.sh"
 description = "Run E2E tests with log profiling (starts Docker stack, captures merged timeline)"
 depends = ["setup_hooks", "local_up"]
 run = "bash ../local_stack/profile.sh {{ arg(i=0, name='test_path', default='integration_test/auth/') }}"
+
+[tasks.emulator]
+description = "Launch Android emulator (auto-detects DISPLAY, XWayland on Linux)"
+run = "bash ../local_stack/emulator.sh"
+
+[tasks.emulator_headless]
+description = "Launch Android emulator headless (offscreen, no window)"
+run = "bash ../local_stack/emulator.sh --headless"
+
+[tasks.emulator_wipe]
+description = "Launch Android emulator with -wipe-data (nuclear option for storage issues)"
+run = "bash ../local_stack/emulator.sh --wipe"

--- a/mobile/test/integration_test_helpers/navigation_helpers_l10n_test.dart
+++ b/mobile/test/integration_test_helpers/navigation_helpers_l10n_test.dart
@@ -1,0 +1,20 @@
+// ABOUTME: Regression test for localized copy usage in E2E navigation helpers
+// ABOUTME: Prevents helpers from drifting back to hardcoded auth labels
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('auth navigation helpers resolve auth labels from l10n', () {
+    final source = File(
+      'integration_test/helpers/navigation_helpers.dart',
+    ).readAsStringSync();
+
+    expect(source, contains('lookupAppLocalizations'));
+    expect(source, isNot(contains("'Create a new Divine account'")));
+    expect(source, isNot(contains("'Sign in with an existing account'")));
+    expect(source, isNot(contains("'Create account'")));
+    expect(source, isNot(contains("'Sign in'")));
+  });
+}

--- a/mobile/test/screens/auth/reset_password_test.dart
+++ b/mobile/test/screens/auth/reset_password_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/reset_password.dart';
 
+import '../../../integration_test/helpers/navigation_helpers.dart';
 import '../../helpers/autofill_context_mock.dart';
 import '../../helpers/test_provider_overrides.dart';
 
@@ -133,6 +134,36 @@ void main() {
           );
 
           expect(usernameField, findsNothing);
+        },
+      );
+
+      testWidgets(
+        'reset password helper fills confirmation field before submit',
+        (tester) async {
+          when(
+            () => mockOAuth.resetPassword(
+              token: any(named: 'token'),
+              newPassword: any(named: 'newPassword'),
+            ),
+          ).thenAnswer(
+            (_) async => ResetPasswordResult(success: true),
+          );
+
+          await tester.pumpWidget(buildTestWidget());
+          await tester.pumpAndSettle();
+
+          await enterResetPassword(tester, 'NewSecure123!');
+          await tester.tap(
+            find.widgetWithText(DivineButton, 'Update password'),
+          );
+          await tester.pump();
+
+          verify(
+            () => mockOAuth.resetPassword(
+              token: 'test-token-abc123',
+              newPassword: 'NewSecure123!',
+            ),
+          ).called(1);
         },
       );
 


### PR DESCRIPTION
Closes #4762

## Summary

The E2E skill had too many shell recipes that agents had to copy by hand.
This change moves the repeatable setup, emulator, and local-stack steps into scripts and mise tasks.
It also keeps the auth harness aligned with localized copy so copy edits do not break the happy path again.

## What Changed

The dev harness now owns the deterministic setup work that used to live in prose.
Agents can run the named tasks instead of reconstructing Android SDK, emulator, Docker, and log-diagnostic commands from `SKILL.md`.

- Added `local_stack/android_sdk.sh` to find the Android SDK in standard Linux and macOS locations.
- Added emulator tasks for normal, headless, and wipe launches.
- Defaulted emulator selection to the first available AVD and kept `ANDROID_AVD_HOME` override-friendly.
- Gated Linux X11 / XWayland display probing so macOS launches use the native emulator path.
- Moved local stack startup into `local_stack/up.sh` so `local_up`, `local_up_cached`, and `local_reset` share one service list.
- Made `local_setup` safe to run repeatedly, including fail-loud handling for non-empty `master.key/` directories.
- Made `local_reset` depend on `local_setup` before wiping and restarting the stack.
- Added native Android test XML excerpt printing when patrol reports `Total: 0` with a non-zero exit.
- Trimmed `.claude/skills/e2e-test/SKILL.md` from 256 lines to 179 lines.
- Updated auth E2E helpers to use generated English l10n values instead of hardcoded auth labels.
- Added a reset-password helper that fills both password fields before submitting.
- Squashed the branch to one conventional commit so the semantic commit gate can pass.

## Testing

The script checks cover the review-sensitive shell behavior without launching a full emulator.
The reset-password helper is covered by a widget regression test, and the l10n lookup guard prevents the helper from drifting back to hardcoded auth copy.

- [x] `bash local_stack/test_android_scripts.sh`
- [x] `bash -n local_stack/android_sdk.sh local_stack/emulator.sh local_stack/profile.sh local_stack/setup.sh local_stack/up.sh local_stack/test_android_scripts.sh`
- [x] `flutter test test/integration_test_helpers/navigation_helpers_l10n_test.dart test/screens/auth/reset_password_test.dart`
- [x] `flutter analyze lib test integration_test`
- [x] `git diff --cached --check`
- [ ] `mise tasks deps e2e_test` -> `e2e_test -> local_up -> local_setup`
- [ ] `mise run emulator` launches AVD with no `ANDROID_HOME` exported
- [ ] `bash local_stack/setup.sh` runs silently on a clean working tree
- [ ] Full auth E2E journey against the local Docker stack

## Risks

The app binary is not affected.
The risk is limited to local developer and agent harness behavior.

- Emulator launch behavior depends on the installed Android SDK and available AVDs.
- The full E2E journey still depends on a healthy local Docker stack and emulator storage state.
