### PR TITLE
feat(video-editor): long-press volume button to mute/unmute all timeline tracks

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -87,6 +87,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       _onClipVolumeChanged,
       transformer: sequential(),
     );
+    on<ClipEditorAllClipsVolumeChanged>(_onAllClipsVolumeChanged);
   }
 
   final void Function() onFinalClipInvalidated;
@@ -502,6 +503,23 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     if (state.clips[index].volume == nextVolume) return;
     final updated = List<DivineVideoClip>.of(state.clips);
     updated[index] = updated[index].copyWith(volume: nextVolume);
+    emit(
+      state.copyWith(
+        clips: List.unmodifiable(updated),
+        clipsVolumeRevision: state.clipsVolumeRevision + 1,
+      ),
+    );
+  }
+
+  void _onAllClipsVolumeChanged(
+    ClipEditorAllClipsVolumeChanged event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    final nextVolume = event.volume.clamp(0.0, 1.0);
+    final updated = state.clips
+        .map((c) => c.copyWith(volume: nextVolume))
+        .toList(growable: false);
+    if (updated.isEmpty) return;
     emit(
       state.copyWith(
         clips: List.unmodifiable(updated),

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -519,10 +519,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     Emitter<ClipEditorState> emit,
   ) {
     final nextVolume = event.volume.clamp(0.0, 1.0);
+    if (state.clips.isEmpty) return;
+    if (state.clips.every((c) => c.volume == nextVolume)) return;
     final updated = state.clips
         .map((c) => c.copyWith(volume: nextVolume))
         .toList(growable: false);
-    if (updated.isEmpty) return;
     emit(
       state.copyWith(
         clips: List.unmodifiable(updated),

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -87,7 +87,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       _onClipVolumeChanged,
       transformer: sequential(),
     );
-    on<ClipEditorAllClipsVolumeChanged>(_onAllClipsVolumeChanged);
+    on<ClipEditorAllClipsVolumeChanged>(
+      _onAllClipsVolumeChanged,
+      transformer: sequential(),
+    );
   }
 
   final void Function() onFinalClipInvalidated;

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -208,3 +208,14 @@ class ClipEditorClipVolumeChanged extends ClipEditorEvent {
   @override
   List<Object?> get props => [clipId, volume];
 }
+
+/// Set the same [volume] on every clip.
+/// [volume] is clamped to [0.0, 1.0] by the handler.
+class ClipEditorAllClipsVolumeChanged extends ClipEditorEvent {
+  const ClipEditorAllClipsVolumeChanged({required this.volume});
+
+  final double volume;
+
+  @override
+  List<Object?> get props => [volume];
+}

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -581,10 +581,13 @@ class TimelineOverlayBloc
     Emitter<TimelineOverlayState> emit,
   ) {
     final nextVolume = event.volume.clamp(0.0, 1.0);
+    final affected =
+        state.audioTracks.where((t) => !t.isOriginalSound);
+    if (affected.isEmpty) return;
+    if (affected.every((t) => t.volume == nextVolume)) return;
     final updated = state.audioTracks
         .map((t) => t.isOriginalSound ? t : t.copyWith(volume: nextVolume))
         .toList(growable: false);
-    if (updated.isEmpty) return;
     emit(
       state.copyWith(
         audioTracks: updated,

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -48,6 +48,7 @@ class TimelineOverlayBloc
       _onAudioVolumeChanged,
       transformer: sequential(),
     );
+    on<TimelineOverlayAllAudioVolumeChanged>(_onAllAudioVolumeChanged);
   }
 
   static const _markerMatchTolerance = Duration(milliseconds: 50);
@@ -567,6 +568,23 @@ class TimelineOverlayBloc
     if (state.audioTracks[index].volume == nextVolume) return;
     final updated = List<AudioEvent>.of(state.audioTracks);
     updated[index] = updated[index].copyWith(volume: nextVolume);
+    emit(
+      state.copyWith(
+        audioTracks: updated,
+        audioTracksRevision: state.audioTracksRevision + 1,
+      ),
+    );
+  }
+
+  void _onAllAudioVolumeChanged(
+    TimelineOverlayAllAudioVolumeChanged event,
+    Emitter<TimelineOverlayState> emit,
+  ) {
+    final nextVolume = event.volume.clamp(0.0, 1.0);
+    final updated = state.audioTracks
+        .map((t) => t.isOriginalSound ? t : t.copyWith(volume: nextVolume))
+        .toList(growable: false);
+    if (updated.isEmpty) return;
     emit(
       state.copyWith(
         audioTracks: updated,

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -48,7 +48,10 @@ class TimelineOverlayBloc
       _onAudioVolumeChanged,
       transformer: sequential(),
     );
-    on<TimelineOverlayAllAudioVolumeChanged>(_onAllAudioVolumeChanged);
+    on<TimelineOverlayAllAudioVolumeChanged>(
+      _onAllAudioVolumeChanged,
+      transformer: sequential(),
+    );
   }
 
   static const _markerMatchTolerance = Duration(milliseconds: 50);
@@ -581,8 +584,7 @@ class TimelineOverlayBloc
     Emitter<TimelineOverlayState> emit,
   ) {
     final nextVolume = event.volume.clamp(0.0, 1.0);
-    final affected =
-        state.audioTracks.where((t) => !t.isOriginalSound);
+    final affected = state.audioTracks.where((t) => !t.isOriginalSound);
     if (affected.isEmpty) return;
     if (affected.every((t) => t.volume == nextVolume)) return;
     final updated = state.audioTracks

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -209,3 +209,14 @@ class TimelineOverlayAudioVolumeChanged extends TimelineOverlayEvent {
   @override
   List<Object?> get props => [trackId, volume];
 }
+
+/// Set the same [volume] on every non-original-sound audio track.
+/// [volume] is clamped to [0.0, 1.0] by the handler.
+class TimelineOverlayAllAudioVolumeChanged extends TimelineOverlayEvent {
+  const TimelineOverlayAllAudioVolumeChanged({required this.volume});
+
+  final double volume;
+
+  @override
+  List<Object?> get props => [volume];
+}

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -70,6 +70,27 @@ extension VideoEditorExtensions on ProImageEditorState {
     setState(() {});
   }
 
+  /// Persists both clip and audio-track volumes in a single history entry.
+  ///
+  /// Creates one undo point that captures both changes — use this when clips
+  /// and audio volumes are updated together (e.g. mute-all toggle) so that a
+  /// single undo reverts the entire operation atomically.
+  void setVolumeState({
+    required List<DivineVideoClip> clips,
+    required List<AudioEvent> audioTracks,
+  }) {
+    addHistory(
+      meta: {
+        ...stateManager.activeMeta,
+        VideoEditorConstants.clipsStateHistoryKey:
+            clips.map((c) => c.toJson()).toList(),
+        VideoEditorConstants.audioStateHistoryKey:
+            audioTracks.map((e) => e.toJson()).toList(),
+      },
+    );
+    setState(() {});
+  }
+
   /// Persists clip trim and order state in the editor's history metadata.
   ///
   /// When [skipUpdateHistory] is `false` (default), creates a new history

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -72,9 +72,9 @@ extension VideoEditorExtensions on ProImageEditorState {
 
   /// Persists both clip and audio-track volumes in a single history entry.
   ///
-  /// Creates one undo point that captures both changes — use this when clips
-  /// and audio volumes are updated together (e.g. mute-all toggle) so that a
-  /// single undo reverts the entire operation atomically.
+  /// Canonical history write for volume changes. Creates one undo point that
+  /// captures both tracks, whether a single volume source changed or clips and
+  /// audio volumes were updated together (e.g. mute-all toggle).
   void setVolumeState({
     required List<DivineVideoClip> clips,
     required List<AudioEvent> audioTracks,
@@ -82,10 +82,12 @@ extension VideoEditorExtensions on ProImageEditorState {
     addHistory(
       meta: {
         ...stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey:
-            clips.map((c) => c.toJson()).toList(),
-        VideoEditorConstants.audioStateHistoryKey:
-            audioTracks.map((e) => e.toJson()).toList(),
+        VideoEditorConstants.clipsStateHistoryKey: clips
+            .map((c) => c.toJson())
+            .toList(),
+        VideoEditorConstants.audioStateHistoryKey: audioTracks
+            .map((e) => e.toJson())
+            .toList(),
       },
     );
     setState(() {});

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3412,6 +3412,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "ቅድመ እይታን አጫውት።",
     "videoEditorAudioPausePreviewSemanticLabel": "ቅድመ እይታን ባለበት አቁም",
     "videoEditorAudioUntitledSound": "ርዕስ አልባ ድምጽ",
+    "videoEditorVolumeLongPressHint": "ሁሉንም ትራኮች ያጥፉ ወይም ያብሩ",
     "videoEditorAudioUntitled": "ርዕስ አልባ",
     "videoEditorAudioAddAudio": "ኦዲዮ ያክሉ",
     "videoEditorAudioNoSoundsAvailableTitle": "ምንም ድምፆች የሉም",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2727,6 +2727,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "تشغيل المعاينة",
     "videoEditorAudioUntitled": "بدون عنوان",
     "videoEditorAudioUntitledSound": "صوت بدون عنوان",
+    "videoEditorVolumeLongPressHint": "كتم صوت جميع المسارات أو إلغاء الكتم",
     "videoEditorCannotSplitProcessing": "لا يمكن تقسيم المقطع أثناء معالجته. يرجى الانتظار.",
     "videoEditorClipDeleted": "تم حذف المقطع",
     "videoEditorClipSaveFailed": "فشل حفظ المقطع",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3102,6 +3102,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Пусни предварителен преглед",
     "videoEditorAudioPausePreviewSemanticLabel": "Пауза на прегледа",
     "videoEditorAudioUntitledSound": "Звук без заглавие",
+    "videoEditorVolumeLongPressHint": "Заглуши или включи всички писти",
     "videoEditorAudioUntitled": "Без заглавие",
     "videoEditorAudioAddAudio": "Добави аудио",
     "videoEditorAudioNoSoundsAvailableTitle": "Няма налични звуци",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Vorschau abspielen",
     "videoEditorAudioPausePreviewSemanticLabel": "Vorschau pausieren",
     "videoEditorAudioUntitledSound": "Unbenannter Sound",
+    "videoEditorVolumeLongPressHint": "Alle Spuren stumm schalten oder aktivieren",
     "videoEditorAudioUntitled": "Unbenannt",
     "videoEditorAudioAddAudio": "Audio hinzufügen",
     "videoEditorAudioNoSoundsAvailableTitle": "Keine Sounds verfügbar",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4213,6 +4213,10 @@
   "videoEditorAudioPlayPreviewSemanticLabel": "Play preview",
   "videoEditorAudioPausePreviewSemanticLabel": "Pause preview",
   "videoEditorAudioUntitledSound": "Untitled sound",
+  "videoEditorVolumeLongPressHint": "Mute or unmute all tracks",
+  "@videoEditorVolumeLongPressHint": {
+    "description": "Semantic long-press hint for a volume arc control. Screen readers announce this as the long-press affordance, which mutes or unmutes all timeline tracks at once."
+  },
   "videoEditorAudioUntitled": "Untitled",
   "videoEditorAudioAddAudio": "Add audio",
   "videoEditorAudioNoSoundsAvailableTitle": "No sounds available",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2858,6 +2858,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproducir vista previa",
     "videoEditorAudioPausePreviewSemanticLabel": "Pausar vista previa",
     "videoEditorAudioUntitledSound": "Sonido sin título",
+    "videoEditorVolumeLongPressHint": "Silenciar o activar todas las pistas",
     "videoEditorAudioUntitled": "Sin título",
     "videoEditorAudioAddAudio": "Agregar audio",
     "videoEditorAudioNoSoundsAvailableTitle": "No hay sonidos disponibles",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1752,6 +1752,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "I-play ang preview",
     "videoEditorAudioPausePreviewSemanticLabel": "I-pause ang preview",
     "videoEditorAudioUntitledSound": "Walang pamagat na sound",
+    "videoEditorVolumeLongPressHint": "I-mute o i-unmute ang lahat ng track",
     "videoEditorAudioUntitled": "Walang Pamagat",
     "videoEditorAudioAddAudio": "Magdagdag ng audio",
     "videoEditorAudioNoSoundsAvailableTitle": "Walang available na sound",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Lire l'aperçu",
     "videoEditorAudioPausePreviewSemanticLabel": "Mettre l'aperçu en pause",
     "videoEditorAudioUntitledSound": "Son sans titre",
+    "videoEditorVolumeLongPressHint": "Couper ou rétablir le son de toutes les pistes",
     "videoEditorAudioUntitled": "Sans titre",
     "videoEditorAudioAddAudio": "Ajouter de l'audio",
     "videoEditorAudioNoSoundsAvailableTitle": "Aucun son disponible",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2734,6 +2734,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Putar pratinjau",
     "videoEditorAudioUntitled": "Tanpa judul",
     "videoEditorAudioUntitledSound": "Suara tanpa judul",
+    "videoEditorVolumeLongPressHint": "Bisukan atau aktifkan semua trek",
     "videoEditorCannotSplitProcessing": "Tidak dapat membagi klip saat sedang diproses. Harap tunggu.",
     "videoEditorClipDeleted": "Klip dihapus",
     "videoEditorClipSaveFailed": "Gagal menyimpan klip",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Riproduci anteprima",
     "videoEditorAudioPausePreviewSemanticLabel": "Metti in pausa anteprima",
     "videoEditorAudioUntitledSound": "Suono senza titolo",
+    "videoEditorVolumeLongPressHint": "Silenzia o riattiva tutte le tracce",
     "videoEditorAudioUntitled": "Senza titolo",
     "videoEditorAudioAddAudio": "Aggiungi audio",
     "videoEditorAudioNoSoundsAvailableTitle": "Nessun suono disponibile",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2727,6 +2727,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "プレビューを再生",
     "videoEditorAudioUntitled": "タイトルなし",
     "videoEditorAudioUntitledSound": "タイトルなしのサウンド",
+    "videoEditorVolumeLongPressHint": "すべてのトラックをミュートまたはミュート解除",
     "videoEditorCannotSplitProcessing": "処理中はクリップを分割できません。しばらくお待ちください。",
     "videoEditorClipDeleted": "クリップを削除しました",
     "videoEditorClipSaveFailed": "クリップの保存に失敗しました",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2023,6 +2023,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "미리보기 재생",
     "videoEditorAudioUntitled": "제목 없음",
     "videoEditorAudioUntitledSound": "제목 없는 사운드",
+    "videoEditorVolumeLongPressHint": "모든 트랙 음소거 또는 해제",
     "videoEditorCannotSplitProcessing": "처리 중에는 클립을 분할할 수 없습니다. 잠시 기다려 주세요.",
     "videoEditorClipDeleted": "클립이 삭제되었습니다",
     "videoEditorClipSaveFailed": "클립 저장 실패",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Voorbeeld afspelen",
     "videoEditorAudioPausePreviewSemanticLabel": "Voorbeeld pauzeren",
     "videoEditorAudioUntitledSound": "Naamloos geluid",
+    "videoEditorVolumeLongPressHint": "Alle tracks dempen of hervatten",
     "videoEditorAudioUntitled": "Naamloos",
     "videoEditorAudioAddAudio": "Audio toevoegen",
     "videoEditorAudioNoSoundsAvailableTitle": "Geen geluiden beschikbaar",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Odtwórz podgląd",
     "videoEditorAudioPausePreviewSemanticLabel": "Wstrzymaj podgląd",
     "videoEditorAudioUntitledSound": "Nienazwany dźwięk",
+    "videoEditorVolumeLongPressHint": "Wycisz lub wyłącz wyciszenie wszystkich ścieżek",
     "videoEditorAudioUntitled": "Bez tytułu",
     "videoEditorAudioAddAudio": "Dodaj audio",
     "videoEditorAudioNoSoundsAvailableTitle": "Brak dostępnych dźwięków",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Reproduzir prévia",
     "videoEditorAudioPausePreviewSemanticLabel": "Pausar prévia",
     "videoEditorAudioUntitledSound": "Som sem título",
+    "videoEditorVolumeLongPressHint": "Silenciar ou ativar todas as faixas",
     "videoEditorAudioUntitled": "Sem título",
     "videoEditorAudioAddAudio": "Adicionar áudio",
     "videoEditorAudioNoSoundsAvailableTitle": "Nenhum som disponível",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Redă previzualizarea",
     "videoEditorAudioPausePreviewSemanticLabel": "Pune previzualizarea pe pauză",
     "videoEditorAudioUntitledSound": "Sunet fără titlu",
+    "videoEditorVolumeLongPressHint": "Dezactivați sau activați sunetul tuturor pistelor",
     "videoEditorAudioUntitled": "Fără titlu",
     "videoEditorAudioAddAudio": "Adaugă audio",
     "videoEditorAudioNoSoundsAvailableTitle": "Nu sunt sunete disponibile",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2850,6 +2850,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Spela förhandsvisning",
     "videoEditorAudioPausePreviewSemanticLabel": "Pausa förhandsvisning",
     "videoEditorAudioUntitledSound": "Namnlöst ljud",
+    "videoEditorVolumeLongPressHint": "Tysta eller slå på alla spår",
     "videoEditorAudioUntitled": "Namnlös",
     "videoEditorAudioAddAudio": "Lägg till ljud",
     "videoEditorAudioNoSoundsAvailableTitle": "Inga ljud tillgängliga",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2734,6 +2734,7 @@
     "videoEditorAudioPlayPreviewSemanticLabel": "Önizlemeyi oynat",
     "videoEditorAudioUntitled": "Başlıksız",
     "videoEditorAudioUntitledSound": "Başlıksız ses",
+    "videoEditorVolumeLongPressHint": "Tüm parçaları sessize al veya aç",
     "videoEditorCannotSplitProcessing": "Klip işlenirken bölünemez. Lütfen bekleyin.",
     "videoEditorClipDeleted": "Klip silindi",
     "videoEditorClipSaveFailed": "Klip kaydedilemedi",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12620,6 +12620,12 @@ abstract class AppLocalizations {
   /// **'Untitled sound'**
   String get videoEditorAudioUntitledSound;
 
+  /// Semantic long-press hint for a volume arc control. Screen readers announce this as the long-press affordance, which mutes or unmutes all timeline tracks at once.
+  ///
+  /// In en, this message translates to:
+  /// **'Mute or unmute all tracks'**
+  String get videoEditorVolumeLongPressHint;
+
   /// No description provided for @videoEditorAudioUntitled.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7076,6 +7076,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'ርዕስ አልባ ድምጽ';
 
   @override
+  String get videoEditorVolumeLongPressHint => 'ሁሉንም ትራኮች ያጥፉ ወይም ያብሩ';
+
+  @override
   String get videoEditorAudioUntitled => 'ርዕስ አልባ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7158,6 +7158,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'صوت بدون عنوان';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'كتم صوت جميع المسارات أو إلغاء الكتم';
+
+  @override
   String get videoEditorAudioUntitled => 'بدون عنوان';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7294,6 +7294,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Звук без заглавие';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Заглуши или включи всички писти';
+
+  @override
   String get videoEditorAudioUntitled => 'Без заглавие';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7305,6 +7305,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Unbenannter Sound';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Alle Spuren stumm schalten oder aktivieren';
+
+  @override
   String get videoEditorAudioUntitled => 'Unbenannt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7212,6 +7212,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Untitled sound';
 
   @override
+  String get videoEditorVolumeLongPressHint => 'Mute or unmute all tracks';
+
+  @override
   String get videoEditorAudioUntitled => 'Untitled';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7292,6 +7292,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Sonido sin título';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Silenciar o activar todas las pistas';
+
+  @override
   String get videoEditorAudioUntitled => 'Sin título';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7307,6 +7307,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Walang pamagat na sound';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'I-mute o i-unmute ang lahat ng track';
+
+  @override
   String get videoEditorAudioUntitled => 'Walang Pamagat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7323,6 +7323,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Son sans titre';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Couper ou rétablir le son de toutes les pistes';
+
+  @override
   String get videoEditorAudioUntitled => 'Sans titre';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7195,6 +7195,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Suara tanpa judul';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Bisukan atau aktifkan semua trek';
+
+  @override
   String get videoEditorAudioUntitled => 'Tanpa judul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7288,6 +7288,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Suono senza titolo';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Silenzia o riattiva tutte le tracce';
+
+  @override
   String get videoEditorAudioUntitled => 'Senza titolo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6934,6 +6934,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'タイトルなしのサウンド';
 
   @override
+  String get videoEditorVolumeLongPressHint => 'すべてのトラックをミュートまたはミュート解除';
+
+  @override
   String get videoEditorAudioUntitled => 'タイトルなし';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6957,6 +6957,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorAudioUntitledSound => '제목 없는 사운드';
 
   @override
+  String get videoEditorVolumeLongPressHint => '모든 트랙 음소거 또는 해제';
+
+  @override
   String get videoEditorAudioUntitled => '제목 없음';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7255,6 +7255,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Naamloos geluid';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Alle tracks dempen of hervatten';
+
+  @override
   String get videoEditorAudioUntitled => 'Naamloos';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7373,6 +7373,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Nienazwany dźwięk';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Wycisz lub wyłącz wyciszenie wszystkich ścieżek';
+
+  @override
   String get videoEditorAudioUntitled => 'Bez tytułu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7265,6 +7265,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Som sem título';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Silenciar ou ativar todas as faixas';
+
+  @override
   String get videoEditorAudioUntitled => 'Sem título';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7391,6 +7391,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Sunet fără titlu';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Dezactivați sau activați sunetul tuturor pistelor';
+
+  @override
   String get videoEditorAudioUntitled => 'Fără titlu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7226,6 +7226,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Namnlöst ljud';
 
   @override
+  String get videoEditorVolumeLongPressHint => 'Tysta eller slå på alla spår';
+
+  @override
   String get videoEditorAudioUntitled => 'Namnlös';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7193,6 +7193,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorAudioUntitledSound => 'Başlıksız ses';
 
   @override
+  String get videoEditorVolumeLongPressHint =>
+      'Tüm parçaları sessize al veya aç';
+
+  @override
   String get videoEditorAudioUntitled => 'Başlıksız';
 
   @override

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1020,8 +1020,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             // AudioEvent equality is identity-based (excludes volume), so
             // Equatable cannot detect a volume-only change via the
             // audioTracks list. audioTracksRevision is incremented by
-            // TimelineOverlayAudioVolumeChanged to make the state distinct
-            // and force the listener to fire here.
+            // user-driven audio volume change events to make the state
+            // distinct and force the listener to fire here.
             if (previous.audioTracksRevision != current.audioTracksRevision) {
               return true;
             }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -175,6 +175,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   bool _isTrimmingClip = false;
   bool _isDraggingLayer = false;
 
+  /// Guards against duplicate [addHistory] calls when both
+  /// [ClipEditorBloc.clipsVolumeRevision] and
+  /// [TimelineOverlayBloc.audioTracksRevision] change in the same frame
+  /// (e.g. mute-all toggle). When both revision counters fire, only one
+  /// combined undo point is written instead of two separate ones.
+  bool _isVolumeSavePending = false;
+
   /// Most recent live-preview seek target captured while a layer trim
   /// handle is being dragged. Used at gesture end to sync the
   /// VideoEditorMainBloc's currentPosition (and thus the UI timeline
@@ -263,6 +270,27 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     } else {
       _videoPlayer?.play();
     }
+  }
+
+  /// Coalesces volume-history writes from clip and audio revision changes.
+  ///
+  /// Both the [ClipEditorBloc] (clipsVolumeRevision) and
+  /// [TimelineOverlayBloc] (audioTracksRevision) BlocListeners call this
+  /// helper. If both revision counters fire in the same frame — as happens
+  /// during a mute-all toggle — the [addPostFrameCallback] runs only once,
+  /// writing a single combined undo point that covers clips + audio rather
+  /// than two separate entries.
+  void _scheduleVolumeHistoryWrite() {
+    if (_isVolumeSavePending) return;
+    _isVolumeSavePending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _isVolumeSavePending = false;
+      if (!mounted) return;
+      VideoEditorScope.of(context).editor?.setVolumeState(
+        clips: context.read<ClipEditorBloc>().state.clips,
+        audioTracks: context.read<TimelineOverlayBloc>().state.audioTracks,
+      );
+    });
   }
 
   /// Handles seek requests from BLoC (e.g. timeline scrubbing).
@@ -1031,14 +1059,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
           },
         ),
         // Persist audio track volume changes to the ProImageEditor undo
-        // history.  audioTracksRevision is incremented exclusively by
-        // TimelineOverlayAudioVolumeChanged, so this listener fires once
-        // per volume-dial release and creates exactly one undo point.
+        // history. Both this listener and the clipsVolumeRevision listener
+        // below call _scheduleVolumeHistoryWrite, which coalesces concurrent
+        // revision bumps (e.g. mute-all toggle) into a single combined undo
+        // point instead of two separate entries.
         BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
           listenWhen: (previous, current) =>
               previous.audioTracksRevision != current.audioTracksRevision,
           listener: (context, state) {
-            scope.requireEditor.setSoundVolumes(state.audioTracks);
+            _scheduleVolumeHistoryWrite();
           },
         ),
         BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
@@ -1115,15 +1144,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
           },
         ),
         // Persist clip volume changes to the ProImageEditor undo history.
-        // clipsVolumeRevision is incremented exclusively by
-        // ClipEditorClipVolumeChanged, so this listener creates exactly one
-        // undo point per volume-dial release without duplicating the history
-        // entries written by trim/reorder operations.
+        // Both this listener and the audioTracksRevision listener above
+        // call _scheduleVolumeHistoryWrite, which coalesces concurrent
+        // revision bumps (e.g. mute-all toggle) into a single combined undo
+        // point instead of two separate entries.
         BlocListener<ClipEditorBloc, ClipEditorState>(
           listenWhen: (previous, current) =>
               previous.clipsVolumeRevision != current.clipsVolumeRevision,
           listener: (context, state) {
-            scope.requireEditor.setClipState(state.clips);
+            _scheduleVolumeHistoryWrite();
           },
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
@@ -141,6 +141,7 @@ class _VolumeButton extends StatelessWidget {
           : (hasModifiedVolume ? VineTheme.accentYellow : null),
       backgroundColor: isVolumeEditMode ? VineTheme.accentYellow : null,
       semanticLabel: context.l10n.videoEditorVolumeSemanticLabel,
+      semanticLongPressHint: context.l10n.videoEditorVolumeLongPressHint,
       onPressed: () => context.read<VideoEditorMainBloc>().add(
         const VideoEditorVolumeEditModeToggled(),
       ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
@@ -7,6 +7,7 @@ import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bl
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_volume_mute_toggle.dart';
 import 'package:time_formatter/time_formatter.dart';
 
 class VideoEditorTimelineHeader extends StatelessWidget {
@@ -143,6 +144,7 @@ class _VolumeButton extends StatelessWidget {
       onPressed: () => context.read<VideoEditorMainBloc>().add(
         const VideoEditorVolumeEditModeToggled(),
       ),
+      onLongPress: () => toggleAllTimelineVolumeMuted(context),
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_volume.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_volume.dart
@@ -2,11 +2,13 @@ import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_volume_mute_toggle.dart';
 
 /// Panel shown when the user taps the volume button in the timeline header.
 ///
@@ -91,6 +93,8 @@ class VideoEditorTimelineVolume extends StatelessWidget {
                             volume: v,
                           ),
                         ),
+                        onLongPress: () =>
+                            toggleAllTimelineVolumeMuted(context),
                       ),
                   ],
                 ),
@@ -119,6 +123,8 @@ class VideoEditorTimelineVolume extends StatelessWidget {
                                 volume: v,
                               ),
                             ),
+                        onLongPress: () =>
+                            toggleAllTimelineVolumeMuted(context),
                       ),
                   ],
                 ),
@@ -138,6 +144,7 @@ class _VolumeArc extends StatefulWidget {
     required this.volume,
     required this.volumePreviewNotifier,
     required this.onChanged,
+    this.onLongPress,
   });
 
   final double height;
@@ -150,6 +157,9 @@ class _VolumeArc extends StatefulWidget {
   /// pointer tracking, which would trigger the
   /// `!_debugDuringDeviceUpdate` assertion in mouse_tracker.dart.
   final ValueChanged<double> onChanged;
+
+  /// Called on long press — mutes/unmutes all clips and audio tracks at once.
+  final VoidCallback? onLongPress;
 
   @override
   State<_VolumeArc> createState() => _VolumeArcState();
@@ -246,12 +256,14 @@ class _VolumeArcState extends State<_VolumeArc> {
             // fires onTap when the gesture didn't escalate to a pan, so
             // taps and drags don't conflict.
             onTap: () {
+              HapticFeedback.lightImpact();
               final next = _localVolume > 0.001
                   ? 0.0
                   : (_lastUnmutedVolume > 0 ? _lastUnmutedVolume : 1.0);
               setState(() => _localVolume = next);
               widget.onChanged(next);
             },
+            onLongPress: widget.onLongPress,
             // Press-and-drag: relative gesture. Up = louder, down =
             // quieter. The arc itself is not directly hit-tested.
             onPanStart: _onPanStart,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_volume.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_volume.dart
@@ -85,6 +85,8 @@ class VideoEditorTimelineVolume extends StatelessWidget {
                         semanticLabel: context.l10n.videoEditorClipVolumeLabel(
                           i + 1,
                         ),
+                        semanticLongPressHint:
+                            context.l10n.videoEditorVolumeLongPressHint,
                         volume: clips[i].volume,
                         volumePreviewNotifier: volumePreviewNotifier,
                         onChanged: (v) => context.read<ClipEditorBloc>().add(
@@ -114,6 +116,8 @@ class VideoEditorTimelineVolume extends StatelessWidget {
                                 customTracks[i].title!.isNotEmpty
                             ? customTracks[i].title!
                             : context.l10n.videoEditorAudioUntitledSound,
+                        semanticLongPressHint:
+                            context.l10n.videoEditorVolumeLongPressHint,
                         volume: customTracks[i].volume,
                         volumePreviewNotifier: volumePreviewNotifier,
                         onChanged: (v) =>
@@ -145,6 +149,7 @@ class _VolumeArc extends StatefulWidget {
     required this.volumePreviewNotifier,
     required this.onChanged,
     this.onLongPress,
+    this.semanticLongPressHint,
   });
 
   final double height;
@@ -160,6 +165,9 @@ class _VolumeArc extends StatefulWidget {
 
   /// Called on long press — mutes/unmutes all clips and audio tracks at once.
   final VoidCallback? onLongPress;
+
+  /// Hint text announced by screen readers for the long-press action.
+  final String? semanticLongPressHint;
 
   @override
   State<_VolumeArc> createState() => _VolumeArcState();
@@ -248,6 +256,8 @@ class _VolumeArcState extends State<_VolumeArc> {
         label: widget.semanticLabel,
         slider: true,
         value: '${(_localVolume * 100).round()}%',
+        onLongPressHint: widget.semanticLongPressHint,
+        onLongPress: widget.onLongPress,
         child: SizedBox(
           height: widget.height,
           child: GestureDetector(

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_volume_mute_toggle.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_volume_mute_toggle.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+
+/// Toggles mute on every video clip and every non-original-sound audio track
+/// at once.
+///
+/// If anything is currently audible (any clip or custom track with
+/// `volume > 0`), this mutes everything to `0.0`. Otherwise it restores all
+/// to `1.0`. Triggers `HapticFeedback.mediumImpact()` to acknowledge the
+/// gesture — call sites should not add their own haptic on top.
+///
+/// Both the timeline header's volume button (long-press) and the per-arc
+/// volume controls in [VideoEditorTimelineVolume] route through this so
+/// behaviour stays in lockstep.
+void toggleAllTimelineVolumeMuted(BuildContext context) {
+  final clipBloc = context.read<ClipEditorBloc>();
+  final overlayBloc = context.read<TimelineOverlayBloc>();
+
+  final clips = clipBloc.state.clips;
+  final customAudioTracks = overlayBloc.state.audioTracks
+      .where((t) => !t.isOriginalSound)
+      .toList(growable: false);
+
+  final allMuted =
+      clips.every((c) => c.volume == 0.0) &&
+      (customAudioTracks.isEmpty ||
+          customAudioTracks.every((t) => t.volume == 0.0));
+  final targetVolume = allMuted ? 1.0 : 0.0;
+
+  HapticFeedback.mediumImpact();
+  clipBloc.add(ClipEditorAllClipsVolumeChanged(volume: targetVolume));
+  overlayBloc.add(
+    TimelineOverlayAllAudioVolumeChanged(volume: targetVolume),
+  );
+}

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -42,7 +42,8 @@ enum DivineIconButtonSize {
 /// An icon-only button component following the Divine design system.
 ///
 /// The button's appearance is determined by [type] and [size]. The disabled
-/// state is automatically applied when [onPressed] is null.
+/// state is automatically applied when both [onPressed] and [onLongPress] are
+/// null.
 ///
 /// Both [DivineIconButtonSize.base] and [DivineIconButtonSize.small] have
 /// the same 48px tap target. The small variant appears 40px with a 4px
@@ -80,6 +81,7 @@ class DivineIconButton extends StatelessWidget {
     this.foregroundColor,
     this.semanticLabel,
     this.semanticValue,
+    this.semanticLongPressHint,
     super.key,
   });
 
@@ -87,7 +89,9 @@ class DivineIconButton extends StatelessWidget {
   final DivineIconName icon;
 
   /// Called when the button is tapped.
-  /// If null, the button is displayed in its disabled state.
+  ///
+  /// If both [onPressed] and [onLongPress] are null, the button is displayed
+  /// in its disabled state.
   final VoidCallback? onPressed;
 
   /// Called when the user long-presses.
@@ -111,6 +115,11 @@ class DivineIconButton extends StatelessWidget {
   /// Semantic value for accessibility (e.g. a count or status).
   final String? semanticValue;
 
+  /// Hint announced by screen readers to describe the long-press action.
+  ///
+  /// Only meaningful when [onLongPress] is set.
+  final String? semanticLongPressHint;
+
   @override
   Widget build(BuildContext context) {
     return _DivineIconButtonContent(
@@ -123,6 +132,7 @@ class DivineIconButton extends StatelessWidget {
       foregroundColor: foregroundColor,
       semanticLabel: semanticLabel,
       semanticValue: semanticValue,
+      semanticLongPressHint: semanticLongPressHint,
     );
   }
 }
@@ -138,6 +148,7 @@ class _DivineIconButtonContent extends StatelessWidget {
     this.foregroundColor,
     this.semanticLabel,
     this.semanticValue,
+    this.semanticLongPressHint,
   });
 
   final DivineIconName icon;
@@ -149,6 +160,7 @@ class _DivineIconButtonContent extends StatelessWidget {
   final Color? foregroundColor;
   final String? semanticLabel;
   final String? semanticValue;
+  final String? semanticLongPressHint;
 
   static const _borderWidth = 2.0;
 
@@ -239,6 +251,7 @@ class _DivineIconButtonContent extends StatelessWidget {
     Widget button = Semantics(
       label: semanticLabel,
       value: semanticValue,
+      onLongPressHint: semanticLongPressHint,
       button: true,
       enabled: _isEnabled,
       child: Padding(

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -251,6 +251,7 @@ class _DivineIconButtonContent extends StatelessWidget {
     Widget button = Semantics(
       label: semanticLabel,
       value: semanticValue,
+      onLongPress: onLongPress,
       onLongPressHint: semanticLongPressHint,
       button: true,
       enabled: _isEnabled,

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -73,6 +73,7 @@ class DivineIconButton extends StatelessWidget {
   const DivineIconButton({
     required this.icon,
     required this.onPressed,
+    this.onLongPress,
     this.type = DivineIconButtonType.primary,
     this.size = DivineIconButtonSize.base,
     this.backgroundColor,
@@ -88,6 +89,9 @@ class DivineIconButton extends StatelessWidget {
   /// Called when the button is tapped.
   /// If null, the button is displayed in its disabled state.
   final VoidCallback? onPressed;
+
+  /// Called when the user long-presses.
+  final VoidCallback? onLongPress;
 
   /// The visual style type of the button.
   final DivineIconButtonType type;
@@ -112,6 +116,7 @@ class DivineIconButton extends StatelessWidget {
     return _DivineIconButtonContent(
       icon: icon,
       onPressed: onPressed,
+      onLongPress: onLongPress,
       type: type,
       size: size,
       backgroundColor: backgroundColor,
@@ -126,6 +131,7 @@ class _DivineIconButtonContent extends StatelessWidget {
   const _DivineIconButtonContent({
     required this.icon,
     required this.onPressed,
+    required this.onLongPress,
     required this.type,
     required this.size,
     this.backgroundColor,
@@ -136,6 +142,7 @@ class _DivineIconButtonContent extends StatelessWidget {
 
   final DivineIconName icon;
   final VoidCallback? onPressed;
+  final VoidCallback? onLongPress;
   final DivineIconButtonType type;
   final DivineIconButtonSize size;
   final Color? backgroundColor;
@@ -145,7 +152,7 @@ class _DivineIconButtonContent extends StatelessWidget {
 
   static const _borderWidth = 2.0;
 
-  bool get _isEnabled => onPressed != null;
+  bool get _isEnabled => onPressed != null || onLongPress != null;
 
   /// Inner padding around the icon.
   double get _padding => switch (size) {
@@ -243,6 +250,7 @@ class _DivineIconButtonContent extends StatelessWidget {
             type: .transparency,
             child: InkWell(
               onTap: onPressed,
+              onLongPress: onLongPress,
               borderRadius: BorderRadius.circular(_borderRadius),
               splashColor: _iconColor.withValues(alpha: 0.1),
               highlightColor: _iconColor.withValues(alpha: 0.05),

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -14,6 +14,7 @@ void main() {
       Color? backgroundColor,
       Color? foregroundColor,
       String? semanticLabel,
+      String? semanticLongPressHint,
     }) {
       return MaterialApp(
         home: Scaffold(
@@ -27,6 +28,7 @@ void main() {
               backgroundColor: backgroundColor,
               foregroundColor: foregroundColor,
               semanticLabel: semanticLabel,
+              semanticLongPressHint: semanticLongPressHint,
             ),
           ),
         ),
@@ -57,6 +59,30 @@ void main() {
           findsOneWidget,
         );
       });
+
+      testWidgets('applies semantic long-press hint when set', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            semanticLongPressHint: 'Mute all tracks',
+            onLongPress: () {},
+          ),
+        );
+
+        final semantics = tester.getSemantics(find.byType(DivineIconButton));
+        expect(semantics.hintOverrides?.onLongPressHint, 'Mute all tracks');
+      });
+
+      testWidgets(
+        'has no long-press hint when semanticLongPressHint is null',
+        (tester) async {
+          await tester.pumpWidget(buildTestWidget(onPressed: () {}));
+
+          final semantics = tester.getSemantics(
+            find.byType(DivineIconButton),
+          );
+          expect(semantics.hintOverrides?.onLongPressHint, isNull);
+        },
+      );
     });
 
     group('interaction', () {

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -8,6 +8,7 @@ void main() {
     Widget buildTestWidget({
       DivineIconName icon = DivineIconName.x,
       VoidCallback? onPressed,
+      VoidCallback? onLongPress,
       DivineIconButtonType type = DivineIconButtonType.primary,
       DivineIconButtonSize size = DivineIconButtonSize.base,
       Color? backgroundColor,
@@ -20,6 +21,7 @@ void main() {
             child: DivineIconButton(
               icon: icon,
               onPressed: onPressed,
+              onLongPress: onLongPress,
               type: type,
               size: size,
               backgroundColor: backgroundColor,
@@ -79,6 +81,36 @@ void main() {
 
         expect(pressed, isFalse);
       });
+
+      testWidgets('calls onLongPress when long-pressed', (tester) async {
+        var longPressed = false;
+        await tester.pumpWidget(
+          buildTestWidget(
+            onPressed: () {},
+            onLongPress: () => longPressed = true,
+          ),
+        );
+
+        await tester.longPress(find.byType(DivineIconButton));
+        await tester.pumpAndSettle();
+
+        expect(longPressed, isTrue);
+      });
+
+      testWidgets(
+        'is enabled and fires onLongPress when only onLongPress is set',
+        (tester) async {
+          var longPressed = false;
+          await tester.pumpWidget(
+            buildTestWidget(onLongPress: () => longPressed = true),
+          );
+
+          await tester.longPress(find.byType(DivineIconButton));
+          await tester.pumpAndSettle();
+
+          expect(longPressed, isTrue);
+        },
+      );
     });
 
     group('icon sizing', () {

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -1,5 +1,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -70,6 +71,10 @@ void main() {
 
         final semantics = tester.getSemantics(find.byType(DivineIconButton));
         expect(semantics.hintOverrides?.onLongPressHint, 'Mute all tracks');
+        expect(
+          semantics.getSemanticsData().hasAction(SemanticsAction.longPress),
+          isTrue,
+        );
       });
 
       testWidgets(

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1175,6 +1175,59 @@ void main() {
       );
     });
 
+    group('ClipEditorAllClipsVolumeChanged', () {
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clamps below 0 to 0 on every clip, bumps revision, '
+        'keeps clips unmodifiable',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorAllClipsVolumeChanged(volume: -1.0),
+        ),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having(
+                (s) => s.clips.map((c) => c.volume).toList(),
+                'clip volumes',
+                [0.0, 0.0],
+              )
+              .having((s) => s.clipsVolumeRevision, 'clipsVolumeRevision', 1),
+        ],
+        verify: (bloc) {
+          expect(
+            () => (bloc.state.clips as List).add(_createClip(id: 'extra')),
+            throwsUnsupportedError,
+          );
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clamps above 1 to 1 on every clip',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorAllClipsVolumeChanged(volume: 2.0),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.clips.map((c) => c.volume).toList(),
+            'clip volumes',
+            [1.0, 1.0],
+          ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'is no-op when there are no clips',
+        build: buildBloc,
+        seed: () => const ClipEditorState(),
+        act: (bloc) => bloc.add(
+          const ClipEditorAllClipsVolumeChanged(volume: 0.0),
+        ),
+        expect: () => <ClipEditorState>[],
+      );
+    });
+
     // =========================================================
     // EVENT EQUALITY
     // =========================================================

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1204,7 +1204,11 @@ void main() {
       blocTest<ClipEditorBloc, ClipEditorState>(
         'clamps above 1 to 1 on every clip',
         build: buildBloc,
-        seed: () => ClipEditorState(clips: twoClips),
+        seed: () => ClipEditorState(
+          clips: twoClips
+              .map((c) => c.copyWith(volume: 0.5))
+              .toList(growable: false),
+        ),
         act: (bloc) => bloc.add(
           const ClipEditorAllClipsVolumeChanged(volume: 2.0),
         ),
@@ -1223,6 +1227,16 @@ void main() {
         seed: () => const ClipEditorState(),
         act: (bloc) => bloc.add(
           const ClipEditorAllClipsVolumeChanged(volume: 0.0),
+        ),
+        expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'is no-op when every clip already has the clamped target volume',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorAllClipsVolumeChanged(volume: 2.0),
         ),
         expect: () => <ClipEditorState>[],
       );

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -252,6 +252,93 @@ void main() {
       );
     });
 
+    group(TimelineOverlayAllAudioVolumeChanged, () {
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'clamps below 0 to 0 on every custom track and bumps history revision',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          audioTracks: [
+            _audioEvent(
+              id: 'sound-1',
+              start: const Duration(seconds: 1),
+              end: const Duration(seconds: 4),
+            ),
+            _audioEvent(
+              id: 'sound-2',
+              start: const Duration(seconds: 5),
+              end: const Duration(seconds: 8),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayAllAudioVolumeChanged(volume: -1.0),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.audioTracks.map((t) => t.volume).toList(),
+                'audio volumes',
+                [0.0, 0.0],
+              )
+              .having((s) => s.audioTracksRevision, 'audioTracksRevision', 1)
+              .having(
+                (s) => s.audioTracksPlayerRevision,
+                'audioTracksPlayerRevision',
+                0,
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'preserves original-sound tracks (id starts with `video_`) and '
+        'only mutes custom tracks',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          audioTracks: [
+            _audioEvent(
+              id: 'video_clip-a',
+              start: Duration.zero,
+              end: const Duration(seconds: 3),
+            ),
+            _audioEvent(
+              id: 'sound-1',
+              start: const Duration(seconds: 1),
+              end: const Duration(seconds: 4),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayAllAudioVolumeChanged(volume: 0.0),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.audioTracks
+                    .firstWhere((t) => t.id == 'video_clip-a')
+                    .volume,
+                'original-sound volume',
+                1.0,
+              )
+              .having(
+                (s) =>
+                    s.audioTracks.firstWhere((t) => t.id == 'sound-1').volume,
+                'custom track volume',
+                0.0,
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'is no-op when there are no audio tracks',
+        build: TimelineOverlayBloc.new,
+        seed: TimelineOverlayState.new,
+        act: (bloc) => bloc.add(
+          const TimelineOverlayAllAudioVolumeChanged(volume: 0.0),
+        ),
+        expect: () => <TimelineOverlayState>[],
+      );
+    });
+
     group(TimelineOverlayItemMoved, () {
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'shifts startTime and endTime by same delta',

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -337,6 +337,53 @@ void main() {
         ),
         expect: () => <TimelineOverlayState>[],
       );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'is no-op when only original-sound tracks are present',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          audioTracks: [
+            _audioEvent(
+              id: 'video_clip-a',
+              start: Duration.zero,
+              end: const Duration(seconds: 3),
+            ),
+            _audioEvent(
+              id: 'video_clip-b',
+              start: const Duration(seconds: 3),
+              end: const Duration(seconds: 6),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayAllAudioVolumeChanged(volume: 0.0),
+        ),
+        expect: () => <TimelineOverlayState>[],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'is no-op when every custom track is already at the clamped '
+        'target volume',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          audioTracks: [
+            _audioEvent(
+              id: 'sound-1',
+              start: const Duration(seconds: 1),
+              end: const Duration(seconds: 4),
+            ),
+            _audioEvent(
+              id: 'sound-2',
+              start: const Duration(seconds: 5),
+              end: const Duration(seconds: 8),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayAllAudioVolumeChanged(volume: 2.0),
+        ),
+        expect: () => <TimelineOverlayState>[],
+      );
     });
 
     group(TimelineOverlayItemMoved, () {

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_volume_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_volume_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Covers clip/custom-audio rendering and volume interactions.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
@@ -114,6 +115,24 @@ void main() {
       expect(volumePreviewNotifier.value, isNull);
       expect(overlayBloc.state.audioTracks.first.volume, lessThan(0.1));
       expect(overlayBloc.state.audioTracksRevision, 1);
+    });
+
+    testWidgets('clip arc exposes long-press semantic action and hint', (
+      tester,
+    ) async {
+      clipBloc.add(ClipEditorInitialized([_createTestClip(id: 'clip-a')]));
+
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildWidget());
+      await tester.pump();
+
+      final data = tester.getSemantics(find.bySemanticsLabel('Clip 1'));
+      expect(
+        data.getSemanticsData().hasAction(SemanticsAction.longPress),
+        isTrue,
+      );
+
+      handle.dispose();
     });
   });
 }


### PR DESCRIPTION
Closes #4774

## Description

Long-pressing the volume button in the video editor toolbar (and on individual timeline volume controls) now toggles mute/unmute for **all** clips and custom audio tracks at once. Original-sound audio tracks (`isOriginalSound`) are intentionally preserved so the source video audio is not affected.

Implementation highlights:

- New shared helper `toggleAllTimelineVolumeMuted(BuildContext)` in `video_editor_volume_mute_toggle.dart` — single source of truth, deduped between the header button and the per-track volume control. Fires `HapticFeedback.mediumImpact()` on toggle.
- Wired `onLongPress` on `_VolumeButton` (header) and `onLongPressAll` (timeline volume slider) to the helper.
- Per-track `onTap` (single-clip tap-to-mute on the timeline arc) fires `HapticFeedback.lightImpact()` — lighter intensity than the long-press global mute, giving the user distinct tactile feedback for each action and confirming the tap registered.
- New BLoC events:
  - `ClipEditorAllClipsVolumeChanged` → clamps to `[0, 1]`, uses `.toList(growable: false)`, early-returns on empty, emits `List.unmodifiable(...)` and bumps `clipsVolumeRevision`.
  - `TimelineOverlayAllAudioVolumeChanged` → same clamping/list semantics, preserves tracks where `isOriginalSound == true`, bumps only `audioTracksRevision` (not `audioTracksPlayerRevision`).
- `DivineIconButton`: added public `VoidCallback? onLongPress` parameter; `_isEnabled` is now true when either `onPressed` or `onLongPress` is set.

Requested on discord [here](https://discord.com/channels/1470168817589158040/1470256031434149953/1509093657217601646)


## Out of Scope

None.

## Verification

- `flutter analyze lib/widgets/video_editor/timeline_editor lib/blocs/video_editor test/blocs/video_editor` → clean.
- Scoped BLoC tests (`clip_editor_bloc_test.dart`, `timeline_overlay_bloc_test.dart`) → **90/90 passing**, including 3 new tests per new event (clamp, no-op on empty, original-sound preservation, revision-bump invariants).
- `divine_ui` package full suite + coverage gate → **587/587 passing**, 100% line coverage maintained (2 new `onLongPress` tests added for `DivineIconButton`).

## Manual Test Plan

1. Open the video editor with at least one clip and one custom audio track.
2. Long-press the volume button in the header → all clips and custom audio tracks mute; original-sound tracks remain at their previous volume. Medium-impact haptic fires.
3. Long-press again → everything unmutes back to full volume.
4. Long-press a per-track volume control → same behavior.
5. Single-tap a per-track volume arc → that clip toggles mute; light-impact haptic confirms the tap.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)