### PR TITLE
fix(audio): allow choosing audio start time for community sounds

### DIFF
--- a/mobile/lib/blocs/video_editor/audio_timing/audio_timing_cubit.dart
+++ b/mobile/lib/blocs/video_editor/audio_timing/audio_timing_cubit.dart
@@ -46,17 +46,30 @@ class AudioTimingCubit extends Cubit<AudioTimingState> {
 
   static const _logName = 'AudioTimingCubit';
 
+  /// Minimum amount of audio (in seconds) that must remain playable after
+  /// the chosen start offset.
+  ///
+  /// Bounds the scrollable range so users can position the start anywhere
+  /// from `0` up to `audioDuration - minRemainingAudioSecs`, even when the
+  /// remaining audio is shorter than the video's max duration. The video
+  /// will simply play unscored audio for the trailing portion.
+  static const double minRemainingAudioSecs = 0.5;
+
   /// Maximum video duration in seconds.
   static double get _maxDurationSecs =>
       VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
 
   /// The scrollable audio range in seconds.
   ///
-  /// This is the amount of audio that extends beyond the video duration.
-  /// Returns 0 if audio is shorter than the video duration.
+  /// Allows the start offset to span from `0` to
+  /// `audioDuration - minRemainingAudioSecs`. Returns 0 when the audio is
+  /// shorter than [minRemainingAudioSecs].
   double get _scrollableAudioSecs {
     final audioDuration = state.audioDuration ?? 0;
-    return (audioDuration - _maxDurationSecs).clamp(0.0, double.infinity);
+    return (audioDuration - minRemainingAudioSecs).clamp(
+      0.0,
+      double.infinity,
+    );
   }
 
   /// Initializes the cubit: computes initial offset, starts playback.
@@ -74,7 +87,7 @@ class AudioTimingCubit extends Cubit<AudioTimingState> {
 
     // Restore previous selection offset (normalized 0-1)
     var initialOffset = 0.0;
-    final scrollableAudioSecs = (audioDuration - _maxDurationSecs).clamp(
+    final scrollableAudioSecs = (audioDuration - minRemainingAudioSecs).clamp(
       0.0,
       double.infinity,
     );

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -550,17 +550,23 @@ class _AudioWaveformSelector extends StatelessWidget {
     // The selection's left edge (in audio time) can range from 0 to
     // `audioDuration - minRemainingAudio`, allowing users to pick a late
     // start even when the trailing audio is shorter than the video.
-    // `selectionWidth` represents `maxDuration` worth of audio in pixels,
-    // so the minimum-remaining slice occupies `selectionWidth * (minRem /
-    // maxDuration)` pixels and must remain inside the selection.
+    // `selectionWidth` always represents min(audioDurationSecs, maxDurationSecs)
+    // worth of audio — full duration for short clips, maxDuration for long ones —
+    // so the minimum-remaining slice width must use the same basis as the
+    // denominator.
     final double maxScrollableDistance;
     if (audioDurationSecs <= 0 ||
         audioDurationSecs <= AudioTimingCubit.minRemainingAudioSecs) {
       maxScrollableDistance = 0;
     } else {
+      // For short audio selectionWidth represents audioDurationSecs;
+      // for long audio it represents maxDurationSecs.
+      final waveformBasisSecs = audioDurationSecs < maxDurationSecs
+          ? audioDurationSecs
+          : maxDurationSecs;
       final minVisibleWidth =
           selectionWidth *
-          (AudioTimingCubit.minRemainingAudioSecs / maxDurationSecs);
+          (AudioTimingCubit.minRemainingAudioSecs / waveformBasisSecs);
       maxScrollableDistance = (fullWaveformWidth - minVisibleWidth).clamp(
         0.0,
         double.infinity,

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -402,20 +402,35 @@ class _VideoDurationTimeline extends StatelessWidget {
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width - 32;
     final segmentWidth = screenWidth * selectionWidthRatio;
-
-    // Calculate scrollable distance based on audio duration
-    final maxDurationSecs =
-        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
     final audioDurationSecs = audioDuration ?? 0;
 
-    // Short audio: no scrolling (segment fills timeline relative to audio)
-    // Long audio: scrollable distance proportional to excess audio
+    // Scrollable distance lets the segment's left edge reach
+    // `audioDuration - minRemainingAudio`, so users can pick a late start
+    // even when the trailing audio is shorter than the video duration.
+    // `screenWidth` represents `audioDurationSecs` worth of time, so the
+    // minimum-remaining slice occupies this many pixels on screen.
     final double maxScrollableDistance;
-    if (audioDurationSecs <= 0 || audioDurationSecs <= maxDurationSecs) {
+    if (audioDurationSecs <= 0 ||
+        audioDurationSecs <= AudioTimingCubit.minRemainingAudioSecs) {
       maxScrollableDistance = 0;
     } else {
-      maxScrollableDistance = screenWidth - segmentWidth;
+      final minRemainingWidth =
+          screenWidth *
+          (AudioTimingCubit.minRemainingAudioSecs / audioDurationSecs);
+      maxScrollableDistance = (screenWidth - minRemainingWidth).clamp(
+        0.0,
+        double.infinity,
+      );
     }
+
+    final segmentLeft = startOffset * maxScrollableDistance;
+    // Shrink the segment when the remaining audio is shorter than the video's
+    // max duration, mirroring how [AudioTimingCubit] clamps the playable clip
+    // to the tail of the source.
+    final effectiveSegmentWidth = segmentWidth.clamp(
+      0.0,
+      (screenWidth - segmentLeft).clamp(0.0, double.infinity),
+    );
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -458,9 +473,9 @@ class _VideoDurationTimeline extends StatelessWidget {
               child: Stack(
                 children: [
                   Positioned(
-                    left: startOffset * maxScrollableDistance,
+                    left: segmentLeft,
                     child: Container(
-                      width: segmentWidth,
+                      width: effectiveSegmentWidth,
                       height: 8,
                       decoration: BoxDecoration(
                         color: VineTheme.vineGreen,
@@ -530,14 +545,42 @@ class _AudioWaveformSelector extends StatelessWidget {
           selectionWidth * (audioDurationSecs / maxDurationSecs);
     }
 
-    // Calculate how far the waveform can scroll
-    final maxScrollableDistance = (fullWaveformWidth - selectionWidth).clamp(
-      0.0,
-      double.infinity,
-    );
+    // Calculate how far the waveform can scroll.
+    //
+    // The selection's left edge (in audio time) can range from 0 to
+    // `audioDuration - minRemainingAudio`, allowing users to pick a late
+    // start even when the trailing audio is shorter than the video.
+    // `selectionWidth` represents `maxDuration` worth of audio in pixels,
+    // so the minimum-remaining slice occupies `selectionWidth * (minRem /
+    // maxDuration)` pixels and must remain inside the selection.
+    final double maxScrollableDistance;
+    if (audioDurationSecs <= 0 ||
+        audioDurationSecs <= AudioTimingCubit.minRemainingAudioSecs) {
+      maxScrollableDistance = 0;
+    } else {
+      final minVisibleWidth =
+          selectionWidth *
+          (AudioTimingCubit.minRemainingAudioSecs / maxDurationSecs);
+      maxScrollableDistance = (fullWaveformWidth - minVisibleWidth).clamp(
+        0.0,
+        double.infinity,
+      );
+    }
     // Waveform position: at offset 0, waveform starts at selection left edge
     // at offset 1, waveform ends at selection right edge
     final waveformLeft = selectionLeft - startOffset * maxScrollableDistance;
+
+    // Shrink the green selection when the trailing audio is shorter than the
+    // video's max duration, so the box matches the actual playable clip
+    // (mirrors [AudioTimingCubit._setClippedAudioSource]'s end clamp).
+    final waveformRight = waveformLeft + fullWaveformWidth;
+    final remainingSelectionWidth = (waveformRight - selectionLeft).clamp(
+      0.0,
+      double.infinity,
+    );
+    final effectiveSelectionWidth = selectionWidth < remainingSelectionWidth
+        ? selectionWidth
+        : remainingSelectionWidth;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -588,7 +631,7 @@ class _AudioWaveformSelector extends StatelessWidget {
                     top: 0,
                     bottom: 0,
                     child: Container(
-                      width: selectionWidth,
+                      width: effectiveSelectionWidth,
                       decoration: BoxDecoration(
                         color: VineTheme.primary,
                         borderRadius: .circular(24),
@@ -642,7 +685,7 @@ class _AudioWaveformSelector extends StatelessWidget {
                     top: 0,
                     bottom: 0,
                     child: Container(
-                      width: selectionWidth,
+                      width: effectiveSelectionWidth,
                       decoration: BoxDecoration(
                         borderRadius: .circular(24),
                         border: Border.all(

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -76,6 +76,16 @@ class VideoAudioEditorTimingScreen extends StatefulWidget {
   /// Route path.
   static const path = '/video-audio-timing';
 
+  @visibleForTesting
+  static const videoDurationSegmentKey = Key(
+    'video-audio-timing-video-duration-segment',
+  );
+
+  @visibleForTesting
+  static const waveformSelectionKey = Key(
+    'video-audio-timing-waveform-selection',
+  );
+
   @override
   State<VideoAudioEditorTimingScreen> createState() =>
       _VideoAudioEditorTimingScreenState();
@@ -475,6 +485,7 @@ class _VideoDurationTimeline extends StatelessWidget {
                   Positioned(
                     left: segmentLeft,
                     child: Container(
+                      key: VideoAudioEditorTimingScreen.videoDurationSegmentKey,
                       width: effectiveSegmentWidth,
                       height: 8,
                       decoration: BoxDecoration(
@@ -637,6 +648,7 @@ class _AudioWaveformSelector extends StatelessWidget {
                     top: 0,
                     bottom: 0,
                     child: Container(
+                      key: VideoAudioEditorTimingScreen.waveformSelectionKey,
                       width: effectiveSelectionWidth,
                       decoration: BoxDecoration(
                         color: VineTheme.primary,

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
-import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/utils/video_editor_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/utils/video_editor_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -89,7 +90,7 @@ class AudioEditorSelectionOverlay extends StatelessWidget {
               size: .small,
               icon: .caretRight,
               semanticLabel: context.l10n.videoEditorDoneSemanticLabel,
-              onPressed: onTapDone,
+              onPressed: isLoading ? null : onTapDone,
             ),
           ],
         ),
@@ -111,12 +112,11 @@ class _AudioPlaybackProgressButton extends StatelessWidget {
 
   static const double _buttonVisualSize = 42;
   static const double _buttonBorderRadius = 16;
-  static const _switchDuration = Duration(milliseconds: 300);
 
   @override
   Widget build(BuildContext context) {
     return AnimatedSwitcher(
-      duration: _switchDuration,
+      duration: VineTheme.defaultAnimationDuration,
       child: isLoading
           ? const BrandedLoadingIndicator(size: _buttonVisualSize)
           : StreamBuilder<bool>(

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/utils/video_editor_utils.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:sound_service/sound_service.dart';
 
 class AudioEditorSelectionOverlay extends StatelessWidget {
@@ -13,6 +14,7 @@ class AudioEditorSelectionOverlay extends StatelessWidget {
     required this.audioService,
     required this.onTogglePlayState,
     required this.onTapDone,
+    this.isLoading = false,
     super.key,
   });
 
@@ -20,6 +22,7 @@ class AudioEditorSelectionOverlay extends StatelessWidget {
   final AudioPlaybackService audioService;
   final VoidCallback onTogglePlayState;
   final VoidCallback onTapDone;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -78,6 +81,7 @@ class AudioEditorSelectionOverlay extends StatelessWidget {
 
             _AudioPlaybackProgressButton(
               audioService: audioService,
+              isLoading: isLoading,
               onPressed: onTogglePlayState,
             ),
             DivineIconButton(
@@ -98,63 +102,73 @@ class _AudioPlaybackProgressButton extends StatelessWidget {
   const _AudioPlaybackProgressButton({
     required this.audioService,
     required this.onPressed,
+    this.isLoading = false,
   });
 
   final AudioPlaybackService audioService;
   final VoidCallback onPressed;
+  final bool isLoading;
 
   static const double _buttonVisualSize = 42;
   static const double _buttonBorderRadius = 16;
+  static const _switchDuration = Duration(milliseconds: 300);
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<bool>(
-      stream: audioService.playingStream,
-      initialData: audioService.isPlaying,
-      builder: (context, playingSnapshot) {
-        final isPlaying = playingSnapshot.data ?? false;
-        return StreamBuilder<Duration?>(
-          stream: audioService.durationStream,
-          initialData: audioService.duration,
-          builder: (context, durationSnapshot) {
-            return StreamBuilder<Duration>(
-              stream: audioService.positionStream,
-              initialData: Duration.zero,
-              builder: (context, positionSnapshot) {
-                final durationMs = durationSnapshot.data?.inMilliseconds ?? 0;
-                final positionMs = positionSnapshot.data?.inMilliseconds ?? 0;
-                final progress = durationMs <= 0
-                    ? 0.0
-                    : (positionMs / durationMs).clamp(0.0, 1.0);
+    return AnimatedSwitcher(
+      duration: _switchDuration,
+      child: isLoading
+          ? const BrandedLoadingIndicator(size: _buttonVisualSize)
+          : StreamBuilder<bool>(
+              stream: audioService.playingStream,
+              initialData: audioService.isPlaying,
+              builder: (context, playingSnapshot) {
+                final isPlaying = playingSnapshot.data ?? false;
+                return StreamBuilder<Duration?>(
+                  stream: audioService.durationStream,
+                  initialData: audioService.duration,
+                  builder: (context, durationSnapshot) {
+                    return StreamBuilder<Duration>(
+                      stream: audioService.positionStream,
+                      initialData: Duration.zero,
+                      builder: (context, positionSnapshot) {
+                        final durationMs =
+                            durationSnapshot.data?.inMilliseconds ?? 0;
+                        final positionMs =
+                            positionSnapshot.data?.inMilliseconds ?? 0;
+                        final progress = durationMs <= 0
+                            ? 0.0
+                            : (positionMs / durationMs).clamp(0.0, 1.0);
 
-                return SizedBox.square(
-                  dimension: _buttonVisualSize,
-                  child: CustomPaint(
-                    foregroundPainter: _CircularProgressBorderPainter(
-                      progress: progress,
-                      borderRadius: _buttonBorderRadius,
-                    ),
-                    child: Center(
-                      child: DivineIconButton(
-                        type: .ghostSecondary,
-                        icon: isPlaying ? .pauseFill : .playFill,
-                        semanticLabel: isPlaying
-                            ? context
-                                  .l10n
-                                  .videoEditorAudioPausePreviewSemanticLabel
-                            : context
-                                  .l10n
-                                  .videoEditorAudioPlayPreviewSemanticLabel,
-                        onPressed: onPressed,
-                      ),
-                    ),
-                  ),
+                        return SizedBox.square(
+                          dimension: _buttonVisualSize,
+                          child: CustomPaint(
+                            foregroundPainter: _CircularProgressBorderPainter(
+                              progress: progress,
+                              borderRadius: _buttonBorderRadius,
+                            ),
+                            child: Center(
+                              child: DivineIconButton(
+                                type: .ghostSecondary,
+                                icon: isPlaying ? .pauseFill : .playFill,
+                                semanticLabel: isPlaying
+                                    ? context
+                                          .l10n
+                                          .videoEditorAudioPausePreviewSemanticLabel
+                                    : context
+                                          .l10n
+                                          .videoEditorAudioPlayPreviewSemanticLabel,
+                                onPressed: onPressed,
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    );
+                  },
                 );
               },
-            );
-          },
-        );
-      },
+            ),
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -101,6 +101,7 @@ class _AudioSelectionBottomSheetState
   AudioEvent? _selectedItem;
   AudioCategory _category = .divine;
   String _searchQuery = '';
+  bool _isLoadingAudio = false;
 
   late final _tabController = TabController(
     length: AudioCategory.values.length,
@@ -188,10 +189,12 @@ class _AudioSelectionBottomSheetState
       var resolvedSound = sound;
       if (shouldReload) {
         await _audioService.stop();
+        if (mounted) setState(() => _isLoadingAudio = true);
         final loadedDuration =
             sound.isLocalImport && sound.localFilePath != null
             ? await _audioService.loadAudioFromFile(sound.localFilePath!)
             : await _audioService.loadAudio(sound.url!);
+        if (mounted) setState(() => _isLoadingAudio = false);
         _loadedSoundId = sound.id;
         // Backfill missing duration so the selection overlay and list
         // tile can show a correct timestamp for Nostr sounds that don't
@@ -479,6 +482,7 @@ class _AudioSelectionBottomSheetState
                 ? AudioEditorSelectionOverlay(
                     audio: _selectedItem!,
                     audioService: _audioService,
+                    isLoading: _isLoadingAudio,
                     onTapDone: _handleDoneSelection,
                     onTogglePlayState: _togglePlayPause,
                   )

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -37,12 +37,14 @@ class AudioSelectionBottomSheet extends ConsumerStatefulWidget {
     required this.scrollController,
     this.localAudioImportService,
     this.pickAudioFile,
+    @visibleForTesting this.audioService,
     super.key,
   });
 
   final ScrollController scrollController;
   final LocalAudioImportService? localAudioImportService;
   final Future<FilePickerResult?> Function()? pickAudioFile;
+  final AudioPlaybackService? audioService;
 
   static Future<AudioEvent?> show(BuildContext context) {
     return VineBottomSheet.show<AudioEvent>(
@@ -95,7 +97,7 @@ class AudioSelectionBottomSheet extends ConsumerStatefulWidget {
 class _AudioSelectionBottomSheetState
     extends ConsumerState<AudioSelectionBottomSheet>
     with SingleTickerProviderStateMixin {
-  final _audioService = AudioPlaybackService();
+  late final AudioPlaybackService _audioService;
   final _searchController = TextEditingController();
   String? _loadedSoundId;
   AudioEvent? _selectedItem;
@@ -111,6 +113,7 @@ class _AudioSelectionBottomSheetState
   @override
   void initState() {
     super.initState();
+    _audioService = widget.audioService ?? AudioPlaybackService();
     _tabController.addListener(_onTabChanged);
   }
 
@@ -188,8 +191,8 @@ class _AudioSelectionBottomSheetState
       await _audioService.seek(.zero);
       var resolvedSound = sound;
       if (shouldReload) {
-        await _audioService.stop();
         if (mounted) setState(() => _isLoadingAudio = true);
+        await _audioService.stop();
         try {
           final loadedDuration =
               sound.isLocalImport && sound.localFilePath != null

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -190,19 +190,22 @@ class _AudioSelectionBottomSheetState
       if (shouldReload) {
         await _audioService.stop();
         if (mounted) setState(() => _isLoadingAudio = true);
-        final loadedDuration =
-            sound.isLocalImport && sound.localFilePath != null
-            ? await _audioService.loadAudioFromFile(sound.localFilePath!)
-            : await _audioService.loadAudio(sound.url!);
-        if (mounted) setState(() => _isLoadingAudio = false);
-        _loadedSoundId = sound.id;
-        // Backfill missing duration so the selection overlay and list
-        // tile can show a correct timestamp for Nostr sounds that don't
-        // carry a duration tag.
-        if (sound.duration == null && loadedDuration != null) {
-          resolvedSound = sound.copyWith(
-            duration: loadedDuration.inMilliseconds / 1000.0,
-          );
+        try {
+          final loadedDuration =
+              sound.isLocalImport && sound.localFilePath != null
+              ? await _audioService.loadAudioFromFile(sound.localFilePath!)
+              : await _audioService.loadAudio(sound.url!);
+          _loadedSoundId = sound.id;
+          // Backfill missing duration so the selection overlay and list
+          // tile can show a correct timestamp for Nostr sounds that don't
+          // carry a duration tag.
+          if (sound.duration == null && loadedDuration != null) {
+            resolvedSound = sound.copyWith(
+              duration: loadedDuration.inMilliseconds / 1000.0,
+            );
+          }
+        } finally {
+          if (mounted) setState(() => _isLoadingAudio = false);
         }
       }
 
@@ -211,6 +214,7 @@ class _AudioSelectionBottomSheetState
           _selectedItem = resolvedSound;
         });
       }
+      if (!mounted) return;
       // Blocks here for the entire duration of playback — only
       // releases once the song finishes playing to the end or was paused.
       await _audioService.play();
@@ -223,7 +227,7 @@ class _AudioSelectionBottomSheetState
     } finally {
       if (_selectedItem == sound) {
         await _audioService.pause();
-        setState(() {});
+        if (mounted) setState(() {});
       }
     }
   }

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -402,6 +402,9 @@ class VineTheme {
   /// Duration of a single skeleton shimmer sweep.
   static const Duration skeletonDuration = Duration(milliseconds: 1500);
 
+  /// Default duration for UI animations and transitions.
+  static const Duration defaultAnimationDuration = Duration(milliseconds: 300);
+
   /// Tab text style using Bricolage Grotesque bold.
   static TextStyle tabTextStyle({Color color = whiteText}) =>
       GoogleFonts.bricolageGrotesque(

--- a/mobile/test/blocs/video_editor/audio_timing/audio_timing_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/audio_timing/audio_timing_cubit_test.dart
@@ -160,9 +160,9 @@ void main() {
         'restores previous offset from sound startOffset',
         build: () => buildCubit(
           sound: _createTestSound(
-            // maxDuration = 6.3s, scrollable = 20 - 6.3 = 13.7s
-            // For offset 0.5: startTime = 0.5 * 13.7 = 6.85s
-            startOffset: const Duration(milliseconds: 6850),
+            // minRemainingAudio = 0.5s, scrollable = 20 - 0.5 = 19.5s
+            // For offset 0.5: startTime = 0.5 * 19.5 = 9.75s
+            startOffset: const Duration(milliseconds: 9750),
           ),
         ),
         act: (cubit) => cubit.initialize(),
@@ -179,12 +179,14 @@ void main() {
       );
 
       blocTest<AudioTimingCubit, AudioTimingState>(
-        'uses offset 0 when audio is shorter than maxDuration',
-        build: () => buildCubit(sound: _createTestSound(duration: 3)),
+        'uses offset 0 when audio is shorter than minRemainingAudio',
+        build: () => buildCubit(
+          sound: _createTestSound(duration: 0.3),
+        ),
         act: (cubit) => cubit.initialize(),
         expect: () => [
           isA<AudioTimingState>()
-              .having((s) => s.audioDuration, 'audioDuration', 3)
+              .having((s) => s.audioDuration, 'audioDuration', 0.3)
               .having((s) => s.startOffset, 'startOffset', 0),
           isA<AudioTimingState>().having(
             (s) => s.isPlaying,
@@ -468,25 +470,27 @@ void main() {
     });
 
     group('calculateStartOffset', () {
-      test('returns Duration.zero when audio is shorter than maxDuration', () {
-        final cubit = buildCubit(sound: _createTestSound(duration: 3));
-        // Simulate initialized state
-        cubit.emit(const AudioTimingState(audioDuration: 3, startOffset: 0.5));
+      test('returns Duration.zero when audio is shorter than minRemaining', () {
+        final cubit = buildCubit(sound: _createTestSound(duration: 0.3));
+        // audioDuration (0.3s) <= minRemainingAudioSecs (0.5s),
+        // so scrollable = 0 → always zero
+        cubit.emit(
+          const AudioTimingState(audioDuration: 0.3, startOffset: 0.5),
+        );
 
-        // Audio (3s) < maxDuration (6.3s), so scrollable = 0 → always zero
         expect(cubit.calculateStartOffset(), equals(Duration.zero));
         cubit.close();
       });
 
       test('returns correct offset for 20s audio at midpoint', () {
         final cubit = buildCubit(sound: _createTestSound());
-        // maxDuration = 6.3s, scrollable = 20 - 6.3 = 13.7s
-        // At offset 0.5: startTime = 0.5 * 13.7 = 6.85s = 6850ms
+        // minRemaining = 0.5s, scrollable = 20 - 0.5 = 19.5s
+        // At offset 0.5: startTime = 0.5 * 19.5 = 9.75s = 9750ms
         cubit.emit(const AudioTimingState(audioDuration: 20, startOffset: 0.5));
 
         expect(
           cubit.calculateStartOffset(),
-          equals(const Duration(milliseconds: 6850)),
+          equals(const Duration(milliseconds: 9750)),
         );
         cubit.close();
       });
@@ -501,15 +505,36 @@ void main() {
 
       test('returns maximum offset at 1.0', () {
         final cubit = buildCubit(sound: _createTestSound());
-        // scrollable = 20 - 6.3 = 13.7s
+        // scrollable = 20 - 0.5 = 19.5s
         cubit.emit(const AudioTimingState(audioDuration: 20, startOffset: 1.0));
 
         expect(
           cubit.calculateStartOffset(),
-          equals(const Duration(milliseconds: 13700)),
+          equals(const Duration(milliseconds: 19500)),
         );
         cubit.close();
       });
+
+      test(
+        'allows start offset past audioDuration - maxDuration '
+        '(short remainder)',
+        () {
+          // 10s audio, video maxDuration = 6.3s.
+          // Old behaviour capped startOffset at 10 - 6.3 = 3.7s.
+          // New behaviour allows up to 10 - 0.5 = 9.5s, leaving 0.5s of
+          // audio playback for the remainder of the video.
+          final cubit = buildCubit(sound: _createTestSound(duration: 10));
+          cubit.emit(
+            const AudioTimingState(audioDuration: 10, startOffset: 1.0),
+          );
+
+          expect(
+            cubit.calculateStartOffset(),
+            equals(const Duration(milliseconds: 9500)),
+          );
+          cubit.close();
+        },
+      );
     });
 
     group('player state changes', () {

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -273,6 +273,52 @@ void main() {
       expect(find.byType(VideoAudioEditorTimingScreen), findsOneWidget);
     });
 
+    testWidgets(
+      'shrinks the selected segment to the remaining audio tail at max offset',
+      (tester) async {
+        tester.view.physicalSize = const Size(800, 1200);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final sound = _createTestAudioEvent(
+          title: 'Tail Track',
+          duration: 10.0,
+        );
+
+        await tester.pumpWidget(buildWidget(sound: sound));
+        await tester.pump();
+
+        await tester.drag(
+          find.byKey(VideoAudioEditorTimingScreen.videoDurationSegmentKey),
+          const Offset(1000, 0),
+        );
+        await tester.pump();
+
+        const screenWidth = 800.0 - 32.0;
+        const expectedTailWidth = screenWidth * (0.5 / 10.0);
+
+        expect(
+          tester
+              .getSize(
+                find.byKey(
+                  VideoAudioEditorTimingScreen.videoDurationSegmentKey,
+                ),
+              )
+              .width,
+          closeTo(expectedTailWidth, 0.1),
+        );
+        expect(
+          tester
+              .getSize(
+                find.byKey(VideoAudioEditorTimingScreen.waveformSelectionKey),
+              )
+              .width,
+          closeTo(expectedTailWidth, 0.1),
+        );
+      },
+    );
+
     testWidgets('has route name and path constants', (tester) async {
       expect(
         VideoAudioEditorTimingScreen.routeName,

--- a/mobile/test/widgets/video_editor/audio_editor/audio_editor_selection_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_editor_selection_overlay_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart';
 import 'package:sound_service/sound_service.dart';
 
@@ -53,6 +54,7 @@ void main() {
       required AudioEvent audio,
       VoidCallback? onTogglePlayState,
       VoidCallback? onTapDone,
+      bool isLoading = false,
     }) {
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -63,6 +65,7 @@ void main() {
             audioService: audioService,
             onTogglePlayState: onTogglePlayState ?? () {},
             onTapDone: onTapDone ?? () {},
+            isLoading: isLoading,
           ),
         ),
       );
@@ -147,6 +150,27 @@ void main() {
 
         expect(done, isTrue);
       });
+
+      testWidgets('disables done while audio is loading', (tester) async {
+        var done = false;
+        await tester.pumpWidget(
+          buildWidget(
+            audio: _createTestAudio(title: 'Track'),
+            onTapDone: () => done = true,
+            isLoading: true,
+          ),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoEditorDoneSemanticLabel),
+          warnIfMissed: false,
+        );
+        await tester.pump();
+
+        expect(done, isFalse);
+      });
     });
 
     group('Playing state', () {
@@ -165,6 +189,24 @@ void main() {
         expect(
           find.bySemanticsLabel(l10n.videoEditorAudioPausePreviewSemanticLabel),
           findsOneWidget,
+        );
+      });
+    });
+
+    group('Loading state', () {
+      testWidgets('shows loading indicator instead of play control', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(audio: _createTestAudio(title: 'Track'), isLoading: true),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(l10n.videoEditorAudioPlayPreviewSemanticLabel),
+          findsNothing,
         );
       });
     });

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -8,6 +8,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/saved_sounds_provider.dart';
@@ -18,6 +19,7 @@ import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_category_bar.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_list_tile.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart';
+import 'package:sound_service/sound_service.dart';
 
 AudioEvent _createTestAudioEvent({
   String id = 'test-sound-id',
@@ -42,6 +44,8 @@ AudioEvent _createTestAudioEvent({
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
+class _MockAudioPlaybackService extends Mock implements AudioPlaybackService {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -60,6 +64,7 @@ void main() {
       AsyncValue<List<AudioEvent>>? trendingSoundsAsync,
       List<AudioEvent> savedSounds = const [],
       List<VineSound> bundledSounds = const [],
+      AudioPlaybackService? audioService,
     }) {
       return ProviderScope(
         overrides: [
@@ -78,7 +83,10 @@ void main() {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: AudioSelectionBottomSheet(scrollController: scrollController),
+            body: AudioSelectionBottomSheet(
+              scrollController: scrollController,
+              audioService: audioService,
+            ),
           ),
         ),
       );
@@ -220,6 +228,63 @@ void main() {
         await tester.pump(const Duration(milliseconds: 500));
 
         expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+      });
+
+      testWidgets('shows selected-audio loading before stop completes', (
+        tester,
+      ) async {
+        final audioService = _MockAudioPlaybackService();
+        final stopCompleter = Completer<void>();
+        final sound = _createTestAudioEvent(title: 'Slow Load');
+        Future<void> completeImmediately(Invocation _) => Future<void>.value();
+        Future<Duration> loadDuration(Invocation _) =>
+            Future.value(const Duration(seconds: 5));
+        Future<void> waitForStop(Invocation _) => stopCompleter.future;
+
+        when(() => audioService.isPlaying).thenReturn(false);
+        when(
+          () => audioService.playingStream,
+        ).thenAnswer((_) => const Stream<bool>.empty());
+        when(
+          () => audioService.durationStream,
+        ).thenAnswer((_) => const Stream<Duration?>.empty());
+        when(
+          () => audioService.positionStream,
+        ).thenAnswer((_) => const Stream<Duration>.empty());
+        when(() => audioService.duration).thenReturn(null);
+        when(
+          () => audioService.seek(Duration.zero),
+        ).thenAnswer(completeImmediately);
+        when(audioService.stop).thenAnswer(waitForStop);
+        when(
+          () => audioService.loadAudio(sound.url!),
+        ).thenAnswer(loadDuration);
+        when(audioService.play).thenAnswer(completeImmediately);
+        when(audioService.pause).thenAnswer(completeImmediately);
+        when(audioService.dispose).thenAnswer(completeImmediately);
+
+        await tester.pumpWidget(
+          buildWidget(
+            trendingSoundsAsync: AsyncValue.data([sound]),
+            audioService: audioService,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Slow Load'));
+        await tester.pump();
+
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        verifyNever(() => audioService.loadAudio(sound.url!));
+
+        stopCompleter.complete();
+        await tester.pumpAndSettle();
+
+        verify(() => audioService.loadAudio(sound.url!)).called(1);
       });
     });
 


### PR DESCRIPTION
## Description

Fixes a bug where users could not select a custom audio start time for community sounds in the video editor.

The root cause was that `AudioTimingCubit` required the remaining audio (from the chosen start offset to the end of the source) to be at least as long as the video's maximum duration (6.3 s). This made most of the waveform non-draggable — any start position that left less than 6.3 s of tail audio was rejected, effectively locking the start time to the very beginning.

The fix introduces `minRemainingAudioSecs = 0.5` so users can scroll the waveform all the way to within 0.5 s of the audio's end. The visible segment indicator on the timeline is also clamped to the actual playable clip length so it shrinks visually as the user approaches the end of the source audio.

## Type of Change

- [x] Bug fix

## Changes

- **`AudioTimingCubit`** — added `static const double minRemainingAudioSecs = 0.5`; `_scrollableAudioSecs` and `initialize()` now use this constant instead of implicitly requiring a full-video-length tail
- **`VideoAudioEditorTimingScreen`** — `_VideoDurationTimeline` now clamps the segment indicator width so it reflects the actual playable clip rather than always showing a full-width bar near the end of the waveform
- **`AudioEditorSelectionOverlay`** — replaced inline `Duration(milliseconds: 300)` with `VineTheme.defaultAnimationDuration`
- **`AudioSelectionBottomSheet`** — added `isLoading` state while audio loads, preventing interaction with a not-yet-ready audio service

## Testing

- Updated `audio_timing_cubit_test.dart` — all 32 tests pass
- `flutter analyze` reports no issues

Closes #4753