### PR TITLE
feat(router): unified async VideoEvent resolver and :videoId path for /video-edit (#4390)

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -29,6 +29,7 @@ import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/subscribed_list_video_cache.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/services/video_event_resolver.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_filter_builder.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
@@ -250,6 +251,23 @@ VideoSharingService? videoSharingService(Ref ref) {
     authService: authService,
     profileRepository: profileRepository,
     dmRepository: dmRepository,
+  );
+}
+
+/// Unified resolver for fetching a [VideoEvent] by its event id, with
+/// in-memory → personal cache → relay fallback. See [VideoEventResolver].
+@Riverpod(keepAlive: true)
+VideoEventResolver videoEventResolver(Ref ref) {
+  final nostrService = ref.watch(nostrServiceProvider);
+  final videoEventService = ref.watch(videoEventServiceProvider);
+  final personalEventCache = ref.watch(personalEventCacheServiceProvider);
+  final authService = ref.watch(authServiceProvider);
+
+  return VideoEventResolver(
+    videoEventService: videoEventService,
+    personalEventCache: personalEventCache,
+    subscribe: nostrService.subscribe,
+    viewerPubkeyHex: () => authService.currentPublicKeyHex,
   );
 }
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -557,6 +557,62 @@ final class VideoSharingServiceProvider
 String _$videoSharingServiceHash() =>
     r'c67ca5b381903ab2a6d29bc2f64e057661279598';
 
+/// Unified resolver for fetching a [VideoEvent] by its event id, with
+/// in-memory → personal cache → relay fallback. See [VideoEventResolver].
+
+@ProviderFor(videoEventResolver)
+const videoEventResolverProvider = VideoEventResolverProvider._();
+
+/// Unified resolver for fetching a [VideoEvent] by its event id, with
+/// in-memory → personal cache → relay fallback. See [VideoEventResolver].
+
+final class VideoEventResolverProvider
+    extends
+        $FunctionalProvider<
+          VideoEventResolver,
+          VideoEventResolver,
+          VideoEventResolver
+        >
+    with $Provider<VideoEventResolver> {
+  /// Unified resolver for fetching a [VideoEvent] by its event id, with
+  /// in-memory → personal cache → relay fallback. See [VideoEventResolver].
+  const VideoEventResolverProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'videoEventResolverProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$videoEventResolverHash();
+
+  @$internal
+  @override
+  $ProviderElement<VideoEventResolver> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  VideoEventResolver create(Ref ref) {
+    return videoEventResolver(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VideoEventResolver value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VideoEventResolver>(value),
+    );
+  }
+}
+
+String _$videoEventResolverHash() =>
+    r'a076181f7238f6f3cb91443d714872abb5805ee0';
+
 /// Service that orchestrates the video-metadata-edit republish flow.
 
 @ProviderFor(videoMetadataUpdateService)

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -1096,16 +1096,18 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (_, st) => const VideoMetadataScreen(),
       ),
       GoRoute(
-        path: VideoMetadataEditScreen.path,
+        path: '${VideoMetadataEditScreen.path}/:videoId',
         name: VideoMetadataEditScreen.routeName,
         builder: (ctx, st) {
-          // TODO(#4390): Replace this extra-only route with an ID-based resolver
-          // so /video-edit can be reconstructed from URL state.
-          final video = st.extra as VideoEvent?;
-          if (video == null) {
+          final videoId = st.pathParameters['videoId'];
+          if (videoId == null || videoId.isEmpty) {
             return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
           }
-          return VideoMetadataEditScreen(video: video);
+          final prefetched = st.extra as VideoEvent?;
+          return VideoMetadataEditScreen(
+            videoId: videoId,
+            prefetched: prefetched,
+          );
         },
       ),
       GoRoute(

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -278,6 +278,10 @@ RouteContext parseRoute(String path) {
       return const RouteContext(type: RouteType.videoMetadata);
 
     case 'video-edit':
+      if (segments.length > 1) {
+        final videoId = _safeDecode(segments[1]);
+        return RouteContext(type: RouteType.videoEdit, videoId: videoId);
+      }
       return const RouteContext(type: RouteType.videoEdit);
 
     case 'settings':
@@ -536,6 +540,9 @@ String buildRoute(RouteContext context) {
       return VideoMetadataScreen.path;
 
     case RouteType.videoEdit:
+      if (context.videoId != null) {
+        return VideoMetadataEditScreen.pathFor(context.videoId!);
+      }
       return VideoMetadataEditScreen.path;
 
     case RouteType.settings:

--- a/mobile/lib/screens/video_metadata/video_metadata_edit_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_edit_screen.dart
@@ -1,27 +1,93 @@
 // ABOUTME: Screen wrapper for the full-screen video metadata edit flow.
+// ABOUTME: Resolves the VideoEvent by id (with optional prefetched fast-path).
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/router/route_error_screen.dart';
 import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart';
 
 /// Screen entry-point for editing an already-published [VideoEvent].
 ///
-/// TODO(#4390): Switch this route to an ID-based resolver so it can be
-/// deep-linked and restored without relying on GoRouter [extra].
+/// The screen is keyed on a [videoId] so the route is deep-linkable. When a
+/// [prefetched] [VideoEvent] is available (e.g. from a feed-side tap), it is
+/// used immediately as a fast path; otherwise the screen resolves the id via
+/// the [videoEventResolverProvider] (in-memory → personal cache → relay).
 ///
-/// Navigate to this screen by pushing [path] with [extra] set to the
-/// [VideoEvent] to edit:
+/// Navigate to this screen with [pathFor]:
 /// ```dart
-/// context.push(VideoMetadataEditScreen.path, extra: video);
+/// context.push(
+///   VideoMetadataEditScreen.pathFor(video.id),
+///   extra: video, // optional fast-path
+/// );
 /// ```
-class VideoMetadataEditScreen extends StatelessWidget {
+class VideoMetadataEditScreen extends ConsumerStatefulWidget {
   static const routeName = 'video-edit';
   static const path = '/video-edit';
 
-  const VideoMetadataEditScreen({required this.video, super.key});
+  /// Build a concrete `/video-edit/:videoId` path for [videoId].
+  static String pathFor(String videoId) =>
+      '$path/${Uri.encodeComponent(videoId)}';
 
-  final VideoEvent video;
+  const VideoMetadataEditScreen({
+    required this.videoId,
+    this.prefetched,
+    super.key,
+  });
+
+  final String videoId;
+  final VideoEvent? prefetched;
 
   @override
-  Widget build(BuildContext context) => VideoMetadataEditStack(video: video);
+  ConsumerState<VideoMetadataEditScreen> createState() =>
+      _VideoMetadataEditScreenState();
+}
+
+class _VideoMetadataEditScreenState
+    extends ConsumerState<VideoMetadataEditScreen> {
+  VideoEvent? _resolved;
+  bool _resolveFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.prefetched != null && widget.prefetched!.id == widget.videoId) {
+      _resolved = widget.prefetched;
+    } else {
+      _resolve();
+    }
+  }
+
+  Future<void> _resolve() async {
+    final resolver = ref.read(videoEventResolverProvider);
+    final video = await resolver.resolveById(
+      widget.videoId,
+      allowOwnContentBypass: true,
+    );
+    if (!mounted) return;
+    setState(() {
+      _resolved = video;
+      _resolveFailed = video == null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final resolved = _resolved;
+    if (resolved != null) {
+      return VideoMetadataEditStack(video: resolved);
+    }
+    if (_resolveFailed) {
+      return RouteErrorScreen(message: context.l10n.routeInvalidVideoId);
+    }
+    return const Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      body: Center(
+        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+      ),
+    );
+  }
 }

--- a/mobile/lib/services/video_event_resolver.dart
+++ b/mobile/lib/services/video_event_resolver.dart
@@ -1,0 +1,161 @@
+// ABOUTME: Unified async resolver for fetching a VideoEvent by event id.
+// ABOUTME: Tries in-memory VideoEventService, then personal Hive cache, then relay.
+
+import 'dart:async';
+
+import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Callback to subscribe to Nostr events.
+typedef NostrSubscribeById = Stream<Event> Function(List<Filter> filters);
+
+/// Resolves a [VideoEvent] for a given event id, with a layered fallback:
+///
+/// 1. In-memory feeds via [VideoEventService.getVideoEventById]
+/// 2. Personal Hive cache via [PersonalEventCacheService.getEventById]
+/// 3. Relay fetch via [Filter.ids]
+///
+/// When [allowOwnContentBypass] is true and the resolved video's author
+/// matches [viewerPubkeyHex], the Divine-hosted-only hide filter is bypassed
+/// so the owner can always reach their own content (e.g. for editing).
+///
+/// See `tasks/issues/4390-unified-video-resolver.md` and issue #4390.
+class VideoEventResolver {
+  VideoEventResolver({
+    required VideoEventService videoEventService,
+    required PersonalEventCacheService personalEventCache,
+    required NostrSubscribeById subscribe,
+    required String? Function() viewerPubkeyHex,
+  }) : _videoEventService = videoEventService,
+       _personalEventCache = personalEventCache,
+       _subscribe = subscribe,
+       _viewerPubkeyHex = viewerPubkeyHex;
+
+  final VideoEventService _videoEventService;
+  final PersonalEventCacheService _personalEventCache;
+  final NostrSubscribeById _subscribe;
+  final String? Function() _viewerPubkeyHex;
+
+  static const _logName = 'VideoEventResolver';
+
+  /// Resolve a [VideoEvent] by its event id.
+  ///
+  /// Returns null if the id cannot be resolved within [timeout].
+  Future<VideoEvent?> resolveById(
+    String eventId, {
+    bool allowOwnContentBypass = false,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    if (eventId.isEmpty) return null;
+
+    // 1) In-memory feeds.
+    final cached = _videoEventService.getVideoEventById(eventId);
+    if (cached != null && _passesFilter(cached, allowOwnContentBypass)) {
+      return cached;
+    }
+
+    // 2) Personal Hive cache.
+    final cachedEvent = _personalEventCache.getEventById(eventId);
+    if (cachedEvent != null) {
+      final parsed = _tryParse(cachedEvent);
+      if (parsed != null && _passesFilter(parsed, allowOwnContentBypass)) {
+        return parsed;
+      }
+    }
+
+    // 3) Relay fetch.
+    try {
+      final fetched = await _fetchFromRelay(eventId, timeout);
+      if (fetched != null && _passesFilter(fetched, allowOwnContentBypass)) {
+        return fetched;
+      }
+    } catch (e, st) {
+      Log.error(
+        'Relay fetch failed for $eventId: $e',
+        name: _logName,
+        category: LogCategory.video,
+        error: e,
+        stackTrace: st,
+      );
+    }
+
+    return null;
+  }
+
+  bool _passesFilter(VideoEvent video, bool allowOwnContentBypass) {
+    if (allowOwnContentBypass) {
+      final viewer = _viewerPubkeyHex();
+      if (viewer != null && viewer == video.pubkey) {
+        return true;
+      }
+    }
+    return !_videoEventService.shouldHideVideo(video);
+  }
+
+  VideoEvent? _tryParse(Event event) {
+    if (!NIP71VideoKinds.isAcceptableVideoKind(event.kind)) {
+      return null;
+    }
+    try {
+      return VideoEvent.fromNostrEvent(event, permissive: true);
+    } catch (e) {
+      Log.warning(
+        'Failed to parse cached event ${event.id} as VideoEvent: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+
+  Future<VideoEvent?> _fetchFromRelay(String eventId, Duration timeout) async {
+    final filter = Filter(ids: [eventId]);
+    final completer = Completer<VideoEvent?>();
+
+    late StreamSubscription<Event> subscription;
+    subscription = _subscribe([filter]).listen(
+      (event) {
+        final parsed = _tryParse(event);
+        if (parsed == null) return;
+        if (!completer.isCompleted) {
+          completer.complete(parsed);
+        }
+        unawaited(subscription.cancel());
+      },
+      onError: (Object error) {
+        Log.error(
+          'Relay error fetching $eventId: $error',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        if (!completer.isCompleted) {
+          completer.complete(null);
+        }
+        unawaited(subscription.cancel());
+      },
+      onDone: () {
+        if (!completer.isCompleted) {
+          completer.complete(null);
+        }
+      },
+    );
+
+    return completer.future.timeout(
+      timeout,
+      onTimeout: () {
+        Log.warning(
+          'Timed out resolving event $eventId after ${timeout.inSeconds}s',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        unawaited(subscription.cancel());
+        return null;
+      },
+    );
+  }
+}

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -932,7 +932,10 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
   );
 
   void _showEditDialog() {
-    context.push(VideoMetadataEditScreen.path, extra: widget.video);
+    context.push(
+      VideoMetadataEditScreen.pathFor(widget.video.id),
+      extra: widget.video,
+    );
   }
 
   /// Show delete confirmation dialog
@@ -1462,7 +1465,7 @@ class _CreateBookmarkSetDialogState
 
 /// Public helper to show the edit screen for a video from anywhere.
 void showEditDialogForVideo(BuildContext context, VideoEvent video) {
-  context.push(VideoMetadataEditScreen.path, extra: video);
+  context.push(VideoMetadataEditScreen.pathFor(video.id), extra: video);
 }
 
 /// Action tile for "Use this sound" feature.

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -393,6 +393,13 @@ void main() {
         final context = parseRoute('/video-edit');
         expect(context.type, RouteType.videoEdit);
       });
+      test('/video-edit/:videoId parses videoId', () {
+        final context = parseRoute(
+          VideoMetadataEditScreen.pathFor('test-id-abc'),
+        );
+        expect(context.type, RouteType.videoEdit);
+        expect(context.videoId, 'test-id-abc');
+      });
     });
 
     group('Edge cases', () {
@@ -454,7 +461,7 @@ void main() {
       'settings': SettingsScreen.path,
       'badges': BadgesScreen.path,
       'relay settings': RelaySettingsScreen.path,
-      'video edit': VideoMetadataEditScreen.path,
+      'video edit': VideoMetadataEditScreen.pathFor('test-id-abc'),
       'invites': InvitesScreen.path,
       'people list create': CreatePeopleListPage.path,
       'people list members': '/people-lists/list%3A123',
@@ -490,7 +497,7 @@ void main() {
         RouteType.videoRecorder: VideoRecorderScreen.path,
         RouteType.videoEditor: VideoEditorScreen.path,
         RouteType.videoMetadata: VideoMetadataScreen.path,
-        RouteType.videoEdit: VideoMetadataEditScreen.path,
+        RouteType.videoEdit: VideoMetadataEditScreen.pathFor('test-id-abc'),
         RouteType.importKey: KeyImportScreen.path,
         RouteType.invites: InvitesScreen.path,
         RouteType.badges: BadgesScreen.path,

--- a/mobile/test/services/video_event_resolver_test.dart
+++ b/mobile/test/services/video_event_resolver_test.dart
@@ -113,21 +113,23 @@ void main() {
       expect(result, isNull);
     });
 
-    test('owner bypass returns video even when shouldHideVideo is true',
-        () async {
-      final video = _videoEvent(id: eventId, pubkey: ownerPubkey);
-      when(() => videoService.getVideoEventById(eventId)).thenReturn(video);
-      when(() => videoService.shouldHideVideo(video)).thenReturn(true);
-      viewerPubkey = ownerPubkey;
+    test(
+      'owner bypass returns video even when shouldHideVideo is true',
+      () async {
+        final video = _videoEvent(id: eventId, pubkey: ownerPubkey);
+        when(() => videoService.getVideoEventById(eventId)).thenReturn(video);
+        when(() => videoService.shouldHideVideo(video)).thenReturn(true);
+        viewerPubkey = ownerPubkey;
 
-      final resolver = build(subscribe: (_) => const Stream.empty());
-      final result = await resolver.resolveById(
-        eventId,
-        allowOwnContentBypass: true,
-      );
+        final resolver = build(subscribe: (_) => const Stream.empty());
+        final result = await resolver.resolveById(
+          eventId,
+          allowOwnContentBypass: true,
+        );
 
-      expect(result, same(video));
-    });
+        expect(result, same(video));
+      },
+    );
 
     test('without bypass, hidden video resolves to null', () async {
       final video = _videoEvent(id: eventId, pubkey: ownerPubkey);

--- a/mobile/test/services/video_event_resolver_test.dart
+++ b/mobile/test/services/video_event_resolver_test.dart
@@ -1,0 +1,191 @@
+// ABOUTME: Tests for VideoEventResolver - layered video event resolution.
+// ABOUTME: Covers in-memory, personal cache, relay fetch, and own-content bypass.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/video_event_resolver.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeVideoEvent());
+  });
+
+  group('VideoEventResolver', () {
+    const ownerPubkey = 'owner-pubkey';
+    const otherPubkey = 'other-pubkey';
+    const eventId = 'video-event-id-1';
+
+    late _MockVideoEventService videoService;
+    late _MockPersonalEventCacheService cache;
+    late StreamController<Event> relayController;
+    String? viewerPubkey;
+
+    VideoEventResolver build({
+      Stream<Event> Function(List<Filter>)? subscribe,
+    }) {
+      return VideoEventResolver(
+        videoEventService: videoService,
+        personalEventCache: cache,
+        subscribe: subscribe ?? (_) => relayController.stream,
+        viewerPubkeyHex: () => viewerPubkey,
+      );
+    }
+
+    setUp(() {
+      videoService = _MockVideoEventService();
+      cache = _MockPersonalEventCacheService();
+      relayController = StreamController<Event>.broadcast();
+      viewerPubkey = null;
+
+      // Default stubs: nothing found, nothing hidden.
+      when(() => videoService.getVideoEventById(any())).thenReturn(null);
+      when(() => videoService.shouldHideVideo(any())).thenReturn(false);
+      when(() => cache.getEventById(any())).thenReturn(null);
+    });
+
+    tearDown(() async {
+      await relayController.close();
+    });
+
+    test('returns in-memory hit without touching cache or relay', () async {
+      final video = _videoEvent(id: eventId, pubkey: otherPubkey);
+      when(() => videoService.getVideoEventById(eventId)).thenReturn(video);
+
+      final resolver = build(subscribe: (_) => const Stream.empty());
+      final result = await resolver.resolveById(eventId);
+
+      expect(result, same(video));
+      verifyNever(() => cache.getEventById(any()));
+    });
+
+    test('returns personal cache hit when in-memory misses', () async {
+      final event = _kind34236Event(id: eventId, pubkey: otherPubkey);
+      when(() => cache.getEventById(eventId)).thenReturn(event);
+
+      final resolver = build(subscribe: (_) => const Stream.empty());
+      final result = await resolver.resolveById(eventId);
+
+      expect(result, isNotNull);
+      expect(result!.id, eventId);
+      expect(result.pubkey, otherPubkey);
+    });
+
+    test('fetches from relay when nothing cached', () async {
+      final event = _kind34236Event(id: eventId, pubkey: otherPubkey);
+      final resolver = build();
+
+      final future = resolver.resolveById(eventId);
+      relayController.add(event);
+
+      final result = await future;
+      expect(result, isNotNull);
+      expect(result!.id, eventId);
+    });
+
+    test('returns null when relay closes without an event', () async {
+      final resolver = build();
+      final future = resolver.resolveById(eventId);
+      await relayController.close();
+
+      expect(await future, isNull);
+    });
+
+    test('returns null on relay timeout', () async {
+      final resolver = build();
+      final result = await resolver.resolveById(
+        eventId,
+        timeout: const Duration(milliseconds: 50),
+      );
+      expect(result, isNull);
+    });
+
+    test('owner bypass returns video even when shouldHideVideo is true',
+        () async {
+      final video = _videoEvent(id: eventId, pubkey: ownerPubkey);
+      when(() => videoService.getVideoEventById(eventId)).thenReturn(video);
+      when(() => videoService.shouldHideVideo(video)).thenReturn(true);
+      viewerPubkey = ownerPubkey;
+
+      final resolver = build(subscribe: (_) => const Stream.empty());
+      final result = await resolver.resolveById(
+        eventId,
+        allowOwnContentBypass: true,
+      );
+
+      expect(result, same(video));
+    });
+
+    test('without bypass, hidden video resolves to null', () async {
+      final video = _videoEvent(id: eventId, pubkey: ownerPubkey);
+      when(() => videoService.getVideoEventById(eventId)).thenReturn(video);
+      when(() => videoService.shouldHideVideo(video)).thenReturn(true);
+      viewerPubkey = ownerPubkey;
+
+      final resolver = build(subscribe: (_) => const Stream.empty());
+      final result = await resolver.resolveById(eventId);
+
+      expect(result, isNull);
+    });
+
+    test('bypass does not apply when viewer is not the author', () async {
+      final video = _videoEvent(id: eventId, pubkey: ownerPubkey);
+      when(() => videoService.getVideoEventById(eventId)).thenReturn(video);
+      when(() => videoService.shouldHideVideo(video)).thenReturn(true);
+      viewerPubkey = otherPubkey;
+
+      final resolver = build(subscribe: (_) => const Stream.empty());
+      final result = await resolver.resolveById(
+        eventId,
+        allowOwnContentBypass: true,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('returns null for empty id', () async {
+      final resolver = build(subscribe: (_) => const Stream.empty());
+      expect(await resolver.resolveById(''), isNull);
+      verifyNever(() => videoService.getVideoEventById(any()));
+    });
+  });
+}
+
+VideoEvent _videoEvent({required String id, required String pubkey}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: 1700000000,
+    content: 'content',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+    videoUrl: 'https://example.com/video.mp4',
+  );
+}
+
+Event _kind34236Event({required String id, required String pubkey}) {
+  return Event.fromJson({
+    'id': id,
+    'pubkey': pubkey,
+    'created_at': 1700000000,
+    'kind': 34236,
+    'tags': [
+      ['d', 'd-tag-$id'],
+      ['url', 'https://example.com/video.mp4'],
+    ],
+    'content': 'content',
+    'sig': 'signature',
+  });
+}


### PR DESCRIPTION
Closes #4390

## Summary

Introduces a unified async `VideoEvent` resolver and migrates `/video-edit` to a path-parameter route (`/video-edit/:videoId`), so the metadata edit screen is reachable from deep links, refreshes, and shares — not only from in-memory feed state.

## Changes

### New: `VideoEventResolver` service
- `mobile/lib/services/video_event_resolver.dart` — layered lookup:
  1. `VideoEventService.getVideoEventById` (in-memory feed cache)
  2. `PersonalEventCacheService.getEventById` → `VideoEvent.fromNostrEvent(e, permissive: true)`
  3. Relay query via `NostrClient.subscribe([Filter(ids: [id])])` with `Completer` + timeout
- Honors `ContentModeration.shouldHideVideo`, with `allowOwnContentBypass` so the owner can always edit their own (even hidden) videos.
- Exposed via `videoEventResolverProvider` (`@Riverpod(keepAlive: true)`).

### Route migration
- `/video-edit` → `/video-edit/:videoId` (TypedGoRoute path param). Missing id renders `RouteErrorScreen`.
- `VideoMetadataEditScreen` is now a `ConsumerStatefulWidget` driven by `widget.videoId` with optional `widget.prefetched` fast-path.
- New `VideoMetadataEditScreen.pathFor(String videoId)` helper for safe URL construction.
- `PageContextProvider` parses the second path segment as `videoId` and `buildRoute` emits the full path including the id.
- `share_video_menu` callsites updated to push `pathFor(video.id)` with a prefetched `extra`.

### Tests
- `mobile/test/services/video_event_resolver_test.dart` — 9 tests, all green: in-memory hit, personal cache hit, relay success, relay onDone null, timeout null, owner bypass returns hidden video, no-bypass hides, non-owner bypass null, empty id short-circuits.
- `mobile/test/router/route_coverage_test.dart` updated for the `:videoId` segment and round-trip.

## Verification

- `dart run build_runner build --delete-conflicting-outputs` ✅
- `dart format` ✅
- `flutter analyze lib test integration_test` ✅ (`No issues found!`)
- Resolver tests 9/9, route coverage 83/83 ✅
