### PR TITLE
ci(architecture): ratchet sanctioned ChangeNotifiers (#4738)

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -42,6 +42,8 @@ jobs:
         run: bash scripts/check_raw_logging.sh
       - name: 🚧 Verify Riverpod boundary (@riverpod / StateProvider locations)
         run: bash scripts/check_riverpod_boundary.sh
+      - name: 🚧 Verify ChangeNotifier boundary (sanctioned-allowlist ratchet)
+        run: bash scripts/check_changenotifier_boundary.sh
       - name: 🚧 Verify UI does not import services directly (layering ratchet)
         run: |
           # Provide origin/main so the ratchet can compare the baseline against

--- a/docs/BLOC_UI_MIGRATION_PRD.md
+++ b/docs/BLOC_UI_MIGRATION_PRD.md
@@ -74,6 +74,14 @@ The "ChangeNotifier count trends down" outcome of #4744 is delivered by the
 #4738 ratchet (no new ones land) and by #4338 Track D (god-object removal) —
 **not** by migrating any file in this table.
 
+**Guard scope.** `check_changenotifier_boundary.sh` matches both
+`extends ChangeNotifier` and the `with … ChangeNotifier` mixin form, so the
+boundary can't be sidestepped with mixin syntax. It scans `mobile/lib/` only —
+`mobile/packages/**` is intentionally out of scope: the standalone pub packages
+(e.g. `pooled_video_player`, `hls_auth_web_player`) own their own architecture
+and are not part of #4744's app-UI-state lane. This mirrors
+`check_riverpod_boundary.sh`, which also scans `mobile/lib/` only.
+
 ## Allowed / Disallowed Patterns
 
 | Pattern | Verdict | Notes |
@@ -123,7 +131,7 @@ currently disabled by an rxdart version conflict, so enforcement is shell-based.
 | Guard | Enforces | Model |
 |-------|----------|-------|
 | `check_riverpod_boundary.sh` | No new `@riverpod` / `StateProvider` for UI state outside allowed provider dirs | Zero-tolerance (directory exclusion) |
-| `check_changenotifier_boundary.sh` | No new `extends ChangeNotifier` outside the file allowlist (the "Sanctioned Riverpod (STAYS)" list above) | Zero-tolerance (file allowlist). Adding a new sanctioned ChangeNotifier requires extending both the docs table and the script's allowlist together. |
+| `check_changenotifier_boundary.sh` | No new `extends ChangeNotifier` or `with … ChangeNotifier` mixin form in `lib/` outside the file allowlist (the "Sanctioned Riverpod (STAYS)" list above); `packages/**` out of scope | Zero-tolerance (file allowlist). Adding a new sanctioned ChangeNotifier requires extending both the docs table and the script's allowlist together. |
 | `check_ui_service_boundary.sh` | UI files under `mobile/lib/**/{screens,widgets,view,views}/**` must not import a service (`package:openvine/services/` or relative `../services/`, either quote style) — reach data through a BLoC/Cubit | **True ratchet vs `origin/main`**: NEW (undeclared), STALE (fixed but still baselined), and GROWTH (baseline grew vs `origin/main`) all fail; baseline may only shrink |
 
 **Working with the UI→service ratchet.** Pre-existing violators are frozen in

--- a/docs/BLOC_UI_MIGRATION_PRD.md
+++ b/docs/BLOC_UI_MIGRATION_PRD.md
@@ -41,6 +41,39 @@ BLoC/Cubit **owns**:
 - All UI side effects (navigation triggers, snackbar signals, dialog sequencing)
 - All loading/error/success state managed by a screen or feature
 
+## Sanctioned Riverpod (STAYS — not migration targets)
+
+The following files are **DI / infrastructure**, not feature UI state, and are
+out of scope for the #4744 Riverpod → BLoC migration. They are baselined by the
+`check_changenotifier_boundary.sh` ratchet (#4738) so the list cannot silently
+regrow.
+
+**Inclusion criterion:** the file owns infrastructure / a service / a cache /
+router-plumbing / preferences; it holds **0 feature UI state**. Migrating it to
+a UI BLoC would be the wrong layer.
+
+| File | Role |
+|------|------|
+| `lib/providers/individual_video_providers.dart` | Native `VideoPlayerController` lifecycle + fallback/retry/caching (`DisposedControllersTracker extends ChangeNotifier`). |
+| `lib/features/feature_flags/services/feature_flag_service.dart` | Feature-flag service. |
+| `lib/router/app_router.dart` | `_StreamListenable extends ChangeNotifier` — GoRouter `refreshListenable` adapter. |
+| `lib/services/connection_status_service.dart` | Connectivity monitor. |
+| `lib/services/content_filter_service.dart` | Adult-content / category filters. |
+| `lib/services/curated_list_service.dart` | NIP-51 curated lists. |
+| `lib/services/divine_host_filter_service.dart` | Divine-hosted-only filter preference. |
+| `lib/services/environment_service.dart` | Build environment (dev/staging/prod). |
+| `lib/services/feed_aspect_ratio_preference_service.dart` | Feed aspect-ratio preference. |
+| `lib/services/nip05_verification_service.dart` | NIP-05 verification cache. |
+| `lib/services/og_viner_cache_service.dart` | OG Vine cache. |
+| `lib/services/pending_action_service.dart` | Offline action queue. |
+| `lib/services/relay_statistics_service.dart` | Per-relay stats counters. |
+| `lib/services/subscribed_list_video_cache.dart` | Subscribed-list video cache. |
+| `lib/services/video_event_service.dart` | Video-event god-object cache. **Dissolved separately by #4338 Track D**, not by #4744. |
+
+The "ChangeNotifier count trends down" outcome of #4744 is delivered by the
+#4738 ratchet (no new ones land) and by #4338 Track D (god-object removal) —
+**not** by migrating any file in this table.
+
 ## Allowed / Disallowed Patterns
 
 | Pattern | Verdict | Notes |
@@ -90,6 +123,7 @@ currently disabled by an rxdart version conflict, so enforcement is shell-based.
 | Guard | Enforces | Model |
 |-------|----------|-------|
 | `check_riverpod_boundary.sh` | No new `@riverpod` / `StateProvider` for UI state outside allowed provider dirs | Zero-tolerance (directory exclusion) |
+| `check_changenotifier_boundary.sh` | No new `extends ChangeNotifier` outside the file allowlist (the "Sanctioned Riverpod (STAYS)" list above) | Zero-tolerance (file allowlist). Adding a new sanctioned ChangeNotifier requires extending both the docs table and the script's allowlist together. |
 | `check_ui_service_boundary.sh` | UI files under `mobile/lib/**/{screens,widgets,view,views}/**` must not import a service (`package:openvine/services/` or relative `../services/`, either quote style) — reach data through a BLoC/Cubit | **True ratchet vs `origin/main`**: NEW (undeclared), STALE (fixed but still baselined), and GROWTH (baseline grew vs `origin/main`) all fail; baseline may only shrink |
 
 **Working with the UI→service ratchet.** Pre-existing violators are frozen in

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -35,8 +35,11 @@ typedef OnListSubscribedCallback =
 /// Called with listId when a list is unsubscribed
 typedef OnListUnsubscribedCallback = void Function(String listId);
 
-/// Service for managing NIP-51 curated lists
-/// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
+/// Service for managing NIP-51 curated lists.
+///
+/// Sanctioned ChangeNotifier per the "Sanctioned Riverpod (STAYS)" list in
+/// `docs/BLOC_UI_MIGRATION_PRD.md` — this is a Nostr-list cache + sync service,
+/// not feature UI state, and is baselined by `check_changenotifier_boundary.sh`.
 class CuratedListService extends ChangeNotifier {
   CuratedListService({
     required NostrClient nostrService,

--- a/mobile/scripts/check_changenotifier_boundary.sh
+++ b/mobile/scripts/check_changenotifier_boundary.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Fails CI if a new `extends ChangeNotifier` appears in mobile/lib/ outside
+# the sanctioned allowlist.
+#
+# Rule enforced:
+#   * No `extends ChangeNotifier` in mobile/lib/ outside the file allowlist
+#     below. Adding a new sanctioned ChangeNotifier requires editing both
+#     this script's ALLOWLIST and the "Sanctioned Riverpod (STAYS)" table
+#     in docs/BLOC_UI_MIGRATION_PRD.md in the same PR.
+#
+# Background:
+#   Divine is mid-migration from Riverpod / ChangeNotifier to BLoC/Cubit for
+#   UI state. The "Sanctioned Riverpod (STAYS)" section in
+#   docs/BLOC_UI_MIGRATION_PRD.md enumerates the files that hold infrastructure
+#   (DI / services / caches / router plumbing) and are out of scope for
+#   #4744's Riverpod → BLoC lane. This guard prevents the carve-out from
+#   silently regrowing — every new UI-state ChangeNotifier in mobile/lib/
+#   must be migrated to a Cubit, not added here.
+#
+# Allowlist policy:
+#   * Files in ALLOWLIST below must hold ZERO feature UI state — they own
+#     infrastructure, a service, a cache, router plumbing, or preferences.
+#   * Adding a file to ALLOWLIST is reviewed against that criterion and must
+#     come with a matching docs table entry.
+#
+# Usage:
+#   bash mobile/scripts/check_changenotifier_boundary.sh
+#   (run from the repository root or from mobile/)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Allowlist — paths are relative to mobile/lib/. Keep in sync with the
+# "Sanctioned Riverpod (STAYS)" table in docs/BLOC_UI_MIGRATION_PRD.md.
+# ---------------------------------------------------------------------------
+
+ALLOWLIST=(
+  "providers/individual_video_providers.dart"
+  "features/feature_flags/services/feature_flag_service.dart"
+  "router/app_router.dart"
+  "services/connection_status_service.dart"
+  "services/content_filter_service.dart"
+  "services/curated_list_service.dart"
+  "services/divine_host_filter_service.dart"
+  "services/environment_service.dart"
+  "services/feed_aspect_ratio_preference_service.dart"
+  "services/nip05_verification_service.dart"
+  "services/og_viner_cache_service.dart"
+  "services/pending_action_service.dart"
+  "services/relay_statistics_service.dart"
+  "services/subscribed_list_video_cache.dart"
+  "services/video_event_service.dart"
+)
+
+# ---------------------------------------------------------------------------
+# Find every file under mobile/lib/ that contains `extends ChangeNotifier`,
+# excluding generated files and build artifacts. Then filter out allowlisted
+# entries. Anything that survives is a violation.
+# ---------------------------------------------------------------------------
+
+GLOBAL_EXCLUDES=(
+  -not -path "*/.dart_tool/*"
+  -not -path "*/build/*"
+  -not -name "*.g.dart"
+  -not -name "*.freezed.dart"
+  -not -name "*.mocks.dart"
+)
+
+FOUND=$(
+  find "$MOBILE_DIR/lib" \
+    "${GLOBAL_EXCLUDES[@]}" \
+    -name "*.dart" -print0 \
+  | xargs -0 grep -l "extends ChangeNotifier" 2>/dev/null \
+  || true
+)
+
+VIOLATIONS=""
+if [[ -n "$FOUND" ]]; then
+  while IFS= read -r abs_path; do
+    rel="${abs_path#$MOBILE_DIR/lib/}"
+    allowed=0
+    for entry in "${ALLOWLIST[@]}"; do
+      if [[ "$rel" == "$entry" ]]; then
+        allowed=1
+        break
+      fi
+    done
+    if [[ "$allowed" -eq 0 ]]; then
+      VIOLATIONS+="  mobile/lib/$rel"$'\n'
+    fi
+  done <<< "$FOUND"
+fi
+
+if [[ -n "$VIOLATIONS" ]]; then
+  echo "FAIL [changenotifier_boundary]: new \`extends ChangeNotifier\` found outside the sanctioned allowlist:"
+  printf '%s' "$VIOLATIONS"
+  echo ""
+  echo "For UI state, use a BLoC/Cubit instead of \`extends ChangeNotifier\`."
+  echo "If the new class is genuinely DI / service / cache / router plumbing"
+  echo "(0 feature UI state), add it to the ALLOWLIST in this script AND to"
+  echo "the 'Sanctioned Riverpod (STAYS)' table in docs/BLOC_UI_MIGRATION_PRD.md"
+  echo "in the same PR."
+  exit 1
+fi
+
+echo "OK: No new ChangeNotifier classes outside the sanctioned allowlist."

--- a/mobile/scripts/check_changenotifier_boundary.sh
+++ b/mobile/scripts/check_changenotifier_boundary.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
-# Fails CI if a new `extends ChangeNotifier` appears in mobile/lib/ outside
-# the sanctioned allowlist.
+# Fails CI if a new ChangeNotifier subclass — via `extends ChangeNotifier`
+# or a `with ... ChangeNotifier` mixin clause — appears in mobile/lib/
+# outside the sanctioned allowlist.
 #
 # Rule enforced:
-#   * No `extends ChangeNotifier` in mobile/lib/ outside the file allowlist
-#     below. Adding a new sanctioned ChangeNotifier requires editing both
-#     this script's ALLOWLIST and the "Sanctioned Riverpod (STAYS)" table
-#     in docs/BLOC_UI_MIGRATION_PRD.md in the same PR.
+#   * No `extends ChangeNotifier` and no `with ... ChangeNotifier` mixin
+#     clause in mobile/lib/ outside the file allowlist below. Both forms
+#     produce a ChangeNotifier, so a guard that matched only `extends`
+#     would be trivially bypassable with the mixin syntax. Adding a new
+#     sanctioned ChangeNotifier requires editing both this script's
+#     ALLOWLIST and the "Sanctioned Riverpod (STAYS)" table in
+#     docs/BLOC_UI_MIGRATION_PRD.md in the same PR.
+#
+# Scope:
+#   * Only mobile/lib/ is scanned. mobile/packages/** is intentionally out
+#     of scope — the standalone pub packages own their own architecture and
+#     are not part of #4744's app-UI-state migration lane. This mirrors
+#     check_riverpod_boundary.sh, which also scans mobile/lib/ only.
 #
 # Background:
 #   Divine is mid-migration from Riverpod / ChangeNotifier to BLoC/Cubit for
@@ -56,10 +66,21 @@ ALLOWLIST=(
 )
 
 # ---------------------------------------------------------------------------
-# Find every file under mobile/lib/ that contains `extends ChangeNotifier`,
+# Find every file under mobile/lib/ that declares a ChangeNotifier subclass —
+# via `extends ChangeNotifier` or a `with ... ChangeNotifier` mixin clause —
 # excluding generated files and build artifacts. Then filter out allowlisted
 # entries. Anything that survives is a violation.
+#
+# Matcher notes:
+#   * The trailing `\b` keeps `ChangeNotifierProvider` / `ChangeNotifierX`
+#     from matching — only the bare `ChangeNotifier` type counts.
+#   * The `with [..]*ChangeNotifier` branch catches the mixin form in any
+#     slot (`with ChangeNotifier`, `with Foo, ChangeNotifier`). Anchoring on
+#     the `with ` keyword (vs. a bare `, ChangeNotifier`) keeps parameter /
+#     field declarations of type ChangeNotifier from tripping the guard.
 # ---------------------------------------------------------------------------
+
+CHANGENOTIFIER_PATTERN='extends ChangeNotifier\b|with [A-Za-z0-9_<>, ]*ChangeNotifier\b'
 
 GLOBAL_EXCLUDES=(
   -not -path "*/.dart_tool/*"
@@ -73,7 +94,7 @@ FOUND=$(
   find "$MOBILE_DIR/lib" \
     "${GLOBAL_EXCLUDES[@]}" \
     -name "*.dart" -print0 \
-  | xargs -0 grep -l "extends ChangeNotifier" 2>/dev/null \
+  | xargs -0 grep -l -E "$CHANGENOTIFIER_PATTERN" 2>/dev/null \
   || true
 )
 
@@ -95,10 +116,10 @@ if [[ -n "$FOUND" ]]; then
 fi
 
 if [[ -n "$VIOLATIONS" ]]; then
-  echo "FAIL [changenotifier_boundary]: new \`extends ChangeNotifier\` found outside the sanctioned allowlist:"
+  echo "FAIL [changenotifier_boundary]: new ChangeNotifier subclass (\`extends ChangeNotifier\` or \`with ... ChangeNotifier\` mixin) found outside the sanctioned allowlist:"
   printf '%s' "$VIOLATIONS"
   echo ""
-  echo "For UI state, use a BLoC/Cubit instead of \`extends ChangeNotifier\`."
+  echo "For UI state, use a BLoC/Cubit instead of a ChangeNotifier subclass."
   echo "If the new class is genuinely DI / service / cache / router plumbing"
   echo "(0 feature UI state), add it to the ALLOWLIST in this script AND to"
   echo "the 'Sanctioned Riverpod (STAYS)' table in docs/BLOC_UI_MIGRATION_PRD.md"


### PR DESCRIPTION
## Description

Wave 0 ChangeNotifier UI ratchet. Implements #4738 and ships the matching docs section that #4744 WS-4 carves out.

Three pieces, intentionally atomic:

1. **Docs** — `docs/BLOC_UI_MIGRATION_PRD.md` gains a new "Sanctioned Riverpod (STAYS — not migration targets)" section that enumerates the 15 `extends ChangeNotifier` files + `lib/providers/individual_video_providers.dart` and states the inclusion criterion ("DI / service / cache / router plumbing; 0 feature UI state").
2. **Ratchet** — `mobile/scripts/check_changenotifier_boundary.sh` mirrors `check_riverpod_boundary.sh`'s structure: presence-check + file allowlist. The allowlist is the same 15 files. Wired into `mobile_ci.yaml` immediately after the Riverpod boundary step. Adding a new sanctioned ChangeNotifier now requires editing both the script and the docs table in the same PR.
3. **Stale comment fix** — `lib/services/curated_list_service.dart:39` previously said `// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod` while still declaring `class CuratedListService extends ChangeNotifier { ... }` on the next line. Replaced with a doc comment that points at the STAYS section.

**Related Issue:** Closes #4738 · Relates to #4744 (WS-4) · Parent epic #4338

## Out of Scope

- Migrating any of the 15 sanctioned ChangeNotifiers. That is explicitly *not* the goal — they hold infrastructure, not UI state.
- The `video_event_service.dart` god-object removal. That belongs to #4338 Track D, not this lane.

## Verification

- `bash scripts/check_changenotifier_boundary.sh` → `OK: No new ChangeNotifier classes outside the sanctioned allowlist.`
- `dart format --output=none --set-exit-if-changed lib/services/curated_list_service.dart` → clean.
- `flutter analyze lib/services/curated_list_service.dart` → `No issues found!`.
- Sanity: removing a file from the script's `ALLOWLIST` and re-running surfaces it as a violation — confirms the matcher works.

## Type of Change

- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🧹 Code refactor

## Notes for review

- The script intentionally mirrors `check_riverpod_boundary.sh`'s shape (find + grep + exclude generated files + manual fail message), with a file-allowlist twist instead of directory-based exclusion — the carve-out is per-file, not per-directory.
- The CI step is `set -euo pipefail` and exits non-zero on the first new violation. Mirrors the existing Riverpod ratchet's failure model.
- Adding/removing a sanctioned ChangeNotifier (e.g. when `video_event_service` is eventually dissolved by #4338 Track D) is a two-line edit per location: one in the docs table, one in the script `ALLOWLIST`.
