### PR TITLE
refactor(videos_repository): relocate merge helpers from app layer

### DIFF
--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -16,10 +16,10 @@ import 'package:openvine/providers/profile_feed_session_cache.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/state/video_feed_state.dart';
-import 'package:openvine/utils/video_event_merge_utils.dart';
 import 'package:openvine/utils/video_nostr_enrichment.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_feed_provider.g.dart';
 

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -39,7 +39,8 @@ part 'profile_feed_provider.g.dart';
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
 /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+/// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
 /// changes.
 ///

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -24,7 +24,8 @@ part of 'profile_feed_provider.dart';
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
 /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+/// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
 /// changes.
 ///
@@ -53,7 +54,8 @@ const profileFeedProvider = ProfileFeedFamily._();
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
 /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+/// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
 /// changes.
 ///
@@ -80,7 +82,8 @@ final class ProfileFeedProvider
   /// or stale figures while the API reflects current aggregates. When only Nostr
   /// data exists (no REST row, no cache backfill), relay values remain the sole
   /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-  /// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+  /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+  /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
   /// Nostr enrichment) must stay aligned with this policy whenever merge logic
   /// changes.
   ///
@@ -143,7 +146,8 @@ String _$profileFeedHash() => r'f4edbba3f186efbb6c11d643830f26f36640b3fe';
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
 /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+/// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
 /// changes.
 ///
@@ -187,7 +191,8 @@ final class ProfileFeedFamily extends $Family
   /// or stale figures while the API reflects current aggregates. When only Nostr
   /// data exists (no REST row, no cache backfill), relay values remain the sole
   /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-  /// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+  /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+  /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
   /// Nostr enrichment) must stay aligned with this policy whenever merge logic
   /// changes.
   ///
@@ -220,7 +225,8 @@ final class ProfileFeedFamily extends $Family
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
 /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
-/// [mergeRawTagsForVideoMerge], and shared `video_event_merge_utils` (used from
+/// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
+/// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
 /// changes.
 ///

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show Filter;
-import 'package:openvine/utils/video_event_merge_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 /// Enrich REST API videos with full Nostr event data.
 ///

--- a/mobile/packages/videos_repository/lib/src/video_merge_helpers.dart
+++ b/mobile/packages/videos_repository/lib/src/video_merge_helpers.dart
@@ -1,11 +1,16 @@
-// ABOUTME: Shared merge helpers for profile and Nostr enrichment code paths
-// ABOUTME: Keeps engagement parity with Funnelcake when relay/Nostr copies
-// ABOUTME: disagree (#3384); no imports from profile_feed to avoid cycles.
+/// Shared merge helpers for profile and Nostr enrichment code paths.
+///
+/// Keeps engagement parity with Funnelcake when relay/Nostr copies disagree
+/// (#3384). Lives in `videos_repository` because both the package's author-feed
+/// composition and the app-layer Nostr enrichment utility consume them — the
+/// repository is the canonical owner of the merge policy.
+library;
 
 import 'dart:math' as math;
 
-/// [primary] wins on duplicate keys after spreading `{...secondary, ...primary}`,
-/// except `views`: the higher parsed non-negative count wins (#3384).
+/// Merges raw video tags with primary-wins semantics on duplicate keys
+/// (`{...secondary, ...primary}`), except `views`: the higher parsed
+/// non-negative count wins (#3384).
 ///
 /// Used by profile relay/REST merge and by Nostr enrichment (#3384).
 Map<String, String> mergeVideoRawTagsPrimaryWins(

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -13,5 +13,6 @@ export 'src/popular_videos_page.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';
+export 'src/video_merge_helpers.dart';
 export 'src/video_search_sort.dart';
 export 'src/videos_repository.dart';

--- a/mobile/packages/videos_repository/test/src/video_merge_helpers_test.dart
+++ b/mobile/packages/videos_repository/test/src/video_merge_helpers_test.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Unit tests for shared profile/enrichment tag merge (#3384).
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:openvine/utils/video_event_merge_utils.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 void main() {
   group('mergeVideoRawTagsPrimaryWins', () {


### PR DESCRIPTION
## Description

Preparatory mechanical refactor for #4788 (WS-3). No behavior change.

Moves the two shared merge helpers from `mobile/lib/utils/video_event_merge_utils.dart` into the `videos_repository` package and updates the two production callers (`profile_feed_provider.dart`, `video_nostr_enrichment.dart`) to import from the package. The package becomes the canonical owner of the merge policy (#3384 REST-count-wins) because the upcoming `getAuthorFeed` composition will consume these helpers directly — keeping them in `lib/utils/` would force the pure package to import from app-layer code.

**Files moved:**
- `mobile/lib/utils/video_event_merge_utils.dart` → `mobile/packages/videos_repository/lib/src/video_merge_helpers.dart`
- `mobile/test/utils/video_event_merge_utils_test.dart` → `mobile/packages/videos_repository/test/src/video_merge_helpers_test.dart`

**Imports updated:**
- `mobile/lib/utils/video_nostr_enrichment.dart` → `package:videos_repository/videos_repository.dart`
- `mobile/lib/providers/profile_feed_provider.dart` → `package:videos_repository/videos_repository.dart`

The package barrel exports the new file. The relocated test imports through the barrel, so the test still exercises the public surface.

**Related Issue:** Relates to #4788 (WS-3) · Parent #4744 · Epic #4338

## Out of Scope

The `getAuthorFeed` / `loadMoreAuthorFeed` composition itself, and moving the higher-level `mergeTwoProfileVideos` / `mergeProfileEngagementCount` static methods out of `ProfileFeedNotifier`, all follow in the next PR for #4788 (kept separate because that PR adds ~500–700 LOC of new logic + repository tests and deserves its own review focus). This PR is the mechanical preparation so that follow-up can land cleanly on top of `main`.

## Verification

- `flutter analyze lib/providers/profile_feed_provider.dart lib/utils/video_nostr_enrichment.dart` → `No issues found!`
- `flutter test packages/videos_repository/test/src/video_merge_helpers_test.dart` → 7/7 passing in the new location.
- Sanity check: the two production import sites compile and the relocated test exercises the same cases as before.

## Type of Change

- [x] 🧹 Code refactor
