### PR TITLE
refactor(state): migrate BlossomSettingsScreen to a Cubit

### DIFF
--- a/mobile/lib/blocs/blossom_settings/blossom_settings_cubit.dart
+++ b/mobile/lib/blocs/blossom_settings/blossom_settings_cubit.dart
@@ -71,6 +71,7 @@ class BlossomSettingsCubit extends Cubit<BlossomSettingsState> {
   /// [BlossomSaveFailureKey] the View maps to a localized snackbar.
   Future<void> save(String serverUrl) async {
     final trimmed = serverUrl.trim();
+    _resetPreviousSaveFailure();
     if (state.isBlossomEnabled && trimmed.isNotEmpty) {
       final validationError = _validateServerUrl(trimmed);
       if (validationError != null) {
@@ -102,6 +103,19 @@ class BlossomSettingsCubit extends Cubit<BlossomSettingsState> {
         ),
       );
     }
+  }
+
+  void _resetPreviousSaveFailure() {
+    if (state.status != BlossomSettingsStatus.saveFailure &&
+        state.saveFailureMessageKey == null) {
+      return;
+    }
+    emit(
+      state.copyWith(
+        status: BlossomSettingsStatus.ready,
+        saveFailureMessageKey: null,
+      ),
+    );
   }
 
   BlossomSaveFailureKey? _validateServerUrl(String raw) {

--- a/mobile/lib/blocs/blossom_settings/blossom_settings_cubit.dart
+++ b/mobile/lib/blocs/blossom_settings/blossom_settings_cubit.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Screen-scoped Cubit for the BlossomSettingsScreen. Owns the
+// ABOUTME: enable toggle and save status; the server-URL TextEditingController
+// ABOUTME: stays in the View (the "first hybrid" pattern).
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/blossom_settings/blossom_settings_state.dart';
+
+/// Cubit backing `BlossomSettingsScreen`.
+///
+/// "First hybrid" migration: the `TextEditingController` lives in the View,
+/// not in this Cubit. The Cubit owns the **committed** server URL (snapshotted
+/// once on `load()` so the View can seed its controller) and the **save
+/// lifecycle** (loading / ready / saving / saveSuccess / saveFailure). The
+/// View hands the controller's current text back to `save(serverUrl)` at the
+/// moment of submission.
+///
+/// URL validation matches the pre-migration screen exactly:
+///  - `Uri.tryParse` + `hasScheme` + `hasAuthority` are required.
+///  - Scheme must be `https`, except for the documented loopback exception
+///    (10.0.2.2, localhost, 127.0.0.1) that keeps the local Docker stack
+///    working under release native transport security (#3358 / #3788).
+class BlossomSettingsCubit extends Cubit<BlossomSettingsState> {
+  BlossomSettingsCubit({required BlossomUploadService blossomUploadService})
+    : _service = blossomUploadService,
+      super(const BlossomSettingsState());
+
+  final BlossomUploadService _service;
+
+  /// Hosts on which a plain `http://` URL is accepted (release native
+  /// transport security pins the same allowlist — see #3358 / #3788).
+  static const Set<String> _loopbackHttpHosts = {
+    '10.0.2.2',
+    'localhost',
+    '127.0.0.1',
+  };
+
+  /// Snapshots the persisted settings into state. The committed
+  /// `serverUrl` is exposed as [BlossomSettingsState.initialServerUrl] so
+  /// the View can seed its `TextEditingController` once on the
+  /// `loading → ready` transition.
+  Future<void> load() async {
+    emit(state.copyWith(status: BlossomSettingsStatus.loading));
+    try {
+      final isEnabled = await _service.isBlossomEnabled();
+      final serverUrl = await _service.getBlossomServer();
+      emit(
+        state.copyWith(
+          status: BlossomSettingsStatus.ready,
+          isBlossomEnabled: isEnabled,
+          initialServerUrl: serverUrl ?? '',
+        ),
+      );
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(state.copyWith(status: BlossomSettingsStatus.ready));
+    }
+  }
+
+  /// Toggle the "use custom Blossom server" flag locally. Not persisted
+  /// until `save(...)` runs.
+  void setEnabled(bool value) {
+    emit(state.copyWith(isBlossomEnabled: value));
+  }
+
+  /// Persist [serverUrl] + the enable flag.
+  ///
+  /// On success: emits `saveSuccess`. The View handles snackbar + pop on
+  /// that transition via `BlocListener`.
+  /// On validation or service failure: emits `saveFailure` with a
+  /// [BlossomSaveFailureKey] the View maps to a localized snackbar.
+  Future<void> save(String serverUrl) async {
+    final trimmed = serverUrl.trim();
+    if (state.isBlossomEnabled && trimmed.isNotEmpty) {
+      final validationError = _validateServerUrl(trimmed);
+      if (validationError != null) {
+        emit(
+          state.copyWith(
+            status: BlossomSettingsStatus.saveFailure,
+            saveFailureMessageKey: validationError,
+          ),
+        );
+        return;
+      }
+    }
+
+    emit(state.copyWith(status: BlossomSettingsStatus.saving));
+    try {
+      await _service.setBlossomEnabled(state.isBlossomEnabled);
+      if (state.isBlossomEnabled && trimmed.isNotEmpty) {
+        await _service.setBlossomServer(trimmed);
+      } else {
+        await _service.setBlossomServer(null);
+      }
+      emit(state.copyWith(status: BlossomSettingsStatus.saveSuccess));
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(
+        state.copyWith(
+          status: BlossomSettingsStatus.saveFailure,
+          saveFailureMessageKey: BlossomSaveFailureKey.genericFailure,
+        ),
+      );
+    }
+  }
+
+  BlossomSaveFailureKey? _validateServerUrl(String raw) {
+    final uri = Uri.tryParse(raw);
+    if (uri == null || !uri.hasScheme || !uri.hasAuthority) {
+      return BlossomSaveFailureKey.invalidServerUrl;
+    }
+    final scheme = uri.scheme.toLowerCase();
+    final host = uri.host.toLowerCase();
+    final isLoopbackHttp =
+        scheme == 'http' && _loopbackHttpHosts.contains(host);
+    if (scheme != 'https' && !isLoopbackHttp) {
+      return BlossomSaveFailureKey.mustUseHttps;
+    }
+    return null;
+  }
+}

--- a/mobile/lib/blocs/blossom_settings/blossom_settings_state.dart
+++ b/mobile/lib/blocs/blossom_settings/blossom_settings_state.dart
@@ -4,6 +4,8 @@
 
 import 'package:equatable/equatable.dart';
 
+const _unset = Object();
+
 /// Lifecycle of the blossom settings screen.
 ///
 /// `saveSuccess` and `saveFailure` are terminal-for-this-attempt states the
@@ -54,14 +56,15 @@ class BlossomSettingsState extends Equatable {
     BlossomSettingsStatus? status,
     bool? isBlossomEnabled,
     String? initialServerUrl,
-    BlossomSaveFailureKey? saveFailureMessageKey,
+    Object? saveFailureMessageKey = _unset,
   }) {
     return BlossomSettingsState(
       status: status ?? this.status,
       isBlossomEnabled: isBlossomEnabled ?? this.isBlossomEnabled,
       initialServerUrl: initialServerUrl ?? this.initialServerUrl,
-      saveFailureMessageKey:
-          saveFailureMessageKey ?? this.saveFailureMessageKey,
+      saveFailureMessageKey: identical(saveFailureMessageKey, _unset)
+          ? this.saveFailureMessageKey
+          : saveFailureMessageKey as BlossomSaveFailureKey?,
     );
   }
 

--- a/mobile/lib/blocs/blossom_settings/blossom_settings_state.dart
+++ b/mobile/lib/blocs/blossom_settings/blossom_settings_state.dart
@@ -1,0 +1,91 @@
+// ABOUTME: State for BlossomSettingsCubit — the enable toggle, the persisted
+// ABOUTME: server URL snapshot used to seed the View's TextEditingController,
+// ABOUTME: and the save lifecycle status.
+
+import 'package:equatable/equatable.dart';
+
+/// Lifecycle of the blossom settings screen.
+///
+/// `saveSuccess` and `saveFailure` are terminal-for-this-attempt states the
+/// View listens to via `BlocListener` to drive a snackbar + back-navigation.
+enum BlossomSettingsStatus {
+  initial,
+  loading,
+  ready,
+  saving,
+  saveSuccess,
+  saveFailure,
+}
+
+/// State for `BlossomSettingsCubit`.
+///
+/// "First hybrid" migration: the `TextEditingController` for the server URL
+/// stays in the View (controllers are UI plumbing, not Cubit state). This
+/// state only carries the **committed** server URL ([initialServerUrl]) —
+/// the value the View should seed the controller with when entering the
+/// `ready` state. Once the user types, the in-flight URL lives only in the
+/// controller until the View hands it back to `save(...)`.
+class BlossomSettingsState extends Equatable {
+  const BlossomSettingsState({
+    this.status = BlossomSettingsStatus.initial,
+    this.isBlossomEnabled = false,
+    this.initialServerUrl = '',
+    this.saveFailureMessageKey,
+  });
+
+  final BlossomSettingsStatus status;
+  final bool isBlossomEnabled;
+
+  /// Persisted server URL snapshotted at `load()` time.
+  ///
+  /// The View uses this to seed its `TextEditingController` once when the
+  /// status transitions to `ready` — after that, the controller is the
+  /// source of truth until the user taps Save.
+  final String initialServerUrl;
+
+  /// Identifies which l10n key the View should show on `saveFailure`.
+  ///
+  /// State doesn't carry error strings (per `state_management.md`) — this is
+  /// a closed set of three keys (`invalidServerUrl`, `mustUseHttps`,
+  /// `genericFailure`) that the View maps to `context.l10n.xxx`.
+  final BlossomSaveFailureKey? saveFailureMessageKey;
+
+  BlossomSettingsState copyWith({
+    BlossomSettingsStatus? status,
+    bool? isBlossomEnabled,
+    String? initialServerUrl,
+    BlossomSaveFailureKey? saveFailureMessageKey,
+  }) {
+    return BlossomSettingsState(
+      status: status ?? this.status,
+      isBlossomEnabled: isBlossomEnabled ?? this.isBlossomEnabled,
+      initialServerUrl: initialServerUrl ?? this.initialServerUrl,
+      saveFailureMessageKey:
+          saveFailureMessageKey ?? this.saveFailureMessageKey,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    status,
+    isBlossomEnabled,
+    initialServerUrl,
+    saveFailureMessageKey,
+  ];
+}
+
+/// Reasons a `save(...)` attempt failed.
+///
+/// Closed set so the View can map to `context.l10n.xxx` without holding
+/// error strings in state.
+enum BlossomSaveFailureKey {
+  /// URL failed `Uri.tryParse` / missing scheme/authority.
+  invalidServerUrl,
+
+  /// URL parsed but uses non-loopback `http://` — release native transport
+  /// security would block the upload at the OS layer (#3358 / #3788).
+  mustUseHttps,
+
+  /// Service call threw.
+  genericFailure,
+}

--- a/mobile/lib/screens/blossom_settings_screen.dart
+++ b/mobile/lib/screens/blossom_settings_screen.dart
@@ -3,37 +3,51 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/blossom_settings/blossom_settings_cubit.dart';
+import 'package:openvine/blocs/blossom_settings/blossom_settings_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:unified_logger/unified_logger.dart';
 
-class BlossomSettingsScreen extends ConsumerStatefulWidget {
+/// Page: bridges `BlossomUploadService` into [BlossomSettingsCubit].
+class BlossomSettingsScreen extends ConsumerWidget {
+  const BlossomSettingsScreen({super.key});
+
   /// Route name for this screen.
   static const routeName = 'blossom-settings';
 
   /// Path for this route.
   static const path = '/blossom-settings';
 
-  const BlossomSettingsScreen({super.key});
-
   @override
-  ConsumerState<BlossomSettingsScreen> createState() =>
-      _BlossomSettingsScreenState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final blossomUploadService = ref.watch(blossomUploadServiceProvider);
+    return BlocProvider(
+      key: ValueKey(blossomUploadService),
+      create: (_) =>
+          BlossomSettingsCubit(blossomUploadService: blossomUploadService)
+            ..load(),
+      child: const BlossomSettingsView(),
+    );
+  }
 }
 
-class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
-  final _serverController = TextEditingController();
-  bool _isBlossomEnabled = false;
-  bool _isLoading = true;
-  bool _isSaving = false;
+/// View: renders blossom settings from the Cubit state. The server-URL
+/// `TextEditingController` is owned here (the "first hybrid" pattern —
+/// controllers are UI plumbing, not Cubit state).
+class BlossomSettingsView extends StatefulWidget {
+  @visibleForTesting
+  const BlossomSettingsView({super.key});
 
   @override
-  void initState() {
-    super.initState();
-    _loadSettings();
-  }
+  State<BlossomSettingsView> createState() => _BlossomSettingsViewState();
+}
+
+class _BlossomSettingsViewState extends State<BlossomSettingsView> {
+  final _serverController = TextEditingController();
+  bool _seededFromState = false;
 
   @override
   void dispose() {
@@ -41,332 +55,279 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
     super.dispose();
   }
 
-  Future<void> _loadSettings() async {
-    try {
-      final blossomService = ref.read(blossomUploadServiceProvider);
-
-      final isEnabled = await blossomService.isBlossomEnabled();
-      final serverUrl = await blossomService.getBlossomServer();
-
-      if (mounted) {
-        setState(() {
-          _isBlossomEnabled = isEnabled;
-          _serverController.text = serverUrl ?? '';
-          _isLoading = false;
-        });
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to load Blossom settings: $e',
-        name: 'BlossomSettingsScreen',
-        category: LogCategory.ui,
-      );
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-    }
-  }
-
-  Future<void> _saveSettings() async {
-    // Validate URL if Blossom is enabled
-    if (_isBlossomEnabled && _serverController.text.isNotEmpty) {
-      final uri = Uri.tryParse(_serverController.text);
-      if (uri == null || !uri.hasScheme || !uri.hasAuthority) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.blossomValidServerUrl),
-            backgroundColor: VineTheme.error,
-          ),
-        );
-        return;
-      }
-      // Reject non-loopback http:// — release native transport security
-      // (#3358 / PR #3788) blocks the upload at the OS layer with no
-      // user-facing hint. Loopback http:// (10.0.2.2, localhost,
-      // 127.0.0.1) keeps working for the local Docker stack — mirrors
-      // the allowlist pinned in the native configs.
-      final scheme = uri.scheme.toLowerCase();
-      final host = uri.host.toLowerCase();
-      final isLoopbackHttp =
-          scheme == 'http' &&
-          (host == '10.0.2.2' || host == 'localhost' || host == '127.0.0.1');
-      if (scheme != 'https' && !isLoopbackHttp) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.blossomServerUrlMustUseHttps),
-            backgroundColor: VineTheme.error,
-          ),
-        );
-        return;
-      }
-    }
-
-    setState(() {
-      _isSaving = true;
-    });
-
-    try {
-      final blossomService = ref.read(blossomUploadServiceProvider);
-
-      // Save settings
-      await blossomService.setBlossomEnabled(_isBlossomEnabled);
-
-      if (_isBlossomEnabled && _serverController.text.isNotEmpty) {
-        await blossomService.setBlossomServer(_serverController.text);
-      } else {
-        await blossomService.setBlossomServer(null);
-      }
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              context.l10n.blossomSettingsSaved,
-              style: const TextStyle(color: VineTheme.whiteText),
-            ),
-            backgroundColor: VineTheme.vineGreen,
-          ),
-        );
-        context.pop();
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to save Blossom settings: $e',
-        name: 'BlossomSettingsScreen',
-        category: LogCategory.ui,
-      );
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.blossomFailedToSaveSettings('$e')),
-            backgroundColor: VineTheme.error,
-          ),
-        );
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isSaving = false;
-        });
-      }
+  void _seedControllerIfNeeded(BlossomSettingsState state) {
+    if (_seededFromState) return;
+    if (state.status == BlossomSettingsStatus.ready ||
+        state.status == BlossomSettingsStatus.saving) {
+      _serverController.text = state.initialServerUrl;
+      _seededFromState = true;
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: DiVineAppBar(
-        title: context.l10n.nostrSettingsMediaServers,
-        showBackButton: true,
-        onBackPressed: context.pop,
-        actions: _isLoading
-            ? const []
-            : [
-                DiVineAppBarAction(
-                  icon: SvgIconSource(DivineIconName.check.assetPath),
-                  onPressed: _isSaving ? null : _saveSettings,
-                  tooltip: context.l10n.blossomSaveTooltip,
-                ),
-              ],
-      ),
-      backgroundColor: VineTheme.backgroundColor,
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: VineTheme.vineGreen),
-            )
-          : Align(
-              alignment: Alignment.topCenter,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 600),
-                child: ListView(
-                  padding: const EdgeInsets.all(16),
-                  children: [
-                    // Info card
-                    Card(
-                      color: VineTheme.backgroundColor.withValues(alpha: 0.7),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        side: BorderSide(
-                          color: VineTheme.vineGreen.withValues(alpha: 0.3),
-                        ),
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                DivineIcon(
-                                  icon: DivineIconName.info,
-                                  color: VineTheme.vineGreen.withValues(
-                                    alpha: 0.8,
-                                  ),
-                                ),
-                                const SizedBox(width: 8),
-                                Text(
-                                  context.l10n.blossomAboutTitle,
-                                  style: const TextStyle(
-                                    color: VineTheme.vineGreen,
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 12),
-                            Text(
-                              context.l10n.blossomAboutDescription,
-                              style: const TextStyle(
-                                color: VineTheme.onSurface,
-                                fontSize: 14,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-
-                    // Enable/Disable toggle
-                    SwitchListTile(
-                      title: Text(
-                        context.l10n.blossomUseCustomServer,
-                        style: const TextStyle(
-                          color: VineTheme.whiteText,
-                          fontSize: 16,
-                        ),
-                      ),
-                      subtitle: Text(
-                        _isBlossomEnabled
-                            ? context.l10n.blossomCustomServerEnabledSubtitle
-                            : context.l10n.blossomCustomServerDisabledSubtitle,
-                        style: const TextStyle(color: VineTheme.onSurfaceMuted),
-                      ),
-                      value: _isBlossomEnabled,
-                      onChanged: (value) {
-                        setState(() {
-                          _isBlossomEnabled = value;
-                        });
-                      },
-                      activeThumbColor: VineTheme.vineGreen,
-                      inactiveThumbColor: VineTheme.lightText,
-                      inactiveTrackColor: VineTheme.lightText.withValues(
-                        alpha: 0.3,
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-
-                    // Server URL input (only shown when custom server is enabled)
-                    if (_isBlossomEnabled) ...[
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            context.l10n.blossomCustomServerUrl,
-                            style: const TextStyle(
-                              color: VineTheme.whiteText,
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          TextField(
-                            controller: _serverController,
-                            style: const TextStyle(color: VineTheme.whiteText),
-                            decoration: InputDecoration(
-                              hintText: 'https://blossom.band',
-                              hintStyle: const TextStyle(
-                                color: VineTheme.onSurfaceDisabled,
-                              ),
-                              filled: true,
-                              fillColor: VineTheme.whiteText.withValues(
-                                alpha: 0.1,
-                              ),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide(
-                                  color: VineTheme.vineGreen.withValues(
-                                    alpha: 0.3,
-                                  ),
-                                ),
-                              ),
-                              enabledBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide(
-                                  color: VineTheme.vineGreen.withValues(
-                                    alpha: 0.3,
-                                  ),
-                                ),
-                              ),
-                              focusedBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: const BorderSide(
-                                  color: VineTheme.vineGreen,
-                                ),
-                              ),
-                              prefixIcon: const Icon(
-                                Icons.cloud_upload,
-                                color: VineTheme.vineGreen,
-                              ),
-                            ),
-                            keyboardType: TextInputType.url,
-                            autocorrect: false,
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            context.l10n.blossomCustomServerHelper,
-                            style: const TextStyle(
-                              color: VineTheme.onSurfaceMuted,
-                              fontSize: 12,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 30),
-
-                      // Popular Blossom servers section
-                      Text(
-                        context.l10n.blossomPopularServers,
-                        style: const TextStyle(
-                          color: VineTheme.whiteText,
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      _buildServerOption(
-                        'https://blossom.band',
-                        'Blossom Band',
-                      ),
-                      _buildServerOption(
-                        'https://cdn.satellite.earth',
-                        'Satellite Earth',
-                      ),
-                      _buildServerOption(
-                        'https://blossom.primal.net',
-                        'Primal',
-                      ),
-                      _buildServerOption(
-                        'https://nostr.download',
-                        'Nostr Download',
-                      ),
-                      _buildServerOption(
-                        'https://cdn.nostrcheck.me',
-                        'NostrCheck',
-                      ),
-                    ],
-                  ],
-                ),
+    return BlocConsumer<BlossomSettingsCubit, BlossomSettingsState>(
+      listenWhen: (prev, curr) => prev.status != curr.status,
+      listener: (context, state) {
+        if (state.status == BlossomSettingsStatus.saveSuccess) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                context.l10n.blossomSettingsSaved,
+                style: const TextStyle(color: VineTheme.whiteText),
               ),
+              backgroundColor: VineTheme.vineGreen,
             ),
+          );
+          context.pop();
+        } else if (state.status == BlossomSettingsStatus.saveFailure) {
+          final messenger = ScaffoldMessenger.of(context);
+          final message = switch (state.saveFailureMessageKey) {
+            BlossomSaveFailureKey.invalidServerUrl =>
+              context.l10n.blossomValidServerUrl,
+            BlossomSaveFailureKey.mustUseHttps =>
+              context.l10n.blossomServerUrlMustUseHttps,
+            BlossomSaveFailureKey.genericFailure ||
+            null => context.l10n.blossomFailedToSaveSettings(''),
+          };
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text(message),
+              backgroundColor: VineTheme.error,
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        _seedControllerIfNeeded(state);
+        final isLoading =
+            state.status == BlossomSettingsStatus.loading ||
+            state.status == BlossomSettingsStatus.initial;
+        final isSaving = state.status == BlossomSettingsStatus.saving;
+        return Scaffold(
+          appBar: DiVineAppBar(
+            title: context.l10n.nostrSettingsMediaServers,
+            showBackButton: true,
+            onBackPressed: context.pop,
+            actions: isLoading
+                ? const []
+                : [
+                    DiVineAppBarAction(
+                      icon: SvgIconSource(DivineIconName.check.assetPath),
+                      onPressed: isSaving
+                          ? null
+                          : () => context.read<BlossomSettingsCubit>().save(
+                              _serverController.text,
+                            ),
+                      tooltip: context.l10n.blossomSaveTooltip,
+                    ),
+                  ],
+          ),
+          backgroundColor: VineTheme.backgroundColor,
+          body: isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: VineTheme.vineGreen),
+                )
+              : Align(
+                  alignment: Alignment.topCenter,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 600),
+                    child: ListView(
+                      padding: const EdgeInsets.all(16),
+                      children: [
+                        const _AboutCard(),
+                        const SizedBox(height: 20),
+                        const _EnableToggle(),
+                        const SizedBox(height: 20),
+                        if (state.isBlossomEnabled)
+                          _ServerUrlSection(
+                            controller: _serverController,
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+        );
+      },
     );
   }
+}
 
-  Widget _buildServerOption(String url, String name) {
+class _AboutCard extends StatelessWidget {
+  const _AboutCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: VineTheme.backgroundColor.withValues(alpha: 0.7),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: VineTheme.vineGreen.withValues(alpha: 0.3)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                DivineIcon(
+                  icon: DivineIconName.info,
+                  color: VineTheme.vineGreen.withValues(alpha: 0.8),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  context.l10n.blossomAboutTitle,
+                  style: const TextStyle(
+                    color: VineTheme.vineGreen,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              context.l10n.blossomAboutDescription,
+              style: const TextStyle(color: VineTheme.onSurface, fontSize: 14),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EnableToggle extends StatelessWidget {
+  const _EnableToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled = context.select(
+      (BlossomSettingsCubit cubit) => cubit.state.isBlossomEnabled,
+    );
+    return SwitchListTile(
+      title: Text(
+        context.l10n.blossomUseCustomServer,
+        style: const TextStyle(color: VineTheme.whiteText, fontSize: 16),
+      ),
+      subtitle: Text(
+        isEnabled
+            ? context.l10n.blossomCustomServerEnabledSubtitle
+            : context.l10n.blossomCustomServerDisabledSubtitle,
+        style: const TextStyle(color: VineTheme.onSurfaceMuted),
+      ),
+      value: isEnabled,
+      onChanged: (value) =>
+          context.read<BlossomSettingsCubit>().setEnabled(value),
+      activeThumbColor: VineTheme.vineGreen,
+      inactiveThumbColor: VineTheme.lightText,
+      inactiveTrackColor: VineTheme.lightText.withValues(alpha: 0.3),
+    );
+  }
+}
+
+class _ServerUrlSection extends StatelessWidget {
+  const _ServerUrlSection({required this.controller});
+
+  final TextEditingController controller;
+
+  static const _popularServers = <(String url, String name)>[
+    ('https://blossom.band', 'Blossom Band'),
+    ('https://cdn.satellite.earth', 'Satellite Earth'),
+    ('https://blossom.primal.net', 'Primal'),
+    ('https://nostr.download', 'Nostr Download'),
+    ('https://cdn.nostrcheck.me', 'NostrCheck'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          context.l10n.blossomCustomServerUrl,
+          style: const TextStyle(
+            color: VineTheme.whiteText,
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: controller,
+          style: const TextStyle(color: VineTheme.whiteText),
+          decoration: InputDecoration(
+            hintText: 'https://blossom.band',
+            hintStyle: const TextStyle(color: VineTheme.onSurfaceDisabled),
+            filled: true,
+            fillColor: VineTheme.whiteText.withValues(alpha: 0.1),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(
+                color: VineTheme.vineGreen.withValues(alpha: 0.3),
+              ),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(
+                color: VineTheme.vineGreen.withValues(alpha: 0.3),
+              ),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: const BorderSide(color: VineTheme.vineGreen),
+            ),
+            prefixIcon: const Icon(
+              Icons.cloud_upload,
+              color: VineTheme.vineGreen,
+            ),
+          ),
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          context.l10n.blossomCustomServerHelper,
+          style: const TextStyle(
+            color: VineTheme.onSurfaceMuted,
+            fontSize: 12,
+          ),
+        ),
+        const SizedBox(height: 30),
+        Text(
+          context.l10n.blossomPopularServers,
+          style: const TextStyle(
+            color: VineTheme.whiteText,
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 12),
+        for (final entry in _popularServers)
+          _ServerOption(
+            url: entry.$1,
+            name: entry.$2,
+            onSelect: () => controller.text = entry.$1,
+          ),
+      ],
+    );
+  }
+}
+
+class _ServerOption extends StatelessWidget {
+  const _ServerOption({
+    required this.url,
+    required this.name,
+    required this.onSelect,
+  });
+
+  final String url;
+  final String name;
+  final VoidCallback onSelect;
+
+  @override
+  Widget build(BuildContext context) {
     return Card(
       color: VineTheme.whiteText.withValues(alpha: 0.05),
       margin: const EdgeInsets.only(bottom: 8),
@@ -374,17 +335,16 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
         title: Text(name, style: const TextStyle(color: VineTheme.whiteText)),
         subtitle: Text(
           url,
-          style: const TextStyle(color: VineTheme.onSurfaceMuted, fontSize: 12),
+          style: const TextStyle(
+            color: VineTheme.onSurfaceMuted,
+            fontSize: 12,
+          ),
         ),
         trailing: const DivineIcon(
           icon: DivineIconName.arrowRight,
           color: VineTheme.vineGreen,
         ),
-        onTap: () {
-          setState(() {
-            _serverController.text = url;
-          });
-        },
+        onTap: onSelect,
       ),
     );
   }

--- a/mobile/lib/screens/blossom_settings_screen.dart
+++ b/mobile/lib/screens/blossom_settings_screen.dart
@@ -55,6 +55,9 @@ class _BlossomSettingsViewState extends State<BlossomSettingsView> {
     super.dispose();
   }
 
+  /// Seeds the server-URL field exactly once, on the first `ready`/`saving`
+  /// state. After the first seed the [TextEditingController] owns the value;
+  /// later state emissions intentionally do not overwrite the user's input.
   void _seedControllerIfNeeded(BlossomSettingsState state) {
     if (_seededFromState) return;
     if (state.status == BlossomSettingsStatus.ready ||

--- a/mobile/test/blocs/blossom_settings/blossom_settings_cubit_test.dart
+++ b/mobile/test/blocs/blossom_settings/blossom_settings_cubit_test.dart
@@ -1,0 +1,257 @@
+// ABOUTME: Unit tests for BlossomSettingsCubit — load snapshot, enable toggle,
+// ABOUTME: URL validation (https + loopback-http carve-out), and the
+// ABOUTME: save success / failure transitions the View listens on.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/blossom_settings/blossom_settings_cubit.dart';
+import 'package:openvine/blocs/blossom_settings/blossom_settings_state.dart';
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+void main() {
+  group(BlossomSettingsCubit, () {
+    late _MockBlossomUploadService service;
+
+    setUp(() {
+      service = _MockBlossomUploadService();
+      when(() => service.isBlossomEnabled()).thenAnswer((_) async => false);
+      when(() => service.getBlossomServer()).thenAnswer((_) async => null);
+      when(() => service.setBlossomEnabled(any())).thenAnswer((_) async {});
+      when(() => service.setBlossomServer(any())).thenAnswer((_) async {});
+    });
+
+    BlossomSettingsCubit buildCubit() =>
+        BlossomSettingsCubit(blossomUploadService: service);
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'load snapshots persisted settings into state',
+      setUp: () {
+        when(() => service.isBlossomEnabled()).thenAnswer((_) async => true);
+        when(
+          () => service.getBlossomServer(),
+        ).thenAnswer((_) async => 'https://blossom.band');
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const BlossomSettingsState(status: BlossomSettingsStatus.loading),
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.ready,
+          isBlossomEnabled: true,
+          initialServerUrl: 'https://blossom.band',
+        ),
+      ],
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'load emits ready with empty serverUrl when none persisted',
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const BlossomSettingsState(status: BlossomSettingsStatus.loading),
+        const BlossomSettingsState(status: BlossomSettingsStatus.ready),
+      ],
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'load surfaces service failure via addError and falls back to ready',
+      setUp: () {
+        when(
+          () => service.isBlossomEnabled(),
+        ).thenThrow(StateError('prefs unavailable'));
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const BlossomSettingsState(status: BlossomSettingsStatus.loading),
+        const BlossomSettingsState(status: BlossomSettingsStatus.ready),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'setEnabled toggles isBlossomEnabled without persisting',
+      seed: () =>
+          const BlossomSettingsState(status: BlossomSettingsStatus.ready),
+      build: buildCubit,
+      act: (cubit) => cubit.setEnabled(true),
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.ready,
+          isBlossomEnabled: true,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(() => service.setBlossomEnabled(any()));
+        verifyNever(() => service.setBlossomServer(any()));
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save with https URL persists and emits saveSuccess',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.save('https://blossom.band'),
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saving,
+          isBlossomEnabled: true,
+        ),
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveSuccess,
+          isBlossomEnabled: true,
+        ),
+      ],
+      verify: (_) {
+        verify(() => service.setBlossomEnabled(true)).called(1);
+        verify(
+          () => service.setBlossomServer('https://blossom.band'),
+        ).called(1);
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save with disabled toggle clears the server URL (null)',
+      seed: () =>
+          const BlossomSettingsState(status: BlossomSettingsStatus.ready),
+      build: buildCubit,
+      act: (cubit) => cubit.save('https://blossom.band'),
+      expect: () => [
+        const BlossomSettingsState(status: BlossomSettingsStatus.saving),
+        const BlossomSettingsState(status: BlossomSettingsStatus.saveSuccess),
+      ],
+      verify: (_) {
+        verify(() => service.setBlossomEnabled(false)).called(1);
+        verify(() => service.setBlossomServer(null)).called(1);
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save with loopback http://10.0.2.2 URL succeeds',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.save('http://10.0.2.2:8000'),
+      verify: (_) {
+        verify(
+          () => service.setBlossomServer('http://10.0.2.2:8000'),
+        ).called(1);
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save rejects non-loopback http:// with mustUseHttps failure key',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.save('http://example.com/blossom'),
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveFailure,
+          isBlossomEnabled: true,
+          saveFailureMessageKey: BlossomSaveFailureKey.mustUseHttps,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(() => service.setBlossomEnabled(any()));
+        verifyNever(() => service.setBlossomServer(any()));
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save rejects unparseable URL with invalidServerUrl failure key',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.save('not a url'),
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveFailure,
+          isBlossomEnabled: true,
+          saveFailureMessageKey: BlossomSaveFailureKey.invalidServerUrl,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(() => service.setBlossomServer(any()));
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save service failure emits genericFailure key + addError',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      setUp: () {
+        when(
+          () => service.setBlossomEnabled(any()),
+        ).thenThrow(StateError('prefs write failed'));
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.save('https://blossom.band'),
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saving,
+          isBlossomEnabled: true,
+        ),
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveFailure,
+          isBlossomEnabled: true,
+          saveFailureMessageKey: BlossomSaveFailureKey.genericFailure,
+        ),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save trims whitespace before validating',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.save('  https://blossom.band  '),
+      verify: (_) {
+        verify(
+          () => service.setBlossomServer('https://blossom.band'),
+        ).called(1);
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'save with enabled+empty URL clears server without validation error',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.save(''),
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saving,
+          isBlossomEnabled: true,
+        ),
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveSuccess,
+          isBlossomEnabled: true,
+        ),
+      ],
+      verify: (_) {
+        verify(() => service.setBlossomEnabled(true)).called(1);
+        verify(() => service.setBlossomServer(null)).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/blocs/blossom_settings/blossom_settings_cubit_test.dart
+++ b/mobile/test/blocs/blossom_settings/blossom_settings_cubit_test.dart
@@ -189,6 +189,39 @@ void main() {
     );
 
     blocTest<BlossomSettingsCubit, BlossomSettingsState>(
+      'repeated validation failures emit a fresh saveFailure transition',
+      seed: () => const BlossomSettingsState(
+        status: BlossomSettingsStatus.ready,
+        isBlossomEnabled: true,
+      ),
+      build: buildCubit,
+      act: (cubit) async {
+        await cubit.save('http://example.com/blossom');
+        await cubit.save('http://example.com/blossom');
+      },
+      expect: () => [
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveFailure,
+          isBlossomEnabled: true,
+          saveFailureMessageKey: BlossomSaveFailureKey.mustUseHttps,
+        ),
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.ready,
+          isBlossomEnabled: true,
+        ),
+        const BlossomSettingsState(
+          status: BlossomSettingsStatus.saveFailure,
+          isBlossomEnabled: true,
+          saveFailureMessageKey: BlossomSaveFailureKey.mustUseHttps,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(() => service.setBlossomEnabled(any()));
+        verifyNever(() => service.setBlossomServer(any()));
+      },
+    );
+
+    blocTest<BlossomSettingsCubit, BlossomSettingsState>(
       'save service failure emits genericFailure key + addError',
       seed: () => const BlossomSettingsState(
         status: BlossomSettingsStatus.ready,

--- a/mobile/test/screens/settings/blossom_settings_screen_test.dart
+++ b/mobile/test/screens/settings/blossom_settings_screen_test.dart
@@ -3,10 +3,12 @@
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/blossom_settings/blossom_settings_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/blossom_settings_screen.dart';
@@ -163,6 +165,41 @@ void main() {
         // below would still find zero occurrences — the assertion that
         // matters is the one above).
         expect(german.blossomValidServerUrl, isNotEmpty);
+      },
+    );
+
+    testWidgets(
+      'seeds the server-URL field exactly once; later '
+      'initialServerUrl emissions do not overwrite user input',
+      (tester) async {
+        // First load() seeds the field with the persisted '' (setUp stub).
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        // User edits the field — the controller is now the source of truth.
+        const userInput = 'https://typed-by-user.example';
+        await tester.enterText(find.byType(TextField), userInput);
+        await tester.pumpAndSettle();
+
+        // Re-stub the service so the next load() snapshots a *different*
+        // initialServerUrl, then drive a second load() through the live
+        // cubit to emit a fresh `ready` state with that value.
+        when(
+          () => mockService.getBlossomServer(),
+        ).thenAnswer((_) async => 'https://persisted-elsewhere.example');
+        final cubit = BlocProvider.of<BlossomSettingsCubit>(
+          tester.element(find.byType(BlossomSettingsView)),
+        );
+        await cubit.load();
+        await tester.pumpAndSettle();
+
+        // The one-shot seed contract: the second emission must NOT clobber
+        // the user's typed value.
+        expect(find.text(userInput), findsOneWidget);
+        expect(
+          find.text('https://persisted-elsewhere.example'),
+          findsNothing,
+        );
       },
     );
   });

--- a/mobile/test/widgets/all_settings_screens_scaffold_test.dart
+++ b/mobile/test/widgets/all_settings_screens_scaffold_test.dart
@@ -1,16 +1,33 @@
 // ABOUTME: Comprehensive widget test for ALL settings screens scaffold structure
 // ABOUTME: Ensures all settings screens use consistent Vine theme (green AppBar, black background)
 
+import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/blossom_settings_screen.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
 
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
 void main() {
   group('All Settings Screens Scaffold Consistency', () {
+    late _MockBlossomUploadService mockBlossomService;
+
+    setUp(() {
+      mockBlossomService = _MockBlossomUploadService();
+      when(
+        () => mockBlossomService.isBlossomEnabled(),
+      ).thenAnswer((_) async => false);
+      when(
+        () => mockBlossomService.getBlossomServer(),
+      ).thenAnswer((_) async => null);
+    });
+
     testWidgets('RelaySettingsScreen has nav green AppBar', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
@@ -36,8 +53,11 @@ void main() {
 
     testWidgets('BlossomSettingsScreen has nav green AppBar', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [
+            blossomUploadServiceProvider.overrideWithValue(mockBlossomService),
+          ],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: BlossomSettingsScreen(),


### PR DESCRIPTION
## Description

Continues #4744 WS-1. Same template as #4749 / #4750 / #4751 / #4791, extended with the **"first hybrid" pattern**: the `TextEditingController` for the server URL stays in the View (controllers are UI plumbing, not Cubit state — the brainstorm precedent for the remaining WS-1 hybrids).

`BlossomSettingsCubit` owns:

- The enable toggle (locally; not persisted until save).
- The save lifecycle status (`loading` / `ready` / `saving` / `saveSuccess` / `saveFailure`).
- The persisted server URL as a one-time `initialServerUrl` snapshot the View seeds its controller from on the `loading → ready` transition.
- The URL validation: scheme must be `https`, with the documented loopback carve-out (`10.0.2.2` / `localhost` / `127.0.0.1`) that keeps the local Docker stack working under release native transport security (#3358 / #3788).

Save failures use a `BlossomSaveFailureKey` enum (`invalidServerUrl`, `mustUseHttps`, `genericFailure`) — no error strings in state per `state_management.md`. The View maps the key to `context.l10n.xxx` inside a `BlocListener` that also drives the saved-snackbar + `context.pop()` on `saveSuccess`.

**Page/View split.** The `ConsumerWidget` Page reads `blossomUploadServiceProvider`, gates the `BlocProvider` on a `ValueKey` over it, and calls `..load()`. The View is a `StatefulWidget` (the controller is local state) marked `@visibleForTesting`. The previous `_buildServerOption` helper became a private `_ServerOption` widget; the about card, enable toggle, and server-URL section all extracted into private widgets too.

**Related Issue:** Relates to #4744 (WS-1) · Parent epic #4338

## Out of Scope

- The four remaining WS-1 slices (progress sheets, `content_preferences`, feedback dialogs, `sounds`, `relay_settings`) follow as their own PRs.

## Verification

- `flutter analyze lib/blocs/blossom_settings/ lib/screens/blossom_settings_screen.dart test/blocs/blossom_settings/` → `No issues found!`
- `flutter test test/blocs/blossom_settings/blossom_settings_cubit_test.dart` → **12/12 passing**: load snapshot, load service-failure path (`addError` + still emits ready), `setEnabled` no-persist, save (https + loopback http + disabled clears server + trim whitespace + empty URL clears), and all three failure keys (`invalidServerUrl`, `mustUseHttps`, `genericFailure` with `addError`).
- `flutter test test/screens/settings/blossom_settings_screen_test.dart` → **8/8 pre-existing tests pass unchanged**. The URL-validation behavior they pin (https URLs save, all three loopback http variants save, non-loopback http and unparseable URLs surface the localized snackbar) flows through the Cubit identically to the pre-migration `setState` path.
- `dart format --output=none --set-exit-if-changed` → clean.

## Type of Change

- [x] 🧹 Code refactor

## Notes for review

- The "first hybrid" idea is in the brainstorm: a screen that keeps a `TextEditingController` in the View because controllers are UI plumbing. The Cubit only carries the committed server URL (`initialServerUrl`) — the in-flight value lives in the controller until the user taps Save and the View hands it back via `cubit.save(_serverController.text)`.
- `_seedControllerIfNeeded` runs in `build` and uses a `_seededFromState` boolean so the seed happens exactly once per `BlossomSettingsView` lifetime — re-keying the `BlocProvider` on a new service identity disposes the View and the new one re-seeds from the fresh load.
- The 8 existing widget tests in `test/screens/settings/blossom_settings_screen_test.dart` exercise the validation snackbars + l10n pipeline end-to-end. They were the most useful behavior-parity gate and all pass unchanged against the Cubit path.
