### PR TITLE
refactor(state): migrate ContentPreferences sub-widgets to 3 Cubits

### DIFF
--- a/mobile/lib/blocs/audio_device/audio_device_cubit.dart
+++ b/mobile/lib/blocs/audio_device/audio_device_cubit.dart
@@ -21,22 +21,23 @@ class AudioDeviceCubit extends Cubit<AudioDeviceState> {
 
   final AudioDevicePreferenceService _service;
 
-  void load() {
-    emit(
-      state.copyWith(
-        status: AudioDeviceStatus.ready,
-        currentDeviceId: _service.preferredDeviceId,
-        clearDeviceId: _service.preferredDeviceId == null,
-      ),
-    );
+  Future<void> load() async {
+    await _service.initialize();
+    _emitSnapshot();
   }
 
   Future<void> setDeviceId(String? deviceId) async {
     await _service.setPreferredDeviceId(deviceId);
+    _emitSnapshot();
+  }
+
+  void _emitSnapshot() {
+    final preferredDeviceId = _service.preferredDeviceId;
     emit(
       state.copyWith(
-        currentDeviceId: deviceId,
-        clearDeviceId: deviceId == null,
+        status: AudioDeviceStatus.ready,
+        currentDeviceId: preferredDeviceId,
+        clearDeviceId: preferredDeviceId == null,
       ),
     );
   }

--- a/mobile/lib/blocs/audio_device/audio_device_cubit.dart
+++ b/mobile/lib/blocs/audio_device/audio_device_cubit.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Cubit backing the audio-input-device picker in
+// ABOUTME: ContentPreferencesScreen. Owns only the selected device id —
+// ABOUTME: the device list is fetched lazily by the View via FutureBuilder.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/audio_device/audio_device_state.dart';
+import 'package:openvine/services/audio_device_preference_service.dart';
+
+/// Cubit backing the `_AudioDeviceSelector` tile in
+/// `ContentPreferencesScreen`.
+///
+/// The list of available audio devices is fetched by the View via
+/// `DivineCamera.listAudioDevices()` — it's a one-shot async UI concern
+/// (the picker isn't reactive to hot-plugging mid-screen), so the Cubit
+/// only owns the persisted selection. `null` means the user is on
+/// "Auto (recommended)".
+class AudioDeviceCubit extends Cubit<AudioDeviceState> {
+  AudioDeviceCubit({required AudioDevicePreferenceService service})
+    : _service = service,
+      super(const AudioDeviceState());
+
+  final AudioDevicePreferenceService _service;
+
+  void load() {
+    emit(
+      state.copyWith(
+        status: AudioDeviceStatus.ready,
+        currentDeviceId: _service.preferredDeviceId,
+        clearDeviceId: _service.preferredDeviceId == null,
+      ),
+    );
+  }
+
+  Future<void> setDeviceId(String? deviceId) async {
+    await _service.setPreferredDeviceId(deviceId);
+    emit(
+      state.copyWith(
+        currentDeviceId: deviceId,
+        clearDeviceId: deviceId == null,
+      ),
+    );
+  }
+}

--- a/mobile/lib/blocs/audio_device/audio_device_state.dart
+++ b/mobile/lib/blocs/audio_device/audio_device_state.dart
@@ -1,0 +1,38 @@
+// ABOUTME: State for AudioDeviceCubit — currently-selected microphone
+// ABOUTME: preference. The device list itself is fetched lazily by the View
+// ABOUTME: via DivineCamera.listAudioDevices(); only the user pick lives here.
+
+import 'package:equatable/equatable.dart';
+
+/// Load lifecycle of the audio-device picker tile.
+enum AudioDeviceStatus { loading, ready }
+
+/// State for `AudioDeviceCubit`.
+///
+/// [currentDeviceId] is null when the user has chosen "Auto (recommended)",
+/// matching the persisted-null convention of `AudioDevicePreferenceService`.
+class AudioDeviceState extends Equatable {
+  const AudioDeviceState({
+    this.status = AudioDeviceStatus.loading,
+    this.currentDeviceId,
+  });
+
+  final AudioDeviceStatus status;
+  final String? currentDeviceId;
+
+  AudioDeviceState copyWith({
+    AudioDeviceStatus? status,
+    String? currentDeviceId,
+    bool clearDeviceId = false,
+  }) {
+    return AudioDeviceState(
+      status: status ?? this.status,
+      currentDeviceId: clearDeviceId
+          ? null
+          : (currentDeviceId ?? this.currentDeviceId),
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, currentDeviceId];
+}

--- a/mobile/lib/blocs/audio_sharing/audio_sharing_cubit.dart
+++ b/mobile/lib/blocs/audio_sharing/audio_sharing_cubit.dart
@@ -1,0 +1,28 @@
+// ABOUTME: Cubit backing the audio-sharing toggle in ContentPreferencesScreen.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/audio_sharing/audio_sharing_state.dart';
+import 'package:openvine/services/audio_sharing_preference_service.dart';
+
+/// Cubit backing the `_AudioSharingToggle` tile in `ContentPreferencesScreen`.
+class AudioSharingCubit extends Cubit<AudioSharingState> {
+  AudioSharingCubit({required AudioSharingPreferenceService service})
+    : _service = service,
+      super(const AudioSharingState());
+
+  final AudioSharingPreferenceService _service;
+
+  void load() {
+    emit(
+      state.copyWith(
+        status: AudioSharingStatus.ready,
+        isEnabled: _service.isAudioSharingEnabled,
+      ),
+    );
+  }
+
+  Future<void> setEnabled(bool value) async {
+    await _service.setAudioSharingEnabled(value);
+    emit(state.copyWith(isEnabled: _service.isAudioSharingEnabled));
+  }
+}

--- a/mobile/lib/blocs/audio_sharing/audio_sharing_state.dart
+++ b/mobile/lib/blocs/audio_sharing/audio_sharing_state.dart
@@ -1,0 +1,30 @@
+// ABOUTME: State for AudioSharingCubit — the audio-sharing toggle preference.
+
+import 'package:equatable/equatable.dart';
+
+/// Load lifecycle of the audio-sharing tile.
+enum AudioSharingStatus { loading, ready }
+
+/// State for `AudioSharingCubit`.
+class AudioSharingState extends Equatable {
+  const AudioSharingState({
+    this.status = AudioSharingStatus.loading,
+    this.isEnabled = false,
+  });
+
+  final AudioSharingStatus status;
+  final bool isEnabled;
+
+  AudioSharingState copyWith({
+    AudioSharingStatus? status,
+    bool? isEnabled,
+  }) {
+    return AudioSharingState(
+      status: status ?? this.status,
+      isEnabled: isEnabled ?? this.isEnabled,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, isEnabled];
+}

--- a/mobile/lib/blocs/language_setting/language_setting_cubit.dart
+++ b/mobile/lib/blocs/language_setting/language_setting_cubit.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Cubit backing the content-language tile in ContentPreferencesScreen.
+// ABOUTME: Wraps LanguagePreferenceService for set/clear actions and snapshots
+// ABOUTME: the post-write state so the UI no longer needs setState({}).
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/language_setting/language_setting_state.dart';
+import 'package:openvine/services/language_preference_service.dart';
+
+/// Cubit backing the `_LanguageSetting` tile in `ContentPreferencesScreen`.
+///
+/// `LanguagePreferenceService` is a plain prefs-backed singleton (no stream),
+/// so the cubit re-reads the service after each mutation and emits the
+/// canonical post-write snapshot — same approach as the existing settings
+/// Cubits in this lane.
+class LanguageSettingCubit extends Cubit<LanguageSettingState> {
+  LanguageSettingCubit({required LanguagePreferenceService service})
+    : _service = service,
+      super(const LanguageSettingState());
+
+  final LanguagePreferenceService _service;
+
+  Future<void> load() async {
+    emit(state.copyWith(status: LanguageSettingStatus.loading));
+    await _service.initialize();
+    _emitSnapshot();
+  }
+
+  Future<void> setLanguage(String languageCode) async {
+    await _service.setContentLanguage(languageCode);
+    _emitSnapshot();
+  }
+
+  Future<void> clearLanguage() async {
+    await _service.clearContentLanguage();
+    _emitSnapshot();
+  }
+
+  void _emitSnapshot() {
+    emit(
+      state.copyWith(
+        status: LanguageSettingStatus.ready,
+        currentCode: _service.contentLanguage,
+        isCustomLanguageSet: _service.isCustomLanguageSet,
+      ),
+    );
+  }
+}

--- a/mobile/lib/blocs/language_setting/language_setting_state.dart
+++ b/mobile/lib/blocs/language_setting/language_setting_state.dart
@@ -1,0 +1,40 @@
+// ABOUTME: State for LanguageSettingCubit — content-language preference
+// ABOUTME: snapshot. `currentCode` is whatever the service is currently
+// ABOUTME: resolving to (custom override or device default).
+
+import 'package:equatable/equatable.dart';
+
+/// Load lifecycle of the language-setting tile.
+enum LanguageSettingStatus { loading, ready }
+
+/// State for `LanguageSettingCubit`.
+class LanguageSettingState extends Equatable {
+  const LanguageSettingState({
+    this.status = LanguageSettingStatus.loading,
+    this.currentCode = '',
+    this.isCustomLanguageSet = false,
+  });
+
+  final LanguageSettingStatus status;
+
+  /// ISO-639-1 code currently in effect (custom override or device default).
+  final String currentCode;
+
+  /// Whether the user has overridden the device default with a custom pick.
+  final bool isCustomLanguageSet;
+
+  LanguageSettingState copyWith({
+    LanguageSettingStatus? status,
+    String? currentCode,
+    bool? isCustomLanguageSet,
+  }) {
+    return LanguageSettingState(
+      status: status ?? this.status,
+      currentCode: currentCode ?? this.currentCode,
+      isCustomLanguageSet: isCustomLanguageSet ?? this.isCustomLanguageSet,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, currentCode, isCustomLanguageSet];
+}

--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -398,11 +398,6 @@ class _AudioDeviceSelectorTile extends StatelessWidget {
     return _formatAudioDeviceName(context, match.first.name);
   }
 
-  String _formatAudioDeviceName(BuildContext context, String name) {
-    if (name.isEmpty) return context.l10n.contentPreferencesUnknownMicrophone;
-    return name;
-  }
-
   Future<void> _showAudioDevicePicker(
     BuildContext context, {
     required List<AudioDevice> devices,
@@ -416,76 +411,99 @@ class _AudioDeviceSelectorTile extends StatelessWidget {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Text(
-                sheetContext.l10n.contentPreferencesSelectAudioInput,
-                style: const TextStyle(
-                  color: VineTheme.whiteText,
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            const Divider(color: VineTheme.lightText, height: 1),
-            ListTile(
-              leading: Icon(
-                currentDeviceId == null
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_off,
-                color: VineTheme.vineGreen,
-              ),
-              title: Text(
-                sheetContext.l10n.contentPreferencesAutoRecommended,
-                style: const TextStyle(color: VineTheme.whiteText),
-              ),
-              subtitle: Text(
-                sheetContext.l10n.contentPreferencesAutoSelectsBest,
-                style: const TextStyle(
-                  color: VineTheme.lightText,
-                  fontSize: 12,
-                ),
-              ),
-              onTap: () async {
-                await cubit.setDeviceId(null);
-                if (sheetContext.mounted) Navigator.pop(sheetContext);
-              },
-            ),
-            const Divider(color: VineTheme.lightText, height: 1),
-            ...devices.map(
-              (device) => ListTile(
-                leading: Icon(
-                  currentDeviceId == device.id
-                      ? Icons.radio_button_checked
-                      : Icons.radio_button_off,
-                  color: VineTheme.vineGreen,
-                ),
-                title: Text(
-                  _formatAudioDeviceName(sheetContext, device.name),
-                  style: const TextStyle(color: VineTheme.whiteText),
-                ),
-                subtitle: Text(
-                  device.id,
-                  style: const TextStyle(
-                    color: VineTheme.lightText,
-                    fontSize: 11,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-                onTap: () async {
-                  await cubit.setDeviceId(device.id);
-                  if (sheetContext.mounted) Navigator.pop(sheetContext);
-                },
-              ),
-            ),
-            const SizedBox(height: 16),
-          ],
+        child: _AudioDevicePickerContent(
+          devices: devices,
+          currentDeviceId: currentDeviceId,
+          onUseAuto: () async {
+            await cubit.setDeviceId(null);
+            if (sheetContext.mounted) Navigator.pop(sheetContext);
+          },
+          onSelectDevice: (deviceId) async {
+            await cubit.setDeviceId(deviceId);
+            if (sheetContext.mounted) Navigator.pop(sheetContext);
+          },
         ),
       ),
     );
   }
+}
+
+class _AudioDevicePickerContent extends StatelessWidget {
+  const _AudioDevicePickerContent({
+    required this.devices,
+    required this.currentDeviceId,
+    required this.onUseAuto,
+    required this.onSelectDevice,
+  });
+
+  final List<AudioDevice> devices;
+  final String? currentDeviceId;
+  final VoidCallback onUseAuto;
+  final ValueChanged<String> onSelectDevice;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            context.l10n.contentPreferencesSelectAudioInput,
+            style: const TextStyle(
+              color: VineTheme.whiteText,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        const Divider(color: VineTheme.lightText, height: 1),
+        ListTile(
+          leading: Icon(
+            currentDeviceId == null
+                ? Icons.radio_button_checked
+                : Icons.radio_button_off,
+            color: VineTheme.vineGreen,
+          ),
+          title: Text(
+            context.l10n.contentPreferencesAutoRecommended,
+            style: const TextStyle(color: VineTheme.whiteText),
+          ),
+          subtitle: Text(
+            context.l10n.contentPreferencesAutoSelectsBest,
+            style: const TextStyle(color: VineTheme.lightText, fontSize: 12),
+          ),
+          onTap: onUseAuto,
+        ),
+        const Divider(color: VineTheme.lightText, height: 1),
+        ...devices.map(
+          (device) => ListTile(
+            leading: Icon(
+              currentDeviceId == device.id
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_off,
+              color: VineTheme.vineGreen,
+            ),
+            title: Text(
+              _formatAudioDeviceName(context, device.name),
+              style: const TextStyle(color: VineTheme.whiteText),
+            ),
+            subtitle: Text(
+              device.id,
+              style: const TextStyle(color: VineTheme.lightText, fontSize: 11),
+              overflow: TextOverflow.ellipsis,
+            ),
+            onTap: () => onSelectDevice(device.id),
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}
+
+String _formatAudioDeviceName(BuildContext context, String name) {
+  if (name.isEmpty) return context.l10n.contentPreferencesUnknownMicrophone;
+  return name;
 }

--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Content preferences screen for language, audio sharing, and content filters
-// ABOUTME: Moved from old settings screen with helper methods converted to widget classes
+// ABOUTME: Composes three small Cubits (one per independent sub-setting).
 
 import 'dart:ui';
 
@@ -7,8 +7,12 @@ import 'package:divine_camera/divine_camera.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/audio_device/audio_device_cubit.dart';
+import 'package:openvine/blocs/audio_sharing/audio_sharing_cubit.dart';
+import 'package:openvine/blocs/language_setting/language_setting_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
@@ -37,32 +41,7 @@ class ContentPreferencesScreen extends ConsumerWidget {
           child: ListView(
             children: [
               const _LanguageSetting(),
-              ListTile(
-                leading: const DivineIcon(
-                  icon: DivineIconName.funnelSimple,
-                  color: VineTheme.vineGreen,
-                ),
-                title: Text(
-                  context.l10n.contentPreferencesContentFilters,
-                  style: const TextStyle(
-                    color: VineTheme.whiteText,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                subtitle: Text(
-                  context.l10n.contentPreferencesContentFiltersSubtitle,
-                  style: const TextStyle(
-                    color: VineTheme.lightText,
-                    fontSize: 14,
-                  ),
-                ),
-                trailing: const DivineIcon(
-                  icon: DivineIconName.caretRight,
-                  color: VineTheme.lightText,
-                ),
-                onTap: () => context.push(ContentFiltersScreen.path),
-              ),
+              const _ContentFiltersTile(),
               const AccountContentLabelsTile(),
               const _AudioSharingToggle(),
               if (!kIsWeb && defaultTargetPlatform != TargetPlatform.linux)
@@ -75,19 +54,59 @@ class ContentPreferencesScreen extends ConsumerWidget {
   }
 }
 
-class _LanguageSetting extends ConsumerStatefulWidget {
+class _ContentFiltersTile extends StatelessWidget {
+  const _ContentFiltersTile();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const DivineIcon(
+        icon: DivineIconName.funnelSimple,
+        color: VineTheme.vineGreen,
+      ),
+      title: Text(
+        context.l10n.contentPreferencesContentFilters,
+        style: const TextStyle(
+          color: VineTheme.whiteText,
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      subtitle: Text(
+        context.l10n.contentPreferencesContentFiltersSubtitle,
+        style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
+      ),
+      trailing: const DivineIcon(
+        icon: DivineIconName.caretRight,
+        color: VineTheme.lightText,
+      ),
+      onTap: () => context.push(ContentFiltersScreen.path),
+    );
+  }
+}
+
+class _LanguageSetting extends ConsumerWidget {
   const _LanguageSetting();
 
   @override
-  ConsumerState<_LanguageSetting> createState() => _LanguageSettingState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final service = ref.watch(languagePreferenceServiceProvider);
+    return BlocProvider(
+      key: ValueKey(service),
+      create: (_) => LanguageSettingCubit(service: service)..load(),
+      child: const _LanguageSettingTile(),
+    );
+  }
 }
 
-class _LanguageSettingState extends ConsumerState<_LanguageSetting> {
+class _LanguageSettingTile extends StatelessWidget {
+  const _LanguageSettingTile();
+
   @override
   Widget build(BuildContext context) {
-    final languageService = ref.watch(languagePreferenceServiceProvider);
-    final currentCode = languageService.contentLanguage;
-    final isCustom = languageService.isCustomLanguageSet;
+    final state = context.watch<LanguageSettingCubit>().state;
+    final currentCode = state.currentCode;
+    final isCustom = state.isCustomLanguageSet;
     final displayName = LanguagePreferenceService.displayNameFor(currentCode);
     final subtitle = isCustom
         ? displayName
@@ -116,16 +135,13 @@ class _LanguageSettingState extends ConsumerState<_LanguageSetting> {
         icon: DivineIconName.caretRight,
         color: VineTheme.lightText,
       ),
-      onTap: () => _showLanguagePicker(languageService),
+      onTap: () => _showLanguagePicker(context),
     );
   }
 
-  Future<void> _showLanguagePicker(
-    LanguagePreferenceService languageService,
-  ) async {
-    final currentCode = languageService.contentLanguage;
-    final isCustom = languageService.isCustomLanguageSet;
-
+  Future<void> _showLanguagePicker(BuildContext context) async {
+    final cubit = context.read<LanguageSettingCubit>();
+    final state = cubit.state;
     await showModalBottomSheet<void>(
       context: context,
       backgroundColor: VineTheme.cardBackground,
@@ -133,112 +149,24 @@ class _LanguageSettingState extends ConsumerState<_LanguageSetting> {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       isScrollControlled: true,
-      builder: (context) => DraggableScrollableSheet(
+      builder: (sheetContext) => DraggableScrollableSheet(
         initialChildSize: 0.6,
         maxChildSize: 0.85,
         minChildSize: 0.3,
         expand: false,
-        builder: (context, scrollController) => SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  context.l10n.contentPreferencesContentLanguage,
-                  style: const TextStyle(
-                    color: VineTheme.whiteText,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  context.l10n.contentPreferencesTagYourVideos,
-                  style: const TextStyle(
-                    color: VineTheme.lightText,
-                    fontSize: 13,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              const Divider(color: VineTheme.lightText, height: 1),
-              ListTile(
-                leading: Icon(
-                  !isCustom
-                      ? Icons.radio_button_checked
-                      : Icons.radio_button_off,
-                  color: VineTheme.vineGreen,
-                ),
-                title: Text(
-                  context.l10n.contentPreferencesUseDeviceLanguage,
-                  style: const TextStyle(color: VineTheme.whiteText),
-                ),
-                subtitle: Text(
-                  LanguagePreferenceService.displayNameFor(
-                    PlatformDispatcher.instance.locale.languageCode,
-                  ),
-                  style: const TextStyle(
-                    color: VineTheme.lightText,
-                    fontSize: 12,
-                  ),
-                ),
-                onTap: () async {
-                  await languageService.clearContentLanguage();
-                  if (context.mounted) {
-                    setState(() {});
-                    Navigator.pop(context);
-                  }
-                },
-              ),
-              const Divider(color: VineTheme.lightText, height: 1),
-              Expanded(
-                child: ListView.builder(
-                  controller: scrollController,
-                  itemCount:
-                      LanguagePreferenceService.supportedLanguages.length,
-                  itemBuilder: (context, index) {
-                    final entry = LanguagePreferenceService
-                        .supportedLanguages
-                        .entries
-                        .elementAt(index);
-                    final code = entry.key;
-                    final name = entry.value;
-                    final isSelected = isCustom && currentCode == code;
-
-                    return ListTile(
-                      leading: Icon(
-                        isSelected
-                            ? Icons.radio_button_checked
-                            : Icons.radio_button_off,
-                        color: VineTheme.vineGreen,
-                      ),
-                      title: Text(
-                        name,
-                        style: const TextStyle(color: VineTheme.whiteText),
-                      ),
-                      subtitle: Text(
-                        code.toUpperCase(),
-                        style: const TextStyle(
-                          color: VineTheme.lightText,
-                          fontSize: 12,
-                        ),
-                      ),
-                      onTap: () async {
-                        await languageService.setContentLanguage(code);
-                        if (context.mounted) {
-                          setState(() {});
-                          Navigator.pop(context);
-                        }
-                      },
-                    );
-                  },
-                ),
-              ),
-            ],
+        builder: (_, scrollController) => SafeArea(
+          child: _LanguagePickerContent(
+            scrollController: scrollController,
+            currentCode: state.currentCode,
+            isCustomLanguageSet: state.isCustomLanguageSet,
+            onUseDeviceLanguage: () async {
+              await cubit.clearLanguage();
+              if (sheetContext.mounted) Navigator.pop(sheetContext);
+            },
+            onSelectLanguage: (code) async {
+              await cubit.setLanguage(code);
+              if (sheetContext.mounted) Navigator.pop(sheetContext);
+            },
           ),
         ),
       ),
@@ -246,28 +174,131 @@ class _LanguageSettingState extends ConsumerState<_LanguageSetting> {
   }
 }
 
-class _AudioSharingToggle extends ConsumerStatefulWidget {
+class _LanguagePickerContent extends StatelessWidget {
+  const _LanguagePickerContent({
+    required this.scrollController,
+    required this.currentCode,
+    required this.isCustomLanguageSet,
+    required this.onUseDeviceLanguage,
+    required this.onSelectLanguage,
+  });
+
+  final ScrollController scrollController;
+  final String currentCode;
+  final bool isCustomLanguageSet;
+  final VoidCallback onUseDeviceLanguage;
+  final ValueChanged<String> onSelectLanguage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            context.l10n.contentPreferencesContentLanguage,
+            style: const TextStyle(
+              color: VineTheme.whiteText,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            context.l10n.contentPreferencesTagYourVideos,
+            style: const TextStyle(color: VineTheme.lightText, fontSize: 13),
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Divider(color: VineTheme.lightText, height: 1),
+        ListTile(
+          leading: Icon(
+            !isCustomLanguageSet
+                ? Icons.radio_button_checked
+                : Icons.radio_button_off,
+            color: VineTheme.vineGreen,
+          ),
+          title: Text(
+            context.l10n.contentPreferencesUseDeviceLanguage,
+            style: const TextStyle(color: VineTheme.whiteText),
+          ),
+          subtitle: Text(
+            LanguagePreferenceService.displayNameFor(
+              PlatformDispatcher.instance.locale.languageCode,
+            ),
+            style: const TextStyle(color: VineTheme.lightText, fontSize: 12),
+          ),
+          onTap: onUseDeviceLanguage,
+        ),
+        const Divider(color: VineTheme.lightText, height: 1),
+        Expanded(
+          child: ListView.builder(
+            controller: scrollController,
+            itemCount: LanguagePreferenceService.supportedLanguages.length,
+            itemBuilder: (context, index) {
+              final entry = LanguagePreferenceService.supportedLanguages.entries
+                  .elementAt(index);
+              final code = entry.key;
+              final name = entry.value;
+              final isSelected = isCustomLanguageSet && currentCode == code;
+
+              return ListTile(
+                leading: Icon(
+                  isSelected
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_off,
+                  color: VineTheme.vineGreen,
+                ),
+                title: Text(
+                  name,
+                  style: const TextStyle(color: VineTheme.whiteText),
+                ),
+                subtitle: Text(
+                  code.toUpperCase(),
+                  style: const TextStyle(
+                    color: VineTheme.lightText,
+                    fontSize: 12,
+                  ),
+                ),
+                onTap: () => onSelectLanguage(code),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AudioSharingToggle extends ConsumerWidget {
   const _AudioSharingToggle();
 
   @override
-  ConsumerState<_AudioSharingToggle> createState() =>
-      _AudioSharingToggleState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final service = ref.watch(audioSharingPreferenceServiceProvider);
+    return BlocProvider(
+      key: ValueKey(service),
+      create: (_) => AudioSharingCubit(service: service)..load(),
+      child: const _AudioSharingToggleTile(),
+    );
+  }
 }
 
-class _AudioSharingToggleState extends ConsumerState<_AudioSharingToggle> {
+class _AudioSharingToggleTile extends StatelessWidget {
+  const _AudioSharingToggleTile();
+
   @override
   Widget build(BuildContext context) {
-    final audioSharingService = ref.watch(
-      audioSharingPreferenceServiceProvider,
+    final isEnabled = context.select(
+      (AudioSharingCubit cubit) => cubit.state.isEnabled,
     );
-    final isEnabled = audioSharingService.isAudioSharingEnabled;
-
     return SwitchListTile(
       value: isEnabled,
-      onChanged: (value) async {
-        await audioSharingService.setAudioSharingEnabled(value);
-        setState(() {});
-      },
+      onChanged: (value) => context.read<AudioSharingCubit>().setEnabled(value),
       title: Text(
         context.l10n.contentPreferencesAudioSharing,
         style: const TextStyle(
@@ -289,38 +320,40 @@ class _AudioSharingToggleState extends ConsumerState<_AudioSharingToggle> {
   }
 }
 
-class _AudioDeviceSelector extends ConsumerStatefulWidget {
+class _AudioDeviceSelector extends ConsumerWidget {
   const _AudioDeviceSelector();
 
   @override
-  ConsumerState<_AudioDeviceSelector> createState() =>
-      _AudioDeviceSelectorState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final service = ref.watch(audioDevicePreferenceServiceProvider);
+    return BlocProvider(
+      key: ValueKey(service),
+      create: (_) => AudioDeviceCubit(service: service)..load(),
+      child: const _AudioDeviceSelectorTile(),
+    );
+  }
 }
 
-class _AudioDeviceSelectorState extends ConsumerState<_AudioDeviceSelector> {
+class _AudioDeviceSelectorTile extends StatelessWidget {
+  const _AudioDeviceSelectorTile();
+
   @override
   Widget build(BuildContext context) {
-    final audioDevicePref = ref.watch(audioDevicePreferenceServiceProvider);
-
     return FutureBuilder<List<AudioDevice>>(
       future: DivineCamera.instance.listAudioDevices(),
       builder: (context, snapshot) {
         if (!snapshot.hasData || snapshot.data!.length <= 1) {
           return const SizedBox.shrink();
         }
-
         final devices = snapshot.data!;
-        final currentDevice = audioDevicePref.preferredDeviceId;
-
-        String currentDisplayName;
-        if (currentDevice == null) {
-          currentDisplayName = context.l10n.contentPreferencesAutoRecommended;
-        } else {
-          final device = devices.where((d) => d.id == currentDevice);
-          currentDisplayName = device.isNotEmpty
-              ? _formatAudioDeviceName(device.first.name)
-              : context.l10n.contentPreferencesAutoRecommended;
-        }
+        final currentDeviceId = context.select(
+          (AudioDeviceCubit cubit) => cubit.state.currentDeviceId,
+        );
+        final currentDisplayName = _resolveCurrentDisplayName(
+          context,
+          devices: devices,
+          currentDeviceId: currentDeviceId,
+        );
 
         return ListTile(
           leading: const Icon(Icons.mic, color: VineTheme.vineGreen),
@@ -340,30 +373,49 @@ class _AudioDeviceSelectorState extends ConsumerState<_AudioDeviceSelector> {
             icon: DivineIconName.caretRight,
             color: VineTheme.lightText,
           ),
-          onTap: () => _showAudioDevicePicker(devices, currentDevice),
+          onTap: () => _showAudioDevicePicker(
+            context,
+            devices: devices,
+            currentDeviceId: currentDeviceId,
+          ),
         );
       },
     );
   }
 
-  String _formatAudioDeviceName(String name) {
+  String _resolveCurrentDisplayName(
+    BuildContext context, {
+    required List<AudioDevice> devices,
+    required String? currentDeviceId,
+  }) {
+    if (currentDeviceId == null) {
+      return context.l10n.contentPreferencesAutoRecommended;
+    }
+    final match = devices.where((d) => d.id == currentDeviceId);
+    if (match.isEmpty) {
+      return context.l10n.contentPreferencesAutoRecommended;
+    }
+    return _formatAudioDeviceName(context, match.first.name);
+  }
+
+  String _formatAudioDeviceName(BuildContext context, String name) {
     if (name.isEmpty) return context.l10n.contentPreferencesUnknownMicrophone;
     return name;
   }
 
   Future<void> _showAudioDevicePicker(
-    List<AudioDevice> devices,
-    String? currentDevice,
-  ) async {
-    final audioDevicePref = ref.read(audioDevicePreferenceServiceProvider);
-
+    BuildContext context, {
+    required List<AudioDevice> devices,
+    required String? currentDeviceId,
+  }) async {
+    final cubit = context.read<AudioDeviceCubit>();
     await showModalBottomSheet<void>(
       context: context,
       backgroundColor: VineTheme.cardBackground,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
-      builder: (context) => SafeArea(
+      builder: (sheetContext) => SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -371,7 +423,7 @@ class _AudioDeviceSelectorState extends ConsumerState<_AudioDeviceSelector> {
             Padding(
               padding: const EdgeInsets.all(16),
               child: Text(
-                context.l10n.contentPreferencesSelectAudioInput,
+                sheetContext.l10n.contentPreferencesSelectAudioInput,
                 style: const TextStyle(
                   color: VineTheme.whiteText,
                   fontSize: 18,
@@ -382,41 +434,38 @@ class _AudioDeviceSelectorState extends ConsumerState<_AudioDeviceSelector> {
             const Divider(color: VineTheme.lightText, height: 1),
             ListTile(
               leading: Icon(
-                currentDevice == null
+                currentDeviceId == null
                     ? Icons.radio_button_checked
                     : Icons.radio_button_off,
                 color: VineTheme.vineGreen,
               ),
               title: Text(
-                context.l10n.contentPreferencesAutoRecommended,
+                sheetContext.l10n.contentPreferencesAutoRecommended,
                 style: const TextStyle(color: VineTheme.whiteText),
               ),
               subtitle: Text(
-                context.l10n.contentPreferencesAutoSelectsBest,
+                sheetContext.l10n.contentPreferencesAutoSelectsBest,
                 style: const TextStyle(
                   color: VineTheme.lightText,
                   fontSize: 12,
                 ),
               ),
               onTap: () async {
-                await audioDevicePref.setPreferredDeviceId(null);
-                if (context.mounted) {
-                  setState(() {});
-                  Navigator.pop(context);
-                }
+                await cubit.setDeviceId(null);
+                if (sheetContext.mounted) Navigator.pop(sheetContext);
               },
             ),
             const Divider(color: VineTheme.lightText, height: 1),
             ...devices.map(
               (device) => ListTile(
                 leading: Icon(
-                  currentDevice == device.id
+                  currentDeviceId == device.id
                       ? Icons.radio_button_checked
                       : Icons.radio_button_off,
                   color: VineTheme.vineGreen,
                 ),
                 title: Text(
-                  _formatAudioDeviceName(device.name),
+                  _formatAudioDeviceName(sheetContext, device.name),
                   style: const TextStyle(color: VineTheme.whiteText),
                 ),
                 subtitle: Text(
@@ -428,11 +477,8 @@ class _AudioDeviceSelectorState extends ConsumerState<_AudioDeviceSelector> {
                   overflow: TextOverflow.ellipsis,
                 ),
                 onTap: () async {
-                  await audioDevicePref.setPreferredDeviceId(device.id);
-                  if (context.mounted) {
-                    setState(() {});
-                    Navigator.pop(context);
-                  }
+                  await cubit.setDeviceId(device.id);
+                  if (sheetContext.mounted) Navigator.pop(sheetContext);
                 },
               ),
             ),

--- a/mobile/test/blocs/audio_device/audio_device_cubit_test.dart
+++ b/mobile/test/blocs/audio_device/audio_device_cubit_test.dart
@@ -1,0 +1,82 @@
+// ABOUTME: Unit tests for AudioDeviceCubit — load + setDeviceId (incl. null
+// ABOUTME: meaning Auto recommended).
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/audio_device/audio_device_cubit.dart';
+import 'package:openvine/blocs/audio_device/audio_device_state.dart';
+import 'package:openvine/services/audio_device_preference_service.dart';
+
+class _MockAudioDevicePreferenceService extends Mock
+    implements AudioDevicePreferenceService {}
+
+void main() {
+  group(AudioDeviceCubit, () {
+    late _MockAudioDevicePreferenceService service;
+
+    setUp(() {
+      service = _MockAudioDevicePreferenceService();
+      when(() => service.preferredDeviceId).thenReturn(null);
+      when(() => service.setPreferredDeviceId(any())).thenAnswer((_) async {});
+    });
+
+    AudioDeviceCubit buildCubit() => AudioDeviceCubit(service: service);
+
+    blocTest<AudioDeviceCubit, AudioDeviceState>(
+      'load with null preference emits ready + Auto',
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const AudioDeviceState(status: AudioDeviceStatus.ready),
+      ],
+    );
+
+    blocTest<AudioDeviceCubit, AudioDeviceState>(
+      'load with persisted device snapshots it',
+      setUp: () {
+        when(() => service.preferredDeviceId).thenReturn('mic-1');
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const AudioDeviceState(
+          status: AudioDeviceStatus.ready,
+          currentDeviceId: 'mic-1',
+        ),
+      ],
+    );
+
+    blocTest<AudioDeviceCubit, AudioDeviceState>(
+      'setDeviceId(non-null) delegates and emits new device',
+      seed: () => const AudioDeviceState(status: AudioDeviceStatus.ready),
+      build: buildCubit,
+      act: (cubit) => cubit.setDeviceId('mic-2'),
+      expect: () => [
+        const AudioDeviceState(
+          status: AudioDeviceStatus.ready,
+          currentDeviceId: 'mic-2',
+        ),
+      ],
+      verify: (_) {
+        verify(() => service.setPreferredDeviceId('mic-2')).called(1);
+      },
+    );
+
+    blocTest<AudioDeviceCubit, AudioDeviceState>(
+      'setDeviceId(null) delegates and emits the cleared Auto state',
+      seed: () => const AudioDeviceState(
+        status: AudioDeviceStatus.ready,
+        currentDeviceId: 'mic-1',
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.setDeviceId(null),
+      expect: () => [
+        const AudioDeviceState(status: AudioDeviceStatus.ready),
+      ],
+      verify: (_) {
+        verify(() => service.setPreferredDeviceId(null)).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/blocs/audio_device/audio_device_cubit_test.dart
+++ b/mobile/test/blocs/audio_device/audio_device_cubit_test.dart
@@ -17,6 +17,7 @@ void main() {
 
     setUp(() {
       service = _MockAudioDevicePreferenceService();
+      when(() => service.initialize()).thenAnswer((_) async {});
       when(() => service.preferredDeviceId).thenReturn(null);
       when(() => service.setPreferredDeviceId(any())).thenAnswer((_) async {});
     });
@@ -30,6 +31,9 @@ void main() {
       expect: () => [
         const AudioDeviceState(status: AudioDeviceStatus.ready),
       ],
+      verify: (_) {
+        verify(() => service.initialize()).called(1);
+      },
     );
 
     blocTest<AudioDeviceCubit, AudioDeviceState>(
@@ -52,10 +56,35 @@ void main() {
       seed: () => const AudioDeviceState(status: AudioDeviceStatus.ready),
       build: buildCubit,
       act: (cubit) => cubit.setDeviceId('mic-2'),
+      setUp: () {
+        when(() => service.preferredDeviceId).thenReturn('mic-2');
+      },
       expect: () => [
         const AudioDeviceState(
           status: AudioDeviceStatus.ready,
           currentDeviceId: 'mic-2',
+        ),
+      ],
+      verify: (_) {
+        verify(() => service.setPreferredDeviceId('mic-2')).called(1);
+      },
+    );
+
+    blocTest<AudioDeviceCubit, AudioDeviceState>(
+      'setDeviceId emits the post-write service snapshot',
+      seed: () => const AudioDeviceState(
+        status: AudioDeviceStatus.ready,
+        currentDeviceId: 'mic-2',
+      ),
+      setUp: () {
+        when(() => service.preferredDeviceId).thenReturn('mic-1');
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.setDeviceId('mic-2'),
+      expect: () => [
+        const AudioDeviceState(
+          status: AudioDeviceStatus.ready,
+          currentDeviceId: 'mic-1',
         ),
       ],
       verify: (_) {

--- a/mobile/test/blocs/audio_sharing/audio_sharing_cubit_test.dart
+++ b/mobile/test/blocs/audio_sharing/audio_sharing_cubit_test.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Unit tests for AudioSharingCubit — load + toggle.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/audio_sharing/audio_sharing_cubit.dart';
+import 'package:openvine/blocs/audio_sharing/audio_sharing_state.dart';
+import 'package:openvine/services/audio_sharing_preference_service.dart';
+
+class _MockAudioSharingPreferenceService extends Mock
+    implements AudioSharingPreferenceService {}
+
+void main() {
+  group(AudioSharingCubit, () {
+    late _MockAudioSharingPreferenceService service;
+
+    setUp(() {
+      service = _MockAudioSharingPreferenceService();
+      when(() => service.isAudioSharingEnabled).thenReturn(false);
+      when(
+        () => service.setAudioSharingEnabled(any()),
+      ).thenAnswer((_) async {});
+    });
+
+    AudioSharingCubit buildCubit() => AudioSharingCubit(service: service);
+
+    blocTest<AudioSharingCubit, AudioSharingState>(
+      'load snapshots service state',
+      setUp: () {
+        when(() => service.isAudioSharingEnabled).thenReturn(true);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const AudioSharingState(
+          status: AudioSharingStatus.ready,
+          isEnabled: true,
+        ),
+      ],
+    );
+
+    blocTest<AudioSharingCubit, AudioSharingState>(
+      'setEnabled delegates to service and emits re-read snapshot',
+      seed: () => const AudioSharingState(status: AudioSharingStatus.ready),
+      setUp: () {
+        when(() => service.isAudioSharingEnabled).thenReturn(true);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.setEnabled(true),
+      expect: () => [
+        const AudioSharingState(
+          status: AudioSharingStatus.ready,
+          isEnabled: true,
+        ),
+      ],
+      verify: (_) {
+        verify(() => service.setAudioSharingEnabled(true)).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/blocs/language_setting/language_setting_cubit_test.dart
+++ b/mobile/test/blocs/language_setting/language_setting_cubit_test.dart
@@ -1,0 +1,98 @@
+// ABOUTME: Unit tests for LanguageSettingCubit — load snapshot, setLanguage,
+// ABOUTME: clearLanguage, all emitting the post-write canonical snapshot.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/language_setting/language_setting_cubit.dart';
+import 'package:openvine/blocs/language_setting/language_setting_state.dart';
+import 'package:openvine/services/language_preference_service.dart';
+
+class _MockLanguagePreferenceService extends Mock
+    implements LanguagePreferenceService {}
+
+void main() {
+  group(LanguageSettingCubit, () {
+    late _MockLanguagePreferenceService service;
+
+    setUp(() {
+      service = _MockLanguagePreferenceService();
+      when(service.initialize).thenAnswer((_) async {});
+      when(() => service.contentLanguage).thenReturn('en');
+      when(() => service.isCustomLanguageSet).thenReturn(false);
+      when(() => service.setContentLanguage(any())).thenAnswer((_) async {});
+      when(service.clearContentLanguage).thenAnswer((_) async {});
+    });
+
+    LanguageSettingCubit buildCubit() => LanguageSettingCubit(service: service);
+
+    blocTest<LanguageSettingCubit, LanguageSettingState>(
+      'load snapshots service state',
+      setUp: () {
+        when(() => service.contentLanguage).thenReturn('es');
+        when(() => service.isCustomLanguageSet).thenReturn(true);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const LanguageSettingState(),
+        const LanguageSettingState(
+          status: LanguageSettingStatus.ready,
+          currentCode: 'es',
+          isCustomLanguageSet: true,
+        ),
+      ],
+      verify: (_) {
+        verify(service.initialize).called(1);
+      },
+    );
+
+    blocTest<LanguageSettingCubit, LanguageSettingState>(
+      'setLanguage delegates to service and emits re-read snapshot',
+      seed: () => const LanguageSettingState(
+        status: LanguageSettingStatus.ready,
+        currentCode: 'en',
+      ),
+      setUp: () {
+        when(() => service.contentLanguage).thenReturn('pt');
+        when(() => service.isCustomLanguageSet).thenReturn(true);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.setLanguage('pt'),
+      expect: () => [
+        const LanguageSettingState(
+          status: LanguageSettingStatus.ready,
+          currentCode: 'pt',
+          isCustomLanguageSet: true,
+        ),
+      ],
+      verify: (_) {
+        verify(() => service.setContentLanguage('pt')).called(1);
+      },
+    );
+
+    blocTest<LanguageSettingCubit, LanguageSettingState>(
+      'clearLanguage delegates to service and emits device-default snapshot',
+      seed: () => const LanguageSettingState(
+        status: LanguageSettingStatus.ready,
+        currentCode: 'pt',
+        isCustomLanguageSet: true,
+      ),
+      setUp: () {
+        when(() => service.contentLanguage).thenReturn('en');
+        when(() => service.isCustomLanguageSet).thenReturn(false);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.clearLanguage(),
+      expect: () => [
+        const LanguageSettingState(
+          status: LanguageSettingStatus.ready,
+          currentCode: 'en',
+        ),
+      ],
+      verify: (_) {
+        verify(service.clearContentLanguage).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -227,6 +227,10 @@ void main() {
 
       final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
       expect(feedVideos.trafficSource, ViewTrafficSource.home);
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
     });
   });
 }

--- a/mobile/test/screens/settings_screen_audio_sharing_test.dart
+++ b/mobile/test/screens/settings_screen_audio_sharing_test.dart
@@ -25,6 +25,7 @@ class _MockAccountLabelService extends Mock implements AccountLabelService {}
 
 void main() {
   group('ContentPreferencesScreen Audio Sharing Toggle', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
     late _MockAudioSharingPreferenceService mockAudioSharingService;
     late _MockLanguagePreferenceService mockLanguageService;
     late _MockAccountLabelService mockAccountLabelService;
@@ -77,9 +78,9 @@ void main() {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.text('Make my audio available for reuse'), findsOneWidget);
+      expect(find.text(l10n.contentPreferencesAudioSharing), findsOneWidget);
       expect(
-        find.text('When enabled, others can use audio from your videos'),
+        find.text(l10n.contentPreferencesAudioSharingSubtitle),
         findsOneWidget,
       );
 
@@ -100,7 +101,7 @@ void main() {
             widget is SwitchListTile &&
             widget.title is Text &&
             (widget.title! as Text).data ==
-                'Make my audio available for reuse' &&
+                l10n.contentPreferencesAudioSharing &&
             !widget.value,
       );
       expect(switchFinder, findsOneWidget);
@@ -122,7 +123,7 @@ void main() {
             widget is SwitchListTile &&
             widget.title is Text &&
             (widget.title! as Text).data ==
-                'Make my audio available for reuse' &&
+                l10n.contentPreferencesAudioSharing &&
             widget.value,
       );
       expect(switchFinder, findsOneWidget);
@@ -146,7 +147,7 @@ void main() {
         (widget) =>
             widget is SwitchListTile &&
             widget.title is Text &&
-            (widget.title! as Text).data == 'Make my audio available for reuse',
+            (widget.title! as Text).data == l10n.contentPreferencesAudioSharing,
       );
 
       await tester.tap(switchFinder);
@@ -169,7 +170,7 @@ void main() {
             widget is SwitchListTile &&
             widget.title is Text &&
             (widget.title! as Text).data ==
-                'Make my audio available for reuse' &&
+                l10n.contentPreferencesAudioSharing &&
             widget.activeThumbColor == VineTheme.vineGreen,
       );
       expect(switchFinder, findsOneWidget);

--- a/mobile/test/screens/settings_screen_audio_sharing_test.dart
+++ b/mobile/test/screens/settings_screen_audio_sharing_test.dart
@@ -40,6 +40,10 @@ void main() {
       when(
         () => mockAudioSharingService.isAudioSharingEnabled,
       ).thenReturn(false);
+      when(
+        () => mockAudioSharingService.setAudioSharingEnabled(any()),
+      ).thenAnswer((_) async {});
+      when(() => mockLanguageService.initialize()).thenAnswer((_) async {});
       when(() => mockLanguageService.contentLanguage).thenReturn('en');
       when(() => mockLanguageService.isCustomLanguageSet).thenReturn(false);
       when(() => mockAccountLabelService.accountLabels).thenReturn({});


### PR DESCRIPTION
## Description

Continues #4744 WS-1. Each independent sub-setting on `ContentPreferencesScreen` gets its own small Cubit per the plan's "do not force one mega-cubit" rule:

- `LanguageSettingCubit` — `load` + `setLanguage` + `clearLanguage`.
- `AudioSharingCubit` — `load` + `setEnabled`.
- `AudioDeviceCubit` — `load` + `setDeviceId` (`null` = "Auto recommended", matching the persisted-null convention of `AudioDevicePreferenceService`).

The three preference services are plain prefs-backed singletons (no stream), so each Cubit re-reads the service after every mutation and emits the canonical post-write snapshot — same pattern as the existing settings Cubits in this lane. The pre-migration `ConsumerStatefulWidget` + `setState({})` after each service call is replaced by `BlocProvider` + `context.select` / `BlocBuilder`.

**Screen refactor.** `ContentPreferencesScreen` stays a `ConsumerWidget` shell. Each sub-widget is now a `ConsumerWidget` Page that watches its service and creates a `BlocProvider` keyed on that service, with a `StatelessWidget` tile child that consumes the Cubit. The two modal pickers (language + audio device) were extracted into private widget classes so the `showModalBottomSheet` builder no longer holds a closure over `setState`. `AccountContentLabelsTile` (already migrated by #4751) and the existing `_ContentFiltersTile` are unchanged.

**Related Issue:** Relates to #4744 (WS-1) · Parent epic #4338

## Out of Scope

- The remaining WS-1 slices (progress sheets, feedback dialogs, `sounds`, `relay_settings`) follow as their own PRs.

## Verification

- `flutter analyze lib/blocs/language_setting/ lib/blocs/audio_sharing/ lib/blocs/audio_device/ lib/screens/settings/content_preferences_screen.dart` → `No issues found!`
- `flutter test test/blocs/language_setting/ test/blocs/audio_sharing/ test/blocs/audio_device/` → **9/9 cubit tests passing** (3 + 2 + 4).
- `dart format --output=none --set-exit-if-changed` → clean.

## Type of Change

- [x] 🧹 Code refactor

## Notes for review

- Three cubits instead of one: each sub-setting has zero coupling to the others (independent services, independent state), so the plan's "do not force one mega-cubit" rule applies cleanly. Each Cubit is ~30-50 LOC.
- `_AudioDeviceSelector` keeps `FutureBuilder<List<AudioDevice>>` for `DivineCamera.instance.listAudioDevices()` because that's a one-shot async UI concern (the picker isn't reactive to hot-plugging mid-screen). The Cubit only owns the persisted selection — the in-state `currentDeviceId` is `null` when the user is on "Auto recommended".
- `AudioDeviceState.copyWith` takes a `clearDeviceId` flag because the default copyWith behavior of `currentDeviceId ?? this.currentDeviceId` would prevent setting it back to null. The cubit's `setDeviceId(null)` and `load()` (when service returns null) both use `clearDeviceId: true`.
