### PR TITLE
refactor(state): migrate SoundsScreen to a Cubit

### DIFF
--- a/mobile/lib/blocs/sounds/sounds_cubit.dart
+++ b/mobile/lib/blocs/sounds/sounds_cubit.dart
@@ -1,0 +1,133 @@
+// ABOUTME: Cubit backing the SoundsScreen — owns the search filter and the
+// ABOUTME: audio-preview lifecycle. Search controller stays in the View
+// ABOUTME: (hybrid pattern per #4744 WS-1 #5 precedent).
+
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/blocs/sounds/sounds_state.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:sound_service/sound_service.dart';
+
+/// Callable that hides the Riverpod `savedSoundsProvider.notifier.saveSound`
+/// surface so the Cubit doesn't need to know about the notifier directly.
+typedef SaveSoundAction = Future<SavedSoundSaveResult> Function(AudioEvent);
+
+/// Cubit backing `SoundsScreen`.
+///
+/// Owns:
+/// - the lowercased [SoundsState.searchQuery] applied to both bundled +
+///   Nostr sound lists in the View,
+/// - the audio-preview lifecycle ([SoundsState.previewingSoundId] +
+///   [SoundsState.isLoadingPreview]).
+///
+/// Transient outcomes (save result, preview unavailable, preview failure)
+/// are returned from the corresponding method as a `Future<Result>` so the
+/// View can pick snackbar copy without state having to carry error strings
+/// (per `state_management.md`).
+class SoundsCubit extends Cubit<SoundsState> {
+  SoundsCubit({
+    required AudioPlaybackService audioPlaybackService,
+    required SaveSoundAction saveSound,
+  }) : _audioPlaybackService = audioPlaybackService,
+       _saveSound = saveSound,
+       super(const SoundsState());
+
+  final AudioPlaybackService _audioPlaybackService;
+  final SaveSoundAction _saveSound;
+
+  void setSearchQuery(String query) {
+    emit(state.copyWith(searchQuery: query.toLowerCase()));
+  }
+
+  /// Filters [sounds] by the current [SoundsState.searchQuery] against the
+  /// lowercased title. Returns the input unchanged when the query is empty.
+  List<AudioEvent> filterSounds(List<AudioEvent> sounds) {
+    final query = state.searchQuery;
+    if (query.isEmpty) return sounds;
+    return sounds.where((sound) {
+      final title = sound.title?.toLowerCase() ?? '';
+      return title.contains(query);
+    }).toList();
+  }
+
+  /// Toggles or starts a preview for [sound].
+  ///
+  /// Returns:
+  /// - [PreviewSoundOutcome.ignored] when a preview is already loading.
+  /// - [PreviewSoundOutcome.stopped] when the user tapped the currently-
+  ///   playing sound — the audio service is stopped and state is cleared.
+  /// - [PreviewSoundOutcome.unavailable] when the sound has no playable URL.
+  /// - [PreviewSoundOutcome.completed] when playback ran to completion (or
+  ///   was stopped) without error.
+  /// - [PreviewSoundOutcome.failed] when the audio service threw — the
+  ///   error is also reported via `addError` for observability.
+  Future<PreviewSoundOutcome> previewSound(AudioEvent sound) async {
+    if (state.isLoadingPreview) return PreviewSoundOutcome.ignored;
+
+    if (state.previewingSoundId == sound.id) {
+      await _stopAudio();
+      _clearPreviewing();
+      return PreviewSoundOutcome.stopped;
+    }
+
+    final url = sound.url;
+    if (url == null || url.isEmpty) {
+      return PreviewSoundOutcome.unavailable;
+    }
+
+    emit(state.copyWith(isLoadingPreview: true));
+    try {
+      await _audioPlaybackService.stop();
+      await _audioPlaybackService.loadAudio(url);
+      emit(
+        state.copyWith(
+          previewingSoundId: sound.id,
+          isLoadingPreview: false,
+        ),
+      );
+      await _audioPlaybackService.play();
+      _clearPreviewing();
+      return PreviewSoundOutcome.completed;
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
+      _clearPreviewing();
+      return PreviewSoundOutcome.failed;
+    }
+  }
+
+  /// Stops any in-flight preview. No-op when nothing is previewing.
+  Future<void> stopPreview() async {
+    if (state.previewingSoundId == null) return;
+    await _stopAudio();
+    _clearPreviewing();
+  }
+
+  /// Delegates to the injected save action and returns the result so the
+  /// View can pick the right snackbar copy.
+  Future<SavedSoundSaveResult> saveSound(AudioEvent sound) => _saveSound(sound);
+
+  Future<void> _stopAudio() async {
+    await _audioPlaybackService.stop();
+  }
+
+  void _clearPreviewing() {
+    if (isClosed) return;
+    emit(state.copyWith(isLoadingPreview: false, clearPreviewingSoundId: true));
+  }
+
+  @override
+  Future<void> close() async {
+    // Stop any in-flight playback so disposing the screen doesn't leave the
+    // audio service playing into the void.
+    if (state.previewingSoundId != null) {
+      try {
+        await _audioPlaybackService.stop();
+      } catch (_) {
+        // Best-effort cleanup; ignore failures during shutdown.
+      }
+    }
+    return super.close();
+  }
+}

--- a/mobile/lib/blocs/sounds/sounds_cubit.dart
+++ b/mobile/lib/blocs/sounds/sounds_cubit.dart
@@ -55,7 +55,9 @@ class SoundsCubit extends Cubit<SoundsState> {
   /// Toggles or starts a preview for [sound].
   ///
   /// Returns:
-  /// - [PreviewSoundOutcome.ignored] when a preview is already loading.
+  /// - [PreviewSoundOutcome.ignored] when a preview is already loading, or
+  ///   when the screen was disposed mid-load (the loaded source is stopped
+  ///   and nothing is left playing).
   /// - [PreviewSoundOutcome.stopped] when the user tapped the currently-
   ///   playing sound — the audio service is stopped and state is cleared.
   /// - [PreviewSoundOutcome.unavailable] when the sound has no playable URL.
@@ -81,6 +83,18 @@ class SoundsCubit extends Cubit<SoundsState> {
     try {
       await _audioPlaybackService.stop();
       await _audioPlaybackService.loadAudio(url);
+      if (isClosed) {
+        // The screen was torn down while the source was still loading —
+        // before [SoundsState.previewingSoundId] was set, so [close] could
+        // not have stopped it. Stop the just-loaded source so it doesn't
+        // keep buffering, and skip emitting into a closed Cubit.
+        try {
+          await _audioPlaybackService.stop();
+        } catch (_) {
+          // Best-effort cleanup during shutdown.
+        }
+        return PreviewSoundOutcome.ignored;
+      }
       emit(
         state.copyWith(
           previewingSoundId: sound.id,
@@ -117,10 +131,23 @@ class SoundsCubit extends Cubit<SoundsState> {
     emit(state.copyWith(isLoadingPreview: false, clearPreviewingSoundId: true));
   }
 
+  /// Closes the Cubit, guaranteeing no preview audio outlives the screen.
+  ///
+  /// This is the **navigate-away cleanup contract**: when the enclosing
+  /// `BlocProvider` is disposed (route pop, account switch, app teardown),
+  /// an actively-playing preview ([SoundsState.previewingSoundId] != null)
+  /// is stopped here. `just_audio`'s `play()` stays pending for the whole
+  /// duration of playback, so a sound that is audibly playing always has its
+  /// id set and is covered by this guard.
+  ///
+  /// The earlier loading phase — where [SoundsState.isLoadingPreview] is true
+  /// but the id isn't set yet — is handled by [previewSound]'s `isClosed`
+  /// bail-out, so every preview phase is covered.
+  ///
+  /// Pinned by the "navigate-away cleanup contract" tests in
+  /// `sounds_cubit_test.dart` and `sounds_screen_test.dart`.
   @override
   Future<void> close() async {
-    // Stop any in-flight playback so disposing the screen doesn't leave the
-    // audio service playing into the void.
     if (state.previewingSoundId != null) {
       try {
         await _audioPlaybackService.stop();

--- a/mobile/lib/blocs/sounds/sounds_state.dart
+++ b/mobile/lib/blocs/sounds/sounds_state.dart
@@ -49,7 +49,8 @@ class SoundsState extends Equatable {
 
 /// Outcome of `SoundsCubit.previewSound(sound)`.
 enum PreviewSoundOutcome {
-  /// `previewSound` was a no-op because a preview is already loading.
+  /// `previewSound` was a no-op: either a preview was already loading, or the
+  /// Cubit was closed mid-load (the loaded source is stopped, nothing plays).
   ignored,
 
   /// Tapping the same sound stopped the currently-playing preview.

--- a/mobile/lib/blocs/sounds/sounds_state.dart
+++ b/mobile/lib/blocs/sounds/sounds_state.dart
@@ -1,0 +1,66 @@
+// ABOUTME: State for SoundsCubit — durable search query + audio-preview
+// ABOUTME: lifecycle. Transient outcomes (save result, preview failure) flow
+// ABOUTME: through method return values, not through state.
+
+import 'package:equatable/equatable.dart';
+
+/// State for `SoundsCubit`.
+///
+/// Only durable UI state lives here. Transient outcomes — "saved to
+/// library", "already saved", "preview unavailable", "preview failed" —
+/// are returned from the corresponding cubit method as a `Future<Result>`
+/// so the View can decide on snackbar copy without state having to carry
+/// error strings.
+class SoundsState extends Equatable {
+  const SoundsState({
+    this.searchQuery = '',
+    this.previewingSoundId,
+    this.isLoadingPreview = false,
+  });
+
+  /// Lowercased search filter applied to bundled + Nostr sound lists.
+  final String searchQuery;
+
+  /// Id of the sound currently playing (null when nothing is previewing).
+  final String? previewingSoundId;
+
+  /// True while the audio service is loading a sound between the user's
+  /// preview tap and `play()` actually starting.
+  final bool isLoadingPreview;
+
+  SoundsState copyWith({
+    String? searchQuery,
+    String? previewingSoundId,
+    bool? isLoadingPreview,
+    bool clearPreviewingSoundId = false,
+  }) {
+    return SoundsState(
+      searchQuery: searchQuery ?? this.searchQuery,
+      previewingSoundId: clearPreviewingSoundId
+          ? null
+          : (previewingSoundId ?? this.previewingSoundId),
+      isLoadingPreview: isLoadingPreview ?? this.isLoadingPreview,
+    );
+  }
+
+  @override
+  List<Object?> get props => [searchQuery, previewingSoundId, isLoadingPreview];
+}
+
+/// Outcome of `SoundsCubit.previewSound(sound)`.
+enum PreviewSoundOutcome {
+  /// `previewSound` was a no-op because a preview is already loading.
+  ignored,
+
+  /// Tapping the same sound stopped the currently-playing preview.
+  stopped,
+
+  /// The sound has no playable URL.
+  unavailable,
+
+  /// Playback completed (or was stopped) without error.
+  completed,
+
+  /// The audio service threw while loading or playing.
+  failed,
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1954,6 +1954,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "ቅድመ እይታን ማጫወት አልተሳካም",
     "soundsFeaturedSounds": "ተለይተው የቀረቡ ድምፆች",
     "soundsTrendingSounds": "በመታየት ላይ ያሉ ድምፆች",
     "soundsAllSounds": "ሁሉም ድምጾች",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1649,6 +1649,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "تعذر تشغيل المعاينة",
     "soundsFeaturedSounds": "أصوات مميزة",
     "soundsTrendingSounds": "أصوات رائجة",
     "soundsAllSounds": "كل الأصوات",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1841,6 +1841,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Неуспешно пускане на визуализация",
     "soundsFeaturedSounds": "Представени звуци",
     "soundsTrendingSounds": "Набиращи популярност звуци",
     "soundsAllSounds": "Всички звуци",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Vorschau-Wiedergabe fehlgeschlagen",
     "soundsFeaturedSounds": "Featured Sounds",
     "soundsTrendingSounds": "Trending Sounds",
     "soundsAllSounds": "Alle Sounds",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2127,6 +2127,7 @@
       }
     }
   },
+  "soundsPreviewFailedGeneric": "Failed to play preview",
   "soundsFeaturedSounds": "Featured Sounds",
   "soundsTrendingSounds": "Trending Sounds",
   "soundsAllSounds": "All Sounds",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1663,6 +1663,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "No se pudo reproducir la previsualización",
     "soundsFeaturedSounds": "Sonidos destacados",
     "soundsTrendingSounds": "Sonidos en tendencia",
     "soundsAllSounds": "Todos los sonidos",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1019,6 +1019,7 @@
     "soundsSearchHint": "Maghanap ng sounds...",
     "soundsPreviewUnavailable": "Hindi ma-preview ang sound - walang available na audio",
     "soundsPreviewFailed": "Hindi na-play ang preview: {error}",
+    "soundsPreviewFailedGeneric": "Hindi na-play ang preview",
     "soundsFeaturedSounds": "Mga Featured Sound",
     "soundsTrendingSounds": "Mga Trending Sound",
     "soundsAllSounds": "Lahat ng Sound",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Échec de la lecture de l'aperçu",
     "soundsFeaturedSounds": "Sons à la une",
     "soundsTrendingSounds": "Sons tendance",
     "soundsAllSounds": "Tous les sons",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1656,6 +1656,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Gagal memutar pratinjau",
     "soundsFeaturedSounds": "Suara Unggulan",
     "soundsTrendingSounds": "Suara Trending",
     "soundsAllSounds": "Semua Suara",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Impossibile riprodurre l'anteprima",
     "soundsFeaturedSounds": "Suoni in evidenza",
     "soundsTrendingSounds": "Suoni di tendenza",
     "soundsAllSounds": "Tutti i suoni",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1649,6 +1649,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "プレビューの再生がうまくいかなかった",
     "soundsFeaturedSounds": "注目のサウンド",
     "soundsTrendingSounds": "トレンドのサウンド",
     "soundsAllSounds": "すべてのサウンド",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -945,6 +945,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "미리 듣기를 재생하지 못했어요",
     "soundsFeaturedSounds": "추천 사운드",
     "soundsTrendingSounds": "인기 사운드",
     "soundsAllSounds": "모든 사운드",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Voorbeluistering afspelen mislukt",
     "soundsFeaturedSounds": "Uitgelichte geluiden",
     "soundsTrendingSounds": "Trending geluiden",
     "soundsAllSounds": "Alle geluiden",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Nie udało się odtworzyć podglądu",
     "soundsFeaturedSounds": "Polecane dźwięki",
     "soundsTrendingSounds": "Trendy w dźwiękach",
     "soundsAllSounds": "Wszystkie dźwięki",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Falha ao reproduzir pré-visualização",
     "soundsFeaturedSounds": "Sons em destaque",
     "soundsTrendingSounds": "Sons em alta",
     "soundsAllSounds": "Todos os sons",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "N-am putut reda previzualizarea",
     "soundsFeaturedSounds": "Sunete recomandate",
     "soundsTrendingSounds": "Sunete în trend",
     "soundsAllSounds": "Toate sunetele",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1659,6 +1659,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Kunde inte spela förhandsvisning",
     "soundsFeaturedSounds": "Utvalda ljud",
     "soundsTrendingSounds": "Trendiga ljud",
     "soundsAllSounds": "Alla ljud",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1656,6 +1656,7 @@
             }
         }
     },
+    "soundsPreviewFailedGeneric": "Önizleme oynatılamadı",
     "soundsFeaturedSounds": "Öne Çıkan Sesler",
     "soundsTrendingSounds": "Trend Sesler",
     "soundsAllSounds": "Tüm Sesler",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6872,6 +6872,12 @@ abstract class AppLocalizations {
   /// **'Failed to play preview: {error}'**
   String soundsPreviewFailed(String error);
 
+  /// No description provided for @soundsPreviewFailedGeneric.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to play preview'**
+  String get soundsPreviewFailedGeneric;
+
   /// No description provided for @soundsFeaturedSounds.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3855,6 +3855,9 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'ቅድመ እይታን ማጫወት አልተሳካም';
+
+  @override
   String get soundsFeaturedSounds => 'ተለይተው የቀረቡ ድምፆች';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3898,6 +3898,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'تعذر تشغيل المعاينة';
+
+  @override
   String get soundsFeaturedSounds => 'أصوات مميزة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3986,6 +3986,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Неуспешно пускане на визуализация';
+
+  @override
   String get soundsFeaturedSounds => 'Представени звуци';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3987,6 +3987,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Vorschau-Wiedergabe fehlgeschlagen';
+
+  @override
   String get soundsFeaturedSounds => 'Featured Sounds';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3940,6 +3940,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Failed to play preview';
+
+  @override
   String get soundsFeaturedSounds => 'Featured Sounds';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3984,6 +3984,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric =>
+      'No se pudo reproducir la previsualización';
+
+  @override
   String get soundsFeaturedSounds => 'Sonidos destacados';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3997,6 +3997,9 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Hindi na-play ang preview';
+
+  @override
   String get soundsFeaturedSounds => 'Mga Featured Sound';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3998,6 +3998,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Échec de la lecture de l\'aperçu';
+
+  @override
   String get soundsFeaturedSounds => 'Sons à la une';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3912,6 +3912,9 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Gagal memutar pratinjau';
+
+  @override
   String get soundsFeaturedSounds => 'Suara Unggulan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3984,6 +3984,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric =>
+      'Impossibile riprodurre l\'anteprima';
+
+  @override
   String get soundsFeaturedSounds => 'Suoni in evidenza';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3748,6 +3748,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'プレビューの再生がうまくいかなかった';
+
+  @override
   String get soundsFeaturedSounds => '注目のサウンド';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3763,6 +3763,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => '미리 듣기를 재생하지 못했어요';
+
+  @override
   String get soundsFeaturedSounds => '추천 사운드';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3956,6 +3956,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Voorbeluistering afspelen mislukt';
+
+  @override
   String get soundsFeaturedSounds => 'Uitgelichte geluiden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4039,6 +4039,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Nie udało się odtworzyć podglądu';
+
+  @override
   String get soundsFeaturedSounds => 'Polecane dźwięki';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3967,6 +3967,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric =>
+      'Falha ao reproduzir pré-visualização';
+
+  @override
   String get soundsFeaturedSounds => 'Sons em destaque';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4056,6 +4056,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'N-am putut reda previzualizarea';
+
+  @override
   String get soundsFeaturedSounds => 'Sunete recomandate';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3939,6 +3939,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Kunde inte spela förhandsvisning';
+
+  @override
   String get soundsFeaturedSounds => 'Utvalda ljud';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3921,6 +3921,9 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get soundsPreviewFailedGeneric => 'Önizleme oynatılamadı';
+
+  @override
   String get soundsFeaturedSounds => 'Öne Çıkan Sesler';
 
   @override

--- a/mobile/lib/screens/sounds_screen.dart
+++ b/mobile/lib/screens/sounds_screen.dart
@@ -37,6 +37,10 @@ class SoundsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final audioService = ref.watch(audioPlaybackServiceProvider);
+    // savedSoundsProvider is app-scoped and never invalidated, so its notifier
+    // identity is stable for the Cubit's lifetime — ref.read is safe here
+    // (state_management.md bridging-rule exception #1). audioService can flip,
+    // so it keys the BlocProvider below.
     final savedSoundsNotifier = ref.read(savedSoundsProvider.notifier);
     return BlocProvider(
       key: ValueKey(audioService),

--- a/mobile/lib/screens/sounds_screen.dart
+++ b/mobile/lib/screens/sounds_screen.dart
@@ -36,14 +36,12 @@ class SoundsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final audioService = ref.watch(audioPlaybackServiceProvider);
-    // savedSoundsProvider is app-scoped and never invalidated, so its notifier
-    // identity is stable for the Cubit's lifetime — ref.read is safe here
-    // (state_management.md bridging-rule exception #1). audioService can flip,
-    // so it keys the BlocProvider below.
+    // Both providers are app-scoped and never invalidated, so their identities
+    // are stable for the Cubit's lifetime — ref.read is safe here
+    // (state_management.md bridging-rule exception #1).
+    final audioService = ref.read(audioPlaybackServiceProvider);
     final savedSoundsNotifier = ref.read(savedSoundsProvider.notifier);
     return BlocProvider(
-      key: ValueKey(audioService),
       create: (_) => SoundsCubit(
         audioPlaybackService: audioService,
         saveSound: savedSoundsNotifier.saveSound,
@@ -126,7 +124,7 @@ class _SoundsViewState extends ConsumerState<SoundsView> {
       case PreviewSoundOutcome.failed:
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(context.l10n.soundsPreviewFailed('')),
+            content: Text(context.l10n.soundsPreviewFailedGeneric),
             duration: const Duration(seconds: 2),
           ),
         );
@@ -293,9 +291,7 @@ class _SoundsBody extends StatelessWidget {
     if (allSounds.isEmpty) return const _EmptyState();
 
     final cubit = context.read<SoundsCubit>();
-    final searchQuery = context.select(
-      (SoundsCubit c) => c.state.searchQuery,
-    );
+    final searchQuery = context.select((SoundsCubit c) => c.state.searchQuery);
 
     final filteredBundled = cubit.filterSounds(bundledSounds);
     final filteredNostr = cubit.filterSounds(nostrSounds);

--- a/mobile/lib/screens/sounds_screen.dart
+++ b/mobile/lib/screens/sounds_screen.dart
@@ -5,9 +5,12 @@ import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/blocs/sounds/sounds_cubit.dart';
+import 'package:openvine/blocs/sounds/sounds_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/saved_sounds_provider.dart';
@@ -17,31 +20,11 @@ import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/sound_tile.dart';
-import 'package:sound_service/sound_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// A screen for browsing and selecting sounds for use in recordings.
-///
-/// Displays:
-/// - Featured sounds (bundled meme sounds from app assets)
-/// - Trending sounds from Nostr (Kind 1063 events)
-/// - Search input for filtering all sounds
-/// - Combined sounds in a vertical list
-///
-/// Usage:
-/// ```dart
-/// Navigator.push(
-///   context,
-///   MaterialPageRoute(
-///     builder: (_) => SoundsScreen(
-///       onSoundSelected: (sound) {
-///         // Handle sound selection
-///       },
-///     ),
-///   ),
-/// );
-/// ```
-class SoundsScreen extends ConsumerStatefulWidget {
+/// Page: bridges `AudioPlaybackService` and `SavedSoundsNotifier.saveSound`
+/// into [SoundsCubit].
+class SoundsScreen extends ConsumerWidget {
   /// Creates a SoundsScreen.
   ///
   /// [onSoundSelected] is called when the user selects a sound.
@@ -52,44 +35,40 @@ class SoundsScreen extends ConsumerStatefulWidget {
   final void Function(AudioEvent sound)? onSoundSelected;
 
   @override
-  ConsumerState<SoundsScreen> createState() => _SoundsScreenState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final audioService = ref.watch(audioPlaybackServiceProvider);
+    final savedSoundsNotifier = ref.read(savedSoundsProvider.notifier);
+    return BlocProvider(
+      key: ValueKey(audioService),
+      create: (_) => SoundsCubit(
+        audioPlaybackService: audioService,
+        saveSound: savedSoundsNotifier.saveSound,
+      ),
+      child: SoundsView(onSoundSelected: onSoundSelected),
+    );
+  }
 }
 
-class _SoundsScreenState extends ConsumerState<SoundsScreen> {
-  final TextEditingController _searchController = TextEditingController();
-  String _searchQuery = '';
-  String? _previewingSoundId;
-  bool _isLoadingPreview = false;
+/// View: renders the sounds browser from Cubit state + Riverpod-provided
+/// sound lists. Owns the search `TextEditingController` (controllers stay
+/// in the View — the hybrid pattern established by #4744 WS-1 #5).
+class SoundsView extends ConsumerStatefulWidget {
+  @visibleForTesting
+  const SoundsView({this.onSoundSelected, super.key});
 
-  /// Cached reference to the audio service for use in dispose
-  AudioPlaybackService? _audioService;
+  final void Function(AudioEvent sound)? onSoundSelected;
+
+  @override
+  ConsumerState<SoundsView> createState() => _SoundsViewState();
+}
+
+class _SoundsViewState extends ConsumerState<SoundsView> {
+  final TextEditingController _searchController = TextEditingController();
 
   @override
   void dispose() {
-    // Stop any playing preview using cached reference (safe in dispose)
-    if (_previewingSoundId != null && _audioService != null) {
-      _audioService!.stop();
-    }
     _searchController.dispose();
     super.dispose();
-  }
-
-  Future<void> _stopPreview() async {
-    if (_previewingSoundId != null) {
-      _audioService ??= ref.read(audioPlaybackServiceProvider);
-      await _audioService!.stop();
-      if (mounted) {
-        setState(() {
-          _previewingSoundId = null;
-        });
-      }
-    }
-  }
-
-  void _onSearchChanged(String query) {
-    setState(() {
-      _searchQuery = query.toLowerCase();
-    });
   }
 
   void _onSoundTap(AudioEvent sound) {
@@ -99,17 +78,17 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       category: LogCategory.ui,
     );
 
-    if (widget.onSoundSelected != null) {
-      widget.onSoundSelected!(sound);
+    final onSoundSelected = widget.onSoundSelected;
+    if (onSoundSelected != null) {
+      onSoundSelected(sound);
     } else {
       unawaited(_saveSoundToLibrary(sound));
     }
   }
 
   Future<void> _saveSoundToLibrary(AudioEvent sound) async {
-    final result = await ref
-        .read(savedSoundsProvider.notifier)
-        .saveSound(sound);
+    final cubit = context.read<SoundsCubit>();
+    final result = await cubit.saveSound(sound);
     if (!mounted) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
@@ -125,94 +104,34 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
   }
 
   Future<void> _onPreviewTap(AudioEvent sound) async {
-    // If already loading, ignore taps
-    if (_isLoadingPreview) return;
-
-    // Cache the audio service reference for dispose safety
-    _audioService ??= ref.read(audioPlaybackServiceProvider);
-    final audioService = _audioService!;
-
-    // If tapping the same sound, toggle play/stop
-    if (_previewingSoundId == sound.id) {
-      Log.info(
-        'Stopping preview: ${sound.title} (${sound.id})',
-        name: 'SoundsScreen',
-        category: LogCategory.ui,
-      );
-      await _stopPreview();
-      return;
-    }
-
-    // Check if sound has a URL to play
-    if (sound.url == null || sound.url!.isEmpty) {
-      Log.warning(
-        'Cannot preview sound: no URL available (${sound.id})',
-        name: 'SoundsScreen',
-        category: LogCategory.ui,
-      );
-      if (mounted) {
+    final cubit = context.read<SoundsCubit>();
+    final outcome = await cubit.previewSound(sound);
+    if (!mounted) return;
+    switch (outcome) {
+      case PreviewSoundOutcome.ignored:
+      case PreviewSoundOutcome.stopped:
+      case PreviewSoundOutcome.completed:
+        return;
+      case PreviewSoundOutcome.unavailable:
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(context.l10n.soundsPreviewUnavailable),
             duration: const Duration(seconds: 2),
           ),
         );
-      }
-      return;
-    }
-
-    Log.info(
-      'Starting preview: ${sound.title} (${sound.id})',
-      name: 'SoundsScreen',
-      category: LogCategory.ui,
-    );
-
-    setState(() {
-      _isLoadingPreview = true;
-    });
-
-    try {
-      // Stop any currently playing audio before loading a new track
-      await audioService.stop();
-      await audioService.loadAudio(sound.url!);
-
-      if (mounted) {
-        setState(() {
-          _previewingSoundId = sound.id;
-          _isLoadingPreview = false;
-        });
-      }
-
-      await audioService.play();
-    } catch (e) {
-      Log.error(
-        'Failed to preview sound: $e',
-        name: 'SoundsScreen',
-        category: LogCategory.ui,
-      );
-      if (mounted) {
+      case PreviewSoundOutcome.failed:
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(context.l10n.soundsPreviewFailed('$e')),
+            content: Text(context.l10n.soundsPreviewFailed('')),
             duration: const Duration(seconds: 2),
           ),
         );
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _previewingSoundId = null;
-          _isLoadingPreview = false;
-        });
-      }
     }
   }
 
   Future<void> _onDetailTap(AudioEvent sound) async {
-    // Bundled sounds don't have detail pages
-    if (sound.isBundled) {
-      return;
-    }
+    // Bundled sounds don't have detail pages.
+    if (sound.isBundled) return;
 
     Log.info(
       'Navigate to sound detail: ${sound.title} (${sound.id})',
@@ -220,23 +139,10 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       category: LogCategory.ui,
     );
 
-    // Stop any playing preview before navigating - must await to ensure it stops
-    await _stopPreview();
-
+    // Stop any playing preview before navigating.
+    await context.read<SoundsCubit>().stopPreview();
     if (!mounted) return;
-
     context.push(SoundDetailScreen.pathForId(sound.id), extra: sound);
-  }
-
-  List<AudioEvent> _filterSounds(List<AudioEvent> sounds) {
-    if (_searchQuery.isEmpty) {
-      return sounds;
-    }
-
-    return sounds.where((sound) {
-      final title = sound.title?.toLowerCase() ?? '';
-      return title.contains(_searchQuery);
-    }).toList();
   }
 
   @override
@@ -254,24 +160,34 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
         ),
         body: Column(
           children: [
-            // Search input
-            _buildSearchInput(),
-
-            // Content
-            Expanded(child: _buildContent()),
+            _SearchInput(controller: _searchController),
+            Expanded(
+              child: _SoundsContent(
+                onSoundTap: _onSoundTap,
+                onPreviewTap: _onPreviewTap,
+                onDetailTap: _onDetailTap,
+              ),
+            ),
           ],
         ),
       ),
     );
   }
+}
 
-  Widget _buildSearchInput() {
+class _SearchInput extends StatelessWidget {
+  const _SearchInput({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(16),
       color: VineTheme.cardBackground,
       child: TextField(
-        controller: _searchController,
-        onChanged: _onSearchChanged,
+        controller: controller,
+        onChanged: (query) => context.read<SoundsCubit>().setSearchQuery(query),
         style: const TextStyle(color: VineTheme.whiteText),
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
@@ -294,12 +210,24 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       ),
     );
   }
+}
 
-  Widget _buildContent() {
+class _SoundsContent extends ConsumerWidget {
+  const _SoundsContent({
+    required this.onSoundTap,
+    required this.onPreviewTap,
+    required this.onDetailTap,
+  });
+
+  final void Function(AudioEvent) onSoundTap;
+  final void Function(AudioEvent) onPreviewTap;
+  final void Function(AudioEvent) onDetailTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final bundledSoundsAsync = ref.watch(soundLibraryServiceProvider);
     final nostrSoundsAsync = ref.watch(trendingSoundsProvider);
 
-    // Convert bundled VineSounds to AudioEvents
     final bundledSounds =
         bundledSoundsAsync.whenOrNull(
           data: (service) {
@@ -311,98 +239,140 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
         <AudioEvent>[];
 
     return nostrSoundsAsync.when(
-      data: (nostrSounds) => _buildSoundsContent(
+      data: (nostrSounds) => _SoundsBody(
         bundledSounds: bundledSounds,
         nostrSounds: nostrSounds,
+        onSoundTap: onSoundTap,
+        onPreviewTap: onPreviewTap,
+        onDetailTap: onDetailTap,
       ),
       loading: () => bundledSounds.isNotEmpty
-          ? _buildSoundsContent(bundledSounds: bundledSounds, nostrSounds: [])
+          ? _SoundsBody(
+              bundledSounds: bundledSounds,
+              nostrSounds: const [],
+              onSoundTap: onSoundTap,
+              onPreviewTap: onPreviewTap,
+              onDetailTap: onDetailTap,
+            )
           : const Center(child: BrandedLoadingIndicator()),
       error: (error, stack) => bundledSounds.isNotEmpty
-          ? _buildSoundsContent(bundledSounds: bundledSounds, nostrSounds: [])
-          : _buildErrorState(error),
+          ? _SoundsBody(
+              bundledSounds: bundledSounds,
+              nostrSounds: const [],
+              onSoundTap: onSoundTap,
+              onPreviewTap: onPreviewTap,
+              onDetailTap: onDetailTap,
+            )
+          : _ErrorState(error: error),
     );
   }
+}
 
-  Widget _buildSoundsContent({
-    required List<AudioEvent> bundledSounds,
-    required List<AudioEvent> nostrSounds,
-  }) {
+class _SoundsBody extends StatelessWidget {
+  const _SoundsBody({
+    required this.bundledSounds,
+    required this.nostrSounds,
+    required this.onSoundTap,
+    required this.onPreviewTap,
+    required this.onDetailTap,
+  });
+
+  final List<AudioEvent> bundledSounds;
+  final List<AudioEvent> nostrSounds;
+  final void Function(AudioEvent) onSoundTap;
+  final void Function(AudioEvent) onPreviewTap;
+  final void Function(AudioEvent) onDetailTap;
+
+  @override
+  Widget build(BuildContext context) {
     final allSounds = [...bundledSounds, ...nostrSounds];
+    if (allSounds.isEmpty) return const _EmptyState();
 
-    if (allSounds.isEmpty) {
-      return _buildEmptyState();
-    }
+    final cubit = context.read<SoundsCubit>();
+    final searchQuery = context.select(
+      (SoundsCubit c) => c.state.searchQuery,
+    );
 
-    final filteredBundled = _filterSounds(bundledSounds);
-    final filteredNostr = _filterSounds(nostrSounds);
+    final filteredBundled = cubit.filterSounds(bundledSounds);
+    final filteredNostr = cubit.filterSounds(nostrSounds);
     final filteredAll = [...filteredBundled, ...filteredNostr];
 
-    // If search is active but no results
-    if (_searchQuery.isNotEmpty && filteredAll.isEmpty) {
-      return _buildNoResultsState();
+    if (searchQuery.isNotEmpty && filteredAll.isEmpty) {
+      return const _NoResultsState();
     }
 
-    return RefreshIndicator(
-      color: VineTheme.onPrimary,
-      backgroundColor: VineTheme.vineGreen,
-      onRefresh: () async {
-        await ref.read(trendingSoundsProvider.notifier).refresh();
-      },
+    return _SoundsRefreshable(
       child: ListView(
         children: [
-          // Featured sounds section (bundled meme sounds) - show when not searching
-          if (_searchQuery.isEmpty && bundledSounds.isNotEmpty) ...[
-            _buildFeaturedSoundsSection(bundledSounds),
+          if (searchQuery.isEmpty && bundledSounds.isNotEmpty) ...[
+            _FeaturedSoundsSection(
+              sounds: bundledSounds,
+              onSoundTap: onSoundTap,
+              onPreviewTap: onPreviewTap,
+            ),
             const SizedBox(height: 16),
           ],
-
-          // Trending Nostr sounds section (only show when not searching)
-          if (_searchQuery.isEmpty && nostrSounds.isNotEmpty) ...[
-            _buildTrendingSoundsSection(nostrSounds),
+          if (searchQuery.isEmpty && nostrSounds.isNotEmpty) ...[
+            _TrendingSoundsSection(
+              sounds: nostrSounds,
+              onSoundTap: onSoundTap,
+              onPreviewTap: onPreviewTap,
+              onDetailTap: onDetailTap,
+            ),
             const SizedBox(height: 16),
           ],
-
-          // All sounds section (search results or combined list)
-          _buildAllSoundsSection(
-            _searchQuery.isNotEmpty ? filteredAll : allSounds,
+          _AllSoundsSection(
+            sounds: searchQuery.isNotEmpty ? filteredAll : allSounds,
+            isSearching: searchQuery.isNotEmpty,
+            onSoundTap: onSoundTap,
+            onPreviewTap: onPreviewTap,
+            onDetailTap: onDetailTap,
           ),
         ],
       ),
     );
   }
+}
 
-  Widget _buildFeaturedSoundsSection(List<AudioEvent> sounds) {
-    // Take first 10 bundled sounds as featured
+class _SoundsRefreshable extends ConsumerWidget {
+  const _SoundsRefreshable({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return RefreshIndicator(
+      color: VineTheme.onPrimary,
+      backgroundColor: VineTheme.vineGreen,
+      onRefresh: () => ref.read(trendingSoundsProvider.notifier).refresh(),
+      child: child,
+    );
+  }
+}
+
+class _FeaturedSoundsSection extends StatelessWidget {
+  const _FeaturedSoundsSection({
+    required this.sounds,
+    required this.onSoundTap,
+    required this.onPreviewTap,
+  });
+
+  final List<AudioEvent> sounds;
+  final void Function(AudioEvent) onSoundTap;
+  final void Function(AudioEvent) onPreviewTap;
+
+  @override
+  Widget build(BuildContext context) {
     final featuredSounds = sounds.take(10).toList();
-
-    if (featuredSounds.isEmpty) {
-      return const SizedBox.shrink();
-    }
+    if (featuredSounds.isEmpty) return const SizedBox.shrink();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Header
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              const Icon(Icons.star, color: VineTheme.vineGreen, size: 20),
-              const SizedBox(width: 8),
-              Text(
-                context.l10n.soundsFeaturedSounds,
-                style: const TextStyle(
-                  color: VineTheme.whiteText,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
+        _SectionHeader(
+          icon: Icons.star,
+          label: context.l10n.soundsFeaturedSounds,
         ),
-
-        // Horizontal list
         SizedBox(
           height: 100,
           child: ListView.builder(
@@ -413,12 +383,11 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
               final sound = featuredSounds[index];
               return Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: SoundTile(
+                child: _SoundTileSelector(
                   sound: sound,
                   compact: true,
-                  isPlaying: _previewingSoundId == sound.id,
-                  onTap: () => _onSoundTap(sound),
-                  onPlayPreview: () => _onPreviewTap(sound),
+                  onSoundTap: onSoundTap,
+                  onPreviewTap: onPreviewTap,
                 ),
               );
             },
@@ -427,42 +396,33 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       ],
     );
   }
+}
 
-  Widget _buildTrendingSoundsSection(List<AudioEvent> sounds) {
-    // Take first 10 sounds as trending
+class _TrendingSoundsSection extends StatelessWidget {
+  const _TrendingSoundsSection({
+    required this.sounds,
+    required this.onSoundTap,
+    required this.onPreviewTap,
+    required this.onDetailTap,
+  });
+
+  final List<AudioEvent> sounds;
+  final void Function(AudioEvent) onSoundTap;
+  final void Function(AudioEvent) onPreviewTap;
+  final void Function(AudioEvent) onDetailTap;
+
+  @override
+  Widget build(BuildContext context) {
     final trendingSounds = sounds.take(10).toList();
-
-    if (trendingSounds.isEmpty) {
-      return const SizedBox.shrink();
-    }
+    if (trendingSounds.isEmpty) return const SizedBox.shrink();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Header
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              const Icon(
-                Icons.local_fire_department,
-                color: VineTheme.vineGreen,
-                size: 20,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                context.l10n.soundsTrendingSounds,
-                style: const TextStyle(
-                  color: VineTheme.whiteText,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
+        _SectionHeader(
+          icon: Icons.local_fire_department,
+          label: context.l10n.soundsTrendingSounds,
         ),
-
-        // Horizontal list
         SizedBox(
           height: 100,
           child: ListView.builder(
@@ -473,13 +433,12 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
               final sound = trendingSounds[index];
               return Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: SoundTile(
+                child: _SoundTileSelector(
                   sound: sound,
                   compact: true,
-                  isPlaying: _previewingSoundId == sound.id,
-                  onTap: () => _onSoundTap(sound),
-                  onPlayPreview: () => _onPreviewTap(sound),
-                  onDetailTap: () => _onDetailTap(sound),
+                  onSoundTap: onSoundTap,
+                  onPreviewTap: onPreviewTap,
+                  onDetailTap: onDetailTap,
                 ),
               );
             },
@@ -488,12 +447,28 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       ],
     );
   }
+}
 
-  Widget _buildAllSoundsSection(List<AudioEvent> sounds) {
+class _AllSoundsSection extends StatelessWidget {
+  const _AllSoundsSection({
+    required this.sounds,
+    required this.isSearching,
+    required this.onSoundTap,
+    required this.onPreviewTap,
+    required this.onDetailTap,
+  });
+
+  final List<AudioEvent> sounds;
+  final bool isSearching;
+  final void Function(AudioEvent) onSoundTap;
+  final void Function(AudioEvent) onPreviewTap;
+  final void Function(AudioEvent) onDetailTap;
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Header
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: Row(
@@ -505,9 +480,9 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
               ),
               const SizedBox(width: 8),
               Text(
-                _searchQuery.isEmpty
-                    ? context.l10n.soundsAllSounds
-                    : context.l10n.soundsSearchResults,
+                isSearching
+                    ? context.l10n.soundsSearchResults
+                    : context.l10n.soundsAllSounds,
                 style: const TextStyle(
                   color: VineTheme.whiteText,
                   fontSize: 16,
@@ -525,8 +500,6 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
             ],
           ),
         ),
-
-        // Sound tiles
         ListView.builder(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
@@ -534,21 +507,84 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
           itemCount: sounds.length,
           itemBuilder: (context, index) {
             final sound = sounds[index];
-            return SoundTile(
+            return _SoundTileSelector(
               sound: sound,
-              isPlaying: _previewingSoundId == sound.id,
-              onTap: () => _onSoundTap(sound),
-              onPlayPreview: () => _onPreviewTap(sound),
-              // Only show detail tap for Nostr sounds (not bundled)
-              onDetailTap: sound.isBundled ? null : () => _onDetailTap(sound),
+              onSoundTap: onSoundTap,
+              onPreviewTap: onPreviewTap,
+              // Bundled sounds don't get a detail-tap affordance.
+              onDetailTap: sound.isBundled ? null : onDetailTap,
             );
           },
         ),
       ],
     );
   }
+}
 
-  Widget _buildEmptyState() {
+class _SoundTileSelector extends StatelessWidget {
+  const _SoundTileSelector({
+    required this.sound,
+    required this.onSoundTap,
+    required this.onPreviewTap,
+    this.onDetailTap,
+    this.compact = false,
+  });
+
+  final AudioEvent sound;
+  final bool compact;
+  final void Function(AudioEvent) onSoundTap;
+  final void Function(AudioEvent) onPreviewTap;
+  final void Function(AudioEvent)? onDetailTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isPlaying = context.select(
+      (SoundsCubit cubit) => cubit.state.previewingSoundId == sound.id,
+    );
+    return SoundTile(
+      sound: sound,
+      compact: compact,
+      isPlaying: isPlaying,
+      onTap: () => onSoundTap(sound),
+      onPlayPreview: () => onPreviewTap(sound),
+      onDetailTap: onDetailTap == null ? null : () => onDetailTap!(sound),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Icon(icon, color: VineTheme.vineGreen, size: 20),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              color: VineTheme.whiteText,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -576,8 +612,13 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       ),
     );
   }
+}
 
-  Widget _buildNoResultsState() {
+class _NoResultsState extends StatelessWidget {
+  const _NoResultsState();
+
+  @override
+  Widget build(BuildContext context) {
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -604,8 +645,15 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
       ),
     );
   }
+}
 
-  Widget _buildErrorState(Object error) {
+class _ErrorState extends ConsumerWidget {
+  const _ErrorState({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
@@ -639,9 +687,7 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
             ),
             const SizedBox(height: 24),
             ElevatedButton.icon(
-              onPressed: () {
-                ref.invalidate(trendingSoundsProvider);
-              },
+              onPressed: () => ref.invalidate(trendingSoundsProvider),
               icon: const DivineIcon(icon: DivineIconName.arrowClockwise),
               label: Text(context.l10n.soundsRetry),
               style: ElevatedButton.styleFrom(

--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -51,7 +51,7 @@ test/screens/profile_screen_router_test.dart
 test/screens/profile_share_edit_buttons_test.dart
 test/screens/profile_video_deletion_test.dart
 test/screens/relay_settings_nip11_info_test.dart
-test/screens/sounds_screen_test.dart
+test/screens/safety_settings_screen_test.dart
 test/screens/video_editor/video_text_editor_screen_test.dart
 test/screens/video_editor_route_test.dart
 test/services/account_deletion_flow_test.dart

--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -51,7 +51,6 @@ test/screens/profile_screen_router_test.dart
 test/screens/profile_share_edit_buttons_test.dart
 test/screens/profile_video_deletion_test.dart
 test/screens/relay_settings_nip11_info_test.dart
-test/screens/safety_settings_screen_test.dart
 test/screens/video_editor/video_text_editor_screen_test.dart
 test/screens/video_editor_route_test.dart
 test/services/account_deletion_flow_test.dart

--- a/mobile/test/blocs/sounds/sounds_cubit_test.dart
+++ b/mobile/test/blocs/sounds/sounds_cubit_test.dart
@@ -1,0 +1,197 @@
+// ABOUTME: Unit tests for SoundsCubit — search filter, audio-preview
+// ABOUTME: lifecycle (toggle, no-url, success, failure), and the saveSound
+// ABOUTME: passthrough.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/sounds/sounds_cubit.dart';
+import 'package:openvine/blocs/sounds/sounds_state.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:sound_service/sound_service.dart';
+
+class _MockAudioPlaybackService extends Mock implements AudioPlaybackService {}
+
+void main() {
+  group(SoundsCubit, () {
+    late _MockAudioPlaybackService audio;
+    late SaveSoundAction saveSound;
+    SavedSoundSaveResult saveSoundResult = SavedSoundSaveResult.saved;
+    final saveSoundCalls = <AudioEvent>[];
+
+    AudioEvent makeSound({
+      String id = 's1',
+      String? url = 'https://cdn.example/s1.mp3',
+      String? title = 'Sound',
+    }) {
+      return AudioEvent(
+        id: id,
+        pubkey: 'pk',
+        createdAt: 0,
+        url: url,
+        title: title,
+      );
+    }
+
+    setUp(() {
+      audio = _MockAudioPlaybackService();
+      saveSoundResult = SavedSoundSaveResult.saved;
+      saveSoundCalls.clear();
+      saveSound = (sound) async {
+        saveSoundCalls.add(sound);
+        return saveSoundResult;
+      };
+      when(audio.stop).thenAnswer((_) async {});
+      when(audio.play).thenAnswer((_) async {});
+      when(() => audio.loadAudio(any())).thenAnswer((_) async => null);
+    });
+
+    SoundsCubit buildCubit() => SoundsCubit(
+      audioPlaybackService: audio,
+      saveSound: saveSound,
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'setSearchQuery lowercases and emits',
+      build: buildCubit,
+      act: (cubit) => cubit.setSearchQuery('MeMe'),
+      expect: () => [const SoundsState(searchQuery: 'meme')],
+    );
+
+    test('filterSounds returns input unchanged with empty query', () {
+      final cubit = buildCubit();
+      final sounds = [makeSound(id: '1', title: 'Drumroll')];
+      expect(cubit.filterSounds(sounds), same(sounds));
+      addTearDown(cubit.close);
+    });
+
+    test('filterSounds matches title case-insensitively', () {
+      final cubit = buildCubit()..setSearchQuery('DRUM');
+      final sounds = [
+        makeSound(id: '1', title: 'Drumroll'),
+        makeSound(id: '2', title: 'Trumpet'),
+      ];
+      final filtered = cubit.filterSounds(sounds);
+      expect(filtered.map((s) => s.id), ['1']);
+      addTearDown(cubit.close);
+    });
+
+    blocTest<SoundsCubit, SoundsState>(
+      'previewSound returns ignored when already loading',
+      seed: () => const SoundsState(isLoadingPreview: true),
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.previewSound(makeSound());
+        expect(outcome, PreviewSoundOutcome.ignored);
+      },
+      expect: () => const <SoundsState>[],
+      verify: (_) {
+        verifyNever(audio.stop);
+        verifyNever(audio.play);
+      },
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'previewSound on currently-playing id stops and clears state',
+      seed: () => const SoundsState(previewingSoundId: 's1'),
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.previewSound(makeSound());
+        expect(outcome, PreviewSoundOutcome.stopped);
+      },
+      expect: () => [const SoundsState()],
+      verify: (_) {
+        verify(audio.stop).called(1);
+        verifyNever(audio.play);
+      },
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'previewSound returns unavailable when URL is missing',
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.previewSound(
+          makeSound(id: 's2', url: null),
+        );
+        expect(outcome, PreviewSoundOutcome.unavailable);
+      },
+      expect: () => const <SoundsState>[],
+      verify: (_) {
+        verifyNever(audio.play);
+      },
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'previewSound success: loads, plays, then clears state',
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.previewSound(makeSound(id: 's3'));
+        expect(outcome, PreviewSoundOutcome.completed);
+      },
+      // States: loading → playing → cleared.
+      expect: () => [
+        const SoundsState(isLoadingPreview: true),
+        const SoundsState(previewingSoundId: 's3'),
+        const SoundsState(),
+      ],
+      verify: (_) {
+        verify(audio.stop).called(1);
+        verify(() => audio.loadAudio('https://cdn.example/s1.mp3')).called(1);
+        verify(audio.play).called(1);
+      },
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'previewSound failure reports addError and returns failed',
+      setUp: () {
+        when(audio.play).thenThrow(StateError('audio bus locked'));
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        final outcome = await cubit.previewSound(makeSound(id: 's4'));
+        expect(outcome, PreviewSoundOutcome.failed);
+      },
+      expect: () => [
+        const SoundsState(isLoadingPreview: true),
+        const SoundsState(previewingSoundId: 's4'),
+        const SoundsState(),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'stopPreview is a no-op when nothing is playing',
+      build: buildCubit,
+      act: (cubit) => cubit.stopPreview(),
+      expect: () => const <SoundsState>[],
+      verify: (_) {
+        verifyNever(audio.stop);
+      },
+    );
+
+    blocTest<SoundsCubit, SoundsState>(
+      'stopPreview clears the playing sound and calls stop',
+      seed: () => const SoundsState(previewingSoundId: 's5'),
+      build: buildCubit,
+      act: (cubit) => cubit.stopPreview(),
+      expect: () => [const SoundsState()],
+      verify: (_) {
+        verify(audio.stop).called(1);
+      },
+    );
+
+    test(
+      'saveSound delegates to injected callable and returns result',
+      () async {
+        final cubit = buildCubit();
+        saveSoundResult = SavedSoundSaveResult.alreadySaved;
+        final sound = makeSound(id: 's6');
+        final result = await cubit.saveSound(sound);
+        expect(result, SavedSoundSaveResult.alreadySaved);
+        expect(saveSoundCalls, [sound]);
+        addTearDown(cubit.close);
+      },
+    );
+  });
+}

--- a/mobile/test/blocs/sounds/sounds_cubit_test.dart
+++ b/mobile/test/blocs/sounds/sounds_cubit_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: lifecycle (toggle, no-url, success, failure), and the saveSound
 // ABOUTME: passthrough.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -178,6 +180,64 @@ void main() {
       expect: () => [const SoundsState()],
       verify: (_) {
         verify(audio.stop).called(1);
+      },
+    );
+
+    test(
+      'close() stops the audio service while a preview is playing '
+      '(navigate-away cleanup contract)',
+      () async {
+        // play() stays pending so the Cubit rests in the "currently
+        // previewing" state, mirroring real playback (just_audio's play()
+        // completes only when the sound is stopped or finishes).
+        final playController = Completer<void>();
+        when(audio.play).thenAnswer((_) => playController.future);
+        final cubit = buildCubit();
+
+        final previewing = cubit.previewSound(makeSound());
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state.previewingSoundId, 's1');
+
+        // Isolate the close()-triggered stop from the pre-load stop().
+        clearInteractions(audio);
+        await cubit.close();
+        verify(audio.stop).called(1);
+
+        // Let the dangling play() future resolve cleanly (no emit-after-close).
+        playController.complete();
+        await previewing;
+      },
+    );
+
+    test(
+      'previewSound stops the loaded source and skips emitting when the '
+      'Cubit is closed mid-load',
+      () async {
+        // Hold loadAudio open so we can close() the Cubit while it is still
+        // in the loading phase (previewingSoundId not yet set).
+        final loadController = Completer<Duration?>();
+        when(
+          () => audio.loadAudio(any()),
+        ).thenAnswer((_) => loadController.future);
+        final cubit = buildCubit();
+
+        final previewing = cubit.previewSound(makeSound(id: 's7'));
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state.isLoadingPreview, isTrue);
+        expect(cubit.state.previewingSoundId, isNull);
+
+        // Navigate away mid-load: close() can't stop yet (no id set).
+        await cubit.close();
+        clearInteractions(audio);
+
+        // Resolving the load must stop the just-loaded source and must NOT
+        // emit into the closed Cubit (which would throw a StateError).
+        loadController.complete(const Duration(seconds: 6));
+        final outcome = await previewing;
+
+        expect(outcome, PreviewSoundOutcome.ignored);
+        verify(audio.stop).called(1);
+        verifyNever(audio.play);
       },
     );
 

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -331,9 +331,8 @@ void main() {
             child: const SoundsScreen(),
             overrides: [
               trendingSoundsProvider.overrideWith(
-                () => MockTrendingSoundsErrorNotifier(
-                  Exception('Network error'),
-                ),
+                () =>
+                    MockTrendingSoundsErrorNotifier(Exception('Network error')),
               ),
               soundLibraryServiceProvider.overrideWith(
                 (_) async => SoundLibraryService(),
@@ -353,9 +352,8 @@ void main() {
             child: const SoundsScreen(),
             overrides: [
               trendingSoundsProvider.overrideWith(
-                () => MockTrendingSoundsErrorNotifier(
-                  Exception('Network error'),
-                ),
+                () =>
+                    MockTrendingSoundsErrorNotifier(Exception('Network error')),
               ),
               soundLibraryServiceProvider.overrideWith(
                 (_) async => SoundLibraryService(),
@@ -794,60 +792,55 @@ void main() {
         verify(() => mockAudioService.loadAudio(any())).called(1);
       });
 
-      testWidgets(
-        'disposing the screen while previewing stops the audio '
-        '(navigate-away cleanup contract)',
-        (tester) async {
-          final testSounds = [
-            createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
-          ];
+      testWidgets('disposing the screen while previewing stops the audio '
+          '(navigate-away cleanup contract)', (tester) async {
+        final testSounds = [
+          createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
+        ];
 
-          // Keep play() pending so the preview rests in the playing state
-          // (previewingSoundId set) when we tear the screen down.
-          final playCompleter = Completer<void>();
-          when(
-            () => mockAudioService.play(),
-          ).thenAnswer((_) => playCompleter.future);
+        // Keep play() pending so the preview rests in the playing state
+        // (previewingSoundId set) when we tear the screen down.
+        final playCompleter = Completer<void>();
+        when(
+          () => mockAudioService.play(),
+        ).thenAnswer((_) => playCompleter.future);
 
-          await tester.pumpWidget(
-            createTestWidget(
-              child: const SoundsScreen(),
-              overrides: [
-                trendingSoundsProvider.overrideWith(
-                  () => MockTrendingSoundsNotifier(sounds: testSounds),
-                ),
-                // Empty bundled sounds → exactly one preview button.
-                soundLibraryServiceProvider.overrideWith(
-                  (_) async => SoundLibraryService(),
-                ),
-                audioPlaybackServiceProvider.overrideWithValue(
-                  mockAudioService,
-                ),
-              ],
-            ),
-          );
-          await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          createTestWidget(
+            child: const SoundsScreen(),
+            overrides: [
+              trendingSoundsProvider.overrideWith(
+                () => MockTrendingSoundsNotifier(sounds: testSounds),
+              ),
+              // Empty bundled sounds → exactly one preview button.
+              soundLibraryServiceProvider.overrideWith(
+                (_) async => SoundLibraryService(),
+              ),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
 
-          await tester.tap(find.byIcon(Icons.play_arrow).first);
-          // Drain stop()/loadAudio microtasks so previewingSoundId is set.
-          await tester.pump();
-          await tester.pump();
-          expect(find.byIcon(Icons.stop), findsWidgets);
+        await tester.tap(find.byIcon(Icons.play_arrow).first);
+        // Drain stop()/loadAudio microtasks so previewingSoundId is set.
+        await tester.pump();
+        await tester.pump();
+        expect(find.byIcon(Icons.stop), findsWidgets);
 
-          clearInteractions(mockAudioService);
+        clearInteractions(mockAudioService);
 
-          // Navigate away: tearing the whole tree down unmounts the
-          // ProviderScope and the BlocProvider, which closes the SoundsCubit.
-          // close() must stop the in-flight preview — SoundsView.dispose()
-          // only disposes the text controller.
-          await tester.pumpWidget(const SizedBox.shrink());
+        // Navigate away: tearing the whole tree down unmounts the
+        // ProviderScope and the BlocProvider, which closes the SoundsCubit.
+        // close() must stop the in-flight preview — SoundsView.dispose()
+        // only disposes the text controller.
+        await tester.pumpWidget(const SizedBox.shrink());
 
-          verify(() => mockAudioService.stop()).called(1);
+        verify(() => mockAudioService.stop()).called(1);
 
-          playCompleter.complete();
-          await tester.pumpAndSettle();
-        },
-      );
+        playCompleter.complete();
+        await tester.pumpAndSettle();
+      });
 
       testWidgets('shows snackbar when sound has no URL', (tester) async {
         final testSounds = [
@@ -897,6 +890,40 @@ void main() {
 
         // loadAudio should NOT have been called
         verifyNever(() => mockAudioService.loadAudio(any()));
+      });
+
+      testWidgets('shows generic snackbar when preview playback fails', (
+        tester,
+      ) async {
+        final testSounds = [
+          createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
+        ];
+        when(
+          () => mockAudioService.play(),
+        ).thenThrow(StateError('audio bus locked'));
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: const SoundsScreen(),
+            overrides: [
+              trendingSoundsProvider.overrideWith(
+                () => MockTrendingSoundsNotifier(sounds: testSounds),
+              ),
+              soundLibraryServiceProvider.overrideWith(
+                (_) async => SoundLibraryService(),
+              ),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.play_arrow).first);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Failed to play preview'), findsOneWidget);
+        expect(find.text('Failed to play preview: '), findsNothing);
       });
     });
 

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -802,6 +802,61 @@ void main() {
         verify(() => mockAudioService.loadAudio(any())).called(1);
       });
 
+      testWidgets(
+        'disposing the screen while previewing stops the audio '
+        '(navigate-away cleanup contract)',
+        (tester) async {
+          final testSounds = [
+            createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
+          ];
+
+          // Keep play() pending so the preview rests in the playing state
+          // (previewingSoundId set) when we tear the screen down.
+          final playCompleter = Completer<void>();
+          when(
+            () => mockAudioService.play(),
+          ).thenAnswer((_) => playCompleter.future);
+
+          await tester.pumpWidget(
+            createTestWidget(
+              child: const SoundsScreen(),
+              overrides: [
+                trendingSoundsProvider.overrideWith(
+                  () => MockTrendingSoundsNotifier(sounds: testSounds),
+                ),
+                // Empty bundled sounds → exactly one preview button.
+                soundLibraryServiceProvider.overrideWith(
+                  (_) async => SoundLibraryService(),
+                ),
+                audioPlaybackServiceProvider.overrideWithValue(
+                  mockAudioService,
+                ),
+              ],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byIcon(Icons.play_arrow).first);
+          // Drain stop()/loadAudio microtasks so previewingSoundId is set.
+          await tester.pump();
+          await tester.pump();
+          expect(find.byIcon(Icons.stop), findsWidgets);
+
+          clearInteractions(mockAudioService);
+
+          // Navigate away: tearing the whole tree down unmounts the
+          // ProviderScope and the BlocProvider, which closes the SoundsCubit.
+          // close() must stop the in-flight preview — SoundsView.dispose()
+          // only disposes the text controller.
+          await tester.pumpWidget(const SizedBox.shrink());
+
+          verify(() => mockAudioService.stop()).called(1);
+
+          playCompleter.complete();
+          await tester.pumpAndSettle();
+        },
+      );
+
       testWidgets('shows snackbar when sound has no URL', (tester) async {
         final testSounds = [
           const AudioEvent(

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -322,60 +322,52 @@ void main() {
     });
 
     group('Error State', () {
-      // TODO(dev): Fix error state tests - AsyncNotifier error propagation
-      // in widget tests needs investigation. The UI code is correct but
-      // mocking async errors in Riverpod widget tests is complex.
-      testWidgets(
-        'shows error message on failure',
-        (tester) async {
-          await tester.pumpWidget(
-            createTestWidget(
-              child: const SoundsScreen(),
-              overrides: [
-                trendingSoundsProvider.overrideWith(
-                  () => MockTrendingSoundsErrorNotifier(
-                    Exception('Network error'),
-                  ),
+      // The error branch only renders _ErrorState when bundled sounds are
+      // also empty; otherwise it falls back to the bundled list. Each test
+      // forces an empty bundled library so the trending error surfaces.
+      testWidgets('shows error message on failure', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: const SoundsScreen(),
+            overrides: [
+              trendingSoundsProvider.overrideWith(
+                () => MockTrendingSoundsErrorNotifier(
+                  Exception('Network error'),
                 ),
-              ],
-            ),
-          );
+              ),
+              soundLibraryServiceProvider.overrideWith(
+                (_) async => SoundLibraryService(),
+              ),
+            ],
+          ),
+        );
 
-          // Pump multiple frames to allow error to propagate
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 100));
+        await tester.pumpAndSettle();
 
-          expect(find.text('Failed to load sounds'), findsOneWidget);
-        },
-        // Skip: AsyncNotifier error mocking needs further investigation
-        skip: true,
-      );
+        expect(find.text('Failed to load sounds'), findsOneWidget);
+      });
 
-      testWidgets(
-        'shows retry button on error',
-        (tester) async {
-          await tester.pumpWidget(
-            createTestWidget(
-              child: const SoundsScreen(),
-              overrides: [
-                trendingSoundsProvider.overrideWith(
-                  () => MockTrendingSoundsErrorNotifier(
-                    Exception('Network error'),
-                  ),
+      testWidgets('shows retry button on error', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: const SoundsScreen(),
+            overrides: [
+              trendingSoundsProvider.overrideWith(
+                () => MockTrendingSoundsErrorNotifier(
+                  Exception('Network error'),
                 ),
-              ],
-            ),
-          );
+              ),
+              soundLibraryServiceProvider.overrideWith(
+                (_) async => SoundLibraryService(),
+              ),
+            ],
+          ),
+        );
 
-          // Pump multiple frames to allow error to propagate
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 100));
+        await tester.pumpAndSettle();
 
-          expect(find.text('Retry'), findsOneWidget);
-        },
-        // Skip: AsyncNotifier error mocking needs further investigation
-        skip: true,
-      );
+        expect(find.text('Retry'), findsOneWidget);
+      });
     });
 
     group('Empty State', () {


### PR DESCRIPTION
## Description

Continues #4744 WS-1. Migrates `SoundsScreen` to the established Cubit template.

`SoundsCubit` owns the durable UI state:
- The lowercased `searchQuery` applied to both bundled + Nostr sound lists.
- The audio-preview lifecycle (`previewingSoundId` + `isLoadingPreview`), mirroring the pre-migration `setState` flow (`loading → playing → cleared` after `play()` completes).

**Transient outcomes use the `Future<Result>`-return idiom** instead of putting transient status flags in state. The View calls `await cubit.previewSound(sound)` and shows a snackbar based on the returned `PreviewSoundOutcome` (`ignored` / `stopped` / `unavailable` / `completed` / `failed`). Same for `saveSound`, which passes the existing `SavedSoundSaveResult` straight back. This keeps state free of error strings per `state_management.md` while letting the View pick localized snackbar copy.

**Hybrid pattern** (per #4792): the search `TextEditingController` stays in the View. The Cubit only sees the resulting query string via `setSearchQuery`.

**Dependency injection.** `Future<SavedSoundSaveResult> Function(AudioEvent)` is injected as a `SaveSoundAction` typedef so the Cubit doesn't reach into `savedSoundsProvider.notifier` directly — the Page reads the notifier from Riverpod and hands its `saveSound` method into the Cubit. Audio playback is injected as `AudioPlaybackService` via the existing app provider.

**Page/View split with private widget extraction.** The 7 `_build*` helpers became 8 private widget classes (`_SearchInput`, `_SoundsContent`, `_SoundsBody`, `_SoundsRefreshable`, `_FeaturedSoundsSection`, `_TrendingSoundsSection`, `_AllSoundsSection`, `_SoundTileSelector`), plus the three states (`_EmptyState`, `_NoResultsState`, `_ErrorState`) and a shared `_SectionHeader`. The `_SoundTileSelector` uses `context.select` so only the currently-playing tile rebuilds when `previewingSoundId` flips.

**Related Issue:** Relates to #4744 (WS-1) · Parent epic #4338

## Out of Scope

- The remaining WS-1 slices (progress sheets, feedback dialogs, `relay_settings`) follow as their own PRs.

## Verification

- `flutter analyze lib/blocs/sounds/ lib/screens/sounds_screen.dart test/blocs/sounds/` → `No issues found!`
- `flutter test test/blocs/sounds/sounds_cubit_test.dart` → **11/11 passing**: `setSearchQuery` lowercasing, `filterSounds` (empty + case-insensitive match), full preview lifecycle (ignored when already loading, toggle-stop on same id, unavailable for missing URL, success path emitting `loading → playing → cleared`, failure path with `addError` + `PreviewSoundOutcome.failed`), `stopPreview` no-op + clearing paths, and `saveSound` passthrough.
- `dart format --output=none --set-exit-if-changed` → clean.

## Type of Change

- [x] 🧹 Code refactor

## Notes for review

- The Cubit's `close()` override calls `audio.stop()` (best-effort, swallowed) so disposing the screen mid-preview doesn't leave the audio service playing into the void — mirrors the pre-migration `dispose()` that called `_audioService!.stop()` against a cached reference.
- The previous screen lost the parameterized `'$e'` in the `soundsPreviewFailed` snackbar; the Cubit reports the underlying error to Crashlytics via `addError` and the View shows the snackbar with an empty error parameter (the l10n key still takes a placeholder). If that snackbar copy needs the exception text back, that's a follow-up — the original behavior leaked exception toString to users which is a separate quality issue.
- `_SoundTileSelector` uses `context.select((SoundsCubit c) => c.state.previewingSoundId == sound.id)` so the rebuild on `previewingSoundId` change is scoped to the one tile, not the whole list.
