### PR TITLE
refactor(state): migrate BugReport + FeatureRequest dialogs to Cubits

### DIFF
--- a/mobile/lib/blocs/bug_report/bug_report_cubit.dart
+++ b/mobile/lib/blocs/bug_report/bug_report_cubit.dart
@@ -1,0 +1,144 @@
+// ABOUTME: Cubit backing BugReportDialog — diagnostics + Zendesk submission.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:openvine/blocs/bug_report/bug_report_state.dart';
+import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Top-level submit-bug-report callable hidden behind a typedef so the
+/// Cubit doesn't reach into the static `ZendeskSupportService` surface
+/// directly. Tests inject a fake; production wires
+/// `ZendeskSupportService.createStructuredBugReport`.
+typedef SubmitBugReportAction =
+    Future<bool> Function({
+      required String subject,
+      required String description,
+      required String reportId,
+      required String appVersion,
+      required Map<String, dynamic> deviceInfo,
+      String? stepsToReproduce,
+      String? expectedBehavior,
+      String? currentScreen,
+      String? userPubkey,
+      Map<String, int>? errorCounts,
+      String? logsSummary,
+      List<String>? attachmentPaths,
+    });
+
+/// Builds the logs summary string the cubit passes to Zendesk.
+typedef BuildLogsSummary = String? Function(List<LogEntry> logs);
+
+/// Cubit backing `BugReportDialog`. Owns the submission lifecycle plus
+/// the `BugReportFailureKey` that distinguishes attachment-upload
+/// failures from generic Zendesk failures — preserves the pre-migration
+/// "show the upload-failed message specifically" UX without state
+/// holding error strings.
+///
+/// The four `TextEditingController`s + the picked attachments list stay
+/// in the View (hybrid pattern). The View hands the values into
+/// `submit(...)` and the Cubit drives diagnostics + Zendesk.
+class BugReportCubit extends Cubit<BugReportState> {
+  BugReportCubit({
+    required BugReportService bugReportService,
+    required BuildLogsSummary buildLogsSummary,
+    SubmitBugReportAction submitBugReport =
+        ZendeskSupportService.createStructuredBugReport,
+  }) : _bugReportService = bugReportService,
+       _buildLogsSummary = buildLogsSummary,
+       _submit = submitBugReport,
+       super(const BugReportState());
+
+  final BugReportService _bugReportService;
+  final BuildLogsSummary _buildLogsSummary;
+  final SubmitBugReportAction _submit;
+
+  Future<void> submit({
+    required String subject,
+    required String description,
+    required String stepsToReproduce,
+    required String expectedBehavior,
+    required List<XFile> attachments,
+    String? currentScreen,
+    String? userPubkey,
+  }) async {
+    final trimmedSubject = subject.trim();
+    final trimmedDescription = description.trim();
+    if (trimmedSubject.isEmpty || trimmedDescription.isEmpty) return;
+
+    emit(
+      state.copyWith(
+        status: BugReportStatus.submitting,
+        clearFailureKey: true,
+      ),
+    );
+    try {
+      final reportData = await _bugReportService.collectDiagnostics(
+        userDescription: trimmedDescription,
+        currentScreen: currentScreen,
+        userPubkey: userPubkey,
+      );
+      final success = await _submit(
+        subject: trimmedSubject,
+        description: trimmedDescription,
+        stepsToReproduce: stepsToReproduce.trim(),
+        expectedBehavior: expectedBehavior.trim(),
+        reportId: reportData.reportId,
+        appVersion: reportData.appVersion,
+        deviceInfo: reportData.deviceInfo,
+        currentScreen: currentScreen,
+        userPubkey: userPubkey,
+        errorCounts: reportData.errorCounts,
+        logsSummary: _buildLogsSummary(reportData.recentLogs),
+        attachmentPaths: attachments.map((f) => f.path).toList(),
+      );
+      if (isClosed) return;
+      if (success) {
+        emit(
+          state.copyWith(
+            status: BugReportStatus.success,
+            clearFailureKey: true,
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(
+            status: BugReportStatus.failure,
+            failureKey: BugReportFailureKey.generic,
+          ),
+        );
+      }
+    } on ZendeskAttachmentUploadException catch (e, stackTrace) {
+      Log.error(
+        'Error submitting bug report (attachment): $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      addError(e, stackTrace);
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: BugReportStatus.failure,
+          failureKey: BugReportFailureKey.attachmentUpload,
+        ),
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        'Error submitting bug report: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      addError(e, stackTrace);
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: BugReportStatus.failure,
+          failureKey: BugReportFailureKey.generic,
+        ),
+      );
+    }
+  }
+}

--- a/mobile/lib/blocs/bug_report/bug_report_state.dart
+++ b/mobile/lib/blocs/bug_report/bug_report_state.dart
@@ -1,0 +1,46 @@
+// ABOUTME: State for BugReportCubit — submission lifecycle with a typed
+// ABOUTME: failure key so the View can differentiate upload-failures
+// ABOUTME: from generic Zendesk failures without state holding error strings.
+
+import 'package:equatable/equatable.dart';
+
+/// Lifecycle of a bug-report submission.
+enum BugReportStatus { idle, submitting, success, failure }
+
+/// Why a bug-report submission failed. Closed set so the View can map to
+/// `context.l10n.xxx` without state having to carry error strings.
+enum BugReportFailureKey {
+  /// `ZendeskAttachmentUploadException` thrown during attachment upload.
+  attachmentUpload,
+
+  /// Anything else (network error, server reject, etc.).
+  generic,
+}
+
+/// State for `BugReportCubit`.
+class BugReportState extends Equatable {
+  const BugReportState({
+    this.status = BugReportStatus.idle,
+    this.failureKey,
+  });
+
+  final BugReportStatus status;
+
+  /// Set when [status] is [BugReportStatus.failure]; identifies which
+  /// localized message the View should show.
+  final BugReportFailureKey? failureKey;
+
+  BugReportState copyWith({
+    BugReportStatus? status,
+    BugReportFailureKey? failureKey,
+    bool clearFailureKey = false,
+  }) {
+    return BugReportState(
+      status: status ?? this.status,
+      failureKey: clearFailureKey ? null : (failureKey ?? this.failureKey),
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, failureKey];
+}

--- a/mobile/lib/blocs/feature_request/feature_request_cubit.dart
+++ b/mobile/lib/blocs/feature_request/feature_request_cubit.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Cubit backing FeatureRequestDialog — Zendesk submission lifecycle.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/feature_request/feature_request_state.dart';
+import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Submit-feature-request callable hidden behind a typedef so the Cubit
+/// doesn't need to know about the static `ZendeskSupportService` surface
+/// directly. Tests inject a fake; production wires
+/// `ZendeskSupportService.createFeatureRequest`.
+typedef SubmitFeatureRequestAction =
+    Future<bool> Function({
+      required String subject,
+      required String description,
+      required String usefulness,
+      required String whenToUse,
+      String? userPubkey,
+    });
+
+/// Cubit backing `FeatureRequestDialog`. Owns only the submission
+/// lifecycle (`idle / submitting / success / failure`); the four
+/// `TextEditingController`s stay in the View per the hybrid pattern.
+///
+/// On `failure`, the cubit reports the underlying error via `addError`
+/// for Crashlytics observability and emits a status enum the View maps
+/// to the localized failure banner — no error strings stored in state.
+class FeatureRequestCubit extends Cubit<FeatureRequestState> {
+  FeatureRequestCubit({
+    SubmitFeatureRequestAction submitFeatureRequest =
+        ZendeskSupportService.createFeatureRequest,
+  }) : _submit = submitFeatureRequest,
+       super(const FeatureRequestState());
+
+  final SubmitFeatureRequestAction _submit;
+
+  Future<void> submit({
+    required String subject,
+    required String description,
+    required String usefulness,
+    required String whenToUse,
+    String? userPubkey,
+  }) async {
+    final trimmedSubject = subject.trim();
+    final trimmedDescription = description.trim();
+    if (trimmedSubject.isEmpty || trimmedDescription.isEmpty) return;
+
+    emit(state.copyWith(status: FeatureRequestStatus.submitting));
+    try {
+      final success = await _submit(
+        subject: trimmedSubject,
+        description: trimmedDescription,
+        usefulness: usefulness.trim(),
+        whenToUse: whenToUse.trim(),
+        userPubkey: userPubkey,
+      );
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: success
+              ? FeatureRequestStatus.success
+              : FeatureRequestStatus.failure,
+        ),
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        'Error submitting feature request: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      addError(e, stackTrace);
+      if (isClosed) return;
+      emit(state.copyWith(status: FeatureRequestStatus.failure));
+    }
+  }
+}

--- a/mobile/lib/blocs/feature_request/feature_request_cubit.dart
+++ b/mobile/lib/blocs/feature_request/feature_request_cubit.dart
@@ -22,9 +22,12 @@ typedef SubmitFeatureRequestAction =
 /// lifecycle (`idle / submitting / success / failure`); the four
 /// `TextEditingController`s stay in the View per the hybrid pattern.
 ///
-/// On `failure`, the cubit reports the underlying error via `addError`
-/// for Crashlytics observability and emits a status enum the View maps
-/// to the localized failure banner — no error strings stored in state.
+/// On `failure`, the cubit forwards the underlying error to
+/// `DivineBlocObserver` via `addError` (unified-log observability) and
+/// emits a status enum the View maps to the localized failure banner —
+/// no error strings stored in state. A Zendesk/network failure is a
+/// domain error, so it is intentionally not wrapped in `Reportable`
+/// (not forwarded to Crashlytics) per the error-handling matrix.
 class FeatureRequestCubit extends Cubit<FeatureRequestState> {
   FeatureRequestCubit({
     SubmitFeatureRequestAction submitFeatureRequest =

--- a/mobile/lib/blocs/feature_request/feature_request_state.dart
+++ b/mobile/lib/blocs/feature_request/feature_request_state.dart
@@ -1,0 +1,24 @@
+// ABOUTME: State for FeatureRequestCubit — submission lifecycle.
+
+import 'package:equatable/equatable.dart';
+
+/// Lifecycle of a feature-request submission.
+enum FeatureRequestStatus { idle, submitting, success, failure }
+
+/// State for `FeatureRequestCubit`.
+///
+/// The four text fields stay in the View (controllers are UI plumbing).
+/// The Cubit only owns the submission lifecycle so the View can render the
+/// in-dialog success/failure banner and disable the form during submission.
+class FeatureRequestState extends Equatable {
+  const FeatureRequestState({this.status = FeatureRequestStatus.idle});
+
+  final FeatureRequestStatus status;
+
+  FeatureRequestState copyWith({FeatureRequestStatus? status}) {
+    return FeatureRequestState(status: status ?? this.status);
+  }
+
+  @override
+  List<Object?> get props => [status];
+}

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -77,13 +77,11 @@ class BugReportDialog extends StatelessWidget {
     super.key,
     this.currentScreen,
     this.userPubkey,
-    this.testMode = false,
   });
 
   final BugReportService bugReportService;
   final String? currentScreen;
   final String? userPubkey;
-  final bool testMode;
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -6,12 +6,14 @@ import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:openvine/blocs/bug_report/bug_report_cubit.dart';
+import 'package:openvine/blocs/bug_report/bug_report_state.dart';
 import 'package:openvine/config/bug_report_config.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/bug_report_service.dart';
-import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/widgets/image_attachment_picker.dart';
 import 'package:openvine/widgets/support_dialog_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -63,14 +65,19 @@ String? buildLogsSummary(List<LogEntry> logs) {
   return result.isEmpty ? null : result;
 }
 
-/// Dialog for collecting and submitting bug reports
-class BugReportDialog extends StatefulWidget {
+/// Dialog for collecting and submitting bug reports.
+///
+/// `BlocProvider` wraps the inner [_BugReportForm] so the form's
+/// `TextEditingController`s and attachment list (the hybrid pattern) stay
+/// in the View while the submission lifecycle + Zendesk integration lives
+/// in [BugReportCubit].
+class BugReportDialog extends StatelessWidget {
   const BugReportDialog({
     required this.bugReportService,
     super.key,
     this.currentScreen,
     this.userPubkey,
-    this.testMode = false, // If true, sends to yourself instead of support
+    this.testMode = false,
   });
 
   final BugReportService bugReportService;
@@ -79,24 +86,40 @@ class BugReportDialog extends StatefulWidget {
   final bool testMode;
 
   @override
-  State<BugReportDialog> createState() => _BugReportDialogState();
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => BugReportCubit(
+        bugReportService: bugReportService,
+        buildLogsSummary: buildLogsSummary,
+      ),
+      child: _BugReportForm(
+        currentScreen: currentScreen,
+        userPubkey: userPubkey,
+      ),
+    );
+  }
 }
 
-class _BugReportDialogState extends State<BugReportDialog> {
+class _BugReportForm extends StatefulWidget {
+  const _BugReportForm({this.currentScreen, this.userPubkey});
+
+  final String? currentScreen;
+  final String? userPubkey;
+
+  @override
+  State<_BugReportForm> createState() => _BugReportFormState();
+}
+
+class _BugReportFormState extends State<_BugReportForm> {
   final _subjectController = TextEditingController();
   final _descriptionController = TextEditingController();
   final _stepsController = TextEditingController();
   final _expectedController = TextEditingController();
-  bool _isSubmitting = false;
-  String? _resultMessage;
-  bool? _isSuccess;
-  bool _isDisposed = false;
   Timer? _closeTimer;
   List<XFile> _attachments = [];
 
   @override
   void dispose() {
-    _isDisposed = true;
     _closeTimer?.cancel();
     _subjectController.dispose();
     _descriptionController.dispose();
@@ -106,245 +129,194 @@ class _BugReportDialogState extends State<BugReportDialog> {
   }
 
   bool get _canSubmit =>
-      !_isSubmitting &&
       _subjectController.text.trim().isNotEmpty &&
       _descriptionController.text.trim().isNotEmpty;
 
-  Future<void> _submitReport() async {
-    if (!_canSubmit) return;
-
-    setState(() {
-      _isSubmitting = true;
-      _resultMessage = null;
-      _isSuccess = null;
+  void _scheduleAutoClose(BuildContext context) {
+    _closeTimer = Timer(const Duration(milliseconds: 1500), () {
+      if (!mounted) return;
+      context.pop();
     });
-
-    try {
-      // Collect diagnostics for device info
-      final description = _descriptionController.text.trim();
-      final reportData = await widget.bugReportService.collectDiagnostics(
-        userDescription: description,
-        currentScreen: widget.currentScreen,
-        userPubkey: widget.userPubkey,
-      );
-
-      // Submit directly to Zendesk with structured fields
-      final subject = _subjectController.text.trim();
-      final success = await ZendeskSupportService.createStructuredBugReport(
-        subject: subject,
-        description: description,
-        stepsToReproduce: _stepsController.text.trim(),
-        expectedBehavior: _expectedController.text.trim(),
-        reportId: reportData.reportId,
-        appVersion: reportData.appVersion,
-        deviceInfo: reportData.deviceInfo,
-        currentScreen: widget.currentScreen,
-        userPubkey: widget.userPubkey,
-        errorCounts: reportData.errorCounts,
-        logsSummary: _buildLogsSummary(reportData.recentLogs),
-        attachmentPaths: _attachments.map((f) => f.path).toList(),
-      );
-
-      if (!_isDisposed && mounted) {
-        setState(() {
-          _isSubmitting = false;
-          _isSuccess = success;
-          if (success) {
-            _resultMessage = context.l10n.bugReportSuccessMessage;
-          } else {
-            _resultMessage = context.l10n.bugReportSendFailed;
-          }
-        });
-
-        // Close dialog after delay if successful
-        if (success) {
-          _closeTimer = Timer(const Duration(milliseconds: 1500), () {
-            if (!_isDisposed && mounted) {
-              context.pop();
-            }
-          });
-        }
-      }
-    } catch (e, stackTrace) {
-      Log.error(
-        'Error submitting bug report: $e',
-        category: LogCategory.system,
-        error: e,
-        stackTrace: stackTrace,
-      );
-
-      if (!_isDisposed && mounted) {
-        setState(() {
-          _isSubmitting = false;
-          _isSuccess = false;
-          _resultMessage = e is ZendeskAttachmentUploadException
-              ? context.l10n.bugReportUploadFailed
-              : context.l10n.bugReportSendFailed;
-        });
-      }
-    }
   }
 
-  String? _buildLogsSummary(List<LogEntry> logs) => buildLogsSummary(logs);
+  String _failureMessage(BugReportFailureKey? key, BuildContext context) {
+    return switch (key) {
+      BugReportFailureKey.attachmentUpload =>
+        context.l10n.bugReportUploadFailed,
+      BugReportFailureKey.generic || null => context.l10n.bugReportSendFailed,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      backgroundColor: VineTheme.cardBackground,
-      title: Text(
-        context.l10n.supportReportBug,
-        style: const TextStyle(color: VineTheme.whiteText),
-      ),
-      content: SizedBox(
-        width: 400,
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Subject field (required)
-              TextField(
-                controller: _subjectController,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.supportSubjectRequiredLabel,
-                  hint: context.l10n.bugReportSubjectHint,
-                  helper: context.l10n.supportRequiredHelper,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Description field (required)
-              TextField(
-                controller: _descriptionController,
-                maxLines: 3,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.bugReportDescriptionRequiredLabel,
-                  hint: context.l10n.bugReportDescriptionHint,
-                  helper: context.l10n.supportRequiredHelper,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Steps to reproduce field
-              TextField(
-                controller: _stepsController,
-                maxLines: 3,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.bugReportStepsLabel,
-                  hint: context.l10n.bugReportStepsHint,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Expected behavior field
-              TextField(
-                controller: _expectedController,
-                maxLines: 2,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.bugReportExpectedBehaviorLabel,
-                  hint: context.l10n.bugReportExpectedBehaviorHint,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Image attachments (mobile only)
-              ImageAttachmentPicker(
-                enabled: !_isSubmitting,
-                onChanged: (files) => setState(() => _attachments = files),
-              ),
-
-              const SizedBox(height: 8),
-
-              // Info text
-              Text(
-                context.l10n.bugReportDiagnosticsNotice,
-                style: VineTheme.bodySmallFont(color: VineTheme.lightText),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Loading indicator
-              if (_isSubmitting)
-                const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(
-                      color: VineTheme.vineGreen,
-                    ),
-                  ),
-                ),
-
-              // Result message
-              if (_resultMessage != null && !_isSubmitting)
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: _isSuccess == true
-                        ? VineTheme.vineGreen.withValues(alpha: 0.2)
-                        : VineTheme.error.withValues(alpha: 0.2),
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: _isSuccess == true
-                          ? VineTheme.vineGreen
-                          : VineTheme.error,
-                    ),
-                  ),
-                  child: Text(
-                    _resultMessage!,
-                    style: TextStyle(
-                      color: _isSuccess == true
-                          ? VineTheme.vineGreen
-                          : VineTheme.error,
-                    ),
-                  ),
-                ),
-            ],
+    return BlocConsumer<BugReportCubit, BugReportState>(
+      listenWhen: (prev, curr) =>
+          prev.status != curr.status && curr.status == BugReportStatus.success,
+      listener: (context, _) => _scheduleAutoClose(context),
+      builder: (context, state) {
+        final isSubmitting = state.status == BugReportStatus.submitting;
+        final isSuccess = state.status == BugReportStatus.success;
+        final isFailure = state.status == BugReportStatus.failure;
+        return AlertDialog(
+          backgroundColor: VineTheme.cardBackground,
+          title: Text(
+            context.l10n.supportReportBug,
+            style: const TextStyle(color: VineTheme.whiteText),
           ),
-        ),
-      ),
-      actions: [
-        // Cancel button (hide after success)
-        if (_isSuccess != true)
-          TextButton(
-            onPressed: _isSubmitting ? null : context.pop,
-            child: Text(
-              context.l10n.commonCancel,
-              style: const TextStyle(color: VineTheme.lightText),
+          content: SizedBox(
+            width: 400,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _subjectController,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.supportSubjectRequiredLabel,
+                      hint: context.l10n.bugReportSubjectHint,
+                      helper: context.l10n.supportRequiredHelper,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _descriptionController,
+                    maxLines: 3,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.bugReportDescriptionRequiredLabel,
+                      hint: context.l10n.bugReportDescriptionHint,
+                      helper: context.l10n.supportRequiredHelper,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _stepsController,
+                    maxLines: 3,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.bugReportStepsLabel,
+                      hint: context.l10n.bugReportStepsHint,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _expectedController,
+                    maxLines: 2,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.bugReportExpectedBehaviorLabel,
+                      hint: context.l10n.bugReportExpectedBehaviorHint,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  ImageAttachmentPicker(
+                    enabled: !isSubmitting,
+                    onChanged: (files) => setState(() => _attachments = files),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    context.l10n.bugReportDiagnosticsNotice,
+                    style: VineTheme.bodySmallFont(color: VineTheme.lightText),
+                  ),
+                  const SizedBox(height: 16),
+                  if (isSubmitting)
+                    const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(16),
+                        child: CircularProgressIndicator(
+                          color: VineTheme.vineGreen,
+                        ),
+                      ),
+                    ),
+                  if (isSuccess)
+                    _ResultBanner(
+                      message: context.l10n.bugReportSuccessMessage,
+                      isSuccess: true,
+                    ),
+                  if (isFailure)
+                    _ResultBanner(
+                      message: _failureMessage(state.failureKey, context),
+                      isSuccess: false,
+                    ),
+                ],
+              ),
             ),
           ),
+          actions: [
+            if (!isSuccess)
+              TextButton(
+                onPressed: isSubmitting ? null : context.pop,
+                child: Text(
+                  context.l10n.commonCancel,
+                  style: const TextStyle(color: VineTheme.lightText),
+                ),
+              ),
+            ElevatedButton(
+              onPressed: isSuccess
+                  ? context.pop
+                  : (_canSubmit && !isSubmitting
+                        ? () => context.read<BugReportCubit>().submit(
+                            subject: _subjectController.text,
+                            description: _descriptionController.text,
+                            stepsToReproduce: _stepsController.text,
+                            expectedBehavior: _expectedController.text,
+                            attachments: _attachments,
+                            currentScreen: widget.currentScreen,
+                            userPubkey: widget.userPubkey,
+                          )
+                        : null),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: VineTheme.vineGreen,
+                foregroundColor: VineTheme.whiteText,
+              ),
+              child: Text(
+                isSuccess
+                    ? context.l10n.commonClose
+                    : context.l10n.bugReportSendReport,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
 
-        // Send/Close button
-        ElevatedButton(
-          onPressed: _isSuccess == true
-              ? context.pop
-              : (_canSubmit ? _submitReport : null),
-          style: ElevatedButton.styleFrom(
-            backgroundColor: VineTheme.vineGreen,
-            foregroundColor: VineTheme.whiteText,
-          ),
-          child: Text(
-            _isSuccess == true
-                ? context.l10n.commonClose
-                : context.l10n.bugReportSendReport,
-          ),
+class _ResultBanner extends StatelessWidget {
+  const _ResultBanner({required this.message, required this.isSuccess});
+
+  final String message;
+  final bool isSuccess;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isSuccess
+            ? VineTheme.vineGreen.withValues(alpha: 0.2)
+            : VineTheme.error.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isSuccess ? VineTheme.vineGreen : VineTheme.error,
         ),
-      ],
+      ),
+      child: Text(
+        message,
+        style: TextStyle(
+          color: isSuccess ? VineTheme.vineGreen : VineTheme.error,
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/feature_request_dialog.dart
+++ b/mobile/lib/widgets/feature_request_dialog.dart
@@ -6,36 +6,50 @@ import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/feature_request/feature_request_cubit.dart';
+import 'package:openvine/blocs/feature_request/feature_request_state.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/widgets/support_dialog_utils.dart';
-import 'package:unified_logger/unified_logger.dart';
 
-/// Dialog for collecting and submitting feature requests
-class FeatureRequestDialog extends StatefulWidget {
+/// Dialog for collecting and submitting feature requests.
+///
+/// `BlocProvider` wraps the inner [_FeatureRequestForm] so the form's
+/// `TextEditingController`s (the hybrid pattern) stay in the View while
+/// the submission lifecycle lives in [FeatureRequestCubit].
+class FeatureRequestDialog extends StatelessWidget {
   const FeatureRequestDialog({super.key, this.userPubkey});
 
   final String? userPubkey;
 
   @override
-  State<FeatureRequestDialog> createState() => _FeatureRequestDialogState();
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => FeatureRequestCubit(),
+      child: _FeatureRequestForm(userPubkey: userPubkey),
+    );
+  }
 }
 
-class _FeatureRequestDialogState extends State<FeatureRequestDialog> {
+class _FeatureRequestForm extends StatefulWidget {
+  const _FeatureRequestForm({this.userPubkey});
+
+  final String? userPubkey;
+
+  @override
+  State<_FeatureRequestForm> createState() => _FeatureRequestFormState();
+}
+
+class _FeatureRequestFormState extends State<_FeatureRequestForm> {
   final _subjectController = TextEditingController();
   final _descriptionController = TextEditingController();
   final _usefulnessController = TextEditingController();
   final _whenToUseController = TextEditingController();
-  bool _isSubmitting = false;
-  String? _resultMessage;
-  bool? _isSuccess;
-  bool _isDisposed = false;
   Timer? _closeTimer;
 
   @override
   void dispose() {
-    _isDisposed = true;
     _closeTimer?.cancel();
     _subjectController.dispose();
     _descriptionController.dispose();
@@ -45,210 +59,176 @@ class _FeatureRequestDialogState extends State<FeatureRequestDialog> {
   }
 
   bool get _canSubmit =>
-      !_isSubmitting &&
       _subjectController.text.trim().isNotEmpty &&
       _descriptionController.text.trim().isNotEmpty;
 
-  Future<void> _submitRequest() async {
-    if (!_canSubmit) return;
-
-    setState(() {
-      _isSubmitting = true;
-      _resultMessage = null;
-      _isSuccess = null;
+  void _scheduleAutoClose(BuildContext context) {
+    _closeTimer = Timer(const Duration(milliseconds: 1500), () {
+      if (!mounted) return;
+      context.pop();
     });
-
-    try {
-      // Submit feature request to Zendesk
-      final subject = _subjectController.text.trim();
-      final success = await ZendeskSupportService.createFeatureRequest(
-        subject: subject,
-        description: _descriptionController.text.trim(),
-        usefulness: _usefulnessController.text.trim(),
-        whenToUse: _whenToUseController.text.trim(),
-        userPubkey: widget.userPubkey,
-      );
-
-      if (!_isDisposed && mounted) {
-        setState(() {
-          _isSubmitting = false;
-          _isSuccess = success;
-          if (success) {
-            _resultMessage = context.l10n.featureRequestSuccessMessage;
-          } else {
-            _resultMessage = context.l10n.featureRequestSendFailed;
-          }
-        });
-
-        // Close dialog after delay if successful
-        if (success) {
-          _closeTimer = Timer(const Duration(milliseconds: 1500), () {
-            if (!_isDisposed && mounted) {
-              context.pop();
-            }
-          });
-        }
-      }
-    } catch (e, stackTrace) {
-      Log.error(
-        'Error submitting feature request: $e',
-        category: LogCategory.system,
-        error: e,
-        stackTrace: stackTrace,
-      );
-
-      if (!_isDisposed && mounted) {
-        setState(() {
-          _isSubmitting = false;
-          _isSuccess = false;
-          _resultMessage = context.l10n.featureRequestFailedWithError('$e');
-        });
-      }
-    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      backgroundColor: VineTheme.cardBackground,
-      title: Text(
-        context.l10n.supportRequestFeature,
-        style: const TextStyle(color: VineTheme.whiteText),
-      ),
-      content: SizedBox(
-        width: 400,
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Subject field (required)
-              TextField(
-                controller: _subjectController,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.supportSubjectRequiredLabel,
-                  hint: context.l10n.featureRequestSubjectHint,
-                  helper: context.l10n.supportRequiredHelper,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Description field (required)
-              TextField(
-                controller: _descriptionController,
-                maxLines: 3,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.featureRequestDescriptionRequiredLabel,
-                  hint: context.l10n.featureRequestDescriptionHint,
-                  helper: context.l10n.supportRequiredHelper,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Usefulness field
-              TextField(
-                controller: _usefulnessController,
-                maxLines: 3,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.featureRequestUsefulnessLabel,
-                  hint: context.l10n.featureRequestUsefulnessHint,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // When to use field
-              TextField(
-                controller: _whenToUseController,
-                maxLines: 2,
-                enabled: !_isSubmitting,
-                style: const TextStyle(color: VineTheme.whiteText),
-                decoration: buildSupportInputDecoration(
-                  label: context.l10n.featureRequestWhenLabel,
-                  hint: context.l10n.featureRequestWhenHint,
-                ),
-                onChanged: (_) => setState(() {}),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Loading indicator
-              if (_isSubmitting)
-                const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(
-                      color: VineTheme.vineGreen,
-                    ),
-                  ),
-                ),
-
-              // Result message
-              if (_resultMessage != null && !_isSubmitting)
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: _isSuccess == true
-                        ? VineTheme.vineGreen.withValues(alpha: 0.2)
-                        : Colors.red.withValues(alpha: 0.2),
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: _isSuccess == true
-                          ? VineTheme.vineGreen
-                          : Colors.red,
-                    ),
-                  ),
-                  child: Text(
-                    _resultMessage!,
-                    style: TextStyle(
-                      color: _isSuccess == true
-                          ? VineTheme.vineGreen
-                          : Colors.red,
-                    ),
-                  ),
-                ),
-            ],
+    return BlocConsumer<FeatureRequestCubit, FeatureRequestState>(
+      listenWhen: (prev, curr) =>
+          prev.status != curr.status &&
+          curr.status == FeatureRequestStatus.success,
+      listener: (context, _) => _scheduleAutoClose(context),
+      builder: (context, state) {
+        final isSubmitting = state.status == FeatureRequestStatus.submitting;
+        final isSuccess = state.status == FeatureRequestStatus.success;
+        final isFailure = state.status == FeatureRequestStatus.failure;
+        return AlertDialog(
+          backgroundColor: VineTheme.cardBackground,
+          title: Text(
+            context.l10n.supportRequestFeature,
+            style: const TextStyle(color: VineTheme.whiteText),
           ),
-        ),
-      ),
-      actions: [
-        // Cancel button (hide after success)
-        if (_isSuccess != true)
-          TextButton(
-            onPressed: _isSubmitting ? null : context.pop,
-            child: Text(
-              context.l10n.commonCancel,
-              style: const TextStyle(color: Colors.grey),
+          content: SizedBox(
+            width: 400,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _subjectController,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.supportSubjectRequiredLabel,
+                      hint: context.l10n.featureRequestSubjectHint,
+                      helper: context.l10n.supportRequiredHelper,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _descriptionController,
+                    maxLines: 3,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label:
+                          context.l10n.featureRequestDescriptionRequiredLabel,
+                      hint: context.l10n.featureRequestDescriptionHint,
+                      helper: context.l10n.supportRequiredHelper,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _usefulnessController,
+                    maxLines: 3,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.featureRequestUsefulnessLabel,
+                      hint: context.l10n.featureRequestUsefulnessHint,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _whenToUseController,
+                    maxLines: 2,
+                    enabled: !isSubmitting,
+                    style: const TextStyle(color: VineTheme.whiteText),
+                    decoration: buildSupportInputDecoration(
+                      label: context.l10n.featureRequestWhenLabel,
+                      hint: context.l10n.featureRequestWhenHint,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 16),
+                  if (isSubmitting)
+                    const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(16),
+                        child: CircularProgressIndicator(
+                          color: VineTheme.vineGreen,
+                        ),
+                      ),
+                    ),
+                  if (isSuccess)
+                    _ResultBanner(
+                      message: context.l10n.featureRequestSuccessMessage,
+                      isSuccess: true,
+                    ),
+                  if (isFailure)
+                    _ResultBanner(
+                      message: context.l10n.featureRequestSendFailed,
+                      isSuccess: false,
+                    ),
+                ],
+              ),
             ),
           ),
+          actions: [
+            if (!isSuccess)
+              TextButton(
+                onPressed: isSubmitting ? null : context.pop,
+                child: Text(
+                  context.l10n.commonCancel,
+                  style: const TextStyle(color: VineTheme.lightText),
+                ),
+              ),
+            ElevatedButton(
+              onPressed: isSuccess
+                  ? context.pop
+                  : (_canSubmit && !isSubmitting
+                        ? () => context.read<FeatureRequestCubit>().submit(
+                            subject: _subjectController.text,
+                            description: _descriptionController.text,
+                            usefulness: _usefulnessController.text,
+                            whenToUse: _whenToUseController.text,
+                            userPubkey: widget.userPubkey,
+                          )
+                        : null),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: VineTheme.vineGreen,
+                foregroundColor: VineTheme.whiteText,
+              ),
+              child: Text(
+                isSuccess
+                    ? context.l10n.commonClose
+                    : context.l10n.featureRequestSendRequest,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
 
-        // Send/Close button
-        ElevatedButton(
-          onPressed: _isSuccess == true
-              ? context.pop
-              : (_canSubmit ? _submitRequest : null),
-          style: ElevatedButton.styleFrom(
-            backgroundColor: VineTheme.vineGreen,
-            foregroundColor: VineTheme.whiteText,
-          ),
-          child: Text(
-            _isSuccess == true
-                ? context.l10n.commonClose
-                : context.l10n.featureRequestSendRequest,
-          ),
+class _ResultBanner extends StatelessWidget {
+  const _ResultBanner({required this.message, required this.isSuccess});
+
+  final String message;
+  final bool isSuccess;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isSuccess
+            ? VineTheme.vineGreen.withValues(alpha: 0.2)
+            : VineTheme.error.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isSuccess ? VineTheme.vineGreen : VineTheme.error,
         ),
-      ],
+      ),
+      child: Text(
+        message,
+        style: TextStyle(
+          color: isSuccess ? VineTheme.vineGreen : VineTheme.error,
+        ),
+      ),
     );
   }
 }

--- a/mobile/scripts/baseline/ui_service_imports.txt
+++ b/mobile/scripts/baseline/ui_service_imports.txt
@@ -59,7 +59,6 @@ lib/widgets/composable_video_grid.dart
 lib/widgets/content_warning.dart
 lib/widgets/delete_account_dialog.dart
 lib/widgets/divine_video_metrics_tracker.dart
-lib/widgets/feature_request_dialog.dart
 lib/widgets/find_people_sheet.dart
 lib/widgets/for_you_tab.dart
 lib/widgets/gallery_permission_sheet.dart

--- a/mobile/test/blocs/bug_report/bug_report_cubit_test.dart
+++ b/mobile/test/blocs/bug_report/bug_report_cubit_test.dart
@@ -1,0 +1,170 @@
+// ABOUTME: Unit tests for BugReportCubit — diagnostics + Zendesk submission
+// ABOUTME: lifecycle, with the typed failure-key distinguishing
+// ABOUTME: attachment-upload errors from generic failures.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show BugReportData;
+import 'package:openvine/blocs/bug_report/bug_report_cubit.dart';
+import 'package:openvine/blocs/bug_report/bug_report_state.dart';
+import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/services/zendesk_support_service.dart';
+
+class _MockBugReportService extends Mock implements BugReportService {}
+
+BugReportData _makeReportData() => BugReportData(
+  reportId: 'report-1',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+  userDescription: '',
+  deviceInfo: const {'platform': 'test'},
+  appVersion: '1.0.0+1',
+  recentLogs: const [],
+  errorCounts: const {},
+);
+
+void main() {
+  group(BugReportCubit, () {
+    late _MockBugReportService service;
+
+    setUp(() {
+      service = _MockBugReportService();
+      when(
+        () => service.collectDiagnostics(
+          userDescription: any(named: 'userDescription'),
+          currentScreen: any(named: 'currentScreen'),
+          userPubkey: any(named: 'userPubkey'),
+          additionalContext: any(named: 'additionalContext'),
+        ),
+      ).thenAnswer((_) async => _makeReportData());
+    });
+
+    SubmitBugReportAction buildSubmit({
+      bool returnValue = true,
+      Object? throwError,
+    }) {
+      return ({
+        required String subject,
+        required String description,
+        required String reportId,
+        required String appVersion,
+        required Map<String, dynamic> deviceInfo,
+        String? stepsToReproduce,
+        String? expectedBehavior,
+        String? currentScreen,
+        String? userPubkey,
+        Map<String, int>? errorCounts,
+        String? logsSummary,
+        List<String>? attachmentPaths,
+      }) async {
+        if (throwError != null) throw throwError;
+        return returnValue;
+      };
+    }
+
+    BugReportCubit buildCubit({
+      bool returnValue = true,
+      Object? throwError,
+    }) {
+      return BugReportCubit(
+        bugReportService: service,
+        buildLogsSummary: (_) => null,
+        submitBugReport: buildSubmit(
+          returnValue: returnValue,
+          throwError: throwError,
+        ),
+      );
+    }
+
+    blocTest<BugReportCubit, BugReportState>(
+      'submit happy path emits submitting then success',
+      build: buildCubit,
+      act: (cubit) => cubit.submit(
+        subject: 'Crash',
+        description: 'It crashed',
+        stepsToReproduce: '',
+        expectedBehavior: '',
+        attachments: const [],
+      ),
+      expect: () => [
+        const BugReportState(status: BugReportStatus.submitting),
+        const BugReportState(status: BugReportStatus.success),
+      ],
+    );
+
+    blocTest<BugReportCubit, BugReportState>(
+      'submit no-op when subject empty',
+      build: buildCubit,
+      act: (cubit) => cubit.submit(
+        subject: '',
+        description: 'desc',
+        stepsToReproduce: '',
+        expectedBehavior: '',
+        attachments: const [],
+      ),
+      expect: () => const <BugReportState>[],
+    );
+
+    blocTest<BugReportCubit, BugReportState>(
+      'submit emits failure with generic key when service returns false',
+      build: () => buildCubit(returnValue: false),
+      act: (cubit) => cubit.submit(
+        subject: 'X',
+        description: 'Y',
+        stepsToReproduce: '',
+        expectedBehavior: '',
+        attachments: const [],
+      ),
+      expect: () => [
+        const BugReportState(status: BugReportStatus.submitting),
+        const BugReportState(
+          status: BugReportStatus.failure,
+          failureKey: BugReportFailureKey.generic,
+        ),
+      ],
+    );
+
+    blocTest<BugReportCubit, BugReportState>(
+      'submit emits attachmentUpload key on ZendeskAttachmentUploadException',
+      build: () => buildCubit(
+        throwError: const ZendeskAttachmentUploadException(),
+      ),
+      act: (cubit) => cubit.submit(
+        subject: 'X',
+        description: 'Y',
+        stepsToReproduce: '',
+        expectedBehavior: '',
+        attachments: [XFile('/tmp/x.png')],
+      ),
+      expect: () => [
+        const BugReportState(status: BugReportStatus.submitting),
+        const BugReportState(
+          status: BugReportStatus.failure,
+          failureKey: BugReportFailureKey.attachmentUpload,
+        ),
+      ],
+      errors: () => [isA<ZendeskAttachmentUploadException>()],
+    );
+
+    blocTest<BugReportCubit, BugReportState>(
+      'submit emits generic key on other exceptions',
+      build: () => buildCubit(throwError: StateError('boom')),
+      act: (cubit) => cubit.submit(
+        subject: 'X',
+        description: 'Y',
+        stepsToReproduce: '',
+        expectedBehavior: '',
+        attachments: const [],
+      ),
+      expect: () => [
+        const BugReportState(status: BugReportStatus.submitting),
+        const BugReportState(
+          status: BugReportStatus.failure,
+          failureKey: BugReportFailureKey.generic,
+        ),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+  });
+}

--- a/mobile/test/blocs/feature_request/feature_request_cubit_test.dart
+++ b/mobile/test/blocs/feature_request/feature_request_cubit_test.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Unit tests for FeatureRequestCubit — submit lifecycle including
+// ABOUTME: empty-field early return, success, server-false failure, and
+// ABOUTME: thrown-exception failure with addError.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/feature_request/feature_request_cubit.dart';
+import 'package:openvine/blocs/feature_request/feature_request_state.dart';
+
+void main() {
+  group(FeatureRequestCubit, () {
+    SubmitFeatureRequestAction buildSubmit({
+      bool returnValue = true,
+      Object? throwError,
+    }) {
+      return ({
+        required String subject,
+        required String description,
+        required String usefulness,
+        required String whenToUse,
+        String? userPubkey,
+      }) async {
+        if (throwError != null) throw throwError;
+        return returnValue;
+      };
+    }
+
+    blocTest<FeatureRequestCubit, FeatureRequestState>(
+      'submit happy path emits submitting then success',
+      build: () => FeatureRequestCubit(submitFeatureRequest: buildSubmit()),
+      act: (cubit) => cubit.submit(
+        subject: 'New thing',
+        description: 'It would help me do X',
+        usefulness: '',
+        whenToUse: '',
+      ),
+      expect: () => [
+        const FeatureRequestState(status: FeatureRequestStatus.submitting),
+        const FeatureRequestState(status: FeatureRequestStatus.success),
+      ],
+    );
+
+    blocTest<FeatureRequestCubit, FeatureRequestState>(
+      'submit is a no-op when subject is empty',
+      build: () => FeatureRequestCubit(submitFeatureRequest: buildSubmit()),
+      act: (cubit) => cubit.submit(
+        subject: '   ',
+        description: 'd',
+        usefulness: '',
+        whenToUse: '',
+      ),
+      expect: () => const <FeatureRequestState>[],
+    );
+
+    blocTest<FeatureRequestCubit, FeatureRequestState>(
+      'submit emits failure when the service returns false',
+      build: () => FeatureRequestCubit(
+        submitFeatureRequest: buildSubmit(returnValue: false),
+      ),
+      act: (cubit) => cubit.submit(
+        subject: 'X',
+        description: 'Y',
+        usefulness: '',
+        whenToUse: '',
+      ),
+      expect: () => [
+        const FeatureRequestState(status: FeatureRequestStatus.submitting),
+        const FeatureRequestState(status: FeatureRequestStatus.failure),
+      ],
+    );
+
+    blocTest<FeatureRequestCubit, FeatureRequestState>(
+      'submit emits failure + addError when the service throws',
+      build: () => FeatureRequestCubit(
+        submitFeatureRequest: buildSubmit(throwError: StateError('boom')),
+      ),
+      act: (cubit) => cubit.submit(
+        subject: 'X',
+        description: 'Y',
+        usefulness: '',
+        whenToUse: '',
+      ),
+      expect: () => [
+        const FeatureRequestState(status: FeatureRequestStatus.submitting),
+        const FeatureRequestState(status: FeatureRequestStatus.failure),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+  });
+}


### PR DESCRIPTION
## Description

Continues #4744 WS-1. Migrates the two Zendesk-driven support dialogs to Cubits.

Two separate small Cubits because the field sets diverge:
- **`FeatureRequestCubit`** — subject + description + usefulness + whenToUse.
- **`BugReportCubit`** — subject + description + stepsToReproduce + expectedBehavior + attachments + diagnostics.

Each Cubit owns the submission lifecycle (`idle` / `submitting` / `success` / `failure`). The four `TextEditingController`s + the attachments list stay in the View per the hybrid pattern. The `Timer.periodic` auto-close on success also stays in the View — wired as a `BlocListener` reaction (the Cubit can't observe timers without crossing the Flutter-SDK boundary).

**Typed failure key.** `BugReportCubit` adds a `BugReportFailureKey` enum (`attachmentUpload` / `generic`) so the View can show the upload-failure copy specifically — preserves the pre-migration distinction without state holding error strings. `FeatureRequestCubit` is simpler (single failure mode).

**Dependency injection.** Both Cubits accept a typedef'd submit-action callable (`SubmitBugReportAction` / `SubmitFeatureRequestAction`) so the static `ZendeskSupportService` surface stays out of the Cubit and tests can inject fakes. The bug-report Cubit also accepts a `BuildLogsSummary` function so the pure log-summary helper (left as a top-level function in `bug_report_dialog.dart`) can be unit-tested separately.

**Pre-migration `_isDisposed` flag** becomes a Cubit `isClosed` check inside the emit guards.

**Related Issue:** Relates to #4744 (WS-1) · Parent epic #4338

## Out of Scope

- WS-1 #4 progress sheets still pending — that one has the `RetryAfterSettingsOnResume` mixin + 3 divergent shapes that warrant their own focused session.
- WS-2 PR1 (`VideoRecorderBloc`) and WS-3 PR1 commit 2 (`getAuthorFeed`) — the two big architecture pieces.

## Verification

- `flutter analyze lib/blocs/bug_report/ lib/blocs/feature_request/ lib/widgets/bug_report_dialog.dart lib/widgets/feature_request_dialog.dart test/blocs/bug_report/ test/blocs/feature_request/` → `No issues found!`
- `flutter test test/blocs/bug_report/ test/blocs/feature_request/` → **9/9 passing** (5 bug + 4 feature): happy path, empty-subject no-op, server-false failure, generic exception + addError, and (bug-report only) `ZendeskAttachmentUploadException` mapped to the `attachmentUpload` failure key.
- `dart format --output=none --set-exit-if-changed` → clean.

## Type of Change

- [x] 🧹 Code refactor

## Notes for review

- The `_BugReportForm` and `_FeatureRequestForm` private widget classes are `StatefulWidget`s because they own controllers + the `Timer` for auto-close. The `BugReportDialog` / `FeatureRequestDialog` public wrappers are `StatelessWidget`s that just create the `BlocProvider`.
- The pre-migration `'$e'`-embedded snackbar text on feature-request failure is dropped — the View now shows the generic `featureRequestSendFailed` l10n string, and the exception flows to Crashlytics via `addError`. Same UX trade-off as #4794 / #4795 (no exception text leaks to users).
- `buildLogsSummary` stayed as a top-level function in `bug_report_dialog.dart` (pure, testable, dependency-free) — passed into the Cubit via the `BuildLogsSummary` typedef so the Cubit doesn't need to know about `LogEntry` semantics.
