### PR TITLE
refactor(state): migrate 3 progress sheets to Cubits

### DIFF
--- a/mobile/lib/blocs/save_original_progress/save_original_progress_cubit.dart
+++ b/mobile/lib/blocs/save_original_progress/save_original_progress_cubit.dart
@@ -41,6 +41,7 @@ class SaveOriginalProgressCubit extends Cubit<SaveOriginalProgressState> {
   /// Reset state to the initial downloading-spinner view. The View calls
   /// this on resume-after-Settings to retry the save flow.
   void reset() {
+    if (isClosed) return;
     emit(const SaveOriginalProgressState());
   }
 }

--- a/mobile/lib/blocs/save_original_progress/save_original_progress_cubit.dart
+++ b/mobile/lib/blocs/save_original_progress/save_original_progress_cubit.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Cubit backing the save-original progress sheet — drives the
+// ABOUTME: watermark download service through downloading -> saving and
+// ABOUTME: exposes the result for the View to switch on.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/blocs/save_original_progress/save_original_progress_state.dart';
+import 'package:openvine/services/watermark_download_service.dart';
+
+/// Cubit backing the `showSaveOriginalSheet(...)` bottom sheet.
+///
+/// Owns the durable progress state (`stage` / `result` / `isProcessing`).
+/// The `RetryAfterSettingsOnResume` mixin stays in the View because it
+/// observes Flutter `WidgetsBinding` — the View calls [reset] from its
+/// retry-after-settings callback to restart the flow.
+class SaveOriginalProgressCubit extends Cubit<SaveOriginalProgressState> {
+  SaveOriginalProgressCubit({
+    required WatermarkDownloadService service,
+    required VideoEvent video,
+  }) : _service = service,
+       _video = video,
+       super(const SaveOriginalProgressState());
+
+  final WatermarkDownloadService _service;
+  final VideoEvent _video;
+
+  /// Run the save-original flow. Safe to call again after [reset] for the
+  /// retry-after-settings flow.
+  Future<void> start() async {
+    final result = await _service.downloadOriginal(
+      video: _video,
+      onProgress: (stage) {
+        if (isClosed) return;
+        emit(state.copyWith(stage: stage));
+      },
+    );
+    if (isClosed) return;
+    emit(state.copyWith(result: result, isProcessing: false));
+  }
+
+  /// Reset state to the initial downloading-spinner view. The View calls
+  /// this on resume-after-Settings to retry the save flow.
+  void reset() {
+    emit(const SaveOriginalProgressState());
+  }
+}

--- a/mobile/lib/blocs/save_original_progress/save_original_progress_state.dart
+++ b/mobile/lib/blocs/save_original_progress/save_original_progress_state.dart
@@ -1,0 +1,37 @@
+// ABOUTME: State for SaveOriginalProgressCubit — stage + result + processing.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/services/watermark_download_service.dart';
+
+/// State for `SaveOriginalProgressCubit`.
+///
+/// While [isProcessing] is true, the View renders the spinner + stage
+/// labels. Once it flips to false, [result] is non-null and the View
+/// switches to the success/permission/failure branch.
+class SaveOriginalProgressState extends Equatable {
+  const SaveOriginalProgressState({
+    this.stage = OriginalSaveStage.downloading,
+    this.result,
+    this.isProcessing = true,
+  });
+
+  final OriginalSaveStage stage;
+  final WatermarkDownloadResult? result;
+  final bool isProcessing;
+
+  SaveOriginalProgressState copyWith({
+    OriginalSaveStage? stage,
+    WatermarkDownloadResult? result,
+    bool? isProcessing,
+    bool clearResult = false,
+  }) {
+    return SaveOriginalProgressState(
+      stage: stage ?? this.stage,
+      result: clearResult ? null : (result ?? this.result),
+      isProcessing: isProcessing ?? this.isProcessing,
+    );
+  }
+
+  @override
+  List<Object?> get props => [stage, result, isProcessing];
+}

--- a/mobile/lib/blocs/save_original_progress/save_original_progress_state.dart
+++ b/mobile/lib/blocs/save_original_progress/save_original_progress_state.dart
@@ -23,11 +23,10 @@ class SaveOriginalProgressState extends Equatable {
     OriginalSaveStage? stage,
     WatermarkDownloadResult? result,
     bool? isProcessing,
-    bool clearResult = false,
   }) {
     return SaveOriginalProgressState(
       stage: stage ?? this.stage,
-      result: clearResult ? null : (result ?? this.result),
+      result: result ?? this.result,
       isProcessing: isProcessing ?? this.isProcessing,
     );
   }

--- a/mobile/lib/blocs/upload_progress/upload_progress_cubit.dart
+++ b/mobile/lib/blocs/upload_progress/upload_progress_cubit.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Cubit backing UploadProgressDialog — polls an upload manager for
+// ABOUTME: progress + status and emits state. Auto-stops polling when the
+// ABOUTME: status reaches readyToPublish.
+
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/upload_progress/upload_progress_state.dart';
+import 'package:openvine/models/pending_upload.dart';
+
+/// Lookup callable hiding the dynamically-typed `UploadManager.getUpload`
+/// surface so the Cubit can be tested without standing up a real manager.
+typedef UploadLookup = PendingUpload? Function(String uploadId);
+
+/// Cubit backing `UploadProgressDialog`. Polls [pollInterval]ms (default
+/// 500ms) via `Timer.periodic`; cancels the timer when the upload reaches
+/// [UploadStatus.readyToPublish] so the View's listener can pop the
+/// dialog.
+class UploadProgressCubit extends Cubit<UploadProgressState> {
+  UploadProgressCubit({
+    required String uploadId,
+    required UploadLookup lookup,
+    Duration pollInterval = const Duration(milliseconds: 500),
+  }) : _uploadId = uploadId,
+       _lookup = lookup,
+       _pollInterval = pollInterval,
+       super(const UploadProgressState());
+
+  final String _uploadId;
+  final UploadLookup _lookup;
+  final Duration _pollInterval;
+  Timer? _pollTimer;
+
+  /// Start polling. Emits an initial snapshot synchronously.
+  void start() {
+    _poll();
+    _pollTimer ??= Timer.periodic(_pollInterval, (_) => _poll());
+  }
+
+  void _poll() {
+    final upload = _lookup(_uploadId);
+    if (upload == null) return;
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        progress: upload.uploadProgress ?? 0.0,
+        status: upload.status,
+      ),
+    );
+    if (upload.status == UploadStatus.readyToPublish) {
+      _pollTimer?.cancel();
+      _pollTimer = null;
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    return super.close();
+  }
+}

--- a/mobile/lib/blocs/upload_progress/upload_progress_state.dart
+++ b/mobile/lib/blocs/upload_progress/upload_progress_state.dart
@@ -1,0 +1,24 @@
+// ABOUTME: State for UploadProgressCubit — current upload progress + status.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/models/pending_upload.dart';
+
+class UploadProgressState extends Equatable {
+  const UploadProgressState({
+    this.progress = 0.0,
+    this.status = UploadStatus.pending,
+  });
+
+  final double progress;
+  final UploadStatus status;
+
+  UploadProgressState copyWith({double? progress, UploadStatus? status}) {
+    return UploadProgressState(
+      progress: progress ?? this.progress,
+      status: status ?? this.status,
+    );
+  }
+
+  @override
+  List<Object?> get props => [progress, status];
+}

--- a/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_cubit.dart
+++ b/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_cubit.dart
@@ -36,6 +36,7 @@ class WatermarkDownloadProgressCubit
 
   /// Retry-after-Settings hook used by the View's lifecycle observer.
   void reset() {
+    if (isClosed) return;
     emit(const WatermarkDownloadProgressState());
   }
 }

--- a/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_cubit.dart
+++ b/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_cubit.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Cubit backing the watermark-download progress sheet.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/blocs/watermark_download_progress/watermark_download_progress_state.dart';
+import 'package:openvine/services/watermark_download_service.dart';
+
+/// Cubit backing the `showWatermarkDownloadSheet(...)` bottom sheet.
+class WatermarkDownloadProgressCubit
+    extends Cubit<WatermarkDownloadProgressState> {
+  WatermarkDownloadProgressCubit({
+    required WatermarkDownloadService service,
+    required VideoEvent video,
+    required String watermarkText,
+  }) : _service = service,
+       _video = video,
+       _watermarkText = watermarkText,
+       super(const WatermarkDownloadProgressState());
+
+  final WatermarkDownloadService _service;
+  final VideoEvent _video;
+  final String _watermarkText;
+
+  Future<void> start() async {
+    final result = await _service.downloadWithWatermark(
+      video: _video,
+      watermarkText: _watermarkText,
+      onProgress: (stage) {
+        if (isClosed) return;
+        emit(state.copyWith(stage: stage));
+      },
+    );
+    if (isClosed) return;
+    emit(state.copyWith(result: result, isProcessing: false));
+  }
+
+  /// Retry-after-Settings hook used by the View's lifecycle observer.
+  void reset() {
+    emit(const WatermarkDownloadProgressState());
+  }
+}

--- a/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_state.dart
+++ b/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_state.dart
@@ -1,0 +1,32 @@
+// ABOUTME: State for WatermarkDownloadProgressCubit.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/services/watermark_download_service.dart';
+
+class WatermarkDownloadProgressState extends Equatable {
+  const WatermarkDownloadProgressState({
+    this.stage = WatermarkDownloadStage.downloading,
+    this.result,
+    this.isProcessing = true,
+  });
+
+  final WatermarkDownloadStage stage;
+  final WatermarkDownloadResult? result;
+  final bool isProcessing;
+
+  WatermarkDownloadProgressState copyWith({
+    WatermarkDownloadStage? stage,
+    WatermarkDownloadResult? result,
+    bool? isProcessing,
+    bool clearResult = false,
+  }) {
+    return WatermarkDownloadProgressState(
+      stage: stage ?? this.stage,
+      result: clearResult ? null : (result ?? this.result),
+      isProcessing: isProcessing ?? this.isProcessing,
+    );
+  }
+
+  @override
+  List<Object?> get props => [stage, result, isProcessing];
+}

--- a/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_state.dart
+++ b/mobile/lib/blocs/watermark_download_progress/watermark_download_progress_state.dart
@@ -18,11 +18,10 @@ class WatermarkDownloadProgressState extends Equatable {
     WatermarkDownloadStage? stage,
     WatermarkDownloadResult? result,
     bool? isProcessing,
-    bool clearResult = false,
   }) {
     return WatermarkDownloadProgressState(
       stage: stage ?? this.stage,
-      result: clearResult ? null : (result ?? this.result),
+      result: result ?? this.result,
       isProcessing: isProcessing ?? this.isProcessing,
     );
   }

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -3,8 +3,11 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/save_original_progress/save_original_progress_cubit.dart';
+import 'package:openvine/blocs/save_original_progress/save_original_progress_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
@@ -13,9 +16,6 @@ import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
 import 'package:share_plus/share_plus.dart';
 
 /// Shows a bottom sheet that tracks original video save progress.
-///
-/// Call this to start the save-original flow. The sheet displays
-/// progress through downloading and saving stages (no watermark step).
 Future<void> showSaveOriginalSheet({
   required BuildContext context,
   required WidgetRef ref,
@@ -34,47 +34,53 @@ Future<void> showSaveOriginalSheet({
   );
 }
 
-class _SaveOriginalProgressSheet extends StatefulWidget {
+class _SaveOriginalProgressSheet extends StatelessWidget {
   const _SaveOriginalProgressSheet({required this.video, required this.ref});
 
   final VideoEvent video;
   final WidgetRef ref;
 
   @override
-  State<_SaveOriginalProgressSheet> createState() =>
-      _SaveOriginalProgressSheetState();
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => SaveOriginalProgressCubit(
+        service: ref.read(watermarkDownloadServiceProvider),
+        video: video,
+      )..start(),
+      child: _SaveOriginalProgressView(ref: ref),
+    );
+  }
 }
 
-class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
-    with RetryAfterSettingsOnResume {
-  OriginalSaveStage _stage = OriginalSaveStage.downloading;
-  WatermarkDownloadResult? _result;
-  bool _isProcessing = true;
+class _SaveOriginalProgressView extends StatefulWidget {
+  const _SaveOriginalProgressView({required this.ref});
+
+  final WidgetRef ref;
 
   @override
-  void initState() {
-    super.initState();
-    _startDownload();
-  }
+  State<_SaveOriginalProgressView> createState() =>
+      _SaveOriginalProgressViewState();
+}
 
-  Future<void> _startDownload() async {
-    final service = widget.ref.read(watermarkDownloadServiceProvider);
-
-    final result = await service.downloadOriginal(
-      video: widget.video,
-      onProgress: (stage) {
-        if (mounted) {
-          setState(() => _stage = stage);
-        }
+class _SaveOriginalProgressViewState extends State<_SaveOriginalProgressView>
+    with RetryAfterSettingsOnResume {
+  Future<void> _openSettings() async {
+    final permissionsService = widget.ref.read(permissionsServiceProvider);
+    final cubit = context.read<SaveOriginalProgressCubit>();
+    await openSettingsAndRetryOnResume(
+      openSettings: permissionsService.openAppSettings,
+      retry: () async {
+        if (!mounted) return;
+        cubit.reset();
+        await cubit.start();
       },
     );
+  }
 
-    if (mounted) {
-      setState(() {
-        _result = result;
-        _isProcessing = false;
-      });
-    }
+  Future<void> _shareFile(WatermarkDownloadSuccess success) async {
+    await SharePlus.instance.share(
+      ShareParams(files: [XFile(success.filePath)]),
+    );
   }
 
   @override
@@ -83,182 +89,174 @@ class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
     return SafeArea(
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Handle bar
-            Container(
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: VineTheme.onSurfaceMuted,
-                borderRadius: BorderRadius.circular(2),
-              ),
+        child:
+            BlocBuilder<SaveOriginalProgressCubit, SaveOriginalProgressState>(
+              builder: (context, state) {
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: VineTheme.onSurfaceMuted,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    if (state.isProcessing) ...[
+                      const SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 3,
+                          color: VineTheme.vineGreen,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        _stageLabel(state.stage, l10n),
+                        style: VineTheme.titleMediumFont(),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        _stageDescription(state.stage, l10n),
+                        style: VineTheme.bodySmallFont(
+                          color: VineTheme.secondaryText,
+                        ),
+                      ),
+                    ] else
+                      ..._resultChildren(context, state.result, l10n),
+                    const SizedBox(height: 8),
+                  ],
+                );
+              },
             ),
-            const SizedBox(height: 24),
-
-            if (_isProcessing) ...[
-              const SizedBox(
-                width: 32,
-                height: 32,
-                child: CircularProgressIndicator(
-                  strokeWidth: 3,
-                  color: VineTheme.vineGreen,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Text(_stageLabel(l10n), style: VineTheme.titleMediumFont()),
-              const SizedBox(height: 8),
-              Text(
-                _stageDescription(l10n),
-                style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-              ),
-            ] else if (_result is WatermarkDownloadSuccess) ...[
-              const DivineIcon(
-                icon: DivineIconName.checkCircle,
-                color: VineTheme.vineGreen,
-                size: 48,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                l10n.saveOriginalSavedToCameraRoll,
-                style: VineTheme.titleMediumFont(),
-              ),
-              const SizedBox(height: 16),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: _shareFile,
-                  icon: const DivineIcon(
-                    icon: DivineIconName.share,
-                    color: VineTheme.onPrimary,
-                  ),
-                  label: Text(l10n.saveOriginalShare),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: VineTheme.vineGreen,
-                    foregroundColor: VineTheme.onPrimary,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: Text(
-                  l10n.saveOriginalDone,
-                  style: VineTheme.labelLargeFont(
-                    color: VineTheme.secondaryText,
-                  ),
-                ),
-              ),
-            ] else if (_result is WatermarkDownloadPermissionDenied) ...[
-              const DivineIcon(
-                icon: DivineIconName.lockSimple,
-                color: VineTheme.vineGreen,
-                size: 48,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                l10n.saveOriginalPhotosAccessNeeded,
-                style: VineTheme.titleMediumFont(),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                l10n.saveOriginalPhotosAccessMessage,
-                style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 16),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  onPressed: _openSettings,
-                  style: FilledButton.styleFrom(
-                    backgroundColor: VineTheme.vineGreen,
-                    foregroundColor: VineTheme.onPrimary,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                  ),
-                  child: Text(l10n.saveOriginalOpenSettings),
-                ),
-              ),
-              const SizedBox(height: 8),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: Text(
-                  l10n.saveOriginalNotNow,
-                  style: VineTheme.labelLargeFont(
-                    color: VineTheme.secondaryText,
-                  ),
-                ),
-              ),
-            ] else if (_result is WatermarkDownloadFailure) ...[
-              const DivineIcon(
-                icon: DivineIconName.warningCircle,
-                color: VineTheme.error,
-                size: 48,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                l10n.saveOriginalDownloadFailed,
-                style: VineTheme.titleMediumFont(),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                (_result! as WatermarkDownloadFailure).reason,
-                style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 16),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: Text(
-                  l10n.saveOriginalDismiss,
-                  style: VineTheme.labelLargeFont(
-                    color: VineTheme.secondaryText,
-                  ),
-                ),
-              ),
-            ],
-
-            const SizedBox(height: 8),
-          ],
-        ),
       ),
     );
   }
 
-  String _stageLabel(AppLocalizations l10n) => switch (_stage) {
-    OriginalSaveStage.downloading => l10n.saveOriginalDownloadingVideo,
-    OriginalSaveStage.saving => l10n.saveOriginalSavingToCameraRoll,
-  };
-
-  String _stageDescription(AppLocalizations l10n) => switch (_stage) {
-    OriginalSaveStage.downloading => l10n.saveOriginalFetchingVideo,
-    OriginalSaveStage.saving => l10n.saveOriginalSavingVideo,
-  };
-
-  Future<void> _openSettings() async {
-    final permissionsService = widget.ref.read(permissionsServiceProvider);
-    await openSettingsAndRetryOnResume(
-      openSettings: permissionsService.openAppSettings,
-      retry: () async {
-        if (!mounted) return;
-        setState(() {
-          _result = null;
-          _stage = OriginalSaveStage.downloading;
-          _isProcessing = true;
-        });
-        await _startDownload();
-      },
-    );
+  List<Widget> _resultChildren(
+    BuildContext context,
+    WatermarkDownloadResult? result,
+    AppLocalizations l10n,
+  ) {
+    return switch (result) {
+      WatermarkDownloadSuccess() => [
+        const DivineIcon(
+          icon: DivineIconName.checkCircle,
+          color: VineTheme.vineGreen,
+          size: 48,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.saveOriginalSavedToCameraRoll,
+          style: VineTheme.titleMediumFont(),
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton.icon(
+            onPressed: () => _shareFile(result),
+            icon: const DivineIcon(
+              icon: DivineIconName.share,
+              color: VineTheme.onPrimary,
+            ),
+            label: Text(l10n.saveOriginalShare),
+            style: FilledButton.styleFrom(
+              backgroundColor: VineTheme.vineGreen,
+              foregroundColor: VineTheme.onPrimary,
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            l10n.saveOriginalDone,
+            style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
+          ),
+        ),
+      ],
+      WatermarkDownloadPermissionDenied() => [
+        const DivineIcon(
+          icon: DivineIconName.lockSimple,
+          color: VineTheme.vineGreen,
+          size: 48,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.saveOriginalPhotosAccessNeeded,
+          style: VineTheme.titleMediumFont(),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.saveOriginalPhotosAccessMessage,
+          style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            onPressed: _openSettings,
+            style: FilledButton.styleFrom(
+              backgroundColor: VineTheme.vineGreen,
+              foregroundColor: VineTheme.onPrimary,
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+            child: Text(l10n.saveOriginalOpenSettings),
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            l10n.saveOriginalNotNow,
+            style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
+          ),
+        ),
+      ],
+      WatermarkDownloadFailure(:final reason) => [
+        const DivineIcon(
+          icon: DivineIconName.warningCircle,
+          color: VineTheme.error,
+          size: 48,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.saveOriginalDownloadFailed,
+          style: VineTheme.titleMediumFont(),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          reason,
+          style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            l10n.saveOriginalDismiss,
+            style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
+          ),
+        ),
+      ],
+      null => const [],
+    };
   }
 
-  Future<void> _shareFile() async {
-    final result = _result;
-    if (result is WatermarkDownloadSuccess) {
-      await SharePlus.instance.share(
-        ShareParams(files: [XFile(result.filePath)]),
-      );
-    }
-  }
+  String _stageLabel(OriginalSaveStage stage, AppLocalizations l10n) =>
+      switch (stage) {
+        OriginalSaveStage.downloading => l10n.saveOriginalDownloadingVideo,
+        OriginalSaveStage.saving => l10n.saveOriginalSavingToCameraRoll,
+      };
+
+  String _stageDescription(OriginalSaveStage stage, AppLocalizations l10n) =>
+      switch (stage) {
+        OriginalSaveStage.downloading => l10n.saveOriginalFetchingVideo,
+        OriginalSaveStage.saving => l10n.saveOriginalSavingVideo,
+      };
 }

--- a/mobile/lib/widgets/upload_progress_dialog.dart
+++ b/mobile/lib/widgets/upload_progress_dialog.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/upload_progress/upload_progress_cubit.dart';
 import 'package:openvine/blocs/upload_progress/upload_progress_state.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/pending_upload.dart';
 
 /// Dialog that shows upload progress and blocks user interaction until complete.
@@ -56,9 +57,9 @@ class _UploadProgressView extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Text(
-                  'Uploading video...',
-                  style: TextStyle(
+                Text(
+                  context.l10n.uploadUploadingVideo,
+                  style: const TextStyle(
                     color: VineTheme.whiteText,
                     fontSize: 18,
                     fontWeight: FontWeight.w600,

--- a/mobile/lib/widgets/upload_progress_dialog.dart
+++ b/mobile/lib/widgets/upload_progress_dialog.dart
@@ -32,14 +32,28 @@ class UploadProgressDialog extends StatelessWidget {
       create: (_) => UploadProgressCubit(
         uploadId: uploadId,
         lookup: (id) => uploadManager.getUpload(id) as PendingUpload?,
-      )..start(),
+      ),
       child: const _UploadProgressView(),
     );
   }
 }
 
-class _UploadProgressView extends StatelessWidget {
+class _UploadProgressView extends StatefulWidget {
   const _UploadProgressView();
+
+  @override
+  State<_UploadProgressView> createState() => _UploadProgressViewState();
+}
+
+class _UploadProgressViewState extends State<_UploadProgressView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<UploadProgressCubit>().start();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/widgets/upload_progress_dialog.dart
+++ b/mobile/lib/widgets/upload_progress_dialog.dart
@@ -1,20 +1,21 @@
 // ABOUTME: Dialog widget that displays blocking upload progress with polling updates
 // ABOUTME: Auto-closes when upload completes, uses Timer.periodic for status polling
 
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/upload_progress/upload_progress_cubit.dart';
+import 'package:openvine/blocs/upload_progress/upload_progress_state.dart';
 import 'package:openvine/models/pending_upload.dart';
 
-/// Dialog that shows upload progress and blocks user interaction until complete
+/// Dialog that shows upload progress and blocks user interaction until complete.
 ///
-/// - Displays progress percentage with progress bar
-/// - Non-dismissible (barrierDismissible: false)
-/// - Polls UploadManager every 500ms for status updates
-/// - Auto-closes when upload status becomes readyToPublish
-class UploadProgressDialog extends StatefulWidget {
+/// - Displays progress percentage with progress bar.
+/// - Non-dismissible (barrierDismissible: false).
+/// - Polls the upload manager every 500ms via [UploadProgressCubit].
+/// - Auto-closes when upload status becomes `readyToPublish`.
+class UploadProgressDialog extends StatelessWidget {
   const UploadProgressDialog({
     required this.uploadId,
     required this.uploadManager,
@@ -22,96 +23,69 @@ class UploadProgressDialog extends StatefulWidget {
   });
 
   final String uploadId;
-  final dynamic uploadManager; // Accept any object with getUpload method
-
-  @override
-  State<UploadProgressDialog> createState() => _UploadProgressDialogState();
-}
-
-class _UploadProgressDialogState extends State<UploadProgressDialog> {
-  Timer? _pollTimer;
-  double _progress = 0.0;
-  UploadStatus _status = UploadStatus.pending;
-
-  @override
-  void initState() {
-    super.initState();
-    _startPolling();
-  }
-
-  @override
-  void dispose() {
-    _pollTimer?.cancel();
-    super.dispose();
-  }
-
-  void _startPolling() {
-    // Initial poll
-    _updateProgress();
-
-    // Poll every 500ms
-    _pollTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
-      _updateProgress();
-    });
-  }
-
-  void _updateProgress() {
-    final upload = widget.uploadManager.getUpload(widget.uploadId);
-    if (upload == null) return;
-
-    setState(() {
-      _progress = upload.uploadProgress ?? 0.0;
-      _status = upload.status;
-    });
-
-    // Auto-close when upload is ready to publish
-    if (_status == UploadStatus.readyToPublish) {
-      _pollTimer?.cancel();
-      if (mounted) {
-        context.pop();
-      }
-    }
-  }
+  final dynamic uploadManager; // Accept any object with getUpload method.
 
   @override
   Widget build(BuildContext context) {
-    final percentageText = '${(_progress * 100).toInt()}%';
+    return BlocProvider(
+      create: (_) => UploadProgressCubit(
+        uploadId: uploadId,
+        lookup: (id) => uploadManager.getUpload(id) as PendingUpload?,
+      )..start(),
+      child: const _UploadProgressView(),
+    );
+  }
+}
 
-    return Dialog(
-      backgroundColor: VineTheme.cardBackground,
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              'Uploading video...',
-              style: TextStyle(
-                color: VineTheme.whiteText,
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-              ),
+class _UploadProgressView extends StatelessWidget {
+  const _UploadProgressView();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<UploadProgressCubit, UploadProgressState>(
+      listenWhen: (prev, curr) =>
+          prev.status != curr.status &&
+          curr.status == UploadStatus.readyToPublish,
+      listener: (context, _) => context.pop(),
+      builder: (context, state) {
+        final percentageText = '${(state.progress * 100).toInt()}%';
+        return Dialog(
+          backgroundColor: VineTheme.cardBackground,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Uploading video...',
+                  style: TextStyle(
+                    color: VineTheme.whiteText,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                LinearProgressIndicator(
+                  value: state.progress,
+                  backgroundColor: VineTheme.cardBackground,
+                  valueColor: const AlwaysStoppedAnimation<Color>(
+                    VineTheme.vineGreen,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  percentageText,
+                  style: const TextStyle(
+                    color: VineTheme.whiteText,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 24),
-            LinearProgressIndicator(
-              value: _progress,
-              backgroundColor: VineTheme.cardBackground,
-              valueColor: const AlwaysStoppedAnimation<Color>(
-                VineTheme.vineGreen,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              percentageText,
-              style: const TextStyle(
-                color: VineTheme.whiteText,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -3,8 +3,11 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/watermark_download_progress/watermark_download_progress_cubit.dart';
+import 'package:openvine/blocs/watermark_download_progress/watermark_download_progress_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
@@ -12,10 +15,6 @@ import 'package:openvine/services/watermark_download_service.dart';
 import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
 import 'package:share_plus/share_plus.dart';
 
-/// Shows a bottom sheet that tracks watermark download progress.
-///
-/// Call this to start the watermark download flow. The sheet displays
-/// progress through downloading, watermarking, and saving stages.
 Future<void> showWatermarkDownloadSheet({
   required BuildContext context,
   required WidgetRef ref,
@@ -38,7 +37,7 @@ Future<void> showWatermarkDownloadSheet({
   );
 }
 
-class _WatermarkDownloadProgressSheet extends StatefulWidget {
+class _WatermarkDownloadProgressSheet extends StatelessWidget {
   const _WatermarkDownloadProgressSheet({
     required this.video,
     required this.watermarkText,
@@ -50,194 +49,231 @@ class _WatermarkDownloadProgressSheet extends StatefulWidget {
   final WidgetRef ref;
 
   @override
-  State<_WatermarkDownloadProgressSheet> createState() =>
-      _WatermarkDownloadProgressSheetState();
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => WatermarkDownloadProgressCubit(
+        service: ref.read(watermarkDownloadServiceProvider),
+        video: video,
+        watermarkText: watermarkText,
+      )..start(),
+      child: _WatermarkDownloadProgressView(ref: ref),
+    );
+  }
 }
 
-class _WatermarkDownloadProgressSheetState
-    extends State<_WatermarkDownloadProgressSheet>
-    with RetryAfterSettingsOnResume {
-  WatermarkDownloadStage _stage = WatermarkDownloadStage.downloading;
-  WatermarkDownloadResult? _result;
-  bool _isProcessing = true;
+class _WatermarkDownloadProgressView extends StatefulWidget {
+  const _WatermarkDownloadProgressView({required this.ref});
+
+  final WidgetRef ref;
 
   @override
-  void initState() {
-    super.initState();
-    _startDownload();
-  }
+  State<_WatermarkDownloadProgressView> createState() =>
+      _WatermarkDownloadProgressViewState();
+}
 
-  Future<void> _startDownload() async {
-    final service = widget.ref.read(watermarkDownloadServiceProvider);
-
-    final result = await service.downloadWithWatermark(
-      video: widget.video,
-      watermarkText: widget.watermarkText,
-      onProgress: (stage) {
-        if (mounted) {
-          setState(() => _stage = stage);
-        }
+class _WatermarkDownloadProgressViewState
+    extends State<_WatermarkDownloadProgressView>
+    with RetryAfterSettingsOnResume {
+  Future<void> _openSettings() async {
+    final permissionsService = widget.ref.read(permissionsServiceProvider);
+    final cubit = context.read<WatermarkDownloadProgressCubit>();
+    await openSettingsAndRetryOnResume(
+      openSettings: permissionsService.openAppSettings,
+      retry: () async {
+        if (!mounted) return;
+        cubit.reset();
+        await cubit.start();
       },
     );
+  }
 
-    if (mounted) {
-      setState(() {
-        _result = result;
-        _isProcessing = false;
-      });
-    }
+  Future<void> _shareFile(WatermarkDownloadSuccess success) async {
+    await SharePlus.instance.share(
+      ShareParams(files: [XFile(success.filePath)]),
+    );
   }
 
   @override
-  Widget build(BuildContext context) => SafeArea(
-    child: Padding(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Handle bar
-          Container(
-            width: 40,
-            height: 4,
-            decoration: BoxDecoration(
-              color: VineTheme.onSurfaceMuted,
-              borderRadius: BorderRadius.circular(2),
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child:
+            BlocBuilder<
+              WatermarkDownloadProgressCubit,
+              WatermarkDownloadProgressState
+            >(
+              builder: (context, state) {
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: VineTheme.onSurfaceMuted,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    if (state.isProcessing) ...[
+                      const SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 3,
+                          color: VineTheme.vineGreen,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        _stageLabel(state.stage, context),
+                        style: VineTheme.titleMediumFont(),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        _stageDescription(state.stage, context),
+                        style: VineTheme.bodySmallFont(
+                          color: VineTheme.secondaryText,
+                        ),
+                      ),
+                    ] else
+                      ..._resultChildren(context, state.result),
+                    const SizedBox(height: 8),
+                  ],
+                );
+              },
+            ),
+      ),
+    );
+  }
+
+  List<Widget> _resultChildren(
+    BuildContext context,
+    WatermarkDownloadResult? result,
+  ) {
+    final l10n = context.l10n;
+    return switch (result) {
+      WatermarkDownloadSuccess() => [
+        const DivineIcon(
+          icon: DivineIconName.checkCircle,
+          color: VineTheme.vineGreen,
+          size: 48,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.watermarkDownloadSavedToCameraRoll,
+          style: VineTheme.titleMediumFont(),
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton.icon(
+            onPressed: () => _shareFile(result),
+            icon: const DivineIcon(
+              icon: DivineIconName.share,
+              color: VineTheme.onPrimary,
+            ),
+            label: Text(l10n.watermarkDownloadShare),
+            style: FilledButton.styleFrom(
+              backgroundColor: VineTheme.vineGreen,
+              foregroundColor: VineTheme.onPrimary,
+              padding: const EdgeInsets.symmetric(vertical: 12),
             ),
           ),
-          const SizedBox(height: 24),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            l10n.watermarkDownloadDone,
+            style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
+          ),
+        ),
+      ],
+      WatermarkDownloadPermissionDenied() => [
+        const DivineIcon(
+          icon: DivineIconName.lockSimple,
+          color: VineTheme.vineGreen,
+          size: 48,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.watermarkDownloadPhotosAccessNeeded,
+          style: VineTheme.titleMediumFont(),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.watermarkDownloadPhotosAccessDescription,
+          style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            onPressed: _openSettings,
+            style: FilledButton.styleFrom(
+              backgroundColor: VineTheme.vineGreen,
+              foregroundColor: VineTheme.onPrimary,
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+            child: Text(l10n.watermarkDownloadOpenSettings),
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            l10n.watermarkDownloadNotNow,
+            style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
+          ),
+        ),
+      ],
+      WatermarkDownloadFailure(:final reason) => [
+        const DivineIcon(
+          icon: DivineIconName.warningCircle,
+          color: VineTheme.error,
+          size: 48,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.watermarkDownloadFailed,
+          style: VineTheme.titleMediumFont(),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          reason,
+          style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            l10n.watermarkDownloadDismiss,
+            style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
+          ),
+        ),
+      ],
+      null => const [],
+    };
+  }
 
-          if (_isProcessing) ...[
-            const SizedBox(
-              width: 32,
-              height: 32,
-              child: CircularProgressIndicator(
-                strokeWidth: 3,
-                color: VineTheme.vineGreen,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(_stageLabel(context), style: VineTheme.titleMediumFont()),
-            const SizedBox(height: 8),
-            Text(
-              _stageDescription(context),
-              style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-            ),
-          ] else if (_result is WatermarkDownloadSuccess) ...[
-            const DivineIcon(
-              icon: DivineIconName.checkCircle,
-              color: VineTheme.vineGreen,
-              size: 48,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              context.l10n.watermarkDownloadSavedToCameraRoll,
-              style: VineTheme.titleMediumFont(),
-            ),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed: _shareFile,
-                icon: const DivineIcon(
-                  icon: DivineIconName.share,
-                  color: VineTheme.onPrimary,
-                ),
-                label: Text(context.l10n.watermarkDownloadShare),
-                style: FilledButton.styleFrom(
-                  backgroundColor: VineTheme.vineGreen,
-                  foregroundColor: VineTheme.onPrimary,
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                ),
-              ),
-            ),
-            const SizedBox(height: 8),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text(
-                context.l10n.watermarkDownloadDone,
-                style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
-              ),
-            ),
-          ] else if (_result is WatermarkDownloadPermissionDenied) ...[
-            const DivineIcon(
-              icon: DivineIconName.lockSimple,
-              color: VineTheme.vineGreen,
-              size: 48,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              context.l10n.watermarkDownloadPhotosAccessNeeded,
-              style: VineTheme.titleMediumFont(),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              context.l10n.watermarkDownloadPhotosAccessDescription,
-              style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: _openSettings,
-                style: FilledButton.styleFrom(
-                  backgroundColor: VineTheme.vineGreen,
-                  foregroundColor: VineTheme.onPrimary,
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                ),
-                child: Text(context.l10n.watermarkDownloadOpenSettings),
-              ),
-            ),
-            const SizedBox(height: 8),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text(
-                context.l10n.watermarkDownloadNotNow,
-                style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
-              ),
-            ),
-          ] else if (_result is WatermarkDownloadFailure) ...[
-            const DivineIcon(
-              icon: DivineIconName.warningCircle,
-              color: VineTheme.error,
-              size: 48,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              context.l10n.watermarkDownloadFailed,
-              style: VineTheme.titleMediumFont(),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              (_result! as WatermarkDownloadFailure).reason,
-              style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text(
-                context.l10n.watermarkDownloadDismiss,
-                style: VineTheme.labelLargeFont(color: VineTheme.secondaryText),
-              ),
-            ),
-          ],
+  String _stageLabel(WatermarkDownloadStage stage, BuildContext context) =>
+      switch (stage) {
+        WatermarkDownloadStage.downloading =>
+          context.l10n.watermarkDownloadStageDownloading,
+        WatermarkDownloadStage.watermarking =>
+          context.l10n.watermarkDownloadStageWatermarking,
+        WatermarkDownloadStage.saving =>
+          context.l10n.watermarkDownloadStageSaving,
+      };
 
-          const SizedBox(height: 8),
-        ],
-      ),
-    ),
-  );
-
-  String _stageLabel(BuildContext context) => switch (_stage) {
-    WatermarkDownloadStage.downloading =>
-      context.l10n.watermarkDownloadStageDownloading,
-    WatermarkDownloadStage.watermarking =>
-      context.l10n.watermarkDownloadStageWatermarking,
-    WatermarkDownloadStage.saving => context.l10n.watermarkDownloadStageSaving,
-  };
-
-  String _stageDescription(BuildContext context) => switch (_stage) {
+  String _stageDescription(
+    WatermarkDownloadStage stage,
+    BuildContext context,
+  ) => switch (stage) {
     WatermarkDownloadStage.downloading =>
       context.l10n.watermarkDownloadStageDownloadingDesc,
     WatermarkDownloadStage.watermarking =>
@@ -245,29 +281,4 @@ class _WatermarkDownloadProgressSheetState
     WatermarkDownloadStage.saving =>
       context.l10n.watermarkDownloadStageSavingDesc,
   };
-
-  Future<void> _openSettings() async {
-    final permissionsService = widget.ref.read(permissionsServiceProvider);
-    await openSettingsAndRetryOnResume(
-      openSettings: permissionsService.openAppSettings,
-      retry: () async {
-        if (!mounted) return;
-        setState(() {
-          _result = null;
-          _stage = WatermarkDownloadStage.downloading;
-          _isProcessing = true;
-        });
-        await _startDownload();
-      },
-    );
-  }
-
-  Future<void> _shareFile() async {
-    final result = _result;
-    if (result is WatermarkDownloadSuccess) {
-      await SharePlus.instance.share(
-        ShareParams(files: [XFile(result.filePath)]),
-      );
-    }
-  }
 }

--- a/mobile/test/blocs/save_original_progress/save_original_progress_cubit_test.dart
+++ b/mobile/test/blocs/save_original_progress/save_original_progress_cubit_test.dart
@@ -1,0 +1,93 @@
+// ABOUTME: Unit tests for SaveOriginalProgressCubit — stage emits, result
+// ABOUTME: emit on completion, reset.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/blocs/save_original_progress/save_original_progress_cubit.dart';
+import 'package:openvine/blocs/save_original_progress/save_original_progress_state.dart';
+import 'package:openvine/services/watermark_download_service.dart';
+
+class _MockService extends Mock implements WatermarkDownloadService {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+void main() {
+  group(SaveOriginalProgressCubit, () {
+    late _MockService service;
+    late VideoEvent video;
+
+    setUpAll(() {
+      registerFallbackValue(_FakeVideoEvent());
+    });
+
+    setUp(() {
+      service = _MockService();
+      video = _FakeVideoEvent();
+    });
+
+    blocTest<SaveOriginalProgressCubit, SaveOriginalProgressState>(
+      'start emits stage progression then success result',
+      build: () => SaveOriginalProgressCubit(service: service, video: video),
+      setUp: () {
+        when(
+          () => service.downloadOriginal(
+            video: any(named: 'video'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final onProgress =
+              invocation.namedArguments[#onProgress]
+                  as ValueChanged<OriginalSaveStage>;
+          onProgress(OriginalSaveStage.saving);
+          return const WatermarkDownloadSuccess('/tmp/v.mp4');
+        });
+      },
+      act: (cubit) => cubit.start(),
+      expect: () => [
+        const SaveOriginalProgressState(stage: OriginalSaveStage.saving),
+        const SaveOriginalProgressState(
+          stage: OriginalSaveStage.saving,
+          result: WatermarkDownloadSuccess('/tmp/v.mp4'),
+          isProcessing: false,
+        ),
+      ],
+    );
+
+    blocTest<SaveOriginalProgressCubit, SaveOriginalProgressState>(
+      'start emits permission-denied result',
+      build: () => SaveOriginalProgressCubit(service: service, video: video),
+      setUp: () {
+        when(
+          () => service.downloadOriginal(
+            video: any(named: 'video'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => const WatermarkDownloadPermissionDenied(),
+        );
+      },
+      act: (cubit) => cubit.start(),
+      expect: () => [
+        const SaveOriginalProgressState(
+          result: WatermarkDownloadPermissionDenied(),
+          isProcessing: false,
+        ),
+      ],
+    );
+
+    blocTest<SaveOriginalProgressCubit, SaveOriginalProgressState>(
+      'reset clears result and flips back to processing',
+      seed: () => const SaveOriginalProgressState(
+        stage: OriginalSaveStage.saving,
+        result: WatermarkDownloadPermissionDenied(),
+        isProcessing: false,
+      ),
+      build: () => SaveOriginalProgressCubit(service: service, video: video),
+      act: (cubit) => cubit.reset(),
+      expect: () => [const SaveOriginalProgressState()],
+    );
+  });
+}

--- a/mobile/test/blocs/upload_progress/upload_progress_cubit_test.dart
+++ b/mobile/test/blocs/upload_progress/upload_progress_cubit_test.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Unit tests for UploadProgressCubit — polling, progress emit,
+// ABOUTME: auto-stop on readyToPublish.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/upload_progress/upload_progress_cubit.dart';
+import 'package:openvine/blocs/upload_progress/upload_progress_state.dart';
+import 'package:openvine/models/pending_upload.dart';
+
+void main() {
+  group(UploadProgressCubit, () {
+    PendingUpload fakeUpload({
+      double progress = 0.0,
+      UploadStatus status = UploadStatus.pending,
+    }) {
+      return PendingUpload(
+        id: 'u1',
+        localVideoPath: '/tmp/v.mp4',
+        nostrPubkey: 'pk',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+        status: status,
+        uploadProgress: progress,
+      );
+    }
+
+    test('polls and emits progress + status', () {
+      fakeAsync((async) {
+        var progress = 0.0;
+        var status = UploadStatus.pending;
+        final cubit = UploadProgressCubit(
+          uploadId: 'u1',
+          lookup: (id) => id == 'u1'
+              ? fakeUpload(progress: progress, status: status)
+              : null,
+          pollInterval: const Duration(milliseconds: 100),
+        )..start();
+
+        async.elapse(Duration.zero);
+        expect(cubit.state.progress, 0.0);
+
+        progress = 0.5;
+        async.elapse(const Duration(milliseconds: 100));
+        expect(cubit.state.progress, 0.5);
+
+        progress = 1.0;
+        status = UploadStatus.readyToPublish;
+        async.elapse(const Duration(milliseconds: 100));
+        expect(cubit.state.status, UploadStatus.readyToPublish);
+        expect(cubit.state.progress, 1.0);
+
+        // Polling should now be stopped. Further elapses don't change state.
+        final lastState = cubit.state;
+        async.elapse(const Duration(milliseconds: 500));
+        expect(cubit.state, lastState);
+
+        cubit.close();
+      });
+    });
+
+    blocTest<UploadProgressCubit, UploadProgressState>(
+      'start with unknown upload id is a no-op (no emit)',
+      build: () => UploadProgressCubit(
+        uploadId: 'missing',
+        lookup: (_) => null,
+        pollInterval: const Duration(seconds: 1),
+      ),
+      act: (cubit) => cubit.start(),
+      expect: () => const <UploadProgressState>[],
+    );
+  });
+}

--- a/mobile/test/blocs/watermark_download_progress/watermark_download_progress_cubit_test.dart
+++ b/mobile/test/blocs/watermark_download_progress/watermark_download_progress_cubit_test.dart
@@ -1,0 +1,94 @@
+// ABOUTME: Unit tests for WatermarkDownloadProgressCubit — stage emits,
+// ABOUTME: result emit, reset.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/blocs/watermark_download_progress/watermark_download_progress_cubit.dart';
+import 'package:openvine/blocs/watermark_download_progress/watermark_download_progress_state.dart';
+import 'package:openvine/services/watermark_download_service.dart';
+
+class _MockService extends Mock implements WatermarkDownloadService {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+void main() {
+  group(WatermarkDownloadProgressCubit, () {
+    late _MockService service;
+    late VideoEvent video;
+
+    setUpAll(() {
+      registerFallbackValue(_FakeVideoEvent());
+    });
+
+    setUp(() {
+      service = _MockService();
+      video = _FakeVideoEvent();
+    });
+
+    WatermarkDownloadProgressCubit buildCubit() =>
+        WatermarkDownloadProgressCubit(
+          service: service,
+          video: video,
+          watermarkText: '@user',
+        );
+
+    blocTest<WatermarkDownloadProgressCubit, WatermarkDownloadProgressState>(
+      'start emits stage progression then success result',
+      build: buildCubit,
+      setUp: () {
+        when(
+          () => service.downloadWithWatermark(
+            video: any(named: 'video'),
+            watermarkText: any(named: 'watermarkText'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final onProgress =
+              invocation.namedArguments[#onProgress]
+                  as ValueChanged<WatermarkDownloadStage>;
+          onProgress(WatermarkDownloadStage.watermarking);
+          onProgress(WatermarkDownloadStage.saving);
+          return const WatermarkDownloadSuccess('/tmp/v.mp4');
+        });
+      },
+      act: (cubit) => cubit.start(),
+      expect: () => [
+        const WatermarkDownloadProgressState(
+          stage: WatermarkDownloadStage.watermarking,
+        ),
+        const WatermarkDownloadProgressState(
+          stage: WatermarkDownloadStage.saving,
+        ),
+        const WatermarkDownloadProgressState(
+          stage: WatermarkDownloadStage.saving,
+          result: WatermarkDownloadSuccess('/tmp/v.mp4'),
+          isProcessing: false,
+        ),
+      ],
+      verify: (_) {
+        verify(
+          () => service.downloadWithWatermark(
+            video: any(named: 'video'),
+            watermarkText: '@user',
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<WatermarkDownloadProgressCubit, WatermarkDownloadProgressState>(
+      'reset clears state',
+      seed: () => const WatermarkDownloadProgressState(
+        stage: WatermarkDownloadStage.saving,
+        result: WatermarkDownloadFailure('boom'),
+        isProcessing: false,
+      ),
+      build: buildCubit,
+      act: (cubit) => cubit.reset(),
+      expect: () => [const WatermarkDownloadProgressState()],
+    );
+  });
+}

--- a/mobile/test/widgets/upload_progress_dialog_test.dart
+++ b/mobile/test/widgets/upload_progress_dialog_test.dart
@@ -21,6 +21,7 @@ class MockUploadManager {
 
 void main() {
   group('UploadProgressDialog', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
     testWidgets('displays current upload progress percentage', (
       WidgetTester tester,
     ) async {
@@ -51,7 +52,7 @@ void main() {
 
       // Assert: Should display "50%"
       expect(find.text('50%'), findsOneWidget);
-      expect(find.text('Uploading video...'), findsOneWidget);
+      expect(find.text(l10n.uploadUploadingVideo), findsOneWidget);
     });
 
     testWidgets('dialog is non-dismissible (barrierDismissible: false)', (
@@ -98,14 +99,14 @@ void main() {
       await tester.pumpAndSettle();
 
       // Verify dialog is shown
-      expect(find.text('Uploading video...'), findsOneWidget);
+      expect(find.text(l10n.uploadUploadingVideo), findsOneWidget);
 
       // Try to dismiss by tapping outside (barrier)
       await tester.tapAt(const Offset(10, 10)); // Tap outside dialog
       await tester.pumpAndSettle();
 
       // Assert: Dialog should still be visible (not dismissed)
-      expect(find.text('Uploading video...'), findsOneWidget);
+      expect(find.text(l10n.uploadUploadingVideo), findsOneWidget);
     });
 
     testWidgets(
@@ -159,7 +160,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Verify dialog is shown
-        expect(find.text('Uploading video...'), findsOneWidget);
+        expect(find.text(l10n.uploadUploadingVideo), findsOneWidget);
         expect(dialogPopped, false);
 
         // Simulate upload completion by updating mock upload

--- a/mobile/test/widgets/upload_progress_dialog_test.dart
+++ b/mobile/test/widgets/upload_progress_dialog_test.dart
@@ -177,6 +177,36 @@ void main() {
       },
     );
 
+    testWidgets('dialog auto-closes when upload is already readyToPublish', (
+      WidgetTester tester,
+    ) async {
+      final goRouter = MockGoRouter();
+      final mockUpload = PendingUpload.create(
+        localVideoPath: '/test/video.mp4',
+        nostrPubkey: 'test_pubkey',
+      ).copyWith(status: UploadStatus.readyToPublish, uploadProgress: 1);
+      final mockManager = MockUploadManager(mockUpload: mockUpload);
+
+      await tester.pumpWidget(
+        MockGoRouterProvider(
+          goRouter: goRouter,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: UploadProgressDialog(
+                uploadId: mockUpload.id,
+                uploadManager: mockManager,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      verify(goRouter.pop).called(1);
+    });
+
     testWidgets('dialog polls UploadManager every 500ms for status updates', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Description

Continues #4744 WS-1. **Closes the WS-1 frontier** — last of the plan's screen/widget Cubit slices. Only WS-2 (`VideoRecorderBloc`) and WS-3 PR1 commit 2 (`getAuthorFeed`) remain on the lane.

Three separate small Cubits because the state shapes diverge:

- **`SaveOriginalProgressCubit`** — `OriginalSaveStage` (downloading / saving) + `WatermarkDownloadResult?` + `isProcessing`.
- **`WatermarkDownloadProgressCubit`** — `WatermarkDownloadStage` (downloading / watermarking / saving) + `WatermarkDownloadResult?` + `isProcessing` + the watermark text captured at construction.
- **`UploadProgressCubit`** — `double progress` + `UploadStatus`, polling via `Timer.periodic` and auto-stopping when status hits `readyToPublish`. `lookup` callback typedef hides the dynamically-typed `uploadManager.getUpload` surface.

**`RetryAfterSettingsOnResume` mixin stays in the View** (observes `WidgetsBindingObserver`, which is a Flutter-SDK concern that BLoCs must not import per `state_management.md`). The View's retry callback calls `cubit.reset()` then `cubit.start()` to restart the flow.

Each public sheet entry (`showSaveOriginalSheet`, `showWatermarkDownloadSheet`, `UploadProgressDialog`) becomes a thin Page wrapping the inner View in a `BlocProvider..start()`. The result-rendering switch uses Dart sealed-class pattern matching so the View enumerates `WatermarkDownloadSuccess` / `WatermarkDownloadPermissionDenied` / `WatermarkDownloadFailure` exhaustively.

**Related Issue:** Relates to #4744 (WS-1) · Parent epic #4338

## Out of Scope

- WS-2 PR1 (`VideoRecorderBloc`) and WS-3 PR1 commit 2 (`getAuthorFeed`) — the two big architectural pieces. Both deferred for their own focused sessions (R1 recording-race risk; WS-3 commit 2 blocked on #4790 merge).

## Verification

- `flutter analyze lib/blocs/{save_original,watermark_download,upload}_progress/ lib/widgets/{save_original_progress_sheet,watermark_download_progress_sheet,upload_progress_dialog}.dart test/blocs/...` → `No issues found!`
- `flutter test test/blocs/save_original_progress/ test/blocs/watermark_download_progress/ test/blocs/upload_progress/` → **7/7 passing**:
  - `SaveOriginalProgressCubit` (3): stage progression + success result, permission-denied result, reset.
  - `WatermarkDownloadProgressCubit` (2): stage progression + success result (watermarkText pinned via mocktail verify), reset.
  - `UploadProgressCubit` (2): progress + status polling with `fakeAsync` + auto-stop after `readyToPublish`; no-emit when upload id is unknown.
- `dart format --output=none --set-exit-if-changed` → clean.

## Type of Change

- [x] 🧹 Code refactor

## Notes for review

- `_RetryAfterSettings` mixin behavior is unchanged — same callback shape, same `WidgetsBinding` observer. Tests cover only the cubit-side state transitions; the lifecycle round-trip is best verified by manual permission-denied → Settings → resume.
- `UploadProgressCubit.close()` cancels the poll Timer; the View's `BlocProvider` does that automatically when the dialog pops.
- The two watermark / save-original sheets render their result switch via sealed pattern matching. `WatermarkDownloadFailure(:final reason)` uses the shorthand getter pattern.
- Pre-migration `setState({})` on permission-denied retry → cubit `reset()` is now a single state emit that flips `isProcessing` back on and clears `result`.
