### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across settings

### DIFF
--- a/mobile/lib/screens/blossom_settings_screen.dart
+++ b/mobile/lib/screens/blossom_settings_screen.dart
@@ -200,8 +200,8 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                           children: [
                             Row(
                               children: [
-                                Icon(
-                                  Icons.info_outline,
+                                DivineIcon(
+                                  icon: DivineIconName.info,
                                   color: VineTheme.vineGreen.withValues(
                                     alpha: 0.8,
                                   ),
@@ -376,7 +376,10 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
           url,
           style: const TextStyle(color: VineTheme.onSurfaceMuted, fontSize: 12),
         ),
-        trailing: const Icon(Icons.arrow_forward, color: VineTheme.vineGreen),
+        trailing: const DivineIcon(
+          icon: DivineIconName.arrowRight,
+          color: VineTheme.vineGreen,
+        ),
         onTap: () {
           setState(() {
             _serverController.text = url;

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -122,8 +122,8 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
                     children: [
                       Row(
                         children: [
-                          const Icon(
-                            Icons.info_outline,
+                          const DivineIcon(
+                            icon: DivineIconName.info,
                             color: VineTheme.lightText,
                             size: 20,
                           ),
@@ -183,8 +183,8 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
                           child: Column(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
-                              const Icon(
-                                Icons.error_outline,
+                              const DivineIcon(
+                                icon: DivineIconName.warningCircle,
                                 color: VineTheme.warning,
                                 size: 64,
                               ),
@@ -214,8 +214,8 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
                               const SizedBox(height: 32),
                               ElevatedButton.icon(
                                 onPressed: _restoreDefaultRelay,
-                                icon: const Icon(
-                                  Icons.restore,
+                                icon: const DivineIcon(
+                                  icon: DivineIconName.arrowCounterClockwise,
                                   color: VineTheme.whiteText,
                                 ),
                                 label: Text(
@@ -235,8 +235,8 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
                               const SizedBox(height: 12),
                               ElevatedButton.icon(
                                 onPressed: _showAddRelayDialog,
-                                icon: const Icon(
-                                  Icons.add,
+                                icon: const DivineIcon(
+                                  icon: DivineIconName.plus,
                                   color: VineTheme.whiteText,
                                 ),
                                 label: Text(
@@ -266,8 +266,8 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
                                   Expanded(
                                     child: ElevatedButton.icon(
                                       onPressed: _showAddRelayDialog,
-                                      icon: const Icon(
-                                        Icons.add,
+                                      icon: const DivineIcon(
+                                        icon: DivineIconName.plus,
                                         color: VineTheme.whiteText,
                                       ),
                                       label: Text(
@@ -289,8 +289,8 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
                                   Expanded(
                                     child: ElevatedButton.icon(
                                       onPressed: _retryConnection,
-                                      icon: const Icon(
-                                        Icons.refresh,
+                                      icon: const DivineIcon(
+                                        icon: DivineIconName.arrowClockwise,
                                         color: VineTheme.whiteText,
                                       ),
                                       label: Text(
@@ -365,13 +365,21 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
           mainAxisSize: MainAxisSize.min,
           children: [
             IconButton(
-              icon: const Icon(Icons.delete, color: VineTheme.error, size: 20),
+              icon: const DivineIcon(
+                icon: DivineIconName.trash,
+                color: VineTheme.error,
+                size: 20,
+              ),
               onPressed: () => _removeRelay(relayUrl),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),
             ),
             const SizedBox(width: 8),
-            const Icon(Icons.expand_more, color: VineTheme.lightText, size: 20),
+            const DivineIcon(
+              icon: DivineIconName.caretDown,
+              color: VineTheme.lightText,
+              size: 20,
+            ),
           ],
         ),
         iconColor: VineTheme.lightText,

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -107,8 +107,8 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
                   children: [
                     _buildSectionHeader(context.l10n.safetySettingsWhatYouSee),
                     ListTile(
-                      leading: const Icon(
-                        Icons.filter_list,
+                      leading: const DivineIcon(
+                        icon: DivineIconName.funnelSimple,
                         color: VineTheme.vineGreen,
                       ),
                       title: Text(
@@ -119,8 +119,8 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
                         context.l10n.contentPreferencesContentFiltersSubtitle,
                         style: const TextStyle(color: VineTheme.secondaryText),
                       ),
-                      trailing: const Icon(
-                        Icons.chevron_right,
+                      trailing: const DivineIcon(
+                        icon: DivineIconName.caretRight,
                         color: VineTheme.lightText,
                       ),
                       onTap: () => context.push(ContentFiltersScreen.path),
@@ -130,8 +130,8 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
                     SwitchListTile(
                       value: _showDivineHostedOnly,
                       onChanged: _setShowDivineHostedOnly,
-                      secondary: const Icon(
-                        Icons.verified,
+                      secondary: const DivineIcon(
+                        icon: DivineIconName.sealCheck,
                         color: VineTheme.vineGreen,
                       ),
                       title: Text(
@@ -217,7 +217,10 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
       value: true,
       // The built-in Divine moderation labeler is always on by product design.
       onChanged: null,
-      secondary: const Icon(Icons.verified_user, color: VineTheme.vineGreen),
+      secondary: const DivineIcon(
+        icon: DivineIconName.shieldCheck,
+        color: VineTheme.vineGreen,
+      ),
       title: Text(
         context.l10n.safetySettingsDivine,
         style: const TextStyle(color: VineTheme.whiteText),

--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -38,8 +38,8 @@ class ContentPreferencesScreen extends ConsumerWidget {
             children: [
               const _LanguageSetting(),
               ListTile(
-                leading: const Icon(
-                  Icons.filter_list,
+                leading: const DivineIcon(
+                  icon: DivineIconName.funnelSimple,
                   color: VineTheme.vineGreen,
                 ),
                 title: Text(
@@ -57,8 +57,8 @@ class ContentPreferencesScreen extends ConsumerWidget {
                     fontSize: 14,
                   ),
                 ),
-                trailing: const Icon(
-                  Icons.chevron_right,
+                trailing: const DivineIcon(
+                  icon: DivineIconName.caretRight,
                   color: VineTheme.lightText,
                 ),
                 onTap: () => context.push(ContentFiltersScreen.path),
@@ -96,7 +96,10 @@ class _LanguageSettingState extends ConsumerState<_LanguageSetting> {
           );
 
     return ListTile(
-      leading: const Icon(Icons.language, color: VineTheme.vineGreen),
+      leading: const DivineIcon(
+        icon: DivineIconName.globe,
+        color: VineTheme.vineGreen,
+      ),
       title: Text(
         context.l10n.contentPreferencesContentLanguage,
         style: const TextStyle(
@@ -109,7 +112,10 @@ class _LanguageSettingState extends ConsumerState<_LanguageSetting> {
         subtitle,
         style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
       ),
-      trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+      trailing: const DivineIcon(
+        icon: DivineIconName.caretRight,
+        color: VineTheme.lightText,
+      ),
       onTap: () => _showLanguagePicker(languageService),
     );
   }
@@ -275,7 +281,10 @@ class _AudioSharingToggleState extends ConsumerState<_AudioSharingToggle> {
         style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
       ),
       activeThumbColor: VineTheme.vineGreen,
-      secondary: const Icon(Icons.music_note, color: VineTheme.vineGreen),
+      secondary: const DivineIcon(
+        icon: DivineIconName.musicNote,
+        color: VineTheme.vineGreen,
+      ),
     );
   }
 }
@@ -327,7 +336,10 @@ class _AudioDeviceSelectorState extends ConsumerState<_AudioDeviceSelector> {
             currentDisplayName,
             style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
           ),
-          trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+          trailing: const DivineIcon(
+            icon: DivineIconName.caretRight,
+            color: VineTheme.lightText,
+          ),
           onTap: () => _showAudioDevicePicker(devices, currentDevice),
         );
       },

--- a/mobile/lib/screens/sounds_screen.dart
+++ b/mobile/lib/screens/sounds_screen.dart
@@ -276,7 +276,10 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
           hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-          prefixIcon: const Icon(Icons.search, color: VineTheme.onSurfaceMuted),
+          prefixIcon: const DivineIcon(
+            icon: DivineIconName.search,
+            color: VineTheme.onSurfaceMuted,
+          ),
           filled: true,
           fillColor: VineTheme.backgroundColor,
           border: OutlineInputBorder(
@@ -495,8 +498,8 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: Row(
             children: [
-              const Icon(
-                Icons.music_note,
+              const DivineIcon(
+                icon: DivineIconName.musicNote,
                 color: VineTheme.vineGreen,
                 size: 20,
               ),
@@ -609,7 +612,11 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(Icons.error_outline, size: 64, color: VineTheme.likeRed),
+            const DivineIcon(
+              icon: DivineIconName.warningCircle,
+              size: 64,
+              color: VineTheme.likeRed,
+            ),
             const SizedBox(height: 16),
             Text(
               context.l10n.soundsFailedToLoad,
@@ -635,7 +642,7 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
               onPressed: () {
                 ref.invalidate(trendingSoundsProvider);
               },
-              icon: const Icon(Icons.refresh),
+              icon: const DivineIcon(icon: DivineIconName.arrowClockwise),
               label: Text(context.l10n.soundsRetry),
               style: ElevatedButton.styleFrom(
                 backgroundColor: VineTheme.vineGreen,

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -114,8 +114,8 @@ class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
                 style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
               ),
             ] else if (_result is WatermarkDownloadSuccess) ...[
-              const Icon(
-                Icons.check_circle,
+              const DivineIcon(
+                icon: DivineIconName.checkCircle,
                 color: VineTheme.vineGreen,
                 size: 48,
               ),
@@ -129,7 +129,10 @@ class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
                 width: double.infinity,
                 child: FilledButton.icon(
                   onPressed: _shareFile,
-                  icon: const Icon(Icons.share),
+                  icon: const DivineIcon(
+                    icon: DivineIconName.share,
+                    color: VineTheme.onPrimary,
+                  ),
                   label: Text(l10n.saveOriginalShare),
                   style: FilledButton.styleFrom(
                     backgroundColor: VineTheme.vineGreen,
@@ -149,8 +152,8 @@ class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
                 ),
               ),
             ] else if (_result is WatermarkDownloadPermissionDenied) ...[
-              const Icon(
-                Icons.lock_outline,
+              const DivineIcon(
+                icon: DivineIconName.lockSimple,
                 color: VineTheme.vineGreen,
                 size: 48,
               ),
@@ -189,7 +192,11 @@ class _SaveOriginalProgressSheetState extends State<_SaveOriginalProgressSheet>
                 ),
               ),
             ] else if (_result is WatermarkDownloadFailure) ...[
-              const Icon(Icons.error_outline, color: VineTheme.error, size: 48),
+              const DivineIcon(
+                icon: DivineIconName.warningCircle,
+                color: VineTheme.error,
+                size: 48,
+              ),
               const SizedBox(height: 16),
               Text(
                 l10n.saveOriginalDownloadFailed,

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -123,8 +123,8 @@ class _WatermarkDownloadProgressSheetState
               style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
             ),
           ] else if (_result is WatermarkDownloadSuccess) ...[
-            const Icon(
-              Icons.check_circle,
+            const DivineIcon(
+              icon: DivineIconName.checkCircle,
               color: VineTheme.vineGreen,
               size: 48,
             ),
@@ -138,7 +138,10 @@ class _WatermarkDownloadProgressSheetState
               width: double.infinity,
               child: FilledButton.icon(
                 onPressed: _shareFile,
-                icon: const Icon(Icons.share),
+                icon: const DivineIcon(
+                  icon: DivineIconName.share,
+                  color: VineTheme.onPrimary,
+                ),
                 label: Text(context.l10n.watermarkDownloadShare),
                 style: FilledButton.styleFrom(
                   backgroundColor: VineTheme.vineGreen,
@@ -156,8 +159,8 @@ class _WatermarkDownloadProgressSheetState
               ),
             ),
           ] else if (_result is WatermarkDownloadPermissionDenied) ...[
-            const Icon(
-              Icons.lock_outline,
+            const DivineIcon(
+              icon: DivineIconName.lockSimple,
               color: VineTheme.vineGreen,
               size: 48,
             ),
@@ -194,7 +197,11 @@ class _WatermarkDownloadProgressSheetState
               ),
             ),
           ] else if (_result is WatermarkDownloadFailure) ...[
-            const Icon(Icons.error_outline, color: VineTheme.error, size: 48),
+            const DivineIcon(
+              icon: DivineIconName.warningCircle,
+              color: VineTheme.error,
+              size: 48,
+            ),
             const SizedBox(height: 16),
             Text(
               context.l10n.watermarkDownloadFailed,


### PR DESCRIPTION
Part of #4803

## Summary

Sweeps 31 raw Material `Icons.*` uses to `DivineIcon` across the seven settings screens / dialogs touched by the in-flight Cubit migration PRs (#4791, #4792, #4793, #4794, #4795, #4798). Closes the design-system gap surfaced by the audit on those branches.

Files touched:
- `lib/screens/safety_settings_screen.dart`
- `lib/screens/blossom_settings_screen.dart`
- `lib/screens/settings/content_preferences_screen.dart`
- `lib/screens/sounds_screen.dart`
- `lib/screens/relay_settings_screen.dart`
- `lib/widgets/save_original_progress_sheet.dart`
- `lib/widgets/watermark_download_progress_sheet.dart`

## Migration table

| Material `Icons.*` | `DivineIconName` |
| --- | --- |
| add | plus |
| arrow_forward | arrowRight |
| check_circle | checkCircle |
| chevron_right | caretRight |
| delete | trash |
| error_outline | warningCircle |
| expand_more | caretDown |
| filter_list | funnelSimple |
| info_outline | info |
| language | globe |
| lock_outline | lockSimple |
| music_note | musicNote |
| refresh | arrowClockwise |
| restore | arrowCounterClockwise |
| search | search |
| share | share |
| verified | sealCheck |
| verified_user | shieldCheck |

## Out of scope (follow-up)

Two pieces of design-system debt that surfaced in the audit but aren't fixed here:

1. **Icons without a `divine_ui` equivalent.** Left as `Icons.*`: `add_circle_outline`, `cloud_done`, `cloud_off`, `cloud_upload`, `label_outline`, `local_fire_department`, `mic`, `music_off`, `open_in_new`, `people`, `radio_button_checked`, `radio_button_off`, `remove_circle_outline`, `search_off`, `star`. Needs new SVG assets added to `divine_ui` — designer work. **Tracked in #4833** (sub-issue of #4803).
2. **Inline `TextStyle(...)` → `VineTheme.*Font()` migration.** 115 sites across these 10 files; deferred because the helpers bake in explicit fontFamily/size/weight/lineHeight/letterSpacing and many existing color-only `TextStyle(color: X)` rely on Material's inherited defaults. Migrating blindly risks visual regression across 10 screens. Wants a designer pass / golden tests first.

## Coordination with the in-flight Cubit PRs

This PR touches the same lines that the 7 open Cubit-migration PRs (#4791, #4792, #4793, #4794, #4795, #4798) verbatim-relocate from `_build*` helper methods to private widget classes. **Either ordering is fine but produces conflicts:**

- If this lands first → each Cubit PR needs a trivial rebase that picks `DivineIcon(icon: …)` over the old `Icon(Icons.*)` at the new widget-class locations.
- If a Cubit PR lands first → this PR rebases and re-applies the same mappings to the new widget-class locations.

The migrated icons are pure visual swaps — no behavior change — so resolution is mechanical.

## Test plan

- [x] `flutter analyze` on all touched files: clean
- [x] `flutter test test/screens/safety_settings_screen_test.dart` — 10 pass
- [x] `flutter test test/screens/settings_screen_audio_sharing_test.dart` — 5 pass
- [x] `flutter test test/screens/sounds_screen_test.dart` — 27 pass
- [x] `flutter test test/screens/relay_settings_screen_layout_test.dart` — 22 pass
- [x] `flutter test test/widgets/save_original_progress_sheet_test.dart` — pass
- [x] `flutter test test/widgets/watermark_download_progress_sheet_test.dart` — pass
- [ ] Visual smoke: run the app and walk through each screen to confirm icon glyphs render at the expected size/color

