### PR TITLE
test(notifications): cover realtime owned-video routing edges (#4768)

### DIFF
--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2380,6 +2380,7 @@ void main() {
         String notificationType = 'reaction',
         String? referencedEventId = 'video_x',
         String? referencedDTag,
+        String? rootEventId,
         bool isReferencedVideo = true,
       }) {
         return RelayNotification(
@@ -2392,6 +2393,7 @@ void main() {
           read: false,
           referencedEventId: referencedEventId,
           referencedDTag: referencedDTag,
+          rootEventId: rootEventId,
           isReferencedVideo: isReferencedVideo,
         );
       }
@@ -2440,6 +2442,32 @@ void main() {
         );
       });
 
+      test('falls back to the payload d-tag for realtime video '
+          'notifications when the authoritative VideoStats omits one '
+          '(#4768)', () async {
+        // Realtime twin of the page-load test "grouped video notifications
+        // fall back to the payload d-tag when the authoritative VideoStats
+        // omits one (#4730)". Owner confirmed, but VideoStats carries no
+        // d-tag → use the payload referencedDTag rather than drop the stable
+        // route.
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x', dTag: ''));
+
+        final result = await repository.enrichOne(
+          raw(referencedDTag: 'payload-dtag'),
+        );
+
+        expect(result, isA<VideoNotification>());
+        final video = result! as VideoNotification;
+        expect(
+          video.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:payload-dtag',
+          ),
+        );
+      });
+
       test('leaves realtime addressable id null when the referenced video '
           'owner is unknown (#4730)', () async {
         // No video stats stubbed → ownership unconfirmed; fall back to the
@@ -2454,6 +2482,39 @@ void main() {
         final video = result! as VideoNotification;
         expect(video.videoAddressableId, isNull);
         expect(video.videoEventId, equals('video_x'));
+      });
+
+      test('builds the realtime addressable id for a rootEventId-anchored '
+          'comment when the recipient owns the root video (#4768)', () async {
+        // Realtime twin of the page-load empty-referencedEventId comment test
+        // (#4730): enrichOne fetches metadata by the rootEventId anchor
+        // (page-load uses referenced_event_id only), so root-video ownership
+        // IS confirmed and the addressable IS synthesized. The differing
+        // payload referencedDTag proves the route uses the VideoStats d-tag.
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats('video_root', makeVideoStats(id: 'video_root'));
+
+        final result = await repository.enrichOne(
+          raw(
+            sourceKind: 1111,
+            notificationType: 'comment',
+            referencedEventId: '',
+            rootEventId: 'video_root',
+            referencedDTag: 'payload-dtag',
+          ),
+        );
+
+        expect(result, isA<VideoNotification>());
+        final video = result! as VideoNotification;
+        expect(video.type, equals(NotificationKind.comment));
+        expect(video.videoEventId, equals('video_root'));
+        expect(
+          video.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:d_video_root',
+          ),
+        );
       });
 
       test('leaves addressable id null when realtime d-tag is empty', () async {


### PR DESCRIPTION
## Description

Adds the two non-blocking realtime (`enrichOne`) coverage gaps left by PR #4759 (the safety fix for issue #4730) around authoritative owned-video routing. **Test-only — no production change.**

- **Positive `rootEventId`-anchored comment test** — a NIP-22 comment with empty `referenced_event_id` + a `root_event_id`, owner == recipient. The realtime `enrichOne` path fetches video metadata by the **root anchor**, confirms ownership, and **synthesizes** the addressable. This pins the documented page-load vs realtime asymmetry **from both sides**: the page-load counterpart (`comment with empty referencedEventId leaves addressable id null and keeps the root video event id`, added in #4759) leaves it null because that path fetches by `referenced_event_id` only.
- **Payload d-tag fallback test** — owner confirmed but the authoritative `VideoStats` omits a d-tag, so the route falls back to the payload `referencedDTag`. The realtime twin of the page-load fallback test from #4759.

Extends the `enrichOne` test group's local `raw()` helper with `rootEventId` (backward-compatible — the existing 10 tests are unaffected).

## Backend contract verification

Verified against `divinevideo/divine-funnelcake` (the notifications + video-stats backend) that every field these tests rely on exists with matching semantics, and that the backend explicitly documents *"clients should prefer `root_event_id` for navigation"* for kind-1111 comments — exactly the path these tests pin.

Note: the empty-`referenced_event_id` shape is a **defensive / legacy-payload edge** — the divine relay requires NIP-22 `E`+`e` tags on comments and the inbox materializer falls `referenced_event_id` back `e`→`E`, so well-formed comments carry a parent id. These tests therefore guard the **safety fallback**, consistent with the deliberate safety-over-stability intent of #4759.

## Verification

- `dart format` → clean
- `flutter analyze packages/notification_repository/lib packages/notification_repository/test` → **No issues found**
- `flutter test packages/notification_repository/test/src/notification_repository_test.dart` → **122 pass** (was 120; +2)

## Type of Change

- [x] ✅ Test coverage (non-blocking; no production behavior change)

Closes #4768
Closes #4767 (duplicate of #4768; same scope)

