### PR TITLE
fix(video-editor): split functionality with robust state management

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -287,6 +287,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     emit(state.copyWith(isEditing: false, isSplitting: true));
 
     ClipSplitFailure? splitFailure;
+    String? splitStartClipId;
+    String? splitEndClipId;
     try {
       // Emit directly from callbacks instead of dispatching events.
       // Cross-event-type handlers run concurrently in BLoC, which
@@ -298,6 +300,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         sourceClip: selectedClip,
         splitPosition: splitPosition,
         onClipsCreated: (startClip, endClip) {
+          splitStartClipId = startClip.id;
+          splitEndClipId = endClip.id;
+
           // splitClip's render phase awaits Future.wait on parallel
           // video renders. If the bloc is closed mid-render (user
           // navigates away from the editor), the late callbacks fire
@@ -378,11 +383,41 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       splitFailure = ClipSplitFailure();
     } finally {
       if (!emit.isDone) {
+        final rollbackClips = splitFailure == null
+            ? null
+            : _clipsWithFailedSplitRolledBack(
+                state.clips,
+                sourceClip: selectedClip,
+                startClipId: splitStartClipId,
+                endClipId: splitEndClipId,
+              );
         emit(
-          state.copyWith(isSplitting: false, lastSplitFailure: splitFailure),
+          state.copyWith(
+            clips: rollbackClips,
+            isSplitting: false,
+            lastSplitFailure: splitFailure,
+            clearLastSplit: splitFailure != null,
+          ),
         );
       }
     }
+  }
+
+  List<DivineVideoClip>? _clipsWithFailedSplitRolledBack(
+    List<DivineVideoClip> clips, {
+    required DivineVideoClip sourceClip,
+    required String? startClipId,
+    required String? endClipId,
+  }) {
+    if (startClipId == null || endClipId == null) return null;
+
+    final startIndex = clips.indexWhere((clip) => clip.id == startClipId);
+    if (startIndex == -1 || startIndex + 1 >= clips.length) return null;
+    if (clips[startIndex + 1].id != endClipId) return null;
+
+    final restoredClips = List<DivineVideoClip>.of(clips)
+      ..replaceRange(startIndex, startIndex + 2, [sourceClip]);
+    return List.unmodifiable(restoredClips);
   }
 
   // === TRIM ===

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -284,8 +284,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     );
 
     // Stop editing mode
-    emit(state.copyWith(isEditing: false));
+    emit(state.copyWith(isEditing: false, isSplitting: true));
 
+    ClipSplitFailure? splitFailure;
     try {
       // Emit directly from callbacks instead of dispatching events.
       // Cross-event-type handlers run concurrently in BLoC, which
@@ -374,6 +375,13 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         name: 'ClipEditorBloc',
         category: LogCategory.video,
       );
+      splitFailure = ClipSplitFailure();
+    } finally {
+      if (!emit.isDone) {
+        emit(
+          state.copyWith(isSplitting: false, lastSplitFailure: splitFailure),
+        );
+      }
     }
   }
 

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -103,6 +103,7 @@ class ClipEditorState extends Equatable {
     bool? isTrimDragging,
     int? clipsVolumeRevision,
     ClipSplitEvent? lastSplit,
+    bool clearLastSplit = false,
     Duration? trimPosition,
     bool clearTrimPosition = false,
     String? trimmingClipId,
@@ -119,7 +120,7 @@ class ClipEditorState extends Equatable {
       isEditing: isEditing ?? this.isEditing,
       isTrimDragging: isTrimDragging ?? this.isTrimDragging,
       clipsVolumeRevision: clipsVolumeRevision ?? this.clipsVolumeRevision,
-      lastSplit: lastSplit ?? this.lastSplit,
+      lastSplit: clearLastSplit ? null : (lastSplit ?? this.lastSplit),
       trimPosition: clearTrimPosition
           ? null
           : (trimPosition ?? this.trimPosition),

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -20,6 +20,8 @@ class ClipEditorState extends Equatable {
     this.trimmingClipId,
     this.isExtractingAudio = false,
     this.lastAudioExtraction,
+    this.isSplitting = false,
+    this.lastSplitFailure,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -72,6 +74,15 @@ class ClipEditorState extends Equatable {
   /// Whether an audio extraction operation is currently running.
   final bool isExtractingAudio;
 
+  /// Whether a split operation is currently in progress (rendering).
+  final bool isSplitting;
+
+  /// One-shot signal emitted when a split rendering operation fails.
+  ///
+  /// Identity-compared so the [BlocListener] in the scaffold fires exactly
+  /// once per failure even if the same error type repeats.
+  final ClipSplitFailure? lastSplitFailure;
+
   /// Last completed audio extraction result. Consumed by the widget layer
   /// to write history (on success) or show an error snackbar (on failure).
   ///
@@ -98,6 +109,8 @@ class ClipEditorState extends Equatable {
     bool clearTrimmingClipId = false,
     bool? isExtractingAudio,
     ClipAudioExtractionResult? lastAudioExtraction,
+    bool? isSplitting,
+    ClipSplitFailure? lastSplitFailure,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -115,6 +128,8 @@ class ClipEditorState extends Equatable {
           : (trimmingClipId ?? this.trimmingClipId),
       isExtractingAudio: isExtractingAudio ?? this.isExtractingAudio,
       lastAudioExtraction: lastAudioExtraction ?? this.lastAudioExtraction,
+      isSplitting: isSplitting ?? this.isSplitting,
+      lastSplitFailure: lastSplitFailure ?? this.lastSplitFailure,
     );
   }
 
@@ -133,6 +148,9 @@ class ClipEditorState extends Equatable {
     isExtractingAudio,
     // Identity-only: each ClipAudioExtractionResult is a fresh instance.
     identityHashCode(lastAudioExtraction),
+    isSplitting,
+    // Identity-only: each ClipSplitFailure is a fresh instance per failure.
+    identityHashCode(lastSplitFailure),
   ];
 }
 
@@ -189,3 +207,13 @@ final class ClipAudioExtractionDiscarded extends ClipAudioExtractionResult {}
 
 /// Extraction failed; widget should show a snackbar.
 final class ClipAudioExtractionFailure extends ClipAudioExtractionResult {}
+
+// === SPLIT FAILURE SIGNAL ===
+
+/// One-shot signal emitted into [ClipEditorState.lastSplitFailure] when a
+/// split rendering operation fails. The scaffold listener uses this to show
+/// an error snackbar to the user.
+///
+/// Identity-compared so each failure produces a distinct notification even
+/// when the same error type repeats consecutively.
+final class ClipSplitFailure {}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3433,6 +3433,7 @@
     "videoEditorStickerSearchHint": "ተለጣፊዎችን ፈልግ...",
     "videoEditorSelectFontSemanticLabel": "ቅርጸ-ቁምፊ ይምረጡ",
     "videoEditorFontUnknown": "ያልታወቀ",
+    "videoEditorSplitFailed": "መከፋፈሉ አልተሳካም። እባክዎ እንደገና ይሞክሩ።",
     "videoEditorSplitPlayheadOutsideClip": "የመጫወቻ ቦታ ለመከፋፈል በተመረጠው ቅንጥብ ውስጥ መሆን አለበት።",
     "videoEditorTimelineTrimStartSemanticLabel": "ጅምር ይከርክሙ",
     "videoEditorTimelineTrimEndSemanticLabel": "መጨረሻውን ይከርክሙ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2814,6 +2814,7 @@
     "videoEditorShowTimelineSemanticLabel": "إظهار الجدول الزمني",
     "videoEditorSplitClip": "تقسيم المقطع",
     "videoEditorSplitLabel": "تقسيم",
+    "videoEditorSplitFailed": "فشل التقسيم. يرجى المحاولة مرة أخرى.",
     "videoEditorSplitPlayheadOutsideClip": "يجب أن يكون رأس التشغيل داخل المقطع المحدد للتقسيم.",
     "videoEditorSplitPositionInvalid": "موضع التقسيم غير صالح. يجب أن يكون كل مقطع {minDurationMs} مللي ثانية على الأقل.",
     "@videoEditorSplitPositionInvalid": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3125,6 +3125,7 @@
     "videoEditorStickerSearchHint": "Търсене на стикери...",
     "videoEditorSelectFontSemanticLabel": "Избери шрифт",
     "videoEditorFontUnknown": "Неизвестен",
+    "videoEditorSplitFailed": "Разделянето не бе успешно. Моля, опитайте отново.",
     "videoEditorSplitPlayheadOutsideClip": "Главата за възпроизвеждане трябва да е в рамките на избрания клип, за да се раздели.",
     "videoEditorTimelineTrimStartSemanticLabel": "Подстригване начало",
     "videoEditorTimelineTrimEndSemanticLabel": "Подстригване на края",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Sticker suchen...",
     "videoEditorSelectFontSemanticLabel": "Schriftart auswählen",
     "videoEditorFontUnknown": "Unbekannt",
+    "videoEditorSplitFailed": "Teilen fehlgeschlagen. Bitte erneut versuchen.",
     "videoEditorSplitPlayheadOutsideClip": "Der Abspielkopf muss innerhalb des ausgewählten Clips liegen, um zu teilen.",
     "videoEditorTimelineTrimStartSemanticLabel": "Anfang trimmen",
     "videoEditorTimelineTrimEndSemanticLabel": "Ende trimmen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4238,6 +4238,7 @@
   "videoEditorStickerSearchHint": "Search stickers...",
   "videoEditorSelectFontSemanticLabel": "Select font",
   "videoEditorFontUnknown": "Unknown",
+  "videoEditorSplitFailed": "Split failed. Please try again.",
   "videoEditorSplitPlayheadOutsideClip": "Playhead must be within the selected clip to split.",
   "videoEditorTimelineTrimStartSemanticLabel": "Trim start",
   "videoEditorTimelineTrimEndSemanticLabel": "Trim end",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2880,6 +2880,7 @@
     "videoEditorStickerSearchHint": "Buscar stickers...",
     "videoEditorSelectFontSemanticLabel": "Seleccionar fuente",
     "videoEditorFontUnknown": "Desconocida",
+    "videoEditorSplitFailed": "Error al dividir. Por favor, inténtalo de nuevo.",
     "videoEditorSplitPlayheadOutsideClip": "El cabezal de reproducción debe estar dentro del clip seleccionado para dividir.",
     "videoEditorTimelineTrimStartSemanticLabel": "Recortar inicio",
     "videoEditorTimelineTrimEndSemanticLabel": "Recortar fin",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1768,6 +1768,7 @@
     "videoEditorStickerSearchHint": "Maghanap ng mga sticker...",
     "videoEditorSelectFontSemanticLabel": "Pumili ng font",
     "videoEditorFontUnknown": "Hindi alam",
+    "videoEditorSplitFailed": "Nabigo ang paghati. Pakisubukan muli.",
     "videoEditorSplitPlayheadOutsideClip": "Dapat nasa loob ng napiling clip ang playhead para mag-split.",
     "videoEditorTimelineTrimStartSemanticLabel": "I-trim ang simula",
     "videoEditorTimelineTrimEndSemanticLabel": "I-trim ang dulo",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Rechercher des stickers...",
     "videoEditorSelectFontSemanticLabel": "Sélectionner une police",
     "videoEditorFontUnknown": "Inconnue",
+    "videoEditorSplitFailed": "Échec de la division. Veuillez réessayer.",
     "videoEditorSplitPlayheadOutsideClip": "La tête de lecture doit se trouver dans le clip sélectionné pour pouvoir le scinder.",
     "videoEditorTimelineTrimStartSemanticLabel": "Rogner le début",
     "videoEditorTimelineTrimEndSemanticLabel": "Rogner la fin",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2821,6 +2821,7 @@
     "videoEditorShowTimelineSemanticLabel": "Tampilkan timeline",
     "videoEditorSplitClip": "Bagi klip",
     "videoEditorSplitLabel": "Bagi",
+    "videoEditorSplitFailed": "Pembagian gagal. Silakan coba lagi.",
     "videoEditorSplitPlayheadOutsideClip": "Playhead harus berada di dalam klip yang dipilih untuk membagi.",
     "videoEditorSplitPositionInvalid": "Posisi pembagian tidak valid. Setiap klip harus minimal {minDurationMs}ms.",
     "@videoEditorSplitPositionInvalid": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Cerca sticker...",
     "videoEditorSelectFontSemanticLabel": "Seleziona carattere",
     "videoEditorFontUnknown": "Sconosciuto",
+    "videoEditorSplitFailed": "Divisione non riuscita. Riprovare.",
     "videoEditorSplitPlayheadOutsideClip": "La testina di riproduzione deve essere all'interno del clip selezionato per dividerlo.",
     "videoEditorTimelineTrimStartSemanticLabel": "Rifila inizio",
     "videoEditorTimelineTrimEndSemanticLabel": "Rifila fine",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2814,6 +2814,7 @@
     "videoEditorShowTimelineSemanticLabel": "タイムラインを表示",
     "videoEditorSplitClip": "クリップを分割",
     "videoEditorSplitLabel": "分割",
+    "videoEditorSplitFailed": "分割に失敗しました。もう一度お試しください。",
     "videoEditorSplitPlayheadOutsideClip": "分割するには再生ヘッドを選択したクリップ内に置いてください。",
     "videoEditorSplitPositionInvalid": "分割位置が無効です。各クリップは最低{minDurationMs}ms必要です。",
     "@videoEditorSplitPositionInvalid": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2110,6 +2110,7 @@
     "videoEditorShowTimelineSemanticLabel": "타임라인 표시",
     "videoEditorSplitClip": "클립 분할",
     "videoEditorSplitLabel": "분할",
+    "videoEditorSplitFailed": "분할에 실패했습니다. 다시 시도해 주세요.",
     "videoEditorSplitPlayheadOutsideClip": "분할하려면 재생 헤드가 선택한 클립 안에 있어야 합니다.",
     "videoEditorSplitPositionInvalid": "분할 위치가 유효하지 않습니다. 각 클립은 최소 {minDurationMs}ms 이상이어야 합니다.",
     "@videoEditorSplitPositionInvalid": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Stickers zoeken...",
     "videoEditorSelectFontSemanticLabel": "Lettertype selecteren",
     "videoEditorFontUnknown": "Onbekend",
+    "videoEditorSplitFailed": "Splitsen mislukt. Probeer het opnieuw.",
     "videoEditorSplitPlayheadOutsideClip": "De afspeelkop moet binnen de geselecteerde clip staan om te splitsen.",
     "videoEditorTimelineTrimStartSemanticLabel": "Begin bijsnijden",
     "videoEditorTimelineTrimEndSemanticLabel": "Einde bijsnijden",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Szukaj naklejek...",
     "videoEditorSelectFontSemanticLabel": "Wybierz czcionkę",
     "videoEditorFontUnknown": "Nieznana",
+    "videoEditorSplitFailed": "Podział nieudany. Spróbuj ponownie.",
     "videoEditorSplitPlayheadOutsideClip": "Aby podzielić, głowica odtwarzania musi znajdować się w wybranym klipie.",
     "videoEditorTimelineTrimStartSemanticLabel": "Przytnij początek",
     "videoEditorTimelineTrimEndSemanticLabel": "Przytnij koniec",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Buscar stickers...",
     "videoEditorSelectFontSemanticLabel": "Selecionar fonte",
     "videoEditorFontUnknown": "Desconhecida",
+    "videoEditorSplitFailed": "Falha na divisão. Tente novamente.",
     "videoEditorSplitPlayheadOutsideClip": "A cabeça de reprodução deve estar dentro do clipe selecionado para dividir.",
     "videoEditorTimelineTrimStartSemanticLabel": "Aparar início",
     "videoEditorTimelineTrimEndSemanticLabel": "Aparar fim",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Caută stickere...",
     "videoEditorSelectFontSemanticLabel": "Selectează fontul",
     "videoEditorFontUnknown": "Necunoscut",
+    "videoEditorSplitFailed": "Împărțire eșuată. Vă rugăm să încercați din nou.",
     "videoEditorSplitPlayheadOutsideClip": "Capul de redare trebuie să fie în clipul selectat pentru a împărți.",
     "videoEditorTimelineTrimStartSemanticLabel": "Taie începutul",
     "videoEditorTimelineTrimEndSemanticLabel": "Taie finalul",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2872,6 +2872,7 @@
     "videoEditorStickerSearchHint": "Sök stickers...",
     "videoEditorSelectFontSemanticLabel": "Välj typsnitt",
     "videoEditorFontUnknown": "Okänt",
+    "videoEditorSplitFailed": "Delning misslyckades. Försök igen.",
     "videoEditorSplitPlayheadOutsideClip": "Uppspelningshuvudet måste vara inom det valda klippet för att dela.",
     "videoEditorTimelineTrimStartSemanticLabel": "Trimma start",
     "videoEditorTimelineTrimEndSemanticLabel": "Trimma slut",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2821,6 +2821,7 @@
     "videoEditorShowTimelineSemanticLabel": "Zaman çizelgesini göster",
     "videoEditorSplitClip": "Klibi böl",
     "videoEditorSplitLabel": "Böl",
+    "videoEditorSplitFailed": "Bölme başarısız oldu. Lütfen tekrar deneyin.",
     "videoEditorSplitPlayheadOutsideClip": "Bölmek için oynatma kafası seçili klip içinde olmalıdır.",
     "videoEditorSplitPositionInvalid": "Bölme konumu geçersiz. Her iki klip de en az {minDurationMs}ms uzunluğunda olmalıdır.",
     "@videoEditorSplitPositionInvalid": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12728,6 +12728,12 @@ abstract class AppLocalizations {
   /// **'Unknown'**
   String get videoEditorFontUnknown;
 
+  /// No description provided for @videoEditorSplitFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Split failed. Please try again.'**
+  String get videoEditorSplitFailed;
+
   /// No description provided for @videoEditorSplitPlayheadOutsideClip.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7133,6 +7133,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoEditorFontUnknown => 'ያልታወቀ';
 
   @override
+  String get videoEditorSplitFailed => 'መከፋፈሉ አልተሳካም። እባክዎ እንደገና ይሞክሩ።';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'የመጫወቻ ቦታ ለመከፋፈል በተመረጠው ቅንጥብ ውስጥ መሆን አለበት።';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7213,6 +7213,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorFontUnknown => 'غير معروف';
 
   @override
+  String get videoEditorSplitFailed => 'فشل التقسيم. يرجى المحاولة مرة أخرى.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'يجب أن يكون رأس التشغيل داخل المقطع المحدد للتقسيم.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7354,6 +7354,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoEditorFontUnknown => 'Неизвестен';
 
   @override
+  String get videoEditorSplitFailed =>
+      'Разделянето не бе успешно. Моля, опитайте отново.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Главата за възпроизвеждане трябва да е в рамките на избрания клип, за да се раздели.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7363,6 +7363,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoEditorFontUnknown => 'Unbekannt';
 
   @override
+  String get videoEditorSplitFailed =>
+      'Teilen fehlgeschlagen. Bitte erneut versuchen.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Der Abspielkopf muss innerhalb des ausgewählten Clips liegen, um zu teilen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7270,6 +7270,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorFontUnknown => 'Unknown';
 
   @override
+  String get videoEditorSplitFailed => 'Split failed. Please try again.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Playhead must be within the selected clip to split.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7351,6 +7351,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoEditorFontUnknown => 'Desconocida';
 
   @override
+  String get videoEditorSplitFailed =>
+      'Error al dividir. Por favor, inténtalo de nuevo.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'El cabezal de reproducción debe estar dentro del clip seleccionado para dividir.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7364,6 +7364,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoEditorFontUnknown => 'Hindi alam';
 
   @override
+  String get videoEditorSplitFailed => 'Nabigo ang paghati. Pakisubukan muli.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Dapat nasa loob ng napiling clip ang playhead para mag-split.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7381,6 +7381,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoEditorFontUnknown => 'Inconnue';
 
   @override
+  String get videoEditorSplitFailed =>
+      'Échec de la division. Veuillez réessayer.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'La tête de lecture doit se trouver dans le clip sélectionné pour pouvoir le scinder.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7253,6 +7253,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorFontUnknown => 'Tidak dikenal';
 
   @override
+  String get videoEditorSplitFailed => 'Pembagian gagal. Silakan coba lagi.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Playhead harus berada di dalam klip yang dipilih untuk membagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7348,6 +7348,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoEditorFontUnknown => 'Sconosciuto';
 
   @override
+  String get videoEditorSplitFailed => 'Divisione non riuscita. Riprovare.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'La testina di riproduzione deve essere all\'interno del clip selezionato per dividerlo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6991,6 +6991,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorFontUnknown => '不明';
 
   @override
+  String get videoEditorSplitFailed => '分割に失敗しました。もう一度お試しください。';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       '分割するには再生ヘッドを選択したクリップ内に置いてください。';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7014,6 +7014,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorFontUnknown => '알 수 없음';
 
   @override
+  String get videoEditorSplitFailed => '분할에 실패했습니다. 다시 시도해 주세요.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       '분할하려면 재생 헤드가 선택한 클립 안에 있어야 합니다.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7313,6 +7313,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorFontUnknown => 'Onbekend';
 
   @override
+  String get videoEditorSplitFailed => 'Splitsen mislukt. Probeer het opnieuw.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'De afspeelkop moet binnen de geselecteerde clip staan om te splitsen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7432,6 +7432,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoEditorFontUnknown => 'Nieznana';
 
   @override
+  String get videoEditorSplitFailed => 'Podział nieudany. Spróbuj ponownie.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Aby podzielić, głowica odtwarzania musi znajdować się w wybranym klipie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7321,6 +7321,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorFontUnknown => 'Desconhecida';
 
   @override
+  String get videoEditorSplitFailed => 'Falha na divisão. Tente novamente.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'A cabeça de reprodução deve estar dentro do clipe selecionado para dividir.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7450,6 +7450,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorFontUnknown => 'Necunoscut';
 
   @override
+  String get videoEditorSplitFailed =>
+      'Împărțire eșuată. Vă rugăm să încercați din nou.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Capul de redare trebuie să fie în clipul selectat pentru a împărți.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7283,6 +7283,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoEditorFontUnknown => 'Okänt';
 
   @override
+  String get videoEditorSplitFailed => 'Delning misslyckades. Försök igen.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Uppspelningshuvudet måste vara inom det valda klippet för att dela.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7249,6 +7249,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorFontUnknown => 'Bilinmiyor';
 
   @override
+  String get videoEditorSplitFailed =>
+      'Bölme başarısız oldu. Lütfen tekrar deneyin.';
+
+  @override
   String get videoEditorSplitPlayheadOutsideClip =>
       'Bölmek için oynatma kafası seçili klip içinde olmalıdır.';
 

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -211,14 +211,7 @@ class VideoEditorSplitService {
         category: .video,
       );
 
-      await Future.wait([
-        ProVideoEditor.instance.renderVideoToFile(outputPath, renderData),
-        // On newer devices, the split operation completes extremely fast. For
-        // that we add a short delay to ensure the progress animation shows
-        // to complete to the user. Without that it will look like a
-        // flickering issue.
-        Future.delayed(const Duration(milliseconds: 300)),
-      ]);
+      await ProVideoEditor.instance.renderVideoToFile(outputPath, renderData);
 
       Log.info(
         '✅ Render complete: ${clip.id}',

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -22,16 +22,19 @@ class TimelineClipControls extends StatefulWidget {
 class _TimelineClipControlsState extends State<TimelineClipControls> {
   @override
   Widget build(BuildContext context) {
-    final clips = context.select((ClipEditorBloc b) => b.state.clips);
-    final isLastClip = clips.length <= 1;
-    final isExtractingAudio = context.select(
-      (ClipEditorBloc b) => b.state.isExtractingAudio,
+    final (clipCount, isExtractingAudio, isSplitting) = context.select(
+      (ClipEditorBloc b) => (
+        b.state.clips.length,
+        b.state.isExtractingAudio,
+        b.state.isSplitting,
+      ),
     );
+    final isLastClip = clipCount <= 1;
 
     return VideoEditorTimelineControls(
       onDelete: isLastClip ? null : () => _deleteClip(context),
       onDuplicated: () => _duplicateClip(context),
-      onSplit: () => _splitClip(context),
+      onSplit: isSplitting ? null : () => _splitClip(context),
       onSpeed: () => _setPlaybackSpeed(context),
       onExtractAudio: () => _requestExtractAudio(context),
       isExtractingAudio: isExtractingAudio,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -140,10 +140,8 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
           listenWhen: (prev, curr) =>
               !_isUserScrolling && prev.currentPosition != curr.currentPosition,
-          listener: (context, state) => _syncScrollToPosition(
-            state.currentPosition,
-            totalDuration,
-          ),
+          listener: (context, state) =>
+              _syncScrollToPosition(state.currentPosition, totalDuration),
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
           listenWhen: (prev, curr) =>
@@ -375,7 +373,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
       // Same clip: toggle editing on/off.
       bloc.add(const ClipEditorEditingToggled());
     } else {
-      // Different clip: select it and always enter editing.
+      // Different clip: select it and enter editing if not already active.
       bloc.add(ClipEditorClipSelected(index));
       if (!state.isEditing) {
         bloc.add(const ClipEditorEditingStarted());
@@ -783,10 +781,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         _totalDuration,
       );
 
-  void _syncScrollToPosition(
-    Duration position,
-    Duration totalDuration,
-  ) {
+  void _syncScrollToPosition(Duration position, Duration totalDuration) {
     if (!_scrollController.hasClients) return;
     if (totalDuration == Duration.zero) return;
 
@@ -1034,9 +1029,7 @@ class _TimelineInteractiveBody extends StatelessWidget {
                                 key: const ValueKey('volume'),
                                 volumePreviewNotifier: volumePreviewNotifier,
                               )
-                            : const SizedBox.shrink(
-                                key: ValueKey('empty'),
-                              ),
+                            : const SizedBox.shrink(key: ValueKey('empty')),
                       ),
                     ),
                   ),

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -43,8 +43,10 @@ class VideoEditorScaffold extends StatelessWidget {
         backgroundColor: VineTheme.backgroundCamera,
         resizeToAvoidBottomInset: false,
         floatingActionButton: const _AddElementFab(),
-        body: _AudioExtractionResultListener(
-          child: _ScaffoldBody(isLoading: isLoading),
+        body: _SplitFailureListener(
+          child: _AudioExtractionResultListener(
+            child: _ScaffoldBody(isLoading: isLoading),
+          ),
         ),
       ),
     );
@@ -80,6 +82,32 @@ class _ScaffoldBody extends StatelessWidget {
   }
 }
 
+/// Listens to [ClipEditorBloc.state.lastSplitFailure] and shows an error
+/// snackbar when a split rendering operation fails.
+///
+/// Kept at the scaffold level (always mounted) so the snackbar fires even
+/// if the timeline controls are hidden while the render is in flight.
+class _SplitFailureListener extends StatelessWidget {
+  const _SplitFailureListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: (prev, curr) =>
+          !identical(prev.lastSplitFailure, curr.lastSplitFailure) &&
+          curr.lastSplitFailure != null,
+      listener: (context, state) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(context.l10n.videoEditorSplitFailed),
+        );
+      },
+      child: child,
+    );
+  }
+}
+
 /// Listens to [ClipEditorBloc.state.lastAudioExtraction] from a widget that
 /// stays mounted for the entire editor session, so the success/failure
 /// side effect (history write or snackbar) survives the user leaving edit
@@ -101,10 +129,7 @@ class _AudioExtractionResultListener extends StatelessWidget {
     );
   }
 
-  void _onAudioExtractionResult(
-    BuildContext context,
-    ClipEditorState state,
-  ) {
+  void _onAudioExtractionResult(BuildContext context, ClipEditorState state) {
     final result = state.lastAudioExtraction;
     if (result == null) return;
 

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -296,12 +296,14 @@ class DivineVideoPlayerController {
         'divine_video_player/player_$_playerId/events',
       );
 
-      final result = await _globalChannel
-          .invokeMethod<Map<Object?, Object?>>('create', {
-            'id': _playerId,
-            'useTexture': useTexture,
-            'useLegacySurface': useLegacySurface,
-          });
+      final result = await _globalChannel.invokeMethod<Map<Object?, Object?>>(
+        'create',
+        {
+          'id': _playerId,
+          'useTexture': useTexture,
+          'useLegacySurface': useLegacySurface,
+        },
+      );
       if (useTexture && result != null) {
         _textureId = result['textureId'] as int?;
       }

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -296,14 +296,12 @@ class DivineVideoPlayerController {
         'divine_video_player/player_$_playerId/events',
       );
 
-      final result = await _globalChannel.invokeMethod<Map<Object?, Object?>>(
-        'create',
-        {
-          'id': _playerId,
-          'useTexture': useTexture,
-          'useLegacySurface': useLegacySurface,
-        },
-      );
+      final result = await _globalChannel
+          .invokeMethod<Map<Object?, Object?>>('create', {
+            'id': _playerId,
+            'useTexture': useTexture,
+            'useLegacySurface': useLegacySurface,
+          });
       if (useTexture && result != null) {
         _textureId = result['textureId'] as int?;
       }
@@ -350,11 +348,17 @@ class DivineVideoPlayerController {
       await _linuxBackend!.setClips(clips, startPosition: startPosition);
       return;
     }
-    await _methodChannel.invokeMethod<void>('setClips', {
-      'clips': clips.map((c) => c.toMap()).toList(),
-      if (startPosition != null && startPosition > Duration.zero)
-        'startPositionMs': startPosition.inMilliseconds,
-    });
+    try {
+      await _methodChannel.invokeMethod<void>('setClips', {
+        'clips': clips.map((c) => c.toMap()).toList(),
+        if (startPosition != null && startPosition > Duration.zero)
+          'startPositionMs': startPosition.inMilliseconds,
+      });
+    } on PlatformException catch (e) {
+      // The native side cancels an in-flight setClips when a newer call
+      // supersedes it. This is benign — the newer call will succeed.
+      if (e.code != 'CANCELLED') rethrow;
+    }
   }
 
   /// Starts or resumes playback.

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -510,6 +510,51 @@ void main() {
           const Duration(seconds: 4),
         );
       });
+
+      test(
+        'setClips swallows PlatformException with code CANCELLED',
+        () async {
+          final id = controller.playerId;
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(
+                MethodChannel('divine_video_player/player_$id'),
+                (call) async {
+                  if (call.method == 'setClips') {
+                    throw PlatformException(code: 'CANCELLED');
+                  }
+                  return null;
+                },
+              );
+
+          // Must not throw.
+          await expectLater(
+            controller.setClips(const [VideoClip(uri: '/a.mp4')]),
+            completes,
+          );
+        },
+      );
+
+      test(
+        'setClips rethrows PlatformException with non-CANCELLED code',
+        () async {
+          final id = controller.playerId;
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(
+                MethodChannel('divine_video_player/player_$id'),
+                (call) async {
+                  if (call.method == 'setClips') {
+                    throw PlatformException(code: 'ERROR');
+                  }
+                  return null;
+                },
+              );
+
+          await expectLater(
+            controller.setClips(const [VideoClip(uri: '/a.mp4')]),
+            throwsA(isA<PlatformException>()),
+          );
+        },
+      );
     });
 
     group('audio tracks', () {

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -499,9 +499,11 @@ void main() {
         expect: () => [
           isA<ClipEditorState>()
               .having((s) => s.isEditing, 'isEditing', isFalse)
+              .having((s) => s.isSplitting, 'isSplitting', isTrue)
               .having((s) => s.isTrimDragging, 'isTrimDragging', isFalse),
           isA<ClipEditorState>()
               .having((s) => s.clips, 'clips', hasLength(2))
+              .having((s) => s.isSplitting, 'isSplitting', isTrue)
               .having(
                 (s) => s.clips.first.duration,
                 'start duration',
@@ -512,6 +514,9 @@ void main() {
                 'end duration',
                 const Duration(seconds: 1),
               ),
+          isA<ClipEditorState>()
+              .having((s) => s.clips, 'clips', hasLength(2))
+              .having((s) => s.isSplitting, 'isSplitting', isFalse),
         ],
       );
 
@@ -590,12 +595,23 @@ void main() {
         },
         act: (bloc) => bloc.add(const ClipEditorSplitRequested()),
         expect: () => [
-          isA<ClipEditorState>().having(
-            (s) => s.isEditing,
-            'isEditing',
-            isFalse,
-          ),
-          isA<ClipEditorState>().having((s) => s.clips, 'clips', hasLength(2)),
+          isA<ClipEditorState>()
+              .having(
+                (s) => s.isEditing,
+                'isEditing',
+                isFalse,
+              )
+              .having(
+                (s) => s.isSplitting,
+                'isSplitting',
+                isTrue,
+              ),
+          isA<ClipEditorState>()
+              .having((s) => s.clips, 'clips', hasLength(2))
+              .having((s) => s.isSplitting, 'isSplitting', isTrue),
+          isA<ClipEditorState>()
+              .having((s) => s.clips, 'clips', hasLength(2))
+              .having((s) => s.isSplitting, 'isSplitting', isFalse),
         ],
       );
 

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -115,6 +115,26 @@ Future<void> _fakeSplitClip({
   onClipsCreated?.call(startClip, endClip);
 }
 
+Future<void> _fakeSplitClipThenFail({
+  required DivineVideoClip sourceClip,
+  required Duration splitPosition,
+  required void Function(DivineVideoClip startClip, DivineVideoClip endClip)?
+  onClipsCreated,
+  required void Function(DivineVideoClip clip, String thumbnailPath)?
+  onThumbnailExtracted,
+  required void Function(DivineVideoClip clip, EditorVideo video)?
+  onClipRendered,
+}) async {
+  await _fakeSplitClip(
+    sourceClip: sourceClip,
+    splitPosition: splitPosition,
+    onClipsCreated: onClipsCreated,
+    onThumbnailExtracted: onThumbnailExtracted,
+    onClipRendered: onClipRendered,
+  );
+  throw StateError('render failed');
+}
+
 void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
@@ -596,16 +616,8 @@ void main() {
         act: (bloc) => bloc.add(const ClipEditorSplitRequested()),
         expect: () => [
           isA<ClipEditorState>()
-              .having(
-                (s) => s.isEditing,
-                'isEditing',
-                isFalse,
-              )
-              .having(
-                (s) => s.isSplitting,
-                'isSplitting',
-                isTrue,
-              ),
+              .having((s) => s.isEditing, 'isEditing', isFalse)
+              .having((s) => s.isSplitting, 'isSplitting', isTrue),
           isA<ClipEditorState>()
               .having((s) => s.clips, 'clips', hasLength(2))
               .having((s) => s.isSplitting, 'isSplitting', isTrue),
@@ -613,6 +625,52 @@ void main() {
               .having((s) => s.clips, 'clips', hasLength(2))
               .having((s) => s.isSplitting, 'isSplitting', isFalse),
         ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'rolls back created split clips when render fails',
+        build: () => buildBloc(splitClip: _fakeSplitClipThenFail),
+        seed: () {
+          final clip = _createClip(
+            id: 'source-clip',
+            duration: const Duration(seconds: 2),
+          );
+          return ClipEditorState(
+            clips: [clip],
+            isEditing: true,
+            splitPosition: const Duration(seconds: 1),
+          );
+        },
+        act: (bloc) => bloc.add(const ClipEditorSplitRequested()),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.isEditing, 'isEditing', isFalse)
+              .having((s) => s.isSplitting, 'isSplitting', isTrue)
+              .having(
+                (s) => s.clips.single.id,
+                'source clip id',
+                'source-clip',
+              ),
+          isA<ClipEditorState>()
+              .having((s) => s.clips, 'clips', hasLength(2))
+              .having((s) => s.isSplitting, 'isSplitting', isTrue)
+              .having((s) => s.lastSplit, 'lastSplit', isNotNull),
+          isA<ClipEditorState>()
+              .having((s) => s.clips, 'clips', hasLength(1))
+              .having(
+                (s) => s.clips.single.id,
+                'restored source clip id',
+                'source-clip',
+              )
+              .having((s) => s.isSplitting, 'isSplitting', isFalse)
+              .having((s) => s.lastSplit, 'lastSplit', isNull)
+              .having(
+                (s) => s.lastSplitFailure,
+                'lastSplitFailure',
+                isA<ClipSplitFailure>(),
+              ),
+        ],
+        errors: () => [isA<StateError>()],
       );
 
       test('validates using VideoEditorSplitService.isValidSplitPosition', () {


### PR DESCRIPTION
 
## Description

Splitting a clip had no error feedback and no guard against triggering multiple concurrent splits. Additionally, the native setClips call threw an unhandled PlatformException when a newer call superseded an in-flight one — a benign race condition.

- Added state management for split operations in ClipEditorBloc, including isSplitting and lastSplitFailure.
- Introduced localized error messages for split failures in multiple languages.
- Updated UI components to reflect the new split state and prevent multiple split actions during an ongoing operation.
- Enhanced video editor service to handle split rendering and added error handling for platform exceptions.
- Implemented a snackbar notification for split failure events at the scaffold level.

**Related Issue:** Closes #none

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
