### PR TITLE
feat(video-editor): composite proof mode progress tracking

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -28,12 +28,25 @@ import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_video_editor/core/models/video/progress_model.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 final videoEditorProvider =
     NotifierProvider<VideoEditorNotifier, VideoEditorProviderState>(
       VideoEditorNotifier.new,
     );
+
+/// Exposes the composite render+proof progress stream for the current draft.
+///
+/// The widget layer should watch this provider instead of importing
+/// [VideoEditorRenderService] directly, keeping the UI/service boundary clean.
+final StreamProvider<ProgressModel> videoEditorCompositeProgressProvider =
+    StreamProvider.autoDispose<ProgressModel>((ref) {
+      // draftId is set once during initialization and does not change within a
+      // session, so a one-time read is sufficient.
+      final draftId = ref.read(videoEditorProvider.notifier).draftId;
+      return VideoEditorRenderService.compositeProgressStreamById(draftId);
+    });
 
 @visibleForTesting
 AudioTrack audioTrackFromSoundForRender(AudioEvent sound) {

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -359,6 +359,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
             clips: draft.clips,
             parameters: parameters,
             editorStateHistory: draft.editorStateHistory,
+            taskId: draft.id,
           );
 
           if (result == null) {

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -22,6 +22,18 @@ import 'package:unified_logger/unified_logger.dart';
 class NativeProofModeService {
   static const MethodChannel _channel = MethodChannel('org.openvine/proofmode');
 
+  @visibleForTesting
+  static Future<NativeProofData?> Function(
+    File videoFile, {
+    required bool enableAdvancedCawgEmbedding,
+    NostrCreatorBindingAssertion? creatorBindingAssertion,
+    Map<String, dynamic>? cawgIdentityAssertion,
+    Map<String, dynamic>? verifiedIdentityBundle,
+    List<DivineVideoClip>? clips,
+    Map<String, dynamic>? editorStateHistory,
+  })?
+  proofFileOverride;
+
   /// Generate native ProofMode proof for a video file.
   ///
   /// Returns [NativeProofData] if proof generation succeeds, null otherwise.
@@ -40,6 +52,19 @@ class NativeProofModeService {
     List<DivineVideoClip>? clips,
     Map<String, dynamic>? editorStateHistory,
   }) async {
+    final override = proofFileOverride;
+    if (override != null) {
+      return override(
+        videoFile,
+        creatorBindingAssertion: creatorBindingAssertion,
+        cawgIdentityAssertion: cawgIdentityAssertion,
+        verifiedIdentityBundle: verifiedIdentityBundle,
+        enableAdvancedCawgEmbedding: enableAdvancedCawgEmbedding,
+        clips: clips,
+        editorStateHistory: editorStateHistory,
+      );
+    }
+
     try {
       // TODO(n8fr8): Incorporate clip-level proof data into the final
       // combined proof. Each clip now carries its own attestation:

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -165,6 +165,65 @@ class _CropParameters {
   String toString() => '($x, $y, ${width}x$height)';
 }
 
+class _RenderProgressTracker {
+  _RenderProgressTracker({
+    required this.taskId,
+    required int clipCount,
+  }) : _proofBudget =
+           VideoEditorRenderService.proofModeProgressBudgetForClipCount(
+             clipCount,
+           ),
+       _proofSteps = clipCount + 1;
+
+  final String taskId;
+  final double _proofBudget;
+  final int _proofSteps;
+  StreamSubscription<ProgressModel>? _renderSubscription;
+
+  double get _renderBudget => 1 - _proofBudget;
+
+  void start() {
+    VideoEditorRenderService._emitCompositeProgress(
+      taskId: taskId,
+      progress: 0,
+    );
+    _renderSubscription = ProVideoEditor.instance
+        .progressStreamById(taskId)
+        .listen((progressModel) {
+          VideoEditorRenderService._emitCompositeProgress(
+            taskId: taskId,
+            progress: progressModel.progress * _renderBudget,
+          );
+        });
+  }
+
+  void markRenderComplete() {
+    VideoEditorRenderService._emitCompositeProgress(
+      taskId: taskId,
+      progress: _renderBudget,
+    );
+  }
+
+  void markProofStepComplete(int completedSteps) {
+    final normalizedSteps = completedSteps.clamp(0, _proofSteps);
+    VideoEditorRenderService._emitCompositeProgress(
+      taskId: taskId,
+      progress: _renderBudget + (_proofBudget * normalizedSteps / _proofSteps),
+    );
+  }
+
+  void complete() {
+    VideoEditorRenderService._emitCompositeProgress(
+      taskId: taskId,
+      progress: 1,
+    );
+  }
+
+  Future<void> dispose() async {
+    await _renderSubscription?.cancel();
+  }
+}
+
 /// Service for rendering final video from multiple clips.
 ///
 /// Handles video rendering with aspect ratio cropping and clip concatenation.
@@ -172,6 +231,37 @@ class VideoEditorRenderService {
   VideoEditorRenderService._();
 
   static const _logName = 'VideoEditorRenderService';
+  static final _compositeProgressController =
+      StreamController<ProgressModel>.broadcast();
+
+  @visibleForTesting
+  static double proofModeProgressBudgetForClipCount(int clipCount) {
+    final normalizedClipCount = clipCount < 1 ? 1 : clipCount;
+    return (normalizedClipCount * 0.01).clamp(0.05, 0.10).toDouble();
+  }
+
+  static Stream<ProgressModel> progressStreamById(String taskId) {
+    return _compositeProgressController.stream.where(
+      (progress) => progress.id == taskId,
+    );
+  }
+
+  static void _emitCompositeProgress({
+    required String taskId,
+    required double progress,
+  }) {
+    _compositeProgressController.add(
+      ProgressModel(id: taskId, progress: progress.clamp(0.0, 1.0).toDouble()),
+    );
+  }
+
+  @visibleForTesting
+  static void emitCompositeProgressForTesting({
+    required String taskId,
+    required double progress,
+  }) {
+    _emitCompositeProgress(taskId: taskId, progress: progress);
+  }
 
   /// Test-only override for [renderVideoToClip].
   ///
@@ -218,73 +308,94 @@ class VideoEditorRenderService {
 
     if (clips.isEmpty) return null;
 
-    Log.debug(
-      '🎬 renderVideoToClip: clips=${clips.length}, '
-      'parameters=${parameters?.toLogString()}',
-      name: _logName,
-      category: LogCategory.video,
-    );
+    final effectiveTaskId = taskId ?? clips.first.id;
+    final progressTracker = _RenderProgressTracker(
+      taskId: effectiveTaskId,
+      clipCount: clips.length,
+    )..start();
 
-    final outputPath = await renderVideo(
-      clips: clips,
-      aspectRatio: clips.first.targetAspectRatio,
-      usePersistentStorage: true,
-      parameters: parameters,
-      taskId: taskId,
-    );
-
-    if (outputPath == null) return null;
-
-    final metaData = await ProVideoEditor.instance.getMetadata(
-      EditorVideo.file(outputPath),
-    );
-
-    // Generate ProofMode attestation
-    Log.debug(
-      '🔐 Generating proofmode attestation for video',
-      name: _logName,
-      category: LogCategory.video,
-    );
-
-    // Ensure all clips have proof attestations before generating the
-    // final combined proof. Clips recorded before the feature was added
-    // or where proof generation failed will be attested now.
-    final attestedClips = await _ensureClipProofs(clips);
-
-    final proofData = await NativeProofModeService.proofFile(
-      File(outputPath),
-      clips: attestedClips,
-      editorStateHistory: editorStateHistory,
-    );
-    final String? proofManifestJson = proofData != null
-        ? jsonEncode(proofData)
-        : null;
-
-    if (proofManifestJson != null) {
-      Log.info(
-        '✅ Proofmode attestation generated',
+    try {
+      Log.debug(
+        '🎬 renderVideoToClip: clips=${clips.length}, '
+        'parameters=${parameters?.toLogString()}',
         name: _logName,
         category: LogCategory.video,
       );
-    } else {
-      Log.warning(
-        '⚠️ No proofmode data available',
+
+      final outputPath = await renderVideo(
+        clips: clips,
+        aspectRatio: clips.first.targetAspectRatio,
+        usePersistentStorage: true,
+        parameters: parameters,
+        taskId: effectiveTaskId,
+      );
+
+      if (outputPath == null) return null;
+
+      progressTracker.markRenderComplete();
+
+      final metaData = await ProVideoEditor.instance.getMetadata(
+        EditorVideo.file(outputPath),
+      );
+
+      // Generate ProofMode attestation
+      Log.debug(
+        '🔐 Generating proofmode attestation for video',
         name: _logName,
         category: LogCategory.video,
       );
+
+      // Ensure all clips have proof attestations before generating the
+      // final combined proof. Clips recorded before the feature was added
+      // or where proof generation failed will be attested now.
+      var completedProofSteps = 0;
+      final attestedClips = await _ensureClipProofs(
+        clips,
+        onClipProcessed: () {
+          completedProofSteps++;
+          progressTracker.markProofStepComplete(completedProofSteps);
+        },
+      );
+
+      final proofData = await NativeProofModeService.proofFile(
+        File(outputPath),
+        clips: attestedClips,
+        editorStateHistory: editorStateHistory,
+      );
+      progressTracker.markProofStepComplete(completedProofSteps + 1);
+      final String? proofManifestJson = proofData != null
+          ? jsonEncode(proofData)
+          : null;
+
+      if (proofManifestJson != null) {
+        Log.info(
+          '✅ Proofmode attestation generated',
+          name: _logName,
+          category: LogCategory.video,
+        );
+      } else {
+        Log.warning(
+          '⚠️ No proofmode data available',
+          name: _logName,
+          category: LogCategory.video,
+        );
+      }
+
+      final clip = DivineVideoClip(
+        id: 'clip-${DateTime.now().millisecondsSinceEpoch}',
+        video: EditorVideo.file(outputPath),
+        duration: metaData.duration,
+        recordedAt: DateTime.now(),
+        originalAspectRatio: clips.first.originalAspectRatio,
+        targetAspectRatio: clips.first.targetAspectRatio,
+        thumbnailPath: clips.first.thumbnailPath,
+      );
+
+      progressTracker.complete();
+      return (clip, proofManifestJson);
+    } finally {
+      await progressTracker.dispose();
     }
-
-    final clip = DivineVideoClip(
-      id: 'clip-${DateTime.now().millisecondsSinceEpoch}',
-      video: EditorVideo.file(outputPath),
-      duration: metaData.duration,
-      recordedAt: DateTime.now(),
-      originalAspectRatio: clips.first.originalAspectRatio,
-      targetAspectRatio: clips.first.targetAspectRatio,
-      thumbnailPath: clips.first.thumbnailPath,
-    );
-
-    return (clip, proofManifestJson);
   }
 
   /// Ensures every clip has a [proofManifestJson].
@@ -293,18 +404,21 @@ class VideoEditorRenderService {
   /// proof, [NativeProofModeService.proofFile] is called on the clip's video
   /// file and the clip is updated with the result.
   static Future<List<DivineVideoClip>> _ensureClipProofs(
-    List<DivineVideoClip> clips,
-  ) async {
+    List<DivineVideoClip> clips, {
+    VoidCallback? onClipProcessed,
+  }) async {
     final result = <DivineVideoClip>[];
     for (final clip in clips) {
       if (clip.proofManifestJson != null) {
         result.add(clip);
+        onClipProcessed?.call();
         continue;
       }
 
       final videoFile = clip.video.file;
       if (videoFile == null) {
         result.add(clip);
+        onClipProcessed?.call();
         continue;
       }
 
@@ -333,6 +447,7 @@ class VideoEditorRenderService {
         );
         result.add(clip);
       }
+      onClipProcessed?.call();
     }
     return result;
   }

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -179,10 +179,14 @@ class _RenderProgressTracker {
   final double _proofBudget;
   final int _proofSteps;
   StreamSubscription<ProgressModel>? _renderSubscription;
+  double _lastProgress = 0;
 
   double get _renderBudget => 1 - _proofBudget;
 
   void start() {
+    // Emit an explicit reset so a reused broadcast stream does not keep showing
+    // the completed progress of a previous render.
+    _lastProgress = 0;
     VideoEditorRenderService._emitCompositeProgress(
       taskId: taskId,
       progress: 0,
@@ -190,37 +194,42 @@ class _RenderProgressTracker {
     _renderSubscription = ProVideoEditor.instance
         .progressStreamById(taskId)
         .listen((progressModel) {
-          VideoEditorRenderService._emitCompositeProgress(
-            taskId: taskId,
-            progress: progressModel.progress * _renderBudget,
-          );
+          _emit(progressModel.progress * _renderBudget);
         });
   }
 
-  void markRenderComplete() {
-    VideoEditorRenderService._emitCompositeProgress(
-      taskId: taskId,
-      progress: _renderBudget,
-    );
+  Future<void> markRenderComplete() async {
+    // Stop listening to render progress so late events from the render stream
+    // cannot regress the composite progress during the proof phase.
+    await _renderSubscription?.cancel();
+    _renderSubscription = null;
+    _emit(_renderBudget);
   }
 
   void markProofStepComplete(int completedSteps) {
     final normalizedSteps = completedSteps.clamp(0, _proofSteps);
-    VideoEditorRenderService._emitCompositeProgress(
-      taskId: taskId,
-      progress: _renderBudget + (_proofBudget * normalizedSteps / _proofSteps),
-    );
+    _emit(_renderBudget + (_proofBudget * normalizedSteps / _proofSteps));
   }
 
   void complete() {
-    VideoEditorRenderService._emitCompositeProgress(
-      taskId: taskId,
-      progress: 1,
-    );
+    _emit(1);
   }
 
   Future<void> dispose() async {
     await _renderSubscription?.cancel();
+    _renderSubscription = null;
+  }
+
+  /// Emits a monotonically increasing composite progress value, guarding
+  /// against backwards jumps caused by out-of-order stream events.
+  void _emit(double progress) {
+    final clamped = progress.clamp(0.0, 1.0);
+    if (clamped <= _lastProgress) return;
+    _lastProgress = clamped;
+    VideoEditorRenderService._emitCompositeProgress(
+      taskId: taskId,
+      progress: clamped,
+    );
   }
 }
 
@@ -237,10 +246,10 @@ class VideoEditorRenderService {
   @visibleForTesting
   static double proofModeProgressBudgetForClipCount(int clipCount) {
     final normalizedClipCount = clipCount < 1 ? 1 : clipCount;
-    return (normalizedClipCount * 0.01).clamp(0.05, 0.10).toDouble();
+    return (normalizedClipCount * 0.01).clamp(0.05, 0.10);
   }
 
-  static Stream<ProgressModel> progressStreamById(String taskId) {
+  static Stream<ProgressModel> compositeProgressStreamById(String taskId) {
     return _compositeProgressController.stream.where(
       (progress) => progress.id == taskId,
     );
@@ -251,7 +260,7 @@ class VideoEditorRenderService {
     required double progress,
   }) {
     _compositeProgressController.add(
-      ProgressModel(id: taskId, progress: progress.clamp(0.0, 1.0).toDouble()),
+      ProgressModel(id: taskId, progress: progress.clamp(0.0, 1.0)),
     );
   }
 
@@ -332,7 +341,7 @@ class VideoEditorRenderService {
 
       if (outputPath == null) return null;
 
-      progressTracker.markRenderComplete();
+      await progressTracker.markRenderComplete();
 
       final metaData = await ProVideoEditor.instance.getMetadata(
         EditorVideo.file(outputPath),

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -211,10 +211,6 @@ class _RenderProgressTracker {
     _emit(_renderBudget + (_proofBudget * normalizedSteps / _proofSteps));
   }
 
-  void complete() {
-    _emit(1);
-  }
-
   Future<void> dispose() async {
     await _renderSubscription?.cancel();
     _renderSubscription = null;
@@ -284,6 +280,20 @@ class VideoEditorRenderService {
     String? taskId,
   })?
   renderVideoToClipOverride;
+
+  /// Test-only override for [renderVideo].
+  ///
+  /// When set, [renderVideo] delegates to this callback instead of running the
+  /// real render pipeline. Reset to `null` in `tearDown`.
+  @visibleForTesting
+  static Future<String?> Function({
+    required List<DivineVideoClip> clips,
+    required bool usePersistentStorage,
+    model.AspectRatio? aspectRatio,
+    CompleteParameters? parameters,
+    String? taskId,
+  })?
+  renderVideoOverride;
 
   // ─────────────────────────────────────────────────────────────────────────
   // Public API
@@ -400,7 +410,6 @@ class VideoEditorRenderService {
         thumbnailPath: clips.first.thumbnailPath,
       );
 
-      progressTracker.complete();
       return (clip, proofManifestJson);
     } finally {
       await progressTracker.dispose();
@@ -481,6 +490,17 @@ class VideoEditorRenderService {
     CompleteParameters? parameters,
     String? taskId,
   }) async {
+    final override = renderVideoOverride;
+    if (override != null) {
+      return override(
+        clips: clips,
+        usePersistentStorage: usePersistentStorage,
+        aspectRatio: aspectRatio,
+        parameters: parameters,
+        taskId: taskId,
+      );
+    }
+
     final cacheDir = await getTemporaryDirectory();
     final outputDir = usePersistentStorage
         ? await getApplicationDocumentsDirectory()

--- a/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
@@ -6,9 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
-import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
-import 'package:pro_video_editor/core/models/video/progress_model.dart';
 
 class VideoEditorProcessingOverlay extends ConsumerWidget {
   const VideoEditorProcessingOverlay({
@@ -27,9 +25,6 @@ class VideoEditorProcessingOverlay extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // draftId is set once during initialization and does not change within a
-    // session, so a one-time read is sufficient.
-    final draftId = ref.read(videoEditorProvider.notifier).draftId;
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 220),
       child: isProcessing || clip.isProcessing
@@ -47,17 +42,21 @@ class VideoEditorProcessingOverlay extends ConsumerWidget {
 
                     // Without RepaintBoundary, the progress indicator repaints
                     // the entire screen while it's running.
+                    // Without RepaintBoundary, the progress indicator repaints
+                    // the entire screen while it's running.
                     RepaintBoundary(
-                      child: StreamBuilder<ProgressModel>(
-                        stream:
-                            VideoEditorRenderService.compositeProgressStreamById(
-                              draftId,
-                            ),
-                        builder: (context, snapshot) {
-                          final progress = (snapshot.data?.progress ?? 0).clamp(
-                            0.0,
-                            1.0,
-                          );
+                      child: Consumer(
+                        builder: (context, ref, _) {
+                          final progress =
+                              (ref
+                                          .watch(
+                                            videoEditorCompositeProgressProvider,
+                                          )
+                                          .asData
+                                          ?.value
+                                          .progress ??
+                                      0)
+                                  .clamp(0.0, 1.0);
                           return PartialCircleSpinner(progress: progress);
                         },
                       ),

--- a/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
@@ -8,7 +8,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 
-class VideoEditorProcessingOverlay extends ConsumerWidget {
+class VideoEditorProcessingOverlay extends StatelessWidget {
   const VideoEditorProcessingOverlay({
     required this.clip,
     super.key,
@@ -24,7 +24,7 @@ class VideoEditorProcessingOverlay extends ConsumerWidget {
   final Widget? inactivePlaceholder;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 220),
       child: isProcessing || clip.isProcessing
@@ -40,8 +40,6 @@ class VideoEditorProcessingOverlay extends ConsumerWidget {
                   children: [
                     const BrandedLoadingIndicator(size: 44),
 
-                    // Without RepaintBoundary, the progress indicator repaints
-                    // the entire screen while it's running.
                     // Without RepaintBoundary, the progress indicator repaints
                     // the entire screen while it's running.
                     RepaintBoundary(

--- a/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
@@ -6,8 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:pro_video_editor/core/models/video/progress_model.dart';
-import 'package:pro_video_editor/core/platform/platform_interface.dart';
 
 class VideoEditorProcessingOverlay extends ConsumerWidget {
   const VideoEditorProcessingOverlay({
@@ -38,16 +39,28 @@ class VideoEditorProcessingOverlay extends ConsumerWidget {
               ),
               color: const Color.fromARGB(180, 0, 0, 0),
               child: Center(
-                // Without RepaintBoundary, the progress indicator repaints
-                // the entire screen while it's running.
-                child: RepaintBoundary(
-                  child: StreamBuilder<ProgressModel>(
-                    stream: ProVideoEditor.instance.progressStreamById(draftId),
-                    builder: (context, snapshot) {
-                      final progress = snapshot.data?.progress ?? 0;
-                      return PartialCircleSpinner(progress: progress);
-                    },
-                  ),
+                child: Column(
+                  mainAxisSize: .min,
+                  spacing: 12,
+                  children: [
+                    const BrandedLoadingIndicator(size: 44),
+
+                    // Without RepaintBoundary, the progress indicator repaints
+                    // the entire screen while it's running.
+                    RepaintBoundary(
+                      child: StreamBuilder<ProgressModel>(
+                        stream: VideoEditorRenderService.progressStreamById(
+                          draftId,
+                        ),
+                        builder: (context, snapshot) {
+                          final progress = (snapshot.data?.progress ?? 0)
+                              .clamp(0.0, 1.0)
+                              .toDouble();
+                          return PartialCircleSpinner(progress: progress);
+                        },
+                      ),
+                    ),
+                  ],
                 ),
               ),
             )

--- a/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_processing_overlay.dart
@@ -49,13 +49,15 @@ class VideoEditorProcessingOverlay extends ConsumerWidget {
                     // the entire screen while it's running.
                     RepaintBoundary(
                       child: StreamBuilder<ProgressModel>(
-                        stream: VideoEditorRenderService.progressStreamById(
-                          draftId,
-                        ),
+                        stream:
+                            VideoEditorRenderService.compositeProgressStreamById(
+                              draftId,
+                            ),
                         builder: (context, snapshot) {
-                          final progress = (snapshot.data?.progress ?? 0)
-                              .clamp(0.0, 1.0)
-                              .toDouble();
+                          final progress = (snapshot.data?.progress ?? 0).clamp(
+                            0.0,
+                            1.0,
+                          );
                           return PartialCircleSpinner(progress: progress);
                         },
                       ),

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -252,10 +252,11 @@ class _InputWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: VineTheme.surfaceBackground,
-      borderRadius: .circular(_borderRadius),
-      clipBehavior: Clip.antiAlias,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.surfaceBackground,
+        borderRadius: .circular(_borderRadius),
+      ),
       child: child,
     );
   }

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -252,11 +252,10 @@ class _InputWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: VineTheme.surfaceBackground,
-        borderRadius: .circular(_borderRadius),
-      ),
+    return Material(
+      color: VineTheme.surfaceBackground,
+      borderRadius: .circular(_borderRadius),
+      clipBehavior: Clip.antiAlias,
       child: child,
     );
   }

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -50,7 +50,6 @@ subscription_manager
 top_hashtags_service
 upload_manager # defer: #4339 oversized-file split
 video_cache_service
-video_editor_render_service
 video_event_service # defer: #4338 Track D demolition
 video_format_preference # defer: #4338 C2 singleton-to-DI
 video_loading_metrics

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:models/models.dart' as models;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
@@ -56,6 +57,11 @@ void main() {
           clipManagerProvider.overrideWith(
             () => _MockClipManagerNotifier([testClip]),
           ),
+          videoEditorProvider.overrideWith(
+            () => _MockVideoEditorNotifier(
+              VideoEditorProviderState(finalRenderedClip: testClip),
+            ),
+          ),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -81,6 +87,11 @@ void main() {
                   publishState: VideoPublishState.error,
                   errorMessage: 'Previous error',
                 ),
+              ),
+            ),
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(
+                VideoEditorProviderState(finalRenderedClip: testClip),
               ),
             ),
           ],
@@ -124,6 +135,11 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
+            ),
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(
+                VideoEditorProviderState(finalRenderedClip: testClip),
+              ),
             ),
           ],
         );
@@ -211,4 +227,14 @@ class _MockVideoPublishNotifier extends VideoPublishNotifier {
 
   @override
   VideoPublishProviderState build() => _initialState;
+}
+
+/// Mock video editor notifier that returns a fixed state.
+class _MockVideoEditorNotifier extends VideoEditorNotifier {
+  _MockVideoEditorNotifier(this._initialState);
+
+  final VideoEditorProviderState _initialState;
+
+  @override
+  VideoEditorProviderState build() => _initialState;
 }

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -1,0 +1,35 @@
+// ABOUTME: Tests for composite export progress allocation in VideoEditorRenderService
+// ABOUTME: Verifies the reserved ProofMode progress budget stays within the intended bounds
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+
+void main() {
+  group('VideoEditorRenderService proof progress allocation', () {
+    test('reserves a minimum of 5 percent for proof finalization', () {
+      expect(
+        VideoEditorRenderService.proofModeProgressBudgetForClipCount(1),
+        closeTo(0.05, 1e-9),
+      );
+      expect(
+        VideoEditorRenderService.proofModeProgressBudgetForClipCount(3),
+        closeTo(0.05, 1e-9),
+      );
+    });
+
+    test('scales proof budget with clip count until the 10 percent cap', () {
+      expect(
+        VideoEditorRenderService.proofModeProgressBudgetForClipCount(5),
+        closeTo(0.05, 1e-9),
+      );
+      expect(
+        VideoEditorRenderService.proofModeProgressBudgetForClipCount(10),
+        closeTo(0.10, 1e-9),
+      );
+      expect(
+        VideoEditorRenderService.proofModeProgressBudgetForClipCount(30),
+        closeTo(0.10, 1e-9),
+      );
+    });
+  });
+}

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -23,6 +23,10 @@ void main() {
         closeTo(0.05, 1e-9),
       );
       expect(
+        VideoEditorRenderService.proofModeProgressBudgetForClipCount(7),
+        closeTo(0.07, 1e-9),
+      );
+      expect(
         VideoEditorRenderService.proofModeProgressBudgetForClipCount(10),
         closeTo(0.10, 1e-9),
       );

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -1,8 +1,65 @@
-// ABOUTME: Tests for composite export progress allocation in VideoEditorRenderService
-// ABOUTME: Verifies the reserved ProofMode progress budget stays within the intended bounds
+// ABOUTME: Tests for composite export progress in VideoEditorRenderService
+// ABOUTME: Verifies render/proof sequencing and ProofMode budget allocation
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+class _ProgressProVideoEditor extends ProVideoEditor {
+  final _progressController = StreamController<ProgressModel>.broadcast();
+
+  @override
+  void initializeStream() {}
+
+  void emitProgress(String taskId, double progress) {
+    _progressController.add(ProgressModel(id: taskId, progress: progress));
+  }
+
+  @override
+  Stream<ProgressModel> progressStreamById(String taskId) {
+    return _progressController.stream.where(
+      (progress) => progress.id == taskId,
+    );
+  }
+
+  @override
+  Future<VideoMetadata> getMetadata(
+    EditorVideo value, {
+    bool checkStreamingOptimization = false,
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    return VideoMetadata(
+      duration: const Duration(seconds: 6),
+      extension: 'mp4',
+      fileSize: 1024,
+      resolution: const Size(1080, 1920),
+      rotation: 0,
+      bitrate: 1_000_000,
+    );
+  }
+
+  Future<void> dispose() => _progressController.close();
+}
+
+Future<void> _flushStreamEvents() => Future<void>.delayed(Duration.zero);
+
+DivineVideoClip _createClip(int index) {
+  return DivineVideoClip(
+    id: 'clip-$index',
+    video: EditorVideo.file('${Directory.systemTemp.path}/clip-$index.mp4'),
+    duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2026, 6, 5, 12, index),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+  );
+}
 
 void main() {
   group('VideoEditorRenderService proof progress allocation', () {
@@ -35,5 +92,125 @@ void main() {
         closeTo(0.10, 1e-9),
       );
     });
+  });
+
+  group('VideoEditorRenderService composite progress sequence', () {
+    late ProVideoEditor originalProVideoEditor;
+    late _ProgressProVideoEditor proVideoEditor;
+
+    setUp(() {
+      originalProVideoEditor = ProVideoEditor.instance;
+      proVideoEditor = _ProgressProVideoEditor();
+      ProVideoEditor.instance = proVideoEditor;
+    });
+
+    tearDown(() async {
+      VideoEditorRenderService.renderVideoOverride = null;
+      NativeProofModeService.proofFileOverride = null;
+      await proVideoEditor.dispose();
+      ProVideoEditor.instance = originalProVideoEditor;
+    });
+
+    test(
+      'scales render progress, counts proof steps, and stays monotonic',
+      () async {
+        const taskId = 'composite-sequence-test';
+        final progressValues = <double>[];
+        final proofCallClipCounts = <int?>[];
+        final editorStateHistory = <String, dynamic>{
+          'clips': ['clip-0', 'clip-1', 'clip-2'],
+        };
+
+        final progressSubscription =
+            VideoEditorRenderService.compositeProgressStreamById(taskId).listen(
+              (progress) => progressValues.add(progress.progress),
+            );
+        addTearDown(progressSubscription.cancel);
+
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+            }) async {
+              expect(usePersistentStorage, isTrue);
+              expect(taskId, equals('composite-sequence-test'));
+
+              proVideoEditor.emitProgress(taskId!, 0.25);
+              await _flushStreamEvents();
+              proVideoEditor.emitProgress(taskId, 0.75);
+              await _flushStreamEvents();
+              proVideoEditor.emitProgress(taskId, 0.40);
+              await _flushStreamEvents();
+
+              return '${Directory.systemTemp.path}/rendered-composite.mp4';
+            };
+
+        NativeProofModeService.proofFileOverride =
+            (
+              File videoFile, {
+              required bool enableAdvancedCawgEmbedding,
+              creatorBindingAssertion,
+              cawgIdentityAssertion,
+              verifiedIdentityBundle,
+              clips,
+              editorStateHistory,
+            }) async {
+              proofCallClipCounts.add(clips?.length);
+
+              if (proofCallClipCounts.length == 1) {
+                proVideoEditor.emitProgress(taskId, 0.10);
+                await _flushStreamEvents();
+              }
+
+              return model.NativeProofData(
+                videoHash: 'proof-${proofCallClipCounts.length}',
+              );
+            };
+
+        final result = await VideoEditorRenderService.renderVideoToClip(
+          clips: [_createClip(0), _createClip(1), _createClip(2)],
+          editorStateHistory: editorStateHistory,
+          taskId: taskId,
+        );
+        await _flushStreamEvents();
+
+        expect(result, isNotNull);
+        expect(result?.$2, isNotNull);
+        expect(
+          proofCallClipCounts,
+          equals([null, null, null, 3]),
+          reason:
+              'three clip-proof steps plus the final combined proofFile step',
+        );
+
+        const renderBudget = 0.95;
+        const proofBudget = 0.05;
+        final expectedProgressValues = [
+          0.0,
+          0.25 * renderBudget,
+          0.75 * renderBudget,
+          renderBudget,
+          renderBudget + proofBudget / 4,
+          renderBudget + proofBudget * 2 / 4,
+          renderBudget + proofBudget * 3 / 4,
+          1.0,
+        ];
+
+        expect(progressValues, hasLength(expectedProgressValues.length));
+        for (var i = 0; i < expectedProgressValues.length; i++) {
+          expect(progressValues[i], closeTo(expectedProgressValues[i], 1e-9));
+        }
+        for (var i = 1; i < progressValues.length; i++) {
+          expect(
+            progressValues[i],
+            greaterThanOrEqualTo(progressValues[i - 1]),
+          );
+        }
+        expect(progressValues.last, equals(1.0));
+      },
+    );
   });
 }

--- a/mobile/test/widgets/video_editor_processing_overlay_test.dart
+++ b/mobile/test/widgets/video_editor_processing_overlay_test.dart
@@ -3,14 +3,19 @@
 
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 DivineVideoClip _createClip({Completer<bool>? processingCompleter}) {
   return DivineVideoClip(
@@ -26,12 +31,31 @@ DivineVideoClip _createClip({Completer<bool>? processingCompleter}) {
 
 void main() {
   group('VideoEditorProcessingOverlay', () {
+    late ProviderContainer container;
+    late SharedPreferences sharedPreferences;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      sharedPreferences = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+        ],
+      );
+      container.read(videoEditorProvider.notifier).setDraftId('draft-test');
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
     testWidgets('should be visible when clip is processing', (tester) async {
       final completer = Completer<bool>();
       final clip = _createClip(processingCompleter: completer);
 
       await tester.pumpWidget(
-        ProviderScope(
+        UncontrolledProviderScope(
+          container: container,
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -55,7 +79,8 @@ void main() {
       final clip = _createClip(); // No processingCompleter
 
       await tester.pumpWidget(
-        ProviderScope(
+        UncontrolledProviderScope(
+          container: container,
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -80,7 +105,8 @@ void main() {
       final clip = _createClip(processingCompleter: completer);
 
       await tester.pumpWidget(
-        ProviderScope(
+        UncontrolledProviderScope(
+          container: container,
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -96,6 +122,40 @@ void main() {
             widget.color == const Color.fromARGB(140, 0, 0, 0),
       );
       expect(overlayFinder, findsNothing);
+    });
+
+    testWidgets('renders composed export progress', (
+      tester,
+    ) async {
+      final clip = _createClip();
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoEditorProcessingOverlay(
+                clip: clip,
+                isProcessing: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      VideoEditorRenderService.emitCompositeProgressForTesting(
+        taskId: 'draft-test',
+        progress: 0.95,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      final spinner = tester.widget<PartialCircleSpinner>(
+        find.byType(PartialCircleSpinner),
+      );
+      expect(spinner.progress, closeTo(0.95, 1e-9));
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
@@ -43,6 +43,11 @@ void main() {
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
+            videoEditorProvider.overrideWith(
+              () => _MockVideoEditorNotifier(
+                VideoEditorProviderState(finalRenderedClip: testClip),
+              ),
+            ),
           ],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
Closes #4811

## Summary

Introduces a unified composite progress stream that covers both the render phase and the ProofMode attestation phase, so the UI overlay reflects the full end-to-end export progress instead of stalling at the end of the render.

## Changes

### `VideoEditorRenderService`
- Added `_RenderProgressTracker` to encapsulate the two-phase progress budget:
  - **Render phase** (`0 -> renderBudget`): forwards raw `ProVideoEditor` progress events, scaled to the render budget.
  - **Proof phase** (`renderBudget -> 1.0`): steps forward per clip attestation and the final `proofFile` call.
- `markRenderComplete()` cancels the render subscription immediately, preventing late render events from regressing composite progress during the proof phase.
- Monotonically increasing emit guard (`_lastProgress`) blocks any out-of-order backwards jumps.
- `proofModeProgressBudgetForClipCount` allocates 1% per clip, clamped to **5-10%**, keeping the proof phase visually brief but non-zero.
- `compositeProgressStreamById` exposes the composite stream, renamed from `progressStreamById` to avoid confusion with the `ProVideoEditor` package method of the same name.
- `_ensureClipProofs` reports progress for each clip proof step and preserves the existing sequential attestation flow.

### `VideoEditorProcessingOverlay`
- Switched from `ProVideoEditor.instance.progressStreamById` to `VideoEditorRenderService.compositeProgressStreamById`, so the `PartialCircleSpinner` shows end-to-end progress.
- Added `BrandedLoadingIndicator` above the spinner for visual continuity during the initial render phase.
- Progress clamps to `0.0-1.0` defensively.

### `VideoPublishProvider`
- `taskId: draft.id` is now passed when calling `renderVideoToClip` in the multi-clip publish path, ensuring the overlay stream ID matches the `draftId` the overlay listens on.

## Tests

- **`video_editor_render_service_test.dart`** (new): verifies ProofMode progress budget bounds and the composite progress sequence, including render scaling, monotonic no-regression behavior, per-clip proof steps, final `proofFile`, and landing at `1.0`.
- **`video_editor_processing_overlay_test.dart`**: updated to use `UncontrolledProviderScope` with a shared `ProviderContainer`; added test for the composite progress stream integration.
