### PR TITLE
fix(video-editor): bump pro_video_editor to 1.17.2 for Android render fix

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1872,10 +1872,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: e16c1e67a2f9e7f91723764642f0dfb188a6ab4de1d3f98f2ec1ac699dd9ee9d
+      sha256: c82f556629a1db5cc285812e62913223ee44fd575c9abcc4ea166bb3b7e52b66
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.3"
+    version: "1.17.2"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -295,7 +295,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.16.3
+  pro_video_editor: ^1.17.2
   pro_image_editor: ^12.4.5
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #4815

## What

Bumps `pro_video_editor` from `^1.16.3` → `^1.17.2`.

## Why

Fixes `PlatformException(RENDER_ERROR, Codec exception: ... name=c2.qti.avc.encoder)` that occurred during the final video render on Android devices using Qualcomm hardware H.264 encoders.

The root cause was fixed upstream in `pro_video_editor` 1.17.2. Per the upstream changelog:

> **FIX(android):** Prevent `RENDER_ERROR` codec exceptions on hardware encoders (e.g. Qualcomm AVC `c2.qti.avc.encoder`) by enabling encoder fallback in the main render path, clamping the requested bitrate into the codec's supported range, and preferring VBR over CBR at high bitrates.
>
> **FIX(android):** Harden the reverse-video pre-render against crashes — clamped bitrate and progressive fallback to avoid `MediaCodec.CodecException`, and the in-memory remux is guarded against `OutOfMemoryError`. On failure the clip gracefully degrades to forward playback.

## Changes

- `mobile/pubspec.yaml`: constraint bumped to `^1.17.2`
- `mobile/pubspec.lock`: regenerated via `flutter pub get` (resolves `pro_video_editor` to `1.17.2`)

## Testing

- `flutter pub get` resolves cleanly to `1.17.2`.
- The encoder fix lives in the upstream native Android render path; verify on a Qualcomm-based device by exporting an edited video and confirming no `RENDER_ERROR`.