### PR TITLE
fix(home-feed): add missing new videos feed mode

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -242,6 +242,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return const VideoFeedSource.following();
     }
 
+    if (saved == FeedMode.latest.name) {
+      return const VideoFeedSource.newVideos();
+    }
+
     return const VideoFeedSource.forYou();
   }
 
@@ -688,6 +692,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           .getVideosForList(
             _curatedListRepository.getOrderedVideoIds(source.listId!),
           )
+          .then((videos) => HomeFeedResult(videos: videos)),
+    VideoFeedSourceType.newVideos =>
+      _videosRepository
+          .getNewVideos(until: until, skipCache: skipCache)
           .then((videos) => HomeFeedResult(videos: videos)),
   };
 

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -25,6 +25,9 @@ enum VideoFeedSourceType {
 
   /// Videos from one subscribed curated list.
   subscribedList,
+
+  /// Most recently published videos (chronological).
+  newVideos,
 }
 
 /// Source selection for [VideoFeedBloc].
@@ -47,10 +50,17 @@ final class VideoFeedSource extends Equatable {
     required String this.listName,
   }) : type = VideoFeedSourceType.subscribedList;
 
+  /// Most recently published videos (chronological).
+  const VideoFeedSource.newVideos()
+    : type = VideoFeedSourceType.newVideos,
+      listId = null,
+      listName = null;
+
   /// Compatibility conversion for legacy mode-based callers.
   factory VideoFeedSource.fromMode(FeedMode mode) => switch (mode) {
     FeedMode.following => const VideoFeedSource.following(),
-    FeedMode.forYou || FeedMode.latest => const VideoFeedSource.forYou(),
+    FeedMode.forYou => const VideoFeedSource.forYou(),
+    FeedMode.latest => const VideoFeedSource.newVideos(),
   };
 
   /// The source type.
@@ -65,6 +75,7 @@ final class VideoFeedSource extends Equatable {
   /// Legacy mode projection for compatibility.
   FeedMode get mode => switch (type) {
     VideoFeedSourceType.forYou => FeedMode.forYou,
+    VideoFeedSourceType.newVideos => FeedMode.latest,
     VideoFeedSourceType.following ||
     VideoFeedSourceType.subscribedList => FeedMode.following,
   };
@@ -72,6 +83,7 @@ final class VideoFeedSource extends Equatable {
   /// Label fallback for UI surfaces that do not have localized copy.
   String get labelFallback => switch (type) {
     VideoFeedSourceType.forYou => FeedMode.forYou.name,
+    VideoFeedSourceType.newVideos => FeedMode.latest.name,
     VideoFeedSourceType.following => FeedMode.following.name,
     VideoFeedSourceType.subscribedList => listName ?? '',
   };
@@ -79,6 +91,7 @@ final class VideoFeedSource extends Equatable {
   /// SharedPreferences value for this source.
   String get persistenceValue => switch (type) {
     VideoFeedSourceType.forYou => FeedMode.forYou.name,
+    VideoFeedSourceType.newVideos => FeedMode.latest.name,
     VideoFeedSourceType.following => FeedMode.following.name,
     VideoFeedSourceType.subscribedList => 'list:$listId',
   };
@@ -134,6 +147,8 @@ final class VideoFeedBlocState extends Equatable {
            source ??
            (mode == FeedMode.following
                ? const VideoFeedSource.following()
+               : mode == FeedMode.latest
+               ? const VideoFeedSource.newVideos()
                : const VideoFeedSource.forYou());
 
   /// The current loading status.

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -86,6 +86,10 @@ class FeedModeSwitch extends StatelessWidget {
           label: l10n.feedModeFollowing,
           value: 'following',
         ),
+        VineBottomSheetSelectionOptionData(
+          label: l10n.feedModeNew,
+          value: 'latest',
+        ),
         ...state.subscribedLists.map(
           (list) => VineBottomSheetSelectionOptionData(
             label: list.name,
@@ -110,6 +114,9 @@ VideoFeedSource _sourceForSelection(String selected, VideoFeedBlocState state) {
   if (selected == 'following') {
     return const VideoFeedSource.following();
   }
+  if (selected == 'latest') {
+    return const VideoFeedSource.newVideos();
+  }
   if (selected.startsWith('list:')) {
     final listId = selected.substring('list:'.length);
     final list = state.subscribedLists.firstWhere((list) => list.id == listId);
@@ -124,6 +131,7 @@ String _labelForSource(VideoFeedBlocState state, AppLocalizations l10n) {
   return switch (source.type) {
     VideoFeedSourceType.forYou => l10n.feedModeForYou,
     VideoFeedSourceType.following => l10n.feedModeFollowing,
+    VideoFeedSourceType.newVideos => l10n.feedModeNew,
     VideoFeedSourceType.subscribedList =>
       _listNameForSource(state) ?? source.listName ?? source.labelFallback,
   };

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -172,7 +172,7 @@ void main() {
         expect(loadedState.isEmpty, isFalse);
       });
 
-      test('copyWith maps legacy latest mode to For You source', () {
+      test('copyWith maps legacy latest mode to New Videos source', () {
         const state = VideoFeedBlocState();
 
         final updated = state.copyWith(
@@ -181,8 +181,8 @@ void main() {
         );
 
         expect(updated.status, VideoFeedStatus.success);
-        expect(updated.mode, FeedMode.forYou);
-        expect(updated.source, const VideoFeedSource.forYou());
+        expect(updated.mode, FeedMode.latest);
+        expect(updated.source, const VideoFeedSource.newVideos());
       });
 
       test('copyWith preserves values when not specified', () {
@@ -239,26 +239,26 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'maps legacy latest start mode to For You',
+        'maps legacy latest start mode to New Videos',
         setUp: () {
           final videos = createTestVideos(5);
 
           when(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
+            () => mockVideosRepository.getNewVideos(
               limit: any(named: 'limit'),
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+          ).thenAnswer((_) async => videos);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.latest)),
         expect: () => [
-          const VideoFeedBlocState(),
+          const VideoFeedBlocState(mode: FeedMode.latest),
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.mode, 'mode', FeedMode.forYou),
+              .having((s) => s.mode, 'mode', FeedMode.latest)
+              .having((s) => s.videos.length, 'videos count', 5),
         ],
       );
 
@@ -355,7 +355,7 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'migrates persisted latest to For You',
+        'restores persisted latest to New Videos',
         setUp: () async {
           final videos = createTestVideos(2);
           SharedPreferences.setMockInitialValues({
@@ -364,13 +364,12 @@ void main() {
           final sharedPreferences = await SharedPreferences.getInstance();
 
           when(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
+            () => mockVideosRepository.getNewVideos(
               limit: any(named: 'limit'),
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+          ).thenAnswer((_) async => videos);
 
           savedModeBloc = VideoFeedBloc(
             videosRepository: mockVideosRepository,
@@ -386,22 +385,21 @@ void main() {
               .having(
                 (s) => s.source.type,
                 'source',
-                VideoFeedSourceType.forYou,
+                VideoFeedSourceType.newVideos,
               )
-              .having((s) => s.mode, 'mode', FeedMode.forYou),
+              .having((s) => s.mode, 'mode', FeedMode.latest),
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having(
                 (s) => s.source.type,
                 'source',
-                VideoFeedSourceType.forYou,
+                VideoFeedSourceType.newVideos,
               )
-              .having((s) => s.mode, 'mode', FeedMode.forYou),
+              .having((s) => s.mode, 'mode', FeedMode.latest),
         ],
         verify: (_) async {
           verify(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
+            () => mockVideosRepository.getNewVideos(
               limit: any(named: 'limit'),
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
@@ -411,7 +409,7 @@ void main() {
           final sharedPreferences = await SharedPreferences.getInstance();
           expect(
             sharedPreferences.getString('selected_feed_mode'),
-            const VideoFeedSource.forYou().persistenceValue,
+            const VideoFeedSource.newVideos().persistenceValue,
           );
         },
       );
@@ -923,18 +921,17 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'legacy latest mode change maps to For You',
+        'legacy latest mode change maps to New Videos',
         setUp: () {
           final videos = createTestVideos(5);
 
           when(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
+            () => mockVideosRepository.getNewVideos(
               limit: any(named: 'limit'),
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+          ).thenAnswer((_) async => videos);
         },
         build: createBloc,
         seed: () => VideoFeedBlocState(
@@ -944,27 +941,27 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoFeedModeChanged(FeedMode.latest)),
         expect: () => [
-          const VideoFeedBlocState(),
+          const VideoFeedBlocState(source: VideoFeedSource.newVideos()),
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.mode, 'mode', FeedMode.forYou)
+              .having((s) => s.mode, 'mode', FeedMode.latest)
               .having((s) => s.videos.length, 'videos count', 5),
         ],
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'does nothing when legacy latest maps to already selected For You',
+        'does nothing when legacy latest maps to already selected New Videos',
         build: createBloc,
         seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
+          source: const VideoFeedSource.newVideos(),
           videos: createTestVideos(5),
         ),
         act: (bloc) => bloc.add(const VideoFeedModeChanged(FeedMode.latest)),
         expect: () => <VideoFeedBlocState>[],
         verify: (_) {
           verifyNever(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
+            () => mockVideosRepository.getNewVideos(
               limit: any(named: 'limit'),
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
@@ -2286,26 +2283,25 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'uses For You feed type for legacy latest mode',
+        'uses New Videos feed type for legacy latest mode',
         setUp: () {
           final videos = createTestVideos(3);
           when(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
+            () => mockVideosRepository.getNewVideos(
               limit: any(named: 'limit'),
               until: any(named: 'until'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+          ).thenAnswer((_) async => videos);
         },
         build: createBlocWithTracker,
         act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.latest)),
         verify: (_) {
-          verify(() => mockTracker.startFeedLoad('forYou')).called(1);
+          verify(() => mockTracker.startFeedLoad('latest')).called(1);
           verify(
-            () => mockTracker.markFirstVideosReceived('forYou', 3),
+            () => mockTracker.markFirstVideosReceived('latest', 3),
           ).called(1);
-          verify(() => mockTracker.markFeedDisplayed('forYou', 3)).called(1);
+          verify(() => mockTracker.markFeedDisplayed('latest', 3)).called(1);
         },
       );
     });

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -114,7 +114,7 @@ void main() {
       });
 
       testWidgets(
-        'dropdown shows For You, Following, and subscribed lists but not New',
+        'dropdown shows For You, Following, New, and subscribed lists',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
             VideoFeedBlocState(
@@ -130,8 +130,8 @@ void main() {
 
           expect(find.text(l10n.feedModeForYou), findsWidgets);
           expect(find.text(l10n.feedModeFollowing), findsOneWidget);
+          expect(find.text(l10n.feedModeNew), findsOneWidget);
           expect(find.text('Best Vines'), findsOneWidget);
-          expect(find.text(l10n.feedModeNew), findsNothing);
         },
       );
 
@@ -179,6 +179,30 @@ void main() {
         verify(
           () => mockBloc.add(
             const VideoFeedSourceChanged(VideoFeedSource.following()),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('dispatches VideoFeedSourceChanged when New selected', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          const VideoFeedBlocState(
+            status: VideoFeedStatus.success,
+            source: VideoFeedSource.forYou(),
+          ),
+        );
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.text(l10n.feedModeForYou));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l10n.feedModeNew));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockBloc.add(
+            const VideoFeedSourceChanged(VideoFeedSource.newVideos()),
           ),
         ).called(1);
       });


### PR DESCRIPTION
Closes #4818

## Description

The home feed was missing the news feed option, which a few users on Discord reported as their preferred mode. This PR brings that mode back while keeping the “For you” feed as the default, so only users who really prefer the news feed need to switch to it.

**Related Issue:** 

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore