### PR TITLE
fix(timeline): add clipSourcePositionToTimelinePosition helper

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -33,6 +33,7 @@ import 'package:openvine/widgets/video_editor/main_editor/video_editor_player.da
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_thumbnail.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_image_editor/pro_image_editor.dart'
     hide AudioTrack, VideoClip;
 import 'package:unified_logger/unified_logger.dart';
@@ -275,36 +276,20 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     _lastTrimPositionInClip = null;
     if (clipId == null || positionInClip == null) return null;
 
-    var precedingDuration = Duration.zero;
-    for (final clip in clips) {
-      if (clip.id == clipId) {
-        // positionInClip and trimStart are both source-time offsets, so
-        // relative is also in source time.
-        final relative = positionInClip - clip.trimStart;
-        if (relative < Duration.zero || relative > clip.trimmedDuration) {
-          return null;
-        }
-        // Convert source-time relative offset to playback time before
-        // combining with precedingDuration (which is already playback-time).
-        final speed = clip.playbackSpeed ?? 1.0;
-        final relativePlayback = speed == 1.0
-            ? relative
-            : Duration(
-                microseconds: (relative.inMicroseconds / speed).round(),
-              );
-        return precedingDuration + relativePlayback;
-      }
-      // Accumulate in playback time (trimmedDuration ÷ speed) so that
-      // speed-adjusted clips contribute the correct wall-clock offset.
-      precedingDuration += clip.playbackDuration;
-    }
-    return null;
+    return clipSourcePositionToTimelinePosition(
+      clips,
+      clipId: clipId,
+      sourcePosition: positionInClip,
+    );
   }
 
-  Future<void> _onSeekRequested(Duration position) async {
+  Future<void> _onSeekRequested(
+    Duration position, {
+    Duration? playTimePosition,
+  }) async {
     if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
-    _proVideoController.setPlayTime(position);
+    _proVideoController.setPlayTime(playTimePosition ?? position);
 
     if (_isSeeking) {
       _pendingSeekPosition = position;
@@ -949,9 +934,21 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
               previous.trimPosition != current.trimPosition &&
               current.trimPosition != null,
           listener: (context, state) {
-            _lastTrimClipId = state.trimmingClipId;
-            _lastTrimPositionInClip = state.trimPosition;
-            _onSeekRequested(state.trimPosition!);
+            final clipId = state.trimmingClipId;
+            final sourcePosition = state.trimPosition;
+            if (clipId == null || sourcePosition == null) return;
+
+            _lastTrimClipId = clipId;
+            _lastTrimPositionInClip = sourcePosition;
+            final playTimePosition = clipSourcePositionToTimelinePosition(
+              state.clips,
+              clipId: clipId,
+              sourcePosition: sourcePosition,
+            );
+            _onSeekRequested(
+              sourcePosition,
+              playTimePosition: playTimePosition,
+            );
           },
         ),
         // Re-export state history when an overlay item drag or trim

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -5,6 +5,41 @@
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 
+/// Converts a [sourcePosition] inside one untrimmed clip to the matching
+/// composite playback position on the full timeline.
+///
+/// Clip trim previews seek the native player in source time because the
+/// preview player is temporarily switched to a single untrimmed clip.
+/// Visual overlays, however, are keyed by composite timeline time. This helper
+/// bridges those coordinate spaces while respecting clip trims and speed.
+Duration? clipSourcePositionToTimelinePosition(
+  List<DivineVideoClip> clips, {
+  required String clipId,
+  required Duration sourcePosition,
+}) {
+  var precedingDuration = Duration.zero;
+  for (final clip in clips) {
+    if (clip.id == clipId) {
+      final relative = sourcePosition - clip.trimStart;
+      if (relative < Duration.zero || relative > clip.trimmedDuration) {
+        return null;
+      }
+
+      final speed = clip.playbackSpeed ?? 1.0;
+      final relativePlayback = speed <= 0 || speed == 1.0
+          ? relative
+          : Duration(
+              microseconds: (relative.inMicroseconds / speed).round(),
+            );
+      return precedingDuration + relativePlayback;
+    }
+
+    precedingDuration += clip.playbackDuration;
+  }
+
+  return null;
+}
+
 /// Converts a composite playback [position] to the corresponding scroll
 /// offset in the timeline content, accounting for the
 /// [TimelineConstants.clipGap]-wide gap between adjacent clip strips.

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -7,16 +7,23 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
-DivineVideoClip _clip(String id, int seconds, {double? speed}) =>
-    DivineVideoClip(
-      id: id,
-      video: EditorVideo.file('/tmp/$id.mp4'),
-      duration: Duration(seconds: seconds),
-      recordedAt: DateTime(2025),
-      targetAspectRatio: .vertical,
-      originalAspectRatio: 9 / 16,
-      playbackSpeed: speed,
-    );
+DivineVideoClip _clip(
+  String id,
+  int seconds, {
+  double? speed,
+  Duration trimStart = Duration.zero,
+  Duration trimEnd = Duration.zero,
+}) => DivineVideoClip(
+  id: id,
+  video: EditorVideo.file('/tmp/$id.mp4'),
+  duration: Duration(seconds: seconds),
+  recordedAt: DateTime(2025),
+  targetAspectRatio: .vertical,
+  originalAspectRatio: 9 / 16,
+  playbackSpeed: speed,
+  trimStart: trimStart,
+  trimEnd: trimEnd,
+);
 
 void main() {
   // Three-clip composition used throughout most tests:
@@ -287,6 +294,107 @@ void main() {
         );
       });
     }
+  });
+
+  group(clipSourcePositionToTimelinePosition, () {
+    test(
+      'maps a second-clip start trim handle to the clip start in timeline',
+      () {
+        final trimClips = [
+          _clip('clip-1', 10),
+          _clip('clip-2', 10, trimStart: const Duration(seconds: 2)),
+        ];
+
+        expect(
+          clipSourcePositionToTimelinePosition(
+            trimClips,
+            clipId: 'clip-2',
+            sourcePosition: const Duration(seconds: 2),
+          ),
+          equals(const Duration(seconds: 10)),
+        );
+      },
+    );
+
+    test('keeps second-clip trim preview outside an early overlay range', () {
+      final trimClips = [
+        _clip('clip-1', 10),
+        _clip('clip-2', 10, trimStart: const Duration(seconds: 1)),
+      ];
+
+      final position = clipSourcePositionToTimelinePosition(
+        trimClips,
+        clipId: 'clip-2',
+        sourcePosition: const Duration(seconds: 1),
+      );
+
+      expect(position, equals(const Duration(seconds: 10)));
+      expect(position, greaterThan(const Duration(seconds: 5)));
+    });
+
+    test('maps positions inside a trimmed target clip', () {
+      final trimClips = [
+        _clip('clip-1', 10),
+        _clip('clip-2', 10, trimStart: const Duration(seconds: 2)),
+      ];
+
+      expect(
+        clipSourcePositionToTimelinePosition(
+          trimClips,
+          clipId: 'clip-2',
+          sourcePosition: const Duration(seconds: 4),
+        ),
+        equals(const Duration(seconds: 12)),
+      );
+    });
+
+    test('respects playback speed for preceding and target clips', () {
+      final trimClips = [
+        _clip('clip-1', 10, speed: 2.0),
+        _clip(
+          'clip-2',
+          10,
+          speed: 2.0,
+          trimStart: const Duration(seconds: 2),
+        ),
+      ];
+
+      expect(
+        clipSourcePositionToTimelinePosition(
+          trimClips,
+          clipId: 'clip-2',
+          sourcePosition: const Duration(seconds: 6),
+        ),
+        equals(const Duration(seconds: 7)),
+      );
+    });
+
+    test('returns null when source position is outside trimmed range', () {
+      final trimClips = [
+        _clip('clip-1', 10),
+        _clip('clip-2', 10, trimStart: const Duration(seconds: 2)),
+      ];
+
+      expect(
+        clipSourcePositionToTimelinePosition(
+          trimClips,
+          clipId: 'clip-2',
+          sourcePosition: const Duration(seconds: 1),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for an unknown clip id', () {
+      expect(
+        clipSourcePositionToTimelinePosition(
+          clips,
+          clipId: 'missing',
+          sourcePosition: Duration.zero,
+        ),
+        isNull,
+      );
+    });
   });
 
   group('DivineVideoClip.playbackDuration', () {


### PR DESCRIPTION
Closes #4824

## Description

Fixes clip trim preview positioning by mapping a trim handle's source-time position back into the composite timeline position before updating the editor play time. This keeps timeline overlays keyed to the full composition while the native player temporarily previews a single untrimmed clip.

Adds focused geometry coverage for trimmed second clips, speed-adjusted clips, out-of-range source positions, and missing clip IDs.

**Related Issue:** None

## Out of Scope

None.

## Verification

- `flutter test test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart`
- `flutter analyze lib/widgets/video_editor/main_editor/video_editor_canvas.dart lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore