### PR TITLE
fix(video-editor): preserve split playback position

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -352,7 +352,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           final index = clips.indexWhere((c) => c.id == clip.id);
           if (index == -1) return;
           final newClips = List<DivineVideoClip>.of(clips);
-          newClips[index] = newClips[index].copyWith(video: video);
+          newClips[index] = newClips[index].copyWith(
+            video: video,
+            duration: clip.duration,
+            trimStart: clip.trimStart,
+            trimEnd: clip.trimEnd,
+          );
           emit(state.copyWith(clips: List.unmodifiable(newClips)));
           Log.debug(
             '\u2705 Clip rendered: ${clip.id}',

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -85,13 +85,17 @@ class VideoEditorSplitService {
       trimEnd: Duration.zero,
       processingCompleter: Completer<bool>(),
     );
-    // End clip: no trimStart needed (the split point is the new start),
-    // keeps the original trimEnd.
-    final endClip = sourceClip.copyWith(
+    // End clip preview: while rendering, this still points at the original
+    // source video, so keep source-time trimStart at the split point.
+    final previewEndClip = sourceClip.copyWith(
       id: endClipId,
+      duration: sourceClip.duration,
+      trimStart: absoluteSplitPos,
+      processingCompleter: Completer<bool>(),
+    );
+    final renderedEndClip = previewEndClip.copyWith(
       duration: sourceClip.duration - absoluteSplitPos,
       trimStart: Duration.zero,
-      processingCompleter: Completer<bool>(),
     );
 
     final documentsPath = await getDocumentsPath();
@@ -100,20 +104,20 @@ class VideoEditorSplitService {
 
     Log.debug(
       '📁 Created split clips - Start: ${splitPosition.inSeconds}s, '
-      'End: ${endClip.duration.inSeconds}s',
+      'End: ${previewEndClip.trimmedDuration.inSeconds}s',
       name: 'VideoEditorSplitService',
       category: .video,
     );
 
     // Notify that clips are created (so they can be added to UI before
     // rendering)
-    onClipsCreated?.call(startClip, endClip);
+    onClipsCreated?.call(startClip, previewEndClip);
 
     // Extract thumbnail for the end clip at the absolute split position
     await _extractThumbnailForClip(
       sourceClip,
       absoluteSplitPos,
-      endClip,
+      previewEndClip,
       onThumbnailExtracted,
     );
 
@@ -140,11 +144,11 @@ class VideoEditorSplitService {
         onClipRendered: onClipRendered,
       ),
       _renderSplitClip(
-        clip: endClip,
+        clip: renderedEndClip,
         outputPath: endClipPath,
         sourceVideo: sourceClip.video,
         renderData: VideoRenderData(
-          id: endClip.id,
+          id: renderedEndClip.id,
           videoSegments: [
             VideoSegment(video: sourceClip.video, startTime: absoluteSplitPos),
           ],

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -66,6 +66,21 @@ class VideoEditorCanvas extends StatelessWidget {
     proVideoController.setPlayTime(startPosition);
   }
 
+  @visibleForTesting
+  static bool shouldSyncPlayerForClipStateChange({
+    required ClipEditorState previous,
+    required ClipEditorState current,
+  }) {
+    if (previous.isTrimDragging && !current.isTrimDragging) return true;
+
+    if (previous.isSplitting && current.isSplitting) return false;
+    if (previous.isSplitting && !current.isSplitting) return true;
+
+    return !current.isTrimDragging &&
+        !previous.isTrimDragging &&
+        previous.clips != current.clips;
+  }
+
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -1032,17 +1047,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
         // released or for non-trim clip changes (reorder, add, remove).
         BlocListener<ClipEditorBloc, ClipEditorState>(
           listenWhen: (previous, current) {
-            // Trim handle released.
-            if (previous.isTrimDragging && !current.isTrimDragging) {
-              return true;
-            }
-            // Non-trim clip changes (reorder, add, remove).
-            if (!current.isTrimDragging &&
-                !previous.isTrimDragging &&
-                previous.clips != current.clips) {
-              return true;
-            }
-            return false;
+            return VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
+              previous: previous,
+              current: current,
+            );
           },
           listener: (context, state) async {
             // See note on the trim-times listener above: skip empty

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -42,6 +42,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var firstFrameRendered: Bool = false
     private var videoWidth: Int = 0
     private var videoHeight: Int = 0
+    /// While paused after an exact seek or composition swap, AVPlayer can settle
+    /// one decoded frame behind the requested time during preroll/texture
+    /// refresh. Keep reporting the requested timeline position until playback
+    /// catches up or another seek replaces it, so Dart's timeline does not drift.
+    private var reportedPositionOverrideMs: Int64?
 
     /// Audio overlay manager for synchronized audio tracks.
     private let audioOverlayManager = AudioOverlayManager()
@@ -173,7 +178,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 }
                 self.templateItem = playerItem
 
-                let startPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value ?? 0
+                let requestedStartPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value
+                let startPositionMs = requestedStartPositionMs ?? 0
+                self.reportedPositionOverrideMs = requestedStartPositionMs
                 // Many encoded videos in the feed have 1 black leading
                 // frame at exactly time 0 — produced by the encoder
                 // before the first real I-frame. Landing on that frame
@@ -400,7 +407,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             result(nil)
             return
         }
-        let time = CMTime(value: Int64(positionMs), timescale: 1000)
+        let targetPositionMs = Int64(positionMs)
+        reportedPositionOverrideMs = targetPositionMs
+        let time = CMTime(value: targetPositionMs, timescale: 1000)
         player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
             guard let self else {
                 result(nil)
@@ -464,6 +473,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             result(nil)
             return
         }
+        let targetPositionMs = Int64((clipOffsets[index] * 1000).rounded())
+        reportedPositionOverrideMs = targetPositionMs
         let targetTime = CMTime(seconds: clipOffsets[index], preferredTimescale: 600)
         player?.seek(to: targetTime, toleranceBefore: .zero, toleranceAfter: .zero) {
             [weak self] _ in
@@ -495,6 +506,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         clipCount = 0
         totalDuration = 0
         firstFrameRendered = false
+        reportedPositionOverrideMs = nil
         currentStatus = "idle"
         errorMessage = nil  // clear stale error so sendStateUpdate never emits
                             // status="error" after media has been released.
@@ -760,14 +772,26 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         guard let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())
-        let positionMs = Int(max(currentTime, 0) * 1000)
+        let actualPositionMs = Int(max(currentTime, 0) * 1000)
+        let positionMs: Int
+        if let overrideMs = reportedPositionOverrideMs {
+            if player.rate > 0 && Int64(actualPositionMs) >= overrideMs {
+                reportedPositionOverrideMs = nil
+                positionMs = actualPositionMs
+            } else {
+                positionMs = Int(max(overrideMs, 0))
+            }
+        } else {
+            positionMs = actualPositionMs
+        }
+        let reportedTime = Double(positionMs) / 1000.0
         let durationMs = Int(totalDuration * 1000)
 
         // Determine current clip index.
         var clipIndex = 0
         for i in 0..<clipOffsets.count {
             let clipEnd = clipOffsets[i] + clipDurations[i]
-            if currentTime < clipEnd + 0.01 {
+            if reportedTime < clipEnd + 0.01 {
                 clipIndex = i
                 break
             }

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -42,6 +42,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var firstFrameRendered: Bool = false
     private var videoWidth: Int = 0
     private var videoHeight: Int = 0
+    /// While paused after an exact seek or composition swap, AVPlayer can settle
+    /// one decoded frame behind the requested time during preroll/texture
+    /// refresh. Keep reporting the requested timeline position until playback
+    /// catches up or another seek replaces it, so Dart's timeline does not drift.
+    private var reportedPositionOverrideMs: Int64?
 
     /// Audio overlay manager for synchronized audio tracks.
     private let audioOverlayManager = AudioOverlayManager()
@@ -171,7 +176,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 }
                 self.templateItem = playerItem
 
-                let startPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value ?? 0
+                let requestedStartPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value
+                let startPositionMs = requestedStartPositionMs ?? 0
+                self.reportedPositionOverrideMs = requestedStartPositionMs
                 let startTime = startPositionMs > 0
                     ? CMTime(value: startPositionMs, timescale: 1000)
                     : CMTime.zero
@@ -366,7 +373,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             result(nil)
             return
         }
-        let time = CMTime(value: Int64(positionMs), timescale: 1000)
+        let targetPositionMs = Int64(positionMs)
+        reportedPositionOverrideMs = targetPositionMs
+        let time = CMTime(value: targetPositionMs, timescale: 1000)
         player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
             guard let self else {
                 result(nil)
@@ -425,6 +434,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             result(nil)
             return
         }
+        let targetPositionMs = Int64((clipOffsets[index] * 1000).rounded())
+        reportedPositionOverrideMs = targetPositionMs
         let targetTime = CMTime(seconds: clipOffsets[index], preferredTimescale: 600)
         player?.seek(to: targetTime, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
             guard let self else {
@@ -455,6 +466,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         clipCount = 0
         totalDuration = 0
         firstFrameRendered = false
+        reportedPositionOverrideMs = nil
         currentStatus = "idle"
         errorMessage = nil  // clear stale error so sendStateUpdate never emits
                             // status="error" after media has been released.
@@ -704,13 +716,25 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         guard let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())
-        let positionMs = Int(max(currentTime, 0) * 1000)
+        let actualPositionMs = Int(max(currentTime, 0) * 1000)
+        let positionMs: Int
+        if let overrideMs = reportedPositionOverrideMs {
+            if player.rate > 0 && Int64(actualPositionMs) >= overrideMs {
+                reportedPositionOverrideMs = nil
+                positionMs = actualPositionMs
+            } else {
+                positionMs = Int(max(overrideMs, 0))
+            }
+        } else {
+            positionMs = actualPositionMs
+        }
+        let reportedTime = Double(positionMs) / 1000.0
         let durationMs = Int(totalDuration * 1000)
 
         var clipIndex = 0
         for i in 0..<clipOffsets.count {
             let clipEnd = clipOffsets[i] + clipDurations[i]
-            if currentTime < clipEnd + 0.01 {
+            if reportedTime < clipEnd + 0.01 {
                 clipIndex = i
                 break
             }

--- a/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
@@ -44,6 +44,28 @@ void main() {
               'finished.',
         );
       });
+
+      test(
+        '$platform reports requested paused position during texture refresh',
+        () {
+          final source = _appleSourceFile(platform).readAsStringSync();
+
+          expect(
+            source,
+            contains('reportedPositionOverrideMs'),
+            reason:
+                'Paused AVPlayer texture refresh can settle one decoded frame '
+                'behind the requested seek target; native state updates should '
+                'keep reporting the requested timeline position.',
+          );
+          expect(
+            source,
+            contains('if let overrideMs = reportedPositionOverrideMs'),
+          );
+          expect(source, contains('Int64(actualPositionMs) >= overrideMs'));
+          expect(source, contains('reportedPositionOverrideMs = nil'));
+        },
+      );
     }
   });
 }

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -107,12 +107,43 @@ Future<void> _fakeSplitClip({
     duration: absoluteSplitPos,
     trimEnd: Duration.zero,
   );
-  final endClip = sourceClip.copyWith(
+  final previewEndClip = sourceClip.copyWith(
     id: '${timestampMs}_end',
+    duration: sourceClip.duration,
+    trimStart: absoluteSplitPos,
+  );
+  onClipsCreated?.call(startClip, previewEndClip);
+}
+
+Future<void> _fakeSplitClipThenRenderEnd({
+  required DivineVideoClip sourceClip,
+  required Duration splitPosition,
+  required void Function(DivineVideoClip startClip, DivineVideoClip endClip)?
+  onClipsCreated,
+  required void Function(DivineVideoClip clip, String thumbnailPath)?
+  onThumbnailExtracted,
+  required void Function(DivineVideoClip clip, EditorVideo video)?
+  onClipRendered,
+}) async {
+  final absoluteSplitPos = sourceClip.trimStart + splitPosition;
+  final timestampMs = DateTime.now().microsecondsSinceEpoch;
+  final startClip = sourceClip.copyWith(
+    id: '${timestampMs}_start',
+    duration: absoluteSplitPos,
+    trimEnd: Duration.zero,
+  );
+  final previewEndClip = sourceClip.copyWith(
+    id: '${timestampMs}_end',
+    duration: sourceClip.duration,
+    trimStart: absoluteSplitPos,
+  );
+  final renderedEndClip = previewEndClip.copyWith(
     duration: sourceClip.duration - absoluteSplitPos,
     trimStart: Duration.zero,
   );
-  onClipsCreated?.call(startClip, endClip);
+  onClipsCreated?.call(startClip, previewEndClip);
+  onClipRendered?.call(startClip, startClip.video);
+  onClipRendered?.call(renderedEndClip, renderedEndClip.video);
 }
 
 Future<void> _fakeSplitClipThenFail({
@@ -532,6 +563,11 @@ void main() {
               .having(
                 (s) => s.clips.last.duration,
                 'end duration',
+                const Duration(seconds: 2),
+              )
+              .having(
+                (s) => s.clips.last.trimmedDuration,
+                'end trimmedDuration',
                 const Duration(seconds: 1),
               ),
           isA<ClipEditorState>()
@@ -564,7 +600,7 @@ void main() {
           equals(const Duration(milliseconds: 500)),
         );
         expect(
-          replacedState.clips.last.duration,
+          replacedState.clips.last.trimmedDuration,
           equals(const Duration(milliseconds: 1500)),
         );
 
@@ -625,6 +661,36 @@ void main() {
               .having((s) => s.clips, 'clips', hasLength(2))
               .having((s) => s.isSplitting, 'isSplitting', isFalse),
         ],
+      );
+
+      test(
+        'applies rendered clip timing after split render completes',
+        () async {
+          final clip = _createClip(
+            id: 'x',
+            duration: const Duration(seconds: 2),
+          );
+
+          final bloc = buildBloc(splitClip: _fakeSplitClipThenRenderEnd);
+
+          bloc.emit(
+            ClipEditorState(
+              clips: [clip],
+              isEditing: true,
+              splitPosition: const Duration(milliseconds: 500),
+            ),
+          );
+
+          bloc.add(const ClipEditorSplitRequested());
+          await bloc.stream.firstWhere((state) => !state.isSplitting);
+
+          final endClip = bloc.state.clips.last;
+          expect(endClip.duration, const Duration(milliseconds: 1500));
+          expect(endClip.trimStart, Duration.zero);
+          expect(endClip.trimmedDuration, const Duration(milliseconds: 1500));
+
+          await bloc.close();
+        },
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -23,6 +23,7 @@ class MockPathProviderPlatform extends Fake
 class MockProVideoEditor extends ProVideoEditor {
   bool shouldThrowError = false;
   final List<String> renderedPaths = [];
+  final List<VideoRenderData> renderedData = [];
 
   @override
   Stream<dynamic> initializeStream() {
@@ -39,6 +40,7 @@ class MockProVideoEditor extends ProVideoEditor {
       throw Exception('Render failed');
     }
     renderedPaths.add(outputPath);
+    renderedData.add(renderData);
     // Simulate successful render
     await Future<void>.delayed(const Duration(milliseconds: 10));
     return outputPath;
@@ -57,6 +59,7 @@ void main() {
     mockProVideoEditor = MockProVideoEditor();
     ProVideoEditor.instance = mockProVideoEditor;
     mockProVideoEditor.renderedPaths.clear();
+    mockProVideoEditor.renderedData.clear();
   });
 
   tearDown(() {
@@ -228,7 +231,9 @@ void main() {
         expect(capturedStartClip, isNotNull);
         expect(capturedEndClip, isNotNull);
         expect(capturedStartClip!.duration, const Duration(seconds: 2));
-        expect(capturedEndClip!.duration, const Duration(seconds: 3));
+        expect(capturedEndClip!.duration, const Duration(seconds: 5));
+        expect(capturedEndClip!.trimStart, const Duration(seconds: 2));
+        expect(capturedEndClip!.trimmedDuration, const Duration(seconds: 3));
       });
 
       test('calls onClipsCreated before rendering', () async {
@@ -453,10 +458,11 @@ void main() {
         expect(capturedStartClip!.trimEnd, Duration.zero);
         expect(capturedStartClip!.trimmedDuration, const Duration(seconds: 2));
 
-        // End clip: 5s–10s (absolute), trimStart=0, trimEnd=2s
-        // trimmedDuration = 5 - 2 = 3s ✓
-        expect(capturedEndClip!.duration, const Duration(seconds: 5));
-        expect(capturedEndClip!.trimStart, Duration.zero);
+        // Preview end clip still points at the original source while the
+        // rendered end file is being produced, so trimStart is absolute.
+        // trimmedDuration = 10 - 5 - 2 = 3s ✓
+        expect(capturedEndClip!.duration, const Duration(seconds: 10));
+        expect(capturedEndClip!.trimStart, const Duration(seconds: 5));
         expect(capturedEndClip!.trimEnd, const Duration(seconds: 2));
         expect(capturedEndClip!.trimmedDuration, const Duration(seconds: 3));
 
@@ -465,6 +471,38 @@ void main() {
           capturedStartClip!.trimmedDuration + capturedEndClip!.trimmedDuration,
           clip.trimmedDuration,
         );
+      });
+
+      test('reports rendered end clip with trimStart reset to zero', () async {
+        final clip = DivineVideoClip(
+          id: 'trimmed-clip',
+          video: EditorVideo.file('/test/video.mp4'),
+          duration: const Duration(seconds: 10),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: model.AspectRatio.square,
+          originalAspectRatio: 9 / 16,
+          trimStart: const Duration(seconds: 3),
+          trimEnd: const Duration(seconds: 2),
+        );
+
+        final renderedClips = <DivineVideoClip>[];
+
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: null,
+          onThumbnailExtracted: null,
+          onClipRendered: (clip, video) => renderedClips.add(clip),
+        );
+
+        final endClip = renderedClips.singleWhere(
+          (clip) => clip.id.endsWith('_end'),
+        );
+
+        expect(endClip.duration, const Duration(seconds: 5));
+        expect(endClip.trimStart, Duration.zero);
+        expect(endClip.trimEnd, const Duration(seconds: 2));
+        expect(endClip.trimmedDuration, const Duration(seconds: 3));
       });
     });
   });

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -2,13 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/draw_editor/video_editor_draw_bloc.dart';
 import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' show ProVideoController;
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
 
 void main() {
   testWidgets('VideoEditorCanvas renders safely with no clips', (tester) async {
@@ -115,6 +119,72 @@ void main() {
       },
     );
   });
+
+  group('VideoEditorCanvas.shouldSyncPlayerForClipStateChange', () {
+    test('skips split render intermediate clip updates', () {
+      final source = _createClip(id: 'source');
+      final start = _createClip(id: 'start');
+      final previewEnd = _createClip(id: 'end');
+
+      final previous = ClipEditorState(
+        clips: [source],
+        isSplitting: true,
+      );
+      final current = ClipEditorState(
+        clips: [start, previewEnd],
+        isSplitting: true,
+      );
+
+      expect(
+        VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
+          previous: previous,
+          current: current,
+        ),
+        isFalse,
+      );
+    });
+
+    test('syncs once when split rendering finishes', () {
+      final start = _createClip(id: 'start');
+      final end = _createClip(id: 'end');
+      final clips = [start, end];
+
+      final previous = ClipEditorState(clips: clips, isSplitting: true);
+      final current = ClipEditorState(clips: clips);
+
+      expect(
+        VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
+          previous: previous,
+          current: current,
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps syncing ordinary non-trim clip changes', () {
+      final source = _createClip(id: 'source');
+      final copy = _createClip(id: 'copy');
+
+      expect(
+        VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
+          previous: ClipEditorState(clips: [source]),
+          current: ClipEditorState(clips: [source, copy]),
+        ),
+        isTrue,
+      );
+    });
+  });
+}
+
+DivineVideoClip _createClip({required String id}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/test/$id.mp4'),
+    duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+  );
 }
 
 /// Captures every event added to the bloc so tests can assert


### PR DESCRIPTION
Closes #4826

## Description

Fixes visible playback jumps when splitting clips in the video editor while preserving the already-correct timeline position.

The split preview now keeps the right-hand temporary clip anchored to the original source-time offset until its rendered file is ready. Once rendering completes, the final clip timing is applied from the rendered clip so duration and trim values stay consistent.

The canvas now also defers native player clip synchronization during split intermediate states. That avoids repeatedly rebuilding the native player composition while `isSplitting` is still active, then syncs once when split rendering completes.

**Related Issue:** None

## Out of Scope

None.

## Verification

- `runTests` on `mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart`
- `runTests` on `mobile/test/services/video_editor/video_editor_split_service_test.dart`
- `runTests` on `mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart`
- Diagnostics checked on the touched Dart files

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore