### PR TITLE
fix(video-recorder): countdown timer is not usable in Classic and Upload mode

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -573,7 +573,10 @@ class VideoRecorderBloc
     );
     unawaited(HapticService.recordingFeedback());
 
-    if (state.timerDuration != TimerDuration.off) {
+    final shouldRunCountdown =
+        state.recorderMode.supportsCountdownTimer &&
+        state.timerDuration != TimerDuration.off;
+    if (shouldRunCountdown) {
       final seconds = state.timerDuration.duration.inSeconds;
       Log.info(
         '⏱️  Starting ${seconds}s countdown before recording',
@@ -1003,6 +1006,10 @@ class VideoRecorderBloc
         recorderMode: mode,
         aspectRatio: mode.defaultAspectRatio,
         showGridLines: mode.supportGridLines,
+        timerDuration: mode.supportsCountdownTimer
+            ? state.timerDuration
+            : TimerDuration.off,
+        countdownValue: 0,
       ),
     );
     final prefs = _readSharedPreferences();
@@ -1027,6 +1034,8 @@ class VideoRecorderBloc
     VideoRecorderTimerCycled event,
     Emitter<VideoRecorderBlocState> emit,
   ) {
+    if (!state.recorderMode.supportsCountdownTimer) return;
+
     final newTimer = switch (state.timerDuration) {
       TimerDuration.off => TimerDuration.three,
       TimerDuration.three => TimerDuration.ten,

--- a/mobile/lib/models/video_recorder/video_recorder_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_mode.dart
@@ -41,6 +41,12 @@ enum VideoRecorderMode {
     .upload => false,
   };
 
+  bool get supportsCountdownTimer => switch (this) {
+    .capture => true,
+    .classic => false,
+    .upload => false,
+  };
+
   model.AspectRatio get defaultAspectRatio => switch (this) {
     .capture => .vertical,
     .classic => .square,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -211,6 +211,20 @@ void main() {
           const VideoRecorderBlocState(),
         ],
       );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'does not enable the timer outside capture mode',
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.classic,
+              aspectRatio: model.AspectRatio.square,
+              showGridLines: true,
+            ),
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderTimerCycled()),
+        expect: () => const <VideoRecorderBlocState>[],
+      );
     });
 
     group('VideoRecorderGridLinesToggled', () {
@@ -408,6 +422,63 @@ void main() {
           act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
           expect: () => const <VideoRecorderBlocState>[],
         );
+
+        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+          'starts classic recording immediately when capture timer was set',
+          setUp: () {
+            when(
+              () => cameraService.startRecording(
+                maxDuration: any(named: 'maxDuration'),
+              ),
+            ).thenAnswer((_) async => true);
+          },
+          build: () => buildBloc()
+            ..emit(
+              const VideoRecorderBlocState(
+                recorderMode: VideoRecorderMode.classic,
+                aspectRatio: model.AspectRatio.square,
+                showGridLines: true,
+                timerDuration: TimerDuration.three,
+              ),
+            ),
+          act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+          expect: () => const [
+            VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.classic,
+              aspectRatio: model.AspectRatio.square,
+              showGridLines: true,
+              timerDuration: TimerDuration.three,
+              isStartingRecording: true,
+            ),
+            VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.classic,
+              recordingState: VideoRecorderState.recording,
+              aspectRatio: model.AspectRatio.square,
+              showGridLines: true,
+              timerDuration: TimerDuration.three,
+              isStartingRecording: true,
+            ),
+            VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.classic,
+              recordingState: VideoRecorderState.recording,
+              aspectRatio: model.AspectRatio.square,
+              showGridLines: true,
+              timerDuration: TimerDuration.three,
+            ),
+          ],
+          verify: (_) {
+            verifyNever(
+              () => cameraService.setVolumeKeysEnabled(
+                enabled: any(named: 'enabled'),
+              ),
+            );
+            verify(
+              () => cameraService.startRecording(
+                maxDuration: const Duration(seconds: 6),
+              ),
+            ).called(1);
+          },
+        );
       },
     );
 
@@ -512,7 +583,13 @@ void main() {
     group('VideoRecorderRecorderModeSet', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'capture → classic flips defaults and clears clips + editor',
-        build: buildBloc,
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              timerDuration: TimerDuration.three,
+              countdownValue: 2,
+            ),
+          ),
         act: (bloc) => bloc.add(
           const VideoRecorderRecorderModeSet(VideoRecorderMode.classic),
         ),


### PR DESCRIPTION
Closes #4832

## Description

**Related Issue:** None.

### Bug

When a user activated the countdown timer in **Capture** mode and then switched to **Classic** or **Upload** mode, the timer was silently inherited. Pressing record would then trigger a 3 s / 10 s countdown even though those modes have no countdown UI and no concept of a delayed start.

Three separate code paths were affected:

| Location | Problem |
|---|---|
| `_onRecordingStartRequested` | Checked `timerDuration != off` without also checking `recorderMode.supportsCountdownTimer` |
| `_applyRecorderMode` | Did not reset `timerDuration` or `countdownValue` when switching to a mode that doesn't support the timer |
| `_onTimerCycled` | Did not guard against being called in a non-timer mode |

### Fix

- Added `supportsCountdownTimer` getter to `VideoRecorderMode` (only `capture` → `true`).
- `_onRecordingStartRequested`: countdown path now requires both `timerDuration != off` **and** `recorderMode.supportsCountdownTimer`.
- `_applyRecorderMode`: resets `timerDuration → off` and `countdownValue → 0` when switching to a mode that doesn't support the timer.
- `_onTimerCycled`: early-returns when the current mode doesn't support the timer.

## Out of Scope

None.

## Verification

- `flutter test test/blocs/video_recorder/video_recorder_bloc_test.dart` — 30 tests, all green.
- `dart format` on changed files — no changes needed.
- Static analysis on all three changed files — no errors.

New BLoC tests added:

1. **`does not enable the timer outside capture mode`** — `VideoRecorderTimerCycled` in Classic mode emits nothing.
2. **`starts classic recording immediately when capture timer was set`** — if `timerDuration` is set while in Classic mode, `VideoRecorderRecordingStartRequested` skips the countdown and calls `startRecording` directly.
3. **`capture → classic flips defaults and clears clips + editor`** (updated) — pre-seeds `timerDuration` + `countdownValue` and asserts both are cleared in the emitted state after the mode switch.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
