### PR TITLE
feat(camera): add hold-to-record functionality for video recording

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -660,7 +660,25 @@ class VideoRecorderBloc
       );
       await WakelockPlus.enable();
       clipManager.startRecording();
-      emit(state.copyWith(isStartingRecording: false));
+      if (state.pendingStopAfterStart) {
+        // A stop was requested while the native start was still in-flight
+        // (brief press in hold-to-record mode).  Dispatch a proper stop now
+        // that the camera is actually recording so the clip is finalized.
+        Log.info(
+          '⏹️  Dispatching pending stop after recording start (brief press)',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+        );
+        emit(
+          state.copyWith(
+            isStartingRecording: false,
+            pendingStopAfterStart: false,
+          ),
+        );
+        add(const VideoRecorderRecordingStopRequested());
+      } else {
+        emit(state.copyWith(isStartingRecording: false));
+      }
     } else {
       Log.warning(
         '⚠️ Recording failed to start or was stopped early',
@@ -670,6 +688,7 @@ class VideoRecorderBloc
       emit(
         state.copyWith(
           isStartingRecording: false,
+          pendingStopAfterStart: false,
           recordingState: VideoRecorderState.idle,
         ),
       );
@@ -685,13 +704,19 @@ class VideoRecorderBloc
     }
 
     if (state.isStartingRecording) {
+      // Recording is still starting (isStartingRecording=true).  The native
+      // camera hasn't begun capturing yet, so calling stopRecording() here is
+      // a no-op that races with startRecording() and can leave the BLoC stuck
+      // in the recording state.  Instead, set the pendingStopAfterStart flag
+      // and let _onRecordingStartRequested dispatch a proper stop once the
+      // native start completes.
       Log.info(
-        '⏳ Stop requested during startup - calling native stop '
-        '(startRecording will handle state)',
+        '⏳ Stop requested during startup - flagging pendingStopAfterStart '
+        '(startRecording will dispatch stop after native start)',
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );
-      unawaited(_cameraService.stopRecording());
+      emit(state.copyWith(pendingStopAfterStart: true));
       return;
     }
 

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -30,6 +30,7 @@ class VideoRecorderBlocState extends Equatable {
     this.showGridLines = false,
     this.isStartingRecording = false,
     this.isStoppingRecording = false,
+    this.pendingStopAfterStart = false,
     this.baseZoomLevel = 1.0,
     this.snappedTo1x = false,
     this.lastRawZoom = 1.0,
@@ -99,6 +100,15 @@ class VideoRecorderBlocState extends Equatable {
   /// Moved out of the notifier's private fields per `state_management.md`.
   final bool isStoppingRecording;
 
+  /// True when a stop was requested while [isStartingRecording] was true.
+  ///
+  /// [_onRecordingStartRequested] checks this flag after the native
+  /// [CameraService.startRecording] call completes and, if set, dispatches a
+  /// proper [VideoRecorderRecordingStopRequested] so that a very brief
+  /// press-and-release in hold-to-record mode always produces a short clip
+  /// rather than an indefinite recording (#hold-to-record-brief-press).
+  final bool pendingStopAfterStart;
+
   /// Zoom level captured at the start of the current pinch gesture.
   ///
   /// Used to compute relative zoom from pinch scale. Moved out of the
@@ -152,6 +162,7 @@ class VideoRecorderBlocState extends Equatable {
     bool? showGridLines,
     bool? isStartingRecording,
     bool? isStoppingRecording,
+    bool? pendingStopAfterStart,
     double? baseZoomLevel,
     bool? snappedTo1x,
     double? lastRawZoom,
@@ -179,6 +190,8 @@ class VideoRecorderBlocState extends Equatable {
       showGridLines: showGridLines ?? this.showGridLines,
       isStartingRecording: isStartingRecording ?? this.isStartingRecording,
       isStoppingRecording: isStoppingRecording ?? this.isStoppingRecording,
+      pendingStopAfterStart:
+          pendingStopAfterStart ?? this.pendingStopAfterStart,
       baseZoomLevel: baseZoomLevel ?? this.baseZoomLevel,
       snappedTo1x: snappedTo1x ?? this.snappedTo1x,
       lastRawZoom: lastRawZoom ?? this.lastRawZoom,
@@ -207,6 +220,7 @@ class VideoRecorderBlocState extends Equatable {
     showGridLines,
     isStartingRecording,
     isStoppingRecording,
+    pendingStopAfterStart,
     baseZoomLevel,
     snappedTo1x,
     lastRawZoom,

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -93,6 +93,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "ካሬ እና ቁመታዊ",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "የDivine ቪዲዮዎችን ሙሉ ድብልቅ አሳይ",
     "generalSettingsVideoShapeSquareOnlySubtitle": "ምግቦችን በክላሲክ ካሬ ቅርጽ ያቆዩ",
+    "generalSettingsHoldToRecord": "ለቀረጻ ይያዙ",
+    "generalSettingsHoldToRecordSubtitle": "ሲይዙ ቀረጻ ይጀምራል፣ ሲለቁ ይቆማል",
     "contentPreferencesTitle": "የይዘት ምርጫዎች",
     "@contentPreferencesTitle": {
         "description": "Content preferences screen app bar title"

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3129,6 +3129,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "مربّع وعمودي",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "اعرض المزيج الكامل لفيديوهات Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "أبقِ التغذيات بالشكل المربّع الكلاسيكي",
+    "generalSettingsHoldToRecord": "اضغط مطولاً للتسجيل",
+    "generalSettingsHoldToRecordSubtitle": "يبدأ التسجيل عند الضغط المطوّل ويتوقف عند الإفراج",
     "contentFiltersAdultContent": "محتوى للبالغين",
     "contentFiltersViolenceGore": "العنف والدماء",
     "contentFiltersSubstances": "المواد",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3297,6 +3297,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Квадратни и портретни",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Покажи целия микс от Divine видеа",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Запази емисиите в класическия квадратен формат",
+    "generalSettingsHoldToRecord": "Задръжте за запис",
+    "generalSettingsHoldToRecordSubtitle": "Записът започва при задържане и спира при отпускане",
     "contentFiltersAdultContent": "СЪДЪРЖАНИЕ ЗА ВЪЗРАСТНИ",
     "contentFiltersViolenceGore": "НАСИЛИЕ И КРЪВ",
     "contentFiltersSubstances": "ВЕЩЕСТВА",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Quadratisch und Hochformat",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Zeig den ganzen Mix der Divine-Videos",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Halt deinen Feed im klassischen Quadratformat",
+    "generalSettingsHoldToRecord": "Gedrückt halten zum Aufnehmen",
+    "generalSettingsHoldToRecordSubtitle": "Die Aufnahme beginnt, wenn du gedrückt hältst, und stoppt, wenn du loslässt",
     "contentFiltersAdultContent": "INHALTE FÜR ERWACHSENE",
     "contentFiltersViolenceGore": "GEWALT & BLUT",
     "contentFiltersSubstances": "SUBSTANZEN",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -93,6 +93,8 @@
   "generalSettingsVideoShapeSquareAndPortrait": "Square and portrait",
   "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Show the full mix of Divine videos",
   "generalSettingsVideoShapeSquareOnlySubtitle": "Keep feeds in the classic square format",
+  "generalSettingsHoldToRecord": "Hold to record",
+  "generalSettingsHoldToRecordSubtitle": "Start recording when you press and hold, then stop when you release",
   "contentPreferencesTitle": "Content Preferences",
   "@contentPreferencesTitle": {
     "description": "Content preferences screen app bar title"

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3144,6 +3144,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Cuadrado y vertical",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Mostrá toda la mezcla de videos de Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Mantené los feeds en el formato cuadrado clásico",
+    "generalSettingsHoldToRecord": "Mantener para grabar",
+    "generalSettingsHoldToRecordSubtitle": "La grabación empieza al mantener pulsado y se detiene al soltar",
     "contentFiltersAdultContent": "CONTENIDO ADULTO",
     "contentFiltersViolenceGore": "VIOLENCIA Y GORE",
     "contentFiltersSubstances": "SUSTANCIAS",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2097,6 +2097,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Square at portrait",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Ipakita ang full mix ng Divine videos",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Panatilihin ang feeds sa classic na square format",
+    "generalSettingsHoldToRecord": "Pindutin nang matagal para mag-record",
+    "generalSettingsHoldToRecordSubtitle": "Magsisimulang mag-record kapag pinindot nang matagal at titigil kapag inalis",
     "settingsBadgesTitle": "Mga Badge",
     "settingsBadgesSubtitle": "Tanggapin ang mga award at tingnan ang status ng issued badge.",
     "badgesTitle": "Mga Badge",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Carré et portrait",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Affiche tout le mix des vidéos Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Garde les fils dans le format carré classique",
+    "generalSettingsHoldToRecord": "Appuyer pour enregistrer",
+    "generalSettingsHoldToRecordSubtitle": "L'enregistrement démarre en maintenant appuyé et s'arrête en relâchant",
     "contentFiltersAdultContent": "CONTENU POUR ADULTES",
     "contentFiltersViolenceGore": "VIOLENCE ET HORREUR",
     "contentFiltersSubstances": "SUBSTANCES",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Persegi dan potret",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Tampilkan semua jenis video Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Pertahankan feed dalam format persegi klasik",
+    "generalSettingsHoldToRecord": "Tahan untuk merekam",
+    "generalSettingsHoldToRecordSubtitle": "Rekaman dimulai saat menahan dan berhenti saat dilepas",
     "contentFiltersAdultContent": "KONTEN DEWASA",
     "contentFiltersViolenceGore": "KEKERASAN & SADIS",
     "contentFiltersSubstances": "ZAT TERLARANG",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Quadrati e verticali",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Mostra tutto il mix di video Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Mantieni i feed nel classico formato quadrato",
+    "generalSettingsHoldToRecord": "Tieni premuto per registrare",
+    "generalSettingsHoldToRecordSubtitle": "La registrazione inizia tenendo premuto e si ferma al rilascio",
     "contentFiltersAdultContent": "CONTENUTI PER ADULTI",
     "contentFiltersViolenceGore": "VIOLENZA E SCENE CRUENTE",
     "contentFiltersSubstances": "SOSTANZE",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3129,6 +3129,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "正方形と縦型",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Divine の動画をフルミックスで表示",
     "generalSettingsVideoShapeSquareOnlySubtitle": "クラシックな正方形フォーマットでフィードを保つ",
+    "generalSettingsHoldToRecord": "長押しで録画",
+    "generalSettingsHoldToRecordSubtitle": "長押しすると録画が始まり、離すと止まります",
     "contentFiltersAdultContent": "アダルトコンテンツ",
     "contentFiltersViolenceGore": "暴力とグロテスク",
     "contentFiltersSubstances": "薬物",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2425,6 +2425,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "정사각형 및 세로형",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Divine 영상의 모든 종류를 보여줘요",
     "generalSettingsVideoShapeSquareOnlySubtitle": "피드를 클래식한 정사각형으로 유지해요",
+    "generalSettingsHoldToRecord": "길게 눌러서 녹화",
+    "generalSettingsHoldToRecordSubtitle": "길게 누르면 녹화가 시작되고, 놓으면 멈춰요",
     "contentFiltersAdultContent": "성인 콘텐츠",
     "contentFiltersViolenceGore": "폭력 및 잔혹 묘사",
     "contentFiltersSubstances": "약물",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Vierkant en portret",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Toon de volledige mix van Divine-video's",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Hou feeds in het klassieke vierkante formaat",
+    "generalSettingsHoldToRecord": "Ingedrukt houden om op te nemen",
+    "generalSettingsHoldToRecordSubtitle": "Opname start wanneer je ingedrukt houdt en stopt wanneer je loslaat",
     "contentFiltersAdultContent": "INHOUD VOOR VOLWASSENEN",
     "contentFiltersViolenceGore": "GEWELD & BLOED",
     "contentFiltersSubstances": "MIDDELEN",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Kwadratowe i pionowe",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Pokazuj pełny miks filmów Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Trzymaj feedy w klasycznym kwadratowym formacie",
+    "generalSettingsHoldToRecord": "Przytrzymaj, aby nagrywać",
+    "generalSettingsHoldToRecordSubtitle": "Nagrywanie rozpoczyna się po przytrzymaniu i zatrzymuje się po zwolnieniu",
     "contentFiltersAdultContent": "TREŚCI DLA DOROSŁYCH",
     "contentFiltersViolenceGore": "PRZEMOC I DRASTYCZNE SCENY",
     "contentFiltersSubstances": "SUBSTANCJE",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Quadrado e retrato",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Mostrar a mistura completa de vídeos do Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Mantenha os feeds no formato quadrado clássico",
+    "generalSettingsHoldToRecord": "Segurar para gravar",
+    "generalSettingsHoldToRecordSubtitle": "A gravação começa ao manter pressionado e para ao soltar",
     "contentFiltersAdultContent": "CONTEÚDO ADULTO",
     "contentFiltersViolenceGore": "VIOLÊNCIA E SANGUE",
     "contentFiltersSubstances": "SUBSTÂNCIAS",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Pătrate și portret",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Arată tot amestecul de videoclipuri Divine",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Păstrează feedurile în formatul clasic pătrat",
+    "generalSettingsHoldToRecord": "Ține apăsat pentru a înregistra",
+    "generalSettingsHoldToRecordSubtitle": "Înregistrarea începe când ții apăsat și se oprește când eliberezi",
     "contentFiltersAdultContent": "CONȚINUT PENTRU ADULȚI",
     "contentFiltersViolenceGore": "VIOLENȚĂ ȘI SÂNGE",
     "contentFiltersSubstances": "SUBSTANȚE",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Kvadrat och stående",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Visa hela mixen av Divine-videor",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Behåll flöden i klassiskt kvadratiskt format",
+    "generalSettingsHoldToRecord": "Håll inne för att spela in",
+    "generalSettingsHoldToRecordSubtitle": "Inspelning startar när du håller inne och stannar när du släpper",
     "contentFiltersAdultContent": "VUXENINNEHÅLL",
     "contentFiltersViolenceGore": "VÅLD OCH BLOD",
     "contentFiltersSubstances": "SUBSTANSER",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3136,6 +3136,8 @@
     "generalSettingsVideoShapeSquareAndPortrait": "Kare ve dikey",
     "generalSettingsVideoShapeSquareAndPortraitSubtitle": "Divine videolarının tam karışımını göster",
     "generalSettingsVideoShapeSquareOnlySubtitle": "Akışları klasik kare formatta tut",
+    "generalSettingsHoldToRecord": "Kayıt için basılı tut",
+    "generalSettingsHoldToRecordSubtitle": "Basılı tuttuğunuzda kayıt başlar, bıraktığınızda durur",
     "contentFiltersAdultContent": "YETİŞKİN İÇERİĞİ",
     "contentFiltersViolenceGore": "ŞİDDET VE KAN",
     "contentFiltersSubstances": "MADDELER",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -436,6 +436,18 @@ abstract class AppLocalizations {
   /// **'Keep feeds in the classic square format'**
   String get generalSettingsVideoShapeSquareOnlySubtitle;
 
+  /// No description provided for @generalSettingsHoldToRecord.
+  ///
+  /// In en, this message translates to:
+  /// **'Hold to record'**
+  String get generalSettingsHoldToRecord;
+
+  /// No description provided for @generalSettingsHoldToRecordSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Start recording when you press and hold, then stop when you release'**
+  String get generalSettingsHoldToRecordSubtitle;
+
   /// Content preferences screen app bar title
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -193,6 +193,12 @@ class AppLocalizationsAm extends AppLocalizations {
       'ምግቦችን በክላሲክ ካሬ ቅርጽ ያቆዩ';
 
   @override
+  String get generalSettingsHoldToRecord => 'ለቀረጻ ይያዙ';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle => 'ሲይዙ ቀረጻ ይጀምራል፣ ሲለቁ ይቆማል';
+
+  @override
   String get contentPreferencesTitle => 'የይዘት ምርጫዎች';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -188,6 +188,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'أبقِ التغذيات بالشكل المربّع الكلاسيكي';
 
   @override
+  String get generalSettingsHoldToRecord => 'اضغط مطولاً للتسجيل';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'يبدأ التسجيل عند الضغط المطوّل ويتوقف عند الإفراج';
+
+  @override
   String get contentPreferencesTitle => 'تفضيلات المحتوى';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -201,6 +201,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Запази емисиите в класическия квадратен формат';
 
   @override
+  String get generalSettingsHoldToRecord => 'Задръжте за запис';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Записът започва при задържане и спира при отпускане';
+
+  @override
   String get contentPreferencesTitle => 'Предпочитания за съдържание';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -199,6 +199,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Halt deinen Feed im klassischen Quadratformat';
 
   @override
+  String get generalSettingsHoldToRecord => 'Gedrückt halten zum Aufnehmen';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Die Aufnahme beginnt, wenn du gedrückt hältst, und stoppt, wenn du loslässt';
+
+  @override
   String get contentPreferencesTitle => 'Inhaltseinstellungen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -199,6 +199,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Keep feeds in the classic square format';
 
   @override
+  String get generalSettingsHoldToRecord => 'Hold to record';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Start recording when you press and hold, then stop when you release';
+
+  @override
   String get contentPreferencesTitle => 'Content Preferences';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -200,6 +200,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mantené los feeds en el formato cuadrado clásico';
 
   @override
+  String get generalSettingsHoldToRecord => 'Mantener para grabar';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'La grabación empieza al mantener pulsado y se detiene al soltar';
+
+  @override
   String get contentPreferencesTitle => 'Preferencias de contenido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -199,6 +199,14 @@ class AppLocalizationsFil extends AppLocalizations {
       'Panatilihin ang feeds sa classic na square format';
 
   @override
+  String get generalSettingsHoldToRecord =>
+      'Pindutin nang matagal para mag-record';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Magsisimulang mag-record kapag pinindot nang matagal at titigil kapag inalis';
+
+  @override
   String get contentPreferencesTitle => 'Mga Content Preference';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -205,6 +205,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Garde les fils dans le format carré classique';
 
   @override
+  String get generalSettingsHoldToRecord => 'Appuyer pour enregistrer';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'L\'enregistrement démarre en maintenant appuyé et s\'arrête en relâchant';
+
+  @override
   String get contentPreferencesTitle => 'Préférences de contenu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -180,6 +180,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Pertahankan feed dalam format persegi klasik';
 
   @override
+  String get generalSettingsHoldToRecord => 'Tahan untuk merekam';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Rekaman dimulai saat menahan dan berhenti saat dilepas';
+
+  @override
   String get contentPreferencesTitle => 'Preferensi Konten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -200,6 +200,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mantieni i feed nel classico formato quadrato';
 
   @override
+  String get generalSettingsHoldToRecord => 'Tieni premuto per registrare';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'La registrazione inizia tenendo premuto e si ferma al rilascio';
+
+  @override
   String get contentPreferencesTitle => 'Preferenze contenuti';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -172,6 +172,12 @@ class AppLocalizationsJa extends AppLocalizations {
       'クラシックな正方形フォーマットでフィードを保つ';
 
   @override
+  String get generalSettingsHoldToRecord => '長押しで録画';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle => '長押しすると録画が始まり、離すと止まります';
+
+  @override
   String get contentPreferencesTitle => 'コンテンツ設定';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -173,6 +173,12 @@ class AppLocalizationsKo extends AppLocalizations {
       '피드를 클래식한 정사각형으로 유지해요';
 
   @override
+  String get generalSettingsHoldToRecord => '길게 눌러서 녹화';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle => '길게 누르면 녹화가 시작되고, 놓으면 멈춰요';
+
+  @override
   String get contentPreferencesTitle => '콘텐츠 환경설정';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -199,6 +199,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Hou feeds in het klassieke vierkante formaat';
 
   @override
+  String get generalSettingsHoldToRecord => 'Ingedrukt houden om op te nemen';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Opname start wanneer je ingedrukt houdt en stopt wanneer je loslaat';
+
+  @override
   String get contentPreferencesTitle => 'Inhoudsvoorkeuren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -201,6 +201,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Trzymaj feedy w klasycznym kwadratowym formacie';
 
   @override
+  String get generalSettingsHoldToRecord => 'Przytrzymaj, aby nagrywać';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Nagrywanie rozpoczyna się po przytrzymaniu i zatrzymuje się po zwolnieniu';
+
+  @override
   String get contentPreferencesTitle => 'Preferencje treści';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -199,6 +199,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mantenha os feeds no formato quadrado clássico';
 
   @override
+  String get generalSettingsHoldToRecord => 'Segurar para gravar';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'A gravação começa ao manter pressionado e para ao soltar';
+
+  @override
   String get contentPreferencesTitle => 'Preferências de conteúdo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -212,6 +212,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Păstrează feedurile în formatul clasic pătrat';
 
   @override
+  String get generalSettingsHoldToRecord => 'Ține apăsat pentru a înregistra';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Înregistrarea începe când ții apăsat și se oprește când eliberezi';
+
+  @override
   String get contentPreferencesTitle => 'Preferințe de conținut';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -187,6 +187,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Behåll flöden i klassiskt kvadratiskt format';
 
   @override
+  String get generalSettingsHoldToRecord => 'Håll inne för att spela in';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Inspelning startar när du håller inne och stannar när du släpper';
+
+  @override
   String get contentPreferencesTitle => 'Innehållsinställningar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -180,6 +180,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Akışları klasik kare formatta tut';
 
   @override
+  String get generalSettingsHoldToRecord => 'Kayıt için basılı tut';
+
+  @override
+  String get generalSettingsHoldToRecordSubtitle =>
+      'Basılı tuttuğunuzda kayıt başlar, bıraktığınızda durur';
+
+  @override
   String get contentPreferencesTitle => 'İçerik Tercihleri';
 
   @override

--- a/mobile/lib/providers/preferences_providers.dart
+++ b/mobile/lib/providers/preferences_providers.dart
@@ -6,6 +6,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/audio_device_preference_service.dart';
 import 'package:openvine/services/audio_sharing_preference_service.dart';
 import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:openvine/services/hold_to_record_preference_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -24,6 +25,12 @@ AudioSharingPreferenceService audioSharingPreferenceService(Ref ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
   return AudioSharingPreferenceService(prefs);
 }
+
+final holdToRecordPreferenceServiceProvider =
+    Provider<HoldToRecordPreferenceService>((ref) {
+      final prefs = ref.watch(sharedPreferencesProvider);
+      return HoldToRecordPreferenceService(prefs);
+    });
 
 /// Audio device preference service for managing the preferred input device
 /// for recording on macOS. keepAlive ensures preference persists.

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -71,6 +71,7 @@ class GeneralSettingsScreen extends ConsumerWidget {
               const _FeedAspectRatioPreferenceTile(),
               _SectionHeader(context.l10n.generalSettingsSectionCreating),
               const _AudioSharingToggle(),
+              const _LongPressRecordingToggle(),
               _SectionHeader(context.l10n.generalSettingsSectionApp),
               const _AppLanguageTile(),
             ],
@@ -270,6 +271,37 @@ class _AudioSharingToggleState extends ConsumerState<_AudioSharingToggle> {
       ),
       activeThumbColor: VineTheme.vineGreen,
       secondary: const Icon(Icons.music_note, color: VineTheme.vineGreen),
+    );
+  }
+}
+
+class _LongPressRecordingToggle extends ConsumerWidget {
+  const _LongPressRecordingToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final service = ref.watch(holdToRecordPreferenceServiceProvider);
+    final isEnabled = service.isHoldToRecordEnabled;
+
+    return SwitchListTile(
+      value: isEnabled,
+      onChanged: (value) async {
+        await service.setHoldToRecordEnabled(value);
+        ref.invalidate(holdToRecordPreferenceServiceProvider);
+      },
+      title: Text(
+        context.l10n.generalSettingsHoldToRecord,
+        style: _titleStyle,
+      ),
+      subtitle: Text(
+        context.l10n.generalSettingsHoldToRecordSubtitle,
+        style: _subtitleStyle,
+      ),
+      activeThumbColor: VineTheme.vineGreen,
+      secondary: const DivineIcon(
+        icon: DivineIconName.cameraRetro,
+        color: VineTheme.vineGreen,
+      ),
     );
   }
 }

--- a/mobile/lib/services/hold_to_record_preference_service.dart
+++ b/mobile/lib/services/hold_to_record_preference_service.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Persists whether pressing the record button starts recording.
+// ABOUTME: Controls the optional hold-to-record camera gesture.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Service for managing the hold-to-record camera gesture preference.
+class HoldToRecordPreferenceService {
+  HoldToRecordPreferenceService(this._prefs)
+    : _isHoldToRecordEnabled = _prefs.getBool(prefsKey) ?? false;
+
+  /// SharedPreferences key for the hold-to-record preference.
+  static const String prefsKey = 'hold_to_record_enabled';
+
+  final SharedPreferences _prefs;
+  bool _isHoldToRecordEnabled;
+
+  /// Whether pressing the record button records until release.
+  bool get isHoldToRecordEnabled => _isHoldToRecordEnabled;
+
+  /// Sets whether pressing the record button records until release.
+  Future<void> setHoldToRecordEnabled(bool enabled) async {
+    await _prefs.setBool(prefsKey, enabled);
+    _isHoldToRecordEnabled = enabled;
+  }
+}

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart';
@@ -36,6 +37,12 @@ class VideoRecorderClassicStack extends ConsumerWidget {
             (hasRemainingDuration || !state.recorderMode.hasRecordingLimit)) ||
         state.isRecording;
 
+    final startsRecordingOnPressDown = ref.watch(
+      holdToRecordPreferenceServiceProvider.select(
+        (service) => service.isHoldToRecordEnabled,
+      ),
+    );
+
     return SafeArea(
       bottom: false,
       child: Column(
@@ -64,6 +71,7 @@ class VideoRecorderClassicStack extends ConsumerWidget {
                         isEnabled: isEnabled,
                         isRecording: state.isRecording,
                         behavior: .opaque,
+                        startsRecordingOnPressDown: startsRecordingOnPressDown,
                         onTapToggle: () => context
                             .read<VideoRecorderBloc>()
                             .add(const VideoRecorderRecordingToggleRequested()),

--- a/mobile/lib/widgets/video_recorder/shutter_gesture_detector.dart
+++ b/mobile/lib/widgets/video_recorder/shutter_gesture_detector.dart
@@ -21,6 +21,7 @@ class ShutterGestureDetector extends StatefulWidget {
     required this.onLongPressStopRecording,
     super.key,
     this.isLongPressSupported = true,
+    this.startsRecordingOnPressDown = false,
     this.onLongPressMoveUpdate,
     this.behavior,
   });
@@ -29,6 +30,7 @@ class ShutterGestureDetector extends StatefulWidget {
   final bool isEnabled;
   final bool isRecording;
   final bool isLongPressSupported;
+  final bool startsRecordingOnPressDown;
   final VoidCallback onTapToggle;
   final VoidCallback onLongPressStartRecording;
   final VoidCallback onLongPressStopRecording;
@@ -41,10 +43,24 @@ class ShutterGestureDetector extends StatefulWidget {
 
 class _ShutterGestureDetectorState extends State<ShutterGestureDetector> {
   bool _startedByLongPress = false;
+  bool _startedByPressDown = false;
 
   void _handleTap() {
     _startedByLongPress = false;
+    _startedByPressDown = false;
     widget.onTapToggle();
+  }
+
+  void _handleTapDown(TapDownDetails _) {
+    if (widget.isRecording) return;
+    _startedByPressDown = true;
+    widget.onLongPressStartRecording();
+  }
+
+  void _handlePressEnd() {
+    if (!_startedByPressDown) return;
+    _startedByPressDown = false;
+    widget.onLongPressStopRecording();
   }
 
   void _handleLongPressStart(LongPressStartDetails _) {
@@ -61,16 +77,33 @@ class _ShutterGestureDetectorState extends State<ShutterGestureDetector> {
 
   @override
   Widget build(BuildContext context) {
+    final usePressDownRecording =
+        widget.isEnabled && widget.startsRecordingOnPressDown;
+
     return GestureDetector(
       behavior: widget.behavior,
-      onTap: widget.isEnabled ? _handleTap : null,
-      onLongPressStart: widget.isEnabled && widget.isLongPressSupported
+      onTapDown: usePressDownRecording ? _handleTapDown : null,
+      onTapUp: usePressDownRecording ? (_) => _handlePressEnd() : null,
+      onTapCancel: usePressDownRecording ? _handlePressEnd : null,
+      onTap: widget.isEnabled && !widget.startsRecordingOnPressDown
+          ? _handleTap
+          : null,
+      onLongPressStart:
+          widget.isEnabled &&
+              widget.isLongPressSupported &&
+              !widget.startsRecordingOnPressDown
           ? _handleLongPressStart
           : null,
-      onLongPressMoveUpdate: widget.isRecording && widget.isLongPressSupported
+      onLongPressMoveUpdate:
+          widget.isRecording &&
+              widget.isLongPressSupported &&
+              !widget.startsRecordingOnPressDown
           ? widget.onLongPressMoveUpdate
           : null,
-      onLongPressUp: widget.isLongPressSupported ? _handleLongPressUp : null,
+      onLongPressUp:
+          widget.isLongPressSupported && !widget.startsRecordingOnPressDown
+          ? _handleLongPressUp
+          : null,
       child: widget.child,
     );
   }

--- a/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/widgets/video_recorder/shutter_gesture_detector.dart';
 
 /// Circular record button for starting/stopping video recording.
@@ -28,8 +29,15 @@ class RecordButton extends ConsumerWidget {
         (p) => p.remainingDuration > const Duration(milliseconds: 30),
       ),
     );
+    final startsRecordingOnPressDown = ref.watch(
+      holdToRecordPreferenceServiceProvider.select(
+        (service) => service.isHoldToRecordEnabled,
+      ),
+    );
 
     final isLongPressSupported = state.timerDuration == .off;
+    final canStartRecordingOnPressDown =
+        isLongPressSupported && startsRecordingOnPressDown;
     final isEnabled =
         (state.canRecord &&
             state.isCameraInitialized &&
@@ -47,6 +55,7 @@ class RecordButton extends ConsumerWidget {
         isEnabled: isEnabled,
         isRecording: state.isRecording,
         isLongPressSupported: isLongPressSupported,
+        startsRecordingOnPressDown: canStartRecordingOnPressDown,
         onTapToggle: () => context.read<VideoRecorderBloc>().add(
           const VideoRecorderRecordingToggleRequested(),
         ),

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -413,21 +413,23 @@ void main() {
 
     group('RecordingStopRequested → start-cancel fast path', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-        'when called during startRecording, fires native stop and returns '
-        'without touching state',
-        setUp: () {
-          when(
-            () => cameraService.stopRecording(),
-          ).thenAnswer((_) async => null);
-        },
+        'when called during startRecording, sets pendingStopAfterStart '
+        'without touching the camera service',
         build: () => buildBloc()
           ..emit(
             const VideoRecorderBlocState(isStartingRecording: true),
           ),
         act: (bloc) => bloc.add(const VideoRecorderRecordingStopRequested()),
-        expect: () => const <VideoRecorderBlocState>[],
+        expect: () => const [
+          VideoRecorderBlocState(
+            isStartingRecording: true,
+            pendingStopAfterStart: true,
+          ),
+        ],
         verify: (_) {
-          verify(() => cameraService.stopRecording()).called(1);
+          // No native stop is fired — the start handler will dispatch a
+          // proper stop after startRecording() completes.
+          verifyNever(() => cameraService.stopRecording());
         },
       );
 

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -283,6 +283,13 @@ void main() {
       scrollable: find.byType(Scrollable),
     );
     expect(find.text('Make my audio available for reuse'), findsOneWidget);
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    await tester.scrollUntilVisible(
+      find.text(l10n.generalSettingsHoldToRecord),
+      120,
+      scrollable: find.byType(Scrollable),
+    );
+    expect(find.text(l10n.generalSettingsHoldToRecord), findsOneWidget);
 
     final captionsToggle = find.byWidgetPredicate(
       (widget) =>

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -51,6 +51,7 @@ class MockCameraPermissionBloc extends Mock implements CameraPermissionBloc {
 }
 
 late VideoRecorderBloc recorderBloc;
+late SharedPreferences testPrefs;
 
 /// Helper to build VideoRecorderView with required providers and the mock bloc.
 Widget buildTestWidget({List<Override> overrides = const []}) {
@@ -62,6 +63,7 @@ Widget buildTestWidget({List<Override> overrides = const []}) {
   when(mockClipLibrary.getAllClips).thenAnswer((_) async => []);
   return ProviderScope(
     overrides: [
+      sharedPreferencesProvider.overrideWithValue(testPrefs),
       draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
       clipLibraryServiceProvider.overrideWithValue(mockClipLibrary),
       ...overrides,
@@ -110,9 +112,9 @@ void main() {
       );
 
       SharedPreferences.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
+      testPrefs = await SharedPreferences.getInstance();
       container = ProviderContainer(
-        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        overrides: [sharedPreferencesProvider.overrideWithValue(testPrefs)],
       );
     });
 

--- a/mobile/test/services/hold_to_record_preference_service_test.dart
+++ b/mobile/test/services/hold_to_record_preference_service_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/hold_to_record_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(HoldToRecordPreferenceService, () {
+    late SharedPreferences prefs;
+    late HoldToRecordPreferenceService service;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      service = HoldToRecordPreferenceService(prefs);
+    });
+
+    test('defaults to disabled', () {
+      expect(service.isHoldToRecordEnabled, isFalse);
+    });
+
+    test('persists enabled preference', () async {
+      await service.setHoldToRecordEnabled(true);
+
+      final reloaded = HoldToRecordPreferenceService(prefs);
+
+      expect(reloaded.isHoldToRecordEnabled, isTrue);
+    });
+
+    test('persists disabled preference', () async {
+      await service.setHoldToRecordEnabled(true);
+      await service.setHoldToRecordEnabled(false);
+
+      final reloaded = HoldToRecordPreferenceService(prefs);
+
+      expect(reloaded.isHoldToRecordEnabled, isFalse);
+    });
+
+    test('uses stable preference key', () {
+      expect(HoldToRecordPreferenceService.prefsKey, 'hold_to_record_enabled');
+    });
+  });
+}

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
@@ -10,11 +10,13 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart';
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockVideoRecorderBloc
     extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
@@ -25,8 +27,11 @@ void main() {
 
   group(VideoRecorderCaptureStack, () {
     late _MockVideoRecorderBloc recorderBloc;
+    late SharedPreferences testPrefs;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      testPrefs = await SharedPreferences.getInstance();
       recorderBloc = _MockVideoRecorderBloc();
       when(() => recorderBloc.state).thenReturn(
         const VideoRecorderBlocState(
@@ -50,6 +55,7 @@ void main() {
 
       return ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(testPrefs),
           clipManagerProvider.overrideWith(
             () => _TestClipManagerNotifier(clips: clips ?? []),
           ),

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
@@ -10,11 +10,13 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart';
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockVideoRecorderBloc
     extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
@@ -29,8 +31,11 @@ void main() {
 
   group(VideoRecorderClassicStack, () {
     late _MockVideoRecorderBloc recorderBloc;
+    late SharedPreferences testPrefs;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      testPrefs = await SharedPreferences.getInstance();
       recorderBloc = _MockVideoRecorderBloc();
       when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
     });
@@ -49,6 +54,7 @@ void main() {
 
       return ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(testPrefs),
           clipManagerProvider.overrideWith(
             () => _TestClipManagerNotifier(clips: clips ?? []),
           ),

--- a/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
+++ b/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
@@ -12,6 +12,7 @@ void main() {
       bool isRecording = false,
       bool isEnabled = true,
       bool isLongPressSupported = true,
+      bool startsRecordingOnPressDown = false,
     }) async {
       await tester.pumpWidget(
         Directionality(
@@ -21,6 +22,7 @@ void main() {
               isEnabled: isEnabled,
               isRecording: isRecording,
               isLongPressSupported: isLongPressSupported,
+              startsRecordingOnPressDown: startsRecordingOnPressDown,
               behavior: HitTestBehavior.opaque,
               onTapToggle: onTapToggle,
               onLongPressStartRecording: onLongPressStartRecording,
@@ -100,6 +102,38 @@ void main() {
       expect(started, equals(1));
       expect(stopped, equals(1));
     });
+
+    testWidgets(
+      'press-down mode starts immediately and release stops recording',
+      (tester) async {
+        var toggled = 0;
+        var started = 0;
+        var stopped = 0;
+        await pumpHost(
+          tester,
+          startsRecordingOnPressDown: true,
+          onTapToggle: () => toggled++,
+          onLongPressStartRecording: () => started++,
+          onLongPressStopRecording: () => stopped++,
+        );
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(ShutterGestureDetector)),
+        );
+        await tester.pump();
+
+        expect(started, equals(1));
+        expect(stopped, equals(0));
+        expect(toggled, equals(0));
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(started, equals(1));
+        expect(stopped, equals(1));
+        expect(toggled, equals(0));
+      },
+    );
 
     testWidgets('release stops only once after a long-press start', (
       tester,

--- a/mobile/test/widgets/video_recorder/video_recorder_record_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_record_button_test.dart
@@ -10,7 +10,9 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockVideoRecorderBloc
     extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
@@ -21,8 +23,11 @@ void main() {
 
   group(RecordButton, () {
     late _MockVideoRecorderBloc recorderBloc;
+    late SharedPreferences sharedPreferences;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sharedPreferences = await SharedPreferences.getInstance();
       recorderBloc = _MockVideoRecorderBloc();
       when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
     });
@@ -43,6 +48,7 @@ void main() {
 
       return ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
           clipManagerProvider.overrideWith(
             () => _TestClipManagerNotifier(clips: clips ?? []),
           ),
@@ -194,6 +200,9 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                sharedPreferencesProvider.overrideWithValue(
+                  sharedPreferences,
+                ),
                 clipManagerProvider.overrideWith(
                   () => _TestClipManagerNotifier(clips: const []),
                 ),
@@ -255,6 +264,9 @@ void main() {
           await tester.pumpWidget(
             ProviderScope(
               overrides: [
+                sharedPreferencesProvider.overrideWithValue(
+                  sharedPreferences,
+                ),
                 clipManagerProvider.overrideWith(
                   () => _TestClipManagerNotifier(clips: const []),
                 ),
@@ -284,6 +296,47 @@ void main() {
               const VideoRecorderRecordingStartRequested(),
             ),
           ).called(1);
+          verify(
+            () => recorderBloc.add(
+              const VideoRecorderRecordingStopRequested(),
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'hold-to-record preference starts on press-down and stops on release',
+        (tester) async {
+          await sharedPreferences.setBool('hold_to_record_enabled', true);
+          when(() => recorderBloc.state).thenReturn(
+            const VideoRecorderBlocState(
+              canRecord: true,
+              isCameraInitialized: true,
+            ),
+          );
+
+          await tester.pumpWidget(buildWidget());
+          await tester.pumpAndSettle();
+
+          final gesture = await tester.startGesture(
+            tester.getCenter(find.byType(RecordButton)),
+          );
+          await tester.pump();
+
+          verify(
+            () => recorderBloc.add(
+              const VideoRecorderRecordingStartRequested(),
+            ),
+          ).called(1);
+          verifyNever(
+            () => recorderBloc.add(
+              const VideoRecorderRecordingToggleRequested(),
+            ),
+          );
+
+          await gesture.up();
+          await tester.pumpAndSettle();
+
           verify(
             () => recorderBloc.add(
               const VideoRecorderRecordingStopRequested(),


### PR DESCRIPTION
Closes #4850

## Description

Discussed on discord [here](https://discord.com/channels/1470168817589158040/1470255950408454164/1510133586047537223)

Adds a **hold-to-record** mode to the video recorder, allowing users to start recording by pressing and holding the shutter button and stop by releasing it — in addition to the existing tap-to-record behaviour.

<img width="322" alt="image" src="https://github.com/user-attachments/assets/23ff4e52-88a6-4d90-9fdb-4e713b12465d" />

**Related Issue:** 

### Changes

- **`VideoRecorderBloc`** — new `holdToRecord` flag in state; updated start/stop logic to handle press-down / release events
- **`VideoRecorderState`** — added `holdToRecord` field
- **`HoldToRecordPreferenceService`** — new service backed by `SharedPreferences` to persist the user's preference
- **`preferencesProviders`** — exposes the new service via Riverpod
- **`GeneralSettingsScreen`** — toggle to enable / disable hold-to-record
- **`VideoRecorderClassicStack`** / **`ShutterGestureDetector`** / **`VideoRecorderRecordButton`** — wired up press/release gesture handling
- **Localizations** — new `cameraSettingsHoldToRecord` key added to all 20 supported locales and generated files regenerated

## Out of Scope

None — follow-up could include hold-to-record support for the web recorder if needed.

## Verification

- `flutter analyze` — clean
- `flutter test mobile/test/blocs/video_recorder/` — green
- `flutter test mobile/test/screens/settings/` — green
- `flutter test mobile/test/services/hold_to_record_preference_service_test.dart` — green
- `flutter test mobile/test/widgets/video_recorder/` — green
- Manually tested tap-to-record and hold-to-record modes on iOS Simulator and Android Emulator

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)