### PR TITLE
fix(stats): prevent bulk stats parser from leaking engagement counts into new videos

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
@@ -112,7 +112,7 @@ class _ActionButton extends StatelessWidget {
   const _ActionButton({
     this.onPressed,
     this.isCommentsInProgress = false,
-    this.totalComments = 1,
+    this.totalComments = 0,
   });
 
   final Function()? onPressed;

--- a/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
@@ -74,7 +74,7 @@ class LikeActionButton extends StatelessWidget {
 class _ActionButton extends StatelessWidget {
   const _ActionButton({
     this.isLiked = false,
-    this.totalLikes = 1,
+    this.totalLikes = 0,
     this.isOwnVideo = false,
     this.video,
     this.onInteracted,

--- a/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
@@ -80,7 +80,7 @@ class RepostActionButton extends StatelessWidget {
 class _ActionButton extends StatelessWidget {
   const _ActionButton({
     this.isReposted = false,
-    this.totalReposts = 1,
+    this.totalReposts = 0,
     this.isOwnVideo = false,
     this.video,
     this.onInteracted,

--- a/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
+++ b/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
@@ -19,47 +19,58 @@ class BulkVideoStatsEntry {
 
   /// Creates a [BulkVideoStatsEntry] from JSON response.
   ///
-  /// Uses deep search to find stats values under various field names
-  /// and nested structures returned by the Funnelcake API.
+  /// Reads engagement values from the top-level map and from the explicit
+  /// `stats` sub-object only. Unbounded recursive search is intentionally
+  /// avoided: it would misattribute engagement counts from unrelated nested
+  /// sections (e.g. vine archive data, author stats) to a fresh video,
+  /// making new uploads appear to already have likes/comments/reposts.
   factory BulkVideoStatsEntry.fromJson(Map<String, dynamic> json) {
+    // The API may nest stats under a "stats" key. Look there first, then
+    // fall back to the top-level map. No deeper recursion is performed.
+    final statsData =
+        json['stats'] is Map<String, dynamic>
+            ? json['stats'] as Map<String, dynamic>
+            : const <String, dynamic>{};
+
     return BulkVideoStatsEntry(
       eventId: (json['event_id'] ?? json['id'] ?? '').toString(),
-      reactions:
-          _findEngagementCountDeep(json, {
-            'reactions',
-            'likes',
-            'like_count',
-            'total_likes',
-          }) ??
-          0,
-      comments:
-          _findEngagementCountDeep(json, {
-            'comments',
-            'comment_count',
-            'total_comments',
-          }) ??
-          0,
-      reposts:
-          _findEngagementCountDeep(json, {
-            'reposts',
-            'repost_count',
-            'total_reposts',
-          }) ??
-          0,
-      loops: _findIntDeep(json, {
-        'loops',
-        'loop_count',
-        'total_loops',
-        'embedded_loops',
-        'computed_loops',
-      }),
-      views: _findIntDeep(json, {
-        'views',
-        'view_count',
-        'total_views',
-        'unique_views',
-        'unique_viewers',
-      }),
+      reactions: _findEngagementCount(
+        statsData,
+        json,
+        const {'reactions', 'likes', 'like_count', 'total_likes'},
+      ),
+      comments: _findEngagementCount(
+        statsData,
+        json,
+        const {'comments', 'comment_count', 'total_comments'},
+      ),
+      reposts: _findEngagementCount(
+        statsData,
+        json,
+        const {'reposts', 'repost_count', 'total_reposts'},
+      ),
+      loops: _findInt(
+        statsData,
+        json,
+        const {
+          'loops',
+          'loop_count',
+          'total_loops',
+          'embedded_loops',
+          'computed_loops',
+        },
+      ),
+      views: _findInt(
+        statsData,
+        json,
+        const {
+          'views',
+          'view_count',
+          'total_views',
+          'unique_views',
+          'unique_viewers',
+        },
+      ),
     );
   }
 
@@ -110,50 +121,48 @@ int? _parseInt(dynamic value) {
   return null;
 }
 
-/// Recursively searches a JSON structure for any key in [targetKeys]
-/// and returns the first successfully parsed int value.
-int? _findIntDeep(dynamic source, Set<String> targetKeys) {
-  if (source is Map) {
-    for (final entry in source.entries) {
-      final key = entry.key.toString().toLowerCase();
-      if (targetKeys.contains(key)) {
+/// Searches [json] first, then [statsData], for any key in [targetKeys] and
+/// returns the first successfully parsed int value, or null if not found.
+///
+/// Only looks in the two provided maps — no recursion into nested objects.
+/// This prevents engagement values from unrelated nested sections (e.g. Vine
+/// archive data, author stats) from leaking into the current video's counters.
+int? _findInt(
+  Map<String, dynamic> statsData,
+  Map<String, dynamic> json,
+  Set<String> targetKeys,
+) {
+  for (final map in [json, statsData]) {
+    for (final entry in map.entries) {
+      if (targetKeys.contains(entry.key.toLowerCase())) {
         final parsed = _parseInt(entry.value);
         if (parsed != null) return parsed;
       }
-    }
-    for (final value in source.values) {
-      final result = _findIntDeep(value, targetKeys);
-      if (result != null) return result;
-    }
-  } else if (source is List) {
-    for (final value in source) {
-      final result = _findIntDeep(value, targetKeys);
-      if (result != null) return result;
     }
   }
   return null;
 }
 
-/// Recursively searches a JSON structure for engagement keys and normalizes
-/// invalid counters to zero.
-int? _findEngagementCountDeep(dynamic source, Set<String> targetKeys) {
-  if (source is Map) {
-    for (final entry in source.entries) {
-      final key = entry.key.toString().toLowerCase();
-      if (targetKeys.contains(key)) {
+/// Searches [json] first, then [statsData], for engagement keys and
+/// normalizes invalid counters (sentinels, negatives) to zero.
+///
+/// Falls through invalid values (sentinel MAX_INT strings, negatives, empty
+/// strings) to the next candidate key before defaulting to 0. An explicit
+/// zero at the top level wins over a non-zero value in the stats sub-object.
+///
+/// Only looks in the two provided maps — no recursion into nested objects.
+int _findEngagementCount(
+  Map<String, dynamic> statsData,
+  Map<String, dynamic> json,
+  Set<String> targetKeys,
+) {
+  for (final map in [json, statsData]) {
+    for (final entry in map.entries) {
+      if (targetKeys.contains(entry.key.toLowerCase())) {
         final parsed = tryParseEngagementCount(entry.value);
         if (parsed != null) return parsed;
       }
     }
-    for (final value in source.values) {
-      final result = _findEngagementCountDeep(value, targetKeys);
-      if (result != null) return result;
-    }
-  } else if (source is List) {
-    for (final value in source) {
-      final result = _findEngagementCountDeep(value, targetKeys);
-      if (result != null) return result;
-    }
   }
-  return null;
+  return 0;
 }

--- a/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
+++ b/mobile/packages/models/lib/src/bulk_video_stats_entry.dart
@@ -27,10 +27,9 @@ class BulkVideoStatsEntry {
   factory BulkVideoStatsEntry.fromJson(Map<String, dynamic> json) {
     // The API may nest stats under a "stats" key. Look there first, then
     // fall back to the top-level map. No deeper recursion is performed.
-    final statsData =
-        json['stats'] is Map<String, dynamic>
-            ? json['stats'] as Map<String, dynamic>
-            : const <String, dynamic>{};
+    final statsData = json['stats'] is Map<String, dynamic>
+        ? json['stats'] as Map<String, dynamic>
+        : const <String, dynamic>{};
 
     return BulkVideoStatsEntry(
       eventId: (json['event_id'] ?? json['id'] ?? '').toString(),

--- a/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
+++ b/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
@@ -245,20 +245,17 @@ void main() {
           expect(
             entry.reactions,
             equals(0),
-            reason:
-                'vine_archive.event.likes must not leak into reactions',
+            reason: 'vine_archive.event.likes must not leak into reactions',
           );
           expect(
             entry.comments,
             equals(0),
-            reason:
-                'vine_archive.event.comments must not leak into comments',
+            reason: 'vine_archive.event.comments must not leak into comments',
           );
           expect(
             entry.reposts,
             equals(0),
-            reason:
-                'vine_archive.event.reposts must not leak into reposts',
+            reason: 'vine_archive.event.reposts must not leak into reposts',
           );
         },
       );

--- a/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
+++ b/mobile/packages/models/test/src/bulk_video_stats_entry_test.dart
@@ -218,6 +218,88 @@ void main() {
       });
     });
 
+    group('cross-contamination guards', () {
+      test(
+        'does not pick up engagement counts from deeply nested objects',
+        () {
+          // A fresh video entry may arrive with deeply-nested sibling sections
+          // (e.g. a vine_archive block or an event sub-object) that contain
+          // non-zero engagement values from unrelated data. The parser must
+          // not assign those values to the current video's engagement counters.
+          final entry = BulkVideoStatsEntry.fromJson(const {
+            'event_id': 'abc123',
+            // Top-level engagement keys are absent / zero for a fresh upload.
+            'reactions': 0,
+            'comments': 0,
+            'reposts': 0,
+            // Deep nested object that has its own engagement data.
+            'vine_archive': {
+              'event': {
+                'likes': 1547,
+                'comments': 320,
+                'reposts': 88,
+              },
+            },
+          });
+
+          expect(
+            entry.reactions,
+            equals(0),
+            reason:
+                'vine_archive.event.likes must not leak into reactions',
+          );
+          expect(
+            entry.comments,
+            equals(0),
+            reason:
+                'vine_archive.event.comments must not leak into comments',
+          );
+          expect(
+            entry.reposts,
+            equals(0),
+            reason:
+                'vine_archive.event.reposts must not leak into reposts',
+          );
+        },
+      );
+
+      test(
+        'does not pick up engagement counts from sibling stats in same payload',
+        () {
+          // If the API includes a sibling stats block for a different context
+          // (e.g. trending stats or author stats) that contains non-zero
+          // engagement values, those must not be attributed to this video.
+          final entry = BulkVideoStatsEntry.fromJson(const {
+            'event_id': 'abc123',
+            // No direct engagement keys on this entry.
+            'author_stats': {
+              'reactions': 9999,
+              'total_likes': 50000,
+            },
+          });
+
+          expect(
+            entry.reactions,
+            equals(0),
+            reason: 'author_stats.reactions must not leak into video reactions',
+          );
+        },
+      );
+
+      test('still reads reactions from allowed stats sub-object', () {
+        // The fix must preserve reading from the explicit "stats" sub-object,
+        // which is the documented one-level nesting the API can return.
+        final entry = BulkVideoStatsEntry.fromJson(const {
+          'event_id': 'abc123',
+          'stats': {'reactions': 42, 'comments': 7, 'reposts': 3},
+        });
+
+        expect(entry.reactions, equals(42));
+        expect(entry.comments, equals(7));
+        expect(entry.reposts, equals(3));
+      });
+    });
+
     group('toString', () {
       test('returns readable representation', () {
         const entry = BulkVideoStatsEntry(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2381,26 +2381,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2381,26 +2381,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:

--- a/mobile/test/widgets/video_feed_item/actions/comment_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/comment_action_button_test.dart
@@ -94,14 +94,16 @@ void main() {
         expect(find.byType(VideoActionButton), findsOneWidget);
       });
 
-      testWidgets('displays default comment count of 1 in preview mode', (
+      testWidgets('displays zero comment count in preview mode', (
         tester,
       ) async {
         await tester.pumpWidget(
           buildSubject(video: testVideo, isPreviewMode: true),
         );
 
-        expect(find.text('1'), findsOneWidget);
+        // Preview mode shows count=0, which renders as the labelWhenZero text.
+        expect(find.text('Reply'), findsOneWidget);
+        expect(find.text('1'), findsNothing);
       });
 
       testWidgets('has correct semantics label in preview mode', (

--- a/mobile/test/widgets/video_feed_item/actions/like_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/like_action_button_test.dart
@@ -143,15 +143,16 @@ void main() {
         expect(find.byType(VideoActionButton), findsOneWidget);
       });
 
-      testWidgets('displays default like count of 1 in preview mode', (
+      testWidgets('displays zero like count in preview mode', (
         tester,
       ) async {
         await tester.pumpWidget(
           buildSubject(video: testVideo, isPreviewMode: true),
         );
 
-        // The default _ActionButton shows totalLikes = 1
-        expect(find.text('1'), findsOneWidget);
+        // Preview mode shows count=0, which renders as the labelWhenZero text.
+        expect(find.text('Like'), findsOneWidget);
+        expect(find.text('1'), findsNothing);
       });
 
       testWidgets('has correct semantics label in preview mode', (

--- a/mobile/test/widgets/video_feed_item/actions/repost_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/repost_action_button_test.dart
@@ -143,15 +143,16 @@ void main() {
         expect(find.byType(VideoActionButton), findsOneWidget);
       });
 
-      testWidgets('displays default repost count of 1 in preview mode', (
+      testWidgets('displays zero repost count in preview mode', (
         tester,
       ) async {
         await tester.pumpWidget(
           buildSubject(video: testVideo, isPreviewMode: true),
         );
 
-        // The default _ActionButton shows totalReposts = 1
-        expect(find.text('1'), findsOneWidget);
+        // Preview mode shows count=0, which renders as the labelWhenZero text.
+        expect(find.text('Revine'), findsOneWidget);
+        expect(find.text('1'), findsNothing);
       });
 
       testWidgets('has correct semantics label in preview mode', (


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
BulkVideoStatsEntry.fromJson used an unbounded recursive walk (_findEngagementCountDeep) that would traverse into any nested sub-object in the API response payload. If the response included unrelated nested sections (e.g. vine archive data, author stats) containing non-zero engagement values, those counts would be attributed to the current video — making fresh uploads appear to already have likes, comments, and reposts.

Replace the unbounded recursive helpers with shallow two-map lookups:
- Top-level entry map (checked first so explicit zeros win)
- Explicit 'stats' sub-object (one level deep, matches all existing API fixtures)

No deeper recursion is performed; sibling keys like author_stats.reactions can no longer contaminate a video's engagement counters.

Also fix preview action button defaults: _ActionButton.totalLikes/totalReposts/ totalComments defaulted to 1 instead of 0, causing the blurred preview overlay to show count=1 on all engagement buttons for every video.


<!--- Describe your changes in detail -->

**Related Issue:** Closes #4756

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
