### PR TITLE
ci(test): shrink untested-services baseline (fix red main floor ratchet)

### DIFF
--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -14,14 +14,12 @@ c2pa_signing_service
 cache_recovery_service
 camera_base_service
 camera_mobile_service
-circuit_breaker_service
 collaborator_invite_local_state_adapter # noise: local-state adapter
 connection_status_service
 content_moderation_service
 crash_reporting_service # defer: #4338 C2 singleton-to-DI
 crosspost_api_client
 curated_list_service
-effective_content_labels
 error_analytics_tracker
 geo_blocking_service
 hashtag_cache_service


### PR DESCRIPTION
## Description

Fixes a **pre-existing red `origin/main`**: the untested-services floor ratchet (#4337 WS-3) is failing STALE on main and on every PR rebased onto current main.

`#4843` and `#4844` added `circuit_breaker_service_test.dart` and `effective_content_labels_test.dart`, but did not shrink the floor baseline that `#4835` froze. Because `mobile_ci.yaml` uses `concurrency: cancel-in-progress`, those two PRs' `Mobile CI` runs were cancelled as they merged in quick succession, so the desync landed uncaught.

The ratchet's STALE rule (a baselined service that gained a same-named test must shrink the floor) now fails for:

- `circuit_breaker_service`
- `effective_content_labels`

This is the exact fix the tooling prints (`UPDATE_BASELINE=1 bash mobile/scripts/check_untested_services_floor.sh`): baseline shrinks **61 → 59** entries, locking in the two coverage wins. All `# reason` annotations on the remaining entries are preserved. No code change.

## Evidence

- `Mobile CI` on `main` HEAD (`55581bd16`) = **failure** (run `26821988784`), on the `🧱 untested-services floor ratchet` step.
- Computed deterministically from `origin/main`'s own tree, `STALE(main)` = `{circuit_breaker_service, effective_content_labels}`.
- After this change, `bash mobile/scripts/check_untested_services_floor.sh` → `OK [untested_services_floor]: no new entries`.

## Type of Change

- [x] 🧹 CI / test-debt ratchet maintenance

## Notes for review

Unblocks all open PRs (including the in-flight #4744 WS-1 Cubit-migration stack) that currently fail the floor ratchet purely from this baseline desync.
