### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across video feed (#4803)

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -852,7 +852,11 @@ class _FeedErrorWidget extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, color: VineTheme.error, size: 64),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            color: VineTheme.error,
+            size: 64,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.feedFailedToLoadVideos,
@@ -912,7 +916,10 @@ class FeedEmptyWidget extends StatelessWidget {
             const SizedBox(height: 24),
             FilledButton.icon(
               onPressed: () => context.go(ExploreScreen.path),
-              icon: const Icon(Icons.explore),
+              icon: const DivineIcon(
+                icon: DivineIconName.compass,
+                color: VineTheme.backgroundColor,
+              ),
               label: Text(context.l10n.feedExploreVideos),
               style: FilledButton.styleFrom(
                 backgroundColor: VineTheme.vineGreen,

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -473,8 +473,8 @@ class _ClassicVinesUnavailableState extends StatelessWidget {
               ),
               child: const Column(
                 children: [
-                  Icon(
-                    Icons.info_outline,
+                  DivineIcon(
+                    icon: DivineIconName.info,
                     color: VineTheme.vineGreen,
                     size: 20,
                   ),

--- a/mobile/lib/widgets/feed_transition_indicator.dart
+++ b/mobile/lib/widgets/feed_transition_indicator.dart
@@ -24,8 +24,8 @@ class FeedTransitionIndicator extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(
-              Icons.check_circle_outline,
+            const DivineIcon(
+              icon: DivineIconName.checkCircle,
               color: VineTheme.success,
               size: 48,
             ),

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -275,8 +275,8 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
               color: VineTheme.backgroundColor,
               child: const Row(
                 children: [
-                  Icon(
-                    Icons.auto_awesome,
+                  DivineIcon(
+                    icon: DivineIconName.sparkle,
                     color: VineTheme.vineGreen,
                     size: 20,
                   ),
@@ -290,8 +290,8 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                     ),
                   ),
                   SizedBox(width: 4),
-                  Icon(
-                    Icons.info_outline,
+                  DivineIcon(
+                    icon: DivineIconName.info,
                     color: VineTheme.secondaryText,
                     size: 16,
                   ),
@@ -337,8 +337,8 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
               // Title
               const Row(
                 children: [
-                  Icon(
-                    Icons.auto_awesome,
+                  DivineIcon(
+                    icon: DivineIconName.sparkle,
                     color: VineTheme.vineGreen,
                     size: 28,
                   ),
@@ -453,7 +453,11 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
                 child: const Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Icon(Icons.code, color: VineTheme.vineGreen, size: 20),
+                    DivineIcon(
+                      icon: DivineIconName.bracketsAngle,
+                      color: VineTheme.vineGreen,
+                      size: 20,
+                    ),
                     SizedBox(width: 12),
                     Expanded(
                       child: Column(
@@ -555,8 +559,8 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Icon(
-            Icons.check_circle_outline,
+          const DivineIcon(
+            icon: DivineIconName.checkCircle,
             color: VineTheme.vineGreen,
             size: 18,
           ),
@@ -621,7 +625,11 @@ class _ForYouEmptyState extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.auto_awesome, size: 64, color: VineTheme.secondaryText),
+          DivineIcon(
+            icon: DivineIconName.sparkle,
+            size: 64,
+            color: VineTheme.secondaryText,
+          ),
           SizedBox(height: 16),
           Text(
             'No Recommendations Yet',

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
@@ -119,8 +119,8 @@ class _SendButton extends StatelessWidget {
                   color: VineTheme.onPrimary,
                 ),
               )
-            : const Icon(
-                Icons.arrow_upward,
+            : const DivineIcon(
+                icon: DivineIconName.arrowUp,
                 size: 22,
                 color: VineTheme.onPrimary,
               ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -206,8 +206,8 @@ class _ContactItem extends StatelessWidget {
                           color: VineTheme.vineGreen,
                           shape: BoxShape.circle,
                         ),
-                        child: const Icon(
-                          Icons.check,
+                        child: const DivineIcon(
+                          icon: DivineIconName.check,
                           size: 14,
                           color: VineTheme.onPrimary,
                         ),

--- a/mobile/lib/widgets/video_feed_item/content_warning_helpers.dart
+++ b/mobile/lib/widgets/video_feed_item/content_warning_helpers.dart
@@ -94,8 +94,8 @@ class ContentWarningBlurOverlay extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Icon(
-                    Icons.warning_amber_rounded,
+                  const DivineIcon(
+                    icon: DivineIconName.warning,
                     color: VineTheme.contentWarningAmber,
                     size: 48,
                   ),

--- a/mobile/lib/widgets/video_feed_item/inspired_by_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/inspired_by_attribution_row.dart
@@ -111,8 +111,8 @@ class _InspiredByContent extends ConsumerWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(
-                Icons.auto_awesome,
+              const DivineIcon(
+                icon: DivineIconName.sparkle,
                 size: 14,
                 color: VineTheme.vineGreen,
               ),
@@ -131,8 +131,8 @@ class _InspiredByContent extends ConsumerWidget {
                 ),
               ),
               const SizedBox(width: 4),
-              const Icon(
-                Icons.chevron_right,
+              const DivineIcon(
+                icon: DivineIconName.caretRight,
                 size: 14,
                 color: VineTheme.onSurfaceVariant,
               ),

--- a/mobile/lib/widgets/video_feed_item/list_attribution_chip.dart
+++ b/mobile/lib/widgets/video_feed_item/list_attribution_chip.dart
@@ -61,8 +61,8 @@ class ListAttributionChip extends StatelessWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(
-                  Icons.playlist_play,
+                const DivineIcon(
+                  icon: DivineIconName.playlist,
                   size: 14,
                   color: VineTheme.vineGreen,
                 ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -125,8 +125,8 @@ class _OriginalSoundSection extends ConsumerWidget {
                   ],
                 ),
               ),
-              const Icon(
-                Icons.chevron_right,
+              const DivineIcon(
+                icon: DivineIconName.caretRight,
                 color: VineTheme.onSurfaceVariant,
                 size: 20,
               ),
@@ -220,8 +220,8 @@ class _SoundListItem extends ConsumerWidget {
                 ],
               ),
             ),
-            const Icon(
-              Icons.chevron_right,
+            const DivineIcon(
+              icon: DivineIconName.caretRight,
               color: VineTheme.onSurfaceVariant,
               size: 20,
             ),

--- a/mobile/lib/widgets/video_feed_item/video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/video_error_overlay.dart
@@ -80,8 +80,10 @@ class VideoErrorOverlay extends ConsumerWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(
-                    _is401Error ? Icons.lock_outline : Icons.error_outline,
+                  DivineIcon(
+                    icon: _is401Error
+                        ? DivineIconName.lockSimple
+                        : DivineIconName.warningCircle,
                     color: VineTheme.whiteText,
                     size: 48,
                   ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -796,7 +796,11 @@ class VideoAuthorRow extends ConsumerWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(Icons.person, size: 14, color: VineTheme.whiteText),
+                const DivineIcon(
+                  icon: DivineIconName.user,
+                  size: 14,
+                  color: VineTheme.whiteText,
+                ),
                 const SizedBox(width: 6),
                 UserName.fromPubKey(
                   video.pubkey,
@@ -844,7 +848,11 @@ class VideoRepostHeader extends ConsumerWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.repeat, color: VineTheme.vineGreen, size: 16),
+          const DivineIcon(
+            icon: DivineIconName.repeat,
+            color: VineTheme.vineGreen,
+            size: 16,
+          ),
           const SizedBox(width: 8),
           Flexible(
             child: Text(
@@ -884,8 +892,8 @@ class _ContentWarningBadge extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(
-            Icons.warning_amber_rounded,
+          const DivineIcon(
+            icon: DivineIconName.warning,
             color: VineTheme.contentWarningAmber,
             size: 14,
           ),
@@ -969,8 +977,8 @@ class _ContentWarningDetailsSheet extends StatelessWidget {
             // Header
             Row(
               children: [
-                const Icon(
-                  Icons.warning_amber_rounded,
+                const DivineIcon(
+                  icon: DivineIconName.warning,
                   color: VineTheme.contentWarningAmber,
                   size: 22,
                 ),
@@ -1044,8 +1052,8 @@ class _ContentWarningDetailsSheet extends StatelessWidget {
                   Navigator.of(context).pop();
                   context.push('/content-filters');
                 },
-                icon: const Icon(
-                  Icons.tune,
+                icon: const DivineIcon(
+                  icon: DivineIconName.slidersHorizontal,
                   size: 18,
                   color: VineTheme.vineGreen,
                 ),

--- a/mobile/test/widgets/list_attribution_chip_test.dart
+++ b/mobile/test/widgets/list_attribution_chip_test.dart
@@ -8,6 +8,9 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group('ListAttributionChip', () {
     CuratedList createTestList({required String id, required String name}) {
@@ -43,8 +46,8 @@ void main() {
 
       // Should not find Wrap widget when listIds is empty
       expect(find.byType(Wrap), findsNothing);
-      // Should not find any playlist_play icons
-      expect(find.byIcon(Icons.playlist_play), findsNothing);
+      // Should not find any playlist icons
+      expect(_divineIcon(DivineIconName.playlist), findsNothing);
     });
 
     testWidgets('displays single list chip when one listId provided', (
@@ -58,7 +61,7 @@ void main() {
       await tester.pump();
 
       expect(find.text('Cool Videos'), findsOneWidget);
-      expect(find.byIcon(Icons.playlist_play), findsOneWidget);
+      expect(_divineIcon(DivineIconName.playlist), findsOneWidget);
     });
 
     testWidgets('displays up to 2 list chips when multiple listIds provided', (
@@ -77,7 +80,7 @@ void main() {
       await tester.pump();
 
       // Should only show 2 chips (not 3)
-      expect(find.byIcon(Icons.playlist_play), findsNWidgets(2));
+      expect(_divineIcon(DivineIconName.playlist), findsNWidgets(2));
     });
 
     testWidgets('uses fallback name "List" when list not found', (
@@ -124,7 +127,9 @@ void main() {
       );
       await tester.pump();
 
-      final icon = tester.widget<Icon>(find.byIcon(Icons.playlist_play));
+      final icon = tester.widget<DivineIcon>(
+        _divineIcon(DivineIconName.playlist),
+      );
       expect(icon.size, equals(14));
       expect(icon.color, equals(VineTheme.vineGreen));
     });

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -9,6 +9,9 @@ import 'package:models/models.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group(MetadataSoundsSection, () {
     const testAudioEventId =
@@ -107,7 +110,7 @@ void main() {
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
     });
 
@@ -147,7 +150,7 @@ void main() {
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
       testWidgets('falls back to original sound when audio event is null', (

--- a/mobile/test/widgets/video_error_overlay_test.dart
+++ b/mobile/test/widgets/video_error_overlay_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for VideoErrorOverlay widget
 // ABOUTME: Verifies error display, 401 age-restricted content handling, and retry functionality
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -16,6 +17,9 @@ import '../builders/test_video_event_builder.dart';
 
 class _MockAgeVerificationService extends Mock
     implements AgeVerificationService {}
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('VideoErrorOverlay', () {
@@ -73,12 +77,12 @@ void main() {
       );
 
       // Should show lock icon for 401
-      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+      expect(_divineIcon(DivineIconName.lockSimple), findsOneWidget);
       expect(find.text('Age-restricted content'), findsOneWidget);
       expect(find.text('Verify Age'), findsOneWidget);
 
       // Should NOT show error icon
-      expect(find.byIcon(Icons.error_outline), findsNothing);
+      expect(_divineIcon(DivineIconName.warningCircle), findsNothing);
     });
 
     testWidgets('displays generic error UI for non-401 errors', (tester) async {
@@ -87,12 +91,12 @@ void main() {
       );
 
       // Should show error icon for non-401
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
       expect(find.text('Video not found'), findsOneWidget);
       expect(find.text('Retry'), findsOneWidget);
 
       // Should NOT show lock icon
-      expect(find.byIcon(Icons.lock_outline), findsNothing);
+      expect(_divineIcon(DivineIconName.lockSimple), findsNothing);
     });
 
     testWidgets('translates 404 error to user-friendly message', (
@@ -193,7 +197,7 @@ void main() {
           buildWidget(errorDescription: 'unauthorized access'),
         );
 
-        expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.lockSimple), findsOneWidget);
         expect(find.text('Age-restricted content'), findsOneWidget);
         expect(find.text('Verify Age'), findsOneWidget);
       },

--- a/mobile/test/widgets/video_overlay_context_title_simple_test.dart
+++ b/mobile/test/widgets/video_overlay_context_title_simple_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Simple widget test for VideoOverlayActions contextTitle display
 // ABOUTME: Verifies hashtag/context indicator chip shows correctly
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -8,6 +9,9 @@ import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 
 import '../builders/test_video_event_builder.dart';
 import '../helpers/test_provider_overrides.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('VideoOverlayActions contextTitle', () {
@@ -90,7 +94,10 @@ void main() {
       await tester.pumpAndSettle();
 
       // Verify both chips are shown
-      expect(find.byIcon(Icons.person), findsOneWidget); // Publisher chip
+      expect(
+        _divineIcon(DivineIconName.user),
+        findsOneWidget,
+      ); // Publisher chip
       expect(find.byIcon(Icons.tag), findsOneWidget); // Context title chip
       expect(find.text('#funny'), findsOneWidget);
     });


### PR DESCRIPTION
## Description

Migrates **25 raw Material `Icons.*`** uses to `DivineIcon` across the **video feed** area, continuing the per-area icon sweep that PR #4802 started for settings. This is the first follow-up slice off the whole-codebase audit posted to #4803.

Files touched (12 source): feed page, For You / Classic Vines tabs, feed transition indicator, and the `video_feed_item` cluster (share message input, share-with section, content-warning helper, inspired-by row, list-attribution chip, sounds metadata section, error overlay, the main item).

Only **exact-glyph** equivalents from the audit's adversarially-verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| arrow_upward           | arrowUp            |
| auto_awesome           | sparkle            |
| check                  | check              |
| check_circle_outline   | checkCircle        |
| chevron_right          | caretRight         |
| code                   | bracketsAngle      |
| error_outline          | warningCircle      |
| explore                | compass            |
| info_outline           | info               |
| lock_outline           | lockSimple         |
| person                 | user               |
| playlist_play          | playlist           |
| repeat                 | repeat             |
| tune                   | slidersHorizontal  |
| warning_amber_rounded  | warning            |

No visual change is expected — `DivineIcon` renders at the same size with the same explicit color tints. The one button-embedded icon (feed empty-state **Explore** button) now passes the button's `foregroundColor` explicitly, because `DivineIcon` (an SVG) doesn't inherit `IconTheme` the way Material `Icon` does.

**Related Issue:** Relates to #4803 (whole-codebase tracker); leftover no-equivalent icons in these files stay tracked under #4833.

## Out of Scope

- `approx` icons in these files (different-glyph substitutes needing design sign-off) and `none` icons (no `divine_ui` equivalent → #4833) are intentionally left as `Icons.*`.
- `param` callsites that pass `Icons.X` as `IconData` into internal helpers (e.g. `for_you_tab`'s `_buildInteractionItem`) — these need a helper-signature change and are a separate workstream per #4803.
- Other areas (sounds, profile, auth, …) — separate follow-up PRs.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 16 changed files — **No issues found!**
- `flutter test` across all affected widget/screen suites (video_error_overlay, list_attribution_chip, metadata_sounds_section, video_overlay_*, content_warning_helpers, feed_videos, metadata_expanded_sheet, video_feed_item_watchdog, video_feed_page, video_feed_page_web, pooled_video_feed_item_repo_swap) — **159 passed, 5 pre-existing skips**
- 4 test files updated: `find.byIcon(Icons.X)` assertions on migrated widgets now use a `DivineIcon` widget-predicate finder.

## Type of Change

- [x] 🧹 Code refactor