### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across sounds (#4803)

### DIFF
--- a/mobile/lib/screens/original_sound_detail_screen.dart
+++ b/mobile/lib/screens/original_sound_detail_screen.dart
@@ -156,14 +156,14 @@ class _OriginalSoundHeader extends StatelessWidget {
             child: videoThumbnailUrl != null
                 ? VineCachedImage(
                     imageUrl: videoThumbnailUrl!,
-                    errorWidget: (_, _, _) => const Icon(
-                      Icons.music_note,
+                    errorWidget: (_, _, _) => const DivineIcon(
+                      icon: DivineIconName.musicNote,
                       color: VineTheme.vineGreen,
                       size: 28,
                     ),
                   )
-                : const Icon(
-                    Icons.music_note,
+                : const DivineIcon(
+                    icon: DivineIconName.musicNote,
                     color: VineTheme.vineGreen,
                     size: 28,
                   ),

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -278,8 +278,8 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                   padding: const EdgeInsets.all(16),
                   child: Row(
                     children: [
-                      const Icon(
-                        Icons.videocam,
+                      const DivineIcon(
+                        icon: DivineIconName.videoCamera,
                         color: VineTheme.vineGreen,
                         size: 20,
                       ),
@@ -412,8 +412,8 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                   color: VineTheme.vineGreen.withValues(alpha: 0.2),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: const Icon(
-                  Icons.music_note,
+                child: const DivineIcon(
+                  icon: DivineIconName.musicNote,
                   color: VineTheme.vineGreen,
                   size: 28,
                 ),
@@ -498,7 +498,11 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                   button: true,
                   child: ElevatedButton.icon(
                     onPressed: widget.onUseSoundTap,
-                    icon: const Icon(Icons.add, size: 20),
+                    icon: const DivineIcon(
+                      icon: DivineIconName.plus,
+                      size: 20,
+                      color: VineTheme.backgroundColor,
+                    ),
                     label: Text(context.l10n.soundUseSound),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: VineTheme.vineGreen,
@@ -714,8 +718,8 @@ class _VideosGrid extends ConsumerWidget {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(
-                      Icons.error_outline,
+                    const DivineIcon(
+                      icon: DivineIconName.warningCircle,
                       size: 64,
                       color: VineTheme.likeRed,
                     ),
@@ -743,7 +747,10 @@ class _VideosGrid extends ConsumerWidget {
                     const SizedBox(height: 24),
                     ElevatedButton.icon(
                       onPressed: onRetry,
-                      icon: const Icon(Icons.refresh),
+                      icon: const DivineIcon(
+                        icon: DivineIconName.arrowClockwise,
+                        color: VineTheme.backgroundColor,
+                      ),
                       label: Text(l10n.soundRetry),
                       style: ElevatedButton.styleFrom(
                         backgroundColor: VineTheme.vineGreen,
@@ -941,8 +948,8 @@ class _VideoGridTile extends StatelessWidget {
               ),
             ),
             const Center(
-              child: Icon(
-                Icons.play_circle_filled,
+              child: DivineIcon(
+                icon: DivineIconName.playCircleFill,
                 color: VineTheme.onSurfaceVariant,
                 size: 32,
               ),
@@ -990,10 +997,9 @@ class _ThumbnailPlaceholder extends StatelessWidget {
         ),
       ),
       child: const Center(
-        child: Icon(
-          Icons.play_circle_outline,
+        child: DivineIcon(
+          icon: DivineIconName.playCircle,
           color: VineTheme.whiteText,
-          size: 24,
         ),
       ),
     );
@@ -1050,7 +1056,10 @@ class _SoundVideoFeedOverlay extends ConsumerWidget {
                 children: [
                   // Close button
                   IconButton(
-                    icon: const Icon(Icons.close, color: VineTheme.whiteText),
+                    icon: const DivineIcon(
+                      icon: DivineIconName.x,
+                      color: VineTheme.whiteText,
+                    ),
                     onPressed: onClose,
                     tooltip: context.l10n.soundCloseTooltip,
                   ),
@@ -1060,8 +1069,8 @@ class _SoundVideoFeedOverlay extends ConsumerWidget {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        const Icon(
-                          Icons.music_note,
+                        const DivineIcon(
+                          icon: DivineIconName.musicNote,
                           color: VineTheme.vineGreen,
                           size: 18,
                         ),

--- a/mobile/lib/widgets/library/sounds_tab.dart
+++ b/mobile/lib/widgets/library/sounds_tab.dart
@@ -287,7 +287,10 @@ class _SearchInput extends StatelessWidget {
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
           hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-          prefixIcon: const Icon(Icons.search, color: VineTheme.onSurfaceMuted),
+          prefixIcon: const DivineIcon(
+            icon: DivineIconName.search,
+            color: VineTheme.onSurfaceMuted,
+          ),
           filled: true,
           fillColor: VineTheme.surfaceContainer,
           border: OutlineInputBorder(
@@ -344,8 +347,8 @@ class _SavedSoundsSection extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: Row(
             children: [
-              const Icon(
-                Icons.music_note,
+              const DivineIcon(
+                icon: DivineIconName.musicNote,
                 color: VineTheme.vineGreen,
                 size: 20,
               ),

--- a/mobile/lib/widgets/sound_tile.dart
+++ b/mobile/lib/widgets/sound_tile.dart
@@ -135,10 +135,9 @@ class SoundTile extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const Icon(
-                  Icons.music_note,
+                const DivineIcon(
+                  icon: DivineIconName.musicNote,
                   color: VineTheme.vineGreen,
-                  size: 24,
                 ),
                 const SizedBox(height: 4),
                 Text(
@@ -193,8 +192,8 @@ class SoundTile extends StatelessWidget {
                       children: [
                         Row(
                           children: [
-                            const Icon(
-                              Icons.music_note,
+                            const DivineIcon(
+                              icon: DivineIconName.musicNote,
                               color: VineTheme.vineGreen,
                               size: 16,
                             ),
@@ -239,10 +238,9 @@ class SoundTile extends StatelessWidget {
                           button: true,
                           child: const Padding(
                             padding: EdgeInsets.all(8),
-                            child: Icon(
-                              Icons.chevron_right,
+                            child: DivineIcon(
+                              icon: DivineIconName.caretRight,
                               color: VineTheme.lightText,
-                              size: 24,
                             ),
                           ),
                         ),

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -125,6 +125,9 @@ Widget createTestWidget({required Widget child, List<dynamic>? overrides}) {
   );
 }
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group('SoundDetailScreen', () {
     late _MockAudioPlaybackService mockAudioService;
@@ -427,7 +430,7 @@ void main() {
 
         await tester.pump();
 
-        expect(find.byIcon(Icons.music_note), findsOneWidget);
+        expect(_divineIcon(DivineIconName.musicNote), findsOneWidget);
       });
     });
 
@@ -477,7 +480,7 @@ void main() {
         await tester.pump();
 
         expect(find.text('Use Sound'), findsOneWidget);
-        expect(find.byIcon(Icons.add), findsOneWidget);
+        expect(_divineIcon(DivineIconName.plus), findsOneWidget);
       });
     });
 
@@ -788,7 +791,7 @@ void main() {
         await tester.pump();
 
         expect(find.text('Videos using this sound'), findsOneWidget);
-        expect(find.byIcon(Icons.videocam), findsOneWidget);
+        expect(_divineIcon(DivineIconName.videoCamera), findsOneWidget);
       });
 
       testWidgets('shows empty state when no videos', (tester) async {
@@ -953,10 +956,10 @@ void main() {
         await tester.pump();
 
         // Find music note icon and verify color
-        final musicIcon = find.byIcon(Icons.music_note);
+        final musicIcon = _divineIcon(DivineIconName.musicNote);
         expect(musicIcon, findsOneWidget);
 
-        final iconWidget = tester.widget<Icon>(musicIcon);
+        final iconWidget = tester.widget<DivineIcon>(musicIcon);
         expect(iconWidget.color, equals(VineTheme.vineGreen));
       });
 
@@ -1161,7 +1164,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // The error body must actually be on screen (no fallback path).
-          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
           // No layout exception should have been thrown while building.
           expect(tester.takeException(), isNull);
         },

--- a/mobile/test/widgets/sound_tile_test.dart
+++ b/mobile/test/widgets/sound_tile_test.dart
@@ -8,6 +8,9 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/sound_tile.dart';
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group('SoundTile', () {
     late AudioEvent testSound;
@@ -88,7 +91,7 @@ void main() {
       testWidgets('displays music note icon', (tester) async {
         await tester.pumpWidget(buildTestWidget());
 
-        expect(find.byIcon(Icons.music_note), findsWidgets);
+        expect(_divineIcon(DivineIconName.musicNote), findsWidgets);
       });
 
       testWidgets('displays play arrow icon', (tester) async {
@@ -100,7 +103,7 @@ void main() {
       testWidgets('displays chevron right icon', (tester) async {
         await tester.pumpWidget(buildTestWidget());
 
-        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
       });
 
       testWidgets('calls onTap when tile is tapped', (tester) async {
@@ -175,7 +178,7 @@ void main() {
       testWidgets('displays music note icon in compact mode', (tester) async {
         await tester.pumpWidget(buildTestWidget(compact: true));
 
-        expect(find.byIcon(Icons.music_note), findsOneWidget);
+        expect(_divineIcon(DivineIconName.musicNote), findsOneWidget);
       });
 
       testWidgets('displays title in compact mode', (tester) async {
@@ -353,8 +356,8 @@ void main() {
       testWidgets('music note uses vineGreen color', (tester) async {
         await tester.pumpWidget(buildTestWidget());
 
-        final musicNoteIcons = tester.widgetList<Icon>(
-          find.byIcon(Icons.music_note),
+        final musicNoteIcons = tester.widgetList<DivineIcon>(
+          _divineIcon(DivineIconName.musicNote),
         );
 
         for (final icon in musicNoteIcons) {
@@ -373,8 +376,8 @@ void main() {
       testWidgets('chevron uses grey color', (tester) async {
         await tester.pumpWidget(buildTestWidget());
 
-        final chevronIcon = tester.widget<Icon>(
-          find.byIcon(Icons.chevron_right),
+        final chevronIcon = tester.widget<DivineIcon>(
+          _divineIcon(DivineIconName.caretRight),
         );
 
         expect(chevronIcon.color, equals(VineTheme.lightText));


### PR DESCRIPTION
## Description

Migrates raw Material `Icons.*` to `DivineIcon` across the **sounds** area — the sound detail screen, original-sound detail header, the library Sounds tab, and the sound tile. Second follow-up slice off the whole-codebase audit on #4803 (after #4867 video feed).

Only **exact-glyph** equivalents from the audit's verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| add                    | plus               |
| chevron_right          | caretRight         |
| close                  | x                  |
| error_outline          | warningCircle      |
| music_note             | musicNote          |
| play_circle_filled     | playCircleFill     |
| play_circle_outline    | playCircle         |
| refresh                | arrowClockwise     |
| search                 | search             |
| videocam               | videoCamera        |

No visual change is expected — same size, same explicit color tints. Button-/input-embedded icons (`plus` on Use Sound, `arrowClockwise` on retry) pass an explicit `color`, because `DivineIcon` (an SVG) doesn't inherit `IconTheme` the way Material `Icon` does.

**Related Issue:** Relates to #4803 (whole-codebase tracker); leftover no-equivalent icons in these files stay tracked under #4833.

## Out of Scope

- `approx` icons left as `Icons.*` pending design sign-off: `stop` (play/stop toggle), `videocam_off_outlined`, `music_off_outlined`.
- `none` icons blocked on new SVGs (#4833): `music_off`, `search_off`, `bookmark_remove_outlined`.
- Other areas (profile, auth, …) — separate follow-up PRs.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 6 changed files — **No issues found!**
- `flutter test` across sound_detail_screen, sound_tile, original_sound_detail_screen, sounds_tab, sounds_screen — **108 passed, 2 pre-existing skips**
- 2 test files updated: `find.byIcon(Icons.X)` assertions on migrated widgets now use a `DivineIcon` widget-predicate finder.

## Type of Change

- [x] 🧹 Code refactor