### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across profile (#4803)

### DIFF
--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -244,7 +244,10 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
             padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
             child: Row(
               children: [
-                const Icon(Icons.code, size: 24, color: VineTheme.whiteText),
+                const DivineIcon(
+                  icon: DivineIconName.bracketsAngle,
+                  color: VineTheme.whiteText,
+                ),
                 const SizedBox(width: 16),
                 Text(
                   context.l10n.profileGetEmbedCode,

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -270,8 +270,8 @@ class _ProfileSetupScreenViewState
                           color: VineTheme.vineGreen,
                           shape: BoxShape.circle,
                         ),
-                        child: const Icon(
-                          Icons.check,
+                        child: const DivineIcon(
+                          icon: DivineIconName.check,
                           color: VineTheme.whiteText,
                           size: 17,
                         ),
@@ -1838,7 +1838,11 @@ class _BannerColorSwatch extends StatelessWidget {
             ),
           ),
           child: isSelected
-              ? const Icon(Icons.check, color: VineTheme.whiteText, size: 20)
+              ? const DivineIcon(
+                  icon: DivineIconName.check,
+                  color: VineTheme.whiteText,
+                  size: 20,
+                )
               : null,
         ),
       ),
@@ -1918,8 +1922,8 @@ class _GetVerifiedTile extends StatelessWidget {
         l10n.profileEditGetVerifiedSubtitle,
         style: VineTheme.bodyMediumFont(color: VineTheme.lightText),
       ),
-      trailing: const Icon(
-        Icons.chevron_right,
+      trailing: const DivineIcon(
+        icon: DivineIconName.caretRight,
         color: VineTheme.lightText,
       ),
       onTap: () => context.read<ProfileEditorBloc>().add(

--- a/mobile/lib/widgets/profile/profile_block_confirmation_dialog.dart
+++ b/mobile/lib/widgets/profile/profile_block_confirmation_dialog.dart
@@ -16,7 +16,11 @@ class ProfileBlockConfirmationDialog extends StatelessWidget {
     backgroundColor: VineTheme.cardBackground,
     title: Row(
       children: [
-        const Icon(Icons.check_circle, color: VineTheme.vineGreen, size: 28),
+        const DivineIcon(
+          icon: DivineIconName.checkCircle,
+          color: VineTheme.vineGreen,
+          size: 28,
+        ),
         const SizedBox(width: 12),
         Text(
           context.l10n.profileUserBlockedTitle,
@@ -54,8 +58,8 @@ class ProfileBlockConfirmationDialog extends StatelessWidget {
             ),
             child: Row(
               children: [
-                const Icon(
-                  Icons.info_outline,
+                const DivineIcon(
+                  icon: DivineIconName.info,
                   color: VineTheme.vineGreen,
                   size: 20,
                 ),

--- a/mobile/lib/widgets/profile/profile_comments_grid.dart
+++ b/mobile/lib/widgets/profile/profile_comments_grid.dart
@@ -196,8 +196,8 @@ class _VideoReplyTile extends StatelessWidget {
               ),
               // Play icon overlay
               const Center(
-                child: Icon(
-                  Icons.play_circle_outline,
+                child: DivineIcon(
+                  icon: DivineIconName.playCircle,
                   color: VineTheme.whiteText,
                   size: 32,
                 ),
@@ -260,8 +260,8 @@ class _ProfileCommentCard extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 8),
-            const Icon(
-              Icons.chevron_right,
+            const DivineIcon(
+              icon: DivineIconName.caretRight,
               color: VineTheme.onSurfaceMuted,
               size: 20,
             ),

--- a/mobile/lib/widgets/profile/verified_account_chip.dart
+++ b/mobile/lib/widgets/profile/verified_account_chip.dart
@@ -56,7 +56,11 @@ class VerifiedAccountChip extends StatelessWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(Icons.public, size: 14, color: VineTheme.lightText),
+                const DivineIcon(
+                  icon: DivineIconName.globe,
+                  size: 14,
+                  color: VineTheme.lightText,
+                ),
                 const SizedBox(width: 6),
                 Text(
                   '${claim.platform}/${claim.identity}',

--- a/mobile/lib/widgets/profile_editor/username_status_indicator.dart
+++ b/mobile/lib/widgets/profile_editor/username_status_indicator.dart
@@ -111,7 +111,11 @@ class _UsernameAvailableIndicator extends StatelessWidget {
       padding: const EdgeInsets.only(top: 8),
       child: Row(
         children: [
-          const Icon(Icons.check_circle, color: VineTheme.vineGreen, size: 16),
+          const DivineIcon(
+            icon: DivineIconName.checkCircle,
+            color: VineTheme.vineGreen,
+            size: 16,
+          ),
           const SizedBox(width: 8),
           Text(
             context.l10n.profileSetupUsernameAvailable,
@@ -156,7 +160,11 @@ class _UsernameReservedIndicator extends StatelessWidget {
         children: [
           Row(
             children: [
-              const Icon(Icons.lock, color: VineTheme.warning, size: 16),
+              const DivineIcon(
+                icon: DivineIconName.lockSimple,
+                color: VineTheme.warning,
+                size: 16,
+              ),
               const SizedBox(width: 8),
               Text(
                 context.l10n.profileSetupUsernameReserved,
@@ -245,7 +253,11 @@ class _UsernameErrorIndicator extends StatelessWidget {
       padding: const EdgeInsets.only(top: 8),
       child: Row(
         children: [
-          const Icon(Icons.error_outline, color: VineTheme.error, size: 16),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            color: VineTheme.error,
+            size: 16,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -61,7 +61,11 @@ class SpecialProfileCheckmark extends StatelessWidget {
           color: VineTheme.info,
           shape: BoxShape.circle,
         ),
-        child: Icon(Icons.check, color: VineTheme.whiteText, size: iconSize),
+        child: DivineIcon(
+          icon: DivineIconName.check,
+          color: VineTheme.whiteText,
+          size: iconSize,
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -139,7 +139,10 @@ class UserProfileTile extends ConsumerWidget {
               if (showAddToList) ...[
                 const SizedBox(width: 4),
                 IconButton(
-                  icon: const Icon(Icons.playlist_add),
+                  icon: const DivineIcon(
+                    icon: DivineIconName.listPlus,
+                    color: VineTheme.onSurfaceVariant,
+                  ),
                   color: VineTheme.onSurfaceVariant,
                   tooltip: context.l10n.peopleListsAddToList,
                   onPressed: () => AddToPeopleListsSheet.show(

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -28,6 +28,9 @@ class _MockProfileEditorBloc
 class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
     implements MyProfileBloc {}
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group('UsernameStatusIndicator', () {
     late _MockProfileEditorBloc mockBloc;
@@ -93,7 +96,7 @@ void main() {
       await tester.pumpWidget(buildIndicator(UsernameStatus.available));
 
       expect(find.text('Username available!'), findsOneWidget);
-      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      expect(_divineIcon(DivineIconName.checkCircle), findsOneWidget);
     });
 
     testWidgets('shows red X when taken', (tester) async {
@@ -109,7 +112,7 @@ void main() {
       await tester.pumpWidget(buildIndicatorWithBloc(UsernameStatus.reserved));
 
       expect(find.text('Username is reserved'), findsOneWidget);
-      expect(find.byIcon(Icons.lock), findsOneWidget);
+      expect(_divineIcon(DivineIconName.lockSimple), findsOneWidget);
     });
 
     testWidgets('shows Contact support link when reserved', (tester) async {
@@ -147,7 +150,7 @@ void main() {
         find.text('Could not check availability. Please try again.'),
         findsOneWidget,
       );
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
     });
 
     testWidgets('shows default error message when no error provided', (
@@ -156,7 +159,7 @@ void main() {
       await tester.pumpWidget(buildIndicator(UsernameStatus.error));
 
       expect(find.text('Failed to check availability'), findsOneWidget);
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
     });
 
     testWidgets('shows format error message', (tester) async {

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests UserName NIP-05 display behavior
 // ABOUTME: Ensures valid NIP-05 does not render a verification checkmark
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,6 +9,10 @@ import 'package:models/models.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/widgets/user_name.dart';
+
+Finder _specialCheckmark() => find.byWidgetPredicate(
+  (w) => w is DivineIcon && w.icon == DivineIconName.check,
+);
 
 void main() {
   const defaultPubkey =
@@ -47,7 +52,7 @@ void main() {
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(find.byIcon(Icons.check), findsNothing);
+    expect(_specialCheckmark(), findsNothing);
   });
 
   testWidgets('shows a checkmark for Kirsten Swasey special profile', (
@@ -59,7 +64,7 @@ void main() {
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
   });
 
   testWidgets('matches the Kirsten Swasey profile URL host', (tester) async {
@@ -69,7 +74,7 @@ void main() {
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
   });
 
   testWidgets('shows a checkmark for Rabble special profile', (tester) async {
@@ -77,7 +82,7 @@ void main() {
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
   });
 
   testWidgets('shows a checkmark for special profile pubkey', (tester) async {
@@ -90,6 +95,6 @@ void main() {
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
   });
 }

--- a/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
+++ b/mobile/test/widgets/user_profile_tile_feature_flag_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Verifies UserProfileTile gates add-to-list on profileListFeatures.
 // ABOUTME: Keeps rollout behavior explicit for follower/following entry points.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -12,6 +13,9 @@ import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 
 import '../helpers/test_provider_overrides.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('UserProfileTile profileListFeatures gating', () {
@@ -36,7 +40,7 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.playlist_add), findsNothing);
+        expect(_divineIcon(DivineIconName.listPlus), findsNothing);
       },
     );
 
@@ -52,7 +56,7 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.playlist_add), findsOneWidget);
+        expect(_divineIcon(DivineIconName.listPlus), findsOneWidget);
       },
     );
 

--- a/mobile/test/widgets/video_explore_tile_nip05_test.dart
+++ b/mobile/test/widgets/video_explore_tile_nip05_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests that VideoExploreTile does not show NIP-05 checkmarks
 // ABOUTME: Ensures valid NIP-05 does not look like account verification
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,6 +21,10 @@ class _MockModerationLabelService extends Mock
 
 class _MockVideoModerationStatusService extends Mock
     implements VideoModerationStatusService {}
+
+Finder _specialCheckmark() => find.byWidgetPredicate(
+  (w) => w is DivineIcon && w.icon == DivineIconName.check,
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -100,7 +105,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsNothing);
+        expect(_specialCheckmark(), findsNothing);
       });
 
       testWidgets('does not show checkmark when NIP-05 verification fails', (
@@ -114,7 +119,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsNothing);
+        expect(_specialCheckmark(), findsNothing);
       });
 
       testWidgets('does not show checkmark when NIP-05 has network error', (
@@ -128,7 +133,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsNothing);
+        expect(_specialCheckmark(), findsNothing);
       });
 
       testWidgets('does not show checkmark when user has no NIP-05', (
@@ -139,7 +144,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsNothing);
+        expect(_specialCheckmark(), findsNothing);
       });
 
       testWidgets('does not show checkmark while verification is pending', (
@@ -153,7 +158,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsNothing);
+        expect(_specialCheckmark(), findsNothing);
       });
 
       testWidgets('shows checkmark for Kirsten Swasey special profile', (
@@ -167,7 +172,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsOneWidget);
+        expect(_specialCheckmark(), findsOneWidget);
       });
     });
   });

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies the inline description opens the metadata sheet.
 
 @Tags(['skip_very_good_optimization'])
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,6 +22,10 @@ import '../../helpers/test_provider_overrides.dart';
 
 AppLocalizations _l10n(WidgetTester tester) =>
     AppLocalizations.of(tester.element(find.byType(Scaffold).first));
+
+Finder _specialCheckmark() => find.byWidgetPredicate(
+  (w) => w is DivineIcon && w.icon == DivineIconName.check,
+);
 
 class _MockVideoInteractionsBloc extends Mock
     implements VideoInteractionsBloc {}
@@ -176,7 +181,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(find.byIcon(Icons.check), findsNothing);
+    expect(_specialCheckmark(), findsNothing);
   });
 
   testWidgets(
@@ -222,7 +227,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Alice'), findsOneWidget);
-      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(_specialCheckmark(), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
## Description

Migrates 14 raw Material `Icons.*` uses to `DivineIcon` across the **profile** area — profile setup, the embed-code router row, the block-confirmation dialog, the comments grid, the verified-account chip, the username status indicator, the special-profile checkmark, and the user profile tile. Third follow-up slice off the whole-codebase audit on #4803 (after #4867 video feed, #4868 sounds).

Only **exact-glyph** equivalents from the audit's verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| check                  | check              |
| check_circle           | checkCircle        |
| chevron_right          | caretRight         |
| code                   | bracketsAngle      |
| error_outline          | warningCircle      |
| info_outline           | info               |
| lock                   | lockSimple         |
| play_circle_outline    | playCircle         |
| playlist_add           | listPlus           |
| public                 | globe              |

No visual change is expected. The user-profile-tile `IconButton` forwards its color onto the `DivineIcon` (which, as an SVG, doesn't inherit `IconTheme`), and a now-redundant `size: 24` is dropped (it's the `DivineIcon` default).

**Related Issue:** Relates to #4803 (whole-codebase tracker).

## Out of Scope

- Other areas (auth, relay, comments, …) — separate follow-up PRs.
- `approx` / `none` icons in these files, if any, stay tracked under #4803 / #4833.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 10 changed files — **No issues found!**
- `flutter test` across profile_setup_screen, user_profile_tile (feature-flag + layout), verified_account_chip, profile_comments_grid, profile_screen_router — **65 passed, 24 pre-existing skips**
- 2 test files updated: `find.byIcon(Icons.X)` assertions on migrated widgets now use a `DivineIcon` widget-predicate finder.

## Type of Change

- [x] 🧹 Code refactor