### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across auth (#4803)

### DIFF
--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -419,8 +419,8 @@ class _CloseButton extends StatelessWidget {
           color: VineTheme.surfaceContainer,
           shape: BoxShape.circle,
         ),
-        child: const Icon(
-          Icons.close,
+        child: const DivineIcon(
+          icon: DivineIconName.x,
           color: VineTheme.vineGreenLight,
           size: 20,
         ),

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -295,8 +295,8 @@ class _InviteCodeEntryPage extends StatelessWidget {
                                 alignment: AlignmentDirectional.centerStart,
                                 child: RoundedIconButton(
                                   onPressed: onBack,
-                                  icon: const Icon(
-                                    Icons.chevron_left,
+                                  icon: const DivineIcon(
+                                    icon: DivineIconName.caretLeft,
                                     color: VineTheme.vineGreenLight,
                                     size: 28,
                                   ),

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -277,10 +277,9 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                               context,
                               showNip07: isNip07Available,
                             ),
-                      icon: const Icon(
-                        Icons.info_outline,
+                      icon: const DivineIcon(
+                        icon: DivineIconName.info,
                         color: VineTheme.vineGreenLight,
-                        size: 24,
                       ),
                     ),
                   ],

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -718,7 +718,11 @@ class _SignerRow extends StatelessWidget {
     return SizedBox(
       width: 22,
       child: supported
-          ? const Icon(Icons.check, color: VineTheme.vineGreen, size: 22)
+          ? const DivineIcon(
+              icon: DivineIconName.check,
+              color: VineTheme.vineGreen,
+              size: 22,
+            )
           : const SizedBox.shrink(),
     );
   }
@@ -751,8 +755,8 @@ class _ErrorContent extends StatelessWidget {
           Center(
             child: Column(
               children: [
-                const Icon(
-                  Icons.error_outline,
+                const DivineIcon(
+                  icon: DivineIconName.warningCircle,
                   color: VineTheme.error,
                   size: 64,
                 ),

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -274,7 +274,10 @@ class _VerificationDialog extends ConsumerWidget {
             backgroundColor: VineTheme.cardBackground,
             title: const Row(
               children: [
-                Icon(Icons.error_outline, color: VineTheme.error),
+                DivineIcon(
+                  icon: DivineIconName.warningCircle,
+                  color: VineTheme.error,
+                ),
                 SizedBox(width: 12),
                 Text(
                   'Verification Failed',
@@ -304,7 +307,10 @@ class _VerificationDialog extends ConsumerWidget {
             backgroundColor: VineTheme.cardBackground,
             title: Row(
               children: [
-                Icon(Icons.check_circle, color: VineTheme.vineGreen),
+                DivineIcon(
+                  icon: DivineIconName.checkCircle,
+                  color: VineTheme.vineGreen,
+                ),
                 SizedBox(width: 12),
                 Text(
                   'Account Secured!',
@@ -324,7 +330,10 @@ class _VerificationDialog extends ConsumerWidget {
           backgroundColor: VineTheme.cardBackground,
           title: const Row(
             children: [
-              Icon(Icons.email_outlined, color: VineTheme.vineGreen),
+              DivineIcon(
+                icon: DivineIconName.envelope,
+                color: VineTheme.vineGreen,
+              ),
               SizedBox(width: 12),
               Text(
                 'Verify Your Email',

--- a/mobile/lib/screens/key_management_screen.dart
+++ b/mobile/lib/screens/key_management_screen.dart
@@ -93,10 +93,9 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
         children: [
           Row(
             children: [
-              const Icon(
-                Icons.info_outline,
+              const DivineIcon(
+                icon: DivineIconName.info,
                 color: VineTheme.vineGreen,
-                size: 24,
               ),
               const SizedBox(width: 12),
               Text(
@@ -243,8 +242,8 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
                 ),
                 child: Row(
                   children: [
-                    const Icon(
-                      Icons.warning_amber,
+                    const DivineIcon(
+                      icon: DivineIconName.warning,
                       color: VineTheme.warning,
                       size: 20,
                     ),
@@ -310,7 +309,11 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
                   width: double.infinity,
                   child: ElevatedButton.icon(
                     onPressed: _isProcessing ? null : () => _exportKey(context),
-                    icon: const Icon(Icons.copy, size: 20),
+                    icon: const DivineIcon(
+                      icon: DivineIconName.copy,
+                      size: 20,
+                      color: VineTheme.whiteText,
+                    ),
                     label: Text(
                       context.l10n.keyManagementCopyNsec,
                       style: const TextStyle(

--- a/mobile/lib/widgets/auth_back_button.dart
+++ b/mobile/lib/widgets/auth_back_button.dart
@@ -38,10 +38,9 @@ class AuthBackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return RoundedIconButton(
       onPressed: !enabled ? null : onPressed ?? () => _handleBackTap(context),
-      icon: const Icon(
-        Icons.chevron_left,
+      icon: const DivineIcon(
+        icon: DivineIconName.caretLeft,
         color: VineTheme.vineGreenLight,
-        size: 24,
       ),
     );
   }

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -37,6 +37,9 @@ class _MockPendingVerificationService extends Mock
 
 class _MockInviteApiClient extends Mock implements InviteApiClient {}
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   late _MockEmailVerificationCubit mockCubit;
   late _MockAuthService mockAuthService;
@@ -206,7 +209,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.close), findsOneWidget);
+        expect(_divineIcon(DivineIconName.x), findsOneWidget);
       });
 
       testWidgets('renders verification link instruction text', (tester) async {
@@ -285,7 +288,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.close), findsNothing);
+        expect(_divineIcon(DivineIconName.x), findsNothing);
       });
     });
 
@@ -335,7 +338,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.close), findsOneWidget);
+        expect(_divineIcon(DivineIconName.x), findsOneWidget);
       });
 
       testWidgets('renders failure instruction text', (tester) async {

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -25,6 +25,9 @@ class _MockAuthService extends Mock implements AuthService {}
 class _MockPendingVerificationService extends Mock
     implements PendingVerificationService {}
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   late _MockKeycastOAuth mockOAuth;
   late _MockAuthService mockAuthService;
@@ -255,7 +258,7 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.info_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.info), findsOneWidget);
       });
     });
 
@@ -266,7 +269,7 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pumpAndSettle();
 
-        await tester.tap(find.byIcon(Icons.info_outline));
+        await tester.tap(_divineIcon(DivineIconName.info));
         await tester.pumpAndSettle();
 
         expect(find.text('Sign-in options'), findsOneWidget);
@@ -284,7 +287,7 @@ void main() {
           await tester.pumpWidget(createTestWidget());
           await tester.pumpAndSettle();
 
-          await tester.tap(find.byIcon(Icons.info_outline));
+          await tester.tap(_divineIcon(DivineIconName.info));
           await tester.pumpAndSettle();
 
           await tester.scrollUntilVisible(

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -23,6 +23,9 @@ class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group(SecureAccountScreen, () {
     late _MockKeycastOAuth mockOAuth;
@@ -126,7 +129,7 @@ void main() {
         await tester.pumpWidget(buildTestWidget());
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+        expect(_divineIcon(DivineIconName.caretLeft), findsOneWidget);
       });
     });
 
@@ -242,7 +245,13 @@ void main() {
 
         // DivineAuthTextField uses DivineIcon (SVG) for password visibility
         // toggles. The password and confirmation fields each have one.
-        expect(find.byType(DivineIcon), findsNWidgets(2));
+        expect(
+          find.descendant(
+            of: find.byType(DivineAuthTextField),
+            matching: find.byType(DivineIcon),
+          ),
+          findsNWidgets(2),
+        );
 
         // Password should be obscured initially
         final textField = tester.widget<TextField>(
@@ -254,7 +263,14 @@ void main() {
         expect(textField.obscureText, isTrue);
 
         // Tap the visibility toggle (GestureDetector wrapping DivineIcon)
-        await tester.tap(find.byType(DivineIcon).first);
+        await tester.tap(
+          find
+              .descendant(
+                of: find.byType(DivineAuthTextField),
+                matching: find.byType(DivineIcon),
+              )
+              .first,
+        );
         await tester.pumpAndSettle();
 
         // Password should now be visible

--- a/mobile/test/widgets/auth_back_button_test.dart
+++ b/mobile/test/widgets/auth_back_button_test.dart
@@ -11,6 +11,9 @@ import 'package:openvine/widgets/rounded_icon_button.dart';
 
 import '../helpers/go_router.dart';
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group(AuthBackButton, () {
     group('renders', () {
@@ -37,7 +40,7 @@ void main() {
           ),
         );
 
-        expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+        expect(_divineIcon(DivineIconName.caretLeft), findsOneWidget);
       });
 
       testWidgets('uses vineGreenLight color for icon', (tester) async {
@@ -50,7 +53,9 @@ void main() {
           ),
         );
 
-        final icon = tester.widget<Icon>(find.byIcon(Icons.chevron_left));
+        final icon = tester.widget<DivineIcon>(
+          _divineIcon(DivineIconName.caretLeft),
+        );
         expect(icon.color, equals(VineTheme.vineGreenLight));
       });
     });


### PR DESCRIPTION
## Description

Migrates 12 raw Material `Icons.*` uses to `DivineIcon` across the **auth / onboarding** area — email verification, the invite gate, login options, nostr-connect, secure-account, key management, and the shared auth back button. Fourth follow-up slice off the whole-codebase audit on #4803 (after #4867 video feed, #4868 sounds, #4869 profile).

Only **exact-glyph** equivalents from the audit's verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| check                  | check              |
| check_circle           | checkCircle        |
| chevron_left           | caretLeft          |
| close                  | x                  |
| copy                   | copy               |
| email_outlined         | envelope           |
| error_outline          | warningCircle      |
| info_outline           | info               |
| warning_amber          | warning            |

No visual change is expected. The key-management copy button passes an explicit color (DivineIcon, an SVG, doesn't inherit `IconTheme`), redundant `size: 24` is dropped (it's the default), and the secure-account password-toggle test is rescoped to `DivineAuthTextField` descendants so the auto-shown verification-dialog envelope icon doesn't inflate the toggle count.

**Related Issue:** Relates to #4803 (whole-codebase tracker).

## Out of Scope

- `forgot_password_dialog`'s email prefix icon — left as `Icons.email_outlined` because it has no explicit color and the input-decoration theme sets no `prefixIconColor`, so the inherited tint is ambiguous (under-migrated to avoid a silent color change; still tracked under #4803).
- Other areas (relay, followers, comments, inbox, apps, shared widgets) — separate follow-up PRs.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 11 changed files — **No issues found!**
- `flutter test` across login_options, secure_account, email_verification, auth_back_button, invite_gate, nostr_connect, key_management — **71 passed**
- 4 test files updated: `find.byIcon(Icons.X)` → `DivineIcon` widget-predicate finder; secure-account toggle-count rescoped to its actual intent.

## Type of Change

- [x] 🧹 Code refactor