### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across small feature areas (#4803)

### DIFF
--- a/mobile/lib/screens/apps/apps_directory_screen.dart
+++ b/mobile/lib/screens/apps/apps_directory_screen.dart
@@ -197,7 +197,10 @@ class _AppsDirectoryRow extends StatelessWidget {
                 const SizedBox(width: 12),
                 const Padding(
                   padding: EdgeInsets.only(top: 6),
-                  child: Icon(Icons.chevron_right, color: VineTheme.lightText),
+                  child: DivineIcon(
+                    icon: DivineIconName.caretRight,
+                    color: VineTheme.lightText,
+                  ),
                 ),
               ],
             ),

--- a/mobile/lib/screens/apps/apps_permissions_screen.dart
+++ b/mobile/lib/screens/apps/apps_permissions_screen.dart
@@ -105,8 +105,8 @@ class _AppsPermissionsEmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(
-              Icons.lock_outline,
+            const DivineIcon(
+              icon: DivineIconName.lockSimple,
               color: VineTheme.vineGreen,
               size: 28,
             ),

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -461,8 +461,8 @@ class _SendButton extends StatelessWidget {
         child: IconButton(
           onPressed: onSubmit,
           padding: EdgeInsets.zero,
-          icon: const Icon(
-            Icons.arrow_upward,
+          icon: const DivineIcon(
+            icon: DivineIconName.arrowUp,
             color: VineTheme.whiteText,
             size: 20,
           ),
@@ -506,8 +506,8 @@ class _EditIndicator extends StatelessWidget {
               width: 20,
               height: 20,
               alignment: Alignment.center,
-              child: const Icon(
-                Icons.close,
+              child: const DivineIcon(
+                icon: DivineIconName.x,
                 size: 16,
                 color: VineTheme.tabIndicatorGreen,
               ),
@@ -554,8 +554,8 @@ class _ReplyIndicator extends StatelessWidget {
               width: 20,
               height: 20,
               alignment: Alignment.center,
-              child: const Icon(
-                Icons.close,
+              child: const DivineIcon(
+                icon: DivineIconName.x,
                 size: 16,
                 color: VineTheme.tabIndicatorGreen,
               ),

--- a/mobile/lib/screens/comments/widgets/comments_header.dart
+++ b/mobile/lib/screens/comments/widgets/comments_header.dart
@@ -28,7 +28,10 @@ class CommentsHeader extends StatelessWidget {
             button: true,
             label: l10n.commentsHeaderCloseLabel,
             child: IconButton(
-              icon: const Icon(Icons.close, color: VineTheme.whiteText),
+              icon: const DivineIcon(
+                icon: DivineIconName.x,
+                color: VineTheme.whiteText,
+              ),
               onPressed: onClose,
             ),
           ),

--- a/mobile/lib/screens/followers/my_followers_screen.dart
+++ b/mobile/lib/screens/followers/my_followers_screen.dart
@@ -214,7 +214,11 @@ class _FollowersErrorBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.followersFailedToLoadList,

--- a/mobile/lib/screens/followers/others_followers_screen.dart
+++ b/mobile/lib/screens/followers/others_followers_screen.dart
@@ -238,7 +238,11 @@ class _FollowersErrorBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.followersFailedToLoadList,

--- a/mobile/lib/screens/following/my_following_screen.dart
+++ b/mobile/lib/screens/following/my_following_screen.dart
@@ -166,8 +166,8 @@ class _FollowingEmptyState extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(
-            Icons.person_add_outlined,
+          const DivineIcon(
+            icon: DivineIconName.userPlus,
             size: 64,
             color: VineTheme.lightText,
           ),
@@ -196,7 +196,11 @@ class _FollowingErrorBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.followingFailedToLoadList,

--- a/mobile/lib/screens/following/others_following_screen.dart
+++ b/mobile/lib/screens/following/others_following_screen.dart
@@ -198,8 +198,8 @@ class _FollowingEmptyState extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(
-            Icons.person_add_outlined,
+          const DivineIcon(
+            icon: DivineIconName.userPlus,
             size: 64,
             color: VineTheme.lightText,
           ),
@@ -228,7 +228,11 @@ class _FollowingErrorBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.followingFailedToLoadList,

--- a/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
@@ -192,8 +192,8 @@ class _MoreButton extends StatelessWidget {
             child: const SizedBox(
               width: 48,
               height: 48,
-              child: Icon(
-                Icons.add,
+              child: DivineIcon(
+                icon: DivineIconName.plus,
                 color: VineTheme.onSurface,
               ),
             ),

--- a/mobile/lib/screens/inbox/new_message_sheet.dart
+++ b/mobile/lib/screens/inbox/new_message_sheet.dart
@@ -199,7 +199,10 @@ class _SearchField extends StatelessWidget {
       child: Row(
         spacing: 8,
         children: [
-          const Icon(Icons.search, color: VineTheme.onSurfaceMuted, size: 24),
+          const DivineIcon(
+            icon: DivineIconName.search,
+            color: VineTheme.onSurfaceMuted,
+          ),
           Expanded(
             child: TextField(
               controller: controller,

--- a/mobile/lib/screens/relay_diagnostic_screen.dart
+++ b/mobile/lib/screens/relay_diagnostic_screen.dart
@@ -696,8 +696,8 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
                   Center(
                     child: ElevatedButton.icon(
                       onPressed: _testDirectEventQuery,
-                      icon: const Icon(
-                        Icons.search,
+                      icon: const DivineIcon(
+                        icon: DivineIconName.search,
                         color: VineTheme.whiteText,
                       ),
                       label: Text(
@@ -723,8 +723,8 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
                     Center(
                       child: ElevatedButton.icon(
                         onPressed: _testNetworkConnectivity,
-                        icon: const Icon(
-                          Icons.play_arrow,
+                        icon: const DivineIcon(
+                          icon: DivineIconName.play,
                           color: VineTheme.whiteText,
                         ),
                         label: Text(
@@ -770,8 +770,8 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
                     Center(
                       child: ElevatedButton.icon(
                         onPressed: _testRestEndpoints,
-                        icon: const Icon(
-                          Icons.play_arrow,
+                        icon: const DivineIcon(
+                          icon: DivineIconName.play,
                           color: VineTheme.whiteText,
                         ),
                         label: Text(
@@ -829,8 +829,8 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
                     Center(
                       child: ElevatedButton.icon(
                         onPressed: _testRestEndpoints,
-                        icon: const Icon(
-                          Icons.play_arrow,
+                        icon: const DivineIcon(
+                          icon: DivineIconName.play,
                           color: VineTheme.whiteText,
                         ),
                         label: Text(
@@ -905,7 +905,10 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
                           ),
                         ),
                       )
-                    : const Icon(Icons.refresh, color: VineTheme.whiteText),
+                    : const DivineIcon(
+                        icon: DivineIconName.arrowClockwise,
+                        color: VineTheme.whiteText,
+                      ),
                 label: Text(
                   _isRetrying
                       ? context.l10n.relayDiagnosticRetrying
@@ -939,8 +942,8 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
                   children: [
                     Row(
                       children: [
-                        const Icon(
-                          Icons.info_outline,
+                        const DivineIcon(
+                          icon: DivineIconName.info,
                           color: VineTheme.secondaryText,
                           size: 20,
                         ),

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -542,7 +542,10 @@ class _PickerSearchInput extends StatelessWidget {
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
           hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-          prefixIcon: const Icon(Icons.search, color: VineTheme.onSurfaceMuted),
+          prefixIcon: const DivineIcon(
+            icon: DivineIconName.search,
+            color: VineTheme.onSurfaceMuted,
+          ),
           filled: true,
           fillColor: VineTheme.backgroundColor,
           border: OutlineInputBorder(
@@ -704,7 +707,11 @@ class _ErrorState extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(Icons.error_outline, size: 64, color: VineTheme.likeRed),
+            const DivineIcon(
+              icon: DivineIconName.warningCircle,
+              size: 64,
+              color: VineTheme.likeRed,
+            ),
             const SizedBox(height: 16),
             Text(
               context.l10n.videoEditorAudioFailedToLoadTitle,
@@ -723,7 +730,10 @@ class _ErrorState extends ConsumerWidget {
               onPressed: () {
                 ref.invalidate(trendingSoundsProvider);
               },
-              icon: const Icon(Icons.refresh),
+              icon: const DivineIcon(
+                icon: DivineIconName.arrowClockwise,
+                color: VineTheme.backgroundColor,
+              ),
               label: Text(context.l10n.commonRetry),
               style: ElevatedButton.styleFrom(
                 backgroundColor: VineTheme.vineGreen,

--- a/mobile/lib/widgets/video_editor/text_editor/video_editor_text_font_selector.dart
+++ b/mobile/lib/widgets/video_editor/text_editor/video_editor_text_font_selector.dart
@@ -97,7 +97,11 @@ class _FontListItem extends StatelessWidget {
                 ),
               ),
               if (isSelected)
-                const Icon(Icons.check, color: VineTheme.primary, size: 28),
+                const DivineIcon(
+                  icon: DivineIconName.check,
+                  color: VineTheme.primary,
+                  size: 28,
+                ),
             ],
           ),
         ),

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for CommentInput component
 // ABOUTME: Tests input field, send button, and posting state behavior
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,6 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/comments/comments.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('CommentInput', () {
@@ -38,7 +42,7 @@ void main() {
       );
 
       expect(find.text('Add comment...'), findsOneWidget);
-      expect(find.byIcon(Icons.arrow_upward), findsNothing);
+      expect(_divineIcon(DivineIconName.arrowUp), findsNothing);
     });
 
     testWidgets('shows send button when text is entered', (tester) async {
@@ -58,7 +62,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Test comment');
       await tester.pump();
 
-      expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+      expect(_divineIcon(DivineIconName.arrowUp), findsOneWidget);
     });
 
     testWidgets('shows video reply button when callback is provided', (
@@ -112,7 +116,7 @@ void main() {
         );
 
         expect(find.byType(CircularProgressIndicator), findsNothing);
-        expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+        expect(_divineIcon(DivineIconName.arrowUp), findsOneWidget);
       },
     );
 
@@ -135,7 +139,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Test comment');
       await tester.pump();
 
-      await tester.tap(find.byIcon(Icons.arrow_upward));
+      await tester.tap(_divineIcon(DivineIconName.arrowUp));
       await tester.pump();
 
       expect(submitted, isTrue);
@@ -260,7 +264,7 @@ void main() {
       );
 
       final label = find.text('Re: alice');
-      final closeIcon = find.byIcon(Icons.close);
+      final closeIcon = _divineIcon(DivineIconName.x);
       expect(label, findsOneWidget);
       expect(closeIcon, findsOneWidget);
 

--- a/mobile/test/screens/comments/comments_header_test.dart
+++ b/mobile/test/screens/comments/comments_header_test.dart
@@ -1,7 +1,11 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/comments/comments.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('CommentsHeader', () {
@@ -21,7 +25,7 @@ void main() {
     testWidgets('displays close button', (tester) async {
       await tester.pumpWidget(buildSubject());
 
-      expect(find.byIcon(Icons.close), findsOneWidget);
+      expect(_divineIcon(DivineIconName.x), findsOneWidget);
     });
 
     testWidgets('calls onClose when close button is tapped', (tester) async {
@@ -30,7 +34,7 @@ void main() {
         buildSubject(onClose: () => closeCallCount++),
       );
 
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(_divineIcon(DivineIconName.x));
       await tester.pump();
 
       expect(closeCallCount, equals(1));

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -5,6 +5,7 @@
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -48,6 +49,9 @@ const testVideoEventId =
     'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
 const testVideoAuthorPubkey =
     'b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234a';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('CommentsScreen', () {
@@ -291,7 +295,7 @@ void main() {
           find.text('${l10n.commentReplyToPrefix} TestUser'),
           findsOneWidget,
         );
-        expect(find.byIcon(Icons.close), findsWidgets);
+        expect(_divineIcon(DivineIconName.x), findsWidgets);
       });
     });
 

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,6 +38,9 @@ AudioEvent _createTestAudioEvent({
     duration: duration ?? 5.0,
   );
 }
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -308,7 +312,7 @@ void main() {
           find.text(l10n.videoEditorAudioFailedToLoadTitle),
           findsOneWidget,
         );
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
       });
 
       testWidgets('renders retry button on error state', (tester) async {


### PR DESCRIPTION
## Description

Batches the clean icon swaps from the **smaller audit areas** into one PR — relay diagnostics, followers/following, inbox (new-message search + reaction picker), comments (input + header), the audio/text video-editor sheets, and the apps directory/permissions screens. **24 swaps across 13 files.** Fifth follow-up slice off the whole-codebase audit on #4803 (after #4867 video feed, #4868 sounds, #4869 profile, #4870 auth).

Only **exact-glyph** equivalents from the audit's verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| add                    | plus               |
| arrow_upward           | arrowUp            |
| check                  | check              |
| chevron_right          | caretRight         |
| close                  | x                  |
| error_outline          | warningCircle      |
| info_outline           | info               |
| lock_outline           | lockSimple         |
| person_add_outlined    | userPlus           |
| play_arrow             | play               |
| refresh                | arrowClockwise     |
| search                 | search             |

No visual change is expected. Button-embedded icons carry explicit / foreground-matched colors, and redundant `size: 24` is dropped (it's the `DivineIcon` default).

**Related Issue:** Relates to #4803 (whole-codebase tracker).

## Out of Scope

Intentionally left as `Icons.*`:
- `message_bubble`'s delivery-status `switch` (returns `IconData`, and includes the approx `access_time`).
- `video_recorder`'s `videocam_off / videocam` ternary (mixed clean + approx).
- `relay_diagnostic`'s `check_circle / error` status ternaries (mixed clean + approx) and its `icon:`-param diagnostic rows.
- No-equivalent tokens (`people_outline`, `music_off`, `search_off`, `upload_file`, `cloud_*`) — tracked under #4833.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 17 changed files — **No issues found!**
- `flutter test` across comments (header/input/screen), audio-selection sheet, message_bubble, others_following, others_followers, apps (directory/permissions), reaction-picker, text-font-selector — **all passed (110+ tests)**
- 4 test files updated: `find.byIcon(Icons.X)` → `DivineIcon` widget-predicate finder.

## Type of Change

- [x] 🧹 Code refactor