### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across misc screens & settings (#4803)

### DIFF
--- a/mobile/lib/app_update/view/update_banner.dart
+++ b/mobile/lib/app_update/view/update_banner.dart
@@ -57,8 +57,8 @@ class _BannerContent extends StatelessWidget {
             ),
           ),
           IconButton(
-            icon: Icon(
-              Icons.close,
+            icon: DivineIcon(
+              icon: DivineIconName.x,
               size: 18,
               color: VineTheme.lightText.withValues(alpha: 0.6),
             ),

--- a/mobile/lib/features/feature_flags/screens/feature_flag_screen.dart
+++ b/mobile/lib/features/feature_flags/screens/feature_flag_screen.dart
@@ -81,8 +81,8 @@ class FeatureFlagScreen extends ConsumerWidget {
                                   padding: const EdgeInsetsDirectional.only(
                                     end: 8,
                                   ),
-                                  child: Icon(
-                                    Icons.edit,
+                                  child: DivineIcon(
+                                    icon: DivineIconName.pencilSimple,
                                     size: 16,
                                     color: Theme.of(
                                       context,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -897,8 +897,8 @@ Future<void> _startOpenVineApp() async {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(
-                  Icons.error_outline_rounded,
+                const DivineIcon(
+                  icon: DivineIconName.warningCircle,
                   color: VineTheme.accentOrange,
                   size: 48,
                 ),

--- a/mobile/lib/mixins/async_value_ui_helpers_mixin.dart
+++ b/mobile/lib/mixins/async_value_ui_helpers_mixin.dart
@@ -66,7 +66,11 @@ mixin AsyncValueUIHelpersMixin {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, color: VineTheme.error, size: 48),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            color: VineTheme.error,
+            size: 48,
+          ),
           const SizedBox(height: 16),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -150,7 +150,10 @@ class _AgeGateBanner extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.lock_outline, color: VineTheme.onSurfaceMuted),
+          const DivineIcon(
+            icon: DivineIconName.lockSimple,
+            color: VineTheme.onSurfaceMuted,
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Text(

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -968,7 +968,10 @@ class _PostAnalyticsDetailScreen extends StatelessWidget {
                           side: const BorderSide(color: VineTheme.outlineMuted),
                           padding: const EdgeInsets.symmetric(vertical: 12),
                         ),
-                        icon: const Icon(Icons.play_circle_outline),
+                        icon: const DivineIcon(
+                          icon: DivineIconName.playCircle,
+                          color: VineTheme.whiteText,
+                        ),
                         label: Text(context.l10n.analyticsOpenPost),
                       ),
                     ),

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -180,7 +180,10 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
                 onPressed: () {
                   ref.invalidate(curatedListVideoEventsProvider(widget.listId));
                 },
-                icon: const Icon(Icons.refresh),
+                icon: const DivineIcon(
+                  icon: DivineIconName.arrowClockwise,
+                  color: VineTheme.backgroundColor,
+                ),
                 label: Text(context.l10n.commonRetry),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: VineTheme.vineGreen,
@@ -252,7 +255,10 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
                   color: VineTheme.scrim50,
                   shape: BoxShape.circle,
                 ),
-                child: const Icon(Icons.arrow_back, color: VineTheme.whiteText),
+                child: const DivineIcon(
+                  icon: DivineIconName.arrowLeft,
+                  color: VineTheme.whiteText,
+                ),
               ),
               onPressed: () {
                 setState(() {

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -155,7 +155,10 @@ class _DeveloperOptionsScreenState
                     ),
                   ),
                   trailing: isSelected
-                      ? const Icon(Icons.check, color: VineTheme.vineGreen)
+                      ? const DivineIcon(
+                          icon: DivineIconName.check,
+                          color: VineTheme.vineGreen,
+                        )
                       : null,
                   onTap: () => _switchEnvironment(context, env, isSelected),
                 );
@@ -308,7 +311,10 @@ class _DeveloperOptionsScreenState
                     ),
                   ),
                   trailing: isSelected
-                      ? const Icon(Icons.check, color: VineTheme.vineGreen)
+                      ? const DivineIcon(
+                          icon: DivineIconName.check,
+                          color: VineTheme.vineGreen,
+                        )
                       : null,
                   onTap: () => _switchFormat(option.format),
                 );

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -442,7 +442,10 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
             const SizedBox(height: 24),
             ElevatedButton.icon(
               onPressed: _streamPublicLists,
-              icon: const Icon(Icons.refresh),
+              icon: const DivineIcon(
+                icon: DivineIconName.arrowClockwise,
+                color: VineTheme.backgroundColor,
+              ),
               label: Text(context.l10n.commonRetry),
               style: ElevatedButton.styleFrom(
                 backgroundColor: VineTheme.vineGreen,
@@ -459,7 +462,11 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(Icons.search, size: 64, color: VineTheme.secondaryText),
+            const DivineIcon(
+              icon: DivineIconName.search,
+              size: 64,
+              color: VineTheme.secondaryText,
+            ),
             const SizedBox(height: 16),
             Text(
               context.l10n.discoverListsEmptyTitle,

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -781,8 +781,8 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
               children: [
                 Row(
                   children: [
-                    const Icon(
-                      Icons.info_outline,
+                    const DivineIcon(
+                      icon: DivineIconName.info,
                       color: VineTheme.vineGreen,
                       size: 20,
                     ),
@@ -1185,8 +1185,8 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Icon(
-                    Icons.arrow_upward,
+                  const DivineIcon(
+                    icon: DivineIconName.arrowUp,
                     color: VineTheme.backgroundColor,
                     size: 18,
                   ),

--- a/mobile/lib/screens/geo_blocked_screen.dart
+++ b/mobile/lib/screens/geo_blocked_screen.dart
@@ -22,7 +22,11 @@ class GeoBlockedScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 // Icon
-                const Icon(Icons.block, size: 80, color: VineTheme.vineGreen),
+                const DivineIcon(
+                  icon: DivineIconName.prohibit,
+                  size: 80,
+                  color: VineTheme.vineGreen,
+                ),
                 const SizedBox(height: 32),
 
                 // Title

--- a/mobile/lib/screens/settings/account_content_labels_tile.dart
+++ b/mobile/lib/screens/settings/account_content_labels_tile.dart
@@ -58,7 +58,10 @@ class _AccountContentLabelsTileView extends StatelessWidget {
                 : context.l10n.contentPreferencesAccountLabelsEmpty,
             style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
           ),
-          trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+          trailing: const DivineIcon(
+            icon: DivineIconName.caretRight,
+            color: VineTheme.lightText,
+          ),
           onTap: () => _selectLabels(context, state.labels),
         );
       },

--- a/mobile/lib/screens/settings/bluesky_settings_screen.dart
+++ b/mobile/lib/screens/settings/bluesky_settings_screen.dart
@@ -183,7 +183,7 @@ class _ProvisioningStatus extends StatelessWidget {
     };
 
     return ListTile(
-      leading: Icon(Icons.info_outline, color: statusColor),
+      leading: DivineIcon(icon: DivineIconName.info, color: statusColor),
       title: Text(
         context.l10n.blueskyStatus,
         style: const TextStyle(

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -59,8 +59,8 @@ class GeneralSettingsScreen extends ConsumerWidget {
                     context.l10n.settingsBlueskyPublishingSubtitle,
                     style: _subtitleStyle,
                   ),
-                  trailing: const Icon(
-                    Icons.chevron_right,
+                  trailing: const DivineIcon(
+                    icon: DivineIconName.caretRight,
                     color: VineTheme.lightText,
                   ),
                   onTap: () => context.push(BlueskySettingsScreen.path),
@@ -127,7 +127,10 @@ class _ClosedCaptionsToggle extends ConsumerWidget {
       ),
       subtitle: Text(context.l10n.generalSettingsClosedCaptionsSubtitle),
       activeThumbColor: VineTheme.vineGreen,
-      secondary: const Icon(Icons.closed_caption, color: VineTheme.vineGreen),
+      secondary: const DivineIcon(
+        icon: DivineIconName.closedCaptioning,
+        color: VineTheme.vineGreen,
+      ),
     );
   }
 }
@@ -147,10 +150,16 @@ class _FeedAspectRatioPreferenceTile extends ConsumerWidget {
     };
 
     return ListTile(
-      leading: const Icon(Icons.crop_square, color: VineTheme.vineGreen),
+      leading: const DivineIcon(
+        icon: DivineIconName.cropSquare,
+        color: VineTheme.vineGreen,
+      ),
       title: Text(context.l10n.generalSettingsVideoShape, style: _titleStyle),
       subtitle: Text(subtitle, style: _subtitleStyle),
-      trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+      trailing: const DivineIcon(
+        icon: DivineIconName.caretRight,
+        color: VineTheme.lightText,
+      ),
       onTap: () => _showPicker(context, service),
     );
   }
@@ -270,7 +279,10 @@ class _AudioSharingToggleState extends ConsumerState<_AudioSharingToggle> {
         style: _subtitleStyle,
       ),
       activeThumbColor: VineTheme.vineGreen,
-      secondary: const Icon(Icons.music_note, color: VineTheme.vineGreen),
+      secondary: const DivineIcon(
+        icon: DivineIconName.musicNote,
+        color: VineTheme.vineGreen,
+      ),
     );
   }
 }
@@ -323,10 +335,16 @@ class _AppLanguageTile extends StatelessWidget {
             : LocalePreferenceService.nativeNameFor(locale.languageCode);
 
         return ListTile(
-          leading: const Icon(Icons.language, color: VineTheme.vineGreen),
+          leading: const DivineIcon(
+            icon: DivineIconName.globe,
+            color: VineTheme.vineGreen,
+          ),
           title: Text(context.l10n.settingsAppLanguage, style: _titleStyle),
           subtitle: Text(subtitle, style: _subtitleStyle),
-          trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+          trailing: const DivineIcon(
+            icon: DivineIconName.caretRight,
+            color: VineTheme.lightText,
+          ),
           onTap: () => context.push(AppLanguageScreen.path),
         );
       },

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -313,7 +313,10 @@ class _SettingsTile extends StatelessWidget {
         subtitle,
         style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
       ),
-      trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+      trailing: const DivineIcon(
+        icon: DivineIconName.caretRight,
+        color: VineTheme.lightText,
+      ),
       onTap: onTap,
     );
   }

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -259,7 +259,10 @@ class _SupportTile extends StatelessWidget {
         subtitle,
         style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
       ),
-      trailing: const Icon(Icons.chevron_right, color: VineTheme.lightText),
+      trailing: const DivineIcon(
+        icon: DivineIconName.caretRight,
+        color: VineTheme.lightText,
+      ),
       onTap: onTap,
     );
   }

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -260,7 +260,11 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Icon(Icons.error_outline, color: VineTheme.error, size: 64),
+              const DivineIcon(
+                icon: DivineIconName.warningCircle,
+                color: VineTheme.error,
+                size: 64,
+              ),
               const SizedBox(height: 16),
               Text(
                 _error!,

--- a/mobile/lib/screens/video_engagement/video_engagement_list_view.dart
+++ b/mobile/lib/screens/video_engagement/video_engagement_list_view.dart
@@ -133,7 +133,11 @@ class _EngagementErrorBody extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.lightText),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.videoEngagementLoadFailed,

--- a/mobile/test/app_update/view/update_banner_test.dart
+++ b/mobile/test/app_update/view/update_banner_test.dart
@@ -1,5 +1,6 @@
 import 'package:app_update_repository/app_update_repository.dart';
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,6 +10,9 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 
 class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
     implements AppUpdateBloc {}
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group(UpdateBanner, () {
@@ -63,7 +67,7 @@ void main() {
       );
 
       await tester.pumpWidget(buildSubject());
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(_divineIcon(DivineIconName.x));
 
       verify(() => bloc.add(const AppUpdateDismissed())).called(1);
     });

--- a/mobile/test/features/feature_flags/feature_flag_workflow_test.dart
+++ b/mobile/test/features/feature_flags/feature_flag_workflow_test.dart
@@ -16,6 +16,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockSharedPreferences extends Mock implements SharedPreferences {}
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group('Feature Flag System Integration', () {
     late _MockSharedPreferences mockPrefs;
@@ -336,7 +339,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Look for override indicators (edit icons)
-      final editIcons = find.byIcon(Icons.edit);
+      final editIcons = _divineIcon(DivineIconName.pencilSimple);
       expect(editIcons, findsAtLeast(1));
 
       // Look for individual reset buttons

--- a/mobile/test/mixins/async_value_ui_helpers_mixin_test.dart
+++ b/mobile/test/mixins/async_value_ui_helpers_mixin_test.dart
@@ -1,11 +1,15 @@
 // ABOUTME: TDD tests for AsyncValueUIHelpersMixin
 // ABOUTME: Verifies AsyncValue UI handling with consistent loading/error states
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/mixins/async_value_ui_helpers_mixin.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('AsyncValueUIHelpersMixin', () {
@@ -102,7 +106,7 @@ void main() {
           ),
         );
 
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
         expect(find.textContaining('Test error'), findsOneWidget);
       },
     );
@@ -131,7 +135,7 @@ void main() {
       );
 
       expect(find.text('Custom Error: Test error'), findsOneWidget);
-      expect(find.byIcon(Icons.error_outline), findsNothing);
+      expect(_divineIcon(DivineIconName.warningCircle), findsNothing);
     });
 
     testWidgets('SPEC: default loading widget should be centered', (
@@ -186,7 +190,7 @@ void main() {
         );
 
         // Should have error icon
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
 
         // Should have error message
         expect(find.textContaining('Network timeout'), findsOneWidget);

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
@@ -30,6 +31,9 @@ class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   setUpAll(() {
@@ -341,7 +345,7 @@ void main() {
           await tester.pump();
 
           expect(find.text('Video not found'), findsOneWidget);
-          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
           expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
         },
       );
@@ -412,7 +416,7 @@ void main() {
           await tester.pump();
 
           expect(find.textContaining('Failed to load video'), findsOneWidget);
-          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
           expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
         },
       );


### PR DESCRIPTION
## Description

Sweeps the clean icon swaps across the remaining standalone screens (discover, explore, curated-list, developer-options, feature-flags, creator-analytics, video-engagement, video-detail, content-filters, geo-blocked, update-banner, the async-value mixin, app root) **and** the settings screens left untouched by #4802 (general, account-content labels, bluesky, nostr, support-center). **29 swaps across 18 files.** Sixth follow-up slice off the whole-codebase audit on #4803.

Only **exact-glyph** equivalents from the audit's verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| arrow_back             | arrowLeft          |
| arrow_upward           | arrowUp            |
| block                  | prohibit           |
| check                  | check              |
| chevron_right          | caretRight         |
| close                  | x                  |
| closed_caption         | closedCaptioning   |
| crop_square            | cropSquare         |
| edit                   | pencilSimple       |
| error_outline(_rounded)| warningCircle      |
| info_outline           | info               |
| language               | globe              |
| lock_outline           | lockSimple         |
| music_note             | musicNote          |
| play_circle_outline    | playCircle         |
| refresh                | arrowClockwise     |
| search                 | search             |

No visual change is expected. Button-embedded icons carry explicit / foreground-matched colors.

**Related Issue:** Relates to #4803 (whole-codebase tracker).

## Out of Scope

Intentionally left as `Icons.*`:
- `legal_screen`'s `open_in_new / chevron_right` ternary (mixed none + clean).
- `feature_flag`'s cache-info button (`TextButton`, no explicit color → ambiguous inherited tint).
- `discover`'s `check / add` subscribe ternary (no color).
- `video_engagement`'s likers/reposters `switch` (returns `IconData`, param-style).
- `icon:`-param diagnostic rows + no-equivalent tokens (`bug_report`, `analytics_outlined`, `video_library`, `cloud_upload`, `alternate_email`, `travel_explore`, …) — tracked under #4833.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 22 changed files — **No issues found!**
- `flutter test` across async-value mixin, feature-flag workflow, update-banner, video-detail, content-filters — **all passed**
- 4 test files updated: `find.byIcon(Icons.X)` → `DivineIcon` widget-predicate finder.

## Type of Change

- [x] 🧹 Code refactor