### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across video tiles & overlays (#4803)

### DIFF
--- a/mobile/lib/widgets/camera_fab.dart
+++ b/mobile/lib/widgets/camera_fab.dart
@@ -52,7 +52,11 @@ class CameraFAB extends ConsumerWidget {
       },
       backgroundColor: VineTheme.vineGreen,
       foregroundColor: VineTheme.whiteText,
-      child: const Icon(Icons.videocam, size: 32),
+      child: const DivineIcon(
+        icon: DivineIconName.videoCamera,
+        size: 32,
+        color: VineTheme.whiteText,
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -246,7 +246,10 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
               padding: const EdgeInsets.all(16),
               child: Row(
                 children: [
-                  const Icon(Icons.more_vert, color: VineTheme.whiteText),
+                  const DivineIcon(
+                    icon: DivineIconName.dotsThreeVertical,
+                    color: VineTheme.whiteText,
+                  ),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
@@ -260,8 +263,8 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                   ),
                   IconButton(
                     onPressed: context.pop,
-                    icon: const Icon(
-                      Icons.close,
+                    icon: const DivineIcon(
+                      icon: DivineIconName.x,
                       color: VineTheme.secondaryText,
                     ),
                   ),
@@ -278,8 +281,8 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                   color: VineTheme.cardBackground,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: const Icon(
-                  Icons.edit,
+                child: const DivineIcon(
+                  icon: DivineIconName.pencilSimple,
                   color: VineTheme.vineGreen,
                   size: 20,
                 ),
@@ -313,8 +316,8 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                   color: VineTheme.cardBackground,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: const Icon(
-                  Icons.delete_outline,
+                child: const DivineIcon(
+                  icon: DivineIconName.trash,
                   color: VineTheme.error,
                   size: 20,
                 ),
@@ -525,8 +528,8 @@ class _VideoItem extends StatelessWidget {
                       color: VineTheme.vineGreen.withValues(alpha: 0.9),
                       borderRadius: BorderRadius.circular(4),
                     ),
-                    child: const Icon(
-                      Icons.collections,
+                    child: const DivineIcon(
+                      icon: DivineIconName.images,
                       size: 14,
                       color: VineTheme.whiteText,
                     ),

--- a/mobile/lib/widgets/error_message.dart
+++ b/mobile/lib/widgets/error_message.dart
@@ -21,7 +21,11 @@ class ErrorMessage extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.error_outline, color: VineTheme.whiteText, size: 20),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            color: VineTheme.whiteText,
+            size: 20,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(

--- a/mobile/lib/widgets/related_videos_widget.dart
+++ b/mobile/lib/widgets/related_videos_widget.dart
@@ -123,7 +123,11 @@ class _RelatedVideosWidgetState extends ConsumerState<RelatedVideosWidget> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.error_outline, color: VineTheme.error, size: 48),
+              DivineIcon(
+                icon: DivineIconName.warningCircle,
+                color: VineTheme.error,
+                size: 48,
+              ),
               SizedBox(height: 8),
               Text(
                 'Failed to load related videos',

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -171,7 +171,11 @@ class _ThumbnailState extends State<_Thumbnail> {
       );
     }
 
-    return const Icon(Icons.videocam, color: VineTheme.lightText, size: 32);
+    return const DivineIcon(
+      icon: DivineIconName.videoCamera,
+      color: VineTheme.lightText,
+      size: 32,
+    );
   }
 }
 

--- a/mobile/lib/widgets/video_explore_tile.dart
+++ b/mobile/lib/widgets/video_explore_tile.dart
@@ -164,7 +164,11 @@ class _CreatorInfo extends ConsumerWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.person, color: VineTheme.onSurfaceVariant, size: 14),
+          const DivineIcon(
+            icon: DivineIconName.user,
+            color: VineTheme.onSurfaceVariant,
+            size: 14,
+          ),
           const SizedBox(width: 4),
           Flexible(
             child: Text(

--- a/mobile/lib/widgets/video_icon_placeholder.dart
+++ b/mobile/lib/widgets/video_icon_placeholder.dart
@@ -99,7 +99,11 @@ class _VideoIconPlaceholderState extends State<VideoIconPlaceholder>
         ? Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(Icons.play_circle_outline, size: 48, color: iconColor),
+              DivineIcon(
+                icon: DivineIconName.playCircle,
+                size: 48,
+                color: iconColor,
+              ),
               const SizedBox(height: 8),
               Text(
                 'Video',
@@ -146,7 +150,11 @@ class VideoIconPlaceholderCompact extends StatelessWidget {
         color: bgColor,
         borderRadius: BorderRadius.circular(4),
       ),
-      child: Icon(Icons.videocam, size: size * 0.6, color: iconColorValue),
+      child: DivineIcon(
+        icon: DivineIconName.videoCamera,
+        size: size * 0.6,
+        color: iconColorValue,
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_metrics_overlay.dart
+++ b/mobile/lib/widgets/video_metrics_overlay.dart
@@ -119,8 +119,8 @@ class _VideoMetricsOverlayState extends State<VideoMetricsOverlay> {
                               const Spacer(),
                               GestureDetector(
                                 onTap: _clearMetrics,
-                                child: const Icon(
-                                  Icons.clear,
+                                child: const DivineIcon(
+                                  icon: DivineIconName.x,
                                   color: VineTheme.lightText,
                                   size: 16,
                                 ),

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -134,8 +134,8 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
                 color: VineTheme.backgroundColor.withValues(alpha: 0.6),
                 shape: BoxShape.circle,
               ),
-              child: const Icon(
-                Icons.play_arrow,
+              child: const DivineIcon(
+                icon: DivineIconName.play,
                 color: VineTheme.whiteText,
                 size: 32,
               ),

--- a/mobile/test/widgets/video_thumbnail_aspect_ratio_test.dart
+++ b/mobile/test/widgets/video_thumbnail_aspect_ratio_test.dart
@@ -1,11 +1,15 @@
 // ABOUTME: Tests verifying that video thumbnails match the actual video aspect ratio from dimensions metadata
 // ABOUTME: Ensures thumbnails prevent visual jump when video loads by matching video dimensions
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('VideoThumbnailWidget Aspect Ratio', () {
@@ -137,7 +141,7 @@ void main() {
 
       // Verify play icon is present
       expect(
-        find.byIcon(Icons.play_arrow),
+        _divineIcon(DivineIconName.play),
         findsOneWidget,
         reason: 'Play icon should be visible on thumbnail',
       );

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:blurhash_service/blurhash_service.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
@@ -8,6 +9,9 @@ import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 
 import '../test_data/video_test_data.dart';
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('VideoThumbnailWidget', () {
@@ -187,7 +191,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Should show play icon
-      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(_divineIcon(DivineIconName.play), findsOneWidget);
     });
 
     testWidgets('applies border radius when provided', (tester) async {


### PR DESCRIPTION
## Description

First of three **shared-widget** slices for the icon sweep. Covers the video tile / thumbnail / overlay widgets — composable video-grid options sheet, video icon placeholder, video clip thumbnail card, explore tile, thumbnail play button, related-videos error, camera FAB, metrics overlay, and the shared error-message row. **14 swaps across 9 files.** Tracked by #4803.

Only **exact-glyph** equivalents from the audit's verified mapping are swapped:

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| clear                  | x                  |
| close                  | x                  |
| collections            | images             |
| delete_outline         | trash              |
| edit                   | pencilSimple       |
| error_outline          | warningCircle      |
| more_vert              | dotsThreeVertical  |
| person                 | user               |
| play_arrow             | play               |
| play_circle_outline    | playCircle         |
| videocam               | videoCamera        |

No visual change is expected. The camera FAB icon now carries an explicit color to match the FAB `foregroundColor` (`DivineIcon`, an SVG, doesn't inherit `IconTheme`).

**Related Issue:** Relates to #4803 (whole-codebase tracker).

## Out of Scope

Left as `Icons.*`:
- composable-grid `check_circle / error` result ternary (mixed clean + approx).
- metrics-overlay `analytics` (approx → graph, needs design sign-off).
- related-videos `video_library_outlined` (no equivalent → #4833).
- `rounded_icon_button`'s `///` doc-comment example (not live code).

Dropped on rebase:
- `web_video_player.dart` was deleted on `main` by the native-video replacement work, so its two `error_outline → warningCircle` swaps no longer apply. The file is kept deleted (the swap survives in the shared `error_message` / `related_videos` rows).

## Verification

Rebased onto current `origin/main` (`web_video_player.dart` kept deleted), then re-verified on the pinned toolchain:

- `dart format --set-exit-if-changed` on the 11 touched files — clean (0 changed)
- `flutter analyze` on the 11 changed files — **No issues found!**
- `flutter test` across video_thumbnail_widget, video_thumbnail_aspect_ratio, video_explore_tile_nip05, composable_video_grid, video_thumbnail_404, video_clip_thumbnail_card, video_clip_preview — **50 passed** (5 skipped, 0 failed)
- 2 test files updated: `find.byIcon(Icons.play_arrow)` → `DivineIcon` widget-predicate finder.

## Type of Change

- [x] 🧹 Code refactor
