### PR TITLE
style(design-system): migrate raw Icons.* to DivineIcon across menus, dialogs & search (#4803)

### DIFF
--- a/mobile/lib/screens/search_results/widgets/search_user_tile.dart
+++ b/mobile/lib/screens/search_results/widgets/search_user_tile.dart
@@ -86,7 +86,10 @@ class SearchUserTile extends ConsumerWidget {
               ),
               if (showAddToList)
                 IconButton(
-                  icon: const Icon(Icons.playlist_add),
+                  icon: const DivineIcon(
+                    icon: DivineIconName.listPlus,
+                    color: VineTheme.secondaryText,
+                  ),
                   color: VineTheme.secondaryText,
                   tooltip: context.l10n.peopleListsAddToList,
                   onPressed: () => AddToPeopleListsSheet.show(

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -63,8 +63,10 @@ class SelectListDialog extends StatelessWidget {
                   final isInList = list.videoEventIds.contains(video.id);
 
                   return ListTile(
-                    leading: Icon(
-                      isInList ? Icons.check_circle : Icons.playlist_play,
+                    leading: DivineIcon(
+                      icon: isInList
+                          ? DivineIconName.checkCircle
+                          : DivineIconName.playlist,
                       color: isInList
                           ? VineTheme.vineGreen
                           : VineTheme.whiteText,

--- a/mobile/lib/widgets/age_verification_dialog.dart
+++ b/mobile/lib/widgets/age_verification_dialog.dart
@@ -31,8 +31,8 @@ class AgeVerificationDialog extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(
-            Icons.person_outline,
+          const DivineIcon(
+            icon: DivineIconName.user,
             color: VineTheme.vineGreen,
             size: 64,
           ),

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -88,8 +88,8 @@ class _FindPeopleSheetState extends ConsumerState<FindPeopleSheet> {
                 decoration: InputDecoration(
                   hintText: 'Find people',
                   hintStyle: const TextStyle(color: VineTheme.secondaryText),
-                  prefixIcon: const Icon(
-                    Icons.search,
+                  prefixIcon: const DivineIcon(
+                    icon: DivineIconName.search,
                     color: VineTheme.secondaryText,
                   ),
                   filled: true,

--- a/mobile/lib/widgets/list_card.dart
+++ b/mobile/lib/widgets/list_card.dart
@@ -58,8 +58,8 @@ class UserListCard extends StatelessWidget {
                       ],
                     ),
                   ),
-                  const Icon(
-                    Icons.chevron_right,
+                  const DivineIcon(
+                    icon: DivineIconName.caretRight,
                     color: VineTheme.secondaryText,
                   ),
                 ],
@@ -139,8 +139,8 @@ class CuratedListCard extends StatelessWidget {
                       ],
                     ),
                   ),
-                  const Icon(
-                    Icons.chevron_right,
+                  const DivineIcon(
+                    icon: DivineIconName.caretRight,
                     color: VineTheme.secondaryText,
                   ),
                 ],

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -128,7 +128,10 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
     ),
     child: Row(
       children: [
-        const Icon(Icons.share, color: VineTheme.whiteText),
+        const DivineIcon(
+          icon: DivineIconName.share,
+          color: VineTheme.whiteText,
+        ),
         const SizedBox(width: 12),
         Expanded(
           child: Column(
@@ -157,7 +160,10 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
         ),
         IconButton(
           onPressed: () => _safePop(context),
-          icon: const Icon(Icons.close, color: VineTheme.secondaryText),
+          icon: const DivineIcon(
+            icon: DivineIconName.x,
+            color: VineTheme.secondaryText,
+          ),
         ),
       ],
     ),
@@ -350,8 +356,8 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
                   children: [
                     Row(
                       children: [
-                        const Icon(
-                          Icons.info_outline,
+                        const DivineIcon(
+                          icon: DivineIconName.info,
                           color: VineTheme.vineGreen,
                           size: 18,
                         ),
@@ -960,8 +966,10 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
             itemBuilder: (context, index) {
               final list = lists[index];
               return ListTile(
-                leading: Icon(
-                  list.isPublic ? Icons.public : Icons.lock,
+                leading: DivineIcon(
+                  icon: list.isPublic
+                      ? DivineIconName.globe
+                      : DivineIconName.lockSimple,
                   color: VineTheme.vineGreen,
                   size: 20,
                 ),
@@ -1176,7 +1184,10 @@ class _SelectBookmarkSetDialog extends StatelessWidget {
                         color: VineTheme.vineGreen.withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      child: const Icon(Icons.add, color: VineTheme.vineGreen),
+                      child: const DivineIcon(
+                        icon: DivineIconName.plus,
+                        color: VineTheme.vineGreen,
+                      ),
                     ),
                     title: Text(
                       context.l10n.shareMenuCreateNewSet,
@@ -1227,10 +1238,10 @@ class _SelectBookmarkSetDialog extends StatelessWidget {
                           );
 
                           return ListTile(
-                            leading: Icon(
-                              isInSet
-                                  ? Icons.check_circle
-                                  : Icons.bookmark_border,
+                            leading: DivineIcon(
+                              icon: isInSet
+                                  ? DivineIconName.checkCircle
+                                  : DivineIconName.bookmarkSimple,
                               color: isInSet
                                   ? VineTheme.vineGreen
                                   : VineTheme.whiteText,
@@ -1507,8 +1518,8 @@ class _UseThisSoundTile extends ConsumerWidget {
               color: VineTheme.vineGreen.withValues(alpha: 0.2),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: const Icon(
-              Icons.music_note,
+            child: const DivineIcon(
+              icon: DivineIconName.musicNote,
               color: VineTheme.vineGreen,
               size: 20,
             ),

--- a/mobile/lib/widgets/user_search_view.dart
+++ b/mobile/lib/widgets/user_search_view.dart
@@ -196,7 +196,11 @@ class _UserSearchErrorState extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Icon(Icons.error_outline, size: 64, color: VineTheme.error),
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            size: 64,
+            color: VineTheme.error,
+          ),
           const SizedBox(height: 16),
           Text(
             context.l10n.userSearchFailed,

--- a/mobile/test/screens/search_results/widgets/people_section_test.dart
+++ b/mobile/test/screens/search_results/widgets/people_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,6 +20,9 @@ import '../../../helpers/test_provider_overrides.dart';
 
 class _MockUserSearchBloc extends MockBloc<UserSearchEvent, UserSearchState>
     implements UserSearchBloc {}
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group(PeopleSection, () {
@@ -114,7 +118,7 @@ void main() {
 
           await tester.pumpWidget(buildSubject());
 
-          expect(find.byIcon(Icons.playlist_add), findsNothing);
+          expect(_divineIcon(DivineIconName.listPlus), findsNothing);
         },
       );
 
@@ -152,7 +156,7 @@ void main() {
             ),
           );
 
-          expect(find.byIcon(Icons.playlist_add), findsOneWidget);
+          expect(_divineIcon(DivineIconName.listPlus), findsOneWidget);
         },
       );
 

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for SelectListDialog and CreateListDialog widgets
 // ABOUTME: Verifies list selection, list item interactions, and list creation form
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,6 +17,9 @@ class _MockCuratedListService extends Mock implements CuratedListService {}
 
 /// Test data for the fake notifier - set before each test
 List<CuratedList> _fakeLists = [];
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 /// Mock service for the fake notifier - set before tests that need interactions
 _MockCuratedListService? _fakeService;
@@ -101,7 +105,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      expect(_divineIcon(DivineIconName.checkCircle), findsOneWidget);
     });
 
     testWidgets('shows playlist icon for video not in list', (tester) async {
@@ -120,7 +124,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.playlist_play), findsOneWidget);
+      expect(_divineIcon(DivineIconName.playlist), findsOneWidget);
     });
 
     testWidgets('displays video count for each list', (tester) async {

--- a/mobile/test/widgets/age_verification_dialog_test.dart
+++ b/mobile/test/widgets/age_verification_dialog_test.dart
@@ -36,6 +36,9 @@ Widget _createDialogTestApp({ValueChanged<bool?>? onResult}) {
   );
 }
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group(AgeVerificationDialog, () {
     testWidgets('should display all required elements', (tester) async {
@@ -47,7 +50,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.person_outline), findsOneWidget);
+      expect(_divineIcon(DivineIconName.user), findsOneWidget);
       expect(find.text('Age Verification'), findsOneWidget);
       expect(
         find.text(
@@ -123,7 +126,7 @@ void main() {
         ),
       );
 
-      final icon = tester.widget<Icon>(find.byIcon(Icons.person_outline));
+      final icon = tester.widget<DivineIcon>(_divineIcon(DivineIconName.user));
       expect(icon.color, VineTheme.vineGreen);
 
       final yesButton = tester.widget<ElevatedButton>(

--- a/mobile/test/widgets/comprehensive_age_verification_dialog_test.dart
+++ b/mobile/test/widgets/comprehensive_age_verification_dialog_test.dart
@@ -42,6 +42,9 @@ Widget _createDialogTestApp({
   );
 }
 
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
 void main() {
   group('AgeVerificationDialog - Comprehensive Tests', () {
     group('Creation Verification (16+)', () {
@@ -237,7 +240,9 @@ void main() {
         );
 
         // Check icon color
-        final icon = tester.widget<Icon>(find.byIcon(Icons.person_outline));
+        final icon = tester.widget<DivineIcon>(
+          _divineIcon(DivineIconName.user),
+        );
         expect(icon.color, VineTheme.vineGreen);
         expect(icon.size, 64);
 
@@ -332,7 +337,7 @@ void main() {
         );
 
         // Check that all elements are present
-        expect(find.byIcon(Icons.person_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.user), findsOneWidget);
         expect(find.text('Age Verification'), findsOneWidget);
         expect(
           find.text(

--- a/mobile/test/widgets/user_search_view_test.dart
+++ b/mobile/test/widgets/user_search_view_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates UI states for initial, loading, success, failure, and empty results
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,6 +15,9 @@ import '../helpers/test_provider_overrides.dart';
 
 class _MockUserSearchBloc extends MockBloc<UserSearchEvent, UserSearchState>
     implements UserSearchBloc {}
+
+Finder _divineIcon(DivineIconName name) =>
+    find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group('UserSearchView', () {
@@ -149,7 +153,7 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pump();
 
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
         expect(find.text('Search failed'), findsOneWidget);
       });
     });


### PR DESCRIPTION
## Description

**Final shared-widget slice.** Covers the share-video menu, the add-to-list and age-verification dialogs, the find-people sheet, the user-search view, the search-user tile, and the list card. **14 swaps across 7 files.** Tracked by #4803.

Only **exact-glyph** equivalents from the audit's verified mapping are swapped, including three clean-both-branch ternaries (`check_circle / playlist_play`, `public / lock`, `check_circle / bookmark_border`):

| Material `Icons.*`     | `DivineIconName`   |
| ---------------------- | ------------------ |
| add                    | plus               |
| bookmark_border        | bookmarkSimple     |
| check_circle           | checkCircle        |
| chevron_right          | caretRight         |
| close                  | x                  |
| error_outline          | warningCircle      |
| info_outline           | info               |
| lock                   | lockSimple         |
| music_note             | musicNote          |
| person_outline         | user               |
| playlist_add           | listPlus           |
| playlist_play          | playlist           |
| public                 | globe              |
| search                 | search             |
| share                  | share              |

No visual change is expected. The search-user-tile `IconButton` forwards its color onto the `DivineIcon`.

**Related Issue:** Relates to #4803 (whole-codebase tracker).

## Out of Scope

Left as `Icons.*`:
- share-video-menu's `_buildActionTile` `icon: Icons.X` params (needs a helper-signature change), and its `check_circle / error` mixed ternary.
- `arrow_forward_ios` / `folder` (approx).
- `psychology_alt`, `playlist_add_check`, `remove_circle_outline`, `person_search`, `person_off`, `group`, `video_library` (no equivalent → #4833).

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` on all 11 changed files — **No issues found!**
- `flutter test` across age-verification (x2), user-search-view, add-to-list-dialog, find-people-sheet — **50 passed**
- 4 test files updated: `find.byIcon(Icons.X)` → `DivineIcon` widget-predicate finder, incl. `widget<Icon>` → `widget<DivineIcon>` casts.

## Type of Change

- [x] 🧹 Code refactor