### PR TITLE
fix(feed): restore paused playback controls

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -597,7 +597,6 @@ class __OverlayState extends ConsumerState<_Overlay> {
                           PausedVideoOverlay(
                             controller: widget.controller!,
                             isVisible: widget.isActive,
-                            onVolumeToggle: (v) => _feedState?.setVolume(v),
                           ),
                         _FeedItemActions(
                           video: video,
@@ -618,9 +617,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
                           pagePositionListenable: pagePositionListenable,
                         ),
                         Positioned.fill(
-                          child: DoubleTapHeartOverlay(
-                            trigger: _heartTrigger,
-                          ),
+                          child: DoubleTapHeartOverlay(trigger: _heartTrigger),
                         ),
                       ],
                     ),

--- a/mobile/lib/widgets/video_feed_item/paused_video_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/paused_video_overlay.dart
@@ -5,22 +5,17 @@ import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
+import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
 class PausedVideoOverlay extends StatefulWidget {
   const PausedVideoOverlay({
     required this.controller,
     this.isVisible = true,
-    this.onVolumeToggle,
     super.key,
   });
 
   final DivineVideoPlayerController controller;
   final bool isVisible;
-
-  /// Called when the user taps the mute/unmute button.
-  /// Receives the new volume (0.0 or 1.0). Route this to
-  /// [InfiniteVideoFeedState.setVolume] so the feed tracks the value.
-  final void Function(double volume)? onVolumeToggle;
 
   @override
   State<PausedVideoOverlay> createState() => _PausedVideoOverlayState();
@@ -63,30 +58,24 @@ class _PausedVideoOverlayState extends State<PausedVideoOverlay>
   void initState() {
     super.initState();
     _unpauseFeedbackController =
-        AnimationController(
-          vsync: this,
-          duration: _unpauseHideDelay,
-        )..addStatusListener((status) {
-          if (status == AnimationStatus.completed && mounted) {
-            setState(() {
-              _showUnpauseFeedback = false;
-            });
-          }
-        });
-    _unpauseFeedbackOpacity =
-        Tween<double>(
-          begin: 1,
-          end: 0,
-        ).animate(
-          CurvedAnimation(
-            parent: _unpauseFeedbackController,
-            curve: Interval(
-              _unpauseFadeStartDelay.inMilliseconds /
-                  _unpauseHideDelay.inMilliseconds,
-              1,
-            ),
-          ),
-        );
+        AnimationController(vsync: this, duration: _unpauseHideDelay)
+          ..addStatusListener((status) {
+            if (status == AnimationStatus.completed && mounted) {
+              setState(() {
+                _showUnpauseFeedback = false;
+              });
+            }
+          });
+    _unpauseFeedbackOpacity = Tween<double>(begin: 1, end: 0).animate(
+      CurvedAnimation(
+        parent: _unpauseFeedbackController,
+        curve: Interval(
+          _unpauseFadeStartDelay.inMilliseconds /
+              _unpauseHideDelay.inMilliseconds,
+          1,
+        ),
+      ),
+    );
     _subscribe();
   }
 
@@ -262,11 +251,19 @@ class _PausedVideoOverlayState extends State<PausedVideoOverlay>
         final Widget child;
         if (shouldShow) {
           child = Center(
-            child: IgnorePointer(
-              child: CenterPlaybackControl(
-                state: CenterPlaybackControlState.play,
-                semanticsLabel: context.l10n.videoPlayerPlayVideo,
-              ),
+            key: const ValueKey('paused-playback-controls'),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const FeedPlaybackTogglesPill(),
+                const SizedBox(height: 16),
+                IgnorePointer(
+                  child: CenterPlaybackControl(
+                    state: CenterPlaybackControlState.play,
+                    semanticsLabel: context.l10n.videoPlayerPlayVideo,
+                  ),
+                ),
+              ],
             ),
           );
         } else if (shouldShowUnpauseFeedback) {
@@ -290,10 +287,7 @@ class _PausedVideoOverlayState extends State<PausedVideoOverlay>
             return FadeTransition(
               opacity: animation,
               child: ScaleTransition(
-                scale: Tween<double>(
-                  begin: 0.92,
-                  end: 1,
-                ).animate(animation),
+                scale: Tween<double>(begin: 0.92, end: 1).animate(animation),
                 child: child,
               ),
             );

--- a/mobile/test/widgets/video_feed_item/paused_video_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/paused_video_overlay_test.dart
@@ -1,11 +1,24 @@
 import 'dart:async';
 
+import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideoVolumeCubit extends MockCubit<VideoVolumeState>
+    implements VideoVolumeCubit {}
 
 class _FakeDivineVideoPlayerController extends DivineVideoPlayerController {
   _FakeDivineVideoPlayerController() : super();
@@ -32,20 +45,39 @@ class _FakeDivineVideoPlayerController extends DivineVideoPlayerController {
 void main() {
   group(PausedVideoOverlay, () {
     late _FakeDivineVideoPlayerController controller;
+    late FeedAutoAdvanceCubit autoAdvanceCubit;
+    late VideoVolumeCubit volumeCubit;
+    late SharedPreferences mockPrefs;
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
 
     setUp(() {
       controller = _FakeDivineVideoPlayerController();
+      autoAdvanceCubit = FeedAutoAdvanceCubit();
+      volumeCubit = _MockVideoVolumeCubit();
+      when(() => volumeCubit.state).thenReturn(const VideoVolumeState());
+      mockPrefs = createMockSharedPreferences();
     });
 
     tearDown(() async {
       await controller.dispose();
+      await autoAdvanceCubit.close();
     });
 
     Widget buildSubject() {
-      return MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: PausedVideoOverlay(controller: controller)),
+      return ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<FeedAutoAdvanceCubit>.value(value: autoAdvanceCubit),
+              BlocProvider<VideoVolumeCubit>.value(value: volumeCubit),
+            ],
+            child: Scaffold(body: PausedVideoOverlay(controller: controller)),
+          ),
+        ),
       );
     }
 
@@ -77,6 +109,15 @@ void main() {
         await tester.pump(const Duration(milliseconds: 220));
 
         expect(findPlayControl(), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(l10n.videoActionEnableAutoAdvance),
+          findsOneWidget,
+        );
+        expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(l10n.videoSettingsCaptionsDisable),
+          findsOneWidget,
+        );
       },
     );
 


### PR DESCRIPTION
## Summary
- restore CC, mute, and autoplay as a horizontal control row above the centered paused play button
- show the controls only while a video is paused
- add paused overlay tests covering visibility and toggle behavior

## Test Plan
- [x] cd mobile && flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart
- [x] cd mobile && flutter test test/widgets/video_feed_item/actions/cc_action_button_test.dart test/widgets/video_feed_item/actions/more_action_button_test.dart
- [x] cd mobile && flutter test test/widgets/video_feed_item
