### PR TITLE
feat(l10n): localize share-copy + clipboard confirmations (#3628 Area K subset)

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -437,7 +437,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       emit(
         state.copyWith(
           actionResult: ShareSheetCopiedToClipboard(
-            label: 'Link to post copied to clipboard',
+            kind: ShareSheetCopiedKind.postLink,
             text: url,
           ),
         ),
@@ -525,7 +525,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       emit(
         state.copyWith(
           actionResult: ShareSheetCopiedToClipboard(
-            label: 'Nostr event JSON copied to clipboard',
+            kind: ShareSheetCopiedKind.eventJson,
             text: json,
           ),
         ),
@@ -556,7 +556,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       emit(
         state.copyWith(
           actionResult: ShareSheetCopiedToClipboard(
-            label: 'Nostr event ID copied to clipboard',
+            kind: ShareSheetCopiedKind.eventId,
             text: nevent,
           ),
         ),

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -77,11 +77,14 @@ class ShareSheetActionFailure extends ShareSheetActionResult {
   ShareSheetActionFailure();
 }
 
-class ShareSheetCopiedToClipboard extends ShareSheetActionResult {
-  ShareSheetCopiedToClipboard({required this.label, required this.text});
+/// What content was copied, so the UI can pick the localized message.
+enum ShareSheetCopiedKind { postLink, eventJson, eventId }
 
-  /// Human-readable label for the snackbar message.
-  final String label;
+class ShareSheetCopiedToClipboard extends ShareSheetActionResult {
+  ShareSheetCopiedToClipboard({required this.kind, required this.text});
+
+  /// Which content was copied; the UI maps this to a localized message.
+  final ShareSheetCopiedKind kind;
 
   /// Text to copy to clipboard.
   final String text;

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3440,6 +3440,9 @@
       }
     }
   },
+  "shareCopiedPostLink": "Link to post copied to clipboard",
+  "shareCopiedEventJson": "Nostr event JSON copied to clipboard",
+  "shareCopiedEventId": "Nostr event ID copied to clipboard",
   "bugReportSendReport": "Send Report",
   "supportSubjectRequiredLabel": "Subject *",
   "supportRequiredHelper": "Required",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10748,6 +10748,24 @@ abstract class AppLocalizations {
   /// **'This integration tried to leave its approved origin.\n\n{uri}'**
   String appsSandboxBlockedSubtitle(String uri);
 
+  /// No description provided for @shareCopiedPostLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Link to post copied to clipboard'**
+  String get shareCopiedPostLink;
+
+  /// No description provided for @shareCopiedEventJson.
+  ///
+  /// In en, this message translates to:
+  /// **'Nostr event JSON copied to clipboard'**
+  String get shareCopiedEventJson;
+
+  /// No description provided for @shareCopiedEventId.
+  ///
+  /// In en, this message translates to:
+  /// **'Nostr event ID copied to clipboard'**
+  String get shareCopiedEventId;
+
   /// No description provided for @bugReportSendReport.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6016,6 +6016,15 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'ሪፖርት ላክ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6082,6 +6082,15 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'إرسال التقرير';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6198,6 +6198,15 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Изпрати доклад';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6206,6 +6206,15 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Bericht senden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6133,6 +6133,15 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Send Report';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6189,6 +6189,15 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Enviar reporte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6207,6 +6207,15 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Ipadala ang Report';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6212,6 +6212,15 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Envoyer le rapport';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6110,6 +6110,15 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Kirim Laporan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6186,6 +6186,15 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Invia segnalazione';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5891,6 +5891,15 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'レポートを送信';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5914,6 +5914,15 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => '신고 보내기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6163,6 +6163,15 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Rapport verzenden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6278,6 +6278,15 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Wyślij zgłoszenie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6171,6 +6171,15 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Enviar relatório';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6286,6 +6286,15 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Trimite raportul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6136,6 +6136,15 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Skicka rapport';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6113,6 +6113,15 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get shareCopiedPostLink => 'Link to post copied to clipboard';
+
+  @override
+  String get shareCopiedEventJson => 'Nostr event JSON copied to clipboard';
+
+  @override
+  String get shareCopiedEventId => 'Nostr event ID copied to clipboard';
+
+  @override
   String get bugReportSendReport => 'Raporu Gönder';
 
   @override

--- a/mobile/lib/utils/clipboard_utils.dart
+++ b/mobile/lib/utils/clipboard_utils.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:openvine/l10n/l10n.dart';
 
 /// Utility class for clipboard operations with visual feedback.
 ///
@@ -32,6 +33,6 @@ class ClipboardUtils {
   ///
   /// This is a convenience method specifically for copying Nostr public keys.
   static Future<void> copyPubkey(BuildContext context, String npub) async {
-    await copy(context, npub, message: 'Public key copied to clipboard');
+    await copy(context, npub, message: context.l10n.profilePublicKeyCopied);
   }
 }

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -221,7 +221,6 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         :final removed,
         :final wasBookmarkedBeforeToggle,
       ):
-        _safePop(context);
         final snackText = succeeded
             ? (removed
                   ? context.l10n.shareRemovedFromBookmarks
@@ -229,6 +228,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
             : (wasBookmarkedBeforeToggle
                   ? context.l10n.shareFailedToRemoveBookmark
                   : context.l10n.shareFailedToAddBookmark);
+        _safePop(context);
         messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(
             snackText,
@@ -241,19 +241,27 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
           );
         }
       case ShareSheetVideoClipImportResult(:final succeeded):
+        final snackText = succeeded
+            ? context.l10n.shareSheetAddedToClips
+            : context.l10n.shareSheetAddToClipsFailed;
         _safePop(context);
         messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(
-            succeeded
-                ? context.l10n.shareSheetAddedToClips
-                : context.l10n.shareSheetAddToClipsFailed,
+            snackText,
             error: !succeeded,
           ),
         );
-      case ShareSheetCopiedToClipboard(:final label, :final text):
+      case ShareSheetCopiedToClipboard(:final kind, :final text):
+        final snackText = switch (kind) {
+          ShareSheetCopiedKind.postLink => context.l10n.shareCopiedPostLink,
+          ShareSheetCopiedKind.eventJson => context.l10n.shareCopiedEventJson,
+          ShareSheetCopiedKind.eventId => context.l10n.shareCopiedEventId,
+        };
         Clipboard.setData(ClipboardData(text: text));
         _safePop(context);
-        messenger.showSnackBar(DivineSnackbarContainer.snackBar(label));
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(snackText),
+        );
       case ShareSheetShareViaTriggered(
         :final shareUrl,
         :final thumbnailPath,

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -975,9 +975,9 @@ void main() {
                   'https://divine.video/video/test-id',
                 )
                 .having(
-                  (r) => r.label,
-                  'label',
-                  'Link to post copied to clipboard',
+                  (r) => r.kind,
+                  'kind',
+                  ShareSheetCopiedKind.postLink,
                 ),
           ),
         ],
@@ -1168,9 +1168,9 @@ void main() {
             'actionResult',
             isA<ShareSheetCopiedToClipboard>()
                 .having(
-                  (r) => r.label,
-                  'label',
-                  'Nostr event JSON copied to clipboard',
+                  (r) => r.kind,
+                  'kind',
+                  ShareSheetCopiedKind.eventJson,
                 )
                 .having(
                   (r) => r.text.contains('"id"'),
@@ -1223,9 +1223,9 @@ void main() {
             'actionResult',
             isA<ShareSheetCopiedToClipboard>()
                 .having(
-                  (r) => r.label,
-                  'label',
-                  'Nostr event ID copied to clipboard',
+                  (r) => r.kind,
+                  'kind',
+                  ShareSheetCopiedKind.eventId,
                 )
                 .having(
                   (r) => r.text.startsWith('nevent'),

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -557,6 +557,10 @@ const _knownUntranslatedDebt = {
   'appsSandboxLoadingSubtitle',
   'appsSandboxBlockedTitle',
   'appsSandboxBlockedSubtitle',
+  // #3628 Area K (below-UI-layer safe subset)
+  'shareCopiedPostLink',
+  'shareCopiedEventJson',
+  'shareCopiedEventId',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
@@ -269,7 +270,12 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Link to post copied to clipboard'), findsOneWidget);
+        expect(
+          find.text(
+            lookupAppLocalizations(const Locale('en')).shareCopiedPostLink,
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets('shows own-video download actions for owned content', (


### PR DESCRIPTION
## Description

Third slice of #3628 (after #4889 Apps, #4890 main sweep). Handles the **below-UI-layer (Area K)** strings that can be localized **cleanly**, and explicitly defers/waives the ones that can't.

- **share_sheet** — `ShareSheetCopiedToClipboard` carried a display string (`label`) in BLoC state, which violates the "no strings in BLoC state" rule. Replaced with a `ShareSheetCopiedKind` enum (`postLink` / `eventJson` / `eventId`); the share-action button maps kind → `context.l10n` at render time. 3 new keys.
- **clipboard_utils** — `copyPubkey(BuildContext context, …)` already has a context; routed its confirmation through the existing `profilePublicKeyCopied` key (reuse, no new key).
- Tests updated (bloc asserts on `kind`; widget test asserts via `lookupAppLocalizations`).

English copy unchanged → no visible change, no golden churn.

**Related Issue:** Relates to #3628

## Out of Scope (deferred / waived — see follow-up issue)
- **Deferred to a follow-up:** `notification_service` (local/OS notification titles & bodies) and the **video-publish** service/bloc/provider status strings (`video_publish_service`, `background_publish_bloc`, `video_publish_provider`, their `// TODO(l10n)` markers). These are emitted in service/background layers with **no `BuildContext`** and need a UI-maps-status / cached-locale refactor — too risky to rush in critical publish/notification paths.
- **Waived (documented):** `main.dart`'s pre-`MaterialApp` `ErrorWidget.builder` ("Oops, something went wrong") runs in a bare `Directionality` with **no `Localizations` ancestor** (l10n is unavailable by design there); and `AsyncValueUIHelpersMixin._buildDefaultError` (raw-error dev fallback, no context — localizing needs a mixin-API change disproportionate to its value).

## Verification
- `flutter analyze lib test integration_test` → No issues found
- `flutter test test/l10n/arb_consistency_test.dart` → pass
- share_sheet bloc test (41) + share-action-button test (10) → pass
- `scan_strings.py` on changed files → clean

## Type of Change
- [x] 🧹 Code refactor
- [x] 📝 Documentation