### PR TITLE
fix(ios): enable Swift Package Manager

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -363,7 +363,7 @@ dev_dependencies:
 flutter:
   generate: true
   config:
-    enable-swift-package-manager: false
+    enable-swift-package-manager: true
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
Closes #4894

## Summary

Enable Flutter's project-level Swift Package Manager integration in mobile/pubspec.yaml.

## Root Cause

Codemagic already runs flutter config --enable-swift-package-manager, but the app-level Flutter config explicitly set enable-swift-package-manager: false. That forced iOS plugin integration back through CocoaPods, where c2pa_flutter intentionally fails because it only supports SPM.

## Validation

- flutter pub get from mobile/
- flutter build ios --config-only from mobile/
- pre-push hook reported no Dart files changed and skipped Dart checks