### PR TITLE
ci(codemagic): publish Android builds to production

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -502,7 +502,7 @@ workflows:
     publishing:
       google_play:
         credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
-        track: internal
+        track: production
 
   macos-build:
     name: macOS Build


### PR DESCRIPTION
Closes #4900

Summary
- publish the Android Codemagic workflow to the Google Play production track instead of internal
- leave rollout_fraction omitted so Codemagic releases to everyone rather than creating a staged rollout



Verification
- ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml'); puts 'codemagic.yaml parsed'"\n- git diff --check\n- pre-push hook: no merge conflicts with main; no Dart files changed