### PR TITLE
fix: explore search by opening unified search route

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -632,6 +632,15 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       ),
       // SEARCH RESULTS - unified search screen (no bottom nav)
       GoRoute(
+        path: SearchResultsPage.emptyPath,
+        parentNavigatorKey: NavigatorKeys.root,
+        builder: (ctx, st) => SearchResultsPage(
+          requestFocusOnMount: SearchResultsPage.requestFocusOnMountForRoute(
+            st.uri,
+          ),
+        ),
+      ),
+      GoRoute(
         path: SearchResultsPage.path,
         parentNavigatorKey: NavigatorKeys.root,
         builder: (ctx, st) {

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -115,10 +115,6 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
   String? _hashtagMode; // When non-null, showing hashtag feed
   String? _customTitle; // Custom title to override default "Explore"
 
-  // Search bar state
-  final _searchController = TextEditingController();
-  Timer? _searchDebounce;
-
   // Track classics availability to rebuild tabs when it changes
   bool _classicsAvailable = false;
   // Track For You availability (staging only)
@@ -207,7 +203,6 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
     super.initState();
 
     _initTabController();
-    _searchController.addListener(_onSearchChanged);
 
     // Track screen load
     _screenAnalytics.startScreenLoad('explore_screen');
@@ -258,10 +253,6 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
 
   @override
   void dispose() {
-    _searchDebounce?.cancel();
-    _searchController
-      ..removeListener(_onSearchChanged)
-      ..dispose();
     _tabController?.removeListener(_onTabChanged);
     _tabController?.dispose();
     super.dispose();
@@ -272,17 +263,10 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
     );
   }
 
-  void _onSearchChanged() {
-    _searchDebounce?.cancel();
-    final query = _searchController.text.trim();
-    if (query.length < 2) return;
-    _searchDebounce = Timer(const Duration(milliseconds: 300), () {
-      if (!mounted) return;
-      _searchController.clear();
-      context.push(
-        SearchResultsPage.pathForQuery(query, requestFocusOnMount: true),
-      );
-    });
+  void _openSearchPage() {
+    context.push(
+      SearchResultsPage.pathForEmptyQuery(requestFocusOnMount: true),
+    );
   }
 
   void _onTabChanged() {
@@ -498,8 +482,9 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: DivineSearchBar(
-                controller: _searchController,
                 hintText: context.l10n.exploreSearchHint,
+                readOnly: true,
+                onTap: _openSearchPage,
               ),
             ),
           ),

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -31,6 +31,9 @@ class SearchResultsPage extends ConsumerWidget {
   /// Base path prefix (used for route matching and normalization skips).
   static const pathPrefix = '/search-results';
 
+  /// Route path pattern for opening search without a prefilled query.
+  static const String emptyPath = pathPrefix;
+
   /// Route path pattern for GoRouter.
   static const path = '$pathPrefix/:query';
 
@@ -45,6 +48,12 @@ class SearchResultsPage extends ConsumerWidget {
     final encodedQuery = Uri.encodeComponent(query);
     if (!requestFocusOnMount) return '$pathPrefix/$encodedQuery';
     return '$pathPrefix/$encodedQuery?$requestFocusQueryParameter=1';
+  }
+
+  /// Build a path that opens search without a prefilled query.
+  static String pathForEmptyQuery({required bool requestFocusOnMount}) {
+    if (!requestFocusOnMount) return emptyPath;
+    return '$emptyPath?$requestFocusQueryParameter=1';
   }
 
   /// Returns whether a routed prefilled search should claim keyboard focus.

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -122,6 +122,17 @@ void main() {
             },
           ),
           GoRoute(
+            path: SearchResultsPage.emptyPath,
+            builder: (ctx, st) {
+              capturedQuery = '';
+              requestFocusOnMount =
+                  SearchResultsPage.requestFocusOnMountForRoute(
+                    st.uri,
+                  );
+              return const SizedBox.shrink();
+            },
+          ),
+          GoRoute(
             path: SearchResultsPage.path,
             builder: (ctx, st) {
               capturedQuery = st.pathParameters['query'];
@@ -172,6 +183,20 @@ void main() {
 
         expect(tester.takeException(), isNull);
         expect(result.capturedTag, equals(original));
+      },
+    );
+
+    testWidgets(
+      'pathForEmptyQuery opens search without a prefilled query',
+      (tester) async {
+        final result = await navigateAndCapture(
+          tester,
+          SearchResultsPage.pathForEmptyQuery(requestFocusOnMount: true),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedQuery, isEmpty);
+        expect(result.requestFocusOnMount, isTrue);
       },
     );
 


### PR DESCRIPTION
Closes #4902

## Description

Until now, when users wanted to search for something and entered more than two characters, they were automatically redirected to the search page from the explore-page. Based on the feedback and reports we've received on Discord [here](https://discord.com/channels/1470168817589158040/1470255950408454164/1512231471887421532), this was quite annoying for many users.

This PR changes that behavior so the search page opens immediately when users tap on the search bar.



**Related Issue:** None

## Out of Scope

None.

## Verification

- Targeted router tests passed for [mobile/test/router/app_router_test.dart](mobile/test/router/app_router_test.dart)
- Reviewed the route wiring and SearchResultsPage handling for both empty-query and prefilled-query search flows

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore