### PR TITLE
feat(timeline): add width parameter to TimelineTrimHandles for improved drag interaction

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart
@@ -23,6 +23,7 @@ class TimelineTrimHandles extends StatefulWidget {
   const TimelineTrimHandles({
     required this.child,
     required this.height,
+    this.width,
     this.onLeftDragUpdate,
     this.onRightDragUpdate,
     this.onDragStart,
@@ -44,6 +45,11 @@ class TimelineTrimHandles extends StatefulWidget {
 
   /// Total height of the trim container (including border).
   final double height;
+
+  /// Content width of the strip (excluding the handles). When provided,
+  /// the inward part of each grab zone is clamped so the left and right
+  /// hit areas never overlap on narrow strips.
+  final double? width;
 
   /// Called with the horizontal pixel delta when the left handle moves.
   final TrimDragCallback? onLeftDragUpdate;
@@ -117,9 +123,25 @@ class _TimelineTrimHandlesState extends State<TimelineTrimHandles> {
       double.infinity,
     );
 
+    // The grab zone reaches symmetrically around each handle edge:
+    // [outwardHit] points away from the content, [inwardHit] into it.
+    final defaultInward = widget.hitAreaExtra / 2 + widget.borderWidth;
+    var outwardHit = handleW + widget.hitAreaExtra / 2;
+    var inwardHit = defaultInward;
+    // On narrow strips, clamp the inward reach so the left and right hit
+    // areas never overlap — but keep the total grab width constant by
+    // shifting the lost inward part outwards instead of shrinking it.
+    final width = widget.width;
+    if (width != null) {
+      final clampedInward = inwardHit.clamp(0.0, width / 2);
+      outwardHit += inwardHit - clampedInward;
+      inwardHit = clampedInward;
+    }
+    final hitWidth = outwardHit + inwardHit;
+
     return _ExpandedHitSizedBox(
-      expandLeft: handleW + widget.hitAreaExtra,
-      expandRight: handleW + widget.hitAreaExtra,
+      expandLeft: outwardHit,
+      expandRight: outwardHit,
       height: widget.height,
       child: Stack(
         clipBehavior: Clip.none,
@@ -186,11 +208,12 @@ class _TimelineTrimHandlesState extends State<TimelineTrimHandles> {
               ),
             ),
           ),
-          // Left hit area — covers the outer handle + extra grab zone.
+          // Left hit area — symmetric grab zone around the handle edge:
+          // reaches [outwardHit] outwards and [inwardHit] inwards.
           Positioned(
-            left: -(handleW + widget.hitAreaExtra),
+            left: -outwardHit,
             top: 0,
-            width: handleW + widget.hitAreaExtra + widget.borderWidth,
+            width: hitWidth,
             height: widget.height,
             child: Semantics(
               label: context.l10n.videoEditorTimelineTrimStartSemanticLabel,
@@ -202,11 +225,12 @@ class _TimelineTrimHandlesState extends State<TimelineTrimHandles> {
               ),
             ),
           ),
-          // Right hit area — covers the outer handle + extra grab zone.
+          // Right hit area — symmetric grab zone around the handle edge:
+          // reaches [outwardHit] outwards and [inwardHit] inwards.
           Positioned(
-            right: -(handleW + widget.hitAreaExtra),
+            right: -outwardHit,
             top: 0,
-            width: handleW + widget.hitAreaExtra + widget.borderWidth,
+            width: hitWidth,
             height: widget.height,
             child: Semantics(
               label: context.l10n.videoEditorTimelineTrimEndSemanticLabel,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -130,6 +130,7 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
       padding: EdgeInsets.symmetric(horizontal: widget.trimExpand),
       child: TimelineTrimHandles(
         height: TimelineConstants.thumbnailStripHeight,
+        width: widget.clipWidth,
         onLeftDragUpdate: _onLeftDragUpdate,
         onRightDragUpdate: _onRightDragUpdate,
         onDragStart: _onDragStart,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_positioned_item.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_positioned_item.dart
@@ -276,6 +276,7 @@ class _TrimmableOverlayTileState extends State<_TrimmableOverlayTile> {
       padding: EdgeInsets.symmetric(horizontal: widget.trimExpansion),
       child: TimelineTrimHandles(
         height: widget.height - TimelineConstants.overlayRowGap,
+        width: widget.width,
         onDragStart: _onDragStart,
         onDragEnd: _onDragEnd,
         onLeftDragUpdate: _onLeftTrim,

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/timeline_trim_handles_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/timeline_trim_handles_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -16,6 +17,8 @@ void main() {
       VoidCallback? onDragStart,
       VoidCallback? onDragEnd,
       Color? handleColor,
+      double width = 300,
+      double? trimWidth,
       double height = TimelineConstants.thumbnailStripHeight,
       double handleWidth = TimelineConstants.trimHandleWidth,
     }) {
@@ -23,19 +26,22 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: SizedBox(
-            width: 300,
-            child: TimelineTrimHandles(
-              height: height,
-              onLeftDragUpdate: onLeftDragUpdate,
-              onRightDragUpdate: onRightDragUpdate,
-              onDragStart: onDragStart,
-              onDragEnd: onDragEnd,
-              handleColor: handleColor ?? VineTheme.accentYellow,
-              handleWidth: handleWidth,
-              child: const ColoredBox(
-                color: Colors.blue,
-                child: SizedBox.expand(),
+          body: Center(
+            child: SizedBox(
+              width: width,
+              child: TimelineTrimHandles(
+                height: height,
+                width: trimWidth,
+                onLeftDragUpdate: onLeftDragUpdate,
+                onRightDragUpdate: onRightDragUpdate,
+                onDragStart: onDragStart,
+                onDragEnd: onDragEnd,
+                handleColor: handleColor ?? VineTheme.accentYellow,
+                handleWidth: handleWidth,
+                child: const ColoredBox(
+                  color: Colors.blue,
+                  child: SizedBox.expand(),
+                ),
               ),
             ),
           ),
@@ -94,6 +100,33 @@ void main() {
         find.byType(TimelineTrimHandles),
       );
       return box.localToGlobal(Offset.zero);
+    }
+
+    bool hitTestsAt(WidgetTester tester, Offset localPosition) {
+      final box = tester.renderObject<RenderBox>(
+        find.byType(TimelineTrimHandles),
+      );
+      return box.hitTest(BoxHitTestResult(), position: localPosition);
+    }
+
+    double baseOutwardHit({
+      double handleWidth = TimelineConstants.trimHandleWidth,
+    }) {
+      return handleWidth -
+          TimelineConstants.trimBorderWidth +
+          TimelineConstants.trimHitAreaExtra / 2;
+    }
+
+    double narrowOutwardHit(
+      double trimWidth, {
+      double handleWidth = TimelineConstants.trimHandleWidth,
+    }) {
+      const defaultInward =
+          TimelineConstants.trimHitAreaExtra / 2 +
+          TimelineConstants.trimBorderWidth;
+      final clampedInward = defaultInward.clamp(0.0, trimWidth / 2);
+      return baseOutwardHit(handleWidth: handleWidth) +
+          (defaultInward - clampedInward);
     }
 
     group('left handle drag', () {
@@ -177,6 +210,129 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(started, isTrue);
+      });
+
+      testWidgets('accepts a drag from inside the right clip edge', (
+        tester,
+      ) async {
+        final deltas = <double>[];
+        await tester.pumpWidget(buildWidget(onRightDragUpdate: deltas.add));
+
+        final origin = handleOrigin(tester);
+        final box = tester.renderObject<RenderBox>(
+          find.byType(TimelineTrimHandles),
+        );
+        final from =
+            origin +
+            Offset(
+              box.size.width - (TimelineConstants.trimHitAreaExtra / 2),
+              box.size.height / 2,
+            );
+
+        await tester.dragFrom(from, const Offset(-20, 0));
+        await tester.pumpAndSettle();
+
+        expect(deltas, isNotEmpty);
+      });
+    });
+
+    group('narrow widths', () {
+      testWidgets(
+        'extends left hit testing beyond the original outward range',
+        (
+          tester,
+        ) async {
+          const trimWidth = 20.0;
+          await tester.pumpWidget(
+            buildWidget(
+              width: trimWidth,
+              trimWidth: trimWidth,
+            ),
+          );
+
+          final box = tester.renderObject<RenderBox>(
+            find.byType(TimelineTrimHandles),
+          );
+          final outwardHit = narrowOutwardHit(trimWidth);
+          final originalOutwardHit = baseOutwardHit();
+          final probeX =
+              -(originalOutwardHit + (outwardHit - originalOutwardHit) / 2);
+
+          expect(
+            hitTestsAt(tester, Offset(probeX, box.size.height / 2)),
+            isTrue,
+          );
+        },
+      );
+
+      testWidgets(
+        'extends right hit testing beyond the original outward range',
+        (
+          tester,
+        ) async {
+          const trimWidth = 20.0;
+          await tester.pumpWidget(
+            buildWidget(
+              width: trimWidth,
+              trimWidth: trimWidth,
+            ),
+          );
+
+          final box = tester.renderObject<RenderBox>(
+            find.byType(TimelineTrimHandles),
+          );
+          final outwardHit = narrowOutwardHit(trimWidth);
+          final originalOutwardHit = baseOutwardHit();
+          final probeX =
+              box.size.width +
+              originalOutwardHit +
+              (outwardHit - originalOutwardHit) / 2;
+
+          expect(
+            hitTestsAt(tester, Offset(probeX, box.size.height / 2)),
+            isTrue,
+          );
+        },
+      );
+
+      testWidgets('keeps left and right hit areas separated at the midpoint', (
+        tester,
+      ) async {
+        final leftDeltas = <double>[];
+        final rightDeltas = <double>[];
+        const trimWidth = 20.0;
+        await tester.pumpWidget(
+          buildWidget(
+            width: trimWidth,
+            trimWidth: trimWidth,
+            onLeftDragUpdate: leftDeltas.add,
+            onRightDragUpdate: rightDeltas.add,
+          ),
+        );
+
+        final origin = handleOrigin(tester);
+        final box = tester.renderObject<RenderBox>(
+          find.byType(TimelineTrimHandles),
+        );
+        final leftFrom =
+            origin + Offset(trimWidth / 2 - 1, box.size.height / 2);
+        final rightFrom =
+            origin + Offset(trimWidth / 2 + 1, box.size.height / 2);
+
+        await tester.dragFrom(leftFrom, const Offset(8, 0));
+        await tester.pumpAndSettle();
+
+        expect(leftDeltas, isNotEmpty);
+        expect(rightDeltas, isEmpty);
+
+        leftDeltas.clear();
+        rightDeltas.clear();
+
+        await tester.dragFrom(rightFrom, const Offset(-8, 0));
+        await tester.pumpAndSettle();
+
+        expect(leftDeltas, isEmpty);
+        expect(rightDeltas, isNotEmpty);
       });
     });
 


### PR DESCRIPTION
Closes #4908

## Description

Adds an optional `width` parameter to `TimelineTrimHandles` to prevent the left and right hit areas from overlapping on narrow clips.

Previously each handle had a fixed inward grab zone regardless of the strip's content width. On very short clips this caused both hit areas to overlap, making it impossible to reliably target one handle without accidentally triggering the other.

**How it works:**

The grab zone around each handle edge is split into an outward part (`outwardHit`) and an inward part (`inwardHit`). When `width` is provided, `inwardHit` is clamped to at most `width / 2` so the two zones never overlap. To keep the total grab width constant, any inward area that is clamped away is added to `outwardHit` instead of simply discarding it.

**Related Issue:** Relates to #

## Out of Scope

- Auto-scroll or further UX changes during trimming on narrow clips.

## Verification

- `flutter test test/widgets/video_editor/timeline_editor/strips/timeline_trim_handles_test.dart` → 15/15 tests pass.
- New tests cover:
  - Hit-test extends beyond the original outward range for both handles on narrow strips.
  - Left and right hit areas remain separated at the midpoint.
  - A drag from inside the right clip edge still triggers `onRightDragUpdate`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
