### PR TITLE
feat(feeds): send viewer language hints

### DIFF
--- a/mobile/lib/providers/feed_viewer_preference_hints.dart
+++ b/mobile/lib/providers/feed_viewer_preference_hints.dart
@@ -1,0 +1,105 @@
+// ABOUTME: Reads viewer language/country hints used by Funnelcake feed requests.
+// ABOUTME: Keeps feed providers from duplicating preference lookup behavior.
+
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:openvine/providers/permissions_providers.dart';
+import 'package:openvine/providers/preferences_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/locale_preference_service.dart';
+import 'package:riverpod/misc.dart';
+
+const _countryHintTimeout = Duration(milliseconds: 250);
+
+typedef ProviderReader = T Function<T>(ProviderListenable<T> provider);
+
+class FeedViewerPreferenceHints {
+  const FeedViewerPreferenceHints({
+    required this.preferredLanguages,
+    required this.viewerCountry,
+  });
+
+  final List<String> preferredLanguages;
+  final String? viewerCountry;
+}
+
+List<String> buildPreferredFeedLanguages({
+  required String contentLanguage,
+  String? appLocale,
+  Iterable<Locale> deviceLocales = const [],
+}) {
+  final languages = <String>[];
+  final seen = <String>{};
+
+  void addLanguage(String? rawLanguage) {
+    final normalized = _normalizeLanguageHint(rawLanguage);
+    if (normalized == null || !seen.add(normalized)) {
+      return;
+    }
+    languages.add(normalized);
+  }
+
+  addLanguage(contentLanguage);
+  addLanguage(appLocale);
+  for (final locale in deviceLocales) {
+    addLanguage(locale.languageCode);
+  }
+
+  return languages;
+}
+
+Future<FeedViewerPreferenceHints> readFeedViewerPreferenceHints(
+  ProviderReader read,
+) async {
+  final contentLanguage = read(
+    languagePreferenceServiceProvider,
+  ).contentLanguage.trim();
+  final preferredLanguages = buildPreferredFeedLanguages(
+    contentLanguage: contentLanguage,
+    appLocale: _readAppLocale(read),
+    deviceLocales: PlatformDispatcher.instance.locales,
+  );
+
+  String? viewerCountry;
+  try {
+    final geoInfo = await read(
+      geoBlockingServiceProvider,
+    ).getGeoInfo().timeout(_countryHintTimeout);
+    final country = geoInfo.country.trim();
+    if (country.isNotEmpty && country.toUpperCase() != 'UNKNOWN') {
+      viewerCountry = country;
+    }
+  } on Object {
+    viewerCountry = null;
+  }
+
+  return FeedViewerPreferenceHints(
+    preferredLanguages: preferredLanguages,
+    viewerCountry: viewerCountry,
+  );
+}
+
+String? _readAppLocale(ProviderReader read) {
+  try {
+    return read(sharedPreferencesProvider).getString(
+      LocalePreferenceService.prefsKey,
+    );
+  } on Object {
+    return null;
+  }
+}
+
+String? _normalizeLanguageHint(String? rawLanguage) {
+  final trimmed = rawLanguage?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return null;
+  }
+
+  final baseLanguage = trimmed
+      .replaceAll('_', '-')
+      .split('-')
+      .first
+      .toLowerCase();
+  return baseLanguage.isEmpty ? null : baseLanguage;
+}

--- a/mobile/lib/providers/feed_viewer_preference_hints.dart
+++ b/mobile/lib/providers/feed_viewer_preference_hints.dart
@@ -52,9 +52,9 @@ List<String> buildPreferredFeedLanguages({
 Future<FeedViewerPreferenceHints> readFeedViewerPreferenceHints(
   ProviderReader read,
 ) async {
-  final contentLanguage = read(
-    languagePreferenceServiceProvider,
-  ).contentLanguage.trim();
+  final languagePreferenceService = read(languagePreferenceServiceProvider);
+  await languagePreferenceService.initialize();
+  final contentLanguage = languagePreferenceService.contentLanguage.trim();
   final preferredLanguages = buildPreferredFeedLanguages(
     contentLanguage: contentLanguage,
     appLocale: _readAppLocale(read),

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -6,6 +6,7 @@ import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
+import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
@@ -106,9 +107,12 @@ class ForYouFeed extends _$ForYouFeed {
       }
 
       final client = ref.read(funnelcakeApiClientProvider);
+      final hints = await readFeedViewerPreferenceHints(ref.read);
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: limit,
+        preferredLanguages: hints.preferredLanguages,
+        viewerCountry: hints.viewerCountry,
       );
       final resultVideos = response.videos.toVideoEvents();
 
@@ -175,9 +179,12 @@ class ForYouFeed extends _$ForYouFeed {
 
       final client = ref.read(funnelcakeApiClientProvider);
       final newLimit = _currentLimit + 30;
+      final hints = await readFeedViewerPreferenceHints(ref.read);
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: newLimit,
+        preferredLanguages: hints.preferredLanguages,
+        viewerCountry: hints.viewerCountry,
       );
       final resultVideos = response.videos.toVideoEvents();
 

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -8,6 +8,7 @@ import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
 import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
@@ -30,6 +31,7 @@ class ForYouFeed extends _$ForYouFeed {
     // Watch content filter version — rebuilds when preferences change.
     ref.watch(contentFilterVersionProvider);
     ref.watch(divineHostFilterVersionProvider);
+    ref.watch(languagePreferenceVersionProvider);
 
     // Watch blocklist version — rebuilds when block/unblock actions occur.
     ref.watch(blocklistVersionProvider);

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'd203a01918a95d464033a8fe64f0f8be3f32e5ae';
+String _$forYouFeedHash() => r'12746d77ebf27e31e6b9678f5301528d3d6b5438';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'e92035e97715d40c2061becde40caf879bda96af';
+String _$forYouFeedHash() => r'd203a01918a95d464033a8fe64f0f8be3f32e5ae';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -10,6 +10,7 @@ import 'package:openvine/providers/feed_refresh_helpers.dart';
 import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
@@ -43,6 +44,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
     // Watch content filter version — rebuilds when preferences change.
     ref.watch(contentFilterVersionProvider);
     ref.watch(divineHostFilterVersionProvider);
+    ref.watch(languagePreferenceVersionProvider);
 
     // Watch blocklist version — rebuilds when block/unblock actions occur.
     ref.watch(blocklistVersionProvider);

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
+import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
@@ -131,10 +132,13 @@ class PopularVideosFeed extends _$PopularVideosFeed {
     required bool skipCache,
   }) async {
     final videosRepository = ref.read(videosRepositoryProvider);
+    final hints = await readFeedViewerPreferenceHints(ref.read);
     return videosRepository.getPopularVideosPage(
       limit: AppConstants.paginationBatchSize,
       variant: variant,
       skipCache: skipCache,
+      preferredLanguages: hints.preferredLanguages,
+      viewerCountry: hints.viewerCountry,
     );
   }
 
@@ -215,10 +219,13 @@ class PopularVideosFeed extends _$PopularVideosFeed {
 
   Future<PopularVideosPage> _fetchNextPage() async {
     final videosRepository = ref.read(videosRepositoryProvider);
+    final hints = await readFeedViewerPreferenceHints(ref.read);
     return videosRepository.getPopularVideosPage(
       limit: AppConstants.paginationBatchSize,
       cursor: _nextCursor,
       variant: ref.read(popularVideosVariantProvider),
+      preferredLanguages: hints.preferredLanguages,
+      viewerCountry: hints.viewerCountry,
     );
   }
 

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'86e90ef936c2746d0078de0d65f17719f21839eb';
+String _$popularVideosFeedHash() => r'ce442eebf2c4f1d2d488399ba2c9e24157a44d21';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'ce442eebf2c4f1d2d488399ba2c9e24157a44d21';
+String _$popularVideosFeedHash() => r'96b3d6aa20361070cfdea3395665d8d56a55e61a';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/providers/preferences_providers.dart
+++ b/mobile/lib/providers/preferences_providers.dart
@@ -48,5 +48,22 @@ AudioDevicePreferenceService audioDevicePreferenceService(Ref ref) {
 LanguagePreferenceService languagePreferenceService(Ref ref) {
   final service = LanguagePreferenceService();
   service.initialize(); // Initialize asynchronously
+  ref.onDispose(service.dispose);
   return service;
 }
+
+/// Rebuild trigger for consumers that need the latest content-language
+/// preference in request parameters.
+final languagePreferenceVersionProvider = Provider<int>((ref) {
+  final service = ref.watch(languagePreferenceServiceProvider);
+  var version = 0;
+
+  void listener() {
+    version++;
+    ref.invalidateSelf();
+  }
+
+  service.addListener(listener);
+  ref.onDispose(() => service.removeListener(listener));
+  return version;
+});

--- a/mobile/lib/providers/preferences_providers.g.dart
+++ b/mobile/lib/providers/preferences_providers.g.dart
@@ -181,4 +181,4 @@ final class LanguagePreferenceServiceProvider
 }
 
 String _$languagePreferenceServiceHash() =>
-    r'96dfa1a85d20ef92361b088de547a934ca5ccbb7';
+    r'a6e5b3c32d40108a2c44f422fcb95f64e4a68214';

--- a/mobile/lib/services/language_preference_service.dart
+++ b/mobile/lib/services/language_preference_service.dart
@@ -1,8 +1,7 @@
 // ABOUTME: Service for managing the user's preferred content language
 // ABOUTME: Stores ISO-639-1 language code used for NIP-32 labeling on video events
 
-import 'dart:ui';
-
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -12,11 +11,12 @@ import 'package:unified_logger/unified_logger.dart';
 /// self-labeling (`L`/`l` tags with ISO-639-1 namespace).
 ///
 /// When no custom language is set, the device's OS language is used.
-class LanguagePreferenceService {
+class LanguagePreferenceService extends ChangeNotifier {
   /// SharedPreferences key for the content language preference
   static const String prefsKey = 'content_language';
 
   String? _customLanguage;
+  Future<void>? _initializeFuture;
 
   /// Whether the user has overridden the default device language.
   bool get isCustomLanguageSet => _customLanguage != null;
@@ -30,7 +30,8 @@ class LanguagePreferenceService {
 
   /// Initialize the service by loading the saved preference.
   Future<void> initialize() async {
-    await _loadPreference();
+    _initializeFuture ??= _loadPreference();
+    await _initializeFuture;
   }
 
   Future<void> _loadPreference() async {
@@ -54,6 +55,7 @@ class LanguagePreferenceService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(prefsKey, languageCode);
       _customLanguage = languageCode;
+      notifyListeners();
 
       Log.debug(
         'Content language set to: $languageCode',
@@ -75,6 +77,7 @@ class LanguagePreferenceService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(prefsKey);
       _customLanguage = null;
+      notifyListeners();
 
       Log.debug(
         'Content language cleared, using device default',

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -130,6 +130,25 @@ class FunnelcakeApiClient {
     };
   }
 
+  void _addViewerPreferenceQueryParameters(
+    Map<String, String> queryParams, {
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
+  }) {
+    final languages = preferredLanguages
+        .map((language) => language.trim())
+        .where((language) => language.isNotEmpty)
+        .toList();
+    if (languages.isNotEmpty) {
+      queryParams['preferred_languages'] = languages.join(',');
+    }
+
+    final country = viewerCountry?.trim();
+    if (country != null && country.isNotEmpty) {
+      queryParams['viewer_country'] = country;
+    }
+  }
+
   /// Unwraps a funnelcake list response that may be either a raw JSON array
   /// (legacy / `legacy-array-response` flag on) or the post-#238 envelope
   /// shape `{"data": [...], "pagination": {"has_more": bool, "next_cursor":
@@ -524,11 +543,15 @@ class FunnelcakeApiClient {
     required PopularVideosVariant variant,
     int limit = 50,
     int? before,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
     final response = await getV2PopularVideosPage(
       variant: variant,
       limit: limit,
       before: before,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
     );
     return response.videos;
   }
@@ -540,6 +563,8 @@ class FunnelcakeApiClient {
     int limit = 50,
     String? cursor,
     int? before,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
     if (!isAvailable) {
       throw const FunnelcakeNotConfiguredException();
@@ -560,6 +585,11 @@ class FunnelcakeApiClient {
     } else if (before != null) {
       queryParams['before'] = before.toString();
     }
+    _addViewerPreferenceQueryParameters(
+      queryParams,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
 
     final uri = Uri.parse(
       '$_baseUrl/api/v2/videos',
@@ -1894,6 +1924,8 @@ class FunnelcakeApiClient {
     int limit = 20,
     String fallback = 'popular',
     String? category,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
     if (!isAvailable) {
       throw const FunnelcakeNotConfiguredException();
@@ -1910,6 +1942,11 @@ class FunnelcakeApiClient {
     if (category != null && category.isNotEmpty) {
       queryParams['category'] = category;
     }
+    _addViewerPreferenceQueryParameters(
+      queryParams,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
 
     final uri = Uri.parse(
       '$_baseUrl/api/users/$pubkey/recommendations',

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -2782,6 +2782,29 @@ void main() {
           expect(uri.queryParameters.containsKey('before'), isFalse);
         },
       );
+
+      test('sends viewer language and country hints', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('[]', 200));
+
+        await client.getV2PopularVideosPage(
+          variant: PopularVideosVariant.native,
+          preferredLanguages: const ['pt', 'en'],
+          viewerCountry: 'BR',
+        );
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.queryParameters['preferred_languages'], equals('pt,en'));
+        expect(uri.queryParameters['viewer_country'], equals('BR'));
+      });
     });
 
     group('getClassicVines', () {
@@ -4125,6 +4148,33 @@ void main() {
         expect(uri.queryParameters['limit'], equals('10'));
         expect(uri.queryParameters['fallback'], equals('recent'));
         expect(uri.queryParameters['category'], equals('comedy'));
+      });
+
+      test('sends viewer language and country hints', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response('{"videos": [], "source": "popular"}', 200),
+        );
+
+        await client.getRecommendations(
+          pubkey: testPubkey,
+          preferredLanguages: const ['pt'],
+          viewerCountry: 'BR',
+        );
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.path, equals('/api/users/$testPubkey/recommendations'));
+        expect(uri.queryParameters['preferred_languages'], equals('pt'));
+        expect(uri.queryParameters['viewer_country'], equals('BR'));
       });
 
       test('defaults source to unknown when missing', () async {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -64,6 +64,31 @@ int? _decodePopularLegacyBeforeCursor(String? cursor) {
   );
 }
 
+String _popularPreferenceCacheSuffix({
+  List<String> preferredLanguages = const [],
+  String? viewerCountry,
+}) {
+  final languages = preferredLanguages
+      .map((language) => language.trim())
+      .where((language) => language.isNotEmpty)
+      .join(',');
+  final country = viewerCountry?.trim() ?? '';
+
+  if (languages.isEmpty && country.isEmpty) {
+    return '';
+  }
+
+  return ':lang=$languages:country=$country';
+}
+
+bool _hasViewerPreferenceHints({
+  List<String> preferredLanguages = const [],
+  String? viewerCountry,
+}) {
+  return preferredLanguages.any((language) => language.trim().isNotEmpty) ||
+      (viewerCountry?.trim().isNotEmpty ?? false);
+}
+
 /// {@template videos_repository}
 /// Repository for video operations with Nostr.
 ///
@@ -712,8 +737,14 @@ class VideosRepository {
     int? until,
     String? cursor,
     bool skipCache = false,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
-    final cacheKey = 'popular:v2:${variant.name}';
+    final cacheKey =
+        'popular:v2:${variant.name}${_popularPreferenceCacheSuffix(
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
+        )}';
     if (!skipCache && until == null && cursor == null) {
       final cached = _inMemoryFeedCache?.get(cacheKey);
       if (cached != null) {
@@ -742,12 +773,25 @@ class VideosRepository {
       String? nextPageCursor;
 
       while (visible.length < limit) {
-        final response = await _funnelcakeApiClient.getV2PopularVideosPage(
-          variant: variant,
-          limit: limit,
-          cursor: pageCursor,
-          before: before,
-        );
+        final response =
+            _hasViewerPreferenceHints(
+              preferredLanguages: preferredLanguages,
+              viewerCountry: viewerCountry,
+            )
+            ? await _funnelcakeApiClient.getV2PopularVideosPage(
+                variant: variant,
+                limit: limit,
+                cursor: pageCursor,
+                before: before,
+                preferredLanguages: preferredLanguages,
+                viewerCountry: viewerCountry,
+              )
+            : await _funnelcakeApiClient.getV2PopularVideosPage(
+                variant: variant,
+                limit: limit,
+                cursor: pageCursor,
+                before: before,
+              );
         final stats = response.videos;
         if (stats.isEmpty) {
           final page = PopularVideosPage(videos: visible, hasMore: false);
@@ -866,9 +910,14 @@ class VideosRepository {
     PopularVideosVariant? variant,
     int fetchMultiplier = 4,
     bool skipCache = false,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
     final cacheKey = variant != null
-        ? 'popular:v2:${variant.name}'
+        ? 'popular:v2:${variant.name}${_popularPreferenceCacheSuffix(
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          )}'
         : period == null
         ? _popularCacheKey
         : 'popular:${period.wireValue}';
@@ -887,6 +936,8 @@ class VideosRepository {
         limit: limit,
         until: until,
         skipCache: skipCache,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
       );
       return page.videos;
     }
@@ -2015,6 +2066,8 @@ class VideosRepository {
     int limit = _defaultLimit,
     int? until,
     bool skipCache = false,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
     if (until != null) {
       return HomeFeedResult(
@@ -2022,6 +2075,8 @@ class VideosRepository {
           limit: limit,
           until: until,
           skipCache: skipCache,
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
         ),
       );
     }
@@ -2037,14 +2092,27 @@ class VideosRepository {
           limit: limit,
           until: until,
           skipCache: skipCache,
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
         ),
       );
     }
 
-    final response = await _funnelcakeApiClient.getRecommendations(
-      pubkey: effectiveUserPubkey,
-      limit: limit,
-    );
+    final response =
+        _hasViewerPreferenceHints(
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
+        )
+        ? await _funnelcakeApiClient.getRecommendations(
+            pubkey: effectiveUserPubkey,
+            limit: limit,
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          )
+        : await _funnelcakeApiClient.getRecommendations(
+            pubkey: effectiveUserPubkey,
+            limit: limit,
+          );
     final videos = _transformVideoStats(response.videos);
     if (videos.isEmpty) {
       return HomeFeedResult(
@@ -2052,6 +2120,8 @@ class VideosRepository {
           limit: limit,
           until: until,
           skipCache: skipCache,
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
         ),
       );
     }
@@ -2069,9 +2139,24 @@ class VideosRepository {
     int limit = 20,
     String fallback = 'popular',
     String? category,
+    List<String> preferredLanguages = const [],
+    String? viewerCountry,
   }) async {
     if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
       return null;
+    }
+    if (_hasViewerPreferenceHints(
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    )) {
+      return _funnelcakeApiClient.getRecommendations(
+        pubkey: pubkey,
+        limit: limit,
+        fallback: fallback,
+        category: category,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
+      );
     }
     return _funnelcakeApiClient.getRecommendations(
       pubkey: pubkey,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -81,14 +81,6 @@ String _popularPreferenceCacheSuffix({
   return ':lang=$languages:country=$country';
 }
 
-bool _hasViewerPreferenceHints({
-  List<String> preferredLanguages = const [],
-  String? viewerCountry,
-}) {
-  return preferredLanguages.any((language) => language.trim().isNotEmpty) ||
-      (viewerCountry?.trim().isNotEmpty ?? false);
-}
-
 /// {@template videos_repository}
 /// Repository for video operations with Nostr.
 ///
@@ -773,25 +765,14 @@ class VideosRepository {
       String? nextPageCursor;
 
       while (visible.length < limit) {
-        final response =
-            _hasViewerPreferenceHints(
-              preferredLanguages: preferredLanguages,
-              viewerCountry: viewerCountry,
-            )
-            ? await _funnelcakeApiClient.getV2PopularVideosPage(
-                variant: variant,
-                limit: limit,
-                cursor: pageCursor,
-                before: before,
-                preferredLanguages: preferredLanguages,
-                viewerCountry: viewerCountry,
-              )
-            : await _funnelcakeApiClient.getV2PopularVideosPage(
-                variant: variant,
-                limit: limit,
-                cursor: pageCursor,
-                before: before,
-              );
+        final response = await _funnelcakeApiClient.getV2PopularVideosPage(
+          variant: variant,
+          limit: limit,
+          cursor: pageCursor,
+          before: before,
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
+        );
         final stats = response.videos;
         if (stats.isEmpty) {
           final page = PopularVideosPage(videos: visible, hasMore: false);
@@ -2098,21 +2079,12 @@ class VideosRepository {
       );
     }
 
-    final response =
-        _hasViewerPreferenceHints(
-          preferredLanguages: preferredLanguages,
-          viewerCountry: viewerCountry,
-        )
-        ? await _funnelcakeApiClient.getRecommendations(
-            pubkey: effectiveUserPubkey,
-            limit: limit,
-            preferredLanguages: preferredLanguages,
-            viewerCountry: viewerCountry,
-          )
-        : await _funnelcakeApiClient.getRecommendations(
-            pubkey: effectiveUserPubkey,
-            limit: limit,
-          );
+    final response = await _funnelcakeApiClient.getRecommendations(
+      pubkey: effectiveUserPubkey,
+      limit: limit,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
     final videos = _transformVideoStats(response.videos);
     if (videos.isEmpty) {
       return HomeFeedResult(
@@ -2145,24 +2117,13 @@ class VideosRepository {
     if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
       return null;
     }
-    if (_hasViewerPreferenceHints(
-      preferredLanguages: preferredLanguages,
-      viewerCountry: viewerCountry,
-    )) {
-      return _funnelcakeApiClient.getRecommendations(
-        pubkey: pubkey,
-        limit: limit,
-        fallback: fallback,
-        category: category,
-        preferredLanguages: preferredLanguages,
-        viewerCountry: viewerCountry,
-      );
-    }
     return _funnelcakeApiClient.getRecommendations(
       pubkey: pubkey,
       limit: limit,
       fallback: fallback,
       category: category,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
     );
   }
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3000,6 +3000,8 @@ void main() {
             limit: any(named: 'limit'),
             cursor: any(named: 'cursor'),
             before: any(named: 'before'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) async {
           final stats = await mockFunnelcakeClient.getV2PopularVideos(
@@ -3011,6 +3013,42 @@ void main() {
           return V2PopularVideosResponse(videos: stats);
         });
       });
+
+      test(
+        'passes viewer language and country hints to v2 popular API',
+        () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: any(named: 'variant'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer((_) async => const []);
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await repositoryWithApi.getPopularVideosPage(
+            variant: PopularVideosVariant.native,
+            preferredLanguages: const ['pt'],
+            viewerCountry: 'BR',
+          );
+
+          verify(
+            () => mockFunnelcakeClient.getV2PopularVideosPage(
+              variant: PopularVideosVariant.native,
+              limit: 25,
+              preferredLanguages: const ['pt'],
+              viewerCountry: 'BR',
+            ),
+          ).called(1);
+        },
+      );
 
       test(
         'native variant continues paging until it fills a native-only page',
@@ -9337,6 +9375,8 @@ void main() {
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
             category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer(
           (_) async => RecommendationsResponse(
@@ -9371,6 +9411,54 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'passes viewer country hint to recommendations endpoint',
+        () async {
+          final recommended = _createVideoStats(
+            id: 'country-recommended-video',
+            pubkey: 'recommended-pubkey',
+            dTag: 'recommended-dtag',
+            videoUrl: 'https://example.com/country-recommended.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [recommended],
+              source: 'personalized',
+            ),
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+            viewerCountry: 'BR',
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.single.id, equals('country-recommended-video'));
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: 'user-pubkey',
+              limit: 10,
+              viewerCountry: 'BR',
+            ),
+          ).called(1);
+        },
+      );
 
       test(
         'falls back to popular videos when no pubkey is available',
@@ -9732,6 +9820,8 @@ void main() {
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
             category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer(
           (_) async =>
@@ -9748,6 +9838,8 @@ void main() {
           limit: 50,
           fallback: 'recent',
           category: 'sports',
+          preferredLanguages: const ['pt'],
+          viewerCountry: 'BR',
         );
 
         verify(
@@ -9756,6 +9848,8 @@ void main() {
             limit: 50,
             fallback: 'recent',
             category: 'sports',
+            preferredLanguages: const ['pt'],
+            viewerCountry: 'BR',
           ),
         ).called(1);
       });

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -287,6 +287,8 @@ void main() {
             until: any(named: 'until'),
             variant: any(named: 'variant'),
             skipCache: any(named: 'skipCache'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
           requestCount += 1;
@@ -352,6 +354,8 @@ void main() {
             limit: AppConstants.paginationBatchSize,
             variant: PopularVideosVariant.native,
             skipCache: true,
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).called(1);
       },
@@ -364,6 +368,8 @@ void main() {
           until: any(named: 'until'),
           variant: any(named: 'variant'),
           skipCache: any(named: 'skipCache'),
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
         ),
       ).thenAnswer((_) async => _popularPage([_video('popular-age-decayed')]));
 
@@ -388,6 +394,8 @@ void main() {
         () => mockVideosRepository.getPopularVideosPage(
           limit: AppConstants.paginationBatchSize,
           variant: PopularVideosVariant.native,
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
         ),
       ).called(1);
     });
@@ -404,6 +412,8 @@ void main() {
             until: any(named: 'until'),
             variant: any(named: 'variant'),
             skipCache: any(named: 'skipCache'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
           requestCount += 1;
@@ -477,6 +487,8 @@ void main() {
             cursor: any(named: 'cursor'),
             variant: any(named: 'variant'),
             skipCache: any(named: 'skipCache'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) async {
           final cursor = invocation.namedArguments[#cursor] as String?;
@@ -542,6 +554,8 @@ void main() {
           until: any(named: 'until'),
           variant: any(named: 'variant'),
           skipCache: any(named: 'skipCache'),
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
         ),
       ).thenThrow(StateError('age-decayed popular unavailable'));
 
@@ -576,6 +590,8 @@ void main() {
           () => mockFunnelcakeApiClient.getRecommendations(
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((_) {
           requestCount += 1;

--- a/mobile/test/providers/feed_viewer_preference_hints_test.dart
+++ b/mobile/test/providers/feed_viewer_preference_hints_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -14,7 +15,26 @@ class _TestLanguagePreferenceService extends LanguagePreferenceService {
   final String _contentLanguage;
 
   @override
+  Future<void> initialize() async {}
+
+  @override
   String get contentLanguage => _contentLanguage;
+}
+
+class _InitializingLanguagePreferenceService extends LanguagePreferenceService {
+  _InitializingLanguagePreferenceService(this._initializeCompleter);
+
+  final Completer<void> _initializeCompleter;
+  var _initialized = false;
+
+  @override
+  Future<void> initialize() async {
+    await _initializeCompleter.future;
+    _initialized = true;
+  }
+
+  @override
+  String get contentLanguage => _initialized ? 'es' : 'en';
 }
 
 class _TestGeoBlockingService extends GeoBlockingService {
@@ -66,6 +86,47 @@ void main() {
 
       expect(hints.preferredLanguages.first, equals('pt'));
       expect(hints.viewerCountry, equals('BR'));
+    },
+  );
+
+  test(
+    'waits for content language initialization before reading hints',
+    () async {
+      final initializeCompleter = Completer<void>();
+      final container = ProviderContainer(
+        overrides: [
+          languagePreferenceServiceProvider.overrideWithValue(
+            _InitializingLanguagePreferenceService(initializeCompleter),
+          ),
+          geoBlockingServiceProvider.overrideWithValue(
+            _TestGeoBlockingService(
+              GeoBlockResponse(
+                blocked: false,
+                country: 'US',
+                region: 'UNKNOWN',
+                city: 'UNKNOWN',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final hintsFuture = readFeedViewerPreferenceHints(container.read);
+      var completed = false;
+      unawaited(
+        hintsFuture.then<void>((_) {
+          completed = true;
+        }),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(completed, isFalse);
+
+      initializeCompleter.complete();
+      final hints = await hintsFuture;
+
+      expect(hints.preferredLanguages.first, equals('es'));
     },
   );
 

--- a/mobile/test/providers/feed_viewer_preference_hints_test.dart
+++ b/mobile/test/providers/feed_viewer_preference_hints_test.dart
@@ -1,0 +1,97 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/feed_viewer_preference_hints.dart';
+import 'package:openvine/providers/permissions_providers.dart';
+import 'package:openvine/providers/preferences_providers.dart';
+import 'package:openvine/services/geo_blocking_service.dart';
+import 'package:openvine/services/language_preference_service.dart';
+import 'package:riverpod/riverpod.dart';
+
+class _TestLanguagePreferenceService extends LanguagePreferenceService {
+  _TestLanguagePreferenceService(this._contentLanguage);
+
+  final String _contentLanguage;
+
+  @override
+  String get contentLanguage => _contentLanguage;
+}
+
+class _TestGeoBlockingService extends GeoBlockingService {
+  _TestGeoBlockingService(this._response);
+
+  final GeoBlockResponse _response;
+
+  @override
+  Future<GeoBlockResponse> getGeoInfo() async => _response;
+}
+
+void main() {
+  test(
+    'builds ordered unique language hints from content app and device languages',
+    () {
+      final languages = buildPreferredFeedLanguages(
+        contentLanguage: 'pt-BR',
+        appLocale: 'es',
+        deviceLocales: const [Locale('en', 'US'), Locale('pt', 'PT')],
+      );
+
+      expect(languages, equals(['pt', 'es', 'en']));
+    },
+  );
+
+  test(
+    'reads content language and viewer country hints for feed requests',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          languagePreferenceServiceProvider.overrideWithValue(
+            _TestLanguagePreferenceService('pt'),
+          ),
+          geoBlockingServiceProvider.overrideWithValue(
+            _TestGeoBlockingService(
+              GeoBlockResponse(
+                blocked: false,
+                country: 'BR',
+                region: 'UNKNOWN',
+                city: 'UNKNOWN',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final hints = await readFeedViewerPreferenceHints(container.read);
+
+      expect(hints.preferredLanguages.first, equals('pt'));
+      expect(hints.viewerCountry, equals('BR'));
+    },
+  );
+
+  test('omits unknown viewer country', () async {
+    final container = ProviderContainer(
+      overrides: [
+        languagePreferenceServiceProvider.overrideWithValue(
+          _TestLanguagePreferenceService('en'),
+        ),
+        geoBlockingServiceProvider.overrideWithValue(
+          _TestGeoBlockingService(
+            GeoBlockResponse(
+              blocked: false,
+              country: 'UNKNOWN',
+              region: 'UNKNOWN',
+              city: 'UNKNOWN',
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final hints = await readFeedViewerPreferenceHints(container.read);
+
+    expect(hints.preferredLanguages.first, equals('en'));
+    expect(hints.viewerCountry, isNull);
+  });
+}

--- a/mobile/test/services/language_preference_service_test.dart
+++ b/mobile/test/services/language_preference_service_test.dart
@@ -72,6 +72,18 @@ void main() {
         await service.setContentLanguage('ja');
         expect(service.contentLanguage, equals('ja'));
       });
+
+      test('notifies listeners after setting a custom language', () async {
+        await service.initialize();
+        var notifications = 0;
+        service.addListener(() {
+          notifications++;
+        });
+
+        await service.setContentLanguage('pt');
+
+        expect(notifications, equals(1));
+      });
     });
 
     group('clearContentLanguage', () {
@@ -96,6 +108,19 @@ void main() {
 
         final prefs = await SharedPreferences.getInstance();
         expect(prefs.getString(LanguagePreferenceService.prefsKey), isNull);
+      });
+
+      test('notifies listeners after clearing a custom language', () async {
+        await service.initialize();
+        await service.setContentLanguage('de');
+        var notifications = 0;
+        service.addListener(() {
+          notifications++;
+        });
+
+        await service.clearContentLanguage();
+
+        expect(notifications, equals(1));
       });
     });
 


### PR DESCRIPTION
Closes #4910

## Summary
- send content-language and best-effort viewer country hints with For You recommendation requests
- send the same hints through the Popular feed repository/client path
- add Funnelcake API client, videos repository, and provider helper tests for the new query params

## Motivation
For You and Popular should be able to prioritize videos in languages the viewer speaks once Funnelcake ranking consumes these hints.

## Linked issue
None.

## Validation
- flutter analyze lib/providers/feed_viewer_preference_hints.dart lib/providers/for_you_provider.dart lib/providers/popular_videos_feed_provider.dart packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart packages/videos_repository/lib/src/videos_repository.dart test/providers/feed_viewer_preference_hints_test.dart
- flutter test packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
- flutter test packages/videos_repository/test/src/videos_repository_test.dart
- flutter test test/providers/feed_viewer_preference_hints_test.dart
- pre-push hook: analyzer, generated-file verification, and changed-file tests passed

## Visual change
No visual change.