### PR TITLE
fix(router): prevent video feed teardown on background review-status refetch

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -249,7 +249,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       final reviewStatusAsync = ref.read(
         currentMinorAccountReviewStatusProvider,
       );
-      final reviewStatus = reviewStatusAsync.asData?.value;
+      final reviewStatus = reviewStatusAsync.value;
       final moderationConversationId = _moderationConversationId(
         authService,
         reviewStatus?.currentCase,

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -294,7 +294,17 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           isPublicParentConsentRoute ||
           isPublicUnder13Route;
 
-      if (authState == AuthState.authenticated && reviewStatusAsync.isLoading) {
+      // Only bounce to the loading screen on a true cold load (no value yet).
+      // Riverpod keeps the previous value during a background refetch
+      // (isLoading == true while hasValue == true), e.g. when
+      // currentAuthStateProvider re-invalidates on an authStateStream event.
+      // Treating those transient refetches as "loading" would redirect away
+      // from the current route to the review loading screen and back, which
+      // tears down the video feed (VideoStopNavigatorObserver disposes all
+      // controllers on push).
+      if (authState == AuthState.authenticated &&
+          reviewStatusAsync.isLoading &&
+          !reviewStatusAsync.hasValue) {
         if (!isReviewLoadingRoute) {
           return _minorAccountReviewLoadingPath(state.uri.toString());
         }

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -481,6 +481,10 @@ void main() {
         container.invalidate(currentMinorAccountReviewStatusProvider);
         await tester.pumpAndSettle();
         expect(
+          router.routeInformationProvider.value.uri.toString(),
+          MinorAccountReviewScreen.path,
+        );
+        expect(
           container.read(currentMinorAccountReviewStatusProvider).isLoading,
           isTrue,
         );

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -378,5 +378,77 @@ void main() {
           .uri;
       expect(routeUri.path, MinorAccountReviewLoadingScreen.path);
     });
+
+    testWidgets(
+      'does not bounce to the loading gate during a background refetch',
+      (tester) async {
+        // Regression: the review status is a FutureProvider that (in prod)
+        // depends on currentAuthStateProvider, which invalidates itself on
+        // every authStateStream event. A re-run puts the provider into
+        // AsyncLoading while retaining its previous value. The router must
+        // NOT treat that transient refetch as a cold load and bounce to the
+        // loading screen — that redirect is a navigation that tears down the
+        // video feed (VideoStopNavigatorObserver disposes all controllers on
+        // push), which manifested as videos stopping while swiping the feed.
+        //
+        // SupportCenterScreen stands in for any non-review authenticated
+        // route: the loading-bounce decision is independent of the
+        // destination, and it avoids rendering the heavy feed AppShell.
+        var loadCount = 0;
+        final pendingRefetch = Completer<MinorAccountReviewStatus>();
+        final container = ProviderContainer(
+          overrides: [
+            ...getStandardTestOverrides(mockAuthService: mockAuthService),
+            bugReportServiceProvider.overrideWith((ref) => BugReportService()),
+            nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
+            currentMinorAccountReviewStatusProvider.overrideWith((ref) {
+              loadCount++;
+              // First load resolves with an unrestricted status; any later
+              // re-run hangs to emulate an in-flight background refetch.
+              return loadCount == 1
+                  ? Future<MinorAccountReviewStatus>.value(
+                      MinorAccountReviewStatus.active(),
+                    )
+                  : pendingRefetch.future;
+            }),
+          ],
+        );
+        registerContainerTearDown(tester, container);
+        await container.read(currentMinorAccountReviewStatusProvider.future);
+        await pumpRouter(tester, container);
+
+        final router = container.read(goRouterProvider);
+        router.go(SupportCenterScreen.path);
+        await tester.pumpAndSettle();
+        expect(
+          router.routeInformationProvider.value.uri.toString(),
+          SupportCenterScreen.path,
+        );
+
+        // Trigger a background refetch: the provider re-runs and enters the
+        // loading-with-previous-value state (isLoading == true while
+        // hasValue == true).
+        container.invalidate(currentMinorAccountReviewStatusProvider);
+        await tester.pumpAndSettle();
+        expect(
+          container.read(currentMinorAccountReviewStatusProvider).isLoading,
+          isTrue,
+        );
+        expect(
+          container.read(currentMinorAccountReviewStatusProvider).hasValue,
+          isTrue,
+        );
+
+        // Re-evaluate the redirect while the refetch is in flight (a real
+        // navigation, e.g. a swipe-driven page change): it must keep the
+        // current route instead of bouncing to the loading screen.
+        router.go(SupportCenterScreen.path);
+        await tester.pumpAndSettle();
+        expect(
+          router.routeInformationProvider.value.uri.toString(),
+          SupportCenterScreen.path,
+        );
+      },
+    );
   });
 }

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -450,5 +450,59 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'keeps restricted routing during a background refetch',
+      (tester) async {
+        var loadCount = 0;
+        final pendingRefetch = Completer<MinorAccountReviewStatus>();
+        final container = ProviderContainer(
+          overrides: [
+            ...getStandardTestOverrides(mockAuthService: mockAuthService),
+            nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
+            currentMinorAccountReviewStatusProvider.overrideWith((ref) {
+              loadCount++;
+              return loadCount == 1
+                  ? Future<MinorAccountReviewStatus>.value(restrictedStatus())
+                  : pendingRefetch.future;
+            }),
+          ],
+        );
+        registerContainerTearDown(tester, container);
+        await container.read(currentMinorAccountReviewStatusProvider.future);
+        await pumpRouter(tester, container);
+
+        final router = container.read(goRouterProvider);
+        expect(
+          router.routeInformationProvider.value.uri.toString(),
+          MinorAccountReviewScreen.path,
+        );
+
+        container.invalidate(currentMinorAccountReviewStatusProvider);
+        await tester.pumpAndSettle();
+        expect(
+          container.read(currentMinorAccountReviewStatusProvider).isLoading,
+          isTrue,
+        );
+        expect(
+          container.read(currentMinorAccountReviewStatusProvider).hasValue,
+          isTrue,
+        );
+
+        router.go(MinorAccountReviewScreen.path);
+        await tester.pumpAndSettle();
+        expect(
+          router.routeInformationProvider.value.uri.toString(),
+          MinorAccountReviewScreen.path,
+        );
+
+        router.go(VideoFeedPage.pathForIndex(0));
+        await tester.pumpAndSettle();
+        expect(
+          router.routeInformationProvider.value.uri.toString(),
+          MinorAccountReviewScreen.path,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #4914

## Description

**Related Issue:** Introduced by commit aa6ea620 (`feat(auth): add under-16 family guidance flow`)

### Root Cause

Commit aa6ea620 added a `ref.listen` coupling the GoRouter's `refreshListenable` to `currentMinorAccountReviewStatusProvider` (a `FutureProvider`). That provider internally watches `currentAuthStateProvider`, which calls `invalidateSelf()` on **every** `authStateStream` event. This caused the following chain on each event:

1. `currentMinorAccountReviewStatusProvider` re-runs → briefly enters `AsyncLoading` (while still holding its previous value)
2. `ref.listen` fires → `refreshListenable.refresh()` → router redirect re-evaluates
3. Redirect sees `isLoading == true` and bounces to the review loading screen
4. `VideoStopNavigatorObserver.didPush` → `disposeAllVideoControllers()` → **all video players stopped**
5. Future resolves → redirect bounces back to the feed → feed re-initializes from scratch

This was visible in logs as `Disposing player at index N` → `Init player index M` → `Page changed` loops triggered purely by swiping (which fires auth heartbeat events).



### Fix

Guard the loading-screen bounce with `!reviewStatusAsync.hasValue`. Riverpod preserves the previous value during a background refetch (`isLoading == true` while `hasValue == true`). Only on a true cold start is `hasValue == false`, which is the only case warranting the interstitial loading screen.

```dart
// Before
if (authState == AuthState.authenticated && reviewStatusAsync.isLoading) {

// After
if (authState == AuthState.authenticated &&
    reviewStatusAsync.isLoading &&
    !reviewStatusAsync.hasValue) {
```

The minor-account review gating logic (all `isRestricted` redirects) is unaffected — those branches do not depend on `isLoading`.

## Out of Scope

Replacing the `ref.listen` with a more targeted invalidation strategy (e.g. only refreshing on meaningful state transitions). That is a larger refactor and not required for the fix.

## Verification

- `flutter test test/router/minor_account_review_router_test.dart` → 11/11 pass
- New regression test `does not bounce to the loading gate during a background refetch` added; verified it **fails** against the original guard and **passes** with the fix
- `flutter analyze mobile/lib/router/app_router.dart` → no issues

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change