### PR TITLE
fix(timeline): simplify maxDuration calculation for track

### DIFF
--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -2,7 +2,6 @@
 // ABOUTME: video editor timeline. Handles add/remove/move/trim/select/drag
 // ABOUTME: and collapse state for all three strip types.
 
-import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -85,11 +85,9 @@ class TimelineOverlayBloc
           label: track.title ?? track.pubkey,
           maxDuration: track.duration != null
               ? Duration(
-                  milliseconds: math.min(
-                    (track.duration! * 1000).round() -
-                        track.startOffset.inMilliseconds,
-                    VideoEditorConstants.maxDuration.inMilliseconds,
-                  ),
+                  milliseconds:
+                      (track.duration! * 1000).round() -
+                      track.startOffset.inMilliseconds,
                 )
               : VideoEditorConstants.maxDuration,
           waveformLeftChannel: leftCache[track.id],

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -104,6 +104,63 @@ void main() {
       );
 
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'maxDuration equals track duration when longer than VideoEditorConstants.maxDuration',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: const Duration(seconds: 1),
+                end: const Duration(seconds: 4),
+              ).copyWith(
+                duration: 10.0,
+              ), // 10s > VideoEditorConstants.maxDuration (6.3s)
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>().having(
+            (s) => s.items.first.maxDuration,
+            'maxDuration',
+            const Duration(seconds: 10),
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'maxDuration subtracts startOffset from track duration',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: const Duration(seconds: 1),
+                end: const Duration(seconds: 4),
+              ).copyWith(
+                duration: 8.0,
+                startOffset: const Duration(seconds: 2),
+              ),
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>().having(
+            (s) => s.items.first.maxDuration,
+            'maxDuration',
+            const Duration(seconds: 6), // 8000ms - 2000ms
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'clears selection when not trimming',
         build: TimelineOverlayBloc.new,
         seed: () => const TimelineOverlayState(selectedItemId: 'sound-1'),


### PR DESCRIPTION
Closes #4916

## Description

Removes the `math.min(…, VideoEditorConstants.maxDuration)` clamping from the `maxDuration` calculation for audio tracks in `TimelineOverlayBloc`.

`maxDuration` on a `TimelineOverlayItem` represents how far a track can be stretched (i.e. its actual audio length minus `startOffset`). Clamping this to `VideoEditorConstants.maxDuration` (6.3 s) was incorrect — a track can be longer than that; the overall video duration constraint is enforced elsewhere.

Reported on discord [here](https://discord.com/channels/1470168817589158040/1470256031434149953/1511864836152229898)

**Related Issue:** Closes # or Relates to #

**Changes:**
- `timeline_overlay_bloc.dart`: removed `math.min(…)` wrapper, compute `maxDuration` as `(duration * 1000).round() - startOffset.inMilliseconds`
- Added two new BLoC tests covering:
  - Track with `duration > VideoEditorConstants.maxDuration` is no longer clamped
  - `startOffset` is correctly subtracted from the track duration

## Out of Scope

None.

## Verification

```
flutter test mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
```
All 37 tests pass.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
