### PR TITLE
chore(toolchain): upgrade Flutter 3.41.9 → 3.44.0 / Dart 3.12.0

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -92,7 +92,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -110,7 +110,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -128,7 +128,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies

--- a/.github/workflows/mobile_pr_preview_build.yml
+++ b/.github/workflows/mobile_pr_preview_build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: stable
           cache: true
 

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
           cache: true
       - name: 🐳 Start local stack

--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: stable
           cache: true
 

--- a/.github/workflows/models_ci.yaml
+++ b/.github/workflows/models_ci.yaml
@@ -24,5 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/models"
-      flutter_version: "3.41.9"
+      flutter_version: "3.44.0"
       min_coverage: 25

--- a/.github/workflows/sounds_repository.yaml
+++ b/.github/workflows/sounds_repository.yaml
@@ -24,4 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/sounds_repository"
-      flutter_version: "3.41.9"
+      flutter_version: "3.44.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,8 +142,8 @@ effort or intent.
 
 Prerequisites:
 
-- Flutter `^3.41.1`
-- Dart `^3.11.0`
+- Flutter `^3.44.0`
+- Dart `^3.12.0`
 - Xcode for iOS work
 - Android Studio and Android SDK for Android work
 - CocoaPods for Apple platform dependencies

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -368,7 +368,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.41.9
+      flutter: 3.44.0
       xcode: latest
       cocoapods: default
       groups:
@@ -428,7 +428,7 @@ workflows:
           - TEST
           - POC
     environment:
-      flutter: 3.41.9
+      flutter: 3.44.0
       xcode: latest
       cocoapods: default
       groups:
@@ -474,7 +474,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.41.9
+      flutter: 3.44.0
       java: 17
       groups:
         - zendesk_credentials
@@ -527,7 +527,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.41.9
+      flutter: 3.44.0
       xcode: latest
       cocoapods: default
       groups:
@@ -558,7 +558,7 @@ workflows:
     max_build_duration: 60
     instance_type: mac_mini_m2
     environment:
-      flutter: 3.41.9
+      flutter: 3.44.0
       xcode: latest
       cocoapods: default
       groups:
@@ -595,7 +595,7 @@ workflows:
     max_build_duration: 60
     instance_type: linux_x2
     environment:
-      flutter: 3.41.9
+      flutter: 3.44.0
       java: 17
       groups:
         - zendesk_credentials

--- a/mobile/.metadata
+++ b/mobile/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "dbc3660e848145748d81e3c81795571f36307a29"
-  channel: "beta"
+  revision: "559ffa3f75e7402d65a8def9c28389a9b2e6fe42"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: android
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: ios
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: linux
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: macos
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: web
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: windows
-      create_revision: dbc3660e848145748d81e3c81795571f36307a29
-      base_revision: dbc3660e848145748d81e3c81795571f36307a29
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
 
   # User provided section
 

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -65,6 +65,11 @@ linter:
     parameter_assignments: false
     prefer_constructors_over_static_methods: false
     prefer_foreach: false
+    # Newly surfaced by the Dart 3.12 (Flutter 3.44) analyzer on the repo's
+    # named-parameter constructor-injection pattern (~385 app sites); it
+    # conflicts with that prescribed DI convention. Adopting it is a separate
+    # cleanup, not a toolchain-bump side effect.
+    prefer_initializing_formals: false
     public_member_api_docs: false
     sort_pub_dependencies: false
     unintended_html_in_doc_comment: false

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -65,10 +65,8 @@ linter:
     parameter_assignments: false
     prefer_constructors_over_static_methods: false
     prefer_foreach: false
-    # Newly surfaced by the Dart 3.12 (Flutter 3.44) analyzer on the repo's
-    # named-parameter constructor-injection pattern (~385 app sites); it
-    # conflicts with that prescribed DI convention. Adopting it is a separate
-    # cleanup, not a toolchain-bump side effect.
+    # The repo convention is named-parameter constructor injection into private
+    # fields (~385 app sites), so this conflicts with prescribed DI style.
     prefer_initializing_formals: false
     public_member_api_docs: false
     sort_pub_dependencies: false
@@ -77,4 +75,3 @@ linter:
     use_named_constants: false
     omit_local_variable_types: false
     use_setters_to_change_properties: false
-

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -4,7 +4,7 @@ android.enableJetifier=true
 # Allow duplicate classes from java-opentimestamps fat JAR
 android.suppressUnsupportedOptionWarnings=true
 android.enableR8.fullMode=false
-# This builtInKotlin flag was added automatically by Flutter migrator
+# Keep using the explicit org.jetbrains.kotlin.android plugin with AGP 8.11.
 android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
+# Preserve the existing Flutter Gradle DSL behavior during the 3.44 upgrade.
 android.newDsl=false

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -4,3 +4,7 @@ android.enableJetifier=true
 # Allow duplicate classes from java-opentimestamps fat JAR
 android.suppressUnsupportedOptionWarnings=true
 android.enableR8.fullMode=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "3.0.3" apply false
 }

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
+    id("com.android.application") version "8.11.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.20" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "3.0.3" apply false

--- a/mobile/lib/blocs/clips_library/clips_library_state.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_state.dart
@@ -15,8 +15,7 @@ enum ClipSort {
   longestClip,
   shortestClip,
   squareFirst,
-  verticalFirst
-  ;
+  verticalFirst;
 
   static const _persistenceKeys = <ClipSort, String>{
     ClipSort.newestCreation: 'newest_creation',

--- a/mobile/lib/blocs/search_results_filter/search_results_filter_cubit.dart
+++ b/mobile/lib/blocs/search_results_filter/search_results_filter_cubit.dart
@@ -11,8 +11,7 @@ enum SearchResultsFilter {
 
   lists('Lists'),
   tags('Tags'),
-  videos('Videos')
-  ;
+  videos('Videos');
 
   const SearchResultsFilter(this.label);
 

--- a/mobile/lib/blocs/video_editor/draw_editor/video_editor_draw_state.dart
+++ b/mobile/lib/blocs/video_editor/draw_editor/video_editor_draw_state.dart
@@ -12,8 +12,7 @@ enum DrawToolType {
   arrow,
 
   /// Eraser tool.
-  eraser
-  ;
+  eraser;
 
   /// Returns the paint configuration (mode, opacity, stroke width) for this tool.
   DrawToolConfig get config => switch (this) {

--- a/mobile/lib/features/app/startup/startup_phase.dart
+++ b/mobile/lib/features/app/startup/startup_phase.dart
@@ -13,8 +13,7 @@ enum StartupPhase {
   standard(2, 'Standard features'),
 
   /// Nice-to-have warmups and observability that should stay off first paint.
-  deferred(3, 'Deferred services')
-  ;
+  deferred(3, 'Deferred services');
 
   final int priority;
   final String description;

--- a/mobile/lib/models/content_label.dart
+++ b/mobile/lib/models/content_label.dart
@@ -69,8 +69,7 @@ enum ContentLabel {
   misleading('misleading', 'Misleading'),
 
   /// Contains other sensitive content not covered above.
-  other('content-warning', 'Sensitive Content')
-  ;
+  other('content-warning', 'Sensitive Content');
 
   const ContentLabel(this.value, this.displayName);
 

--- a/mobile/lib/models/minor_account_review_status.dart
+++ b/mobile/lib/models/minor_account_review_status.dart
@@ -5,8 +5,7 @@ import 'package:openvine/constants/app_constants.dart';
 
 enum AccountRestrictionStatus {
   active,
-  restrictedMinorReview
-  ;
+  restrictedMinorReview;
 
   static AccountRestrictionStatus fromJsonValue(String? value) {
     return switch (value) {
@@ -26,8 +25,7 @@ enum MinorReviewCaseState {
   needsFollowUp,
   cleared,
   deniedClosed,
-  unknown
-  ;
+  unknown;
 
   static MinorReviewCaseState fromJsonValue(String? value) {
     return switch (value) {
@@ -49,8 +47,7 @@ enum SuspectedAgeBand {
   under13,
   age13To15,
   age16PlusClaimed,
-  unknown
-  ;
+  unknown;
 
   static SuspectedAgeBand fromJsonValue(String? value) {
     return switch (value) {
@@ -66,8 +63,7 @@ enum MinorReviewResolutionType {
   supportEmailOnly,
   parentVideoOrEmail,
   supportReviewOnly,
-  unknown
-  ;
+  unknown;
 
   static MinorReviewResolutionType fromJsonValue(String? value) {
     return switch (value) {

--- a/mobile/lib/models/video_metadata/video_metadata_expiration.dart
+++ b/mobile/lib/models/video_metadata/video_metadata_expiration.dart
@@ -22,8 +22,7 @@ enum VideoMetadataExpiration {
   oneYear,
 
   /// Video expires after 1 decade (10 years, 3650 days).
-  oneDecade
-  ;
+  oneDecade;
 
   /// Returns the duration value for this expiration option.
   ///

--- a/mobile/lib/models/video_recorder/video_recorder_flash_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_flash_mode.dart
@@ -12,8 +12,7 @@ enum DivineFlashMode {
   torch,
 
   /// Flash off mode.
-  off
-  ;
+  off;
 
   /// Icon representing the flash mode.
   DivineIconName get icon => switch (this) {

--- a/mobile/lib/models/video_recorder/video_recorder_timer_duration.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_timer_duration.dart
@@ -12,8 +12,7 @@ enum TimerDuration {
   three,
 
   /// 10 second delay.
-  ten
-  ;
+  ten;
 
   /// Icon representing the timer duration.
   DivineIconName get icon => switch (this) {

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1134,8 +1134,7 @@ enum _AnalyticsWindow {
   last7Days('7D', Duration(days: 7)),
   last28Days('28D', Duration(days: 28)),
   last90Days('90D', Duration(days: 90)),
-  allTime('All', null)
-  ;
+  allTime('All', null);
 
   const _AnalyticsWindow(this.label, this.duration);
 

--- a/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
@@ -86,21 +86,24 @@ class _MuteActionTile extends StatelessWidget {
         decoration: const BoxDecoration(
           border: Border(bottom: BorderSide(color: VineTheme.outlineDisabled)),
         ),
-        child: SwitchListTile(
-          value: isMuted,
-          activeThumbColor: VineTheme.whiteText,
-          activeTrackColor: VineTheme.primary,
-          inactiveThumbColor: VineTheme.onSurfaceDisabled,
-          inactiveTrackColor: VineTheme.surfaceContainer,
-          onChanged: (_) =>
-              Navigator.of(context).pop(ConversationAction.toggleMute),
-          title: Text(
-            context.l10n.inboxActionMute,
-            style: VineTheme.titleMediumFont(),
-          ),
-          secondary: const DivineIcon(
-            icon: DivineIconName.bellSimple,
-            color: VineTheme.onSurface,
+        child: Material(
+          type: MaterialType.transparency,
+          child: SwitchListTile(
+            value: isMuted,
+            activeThumbColor: VineTheme.whiteText,
+            activeTrackColor: VineTheme.primary,
+            inactiveThumbColor: VineTheme.onSurfaceDisabled,
+            inactiveTrackColor: VineTheme.surfaceContainer,
+            onChanged: (_) =>
+                Navigator.of(context).pop(ConversationAction.toggleMute),
+            title: Text(
+              context.l10n.inboxActionMute,
+              style: VineTheme.titleMediumFont(),
+            ),
+            secondary: const DivineIcon(
+              icon: DivineIconName.bellSimple,
+              color: VineTheme.onSurface,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -740,7 +740,7 @@ class _CreateVideoBar extends StatelessWidget {
         opacity: animation,
         child: SizeTransition(
           sizeFactor: animation,
-          axisAlignment: -1,
+          alignment: AlignmentDirectional.topStart,
           child: child,
         ),
       ),

--- a/mobile/lib/services/cawg_verifier_client.dart
+++ b/mobile/lib/services/cawg_verifier_client.dart
@@ -7,8 +7,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 enum VerifierRequiredMethod {
   oauth('oauth'),
-  publicProof('public_proof')
-  ;
+  publicProof('public_proof');
 
   const VerifierRequiredMethod(this.wireValue);
 

--- a/mobile/lib/services/error_analytics_tracker.dart
+++ b/mobile/lib/services/error_analytics_tracker.dart
@@ -49,7 +49,7 @@ class ErrorAnalyticsTracker {
         'location': location,
         'occurrence_count': _errorCounts[errorKey]!,
         'is_fatal': isFatal,
-        if (context != null) ...context,
+        ...?context,
       },
     );
 
@@ -99,7 +99,7 @@ class ErrorAnalyticsTracker {
         'expected_count': ?expectedCount,
         'actual_count': ?actualCount,
         'load_time_ms': ?loadTimeMs,
-        if (additionalContext != null) ...additionalContext,
+        ...?additionalContext,
       },
     );
   }
@@ -122,7 +122,7 @@ class ErrorAnalyticsTracker {
         'operation': operation,
         'timeout_ms': timeoutMs,
         'location': location,
-        if (context != null) ...context,
+        ...?context,
       },
     );
   }
@@ -231,7 +231,7 @@ class ErrorAnalyticsTracker {
         'threshold_ms': thresholdMs,
         'slowness_ratio': (durationMs / thresholdMs).toStringAsFixed(2),
         'location': ?location,
-        if (context != null) ...context,
+        ...?context,
       },
     );
   }

--- a/mobile/lib/services/nip98_auth_service.dart
+++ b/mobile/lib/services/nip98_auth_service.dart
@@ -27,8 +27,7 @@ enum HttpMethod {
   post('POST'),
   put('PUT'),
   delete('DELETE'),
-  patch('PATCH')
-  ;
+  patch('PATCH');
 
   const HttpMethod(this.value);
   final String value;

--- a/mobile/lib/services/screen_analytics_service.dart
+++ b/mobile/lib/services/screen_analytics_service.dart
@@ -167,7 +167,7 @@ class ScreenAnalyticsService {
       parameters: {
         'screen_name': screenName,
         'data_load_time_ms': dataLoadTime,
-        if (dataMetrics != null) ...dataMetrics,
+        ...?dataMetrics,
         ...session.params,
       },
     );
@@ -246,7 +246,7 @@ class ScreenAnalyticsService {
       parameters: {
         'screen_name': screenName,
         'interaction_type': interactionType,
-        if (params != null) ...params,
+        ...?params,
       },
     );
 
@@ -338,7 +338,7 @@ class ScreenAnalyticsService {
           0,
           errorMessage.length > 100 ? 100 : errorMessage.length,
         ),
-        if (context != null) ...context,
+        ...?context,
       },
     );
 

--- a/mobile/lib/services/video_filter_builder.dart
+++ b/mobile/lib/services/video_filter_builder.dart
@@ -25,8 +25,7 @@ enum VideoSortField {
   avgCompletion('avg_completion'),
 
   /// Newest videos first
-  createdAt('created_at')
-  ;
+  createdAt('created_at');
 
   const VideoSortField(this.fieldName);
   final String fieldName;
@@ -44,8 +43,7 @@ enum NIP50SortMode {
   rising('rising'),
 
   /// Events with mixed positive/negative reaction ratios
-  controversial('controversial')
-  ;
+  controversial('controversial');
 
   const NIP50SortMode(this.mode);
   final String mode;

--- a/mobile/lib/widgets/profile/profile_actions_sheet/profile_action_type.dart
+++ b/mobile/lib/widgets/profile/profile_actions_sheet/profile_action_type.dart
@@ -12,8 +12,7 @@ enum ProfileActionType {
   secureAccount,
 
   /// The user has not yet set a custom display name, bio, or picture.
-  completeProfile
-  ;
+  completeProfile;
 
   /// Returns the list of pending actions based on the current profile and
   /// auth state.

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_layer_reorder_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_layer_reorder_sheet.dart
@@ -34,14 +34,15 @@ class _VideoEditorLayerReorderSheetState
   late final List<Layer> _layers = List.from(widget.layers);
 
   /// Reorders the local layer list and forwards the callback to the parent.
-  void _onReorder(int oldIndex, int newIndex) {
+  void _onReorderItem(int oldIndex, int newIndex) {
     Log.debug(
       '🔀 Layer reordered: $oldIndex → $newIndex',
       name: 'LayerReorderSheet',
       category: LogCategory.video,
     );
+    // onReorderItem already adjusts newIndex for the removed item, so the
+    // old `if (oldIndex < newIndex) newIndex--` shift is no longer needed.
     setState(() {
-      if (oldIndex < newIndex) newIndex--;
       final layer = _layers.removeAt(oldIndex);
       _layers.insert(newIndex, layer);
     });
@@ -75,7 +76,7 @@ class _VideoEditorLayerReorderSheetState
         );
       },
       itemCount: _layers.length,
-      onReorder: _onReorder,
+      onReorderItem: _onReorderItem,
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_layer_reorder_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_layer_reorder_sheet.dart
@@ -40,8 +40,6 @@ class _VideoEditorLayerReorderSheetState
       name: 'LayerReorderSheet',
       category: LogCategory.video,
     );
-    // onReorderItem already adjusts newIndex for the removed item, so the
-    // old `if (oldIndex < newIndex) newIndex--` shift is no longer needed.
     setState(() {
       final layer = _layers.removeAt(oldIndex);
       _layers.insert(newIndex, layer);

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
@@ -48,7 +48,7 @@ class TimelineControlsBar extends StatelessWidget {
       duration: _animationDuration,
       transitionBuilder: (child, animation) => SizeTransition(
         sizeFactor: animation,
-        axisAlignment: -1,
+        alignment: AlignmentDirectional.topStart,
         child: child,
       ),
       child: controlsChild,

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -232,7 +232,7 @@ class _TimelineSectionState extends State<_TimelineSection>
             // cache. SizeTransition clips without unmounting.
             SizeTransition(
               sizeFactor: ReverseAnimation(_animation),
-              axisAlignment: -1,
+              alignment: AlignmentDirectional.topStart,
               child: const Padding(
                 padding: .only(top: 12),
                 child: VideoEditorTimelineScaffold(),
@@ -240,7 +240,7 @@ class _TimelineSectionState extends State<_TimelineSection>
             ),
             SizeTransition(
               sizeFactor: _animation,
-              axisAlignment: -1,
+              alignment: AlignmentDirectional.topStart,
               child: const _BottomActions(),
             ),
           ],

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -190,22 +190,25 @@ class _VideoReplyVisibilityToggle extends ConsumerWidget {
 
     return Padding(
       padding: const .symmetric(horizontal: 4),
-      child: SwitchListTile(
-        value: shareReplyToFeed,
-        title: Text(
-          context.l10n.videoMetadataShareReplyToFeedTitle,
-          style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+      child: Material(
+        type: MaterialType.transparency,
+        child: SwitchListTile(
+          value: shareReplyToFeed,
+          title: Text(
+            context.l10n.videoMetadataShareReplyToFeedTitle,
+            style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+          ),
+          subtitle: Text(
+            context.l10n.videoMetadataShareReplyToFeedSubtitle,
+            style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+          ),
+          contentPadding: const .symmetric(horizontal: 12, vertical: 4),
+          activeThumbColor: VineTheme.vineGreen,
+          inactiveThumbColor: VineTheme.lightText,
+          onChanged: (value) {
+            ref.read(videoEditorProvider.notifier).setShareReplyToFeed(value);
+          },
         ),
-        subtitle: Text(
-          context.l10n.videoMetadataShareReplyToFeedSubtitle,
-          style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
-        ),
-        contentPadding: const .symmetric(horizontal: 12, vertical: 4),
-        activeThumbColor: VineTheme.vineGreen,
-        inactiveThumbColor: VineTheme.lightText,
-        onChanged: (value) {
-          ref.read(videoEditorProvider.notifier).setShareReplyToFeed(value);
-        },
       ),
     );
   }
@@ -222,22 +225,25 @@ class _VideoMetadataAudioReuseToggle extends ConsumerWidget {
 
     return Padding(
       padding: const .symmetric(horizontal: 4),
-      child: SwitchListTile(
-        value: allowAudioReuse,
-        title: Text(
-          context.l10n.videoMetadataAudioReuseTitle,
-          style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+      child: Material(
+        type: MaterialType.transparency,
+        child: SwitchListTile(
+          value: allowAudioReuse,
+          title: Text(
+            context.l10n.videoMetadataAudioReuseTitle,
+            style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+          ),
+          subtitle: Text(
+            context.l10n.videoMetadataAudioReuseSubtitle,
+            style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+          ),
+          contentPadding: const .symmetric(horizontal: 12, vertical: 4),
+          activeThumbColor: VineTheme.vineGreen,
+          inactiveThumbColor: VineTheme.lightText,
+          onChanged: (value) {
+            ref.read(videoEditorProvider.notifier).setAllowAudioReuse(value);
+          },
         ),
-        subtitle: Text(
-          context.l10n.videoMetadataAudioReuseSubtitle,
-          style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
-        ),
-        contentPadding: const .symmetric(horizontal: 12, vertical: 4),
-        activeThumbColor: VineTheme.vineGreen,
-        inactiveThumbColor: VineTheme.lightText,
-        onChanged: (value) {
-          ref.read(videoEditorProvider.notifier).setAllowAudioReuse(value);
-        },
       ),
     );
   }

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-flutter = "3.41.9"
+flutter = "3.44.0"
 
 [tasks.local_up]
 description = "Start all local E2E services"

--- a/mobile/packages/divine_quick_actions/lib/src/models/divine_quick_action.dart
+++ b/mobile/packages/divine_quick_actions/lib/src/models/divine_quick_action.dart
@@ -9,8 +9,7 @@ enum DivineQuickActionIosIconStyle {
   template('template'),
 
   /// Uses an SF Symbol name on iOS 13 and newer.
-  system('system')
-  ;
+  system('system');
 
   const DivineQuickActionIosIconStyle(this.value);
 

--- a/mobile/packages/models/lib/src/aspect_ratio.dart
+++ b/mobile/packages/models/lib/src/aspect_ratio.dart
@@ -7,8 +7,7 @@ enum AspectRatio {
   square,
 
   /// 9:16 (default, modern vertical video)
-  vertical
-  ;
+  vertical;
 
   double get value => switch (this) {
     .square => 1,

--- a/mobile/packages/models/lib/src/curation_set.dart
+++ b/mobile/packages/models/lib/src/curation_set.dart
@@ -146,8 +146,7 @@ enum CurationSetType {
     'trending',
     'Trending',
     'Videos getting the most likes and shares right now',
-  )
-  ;
+  );
 
   const CurationSetType(this.id, this.displayName, this.description);
 

--- a/mobile/packages/models/lib/src/divine_filter.dart
+++ b/mobile/packages/models/lib/src/divine_filter.dart
@@ -7,8 +7,7 @@ import 'package:nostr_sdk/filter.dart';
 /// Sort direction for server-side sorting
 enum SortDirection {
   asc,
-  desc
-  ;
+  desc;
 
   String toJson() => name;
 }

--- a/mobile/packages/models/lib/src/feed_type.dart
+++ b/mobile/packages/models/lib/src/feed_type.dart
@@ -5,8 +5,7 @@
 enum FeedType {
   trending('trending', 'Trending Now', 'Popular videos right now'),
   popularNow('popular_now', 'Popular Now', 'Videos gaining popularity'),
-  recent('recent', 'Recent', 'Latest videos from the network')
-  ;
+  recent('recent', 'Recent', 'Latest videos from the network');
 
   const FeedType(this.id, this.displayName, this.description);
 

--- a/mobile/packages/models/lib/src/logging_types.dart
+++ b/mobile/packages/models/lib/src/logging_types.dart
@@ -7,8 +7,7 @@ enum LogLevel {
   debug(700),
   info(800),
   warning(900),
-  error(1000)
-  ;
+  error(1000);
 
   const LogLevel(this.value);
 
@@ -41,8 +40,7 @@ enum LogCategory {
   auth('AUTH'), // Authentication, key management, identity
   storage('STORAGE'), // Local storage, caching, persistence
   api('API'), // External API calls, network requests
-  system('SYSTEM')
-  ; // App lifecycle, initialization, configuration
+  system('SYSTEM'); // App lifecycle, initialization, configuration
 
   const LogCategory(this.name);
 

--- a/mobile/packages/models/lib/src/nostr_app_audit_event.dart
+++ b/mobile/packages/models/lib/src/nostr_app_audit_event.dart
@@ -5,8 +5,7 @@ enum NostrAppAuditDecision {
   denied('denied'),
   promptAllowed('prompt_allowed'),
   promptDenied('prompt_denied'),
-  blocked('blocked')
-  ;
+  blocked('blocked');
 
   const NostrAppAuditDecision(this.wireValue);
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2349,26 +2349,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:
@@ -2770,5 +2770,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.11.0 <3.16.0"
-  flutter: ">=3.41.1 <4.0.0"
+  dart: ">=3.12.0 <3.16.0"
+  flutter: ">=3.44.0 <4.0.0"

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: bloc
-      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
+      sha256: e03b235924e4f509c27b5d6b2f949200e0a91149a9818b4f65eeb56662b75413
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.2.1"
   bloc_concurrency:
     dependency: "direct main"
     description:
@@ -1520,10 +1520,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   mustache_template:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -19,8 +19,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.15+504
 
 environment:
-  sdk: ^3.11.0
-  flutter: ^3.41.1
+  sdk: ^3.12.0
+  flutter: ^3.44.0
 
 workspace:
   - packages/app_update_repository

--- a/mobile/test/services/video_moderation_status_service_test.dart
+++ b/mobile/test/services/video_moderation_status_service_test.dart
@@ -158,17 +158,10 @@ void main() {
     test('falls back when a moderation request times out', () async {
       const hash =
           'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-      final firstResponse = Completer<http.Response>();
-
-      addTearDown(() {
-        if (!firstResponse.isCompleted) {
-          firstResponse.complete(http.Response('late', 200));
-        }
-      });
 
       final client = MockClient((request) async {
         if (request.url.host == 'first.example') {
-          return firstResponse.future;
+          throw TimeoutException('request timed out');
         }
 
         return http.Response(
@@ -192,7 +185,7 @@ void main() {
       );
 
       await expectLater(
-        service.fetchStatus(hash).timeout(const Duration(milliseconds: 100)),
+        service.fetchStatus(hash),
         completion(
           isA<VideoModerationStatus>().having(
             (status) => status.isUnavailableDueToModeration,
@@ -201,10 +194,6 @@ void main() {
           ),
         ),
       );
-
-      if (!firstResponse.isCompleted) {
-        firstResponse.complete(http.Response('late', 200));
-      }
     });
 
     test('falls back across endpoints and caches result', () async {


### PR DESCRIPTION
## Description

Upgrades the Flutter toolchain from **3.41.9 → 3.44.0** (Dart **3.11.5 → 3.12.0**).

Verified end-to-end on the 3.44 toolchain locally (not just resolved):

- `flutter pub get` resolves with **near-zero churn** — only the SDK-pinned `test`/`test_api`/`test_core` packages move; no app or codegen deps change.
- The `build_runner <2.11.0` pin (#3142) **holds** under Dart 3.12: resolution keeps `build_runner` 2.10.5 / `analyzer` 8.4.0, and `dart run build_runner build` regenerates **byte-identical** output (0 changed generated files).
- `flutter analyze lib test integration_test` is **clean**, and a full `dart analyze packages` sweep is clean (0 errors / 0 warnings / 0 deprecations across all packages).

### What changed

1. **Toolchain pins → 3.44.0** across `mise.toml`, all CI workflows, and `codemagic.yaml`; **Gradle 8.12 → 8.14**, **AGP 8.9.1 → 8.11.1**, and **Kotlin 2.1.0 → 2.2.20** (Android release-build floors).
2. **SDK constraints** — pubspec env `^3.12.0` / `^3.44.0`, regenerated `pubspec.lock`, `.metadata` → `stable` + the 3.44.0 revision, and `CONTRIBUTING.md` prerequisites.
3. **3.44 deprecation migrations** (behavior-preserving):
   - `SizeTransition.axisAlignment` → `alignment`. All four sites are vertical transitions with `axisAlignment: -1`, which the SDK maps to `AlignmentDirectional(-1, -1)` (`.topStart`).
   - `ReorderableList.onReorder` → `onReorderItem`, which delivers an already-adjusted `newIndex`; the manual `if (oldIndex < newIndex) newIndex--` shift is dropped. The value forwarded to the parent callback is identical.
   - Null-aware spreads (`...?x`) for the newly-flagged `use_null_aware_elements`, matching the `?element` style already in those files.
4. **`prefer_initializing_formals` disabled** in `mobile/analysis_options.yaml`. The Dart 3.12 analyzer newly flags this across ~385 app sites — the repo's standard named-parameter constructor-injection-into-private-field pattern (`architecture.md`). It's disabled (consistent with the ~40 other VGA rules this file already turns off) rather than mechanically rewriting 385 constructors in a toolchain PR.

`media_kit_video` is left on its existing org-fork SHA (confirmed building on 3.44). AGP is bumped **8.9.1 → 8.11.1** to clear Flutter 3.44's new soft-floor warning (`DependencyVersionChecker.warnAGPVersion` is `8.11.1`) — the same AGP the repo's own packages already pin (`divine_camera`, `image_metadata_stripper`, `divine_quick_actions`), so the app now matches the rest of the monorepo rather than introducing a new version. 8.11.1 needs Gradle ≥ 8.13 (we ship 8.14) and is fine with Kotlin 2.2.20; the Flutter migrator added behavior-preserving `android.builtInKotlin=false` / `android.newDsl=false` flags to `gradle.properties` to keep the existing explicit-KGP setup. `compileSdk` is already 36; iOS/macOS deployment targets already exceed the 3.44 floors.

**Related Issue:** Closes #4846

## Out of Scope

The following need physical devices / a release-build environment and are **not** covered here — they are the dedicated on-device pass:

- **Per-platform release builds**, especially the two vendored path-override plugins `cryptography_flutter` (stale AGP 7.3.1 / compileSdk 34 buildscript) and `app_device_integrity` (Kotlin 1.7.10 / AGP 7.3.0 / compileSdk 33 — carries the #2057 detach-crash fix), plus the `c2pa-android` JitPack artifact under Gradle 8.14 / NDK 28.
- **On-device feature matrix**: `file_picker`, video playback (`media_kit`/`video_player`), ProofMode attestation, C2PA signing, `flutter_secure_storage` nsec load/export, and the video-editor reorder/collapse animations.
- **Golden + patrol** suites under 3.44.
- **Adopting `prefer_initializing_formals`** (the ~385-site cleanup) — a separate, deliberate PR.

## Verification

- `flutter pub get` (3.44) — resolves, minimal lock churn (3 test packages only)
- `flutter pub upgrade --dry-run` — confirms `build_runner` stays `< 2.11.0`
- `dart run build_runner build --delete-conflicting-outputs` — clean, 0 generated-file diffs
- `flutter analyze lib test integration_test` — **No issues found**
- `dart analyze packages` — **No issues found** (whole-workspace)
- `flutter test` (reorder sheet, library screen, screen analytics) — pass
- `flutter build apk --debug` (3.44, AGP 8.11.1, clean rebuild) — **builds successfully** (all plugins incl. vendored compile under AGP 8.11.1)

## Type of Change

- [x] 🛠️ Bug fix (3.44 deprecation migrations, behavior-preserving)
- [x] ✅ Build configuration change (toolchain bump)
- [x] 🗑️ Chore

