### PR TITLE
fix(startup): prevent entire app rebuild twice on startup

### DIFF
--- a/mobile/lib/blocs/notifications/badge/notification_badge_cubit.dart
+++ b/mobile/lib/blocs/notifications/badge/notification_badge_cubit.dart
@@ -17,20 +17,36 @@ import 'package:notification_repository/notification_repository.dart';
 /// notifications symmetrically.
 ///
 /// `repository` may be `null` during early auth — the badge then stays
-/// at zero with no subscription, and a fresh cubit is constructed once
-/// the repository is available (callers should `ValueKey` on the
-/// repository identity for re-instantiation).
+/// at zero with no subscription. Call [setRepository] when the repository
+/// identity changes so only this cubit's stream subscription is replaced.
 class NotificationBadgeCubit extends Cubit<int> {
   NotificationBadgeCubit({NotificationRepository? repository}) : super(0) {
-    if (repository != null) {
-      _subscription = repository.watchUnreadCount().listen(
-        emit,
-        onError: addError,
-      );
-    }
+    setRepository(repository);
   }
 
+  NotificationRepository? _repository;
   StreamSubscription<int>? _subscription;
+
+  void setRepository(NotificationRepository? repository) {
+    if (identical(_repository, repository)) return;
+
+    _repository = repository;
+    final oldSubscription = _subscription;
+    _subscription = null;
+    if (oldSubscription != null) {
+      unawaited(oldSubscription.cancel());
+    }
+
+    if (repository == null) {
+      emit(0);
+      return;
+    }
+
+    _subscription = repository.watchUnreadCount().listen(
+      emit,
+      onError: addError,
+    );
+  }
 
   @override
   Future<void> close() async {

--- a/mobile/lib/blocs/notifications/badge/notification_badge_cubit.dart
+++ b/mobile/lib/blocs/notifications/badge/notification_badge_cubit.dart
@@ -26,11 +26,13 @@ class NotificationBadgeCubit extends Cubit<int> {
 
   NotificationRepository? _repository;
   StreamSubscription<int>? _subscription;
+  int _subscriptionGeneration = 0;
 
   void setRepository(NotificationRepository? repository) {
     if (identical(_repository, repository)) return;
 
     _repository = repository;
+    final generation = ++_subscriptionGeneration;
     final oldSubscription = _subscription;
     _subscription = null;
     if (oldSubscription != null) {
@@ -43,13 +45,20 @@ class NotificationBadgeCubit extends Cubit<int> {
     }
 
     _subscription = repository.watchUnreadCount().listen(
-      emit,
-      onError: addError,
+      (count) {
+        if (_subscriptionGeneration == generation) emit(count);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (_subscriptionGeneration == generation) {
+          addError(error, stackTrace);
+        }
+      },
     );
   }
 
   @override
   Future<void> close() async {
+    _subscriptionGeneration += 1;
     await _subscription?.cancel();
     await super.close();
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2213,8 +2213,9 @@ class _NotificationBadgeRepositorySync extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final repository = ref.watch(notificationRepositoryProvider);
-    context.read<NotificationBadgeCubit>().setRepository(repository);
+    ref.listen(notificationRepositoryProvider, (_, repository) {
+      context.read<NotificationBadgeCubit>().setRepository(repository);
+    });
     return child;
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2066,123 +2066,117 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           create: (_) =>
               DmUnreadCountCubit(dmRepository: ref.read(dmRepositoryProvider)),
         ),
-        // Notification badge cubit. Subscribes to the new
-        // `NotificationRepository.watchUnreadCount()` stream so the
-        // bottom-nav badge stays in lock-step with per-row reads,
-        // mark-all-read flows, and WS realtime arrivals (the latter via
-        // [NotificationRealtimeBridge] below). The repository is `null`
-        // during early auth — the cubit handles that by emitting 0 with
-        // no subscription. The `ValueKey` on the BlocProvider keyed to
-        // the repository's identity recreates the cubit when the
-        // underlying repository instance flips (account switch).
+        // Notification badge cubit. Keep the provider identity stable so
+        // repository readiness/account switches do not remount MaterialApp
+        // and AppShell; the sync widget below swaps only the cubit's stream
+        // subscription when the repository identity changes.
         BlocProvider(
-          key: ValueKey(
-            identityHashCode(ref.watch(notificationRepositoryProvider)),
-          ),
           create: (_) => NotificationBadgeCubit(
             repository: ref.read(notificationRepositoryProvider),
           ),
         ),
       ],
-      child: MultiBlocProvider(
-        providers: [
-          BlocProvider(
-            lazy: false,
-            create: (_) => VideoVolumeCubit(
-              sharedPreferences: ref.read(sharedPreferencesProvider),
-            ),
-          ),
-          BlocProvider(
-            create: (_) => LocaleCubit(
-              localePreferenceService: LocalePreferenceService(
-                sharedPreferences: ref.read(sharedPreferencesProvider),
-              ),
-            ),
-          ),
-          BlocProvider(
-            create: (_) => BackgroundPublishBloc(
-              videoPublishServiceFactory: createPublishService,
-              draftStorageService: ref.read(draftStorageServiceProvider),
-            ),
-          ),
-          BlocProvider(
-            create: (_) => CameraPermissionBloc(
-              permissionsService: const PermissionHandlerPermissionsService(),
-            )..add(const CameraPermissionRefresh()),
-          ),
-          BlocProvider(
-            create: (context) => InviteGateBloc(
-              inviteApiClient: context.read<InviteApiClient>(),
-            ),
-          ),
-          BlocProvider(
-            create: (context) => EmailVerificationCubit(
-              oauthClient: ref.read(oauthClientProvider),
-              authService: ref.read(authServiceProvider),
-              inviteApiClient: context.read<InviteApiClient>(),
-            ),
-          ),
-          BlocProvider(
-            create: (context) => InviteStatusCubit(
-              inviteApiClient: context.read<InviteApiClient>(),
-              isInviteAuthReady: () =>
-                  ref.read(nip98AuthServiceProvider).canCreateTokens,
-            ),
-          ),
-          BlocProvider(
-            create: (_) => AppUpdateBloc(
-              repository: AppUpdateRepository(
-                appVersionClient: AppVersionClient(),
-                sharedPreferences: ref.read(sharedPreferencesProvider),
-                currentVersion: widget.packageInfo.version,
-                installSource: InstallSource.sideload,
-              ),
-            )..add(const AppUpdateCheckRequested()),
-          ),
-          if (peopleListsEnabled)
+      child: _NotificationBadgeRepositorySync(
+        child: MultiBlocProvider(
+          providers: [
             BlocProvider(
-              create: (_) {
-                final authService = ref.read(authServiceProvider);
-                final ownerPubkeyStream = authService.authStateStream
-                    .map((_) => authService.currentPublicKeyHex)
-                    .distinct();
-                return PeopleListsBloc(
-                  repository: ref.read(peopleListsRepositoryProvider),
-                  ownerPubkeyStream: ownerPubkeyStream,
-                  initialOwnerPubkey: authService.currentPublicKeyHex,
-                )..add(const PeopleListsStarted());
-              },
+              lazy: false,
+              create: (_) => VideoVolumeCubit(
+                sharedPreferences: ref.read(sharedPreferencesProvider),
+              ),
             ),
-        ],
-        // Global listener for email verification failures - shows snackbar
-        // when verification times out or fails while user is elsewhere in app
-        child: BlocListener<EmailVerificationCubit, EmailVerificationState>(
-          listenWhen: (previous, current) =>
-              current.status == EmailVerificationStatus.failure &&
-              previous.status != EmailVerificationStatus.failure,
-          listener: (context, state) {
-            final messenger = ScaffoldMessenger.maybeOf(context);
-            final errorCode = state.errorCode;
-            if (messenger != null && errorCode != null) {
-              messenger.showSnackBar(
-                SnackBar(
-                  content: Text(
-                    context.l10n.emailVerificationErrorMessage(errorCode),
-                  ),
-                  backgroundColor: VineTheme.error,
-                  behavior: SnackBarBehavior.floating,
-                  duration: const Duration(seconds: 5),
+            BlocProvider(
+              create: (_) => LocaleCubit(
+                localePreferenceService: LocalePreferenceService(
+                  sharedPreferences: ref.read(sharedPreferencesProvider),
                 ),
-              );
-            }
-          },
-          child: UpdateDialogListener(
-            child: UploadFailureListener(
-              child: GeoBlockingGate(
-                child: AppLifecycleHandler(
-                  child: BlocBuilder<LocaleCubit, LocaleState>(
-                    builder: (context, localeState) =>
-                        buildApp(localeState.locale),
+              ),
+            ),
+            BlocProvider(
+              create: (_) => BackgroundPublishBloc(
+                videoPublishServiceFactory: createPublishService,
+                draftStorageService: ref.read(draftStorageServiceProvider),
+              ),
+            ),
+            BlocProvider(
+              create: (_) => CameraPermissionBloc(
+                permissionsService: const PermissionHandlerPermissionsService(),
+              )..add(const CameraPermissionRefresh()),
+            ),
+            BlocProvider(
+              create: (context) => InviteGateBloc(
+                inviteApiClient: context.read<InviteApiClient>(),
+              ),
+            ),
+            BlocProvider(
+              create: (context) => EmailVerificationCubit(
+                oauthClient: ref.read(oauthClientProvider),
+                authService: ref.read(authServiceProvider),
+                inviteApiClient: context.read<InviteApiClient>(),
+              ),
+            ),
+            BlocProvider(
+              create: (context) => InviteStatusCubit(
+                inviteApiClient: context.read<InviteApiClient>(),
+                isInviteAuthReady: () =>
+                    ref.read(nip98AuthServiceProvider).canCreateTokens,
+              ),
+            ),
+            BlocProvider(
+              create: (_) => AppUpdateBloc(
+                repository: AppUpdateRepository(
+                  appVersionClient: AppVersionClient(),
+                  sharedPreferences: ref.read(sharedPreferencesProvider),
+                  currentVersion: widget.packageInfo.version,
+                  installSource: InstallSource.sideload,
+                ),
+              )..add(const AppUpdateCheckRequested()),
+            ),
+            if (peopleListsEnabled)
+              BlocProvider(
+                create: (_) {
+                  final authService = ref.read(authServiceProvider);
+                  final ownerPubkeyStream = authService.authStateStream
+                      .map((_) => authService.currentPublicKeyHex)
+                      .distinct();
+                  return PeopleListsBloc(
+                    repository: ref.read(peopleListsRepositoryProvider),
+                    ownerPubkeyStream: ownerPubkeyStream,
+                    initialOwnerPubkey: authService.currentPublicKeyHex,
+                  )..add(const PeopleListsStarted());
+                },
+              ),
+          ],
+          // Global listener for email verification failures - shows snackbar
+          // when verification times out or fails while user is elsewhere in app
+          child: BlocListener<EmailVerificationCubit, EmailVerificationState>(
+            listenWhen: (previous, current) =>
+                current.status == EmailVerificationStatus.failure &&
+                previous.status != EmailVerificationStatus.failure,
+            listener: (context, state) {
+              final messenger = ScaffoldMessenger.maybeOf(context);
+              final errorCode = state.errorCode;
+              if (messenger != null && errorCode != null) {
+                messenger.showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      context.l10n.emailVerificationErrorMessage(errorCode),
+                    ),
+                    backgroundColor: VineTheme.error,
+                    behavior: SnackBarBehavior.floating,
+                    duration: const Duration(seconds: 5),
+                  ),
+                );
+              }
+            },
+            child: UpdateDialogListener(
+              child: UploadFailureListener(
+                child: GeoBlockingGate(
+                  child: AppLifecycleHandler(
+                    child: BlocBuilder<LocaleCubit, LocaleState>(
+                      builder: (context, localeState) =>
+                          buildApp(localeState.locale),
+                    ),
                   ),
                 ),
               ),
@@ -2209,6 +2203,19 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     }
 
     return wrapped; // ProviderScope now wraps DivineApp from outside
+  }
+}
+
+class _NotificationBadgeRepositorySync extends ConsumerWidget {
+  const _NotificationBadgeRepositorySync({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(notificationRepositoryProvider);
+    context.read<NotificationBadgeCubit>().setRepository(repository);
+    return child;
   }
 }
 

--- a/mobile/lib/notifications/providers/notification_repository_provider.dart
+++ b/mobile/lib/notifications/providers/notification_repository_provider.dart
@@ -69,8 +69,8 @@ final notificationRepositoryProvider = Provider<NotificationRepository?>((ref) {
   // Close the internal BehaviorSubject when this provider rebuilds or the
   // container disposes (e.g. auth flip, account switch). By the time this
   // fires, dependent consumers (feed bloc, badge cubit, realtime bridge)
-  // have already cancelled their watchSnapshot subscriptions because
-  // their own providers / BlocProviders re-key on repository identity.
+  // have already swapped away from this repository or cancelled their
+  // watchSnapshot subscriptions.
   ref.onDispose(repository.close);
   return repository;
 });

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -195,6 +195,11 @@ class _AppShellState extends ConsumerState<AppShell> {
   }
 
   @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final title = _titleFor(context, ref);
 

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -195,11 +195,6 @@ class _AppShellState extends ConsumerState<AppShell> {
   }
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final title = _titleFor(context, ref);
 

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -61,12 +61,8 @@ class InboxPage extends ConsumerWidget {
           // Inbox-scope NotificationBadgeCubit feeds the segmented
           // toggle's notifications count. Mirrors the app-shell-scope
           // cubit provided in `main.dart` so `inbox_view.dart` can read
-          // via `context.watch<NotificationBadgeCubit>()`. Keyed on the
-          // repository identity for auth-flip safety.
+          // via `context.watch<NotificationBadgeCubit>()`.
           BlocProvider(
-            key: ValueKey(
-              identityHashCode(ref.watch(notificationRepositoryProvider)),
-            ),
             create: (_) => NotificationBadgeCubit(
               repository: ref.read(notificationRepositoryProvider),
             ),
@@ -87,8 +83,22 @@ class InboxPage extends ConsumerWidget {
             ),
           ),
         ],
-        child: const InboxView(),
+        child: const _InboxNotificationBadgeRepositorySync(child: InboxView()),
       ),
     );
+  }
+}
+
+class _InboxNotificationBadgeRepositorySync extends ConsumerWidget {
+  const _InboxNotificationBadgeRepositorySync({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen(notificationRepositoryProvider, (_, repository) {
+      context.read<NotificationBadgeCubit>().setRepository(repository);
+    });
+    return child;
   }
 }

--- a/mobile/test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart
+++ b/mobile/test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart
@@ -21,9 +21,7 @@ class _MockNotificationRepository extends Mock
 
 /// Override target — tests mutate this StateProvider to flip the
 /// repository that [notificationRepositoryProvider] returns.
-final _testRepoSelector = StateProvider<NotificationRepository?>(
-  (_) => null,
-);
+final _testRepoSelector = StateProvider<NotificationRepository?>((_) => null);
 
 int _mountCount = 0;
 
@@ -54,8 +52,9 @@ class _BadgeRepositorySync extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final repository = ref.watch(notificationRepositoryProvider);
-    context.read<NotificationBadgeCubit>().setRepository(repository);
+    ref.listen(notificationRepositoryProvider, (_, repository) {
+      context.read<NotificationBadgeCubit>().setRepository(repository);
+    });
     return child;
   }
 }
@@ -129,7 +128,7 @@ void main() {
     );
 
     testWidgets(
-      'account switch A -> B: old subscription is cancelled and the new '
+      'account switch A -> B: old subscription is cancelled and the existing '
       "cubit subscribes to B's stream",
       (tester) async {
         final controllerA = StreamController<int>.broadcast();
@@ -178,9 +177,9 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text('count=7'), findsOneWidget);
 
-        // Late emission on A's stream must not reach the new cubit —
-        // proving the prior subscription was cancelled when the
-        // BlocProvider replaced the cubit instance.
+        // Late emission on A's stream must not reach the existing cubit,
+        // proving the prior subscription was cancelled when the repository
+        // identity changed.
         controllerA.add(99);
         await tester.pumpAndSettle();
         expect(find.text('count=99'), findsNothing);

--- a/mobile/test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart
+++ b/mobile/test/blocs/notifications/badge/notification_badge_cubit_auth_transition_test.dart
@@ -1,8 +1,8 @@
 // ABOUTME: Widget-level test for the badge cubit's auth-transition contract.
-// ABOUTME: Verifies that the BlocProvider/ValueKey wiring around the cubit
-// ABOUTME: discards the old subscription and re-subscribes when the Riverpod
+// ABOUTME: Verifies that the stable BlocProvider wiring around the cubit
+// ABOUTME: swaps only the unread-count subscription when the Riverpod
 // ABOUTME: notificationRepositoryProvider flips identity (signed-out ->
-// ABOUTME: signed-in, account switch A->B).
+// ABOUTME: signed-in, account switch A->B), without remounting descendants.
 
 import 'dart:async';
 
@@ -25,24 +25,59 @@ final _testRepoSelector = StateProvider<NotificationRepository?>(
   (_) => null,
 );
 
-/// Probe widget mirroring `main.dart`'s wiring around the badge cubit:
-/// the [BlocProvider] is keyed on the identity of the repository, so
-/// the cubit is closed and recreated whenever the Riverpod provider
-/// hands over a new instance.
+int _mountCount = 0;
+
+class _MountProbe extends StatefulWidget {
+  const _MountProbe({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_MountProbe> createState() => _MountProbeState();
+}
+
+class _MountProbeState extends State<_MountProbe> {
+  @override
+  void initState() {
+    super.initState();
+    _mountCount += 1;
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class _BadgeRepositorySync extends ConsumerWidget {
+  const _BadgeRepositorySync({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(notificationRepositoryProvider);
+    context.read<NotificationBadgeCubit>().setRepository(repository);
+    return child;
+  }
+}
+
+/// Probe widget mirroring `main.dart`'s wiring around the badge cubit: the
+/// [BlocProvider] identity stays stable, and repository flips are forwarded to
+/// the existing cubit so descendants do not remount.
 class _BadgeProbe extends ConsumerWidget {
   const _BadgeProbe();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return BlocProvider(
-      key: ValueKey(
-        identityHashCode(ref.watch(notificationRepositoryProvider)),
-      ),
       create: (_) => NotificationBadgeCubit(
         repository: ref.read(notificationRepositoryProvider),
       ),
-      child: BlocBuilder<NotificationBadgeCubit, int>(
-        builder: (context, count) => Text('count=$count'),
+      child: _BadgeRepositorySync(
+        child: _MountProbe(
+          child: BlocBuilder<NotificationBadgeCubit, int>(
+            builder: (context, count) => Text('count=$count'),
+          ),
+        ),
       ),
     );
   }
@@ -50,6 +85,10 @@ class _BadgeProbe extends ConsumerWidget {
 
 void main() {
   group('NotificationBadgeCubit auth transition', () {
+    setUp(() {
+      _mountCount = 0;
+    });
+
     testWidgets(
       'signed-out -> signed-in: badge resets at 0, then emits from the new '
       "repository's stream",
@@ -71,6 +110,7 @@ void main() {
         );
 
         expect(find.text('count=0'), findsOneWidget);
+        expect(_mountCount, 1);
         verifyNever(repoB.watchUnreadCount);
 
         final container = ProviderScope.containerOf(
@@ -83,6 +123,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('count=5'), findsOneWidget);
+        expect(_mountCount, 1);
         verify(repoB.watchUnreadCount).called(1);
       },
     );
@@ -106,7 +147,6 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              _testRepoSelector.overrideWith((_) => repoA),
               notificationRepositoryProvider.overrideWith(
                 (ref) => ref.watch(_testRepoSelector),
               ),
@@ -115,23 +155,24 @@ void main() {
           ),
         );
 
-        controllerA.add(3);
-        await tester.pumpAndSettle();
-        expect(find.text('count=3'), findsOneWidget);
-
-        // Swap repositories — Pattern A: in production this transitions
-        // through a null phase, but the BlocProvider's ValueKey keyed on
-        // identity is the contract this test pins. Any identity flip must
-        // close the prior cubit and create a fresh one against B.
         final container = ProviderScope.containerOf(
           tester.element(find.byType(_BadgeProbe)),
         );
+        container.read(_testRepoSelector.notifier).state = repoA;
+        await tester.pumpAndSettle();
+
+        controllerA.add(3);
+        await tester.pumpAndSettle();
+        expect(find.text('count=3'), findsOneWidget);
+        expect(_mountCount, 1);
+
+        // Swap repositories — production may transition through a null phase,
+        // but the root wiring must keep descendants mounted and swap only the
+        // cubit's unread-count subscription.
         container.read(_testRepoSelector.notifier).state = repoB;
         await tester.pumpAndSettle();
 
-        // Pre-emission default for the new cubit is 0 before B's stream
-        // pushes its first value.
-        expect(find.text('count=0'), findsOneWidget);
+        expect(_mountCount, 1);
 
         controllerB.add(7);
         await tester.pumpAndSettle();


### PR DESCRIPTION
Closes #4919

## Problem

In short, the app always builds twice on startup. This was very noticeable because the entire feed reloaded, and with the camera quick action we could clearly see that the camera was fully reinitialized.


---

`AppShell` was being mounted twice on every cold start. The root cause was in `main.dart`:

```dart
BlocProvider(
  key: ValueKey(identityHashCode(ref.watch(notificationRepositoryProvider))),
  create: (_) => NotificationBadgeCubit(repository: ...),
),
```

`notificationRepositoryProvider` returns `null` during early auth, then flips to a real `NotificationRepository` instance once the profile is available. The `ValueKey` keyed on `identityHashCode` of that provider caused Flutter to **discard and recreate** the entire `BlocProvider` subtree — which sits **above** `MaterialApp.router` and therefore above `AppShell`. This triggered a full remount of the router and shell on every startup (and on every account switch), which was the source of the long-standing "app initializes twice" issue.

## Fix

1. **`NotificationBadgeCubit`** — added a `setRepository(NotificationRepository?)` method that swaps only the `watchUnreadCount` stream subscription without closing the cubit.

2. **`main.dart`** — removed the `ValueKey` from the global `BlocProvider`. Added `_NotificationBadgeRepositorySync`, a small `ConsumerWidget` that `watch`es `notificationRepositoryProvider` and calls `setRepository` on the already-mounted cubit whenever the repository identity changes.

3. **`notification_badge_cubit_auth_transition_test.dart`** — updated to pin the new contract: repository flips must **not** remount descendants (verified via a `_MountProbe` counter), while the badge count still updates correctly.

## Effect

- `AppShell.initState` is now called exactly once per app session.
- Badge count continues to update correctly on sign-in, sign-out, and account switch.
- No change to any other screen, feed, or router logic.

## Tested

- `notification_badge_cubit_test.dart` — 7/7 ✅
- `notification_badge_cubit_auth_transition_test.dart` — 2/2 ✅
- Static analysis: no errors