### PR TITLE
fix(notifications): reclassify misattributed video notifications as actor-anchored

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -959,10 +959,17 @@ class NotificationRepository {
     final (profiles, videosById) = await (profilesFuture, videosFuture).wait;
 
     final consolidated = _consolidateFollows(raw);
-    final videos = _groupVideoAnchored(consolidated, profiles, videosById);
+    final misattributed = <RelayNotification>[];
+    final videos = _groupVideoAnchored(
+      consolidated,
+      profiles,
+      videosById,
+      misattributed: misattributed,
+    );
     final actors = _mapActorAnchored(consolidated, profiles);
+    final reclassified = _reclassifyMisattributed(misattributed, profiles);
 
-    final items = <NotificationItem>[...videos, ...actors]
+    final items = <NotificationItem>[...videos, ...actors, ...reclassified]
       ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
     return _applyBlockFilter(items);
   }
@@ -1025,11 +1032,17 @@ class NotificationRepository {
   /// `referencedEventId` becomes a [VideoNotification], even if only one
   /// actor interacted. Notifications missing `referencedEventId` are
   /// dropped.
+  ///
+  /// Notifications whose referenced video is confirmed to belong to a
+  /// different user are collected in [misattributed] for reclassification
+  /// as actor-anchored notifications (e.g. "liked your comment" instead of
+  /// "liked your video"). This fixes #4813.
   List<VideoNotification> _groupVideoAnchored(
     List<RelayNotification> raw,
     Map<String, UserProfile> profiles,
-    Map<String, VideoStats> videosById,
-  ) {
+    Map<String, VideoStats> videosById, {
+    List<RelayNotification>? misattributed,
+  }) {
     bool isVideoAnchored(NotificationKind k) =>
         k == NotificationKind.like ||
         k == NotificationKind.comment ||
@@ -1045,12 +1058,13 @@ class NotificationRepository {
         referencedVideoEventId: eventId,
         videosById: videosById,
       )) {
-        _logDroppedKnownOwnerMismatch(
+        _logReclassifiedOwnerMismatch(
           notificationId: n.id,
           sourcePubkey: n.sourcePubkey,
           referencedVideoEventId: eventId,
           referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
         );
+        misattributed?.add(n);
         continue;
       }
       final key = _VideoGroupKey(eventId, kind);
@@ -1172,6 +1186,55 @@ class NotificationRepository {
     return result;
   }
 
+  /// Reclassifies video-anchored notifications that were dropped because
+  /// the referenced video is owned by a different user.
+  ///
+  /// Instead of silently dropping these, they are surfaced as
+  /// [ActorNotification]s with the correct kind:
+  /// - `like` (reaction on someone else's video) → `likeComment`
+  ///   ("liked your comment")
+  /// - `comment` (reply on someone else's video) → `reply`
+  ///   ("replied to your comment")
+  /// - `repost` remains dropped — a repost of someone else's video should
+  ///   not notify the commenter.
+  ///
+  /// Fixes #4813: user sees "liked your video" / "commented on your video"
+  /// for interactions that are actually on their comments on other users'
+  /// videos.
+  List<ActorNotification> _reclassifyMisattributed(
+    List<RelayNotification> misattributed,
+    Map<String, UserProfile> profiles,
+  ) {
+    final result = <ActorNotification>[];
+    for (final n in misattributed) {
+      final originalKind = _mapNotificationKind(n);
+      final reclassifiedKind = switch (originalKind) {
+        NotificationKind.like => NotificationKind.likeComment,
+        NotificationKind.comment => NotificationKind.reply,
+        // Reposts on foreign videos are not meaningful for the commenter.
+        _ => null,
+      };
+      if (reclassifiedKind == null) continue;
+      result.add(
+        ActorNotification(
+          id: n.dedupeKey,
+          type: reclassifiedKind,
+          actor: _buildActor(n.sourcePubkey, profiles),
+          timestamp: n.createdAt,
+          isRead: n.read,
+          commentText: _truncateComment(n.content, reclassifiedKind),
+          targetEventId: _actorTargetEventId(reclassifiedKind, n),
+          sourceEventIds: n.sourceEventId.isNotEmpty
+              ? [n.sourceEventId]
+              : const [],
+          notificationIds: n.dedupeKey.isNotEmpty ? [n.dedupeKey] : const [],
+          videoAddressableId: _actorVideoAddressableId(reclassifiedKind, n),
+        ),
+      );
+    }
+    return result;
+  }
+
   /// Enriches a single raw [RelayNotification] for realtime insertion.
   ///
   /// Fetches the actor's profile and (if applicable) the referenced
@@ -1204,13 +1267,36 @@ class NotificationRepository {
         referencedVideoEventId: referenced,
         videosById: videosById,
       )) {
-        _logDroppedKnownOwnerMismatch(
+        _logReclassifiedOwnerMismatch(
           notificationId: raw.id,
           sourcePubkey: raw.sourcePubkey,
           referencedVideoEventId: referenced,
           referencedVideoOwnerPubkey: video?.pubkey,
         );
-        return null;
+        // Reclassify as actor-anchored instead of dropping (#4813).
+        final reclassifiedKind = switch (kind) {
+          NotificationKind.like => NotificationKind.likeComment,
+          NotificationKind.comment => NotificationKind.reply,
+          // Reposts on foreign videos are not meaningful for the commenter.
+          _ => null,
+        };
+        if (reclassifiedKind == null) return null;
+        return ActorNotification(
+          id: raw.dedupeKey,
+          type: reclassifiedKind,
+          actor: actor,
+          timestamp: raw.createdAt,
+          isRead: raw.read,
+          commentText: _truncateComment(raw.content, reclassifiedKind),
+          targetEventId: _actorTargetEventId(reclassifiedKind, raw),
+          sourceEventIds: raw.sourceEventId.isNotEmpty
+              ? [raw.sourceEventId]
+              : const [],
+          notificationIds: raw.dedupeKey.isNotEmpty
+              ? [raw.dedupeKey]
+              : const [],
+          videoAddressableId: _actorVideoAddressableId(reclassifiedKind, raw),
+        );
       }
       final addressableId = _recipientOwnedVideoAddressableId(
         dTag: raw.referencedDTag,
@@ -1354,14 +1440,14 @@ class NotificationRepository {
     return ownerPubkey != _userPubkey;
   }
 
-  void _logDroppedKnownOwnerMismatch({
+  void _logReclassifiedOwnerMismatch({
     required String notificationId,
     required String sourcePubkey,
     required String referencedVideoEventId,
     required String? referencedVideoOwnerPubkey,
   }) {
-    Log.warning(
-      'Dropping misattributed video notification: '
+    Log.info(
+      'Reclassifying misattributed video notification as actor-anchored: '
       'notificationId=$notificationId '
       'sourcePubkey=$sourcePubkey '
       'referencedVideoEventId=$referencedVideoEventId '

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1167,19 +1167,11 @@ class NotificationRepository {
           ? kind
           : NotificationKind.system;
       result.add(
-        ActorNotification(
-          id: n.dedupeKey,
+        _buildActorNotification(
+          n,
           type: mapped,
-          actor: _buildActor(n.sourcePubkey, profiles),
-          timestamp: n.createdAt,
-          isRead: n.read,
-          commentText: _truncateComment(n.content, kind),
-          targetEventId: _actorTargetEventId(mapped, n),
-          sourceEventIds: n.sourceEventId.isNotEmpty
-              ? [n.sourceEventId]
-              : const [],
-          notificationIds: n.dedupeKey.isNotEmpty ? [n.dedupeKey] : const [],
-          videoAddressableId: _actorVideoAddressableId(mapped, n),
+          profiles: profiles,
+          commentKind: kind,
         ),
       );
     }
@@ -1208,27 +1200,17 @@ class NotificationRepository {
     final result = <ActorNotification>[];
     for (final n in misattributed) {
       final originalKind = _mapNotificationKind(n);
-      final reclassifiedKind = switch (originalKind) {
-        NotificationKind.like => NotificationKind.likeComment,
-        NotificationKind.comment => NotificationKind.reply,
-        // Reposts on foreign videos are not meaningful for the commenter.
-        _ => null,
-      };
+      final reclassifiedKind = _reclassifiedMisattributedKind(originalKind);
       if (reclassifiedKind == null) continue;
       result.add(
-        ActorNotification(
-          id: n.dedupeKey,
+        _buildActorNotification(
+          n,
           type: reclassifiedKind,
-          actor: _buildActor(n.sourcePubkey, profiles),
-          timestamp: n.createdAt,
-          isRead: n.read,
-          commentText: _truncateComment(n.content, reclassifiedKind),
-          targetEventId: _actorTargetEventId(reclassifiedKind, n),
-          sourceEventIds: n.sourceEventId.isNotEmpty
-              ? [n.sourceEventId]
-              : const [],
-          notificationIds: n.dedupeKey.isNotEmpty ? [n.dedupeKey] : const [],
-          videoAddressableId: _actorVideoAddressableId(reclassifiedKind, n),
+          profiles: profiles,
+          targetEventId: _reclassifiedMisattributedTargetEventId(
+            reclassifiedKind,
+            n,
+          ),
         ),
       );
     }
@@ -1274,28 +1256,16 @@ class NotificationRepository {
           referencedVideoOwnerPubkey: video?.pubkey,
         );
         // Reclassify as actor-anchored instead of dropping (#4813).
-        final reclassifiedKind = switch (kind) {
-          NotificationKind.like => NotificationKind.likeComment,
-          NotificationKind.comment => NotificationKind.reply,
-          // Reposts on foreign videos are not meaningful for the commenter.
-          _ => null,
-        };
+        final reclassifiedKind = _reclassifiedMisattributedKind(kind);
         if (reclassifiedKind == null) return null;
-        return ActorNotification(
-          id: raw.dedupeKey,
+        return _buildActorNotification(
+          raw,
           type: reclassifiedKind,
-          actor: actor,
-          timestamp: raw.createdAt,
-          isRead: raw.read,
-          commentText: _truncateComment(raw.content, reclassifiedKind),
-          targetEventId: _actorTargetEventId(reclassifiedKind, raw),
-          sourceEventIds: raw.sourceEventId.isNotEmpty
-              ? [raw.sourceEventId]
-              : const [],
-          notificationIds: raw.dedupeKey.isNotEmpty
-              ? [raw.dedupeKey]
-              : const [],
-          videoAddressableId: _actorVideoAddressableId(reclassifiedKind, raw),
+          profiles: profiles,
+          targetEventId: _reclassifiedMisattributedTargetEventId(
+            reclassifiedKind,
+            raw,
+          ),
         );
       }
       final addressableId = _recipientOwnedVideoAddressableId(
@@ -1334,20 +1304,60 @@ class NotificationRepository {
             kind == NotificationKind.reply)
         ? kind
         : NotificationKind.system;
-    return ActorNotification(
-      id: raw.dedupeKey,
+    return _buildActorNotification(
+      raw,
       type: mapped,
-      actor: actor,
-      timestamp: raw.createdAt,
-      isRead: raw.read,
-      commentText: _truncateComment(raw.content, kind),
-      targetEventId: _actorTargetEventId(mapped, raw),
-      sourceEventIds: raw.sourceEventId.isNotEmpty
-          ? [raw.sourceEventId]
-          : const [],
-      notificationIds: raw.dedupeKey.isNotEmpty ? [raw.dedupeKey] : const [],
-      videoAddressableId: _actorVideoAddressableId(mapped, raw),
+      profiles: profiles,
+      commentKind: kind,
     );
+  }
+
+  ActorNotification _buildActorNotification(
+    RelayNotification notification, {
+    required NotificationKind type,
+    required Map<String, UserProfile> profiles,
+    NotificationKind? commentKind,
+    String? targetEventId,
+  }) {
+    return ActorNotification(
+      id: notification.dedupeKey,
+      type: type,
+      actor: _buildActor(notification.sourcePubkey, profiles),
+      timestamp: notification.createdAt,
+      isRead: notification.read,
+      commentText: _truncateComment(notification.content, commentKind ?? type),
+      targetEventId: targetEventId ?? _actorTargetEventId(type, notification),
+      sourceEventIds: notification.sourceEventId.isNotEmpty
+          ? [notification.sourceEventId]
+          : const [],
+      notificationIds: notification.dedupeKey.isNotEmpty
+          ? [notification.dedupeKey]
+          : const [],
+      videoAddressableId: _actorVideoAddressableId(type, notification),
+    );
+  }
+
+  static NotificationKind? _reclassifiedMisattributedKind(
+    NotificationKind originalKind,
+  ) => switch (originalKind) {
+    NotificationKind.like => NotificationKind.likeComment,
+    NotificationKind.comment => NotificationKind.reply,
+    // Reposts on foreign videos are not meaningful for the commenter.
+    _ => null,
+  };
+
+  static String? _reclassifiedMisattributedTargetEventId(
+    NotificationKind reclassifiedKind,
+    RelayNotification notification,
+  ) {
+    final targetCommentId = _nonEmpty(notification.targetCommentId);
+    if (targetCommentId != null) return targetCommentId;
+
+    // Misattributed rows often carry the foreign video as referencedEventId
+    // because FunnelCake included it for navigation context. Without the
+    // comment id, keep the standard actor target fallback so taps can still
+    // resolve or degrade through the existing navigation path.
+    return _actorTargetEventId(reclassifiedKind, notification);
   }
 
   /// Returns null if [s] is null or empty, otherwise [s].

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1157,10 +1157,54 @@ void main() {
         expect(item.type, equals(NotificationKind.like));
       });
 
-      test('reaction on a non-owned video is dropped instead of rendering '
-          'as liked your video', () async {
+      test('reaction on a non-owned video is reclassified as likeComment '
+          'instead of liked your video (#4813)', () async {
         stubNotifications([
           makeNotification(referencedEventId: 'foreign_video'),
+        ]);
+        stubProfiles({});
+        stubVideoStats(
+          'foreign_video',
+          makeVideoStats(id: 'foreign_video', pubkey: 'other_owner_pubkey'),
+        );
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.likeComment));
+      });
+
+      test('comment on a non-owned video is reclassified as reply '
+          'instead of commented on your video (#4813)', () async {
+        stubNotifications([
+          makeNotification(
+            notificationType: 'reply',
+            sourceKind: 1111,
+            referencedEventId: 'foreign_video',
+            rootEventId: 'foreign_video',
+          ),
+        ]);
+        stubProfiles({});
+        stubVideoStats(
+          'foreign_video',
+          makeVideoStats(id: 'foreign_video', pubkey: 'other_owner_pubkey'),
+        );
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.reply));
+      });
+
+      test('repost on a non-owned video is dropped entirely', () async {
+        stubNotifications([
+          makeNotification(
+            notificationType: 'repost',
+            sourceKind: 6,
+            referencedEventId: 'foreign_video',
+          ),
         ]);
         stubProfiles({});
         stubVideoStats(
@@ -2527,8 +2571,8 @@ void main() {
         expect(video.videoAddressableId, isNull);
       });
 
-      test('drops a realtime like when the referenced video is owned by '
-          'someone else', () async {
+      test('reclassifies a realtime like on a non-owned video as likeComment '
+          '(#4813)', () async {
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
         stubVideoStats(
           'video_x',
@@ -2537,7 +2581,9 @@ void main() {
 
         final result = await repository.enrichOne(raw());
 
-        expect(result, isNull);
+        expect(result, isA<ActorNotification>());
+        final actor = result! as ActorNotification;
+        expect(actor.type, equals(NotificationKind.likeComment));
       });
 
       test('returns null for like with null referencedEventId', () async {
@@ -2790,24 +2836,29 @@ void main() {
         },
       );
 
-      test('acceptRealtime drops a video-anchored notification whose '
-          'referenced video is known to be owned by someone else', () async {
-        stubProfiles({
-          allowedPubkey: makeProfile(allowedPubkey, displayName: 'Allowed'),
-        });
-        stubVideoStats(
-          'video_default',
-          makeVideoStats(id: 'video_default', pubkey: 'other_owner_pubkey'),
-        );
+      test(
+        'acceptRealtime reclassifies a video-anchored notification whose '
+        'referenced video is owned by someone else as likeComment (#4813)',
+        () async {
+          stubProfiles({
+            allowedPubkey: makeProfile(allowedPubkey, displayName: 'Allowed'),
+          });
+          stubVideoStats(
+            'video_default',
+            makeVideoStats(id: 'video_default', pubkey: 'other_owner_pubkey'),
+          );
 
-        await repository.acceptRealtime(
-          makeNotification(sourcePubkey: allowedPubkey),
-        );
+          await repository.acceptRealtime(
+            makeNotification(sourcePubkey: allowedPubkey),
+          );
 
-        final snapshot = await repository.watchSnapshot().first;
-        expect(snapshot.items, isEmpty);
-        expect(await repository.watchUnreadCount().first, equals(0));
-      });
+          final snapshot = await repository.watchSnapshot().first;
+          expect(snapshot.items, hasLength(1));
+          final item = snapshot.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(await repository.watchUnreadCount().first, equals(1));
+        },
+      );
 
       test('acceptRealtime drops a video-anchored notification from a '
           'blocked actor', () async {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1160,7 +1160,10 @@ void main() {
       test('reaction on a non-owned video is reclassified as likeComment '
           'instead of liked your video (#4813)', () async {
         stubNotifications([
-          makeNotification(referencedEventId: 'foreign_video'),
+          makeNotification(
+            referencedEventId: 'foreign_video',
+            targetCommentId: 'comment_event_xyz',
+          ),
         ]);
         stubProfiles({});
         stubVideoStats(
@@ -1173,6 +1176,7 @@ void main() {
         expect(page.items, hasLength(1));
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.likeComment));
+        expect(item.targetEventId, equals('comment_event_xyz'));
       });
 
       test('comment on a non-owned video is reclassified as reply '
@@ -1180,9 +1184,10 @@ void main() {
         stubNotifications([
           makeNotification(
             notificationType: 'reply',
-            sourceKind: 1111,
+            sourceKind: 1,
             referencedEventId: 'foreign_video',
             rootEventId: 'foreign_video',
+            targetCommentId: 'comment_event_xyz',
           ),
         ]);
         stubProfiles({});
@@ -1196,6 +1201,7 @@ void main() {
         expect(page.items, hasLength(1));
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.reply));
+        expect(item.targetEventId, equals('comment_event_xyz'));
       });
 
       test('repost on a non-owned video is dropped entirely', () async {
@@ -1293,53 +1299,47 @@ void main() {
         expect(item.type, equals(NotificationKind.comment));
       });
 
-      test(
-        'reply to user comment with root video metadata maps to reply '
-        '($ActorNotification)',
-        () async {
-          stubNotifications([
-            makeNotification(
-              notificationType: 'reply',
-              sourceKind: 1111,
-              sourceEventId: 'reply_event_id',
-              referencedEventId: 'parent_comment_id',
-              rootEventId: 'someone_else_video_id',
-              targetCommentId: 'parent_comment_id',
-            ),
-          ]);
-          stubProfiles({});
+      test('reply to user comment with root video metadata maps to reply '
+          '($ActorNotification)', () async {
+        stubNotifications([
+          makeNotification(
+            notificationType: 'reply',
+            sourceKind: 1111,
+            sourceEventId: 'reply_event_id',
+            referencedEventId: 'parent_comment_id',
+            rootEventId: 'someone_else_video_id',
+            targetCommentId: 'parent_comment_id',
+          ),
+        ]);
+        stubProfiles({});
 
-          final page = await repository.getNotifications();
-          final item = page.items.single as ActorNotification;
-          expect(item.type, equals(NotificationKind.reply));
-          expect(item.targetEventId, equals('parent_comment_id'));
-        },
-      );
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.reply));
+        expect(item.targetEventId, equals('parent_comment_id'));
+      });
 
-      test(
-        'comment-typed nested NIP-22 reply maps to reply '
-        '($ActorNotification)',
-        () async {
-          stubNotifications([
-            makeNotification(
-              notificationType: 'comment',
-              sourceKind: 1111,
-              sourceEventId: 'reply_event_id',
-              referencedEventId: 'parent_comment_id',
-              rootEventId: 'someone_else_video_id',
-              targetCommentId: 'parent_comment_id',
-              content: 'Nested reply to my comment',
-            ),
-          ]);
-          stubProfiles({});
+      test('comment-typed nested NIP-22 reply maps to reply '
+          '($ActorNotification)', () async {
+        stubNotifications([
+          makeNotification(
+            notificationType: 'comment',
+            sourceKind: 1111,
+            sourceEventId: 'reply_event_id',
+            referencedEventId: 'parent_comment_id',
+            rootEventId: 'someone_else_video_id',
+            targetCommentId: 'parent_comment_id',
+            content: 'Nested reply to my comment',
+          ),
+        ]);
+        stubProfiles({});
 
-          final page = await repository.getNotifications();
-          final item = page.items.single as ActorNotification;
-          expect(item.type, equals(NotificationKind.reply));
-          expect(item.targetEventId, equals('parent_comment_id'));
-          expect(item.commentText, equals('Nested reply to my comment'));
-        },
-      );
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.reply));
+        expect(item.targetEventId, equals('parent_comment_id'));
+        expect(item.commentText, equals('Nested reply to my comment'));
+      });
 
       test('reply on a non-video target maps to reply ($ActorNotification) '
           'with targetEventId', () async {
@@ -2425,6 +2425,7 @@ void main() {
         String? referencedEventId = 'video_x',
         String? referencedDTag,
         String? rootEventId,
+        String? targetCommentId,
         bool isReferencedVideo = true,
       }) {
         return RelayNotification(
@@ -2438,6 +2439,7 @@ void main() {
           referencedEventId: referencedEventId,
           referencedDTag: referencedDTag,
           rootEventId: rootEventId,
+          targetCommentId: targetCommentId,
           isReferencedVideo: isReferencedVideo,
         );
       }
@@ -2584,6 +2586,43 @@ void main() {
         expect(result, isA<ActorNotification>());
         final actor = result! as ActorNotification;
         expect(actor.type, equals(NotificationKind.likeComment));
+      });
+
+      test('reclassifies a realtime comment on a non-owned video as reply '
+          'with the target comment id (#4813)', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats(
+          'video_x',
+          makeVideoStats(id: 'video_x', pubkey: 'other_owner_pubkey'),
+        );
+
+        final result = await repository.enrichOne(
+          raw(
+            sourceKind: 1,
+            notificationType: 'comment',
+            rootEventId: 'video_x',
+            targetCommentId: 'comment_evt_id',
+          ),
+        );
+
+        expect(result, isA<ActorNotification>());
+        final actor = result! as ActorNotification;
+        expect(actor.type, equals(NotificationKind.reply));
+        expect(actor.targetEventId, equals('comment_evt_id'));
+      });
+
+      test('drops a realtime repost on a non-owned video (#4813)', () async {
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats(
+          'video_x',
+          makeVideoStats(id: 'video_x', pubkey: 'other_owner_pubkey'),
+        );
+
+        final result = await repository.enrichOne(
+          raw(notificationType: 'repost', sourceKind: 6),
+        );
+
+        expect(result, isNull);
       });
 
       test('returns null for like with null referencedEventId', () async {


### PR DESCRIPTION
## Summary

Fixes #4813 — User receives "liked your video" / "commented on your video" notifications for interactions that are actually on their **comments** on other users' videos.

## Problem

When FunnelCake sends a notification with a `referenced_video` block (for navigation context), the client used `isReferencedVideo: true` as a signal that the reaction/comment target **is** a video. This caused:

1. **Incorrect display**: "liked your video" shown when it should say "liked your comment" (when the video stats fetch failed or returned no owner info)
2. **Silent dropping**: When `_hasKnownReferencedVideoOwnerMismatch` detected the video owner was different, the notification was dropped entirely — the user saw nothing instead of the correct "liked your comment" message

## Fix

When the referenced video's owner doesn't match the current user, instead of dropping the notification, **reclassify** it:

| Original (incorrect) | Reclassified (correct) |
|---|---|
| `like` → "liked your video" | `likeComment` → "liked your comment" |
| `comment` → "commented on your video" | `reply` → "replied to your comment" |
| `repost` | Still dropped (reposts on foreign videos aren't meaningful for the commenter) |

Applied to both:
- Page-load path (`_groupVideoAnchored` → new `_reclassifyMisattributed`)
- Realtime path (`enrichOne` / `acceptRealtime`)

## Testing

- Updated 3 existing tests that expected "drop" behavior to now expect reclassification
- Added 2 new tests: comment→reply reclassification and repost-still-dropped
- All 124 notification_repository tests pass
- All 173 app-layer notification tests pass
- `flutter analyze` clean