### PR TITLE
fix(feed): content filters not reactively applied to feeds

### DIFF
--- a/mobile/lib/providers/route_feed_providers.dart
+++ b/mobile/lib/providers/route_feed_providers.dart
@@ -71,6 +71,7 @@ final videosForExploreRouteProvider = Provider<AsyncValue<VideoFeedState>>((
       final tabVideos = ref.watch(exploreTabVideosProvider);
       if (tabVideos != null && tabVideos.isNotEmpty) {
         ref.watch(divineHostFilterVersionProvider);
+        ref.watch(contentFilterVersionProvider);
         final videoEventService = ref.read(videoEventServiceProvider);
         final visibleTabVideos = videoEventService.filterVideoList(tabVideos);
 

--- a/mobile/lib/providers/video_events_providers.dart
+++ b/mobile/lib/providers/video_events_providers.dart
@@ -113,6 +113,7 @@ class VideoEvents extends _$VideoEvents {
     final videoEventService = ref.watch(videoEventServiceProvider);
     ref.watch(blocklistVersionProvider);
     ref.watch(divineHostFilterVersionProvider);
+    ref.watch(contentFilterVersionProvider);
     final isAppReady = ref.watch(appReadyProvider);
     final isTabActive = ref.watch(isDiscoveryTabActiveProvider);
     final seenVideosState = ref.watch(seenVideosProvider);

--- a/mobile/lib/providers/video_events_providers.g.dart
+++ b/mobile/lib/providers/video_events_providers.g.dart
@@ -137,7 +137,7 @@ final class VideoEventsProvider
   VideoEvents create() => VideoEvents();
 }
 
-String _$videoEventsHash() => r'014d1bb4a907b284e9d3f9f14ef9e2bd08023ace';
+String _$videoEventsHash() => r'c85e9a98766eee60ba6c15e78f11470924433eeb';
 
 /// Stream provider for video events from Nostr
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -313,6 +313,11 @@ VideoLocalStorage videoLocalStorage(Ref ref) {
 /// Creates a VideosRepository for loading video feeds with pagination.
 /// Works without authentication for public feeds.
 ///
+/// Rebuilds (yielding a fresh in-memory cache) when content filter, aspect
+/// ratio, or Divine-host filter preferences change. The version providers
+/// act as rebuild triggers since the underlying services are long-lived
+/// ChangeNotifiers that don't themselves cause provider invalidation.
+///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
 /// - VideoLocalStorage for cache-first lookups and caching results
@@ -321,6 +326,13 @@ VideoLocalStorage videoLocalStorage(Ref ref) {
 /// - FunnelcakeApiClient for trending/popular video sorting
 @Riverpod(keepAlive: true)
 VideosRepository videosRepository(Ref ref) {
+  // Watch version providers to trigger rebuild on preference changes.
+  // These increment when ContentFilterService or FeedAspectRatioPreference
+  // notifies, ensuring a fresh repository (with empty InMemoryFeedCache)
+  // is created after any filter toggle.
+  ref.watch(contentFilterVersionProvider);
+  ref.watch(divineHostFilterVersionProvider);
+
   final nostrClient = ref.watch(nostrServiceProvider);
   final localStorage = ref.watch(videoLocalStorageProvider);
   final contentFilterService = ref.watch(contentFilterServiceProvider);

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -789,6 +789,11 @@ String _$videoLocalStorageHash() => r'0be44203ec8edf59105a013aae374c07637a3ba0';
 /// Creates a VideosRepository for loading video feeds with pagination.
 /// Works without authentication for public feeds.
 ///
+/// Rebuilds (yielding a fresh in-memory cache) when content filter, aspect
+/// ratio, or Divine-host filter preferences change. The version providers
+/// act as rebuild triggers since the underlying services are long-lived
+/// ChangeNotifiers that don't themselves cause provider invalidation.
+///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
 /// - VideoLocalStorage for cache-first lookups and caching results
@@ -803,6 +808,11 @@ const videosRepositoryProvider = VideosRepositoryProvider._();
 ///
 /// Creates a VideosRepository for loading video feeds with pagination.
 /// Works without authentication for public feeds.
+///
+/// Rebuilds (yielding a fresh in-memory cache) when content filter, aspect
+/// ratio, or Divine-host filter preferences change. The version providers
+/// act as rebuild triggers since the underlying services are long-lived
+/// ChangeNotifiers that don't themselves cause provider invalidation.
 ///
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -823,6 +833,11 @@ final class VideosRepositoryProvider
   ///
   /// Creates a VideosRepository for loading video feeds with pagination.
   /// Works without authentication for public feeds.
+  ///
+  /// Rebuilds (yielding a fresh in-memory cache) when content filter, aspect
+  /// ratio, or Divine-host filter preferences change. The version providers
+  /// act as rebuild triggers since the underlying services are long-lived
+  /// ChangeNotifiers that don't themselves cause provider invalidation.
   ///
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)
@@ -863,7 +878,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'08b00ef1de1df3720bb854dca3549b4ea1e2f200';
+String _$videosRepositoryHash() => r'452954ca43d70d7323a40a6a182c697638001baa';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -44,6 +44,7 @@ class VideoFeedPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(divineHostFilterVersionProvider);
+    final contentFilterVersion = ref.watch(contentFilterVersionProvider);
     final videosRepository = ref.watch(videosRepositoryProvider);
     final followRepository = ref.watch(followRepositoryProvider);
     final curatedListRepository = ref.watch(curatedListRepositoryProvider);
@@ -57,7 +58,9 @@ class VideoFeedPage extends ConsumerWidget {
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
 
     return MultiBlocProvider(
-      key: ValueKey('video-feed-$showDivineHostedOnly'),
+      key: ValueKey(
+        'video-feed-$showDivineHostedOnly-$contentFilterVersion',
+      ),
       providers: [
         BlocProvider(
           create: (_) => VideoFeedBloc(

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -853,6 +853,7 @@ class _VideosGridContentState extends ConsumerState<_VideosGridContent> {
   @override
   Widget build(BuildContext context) {
     ref.watch(divineHostFilterVersionProvider);
+    ref.watch(contentFilterVersionProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
     if (_isLoading) {
       return const Center(child: BrandedLoadingIndicator(size: 60));

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -244,6 +244,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
   Widget build(BuildContext context) {
     ref.watch(blocklistVersionProvider);
     ref.watch(divineHostFilterVersionProvider);
+    ref.watch(contentFilterVersionProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
 
     if (_isLoading) {

--- a/mobile/test/providers/videos_repository_filter_reactivity_test.dart
+++ b/mobile/test/providers/videos_repository_filter_reactivity_test.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Regression test for #4755 — verifies that videosRepositoryProvider
+// ABOUTME: rebuilds (yielding a fresh cache) when content filter preferences change.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/content_filter_service.dart';
+import 'package:openvine/services/divine_host_filter_service.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSharedPreferences extends Mock implements SharedPreferences {}
+
+class _MockContentFilterService extends Mock implements ContentFilterService {}
+
+class _MockFeedAspectRatioPreferenceService extends Mock
+    implements FeedAspectRatioPreferenceService {}
+
+class _MockDivineHostFilterService extends Mock
+    implements DivineHostFilterService {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+/// Toggleable version counter that simulates contentFilterVersionProvider
+/// changing when the user changes a filter preference.
+final _filterVersionTrigger = StateProvider<int>((ref) => 0);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeVideoEvent());
+  });
+  group('videosRepositoryProvider filter reactivity (#4755)', () {
+    late _MockSharedPreferences mockPrefs;
+    late _MockContentFilterService mockContentFilter;
+    late _MockFeedAspectRatioPreferenceService mockAspectRatio;
+    late _MockDivineHostFilterService mockDivineHost;
+    late _MockNostrClient mockNostrClient;
+
+    setUp(() {
+      mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getBool(any())).thenReturn(null);
+      when(() => mockPrefs.setBool(any(), any())).thenAnswer(
+        (_) async => true,
+      );
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(() => mockPrefs.setString(any(), any())).thenAnswer(
+        (_) async => true,
+      );
+      when(() => mockPrefs.getInt(any())).thenReturn(null);
+      when(() => mockPrefs.setInt(any(), any())).thenAnswer(
+        (_) async => true,
+      );
+      when(() => mockPrefs.getStringList(any())).thenReturn(null);
+      when(
+        () => mockPrefs.setStringList(any(), any()),
+      ).thenAnswer((_) async => true);
+      when(() => mockPrefs.containsKey(any())).thenReturn(false);
+      when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+      mockContentFilter = _MockContentFilterService();
+      mockAspectRatio = _MockFeedAspectRatioPreferenceService();
+      mockDivineHost = _MockDivineHostFilterService();
+      mockNostrClient = _MockNostrClient();
+
+      when(() => mockNostrClient.isInitialized).thenReturn(true);
+      when(() => mockNostrClient.hasKeys).thenReturn(false);
+      when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+      when(() => mockNostrClient.configuredRelays).thenReturn(<String>[]);
+
+      when(() => mockDivineHost.showDivineHostedOnly).thenReturn(false);
+      when(() => mockAspectRatio.shouldHideVideo(any())).thenReturn(false);
+    });
+
+    test(
+      'rebuilds with fresh instance when contentFilterVersionProvider changes',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(mockPrefs),
+            nostrServiceProvider.overrideWithValue(mockNostrClient),
+            contentFilterServiceProvider.overrideWithValue(mockContentFilter),
+            feedAspectRatioPreferenceServiceProvider.overrideWithValue(
+              mockAspectRatio,
+            ),
+            divineHostFilterServiceProvider.overrideWithValue(mockDivineHost),
+            // Override the version providers with a state provider we control
+            contentFilterVersionProvider.overrideWith((ref) {
+              return ref.watch(_filterVersionTrigger);
+            }),
+            divineHostFilterVersionProvider.overrideWith((ref) => 0),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final repo1 = container.read(videosRepositoryProvider);
+
+        // Simulate a content filter preference change by bumping the version.
+        container.read(_filterVersionTrigger.notifier).state++;
+
+        // Allow provider rebuild to propagate.
+        await Future<void>.delayed(Duration.zero);
+
+        final repo2 = container.read(videosRepositoryProvider);
+
+        expect(
+          identical(repo1, repo2),
+          isFalse,
+          reason:
+              'videosRepositoryProvider must yield a new instance '
+              '(with fresh InMemoryFeedCache) when content filter version '
+              'changes',
+        );
+      },
+    );
+
+    test(
+      'rebuilds with fresh instance when divineHostFilterVersionProvider '
+      'changes',
+      () async {
+        final divineHostTrigger = StateProvider<int>((ref) => 0);
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(mockPrefs),
+            nostrServiceProvider.overrideWithValue(mockNostrClient),
+            contentFilterServiceProvider.overrideWithValue(mockContentFilter),
+            feedAspectRatioPreferenceServiceProvider.overrideWithValue(
+              mockAspectRatio,
+            ),
+            divineHostFilterServiceProvider.overrideWithValue(mockDivineHost),
+            contentFilterVersionProvider.overrideWith((ref) => 0),
+            divineHostFilterVersionProvider.overrideWith((ref) {
+              return ref.watch(divineHostTrigger);
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final repo1 = container.read(videosRepositoryProvider);
+
+        // Simulate divine host filter toggle.
+        container.read(divineHostTrigger.notifier).state++;
+
+        // Allow provider rebuild to propagate.
+        await Future<void>.delayed(Duration.zero);
+
+        final repo2 = container.read(videosRepositoryProvider);
+
+        expect(
+          identical(repo1, repo2),
+          isFalse,
+          reason:
+              'videosRepositoryProvider must yield a new instance '
+              '(with fresh InMemoryFeedCache) when divine host filter version '
+              'changes',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #4755 — Content filters (NSFW Show/Warn/Hide, aspect ratio, Divine-host-only) were no longer consistently blocking content after the latest update.

## Root Cause

A runtime reactivity/cache invalidation problem:

1. `videosRepositoryProvider` did not watch `contentFilterVersionProvider` or `divineHostFilterVersionProvider`. Since the underlying services are long-lived `ChangeNotifier`s (keepAlive), preference changes called `notifyListeners()` and incremented the version counter — but the provider that creates `VideosRepository` (with its `InMemoryFeedCache`) never rebuilt. Old cached results continued to be served.

2. `VideoFeedPage` only keyed its `MultiBlocProvider` on `showDivineHostedOnly`, so NSFW/aspect-ratio filter changes did not recreate the `VideoFeedBloc`. The BLoC held a reference to the old `VideosRepository` with its stale cache and outdated filter closures.

3. Detail screens and several feed providers lacked `contentFilterVersionProvider` watches, so they did not rebuild when preferences changed.

## Changes

| File | Change |
|------|--------|
| `video_providers.dart` | `videosRepositoryProvider` now watches both version providers — rebuilds yield a fresh repository with empty cache |
| `video_feed_page.dart` | `MultiBlocProvider` key includes content filter version — BLoC is recreated on filter changes |
| `video_detail_screen.dart` | Watches `contentFilterVersionProvider` for reactive rebuilds |
| `sound_detail_screen.dart` | Same — watches `contentFilterVersionProvider` |
| `route_feed_providers.dart` | Explore route feed watches `contentFilterVersionProvider` |
| `video_events_providers.dart` | Discovery/real-time provider watches `contentFilterVersionProvider` |
| `videos_repository_filter_reactivity_test.dart` | New regression test verifying provider rebuild on filter version changes |

## Testing

- All existing tests pass (VideoFeedBloc 80 tests, VideoFeedPage 6, VideoDetailScreen 11)
- New regression test confirms `videosRepositoryProvider` yields a fresh instance when version providers change
- `flutter analyze` clean (no new warnings/errors)

## Verification Steps

1. Open app, enable content filters, set to "Filter Out"
2. Browse feed — filtered content should not appear
3. Change filter setting — feed should immediately reload with new filter applied
4. Navigate to a video detail via deep link — should respect current filter state