### PR TITLE
fix(bluesky): correct crosspost status endpoint and response key mapping

### DIFF
--- a/mobile/lib/blocs/crosspost_settings/crosspost_settings_cubit.dart
+++ b/mobile/lib/blocs/crosspost_settings/crosspost_settings_cubit.dart
@@ -28,7 +28,7 @@ class CrosspostSettingsCubit extends Cubit<CrosspostSettingsState> {
   Future<void> loadStatus() async {
     emit(state.copyWith(status: CrosspostSettingsStatus.loading));
     try {
-      final result = await _apiClient.getStatus(_pubkey);
+      final result = await _apiClient.getStatus();
       emit(
         state.copyWith(
           status: CrosspostSettingsStatus.loaded,

--- a/mobile/lib/services/crosspost_api_client.dart
+++ b/mobile/lib/services/crosspost_api_client.dart
@@ -6,28 +6,39 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:keycast_flutter/keycast_flutter.dart';
 
-/// Response model for crosspost status from keycast.
+/// Response model for crosspost status from keycast's `AtprotoStatusResponse`.
 class CrosspostStatus {
   const CrosspostStatus({
     required this.crosspostEnabled,
     this.handle,
     this.provisioningState,
     this.did,
+    this.error,
   });
 
+  /// Builds a status from keycast's `AtprotoStatusResponse` JSON shape:
+  /// `{enabled, state, did, error, username}`.
+  ///
+  /// `username` is the bare local part; the displayable Bluesky handle is
+  /// `<username>.divine.video`.
   factory CrosspostStatus.fromJson(Map<String, dynamic> json) {
+    final username = json['username'] as String?;
     return CrosspostStatus(
-      crosspostEnabled: json['crosspost_enabled'] as bool? ?? false,
-      handle: json['handle'] as String?,
-      provisioningState: json['provisioning_state'] as String?,
+      crosspostEnabled: json['enabled'] as bool? ?? false,
+      handle: username == null ? null : '$username.$_handleDomain',
+      provisioningState: json['state'] as String?,
       did: json['did'] as String?,
+      error: json['error'] as String?,
     );
   }
+
+  static const _handleDomain = 'divine.video';
 
   final bool crosspostEnabled;
   final String? handle;
   final String? provisioningState;
   final String? did;
+  final String? error;
 }
 
 /// Client for keycast crosspost API endpoints.
@@ -56,10 +67,18 @@ class CrosspostApiClient {
     };
   }
 
-  /// Fetch the current crosspost status for [pubkey].
-  Future<CrosspostStatus> getStatus(String pubkey) async {
+  /// Fetch the current crosspost status for the authenticated user.
+  ///
+  /// The bearer token identifies the user, so no pubkey is part of the path.
+  /// keycast returns 200 for any authenticated user (no account link yields
+  /// `enabled:false, state:null`); the 404 branch is a tolerant fallback
+  /// rather than the expected "no account" signal.
+  ///
+  /// Throws [CrosspostApiException] when unauthenticated or on a non-200,
+  /// non-404 response.
+  Future<CrosspostStatus> getStatus() async {
     final headers = await _authHeaders();
-    final uri = Uri.parse('$_serverUrl/api/account/$pubkey/crosspost');
+    final uri = Uri.parse('$_serverUrl/api/user/atproto/status');
     final response = await _httpClient.get(uri, headers: headers);
 
     if (response.statusCode == 404) {

--- a/mobile/lib/services/crosspost_api_client.dart
+++ b/mobile/lib/services/crosspost_api_client.dart
@@ -13,11 +13,10 @@ class CrosspostStatus {
     this.handle,
     this.provisioningState,
     this.did,
-    this.error,
   });
 
   /// Builds a status from keycast's `AtprotoStatusResponse` JSON shape:
-  /// `{enabled, state, did, error, username}`.
+  /// `{enabled, state, did, username}`.
   ///
   /// `username` is the bare local part; the displayable Bluesky handle is
   /// `<username>.divine.video`.
@@ -28,7 +27,6 @@ class CrosspostStatus {
       handle: username == null ? null : '$username.$_handleDomain',
       provisioningState: json['state'] as String?,
       did: json['did'] as String?,
-      error: json['error'] as String?,
     );
   }
 
@@ -38,7 +36,6 @@ class CrosspostStatus {
   final String? handle;
   final String? provisioningState;
   final String? did;
-  final String? error;
 }
 
 /// Client for keycast crosspost API endpoints.

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -18,7 +18,6 @@ collaborator_invite_local_state_adapter # noise: local-state adapter
 connection_status_service
 content_moderation_service
 crash_reporting_service # defer: #4338 C2 singleton-to-DI
-crosspost_api_client
 curated_list_service
 error_analytics_tracker
 geo_blocking_service

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -27,7 +27,7 @@ void main() {
     group('initial state', () {
       test('is CrosspostSettingsState with initial status', () {
         when(
-          () => apiClient.getStatus(testPubkey),
+          () => apiClient.getStatus(),
         ).thenAnswer((_) async => loadedStatus);
         final cubit = CrosspostSettingsCubit(
           apiClient: apiClient,
@@ -41,7 +41,7 @@ void main() {
     group('loadStatus', () {
       test('emits loaded state on successful status fetch', () async {
         when(
-          () => apiClient.getStatus(testPubkey),
+          () => apiClient.getStatus(),
         ).thenAnswer((_) async => loadedStatus);
 
         final cubit = CrosspostSettingsCubit(
@@ -59,7 +59,7 @@ void main() {
       });
 
       test('emits failure state when status fetch fails', () async {
-        when(() => apiClient.getStatus(testPubkey)).thenAnswer(
+        when(() => apiClient.getStatus()).thenAnswer(
           (_) async => throw const CrosspostApiException('Network error'),
         );
 
@@ -75,7 +75,7 @@ void main() {
       });
 
       test('emits disabled state when 404 (no account link)', () async {
-        when(() => apiClient.getStatus(testPubkey)).thenAnswer(
+        when(() => apiClient.getStatus()).thenAnswer(
           (_) async => const CrosspostStatus(crosspostEnabled: false),
         );
 
@@ -97,7 +97,7 @@ void main() {
         'emits loaded with enabled=false on successful toggle',
         setUp: () {
           when(
-            () => apiClient.getStatus(testPubkey),
+            () => apiClient.getStatus(),
           ).thenAnswer((_) async => loadedStatus);
           when(
             () => apiClient.setCrosspost(pubkey: testPubkey, enabled: false),
@@ -130,7 +130,7 @@ void main() {
         'reverts to previous enabled value on toggle failure',
         setUp: () {
           when(
-            () => apiClient.getStatus(testPubkey),
+            () => apiClient.getStatus(),
           ).thenAnswer((_) async => loadedStatus);
           when(
             () => apiClient.setCrosspost(pubkey: testPubkey, enabled: false),
@@ -159,7 +159,7 @@ void main() {
       test('emits toggling state optimistically before API call', () async {
         final completer = Completer<CrosspostStatus>();
         when(
-          () => apiClient.getStatus(testPubkey),
+          () => apiClient.getStatus(),
         ).thenAnswer((_) async => loadedStatus);
         when(
           () => apiClient.setCrosspost(pubkey: testPubkey, enabled: false),

--- a/mobile/test/services/crosspost_api_client_test.dart
+++ b/mobile/test/services/crosspost_api_client_test.dart
@@ -25,7 +25,6 @@ void main() {
       'enabled': true,
       'state': 'ready',
       'did': 'did:plc:test123',
-      'error': null,
       'username': 'testuser',
     };
 
@@ -94,7 +93,6 @@ void main() {
                 'enabled': false,
                 'state': null,
                 'did': null,
-                'error': null,
                 'username': null,
               }),
               200,
@@ -110,7 +108,7 @@ void main() {
         },
       );
 
-      test('exposes error message for failed state', () async {
+      test('maps failed state without requiring a DID', () async {
         when(
           () => httpClient.get(any(), headers: any(named: 'headers')),
         ).thenAnswer(
@@ -119,7 +117,6 @@ void main() {
               'enabled': false,
               'state': 'failed',
               'did': null,
-              'error': 'provisioning failed',
               'username': 'testuser',
             }),
             200,
@@ -129,7 +126,7 @@ void main() {
         final status = await client.getStatus();
 
         expect(status.provisioningState, 'failed');
-        expect(status.error, 'provisioning failed');
+        expect(status.did, isNull);
       });
 
       test('returns disabled default on 404', () async {
@@ -148,10 +145,7 @@ void main() {
           () => httpClient.get(any(), headers: any(named: 'headers')),
         ).thenAnswer((_) async => http.Response('error', 500));
 
-        expect(
-          () => client.getStatus(),
-          throwsA(isA<CrosspostApiException>()),
-        );
+        expect(() => client.getStatus(), throwsA(isA<CrosspostApiException>()));
       });
 
       test('throws CrosspostApiException when no session token', () async {
@@ -213,7 +207,6 @@ void main() {
               'enabled': false,
               'state': 'disabled',
               'did': 'did:plc:test123',
-              'error': null,
               'username': 'testuser',
             }),
             200,

--- a/mobile/test/services/crosspost_api_client_test.dart
+++ b/mobile/test/services/crosspost_api_client_test.dart
@@ -1,0 +1,249 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/crosspost_api_client.dart';
+
+class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  group(CrosspostApiClient, () {
+    late _MockKeycastOAuth oauthClient;
+    late _MockHttpClient httpClient;
+    late CrosspostApiClient client;
+
+    const serverUrl = 'https://login.divine.video';
+    const pubkey = 'abc123def456';
+    const accessToken = 'session-access-token';
+
+    // Real keycast AtprotoStatusResponse shape.
+    const statusJson = {
+      'enabled': true,
+      'state': 'ready',
+      'did': 'did:plc:test123',
+      'error': null,
+      'username': 'testuser',
+    };
+
+    setUpAll(() {
+      registerFallbackValue(Uri());
+    });
+
+    setUp(() {
+      oauthClient = _MockKeycastOAuth();
+      httpClient = _MockHttpClient();
+      client = CrosspostApiClient(
+        oauthClient: oauthClient,
+        serverUrl: serverUrl,
+        httpClient: httpClient,
+      );
+      when(() => oauthClient.getSession()).thenAnswer(
+        (_) async => const KeycastSession(
+          bunkerUrl: 'bunker://test',
+          accessToken: accessToken,
+        ),
+      );
+    });
+
+    group('getStatus', () {
+      test('calls GET /api/user/atproto/status with bearer token', () async {
+        when(
+          () => httpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(jsonEncode(statusJson), 200));
+
+        await client.getStatus();
+
+        final captured = verify(
+          () => httpClient.get(
+            captureAny(),
+            headers: captureAny(named: 'headers'),
+          ),
+        ).captured;
+        final uri = captured[0] as Uri;
+        final headers = captured[1] as Map<String, String>;
+
+        expect(uri.toString(), '$serverUrl/api/user/atproto/status');
+        expect(headers['Authorization'], 'Bearer $accessToken');
+      });
+
+      test('maps keycast response keys to status fields', () async {
+        when(
+          () => httpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(jsonEncode(statusJson), 200));
+
+        final status = await client.getStatus();
+
+        expect(status.crosspostEnabled, isTrue);
+        expect(status.provisioningState, 'ready');
+        expect(status.did, 'did:plc:test123');
+        expect(status.handle, 'testuser.divine.video');
+      });
+
+      test(
+        'returns disabled defaults when not enabled with null state',
+        () async {
+          when(
+            () => httpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response(
+              jsonEncode(const {
+                'enabled': false,
+                'state': null,
+                'did': null,
+                'error': null,
+                'username': null,
+              }),
+              200,
+            ),
+          );
+
+          final status = await client.getStatus();
+
+          expect(status.crosspostEnabled, isFalse);
+          expect(status.provisioningState, isNull);
+          expect(status.handle, isNull);
+          expect(status.did, isNull);
+        },
+      );
+
+      test('exposes error message for failed state', () async {
+        when(
+          () => httpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode(const {
+              'enabled': false,
+              'state': 'failed',
+              'did': null,
+              'error': 'provisioning failed',
+              'username': 'testuser',
+            }),
+            200,
+          ),
+        );
+
+        final status = await client.getStatus();
+
+        expect(status.provisioningState, 'failed');
+        expect(status.error, 'provisioning failed');
+      });
+
+      test('returns disabled default on 404', () async {
+        when(
+          () => httpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('', 404));
+
+        final status = await client.getStatus();
+
+        expect(status.crosspostEnabled, isFalse);
+        expect(status.provisioningState, isNull);
+      });
+
+      test('throws CrosspostApiException on non-200 (non-404)', () async {
+        when(
+          () => httpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('error', 500));
+
+        expect(
+          () => client.getStatus(),
+          throwsA(isA<CrosspostApiException>()),
+        );
+      });
+
+      test('throws CrosspostApiException when no session token', () async {
+        when(() => oauthClient.getSession()).thenAnswer((_) async => null);
+
+        expect(
+          () => client.getStatus(),
+          throwsA(
+            isA<CrosspostApiException>().having(
+              (e) => e.statusCode,
+              'statusCode',
+              401,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('setCrosspost', () {
+      test(
+        'calls PUT /api/account/{pubkey}/crosspost with enabled body',
+        () async {
+          when(
+            () => httpClient.put(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async => http.Response(jsonEncode(statusJson), 200));
+
+          await client.setCrosspost(pubkey: pubkey, enabled: true);
+
+          final captured = verify(
+            () => httpClient.put(
+              captureAny(),
+              headers: any(named: 'headers'),
+              body: captureAny(named: 'body'),
+            ),
+          ).captured;
+          final uri = captured[0] as Uri;
+          final body =
+              jsonDecode(captured[1] as String) as Map<String, dynamic>;
+
+          expect(uri.toString(), '$serverUrl/api/account/$pubkey/crosspost');
+          expect(body, {'enabled': true});
+        },
+      );
+
+      test('maps keycast response keys on toggle', () async {
+        when(
+          () => httpClient.put(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode(const {
+              'enabled': false,
+              'state': 'disabled',
+              'did': 'did:plc:test123',
+              'error': null,
+              'username': 'testuser',
+            }),
+            200,
+          ),
+        );
+
+        final status = await client.setCrosspost(
+          pubkey: pubkey,
+          enabled: false,
+        );
+
+        expect(status.crosspostEnabled, isFalse);
+        expect(status.provisioningState, 'disabled');
+        expect(status.handle, 'testuser.divine.video');
+      });
+
+      test('throws CrosspostApiException on non-200', () async {
+        when(
+          () => httpClient.put(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => http.Response('error', 500));
+
+        expect(
+          () => client.setCrosspost(pubkey: pubkey, enabled: true),
+          throwsA(isA<CrosspostApiException>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #4923

## What & Why

The **Bluesky Publishing** settings screen always showed *"No Bluesky account linked"* and the toggle never reflected real state. The crossposting backend (keycast -> handle-gateway -> atbridge -> rsky-pds) is live and verified in production; the remaining issues were two client bugs in `crosspost_api_client.dart`.

### Bug 1 - wrong status endpoint (405)
`getStatus()` called `GET /api/account/{pubkey}/crosspost`, which is **PUT-only** and returns **405 Method Not Allowed**. Status therefore always fell through to the disabled/"no account" default.

**Fix:** call `GET /api/user/atproto/status` - the bearer token identifies the user, so there's no pubkey path segment. keycast returns `200` for any authenticated user (`enabled:false, state:null` when no link exists), so the `404` branch is now a tolerant fallback rather than the expected signal. The now-unused `pubkey` parameter was dropped.

### Bug 2 - wrong JSON keys
`CrosspostStatus.fromJson` read `crosspost_enabled` / `provisioning_state` / `handle`, but keycast's `AtprotoStatusResponse` returns `enabled` / `state` / `username` / `did`. Mapping corrected:

| field | from |
|---|---|
| `crosspostEnabled` | `enabled` |
| `provisioningState` | `state` |
| `handle` | `<username>.divine.video` (built from bare `username`) |
| `did` | `did` |

`setCrosspost` (`PUT /api/account/{pubkey}/crosspost` with `{"enabled": ...}`) was already correct and is unchanged; the `fromJson` fix covers its response parsing too.

The settings screen already maps `state` values (ready/pending/failed/disabled/null) and reflects `crosspostEnabled`, and `_HandleInfo` now renders the full `username.divine.video` handle - so no screen/cubit logic changes were required.

## Testing

- **New** `test/services/crosspost_api_client_test.dart` (10 tests): asserts `getStatus` hits `GET /api/user/atproto/status` with the bearer header, parses the real `AtprotoStatusResponse` keys, builds the full handle, handles the 404 fallback, error/non-200 paths, and the missing-token 401; asserts `setCrosspost` PUTs the right URL + body.
- Existing cubit & screen tests updated for the new `getStatus()` signature; all green.
- `flutter analyze` clean on all touched files.
- `mobile/scripts/baseline/untested_services.txt` ratcheted to remove `crosspost_api_client` now that the service has a same-named test.

### Remaining manual verification
- [ ] Against **prod keycast** (`https://login.divine.video`) with a logged-in account: status loads without a 405 (shows ready/pending/none from `state`), and toggling persists (returned `enabled` is reflected).

## Out of scope (separate)
- keycast prod Redis broken-pipe storm.
- Whether a brand-new user without a keycast username needs `POST /user/atproto/enable` before the toggle works.
