### PR TITLE
fix(categories): stop crashing on backend category names with no bundled asset

### DIFF
--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -461,6 +461,7 @@ class _CategoryHeaderMascotSlot extends StatelessWidget {
                     visuals.assetPath!,
                     height: 104,
                     width: 132,
+                    errorBuilder: (_, _, _) => const SizedBox.shrink(),
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/categories/category_visuals.dart
+++ b/mobile/lib/widgets/categories/category_visuals.dart
@@ -16,8 +16,11 @@ class CategoryVisuals {
   final String? assetPath;
 
   /// Resolves visuals for any category. Featured categories get custom colors;
-  /// all others cycle through fallback colors. Every category gets an SVG
-  /// asset path derived from its name.
+  /// all others cycle through fallback colors. A category only receives an SVG
+  /// [assetPath] when a matching illustration is actually bundled. Names with
+  /// no bundled asset (e.g. `beverages`, `fighting` served by the backend)
+  /// resolve to a null [assetPath] so consumers degrade to the plain colored
+  /// card instead of throwing "Unable to load asset" (#4398).
   static CategoryVisuals forCategory(VideoCategory category, int index) {
     final name = category.name.toLowerCase();
     final featured = _featuredCategoryVisuals[name];
@@ -31,9 +34,123 @@ class CategoryVisuals {
     return CategoryVisuals(
       backgroundColor: fallback.backgroundColor,
       foregroundColor: fallback.foregroundColor,
-      assetPath: 'assets/categories/$assetName.svg',
+      assetPath: bundledCategoryAssetNames.contains(assetName)
+          ? 'assets/categories/$assetName.svg'
+          : null,
     );
   }
+
+  /// Stems (filename without `.svg`) of every category illustration bundled
+  /// under `assets/categories/`. Single source of truth for whether a derived
+  /// asset path exists in the app bundle, since the backend category list is
+  /// open-ended and not guaranteed to match the bundled illustrations.
+  ///
+  /// Kept in lockstep with the on-disk asset directory by
+  /// `test/widgets/categories/category_visuals_test.dart`; update both together
+  /// when adding or removing a category illustration.
+  static const Set<String> bundledCategoryAssetNames = {
+    'action',
+    'adventure',
+    'animals',
+    'animation',
+    'architecture',
+    'art',
+    'automotive',
+    'award-show',
+    'awards',
+    'baseball',
+    'basketball',
+    'beauty',
+    'beverage',
+    'cars',
+    'celebration',
+    'celebrities',
+    'celebrity',
+    'cityscape',
+    'comedy',
+    'concert',
+    'cooking',
+    'costume',
+    'crafts',
+    'crime',
+    'culture',
+    'dance',
+    'diy',
+    'drama',
+    'education',
+    'emotional',
+    'emotions',
+    'entertainment',
+    'event',
+    'family',
+    'fans',
+    'fantasy',
+    'fashion',
+    'festival',
+    'film',
+    'fitness',
+    'food',
+    'football',
+    'furniture',
+    'gaming',
+    'golf',
+    'grooming',
+    'guitar',
+    'halloween',
+    'health',
+    'hockey',
+    'holiday',
+    'home',
+    'home-improvement',
+    'horror',
+    'hospital',
+    'humor',
+    'interior-design',
+    'interview',
+    'kids',
+    'lifestyle',
+    'magic',
+    'makeup',
+    'medical',
+    'music',
+    'mystery',
+    'nature',
+    'news',
+    'outdoor',
+    'party',
+    'people',
+    'performance',
+    'pets',
+    'politics',
+    'prank',
+    'pranks',
+    'reality-show',
+    'relationship',
+    'relationships',
+    'romance',
+    'school',
+    'science-fiction',
+    'selfie',
+    'shopping',
+    'skateboarding',
+    'skincare',
+    'soccer',
+    'social-gathering',
+    'social-media',
+    'sports',
+    'style',
+    'talk-show',
+    'technology',
+    'television',
+    'toys',
+    'transportation',
+    'travel',
+    'urban',
+    'violence',
+    'vlog',
+    'vlogging',
+    'wrestling',
+  };
 }
 
 const _featuredCategoryVisuals = <String, CategoryVisuals>{

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -181,7 +181,11 @@ class _CategoryTile extends StatelessWidget {
                     top: 0,
                     bottom: 0,
                     child: IgnorePointer(
-                      child: SvgPicture.asset(visuals.assetPath!, height: 88),
+                      child: SvgPicture.asset(
+                        visuals.assetPath!,
+                        height: 88,
+                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                      ),
                     ),
                   ),
               ],

--- a/mobile/test/widgets/categories/category_visuals_test.dart
+++ b/mobile/test/widgets/categories/category_visuals_test.dart
@@ -1,0 +1,134 @@
+// ABOUTME: Guards category illustration resolution against missing-asset
+// ABOUTME: crashes (#4398) and keeps the bundled-asset set in sync with disk.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show VideoCategory;
+import 'package:openvine/widgets/categories/category_visuals.dart';
+
+void main() {
+  group(CategoryVisuals, () {
+    const assetPrefix = 'assets/categories/';
+    const assetSuffix = '.svg';
+
+    String? stemOf(String? assetPath) {
+      if (assetPath == null) return null;
+      expect(assetPath, startsWith(assetPrefix));
+      expect(assetPath, endsWith(assetSuffix));
+      return assetPath.substring(
+        assetPrefix.length,
+        assetPath.length - assetSuffix.length,
+      );
+    }
+
+    CategoryVisuals visualsFor(String name) => CategoryVisuals.forCategory(
+      VideoCategory(name: name, videoCount: 1),
+      0,
+    );
+
+    test('bundledCategoryAssetNames matches the on-disk asset directory', () {
+      final dir = Directory(assetPrefix);
+      expect(
+        dir.existsSync(),
+        isTrue,
+        reason: '${dir.path} not found; run flutter test from mobile/',
+      );
+
+      final onDisk = dir
+          .listSync()
+          .whereType<File>()
+          .map((file) => file.uri.pathSegments.last)
+          .where((name) => name.endsWith(assetSuffix))
+          .map((name) => name.substring(0, name.length - assetSuffix.length))
+          .toSet();
+
+      const set = CategoryVisuals.bundledCategoryAssetNames;
+      expect(
+        set,
+        equals(onDisk),
+        reason:
+            'bundledCategoryAssetNames drifted from $assetPrefix. '
+            'On disk but missing from the set: ${onDisk.difference(set)}. '
+            'In the set but not on disk: ${set.difference(onDisk)}.',
+      );
+    });
+
+    test('forCategory never resolves to an unbundled asset path', () {
+      final names = <String>{
+        ...CategoryVisuals.bundledCategoryAssetNames,
+        'beverages',
+        'fighting',
+        'BEVERAGES',
+        'totally-unknown-category',
+        '',
+      };
+
+      for (final name in names) {
+        final stem = stemOf(visualsFor(name).assetPath);
+        if (stem != null) {
+          expect(
+            CategoryVisuals.bundledCategoryAssetNames,
+            contains(stem),
+            reason: 'category "$name" resolved to unbundled $stem$assetSuffix',
+          );
+        }
+      }
+    });
+
+    test('backend names with no bundled illustration resolve to null', () {
+      // The exact names observed in the #4398 Crashlytics non-fatals.
+      for (final name in const ['beverages', 'fighting']) {
+        expect(
+          visualsFor(name).assetPath,
+          isNull,
+          reason: '$name has no bundled asset and must not derive a path',
+        );
+      }
+    });
+
+    test('bundled non-featured names keep their illustration', () {
+      expect(
+        visualsFor('comedy').assetPath,
+        equals('${assetPrefix}comedy$assetSuffix'),
+      );
+    });
+
+    test('uppercase backend names still resolve case-insensitively', () {
+      expect(
+        visualsFor('Comedy').assetPath,
+        equals('${assetPrefix}comedy$assetSuffix'),
+      );
+    });
+
+    test('fashion resolves to the bundled style illustration', () {
+      expect(
+        visualsFor('fashion').assetPath,
+        equals('${assetPrefix}style$assetSuffix'),
+      );
+    });
+
+    test('every featured category points to a bundled illustration', () {
+      const featured = [
+        'animals',
+        'food',
+        'nature',
+        'sports',
+        'fashion',
+        'music',
+        'fitness',
+        'art',
+      ];
+
+      for (final name in featured) {
+        final stem = stemOf(visualsFor(name).assetPath);
+        expect(stem, isNotNull, reason: 'featured $name should have an asset');
+        expect(
+          CategoryVisuals.bundledCategoryAssetNames,
+          contains(stem),
+          reason: 'featured $name -> $stem$assetSuffix is not bundled',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

`CategoryVisuals.forCategory` derived an SVG path from the raw (lowercased) category name for **every** non-featured category — `assetPath: 'assets/categories/$name.svg'`. The funnelcake category list is open-ended (~100 free-form VLM names) and not guaranteed to match the bundled illustrations, so names with no matching asset produced paths the loader could not resolve and threw **"Unable to load asset"** as Crashlytics non-fatals (#4398). Observed in 1.0.13 for `beverages` (only `beverage.svg` is bundled) and `fighting` (no asset at all).

**The fix (Phase 0 — independent of the taxonomy work in #2547):**

- Gate the derived path on a new `CategoryVisuals.bundledCategoryAssetNames` set — the single source of truth for which category illustrations are actually bundled. A category gets an `assetPath` only when its illustration exists; otherwise `null`.
- Both render call-sites already degrade a `null` `assetPath` to their designed empty state (`categories_tab.dart` guards with `if (visuals.assetPath != null)`; `category_gallery_screen.dart` renders `SizedBox.shrink()`), so missing-asset categories now show the plain colored card instead of crashing — UI stays stable for every category that does have an illustration.
- Added an `errorBuilder` safety net to the two `SvgPicture.asset` call-sites (matching the existing `user_avatar.dart` pattern) so the render sites cannot throw even if the set and the bundle ever drift.
- A unit test enforces `bundledCategoryAssetNames` stays in lockstep with `assets/categories/*.svg` on disk and pins the `beverages` / `fighting` regression.

Maps directly to the issue's acceptance criteria: explicit/existence-safe asset lookup, no asset-load exception for any served category, a test validating every mapping resolves to a bundled file or a defined fallback, and stable behavior for existing valid assets.

**Related Issue:** Closes #4398

## Out of Scope

The category **taxonomy** redesign (canonical allow-list, synonym merging, grouped IA) is tracked separately in #2547 and was intentionally kept out — #2547's design sign-off explicitly asked to keep this crash fix unblocked and independent. This PR adds no new taxonomy and changes no category semantics; it only prevents the missing-asset crash.

## Verification

Run from `mobile/`:

- `flutter analyze lib test integration_test` → **No issues found**
- `flutter test test/widgets/categories/category_visuals_test.dart` → 7/7 pass (drift guard + `beverages`/`fighting` → null + featured-integrity + case-insensitivity)
- `flutter test test/widgets/categories_tab_test.dart test/screens/category_gallery_screen_test.dart` → existing category widget tests stay green (12/12)
- `dart format` clean on all four changed files

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore