### PR TITLE
Add explicit return type annotation to register method

### DIFF
--- a/mobile/overrides/cryptography_flutter-2.3.2/ios/Classes/SwiftCryptographyFlutterPlugin.swift
+++ b/mobile/overrides/cryptography_flutter-2.3.2/ios/Classes/SwiftCryptographyFlutterPlugin.swift
@@ -5,7 +5,7 @@ import Flutter
 import UIKit
 
 public class SwiftCryptographyFlutterPlugin: NSObject, FlutterPlugin {
-  public static func register(with registrar: FlutterPluginRegistrar) {
+  public static func register(with registrar: FlutterPluginRegistrar) -> Void {
     // No-op implementation - cryptography is handled in Dart
   }
 }


### PR DESCRIPTION
## 问题背景
在公共API中，显式返回类型注解可以提高代码的清晰度和一致性，尽管Swift可以推断类型。对于公共静态方法，添加显式返回类型有助于开发者理解API契约，减少潜在的误解。

## 修改内容
在文件 `SwiftCryptographyFlutterPlugin.swift` 中，为公共静态方法 `register(with:)` 添加了显式返回类型 `-> Void`。这个方法原本没有返回类型注解，Swift会推断为 `Void`，但添加后使API更加明确。

## 验证方式
- 代码审查：确认更改仅限于添加返回类型，没有改变方法功能或外部行为。
- 编译检查：确保代码编译通过，无错误或警告。
- 功能测试：由于这是一个插件注册方法且为无操作实现（No-op），不影响现有功能，可通过现有测试套件验证兼容性。