### PR TITLE
refactor(videos_repository): compose author feed via getAuthorFeed (#4788)

### DIFF
--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -38,7 +38,7 @@ part 'profile_feed_provider.g.dart';
 /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
-/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
 /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
 /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
@@ -1207,32 +1207,11 @@ class ProfileFeed extends _$ProfileFeed {
     List<VideoEvent> current,
     List<VideoEvent> incoming,
   ) {
-    final byKey = <String, VideoEvent>{};
-
-    for (final video in current) {
-      byKey[_canonicalVideoKey(video)] = video;
-    }
-
-    for (final video in incoming) {
-      final key = _canonicalVideoKey(video);
-      final existing = byKey[key];
-      byKey[key] = existing == null ? video : _mergeVideo(existing, video);
-    }
-
-    final merged = byKey.values.toList()..sort(_compareVideos);
-    // Drop any session-tombstoned ids (NIP-09 client-side deletes) the
-    // merge carried forward. Does not cover server-side deletes that
-    // happened after the initial REST page load -- those clear on next
-    // full refresh.
-    return _withoutTombstones(merged);
-  }
-
-  /// Merges two [VideoEvent]s for the same addressable video.
-  ///
-  /// Delegates to [mergeTwoProfileVideos] (see class-level engagement policy,
-  /// #3384).
-  VideoEvent _mergeVideo(VideoEvent existing, VideoEvent incoming) {
-    return mergeTwoProfileVideos(existing, incoming);
+    // Dedup + #3384 cross-source merge + newest-first sort live in
+    // videos_repository (the canonical merge-policy owner). Tombstone
+    // filtering stays here because session NIP-09 deletes are an app-layer
+    // concern (relay snapshot) the Flutter-free package does not own.
+    return _withoutTombstones(mergeProfileFeedVideoLists(current, incoming));
   }
 
   VideoEvent _mergeEnrichmentIntoCurrent(
@@ -1299,113 +1278,21 @@ class ProfileFeed extends _$ProfileFeed {
     );
   }
 
-  /// Same logic as [_mergeVideo], exposed for tests (#3384).
+  /// Cross-source merge policy (#3384), exposed for tests.
+  ///
+  /// Delegates to [mergeProfileFeedVideos] — the canonical implementation in
+  /// `videos_repository`. Kept as a thin static so the existing profile-feed
+  /// merge tests have a stable entry point during the migration.
   @visibleForTesting
   static VideoEvent mergeTwoProfileVideos(
     VideoEvent existing,
     VideoEvent incoming,
   ) {
-    final incomingIsNewer =
-        incoming.createdAt > existing.createdAt ||
-        (incoming.createdAt == existing.createdAt &&
-            incoming.id.compareTo(existing.id) < 0);
-    final primary = incomingIsNewer ? incoming : existing;
-    final secondary = incomingIsNewer ? existing : incoming;
-
-    final primaryHasPublishedAt =
-        primary.publishedAt != null && primary.publishedAt!.isNotEmpty;
-    final secondaryHasPublishedAt =
-        secondary.publishedAt != null && secondary.publishedAt!.isNotEmpty;
-    final preserveOriginalTimestamp =
-        !primaryHasPublishedAt && !secondaryHasPublishedAt;
-
-    return primary.copyWith(
-      createdAt: preserveOriginalTimestamp
-          ? math.min(primary.createdAt, secondary.createdAt)
-          : primary.createdAt,
-      timestamp: preserveOriginalTimestamp
-          ? (primary.timestamp.isBefore(secondary.timestamp)
-                ? primary.timestamp
-                : secondary.timestamp)
-          : primary.timestamp,
-      publishedAt: primaryHasPublishedAt
-          ? primary.publishedAt
-          : secondary.publishedAt,
-      rawTags: mergeRawTagsForVideoMerge(primary.rawTags, secondary.rawTags),
-      contentWarningLabels: primary.contentWarningLabels.isNotEmpty
-          ? primary.contentWarningLabels
-          : secondary.contentWarningLabels,
-      title: primary.title ?? secondary.title,
-      videoUrl: primary.videoUrl ?? secondary.videoUrl,
-      thumbnailUrl: primary.thumbnailUrl ?? secondary.thumbnailUrl,
-      duration: primary.duration ?? secondary.duration,
-      dimensions: primary.dimensions ?? secondary.dimensions,
-      mimeType: primary.mimeType ?? secondary.mimeType,
-      sha256: primary.sha256 ?? secondary.sha256,
-      fileSize: primary.fileSize ?? secondary.fileSize,
-      hashtags: primary.hashtags.isNotEmpty
-          ? primary.hashtags
-          : secondary.hashtags,
-      vineId: primary.vineId ?? secondary.vineId,
-      group: primary.group ?? secondary.group,
-      altText: primary.altText ?? secondary.altText,
-      blurhash: primary.blurhash ?? secondary.blurhash,
-      originalLoops: mergeProfileEngagementCount(
-        primary.originalLoops,
-        secondary.originalLoops,
-      ),
-      originalLikes: mergeProfileEngagementCount(
-        primary.originalLikes,
-        secondary.originalLikes,
-      ),
-      originalComments: mergeProfileEngagementCount(
-        primary.originalComments,
-        secondary.originalComments,
-      ),
-      originalReposts: mergeProfileEngagementCount(
-        primary.originalReposts,
-        secondary.originalReposts,
-      ),
-      audioEventId: primary.audioEventId ?? secondary.audioEventId,
-      audioEventRelay: primary.audioEventRelay ?? secondary.audioEventRelay,
-      collaboratorPubkeys: primary.collaboratorPubkeys.isNotEmpty
-          ? primary.collaboratorPubkeys
-          : secondary.collaboratorPubkeys,
-      inspiredByVideo: primary.inspiredByVideo ?? secondary.inspiredByVideo,
-      textTrackRef: primary.textTrackRef ?? secondary.textTrackRef,
-      textTrackContent: primary.textTrackContent ?? secondary.textTrackContent,
-      nostrEventTags: primary.nostrEventTags.isNotEmpty
-          ? primary.nostrEventTags
-          : secondary.nostrEventTags,
-      authorName: primary.authorName ?? secondary.authorName,
-      authorAvatar: primary.authorAvatar ?? secondary.authorAvatar,
-      nostrLikeCount: mergeProfileEngagementCount(
-        primary.nostrLikeCount,
-        secondary.nostrLikeCount,
-      ),
-    );
+    return mergeProfileFeedVideos(existing, incoming);
   }
 
-  String _canonicalVideoKey(VideoEvent video) {
-    return '${video.pubkey}:${video.stableId}'.toLowerCase();
-  }
-
-  int _compareVideos(VideoEvent a, VideoEvent b) {
-    final timestampComparison = _publishedSortKey(
-      b,
-    ).compareTo(_publishedSortKey(a));
-    if (timestampComparison != 0) return timestampComparison;
-    return a.id.compareTo(b.id);
-  }
-
-  int _publishedSortKey(VideoEvent video) {
-    final publishedAt = video.publishedAt;
-    if (publishedAt != null && publishedAt.isNotEmpty) {
-      final parsed = int.tryParse(publishedAt);
-      if (parsed != null) return parsed;
-    }
-    return video.createdAt;
-  }
+  String _canonicalVideoKey(VideoEvent video) =>
+      canonicalProfileFeedVideoKey(video);
 
   bool _sameVideoSequence(List<VideoEvent> left, List<VideoEvent> right) {
     return sameVideoSequenceForMerge(left, right);

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -23,7 +23,7 @@ part of 'profile_feed_provider.dart';
 /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
-/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
 /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
 /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
@@ -53,7 +53,7 @@ const profileFeedProvider = ProfileFeedFamily._();
 /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
-/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
 /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
 /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
@@ -81,7 +81,7 @@ final class ProfileFeedProvider
   /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
   /// or stale figures while the API reflects current aggregates. When only Nostr
   /// data exists (no REST row, no cache backfill), relay values remain the sole
-  /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+  /// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
   /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
   /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
   /// Nostr enrichment) must stay aligned with this policy whenever merge logic
@@ -128,7 +128,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'db75b3519a1256f48efa9961b050fda8c609c12c';
+String _$profileFeedHash() => r'02556c0ebe7328d513371306dc38bb9c7a3b87bb';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
@@ -145,7 +145,7 @@ String _$profileFeedHash() => r'db75b3519a1256f48efa9961b050fda8c609c12c';
 /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
-/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
 /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
 /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic
@@ -190,7 +190,7 @@ final class ProfileFeedFamily extends $Family
   /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
   /// or stale figures while the API reflects current aggregates. When only Nostr
   /// data exists (no REST row, no cache backfill), relay values remain the sole
-  /// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+  /// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
   /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
   /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
   /// Nostr enrichment) must stay aligned with this policy whenever merge logic
@@ -224,7 +224,7 @@ final class ProfileFeedFamily extends $Family
 /// conflicting static Nostr tag values: relay copies may carry `loops` / zero
 /// or stale figures while the API reflects current aggregates. When only Nostr
 /// data exists (no REST row, no cache backfill), relay values remain the sole
-/// source. [_mergeVideo], [mergeTwoProfileVideos], [mergeProfileEngagementCount],
+/// source. [mergeTwoProfileVideos], [mergeProfileEngagementCount],
 /// [mergeRawTagsForVideoMerge], and the shared `videos_repository` helpers
 /// [mergeVideoRawTagsPrimaryWins] / [mergeNullableEngagementMax] (also used from
 /// Nostr enrichment) must stay aligned with this policy whenever merge logic

--- a/mobile/packages/videos_repository/lib/src/author_feed_result.dart
+++ b/mobile/packages/videos_repository/lib/src/author_feed_result.dart
@@ -1,0 +1,76 @@
+// ABOUTME: Result model for a single author's video feed page.
+// ABOUTME: Offset-paginated (distinct from HomeFeedResult's cursor model);
+// ABOUTME: carries the Funnelcake v2 envelope (totalCount/nextOffset/hasMore).
+
+import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
+
+/// {@template author_feed_result}
+/// Result of an author/profile video-feed fetch.
+///
+/// Profile feeds paginate by **offset** and surface the Funnelcake v2
+/// envelope ([totalCount]/[nextOffset]/[hasMore]) that the count UI and
+/// infinite scroll depend on — intentionally separate from `HomeFeedResult`,
+/// whose cursor-based fields (`nextCursor`/`paginationCursor`) do not apply
+/// to a single-author feed.
+///
+/// [videos] are returned **unfiltered** (only NIP-40 expired entries are
+/// dropped at the REST ingress). Blocklist / content-preference /
+/// Divine-host filtering is applied by the consuming cubit on every emit so
+/// block/unblock reflects without a re-fetch (#4782).
+/// {@endtemplate}
+class AuthorFeedResult extends Equatable {
+  /// {@macro author_feed_result}
+  const AuthorFeedResult({
+    required this.authorPubkey,
+    this.videos = const [],
+    this.nextOffset,
+    this.totalCount,
+    this.hasMore,
+  });
+
+  /// The author whose feed this page belongs to (full hex pubkey).
+  final String authorPubkey;
+
+  /// The videos for this page, merged across REST + relay seed and sorted
+  /// newest-first. Unfiltered (see class doc).
+  final List<VideoEvent> videos;
+
+  /// Server-provided offset for the next page, or a client-side estimate when
+  /// the server omits it. `null` when there is no next page.
+  final int? nextOffset;
+
+  /// Total number of videos by this author (from the v2 envelope /
+  /// `X-Total-Count`). `null` when the server does not report it.
+  final int? totalCount;
+
+  /// Whether more pages are available. `null` when unknown (callers fall back
+  /// to a page-size heuristic).
+  final bool? hasMore;
+
+  /// Returns a copy with the given fields replaced.
+  AuthorFeedResult copyWith({
+    String? authorPubkey,
+    List<VideoEvent>? videos,
+    int? nextOffset,
+    int? totalCount,
+    bool? hasMore,
+  }) {
+    return AuthorFeedResult(
+      authorPubkey: authorPubkey ?? this.authorPubkey,
+      videos: videos ?? this.videos,
+      nextOffset: nextOffset ?? this.nextOffset,
+      totalCount: totalCount ?? this.totalCount,
+      hasMore: hasMore ?? this.hasMore,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    authorPubkey,
+    videos,
+    nextOffset,
+    totalCount,
+    hasMore,
+  ];
+}

--- a/mobile/packages/videos_repository/lib/src/author_feed_result.dart
+++ b/mobile/packages/videos_repository/lib/src/author_feed_result.dart
@@ -5,6 +5,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
 
+const Object _unset = Object();
+
 /// {@template author_feed_result}
 /// Result of an author/profile video-feed fetch.
 ///
@@ -52,16 +54,20 @@ class AuthorFeedResult extends Equatable {
   AuthorFeedResult copyWith({
     String? authorPubkey,
     List<VideoEvent>? videos,
-    int? nextOffset,
-    int? totalCount,
-    bool? hasMore,
+    Object? nextOffset = _unset,
+    Object? totalCount = _unset,
+    Object? hasMore = _unset,
   }) {
     return AuthorFeedResult(
       authorPubkey: authorPubkey ?? this.authorPubkey,
       videos: videos ?? this.videos,
-      nextOffset: nextOffset ?? this.nextOffset,
-      totalCount: totalCount ?? this.totalCount,
-      hasMore: hasMore ?? this.hasMore,
+      nextOffset: identical(nextOffset, _unset)
+          ? this.nextOffset
+          : nextOffset as int?,
+      totalCount: identical(totalCount, _unset)
+          ? this.totalCount
+          : totalCount as int?,
+      hasMore: identical(hasMore, _unset) ? this.hasMore : hasMore as bool?,
     );
   }
 

--- a/mobile/packages/videos_repository/lib/src/in_memory_feed_cache.dart
+++ b/mobile/packages/videos_repository/lib/src/in_memory_feed_cache.dart
@@ -2,25 +2,28 @@
 // ABOUTME: Lives in the repository layer so it survives BLoC recreation
 // ABOUTME: but is lost on app restart. Used for instant mode switching.
 
+import 'package:videos_repository/src/author_feed_result.dart';
 import 'package:videos_repository/src/home_feed_result.dart';
 
 /// {@template in_memory_feed_cache}
 /// Volatile, session-scoped cache for feed results.
 ///
 /// Stores [HomeFeedResult] keyed by feed mode name (e.g. `"home"`,
-/// `"latest"`, `"popular"`). The cache lives in memory only — it does
-/// not persist across app restarts.
+/// `"latest"`, `"popular"`), plus [AuthorFeedResult] keyed by author
+/// (e.g. `"author:<pubkeyHex>"`). The cache lives in memory only — it
+/// does not persist across app restarts.
 ///
 /// Because the `VideosRepository` outlives individual BLoC instances,
 /// cached results survive BLoC recreation (e.g. navigating away from
-/// the feed and back), enabling instant mode switches without a
-/// network round-trip.
+/// the feed and back), enabling instant mode switches and instant
+/// profile reseed without a network round-trip.
 /// {@endtemplate}
 class InMemoryFeedCache {
   /// {@macro in_memory_feed_cache}
   InMemoryFeedCache();
 
   final Map<String, HomeFeedResult> _store = {};
+  final Map<String, AuthorFeedResult> _authorStore = {};
 
   /// Returns the cached result for [key], or `null` if not cached.
   HomeFeedResult? get(String key) => _store[key];
@@ -28,9 +31,27 @@ class InMemoryFeedCache {
   /// Stores [result] under [key], replacing any previous entry.
   void set(String key, HomeFeedResult result) => _store[key] = result;
 
-  /// Removes the entry for [key], if present.
-  void remove(String key) => _store.remove(key);
+  /// Returns the cached author-feed result for [key], or `null`.
+  ///
+  /// Author results carry the offset pagination envelope and so are stored
+  /// separately from the cursor-based [HomeFeedResult] entries.
+  AuthorFeedResult? getAuthorFeed(String key) => _authorStore[key];
 
-  /// Clears all cached entries.
-  void clear() => _store.clear();
+  /// Stores an author-feed [result] under [key], replacing any previous entry.
+  void setAuthorFeed(String key, AuthorFeedResult result) =>
+      _authorStore[key] = result;
+
+  /// Removes the entry for [key] from both the home-feed and author-feed
+  /// stores, if present. Keys are namespaced (`"latest"` vs
+  /// `"author:<hex>"`) so clearing both is a safe no-op for the other.
+  void remove(String key) {
+    _store.remove(key);
+    _authorStore.remove(key);
+  }
+
+  /// Clears all cached entries (home-feed and author-feed).
+  void clear() {
+    _store.clear();
+    _authorStore.clear();
+  }
 }

--- a/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
+++ b/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
@@ -1,0 +1,156 @@
+// ABOUTME: Cross-source merge policy for author/profile feeds (#3384).
+// ABOUTME: Canonical owner of the REST-count-wins / max-merge rules so the
+// ABOUTME: repository's author-feed composition and the app-layer profile
+// ABOUTME: code share one implementation.
+
+import 'dart:math' as math;
+
+import 'package:models/models.dart';
+import 'package:videos_repository/src/video_merge_helpers.dart';
+
+/// Canonical dedup key for an addressable profile/author video.
+///
+/// Keys on `pubkey:stableId` (lowercased) so the same addressable video from
+/// the REST source and the relay/Nostr source collapses to one entry.
+String canonicalProfileFeedVideoKey(VideoEvent video) =>
+    '${video.pubkey}:${video.stableId}'.toLowerCase();
+
+/// Merges two [VideoEvent]s for the same addressable video, applying the
+/// #3384 REST-count-wins / max-merge policy.
+///
+/// The "primary" copy is the newer one (greater `createdAt`; ties broken by the
+/// smaller `id`). Metadata scalars take primary-wins (`primary ?? secondary`);
+/// list fields take primary-if-non-empty; every engagement counter takes the
+/// per-counter max ([mergeNullableEngagementMax]); raw tags merge primary-wins
+/// except `views`, which takes the higher parsed count
+/// ([mergeVideoRawTagsPrimaryWins]). When neither copy carries a `publishedAt`,
+/// the merged `createdAt`/`timestamp` preserve the older value so re-merging is
+/// stable.
+VideoEvent mergeProfileFeedVideos(VideoEvent existing, VideoEvent incoming) {
+  final incomingIsNewer =
+      incoming.createdAt > existing.createdAt ||
+      (incoming.createdAt == existing.createdAt &&
+          incoming.id.compareTo(existing.id) < 0);
+  final primary = incomingIsNewer ? incoming : existing;
+  final secondary = incomingIsNewer ? existing : incoming;
+
+  final primaryHasPublishedAt =
+      primary.publishedAt != null && primary.publishedAt!.isNotEmpty;
+  final secondaryHasPublishedAt =
+      secondary.publishedAt != null && secondary.publishedAt!.isNotEmpty;
+  final preserveOriginalTimestamp =
+      !primaryHasPublishedAt && !secondaryHasPublishedAt;
+
+  return primary.copyWith(
+    createdAt: preserveOriginalTimestamp
+        ? math.min(primary.createdAt, secondary.createdAt)
+        : primary.createdAt,
+    timestamp: preserveOriginalTimestamp
+        ? (primary.timestamp.isBefore(secondary.timestamp)
+              ? primary.timestamp
+              : secondary.timestamp)
+        : primary.timestamp,
+    publishedAt: primaryHasPublishedAt
+        ? primary.publishedAt
+        : secondary.publishedAt,
+    rawTags: mergeVideoRawTagsPrimaryWins(primary.rawTags, secondary.rawTags),
+    contentWarningLabels: primary.contentWarningLabels.isNotEmpty
+        ? primary.contentWarningLabels
+        : secondary.contentWarningLabels,
+    title: primary.title ?? secondary.title,
+    videoUrl: primary.videoUrl ?? secondary.videoUrl,
+    thumbnailUrl: primary.thumbnailUrl ?? secondary.thumbnailUrl,
+    duration: primary.duration ?? secondary.duration,
+    dimensions: primary.dimensions ?? secondary.dimensions,
+    mimeType: primary.mimeType ?? secondary.mimeType,
+    sha256: primary.sha256 ?? secondary.sha256,
+    fileSize: primary.fileSize ?? secondary.fileSize,
+    hashtags: primary.hashtags.isNotEmpty
+        ? primary.hashtags
+        : secondary.hashtags,
+    vineId: primary.vineId ?? secondary.vineId,
+    group: primary.group ?? secondary.group,
+    altText: primary.altText ?? secondary.altText,
+    blurhash: primary.blurhash ?? secondary.blurhash,
+    originalLoops: mergeNullableEngagementMax(
+      primary.originalLoops,
+      secondary.originalLoops,
+    ),
+    originalLikes: mergeNullableEngagementMax(
+      primary.originalLikes,
+      secondary.originalLikes,
+    ),
+    originalComments: mergeNullableEngagementMax(
+      primary.originalComments,
+      secondary.originalComments,
+    ),
+    originalReposts: mergeNullableEngagementMax(
+      primary.originalReposts,
+      secondary.originalReposts,
+    ),
+    audioEventId: primary.audioEventId ?? secondary.audioEventId,
+    audioEventRelay: primary.audioEventRelay ?? secondary.audioEventRelay,
+    collaboratorPubkeys: primary.collaboratorPubkeys.isNotEmpty
+        ? primary.collaboratorPubkeys
+        : secondary.collaboratorPubkeys,
+    inspiredByVideo: primary.inspiredByVideo ?? secondary.inspiredByVideo,
+    textTrackRef: primary.textTrackRef ?? secondary.textTrackRef,
+    textTrackContent: primary.textTrackContent ?? secondary.textTrackContent,
+    nostrEventTags: primary.nostrEventTags.isNotEmpty
+        ? primary.nostrEventTags
+        : secondary.nostrEventTags,
+    authorName: primary.authorName ?? secondary.authorName,
+    authorAvatar: primary.authorAvatar ?? secondary.authorAvatar,
+    nostrLikeCount: mergeNullableEngagementMax(
+      primary.nostrLikeCount,
+      secondary.nostrLikeCount,
+    ),
+  );
+}
+
+/// Dedup-merges [current] and [incoming] into one list, applying
+/// [mergeProfileFeedVideos] when both carry the same addressable video, then
+/// sorts newest-first by published/created time (ties broken by `id`).
+///
+/// Does NOT apply NIP-09 tombstone filtering — that is a session-scoped,
+/// relay-source concern owned by the app layer (the profile cubit), kept out
+/// of this Flutter-free package.
+List<VideoEvent> mergeProfileFeedVideoLists(
+  List<VideoEvent> current,
+  List<VideoEvent> incoming,
+) {
+  final byKey = <String, VideoEvent>{};
+
+  for (final video in current) {
+    byKey[canonicalProfileFeedVideoKey(video)] = video;
+  }
+
+  for (final video in incoming) {
+    final key = canonicalProfileFeedVideoKey(video);
+    final existing = byKey[key];
+    byKey[key] = existing == null
+        ? video
+        : mergeProfileFeedVideos(existing, video);
+  }
+
+  return byKey.values.toList()..sort(compareProfileFeedVideos);
+}
+
+/// Newest-first comparator for profile feed videos: orders by the published
+/// timestamp (falling back to `createdAt`), with ties broken by ascending `id`.
+int compareProfileFeedVideos(VideoEvent a, VideoEvent b) {
+  final timestampComparison = _publishedSortKey(
+    b,
+  ).compareTo(_publishedSortKey(a));
+  if (timestampComparison != 0) return timestampComparison;
+  return a.id.compareTo(b.id);
+}
+
+int _publishedSortKey(VideoEvent video) {
+  final publishedAt = video.publishedAt;
+  if (publishedAt != null && publishedAt.isNotEmpty) {
+    final parsed = int.tryParse(publishedAt);
+    if (parsed != null) return parsed;
+  }
+  return video.createdAt;
+}

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -10,9 +10,11 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/src/author_feed_result.dart';
 import 'package:videos_repository/src/home_feed_result.dart';
 import 'package:videos_repository/src/in_memory_feed_cache.dart';
 import 'package:videos_repository/src/popular_videos_page.dart';
+import 'package:videos_repository/src/profile_video_merge.dart';
 import 'package:videos_repository/src/video_content_filter.dart';
 import 'package:videos_repository/src/video_event_filter.dart';
 import 'package:videos_repository/src/video_local_storage.dart';
@@ -25,6 +27,19 @@ const int _videoKind = EventKind.videoVertical;
 
 /// Default number of videos to fetch per page.
 const int _defaultLimit = 25;
+
+/// Author-feed REST page size used for the `hasMore` fallback heuristic when
+/// the v2 envelope omits the flag. Mirrors `AppConstants.paginationBatchSize`
+/// (50) in the app layer — kept here as a package-local const so the
+/// Flutter-free package owns the author-feed composition (#3384 parity).
+const int _authorFeedPaginationBatchSize = 50;
+
+/// Author-feed "has more" threshold for the relay-only page (REST
+/// unavailable). Mirrors `AppConstants.hasMoreContentThreshold` (10).
+const int _authorFeedHasMoreThreshold = 10;
+
+/// In-memory cache key prefix for a single author's feed.
+const String _authorFeedCacheKeyPrefix = 'author:';
 
 /// Timeout for relay search queries.
 ///
@@ -1907,6 +1922,201 @@ class VideosRepository {
       before: before,
     );
     return _transformVideoStats(result.videos);
+  }
+
+  /// Composes a single author's video feed page (profile feed).
+  ///
+  /// Strategy (mirrors [getNewVideos], adapted to offset pagination):
+  /// 1. On the initial page (`offset == null`) returns the in-memory cached
+  ///    [AuthorFeedResult] when present (instant reseed; #4164).
+  /// 2. REST-first: fetches the Funnelcake author page at [offset], reading the
+  ///    v2 envelope (`totalCount`/`nextOffset`/`hasMore`); maps via
+  ///    `toVideoEvents()` (drops NIP-40 expired only — **no** block/content
+  ///    filtering, so the cubit can re-filter on every emit, #4782); hydrates
+  ///    engagement counts (bulk-stats then per-video views, existing-wins);
+  ///    drops backend-leaked p-tagged collaborator events
+  ///    (`v.pubkey != authorPubkey`); merges with [relaySeed] under the #3384
+  ///    cross-source max policy; caches the initial page.
+  /// 3. When Funnelcake is unavailable (or throws [FunnelcakeException]),
+  ///    returns the [relaySeed] alone — the relay/realtime source is owned by
+  ///    the caller (the profile cubit, over `VideoEventService`); this package
+  ///    stays Flutter-free and does not query relays here.
+  ///
+  /// [relaySeed] is the caller's current relay snapshot for the author, merged
+  /// as the cross-source "primary" set. Pass `const []` for load-more pages
+  /// (the caller accumulates new pages into its existing list via
+  /// [mergeProfileFeedVideoLists]).
+  ///
+  /// Returned videos are **unfiltered** (see [AuthorFeedResult]). Throws
+  /// non-[FunnelcakeException] errors to the caller.
+  Future<AuthorFeedResult> getAuthorFeed({
+    required String authorPubkey,
+    int? offset,
+    List<VideoEvent> relaySeed = const [],
+    bool skipCache = false,
+  }) async {
+    final cacheKey = '$_authorFeedCacheKeyPrefix$authorPubkey';
+    final isInitialPage = offset == null;
+
+    if (!skipCache && isInitialPage) {
+      final cached = _inMemoryFeedCache?.getAuthorFeed(cacheKey);
+      if (cached != null) return cached;
+    }
+
+    if (_funnelcakeApiClient != null && _funnelcakeApiClient.isAvailable) {
+      try {
+        final response = await _funnelcakeApiClient.getVideosByAuthor(
+          pubkey: authorPubkey,
+          offset: offset,
+        );
+        final restVideos = response.videos.toVideoEvents();
+        final hydrated = await _hydrateAuthorRestVideos(restVideos);
+        // Guard: the backend author endpoint can leak videos where the pubkey
+        // is a p-tagged collaborator rather than the event author.
+        final authored = hydrated
+            .where((video) => !video.isRepost && video.pubkey == authorPubkey)
+            .toList();
+        final merged = mergeProfileFeedVideoLists(relaySeed, authored);
+
+        final result = AuthorFeedResult(
+          authorPubkey: authorPubkey,
+          videos: merged,
+          totalCount: response.totalCount,
+          nextOffset: response.nextOffset ?? ((offset ?? 0) + hydrated.length),
+          hasMore:
+              response.hasMore ??
+              (hydrated.length >= _authorFeedPaginationBatchSize),
+        );
+
+        if (isInitialPage) {
+          _inMemoryFeedCache?.setAuthorFeed(cacheKey, result);
+        }
+        return result;
+      } on FunnelcakeException {
+        // Fall through to the relay seed.
+      }
+    }
+
+    final seedOnly = mergeProfileFeedVideoLists(relaySeed, const []);
+    return AuthorFeedResult(
+      authorPubkey: authorPubkey,
+      videos: seedOnly,
+      hasMore: seedOnly.length >= _authorFeedHasMoreThreshold,
+    );
+  }
+
+  /// Hydrates author REST videos with engagement counts: bulk-stats first
+  /// (loops/views/reactions/comments/reposts), then a per-video views-endpoint
+  /// pass for rows still missing a view count. Uses **existing-wins** (`??`)
+  /// semantics — distinct from [_hydrateVideosWithBulkStats]'s stale-zero
+  /// heuristic — to preserve profile-feed count parity (#3384).
+  Future<List<VideoEvent>> _hydrateAuthorRestVideos(
+    List<VideoEvent> videos,
+  ) async {
+    if (videos.isEmpty) return videos;
+    final client = _funnelcakeApiClient;
+    if (client == null) return videos;
+    final withBulkStats = await _hydrateAuthorVideosWithBulkStats(
+      videos,
+      client,
+    );
+    return _hydrateAuthorVideosWithViewsEndpoint(withBulkStats, client);
+  }
+
+  Future<List<VideoEvent>> _hydrateAuthorVideosWithBulkStats(
+    List<VideoEvent> videos,
+    FunnelcakeApiClient client,
+  ) async {
+    final idList = videos
+        .map((video) => video.id)
+        .where((id) => id.isNotEmpty)
+        .toList();
+    if (idList.isEmpty) return videos;
+
+    final statsById = <String, BulkVideoStatsEntry>{};
+    for (var i = 0; i < idList.length; i += 100) {
+      final end = i + 100 > idList.length ? idList.length : i + 100;
+      final chunk = idList.sublist(i, end);
+      final response = await client.getBulkVideoStats(chunk);
+      statsById.addAll(response.stats);
+    }
+
+    if (statsById.isEmpty) return videos;
+
+    return videos.map((video) {
+      final stats = statsById[video.id];
+      if (stats == null) return video;
+
+      final mergedTags = <String, String>{...video.rawTags};
+      if (stats.loops != null) {
+        mergedTags['loops'] = stats.loops!.toString();
+      }
+      if (stats.views != null) {
+        mergedTags['views'] = stats.views!.toString();
+      }
+
+      return video.copyWith(
+        rawTags: mergedTags,
+        originalLoops: stats.loops ?? video.originalLoops,
+        originalLikes: video.originalLikes ?? stats.reactions,
+        originalComments: video.originalComments ?? stats.comments,
+        originalReposts: video.originalReposts ?? stats.reposts,
+        nostrLikeCount: video.nostrLikeCount ?? 0,
+      );
+    }).toList();
+  }
+
+  Future<List<VideoEvent>> _hydrateAuthorVideosWithViewsEndpoint(
+    List<VideoEvent> videos,
+    FunnelcakeApiClient client,
+  ) async {
+    final missingViews = videos
+        .where(
+          (video) =>
+              !_authorVideoHasViewLikeCount(video) && video.id.isNotEmpty,
+        )
+        .toList();
+    if (missingViews.isEmpty) return videos;
+
+    final fetchedViews = <String, int>{};
+    for (var i = 0; i < missingViews.length; i += 12) {
+      final end = i + 12 > missingViews.length ? missingViews.length : i + 12;
+      final chunk = missingViews.sublist(i, end);
+      final counts = await Future.wait(
+        chunk.map((video) => client.getVideoViews(video.id)),
+      );
+      for (var j = 0; j < chunk.length; j++) {
+        fetchedViews[chunk[j].id] = counts[j];
+      }
+    }
+
+    if (fetchedViews.isEmpty) return videos;
+
+    return videos.map((video) {
+      final count = fetchedViews[video.id];
+      if (count == null) return video;
+      return video.copyWith(
+        rawTags: <String, String>{...video.rawTags, 'views': '$count'},
+      );
+    }).toList();
+  }
+
+  bool _authorVideoHasViewLikeCount(VideoEvent video) {
+    final viewTags = [
+      video.rawTags['views'],
+      video.rawTags['view_count'],
+      video.rawTags['total_views'],
+      video.rawTags['unique_views'],
+      video.rawTags['unique_viewers'],
+    ];
+    for (final value in viewTags) {
+      if (value == null) continue;
+      final normalized = value.replaceAll(',', '').trim();
+      if (normalized.isEmpty) continue;
+      if (int.tryParse(normalized) != null) return true;
+      if (double.tryParse(normalized) != null) return true;
+    }
+    return false;
   }
 
   /// Fetches a single video by event ID and enriches it with REST-side stats

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -6,10 +6,12 @@
 /// - `VideosRepository` - main repository (orchestrates Nostr + Storage)
 library;
 
+export 'src/author_feed_result.dart';
 export 'src/db_video_local_storage.dart';
 export 'src/home_feed_result.dart';
 export 'src/in_memory_feed_cache.dart';
 export 'src/popular_videos_page.dart';
+export 'src/profile_video_merge.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';

--- a/mobile/packages/videos_repository/test/src/author_feed_result_test.dart
+++ b/mobile/packages/videos_repository/test/src/author_feed_result_test.dart
@@ -1,0 +1,86 @@
+// ABOUTME: Unit tests for the AuthorFeedResult value type.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+VideoEvent _video(String id) => VideoEvent(
+  id: id,
+  pubkey: 'author',
+  createdAt: 1000,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000),
+);
+
+void main() {
+  group('AuthorFeedResult', () {
+    test('defaults videos to empty and envelope fields to null', () {
+      const result = AuthorFeedResult(authorPubkey: 'pub');
+
+      expect(result.authorPubkey, equals('pub'));
+      expect(result.videos, isEmpty);
+      expect(result.nextOffset, isNull);
+      expect(result.totalCount, isNull);
+      expect(result.hasMore, isNull);
+    });
+
+    test('value equality is based on all fields', () {
+      final a = AuthorFeedResult(
+        authorPubkey: 'pub',
+        videos: [_video('a')],
+        nextOffset: 50,
+        totalCount: 120,
+        hasMore: true,
+      );
+      final b = AuthorFeedResult(
+        authorPubkey: 'pub',
+        videos: [_video('a')],
+        nextOffset: 50,
+        totalCount: 120,
+        hasMore: true,
+      );
+
+      expect(a, equals(b));
+    });
+
+    test('differs when any field differs', () {
+      const base = AuthorFeedResult(authorPubkey: 'pub', totalCount: 1);
+      expect(base, isNot(equals(const AuthorFeedResult(authorPubkey: 'pub'))));
+      expect(
+        base,
+        isNot(equals(const AuthorFeedResult(authorPubkey: 'other'))),
+      );
+    });
+
+    test('copyWith replaces only the provided fields', () {
+      const original = AuthorFeedResult(
+        authorPubkey: 'pub',
+        nextOffset: 50,
+        totalCount: 120,
+        hasMore: true,
+      );
+
+      final updated = original.copyWith(nextOffset: 100, hasMore: false);
+
+      expect(updated.authorPubkey, equals('pub'));
+      expect(updated.nextOffset, equals(100));
+      expect(updated.totalCount, equals(120));
+      expect(updated.hasMore, isFalse);
+    });
+
+    test('copyWith keeps fields that are not passed', () {
+      const original = AuthorFeedResult(
+        authorPubkey: 'pub',
+        nextOffset: 50,
+        totalCount: 120,
+        hasMore: true,
+      );
+
+      final updated = original.copyWith(totalCount: 99);
+
+      expect(updated.nextOffset, equals(50)); // kept
+      expect(updated.hasMore, isTrue); // kept
+      expect(updated.totalCount, equals(99));
+    });
+  });
+}

--- a/mobile/packages/videos_repository/test/src/author_feed_result_test.dart
+++ b/mobile/packages/videos_repository/test/src/author_feed_result_test.dart
@@ -82,5 +82,24 @@ void main() {
       expect(updated.hasMore, isTrue); // kept
       expect(updated.totalCount, equals(99));
     });
+
+    test('copyWith can clear nullable envelope fields', () {
+      const original = AuthorFeedResult(
+        authorPubkey: 'pub',
+        nextOffset: 50,
+        totalCount: 120,
+        hasMore: true,
+      );
+
+      final updated = original.copyWith(
+        nextOffset: null,
+        totalCount: null,
+        hasMore: null,
+      );
+
+      expect(updated.nextOffset, isNull);
+      expect(updated.totalCount, isNull);
+      expect(updated.hasMore, isNull);
+    });
   });
 }

--- a/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
+++ b/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
@@ -1,0 +1,221 @@
+// ABOUTME: Unit tests for the profile/author cross-source merge policy (#3384).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+VideoEvent _video({
+  required String id,
+  String pubkey = 'author',
+  int createdAt = 0,
+  DateTime? timestamp,
+  String? title,
+  String? videoUrl,
+  String? publishedAt,
+  String? vineId,
+  Map<String, String> rawTags = const {},
+  List<String> hashtags = const [],
+  List<String> collaboratorPubkeys = const [],
+  List<List<String>> nostrEventTags = const [],
+  List<String> contentWarningLabels = const [],
+  int? originalLikes,
+  int? originalComments,
+  int? originalReposts,
+  int? originalLoops,
+  int? nostrLikeCount,
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: createdAt,
+    content: '',
+    timestamp:
+        timestamp ?? DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+    title: title,
+    videoUrl: videoUrl,
+    publishedAt: publishedAt,
+    vineId: vineId,
+    rawTags: rawTags,
+    hashtags: hashtags,
+    collaboratorPubkeys: collaboratorPubkeys,
+    nostrEventTags: nostrEventTags,
+    contentWarningLabels: contentWarningLabels,
+    originalLikes: originalLikes,
+    originalComments: originalComments,
+    originalReposts: originalReposts,
+    originalLoops: originalLoops,
+    nostrLikeCount: nostrLikeCount,
+  );
+}
+
+void main() {
+  group('canonicalProfileFeedVideoKey', () {
+    test('keys on pubkey:stableId, lowercased', () {
+      expect(
+        canonicalProfileFeedVideoKey(_video(id: 'ABC', pubkey: 'PUB')),
+        equals('pub:abc'),
+      );
+    });
+
+    test('uses vineId as stableId when present', () {
+      expect(
+        canonicalProfileFeedVideoKey(
+          _video(id: 'evt', pubkey: 'pub', vineId: 'vine9'),
+        ),
+        equals('pub:vine9'),
+      );
+    });
+  });
+
+  group('mergeProfileFeedVideos', () {
+    test('takes the max of every engagement counter (#3384)', () {
+      final merged = mergeProfileFeedVideos(
+        _video(
+          id: 'v',
+          createdAt: 1000,
+          originalLikes: 5,
+          originalComments: 9,
+          originalReposts: 1,
+          originalLoops: 100,
+          nostrLikeCount: 2,
+        ),
+        _video(
+          id: 'v',
+          createdAt: 2000,
+          originalLikes: 10,
+          originalComments: 3,
+          originalReposts: 4,
+          originalLoops: 50,
+          nostrLikeCount: 0,
+        ),
+      );
+
+      expect(merged.originalLikes, equals(10));
+      expect(merged.originalComments, equals(9));
+      expect(merged.originalReposts, equals(4));
+      expect(merged.originalLoops, equals(100));
+      expect(merged.nostrLikeCount, equals(2));
+    });
+
+    test('raw tags are primary-wins except views, which takes the max', () {
+      final merged = mergeProfileFeedVideos(
+        _video(
+          id: 'v',
+          createdAt: 1000,
+          rawTags: {'title': 'old', 'views': '100', 'only_old': 'x'},
+        ),
+        _video(
+          id: 'v',
+          createdAt: 2000, // newer => primary
+          rawTags: {'title': 'new', 'views': '50', 'only_new': 'y'},
+        ),
+      );
+
+      expect(merged.rawTags['title'], equals('new')); // primary wins
+      expect(merged.rawTags['views'], equals('100')); // max wins
+      expect(merged.rawTags['only_old'], equals('x')); // secondary-only kept
+      expect(merged.rawTags['only_new'], equals('y'));
+    });
+
+    test('newer createdAt selects the primary metadata copy', () {
+      final merged = mergeProfileFeedVideos(
+        _video(id: 'v', createdAt: 1000, title: 'old', publishedAt: '1000'),
+        _video(id: 'v', createdAt: 2000, title: 'new', publishedAt: '2000'),
+      );
+
+      expect(merged.title, equals('new'));
+    });
+
+    test('primary fields fall back to secondary when null', () {
+      final merged = mergeProfileFeedVideos(
+        _video(id: 'v', createdAt: 1000, videoUrl: 'http://old/v.mp4'),
+        _video(id: 'v', createdAt: 2000, publishedAt: '2000'),
+      );
+
+      expect(merged.videoUrl, equals('http://old/v.mp4'));
+    });
+
+    test('ties on createdAt break toward the smaller id as primary', () {
+      final merged = mergeProfileFeedVideos(
+        _video(id: 'bbb', createdAt: 1000, title: 'b', publishedAt: '5'),
+        _video(id: 'aaa', createdAt: 1000, title: 'a', publishedAt: '5'),
+      );
+
+      // incoming id 'aaa' < existing id 'bbb' => incoming is primary.
+      expect(merged.title, equals('a'));
+    });
+
+    test('preserves the older createdAt when neither has publishedAt', () {
+      final merged = mergeProfileFeedVideos(
+        _video(id: 'v', createdAt: 1000),
+        _video(id: 'v', createdAt: 2000),
+      );
+
+      expect(merged.createdAt, equals(1000));
+    });
+
+    test('primary wins on non-empty list fields and keeps its timestamp', () {
+      final merged = mergeProfileFeedVideos(
+        _video(id: 'v', createdAt: 1000, timestamp: DateTime.utc(2030)),
+        _video(
+          id: 'v',
+          createdAt: 2000, // newer => primary
+          timestamp: DateTime.utc(2000), // earlier than the secondary's
+          hashtags: ['tag'],
+          collaboratorPubkeys: ['collab'],
+          nostrEventTags: [
+            ['e', 'x'],
+          ],
+          contentWarningLabels: ['nsfw'],
+        ),
+      );
+
+      expect(merged.hashtags, equals(['tag']));
+      expect(merged.collaboratorPubkeys, equals(['collab']));
+      expect(
+        merged.nostrEventTags,
+        equals([
+          ['e', 'x'],
+        ]),
+      );
+      expect(merged.contentWarningLabels, equals(['nsfw']));
+      // Neither has publishedAt => keep the earlier timestamp (primary's).
+      expect(merged.timestamp, equals(DateTime.utc(2000)));
+    });
+  });
+
+  group('mergeProfileFeedVideoLists', () {
+    test('dedups the same addressable video and keeps distinct ones', () {
+      final result = mergeProfileFeedVideoLists(
+        [_video(id: 'a', createdAt: 1000, originalLikes: 3, publishedAt: '1')],
+        [
+          _video(id: 'a', createdAt: 1000, originalLikes: 9, publishedAt: '1'),
+          _video(id: 'b', createdAt: 2000, publishedAt: '2'),
+        ],
+      );
+
+      expect(result, hasLength(2));
+      final a = result.firstWhere((v) => v.id == 'a');
+      expect(a.originalLikes, equals(9)); // max merge applied
+    });
+
+    test('sorts newest-first by published time then ascending id', () {
+      final result = mergeProfileFeedVideoLists(
+        [_video(id: 'old', createdAt: 1000, publishedAt: '1000')],
+        [_video(id: 'new', createdAt: 3000, publishedAt: '3000')],
+      );
+
+      expect(result.map((v) => v.id).toList(), equals(['new', 'old']));
+    });
+
+    test('falls back to createdAt and breaks sort ties by ascending id', () {
+      final result = mergeProfileFeedVideoLists(
+        [_video(id: 'bbb', createdAt: 1000)], // no publishedAt
+        [_video(id: 'aaa', createdAt: 1000)], // no publishedAt, same createdAt
+      );
+
+      // createdAt sort key (equal) => tie broken by ascending id.
+      expect(result.map((v) => v.id).toList(), equals(['aaa', 'bbb']));
+    });
+  });
+}

--- a/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
@@ -1,0 +1,283 @@
+// ABOUTME: Tests for VideosRepository.getAuthorFeed — the composed author/
+// ABOUTME: profile feed (REST envelope, collaborator guard, relay-seed merge,
+// ABOUTME: in-memory cache, REST-unavailable + FunnelcakeException fallback).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+const _author = 'author-pubkey';
+
+VideoStats _stats({
+  required String id,
+  String pubkey = _author,
+  String dTag = 'd',
+  String videoUrl = 'https://example.com/v.mp4',
+  Map<String, String> rawTags = const {},
+}) {
+  return VideoStats(
+    id: id,
+    pubkey: pubkey,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+    kind: EventKind.videoVertical,
+    dTag: dTag,
+    title: 'Test',
+    thumbnail: 'https://example.com/t.jpg',
+    videoUrl: videoUrl,
+    reactions: 0,
+    comments: 0,
+    reposts: 0,
+    engagementScore: 0,
+    rawTags: rawTags,
+  );
+}
+
+VideoEvent _seed(String id, {String? vineId, int? originalLikes}) => VideoEvent(
+  id: id,
+  pubkey: _author,
+  createdAt: 1704067200,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+  vineId: vineId,
+  originalLikes: originalLikes,
+);
+
+void main() {
+  setUpAll(() => registerFallbackValue(<String>[]));
+
+  group('VideosRepository.getAuthorFeed', () {
+    late _MockNostrClient nostrClient;
+    late _MockFunnelcakeApiClient funnelcake;
+    late InMemoryFeedCache cache;
+    late VideosRepository repository;
+
+    void stubAuthor(VideosByAuthorResponse response) {
+      when(
+        () => funnelcake.getVideosByAuthor(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer((_) async => response);
+    }
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      funnelcake = _MockFunnelcakeApiClient();
+      cache = InMemoryFeedCache();
+      repository = VideosRepository(
+        nostrClient: nostrClient,
+        funnelcakeApiClient: funnelcake,
+        inMemoryFeedCache: cache,
+      );
+
+      when(() => funnelcake.isAvailable).thenReturn(true);
+      when(
+        () => funnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(
+        () => funnelcake.getVideoViews(any()),
+      ).thenAnswer((_) async => 0);
+    });
+
+    test('surfaces the v2 envelope (totalCount/nextOffset/hasMore)', () async {
+      stubAuthor(
+        VideosByAuthorResponse(
+          videos: [_stats(id: 'a')],
+          totalCount: 42,
+          nextOffset: 50,
+          hasMore: true,
+        ),
+      );
+
+      final result = await repository.getAuthorFeed(authorPubkey: _author);
+
+      expect(result.videos, hasLength(1));
+      expect(result.totalCount, equals(42));
+      expect(result.nextOffset, equals(50));
+      expect(result.hasMore, isTrue);
+    });
+
+    test('hydrates REST videos with bulk stats (existing-wins)', () async {
+      when(() => funnelcake.getBulkVideoStats(any())).thenAnswer(
+        (_) async => const BulkVideoStatsResponse(
+          stats: {
+            'a': BulkVideoStatsEntry(
+              eventId: 'a',
+              reactions: 6,
+              comments: 1,
+              reposts: 0,
+              views: 14,
+              loops: 7,
+            ),
+          },
+        ),
+      );
+      stubAuthor(VideosByAuthorResponse(videos: [_stats(id: 'a')]));
+
+      final result = await repository.getAuthorFeed(authorPubkey: _author);
+
+      final video = result.videos.single;
+      expect(video.originalLoops, equals(7));
+      expect(video.rawTags['loops'], equals('7'));
+      // Bulk-stats supplied the view count, so the per-video views endpoint is
+      // skipped (the value is preserved verbatim, not overwritten with 0).
+      expect(video.rawTags['views'], equals('14'));
+      verifyNever(() => funnelcake.getVideoViews(any()));
+    });
+
+    test(
+      'treats a fractional view count as present, skipping the views endpoint',
+      () async {
+        stubAuthor(
+          VideosByAuthorResponse(
+            videos: [
+              _stats(id: 'a', rawTags: {'views': '12.7'}),
+            ],
+          ),
+        );
+
+        final result = await repository.getAuthorFeed(authorPubkey: _author);
+
+        expect(result.videos, hasLength(1));
+        expect(result.videos.single.rawTags['views'], equals('12.7'));
+        verifyNever(() => funnelcake.getVideoViews(any()));
+      },
+    );
+
+    test(
+      'falls back to a page-size heuristic for nextOffset/hasMore',
+      () async {
+        stubAuthor(VideosByAuthorResponse(videos: [_stats(id: 'a')]));
+
+        final result = await repository.getAuthorFeed(authorPubkey: _author);
+
+        // Envelope omitted -> nextOffset = offset(0) + restCount(1); hasMore is
+        // false because 1 < the 50-row page size.
+        expect(result.nextOffset, equals(1));
+        expect(result.hasMore, isFalse);
+      },
+    );
+
+    test('drops backend-leaked p-tagged collaborator videos', () async {
+      stubAuthor(
+        VideosByAuthorResponse(
+          videos: [
+            _stats(id: 'mine'),
+            _stats(id: 'leaked', pubkey: 'someone-else'),
+          ],
+        ),
+      );
+
+      final result = await repository.getAuthorFeed(authorPubkey: _author);
+
+      expect(result.videos, hasLength(1));
+      expect(result.videos.single.id, equals('mine'));
+      expect(result.videos.single.pubkey, equals(_author));
+    });
+
+    test(
+      'merges the relay seed with REST, deduping by addressable id',
+      () async {
+        // REST `toVideoEvent` derives stableId from the d-tag ('d' here); the
+        // relay seed shares that addressable id so the two copies dedup — the
+        // same identity the production relay snapshot and REST row collapse on.
+        stubAuthor(VideosByAuthorResponse(videos: [_stats(id: 'a')]));
+
+        final result = await repository.getAuthorFeed(
+          authorPubkey: _author,
+          relaySeed: [_seed('a', vineId: 'd', originalLikes: 9)],
+        );
+
+        expect(result.videos, hasLength(1));
+        // Max-merge keeps the relay's higher engagement count (#3384).
+        expect(result.videos.single.originalLikes, equals(9));
+      },
+    );
+
+    test(
+      'caches the initial page and serves it without a second fetch',
+      () async {
+        stubAuthor(VideosByAuthorResponse(videos: [_stats(id: 'a')]));
+
+        await repository.getAuthorFeed(authorPubkey: _author);
+        final second = await repository.getAuthorFeed(authorPubkey: _author);
+
+        expect(second.videos, hasLength(1));
+        verify(
+          () => funnelcake.getVideosByAuthor(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test('load-more pages (offset != null) bypass the cache', () async {
+      stubAuthor(VideosByAuthorResponse(videos: [_stats(id: 'a')]));
+
+      await repository.getAuthorFeed(authorPubkey: _author); // primes cache
+      await repository.getAuthorFeed(authorPubkey: _author, offset: 50);
+
+      verify(
+        () => funnelcake.getVideosByAuthor(
+          pubkey: _author,
+          limit: any(named: 'limit'),
+          offset: 50,
+          before: any(named: 'before'),
+        ),
+      ).called(1);
+    });
+
+    test(
+      'returns the relay seed alone when Funnelcake is unavailable',
+      () async {
+        when(() => funnelcake.isAvailable).thenReturn(false);
+
+        final result = await repository.getAuthorFeed(
+          authorPubkey: _author,
+          relaySeed: [_seed('a')],
+        );
+
+        expect(result.videos.map((v) => v.id).toList(), equals(['a']));
+        verifyNever(
+          () => funnelcake.getVideosByAuthor(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        );
+      },
+    );
+
+    test('falls back to the relay seed on FunnelcakeException', () async {
+      when(
+        () => funnelcake.getVideosByAuthor(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+          before: any(named: 'before'),
+        ),
+      ).thenThrow(const FunnelcakeException('boom'));
+
+      final result = await repository.getAuthorFeed(
+        authorPubkey: _author,
+        relaySeed: [_seed('a')],
+      );
+
+      expect(result.videos.map((v) => v.id).toList(), equals(['a']));
+    });
+  });
+}


### PR DESCRIPTION
## What & why

First slice of **WS-3** (#4788) — move the profile feed's REST-source
composition and the #3384 merge policy out of `profile_feed_provider` into
`videos_repository`, the canonical owner. PR1-commit1 (low-level helper
relocation) shipped in #4790; this is PR1-commit2.

`profile_feed_provider` reimplemented composition that belongs in the
repository, owned the #3384 merge policy, and paginated by **offset** reading
the Funnelcake v2 envelope — which the existing `getVideosByAuthor` discarded
(returning a bare `List`). A literal `getNewVideos` mirror (cursor-based) could
not reproduce profile pagination, so this adds a dedicated author-feed method.

## Changes (data layer only)

**New**
- `getAuthorFeed({authorPubkey, offset, relaySeed, skipCache})` +
  `AuthorFeedResult` — offset-paginated, surfaces `totalCount`/`nextOffset`/`hasMore`.
- `profile_video_merge.dart` — relocated #3384 policy: `mergeProfileFeedVideos`
  (views=max, per-counter MAX), `mergeProfileFeedVideoLists` (dedup + sort,
  **no** tombstones), `canonicalProfileFeedVideoKey`.

**Modified**
- `profile_feed_provider.dart` now delegates its merge to the package (single
  impl, ~135 LOC removed); `@visibleForTesting mergeTwoProfileVideos` kept as a
  thin forwarder so existing provider tests stay green.
- `InMemoryFeedCache` extended with an author sub-store (`author:<hex>`).
- Ported the provider's **existing-wins** REST hydration (bulk-stats + per-video
  views) as `_hydrateAuthor*` — deliberately distinct from the repo's
  stale-zero `_hydrateVideosWithBulkStats` — so profile counts stay identical.

## Behavior parity (R2)

- **#3384 `views = max`** + per-counter MAX preserved (pinned by tests).
- **Two distinct hydration algorithms** kept separate (existing-wins vs the
  repo's stale-zero variant) — counts do not drift.
- **Collaborator guard** (`v.pubkey == authorPubkey`) preserved verbatim. Backend
  cross-check (divine-funnelcake `main`): `/api/users/{pubkey}/videos` is now
  author-strict, so the p-tag leak is not currently present — guard kept anyway
  for parity + contract-safety; a future removal is a separate, sign-off-gated
  cleanup.
- Returned videos are **unfiltered** (drop-expired only); blocklist/content
  filtering stays with the consumer so block/unblock reflects without a re-fetch
  (#4782).
- Relay/realtime source stays app-side (`VideoEventService`) and is merged in via
  the `relaySeed` arg — the package gains **zero** Flutter/app deps.

## Scope notes

- This PR does **not** touch the cubit or UI — `profile_feed_provider` still
  drives the feed (it now just delegates the merge). The `ProfileFeedCubit` (PR2)
  and provider deletion (PR3) follow.
- The repo's Nostr source is the `relaySeed`, not a `getProfileVideos` fallback —
  the profile feed's Nostr is realtime `VideoEventService` (cubit-owned), so the
  repo is cleanly the REST-source composition.

## Tests

29 new package tests (merge policy incl. `views=max`; envelope round-trip;
collaborator guard; relay-seed dedup/merge; cache hit + load-more bypass;
Funnelcake-unavailable + `FunnelcakeException` → seed fallback). Full
`videos_repository` suite (392) and the `profile_feed` provider tests green;
`flutter analyze` + `dart format` clean.