### PR TITLE
docs(funnelcake): pin feed-cursor & followers-total contract (#3545)

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -150,9 +150,11 @@ class FunnelcakeApiClient {
   }
 
   /// Unwraps a funnelcake list response that may be either a raw JSON array
-  /// (legacy / `legacy-array-response` flag on) or the post-#238 envelope
-  /// shape `{"data": [...], "pagination": {"has_more": bool, "next_cursor":
-  /// string|null, "next_offset": int|null}}`.
+  /// (the permanent legacy `/api/...` paths, which serve pre-#238 shapes) or
+  /// the v2 envelope `{"data": [...], "pagination": {"has_more": bool,
+  /// "next_cursor": string|null, "next_offset": int|null}}` served by the
+  /// `/api/v2/...` paths. The v1/v2 split is unconditional — the temporary
+  /// `legacy-array-response` build flag was removed in divine-funnelcake#301.
   ///
   /// Returns a record with:
   /// - `items`: the list of raw JSON objects.
@@ -161,7 +163,7 @@ class FunnelcakeApiClient {
   /// - `nextCursor`: opaque cursor string from the envelope, or `null` when
   ///   the raw-array shape is used (caller computes its own cursor).
   ///
-  /// Mirrors the `unwrapListResponse<T>` helper in divine-web#277.
+  /// Mirrors divine-web's envelope-unwrap logic (introduced in divine-web#277).
   static ({List<dynamic> items, bool? hasMore, String? nextCursor})
   _unwrapListResponse(Object? decoded) {
     if (decoded is List) {
@@ -752,8 +754,10 @@ class FunnelcakeApiClient {
       if (response.statusCode == 200) {
         final raw = jsonDecode(response.body) as Map<String, dynamic>;
 
-        // Tolerate both the legacy shape `{"videos": [...]}` and the
-        // post-funnelcake#238 envelope `{"data": [...], "pagination": {...}}`.
+        // The feed endpoint serves its own `{"videos": [...], "next_cursor",
+        // "has_more"}` shape; also tolerate the `{"data": [...],
+        // "pagination": {...}}` envelope defensively. There is no v2 feed
+        // route.
         final videosData =
             (raw['videos'] as List<dynamic>?) ??
             (raw['data'] as List<dynamic>?) ??
@@ -764,6 +768,11 @@ class FunnelcakeApiClient {
             .toList();
 
         // Pagination metadata may be at top level or under `pagination`.
+        // `next_cursor` is the last video's `created_at` Unix timestamp
+        // (numeric), echoed back via the numeric `before` param. A
+        // non-numeric/opaque cursor (see divine-funnelcake#320) parses to
+        // null here; VideosRepository then continues paging via a
+        // client-computed `before` timestamp. See divine-mobile#3545.
         final pagination = raw['pagination'] as Map<String, dynamic>?;
         final rawCursor = raw['next_cursor'] ?? pagination?['next_cursor'];
         final nextCursor = switch (rawCursor) {

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -792,6 +792,31 @@ void main() {
         expect(result.hasMore, isFalse);
       });
 
+      test(
+        'opaque next_cursor degrades to null while preserving has_more '
+        '(#3545 / funnelcake#320 contract)',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response(
+              '{"videos": [], "next_cursor": "t:1780818341", "has_more": true}',
+              200,
+            ),
+          );
+
+          final result = await client.getHomeFeed(pubkey: testPubkey);
+
+          // Client-level contract: the feed cursor is a bare numeric timestamp
+          // today. If funnelcake#320 ever ships an opaque cursor, int.tryParse
+          // yields null here (not a throw) and has_more still passes through
+          // from the body. (The repository then keeps paging via a
+          // client-computed `before` timestamp — see VideosRepository.)
+          expect(result.nextCursor, isNull);
+          expect(result.hasMore, isTrue);
+        },
+      );
+
       test('filters out videos with empty id or videoUrl', () async {
         const responseWithInvalid =
             '''

--- a/mobile/packages/models/lib/src/home_feed_response.dart
+++ b/mobile/packages/models/lib/src/home_feed_response.dart
@@ -16,10 +16,23 @@ class HomeFeedResponse {
   /// The videos in this page of the feed.
   final List<VideoStats> videos;
 
-  /// Unix timestamp cursor for fetching the next page.
+  /// Unix-timestamp cursor for fetching the next page.
   ///
-  /// Pass this as the `before` parameter to get the next page.
-  /// `null` if there are no more pages.
+  /// This is the `created_at` (Unix seconds) of the last video in the page,
+  /// echoed back as the numeric `before` query parameter to fetch the next
+  /// page. `null` when there are no more pages.
+  ///
+  /// The legacy `/api/users/{pubkey}/feed` endpoint is the only feed route
+  /// (there is no v2 feed envelope), and its cursor is numeric — not the
+  /// opaque `o:`/`t:`-prefixed cursor used by the v2 list endpoints. If
+  /// divine-funnelcake#320 ever unifies all endpoints onto an opaque cursor,
+  /// this field becomes `null` (an opaque string fails `int.tryParse`).
+  /// `VideosRepository` then derives the next page from the oldest video's
+  /// `created_at` and keeps paginating via the numeric `before` param, so the
+  /// feed continues to work as long as the backend still accepts `before`.
+  /// Update this field and the `int.tryParse` parse site in
+  /// `FunnelcakeApiClient.getHomeFeed` together if that param is ever dropped.
+  /// See divine-mobile#3545.
   final int? nextCursor;
 
   /// Whether there are more videos to load.

--- a/mobile/packages/models/lib/src/paginated_pubkeys.dart
+++ b/mobile/packages/models/lib/src/paginated_pubkeys.dart
@@ -12,13 +12,20 @@ class PaginatedPubkeys {
     this.hasMore = false,
   });
 
-  /// Creates a [PaginatedPubkeys] from JSON response.
+  /// Creates a [PaginatedPubkeys] from a JSON response.
   ///
-  /// Tolerates both the legacy shape and the post-funnelcake#238 envelope:
-  /// - Legacy: `{"following": [...], "total": int, "has_more": bool}`
-  ///   (key varies: `following`, `followers`, or `pubkeys`)
-  /// - Envelope: `{"data": [...], "pagination": {"has_more": bool,
-  ///   "next_cursor": string}}`
+  /// Tolerates both response shapes funnelcake can emit. The v1/v2 split is
+  /// permanent and unconditional — there is no longer a `legacy-array-response`
+  /// build flag (it was removed in divine-funnelcake#301):
+  /// - v1 (the path mobile calls, e.g. `/api/users/{pubkey}/followers`):
+  ///   `{"followers": [...], "total": int, "offset": int, "limit": int}`
+  ///   (the list key varies: `followers`, `following`, or `pubkeys`). Here
+  ///   `total` is the ABSOLUTE count and may exceed [pubkeys] length.
+  /// - v2 envelope (`/api/v2/users/{pubkey}/...`, not currently called by
+  ///   mobile): `{"data": [...], "pagination": {"has_more": bool,
+  ///   "next_cursor": string}}`. The v2 `pagination` object has NO `total`
+  ///   field, so [total] falls back to the current page length under this
+  ///   shape. See divine-mobile#3545.
   factory PaginatedPubkeys.fromJson(Map<String, dynamic> json) {
     final pagination = json['pagination'] as Map<String, dynamic>?;
 
@@ -46,7 +53,12 @@ class PaginatedPubkeys {
   /// The list of public keys.
   final List<String> pubkeys;
 
-  /// Total number of results available (may exceed [pubkeys] length).
+  /// Total number of results available.
+  ///
+  /// Absolute count on the v1 endpoints mobile calls (may exceed [pubkeys]
+  /// length). Falls back to the current page length only under the v2
+  /// `{data, pagination}` envelope, which omits an absolute total. See
+  /// divine-mobile#3545.
   final int total;
 
   /// Whether more results are available for pagination.


### PR DESCRIPTION
## Description

Follow-up to #3529 / #3521 closing out **#3545**, which asked two backend-contract questions. Both are now confirmed against current `main` of **divine-funnelcake**, the full request path across the related backend repos, and a **live `api.divine.video` production probe**. This PR is a **docs correction + one degradation test — zero behavior change**.

**Q1 — feed cursor is numeric.** `/api/users/{pubkey}/feed` is the only feed route (no v2 feed) and returns `next_cursor = last_video.created_at.timestamp()` as a string (prod: `"1780818341"`), echoed via the numeric `before` param. Mobile's `int.tryParse` + `HomeFeedResponse.nextCursor: int?` is correct.

**Q2 — followers/following `total` is absolute.** The legacy v1 endpoints mobile calls return `{followers|following: [...], total: int, …}` with an absolute count (prod: `total:16` on a page of 2). The `?? pubkeysData.length` page-length fallback only applies under the v2 `{data, pagination}` envelope (no `total`), which mobile does not call.

**Why the comments needed fixing:** they still referenced a `legacy-array-response` Cargo flag that was **deleted** in divine-funnelcake#301 — the v1/v2 split is now permanent and unconditional.

### Changes
- `paginated_pubkeys.dart` — rewrite `fromJson`/`total` docs (v1 absolute total vs v2 page-length fallback; drop the deleted-flag framing).
- `home_feed_response.dart` — document `nextCursor` as the `created_at` timestamp echoed via `before`; cite funnelcake#320 as the tracked future-opaque-cursor risk.
- `funnelcake_api_client.dart` — fix `_unwrapListResponse`/`getHomeFeed` comments; soften the inaccurate `unwrapListResponse<T>`/divine-web#277 reference.
- `funnelcake_api_client_test.dart` — add a degradation test pinning that an opaque feed cursor yields `null` `nextCursor` while `has_more` is honored (the funnelcake#320 contract).

### Verification
- `dart format` — clean (0 changed)
- `dart analyze packages/models packages/funnelcake_api_client` — No issues found
- `flutter test packages/funnelcake_api_client` — 344 pass (incl. new degradation test)
- `flutter test packages/models/.../paginated_pubkeys_test.dart .../home_feed_response_test.dart` — 20 pass

### Notes
- No logic change: the `json['total'] ?? pubkeysData.length` expression and the `getHomeFeed` cursor `switch` are untouched. Both contracts were already pinned by existing tests; this adds only the missing opaque-cursor degradation pin.
- `PaginatedPubkeys.total` has no non-test consumers (UI counts come from `FollowersSnapshot.count`), so no nullable-total / signature change was made.

**Related Issue:** follow-up to #3545 (already answered & closed); future risk tracked in divine-funnelcake#320.

## Type of Change

- [x] 📝 Documentation
- [ ] ✨ New feature
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore