### PR TITLE
feat(dm): route NIP-17 DMs to kind-10050 inbox relays + harden moderation report DM (#570)

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2554,6 +2554,10 @@
   "reportReceivedTitle": "Report Received",
   "reportReceivedThankYou": "Thank you for helping keep Divine safe.",
   "reportReceivedReviewNotice": "Our team will review your report and take appropriate action. You may receive updates via direct message.",
+  "reportModerationDmDelayed": "We couldn't reach the moderation team directly just now, but your report was received and will be reviewed.",
+  "@reportModerationDmDelayed": {
+    "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
+  },
   "reportLearnMore": "Learn More",
   "reportLearnMoreAt": "Learn more at",
   "reportSafetyUrl": "divine.video/safety",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2558,6 +2558,10 @@
   "@reportModerationDmDelayed": {
     "description": "Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels."
   },
+  "reportContactModeration": "Message the moderation team",
+  "@reportContactModeration": {
+    "description": "Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report."
+  },
   "reportLearnMore": "Learn More",
   "reportLearnMoreAt": "Learn more at",
   "reportSafetyUrl": "divine.video/safety",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8210,6 +8210,12 @@ abstract class AppLocalizations {
   /// **'Our team will review your report and take appropriate action. You may receive updates via direct message.'**
   String get reportReceivedReviewNotice;
 
+  /// Calm, non-blocking notice shown on the report confirmation screen when the secondary NIP-17 direct message to the moderation team failed to send. The report itself still succeeded via other channels.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.'**
+  String get reportModerationDmDelayed;
+
   /// No description provided for @reportLearnMore.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8216,6 +8216,12 @@ abstract class AppLocalizations {
   /// **'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.'**
   String get reportModerationDmDelayed;
 
+  /// Button on the report confirmation screen that opens a direct-message conversation with the Divine moderation team so the user can follow up about their report.
+  ///
+  /// In en, this message translates to:
+  /// **'Message the moderation team'**
+  String get reportContactModeration;
+
   /// No description provided for @reportLearnMore.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4597,6 +4597,9 @@ class AppLocalizationsAm extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'የበለጠ ተማር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4593,6 +4593,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ቡድናችን የእርስዎን ሪፖርት ተመልክቶ ተገቢውን እርምጃ ይወስዳል። ዝማኔዎችን በቀጥታ መልእክት ሊቀበሉ ይችላሉ።';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'የበለጠ ተማር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4650,6 +4650,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'اعرف المزيد';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4646,6 +4646,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'سيُراجع فريقنا بلاغك ويتخذ الإجراء المناسب. قد تتلقى تحديثات عبر رسالة مباشرة.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'اعرف المزيد';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4751,6 +4751,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Научи повече';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4747,6 +4747,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Екипът ни ще прегледа сигнала ти и ще предприеме нужните действия. Може да получаваш новини чрез директно съобщение.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Научи повече';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4758,6 +4758,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Mehr erfahren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4754,6 +4754,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Unser Team prüft deine Meldung und ergreift entsprechende Maßnahmen. Du erhältst möglicherweise Updates per Direktnachricht.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Mehr erfahren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4698,6 +4698,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Our team will review your report and take appropriate action. You may receive updates via direct message.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Learn More';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4702,6 +4702,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Learn More';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4747,6 +4747,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Conocé más';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4743,6 +4743,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Nuestro equipo va a revisar tu reporte y tomar las medidas necesarias. Quizás recibas novedades por mensaje directo.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Conocé más';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4760,6 +4760,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Susuriin ng team namin ang report mo at gagawa ng naaangkop na aksyon. Maaari kang makatanggap ng updates via direct message.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Alamin Pa';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4764,6 +4764,9 @@ class AppLocalizationsFil extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Alamin Pa';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4765,6 +4765,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'En savoir plus';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4761,6 +4761,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Notre équipe va examiner ton signalement et prendre les mesures appropriées. Tu pourras recevoir des mises à jour par message direct.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'En savoir plus';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4673,6 +4673,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Tim kami akan meninjau laporanmu dan mengambil tindakan yang sesuai. Kamu mungkin menerima pembaruan via pesan langsung.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Pelajari Lebih Lanjut';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4677,6 +4677,9 @@ class AppLocalizationsId extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Pelajari Lebih Lanjut';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4744,6 +4744,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il nostro team esaminerà la tua segnalazione e prenderà i provvedimenti del caso. Potresti ricevere aggiornamenti tramite messaggio diretto.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Scopri di più';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4748,6 +4748,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Scopri di più';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4487,6 +4487,9 @@ class AppLocalizationsJa extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'もっと詳しく';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4483,6 +4483,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'チームが報告を確認して、適切に対応するね。ダイレクトメッセージでアップデートが届くかも。';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'もっと詳しく';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4501,6 +4501,9 @@ class AppLocalizationsKo extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => '더 알아보기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4497,6 +4497,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '저희 팀이 신고를 검토하고 적절한 조치를 취할 거예요. 다이렉트 메시지로 업데이트를 받을 수 있어요.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => '더 알아보기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4718,6 +4718,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Ons team bekijkt je melding en onderneemt passende actie. Je kunt updates ontvangen via directe berichten.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Meer info';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4722,6 +4722,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Meer info';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4813,6 +4813,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Dowiedz się więcej';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4809,6 +4809,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nasz zespół przejrzy twoje zgłoszenie i podejmie odpowiednie działania. Możesz otrzymać aktualizacje przez wiadomość bezpośrednią.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Dowiedz się więcej';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4730,6 +4730,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Saiba mais';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4726,6 +4726,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Nossa equipe vai revisar sua denúncia e tomar as medidas adequadas. Você pode receber atualizações por mensagem direta.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Saiba mais';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4830,6 +4830,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Află mai multe';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4826,6 +4826,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Echipa noastră âți va revizui raportul și va lua măsuri corespunzătoare. S-ar putea să primești actualizări prin mesaj direct.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Află mai multe';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4697,6 +4697,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vårt team granskar din rapport och vidtar lämpliga åtgärder. Du kan få uppdateringar via direktmeddelande.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Läs mer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4701,6 +4701,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Läs mer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4685,6 +4685,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
 
   @override
+  String get reportContactModeration => 'Message the moderation team';
+
+  @override
   String get reportLearnMore => 'Daha Fazla Bilgi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4681,6 +4681,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ekibimiz bildirimini inceleyecek ve uygun adımı atacak. Direkt mesaj yoluyla güncelleme alabilirsin.';
 
   @override
+  String get reportModerationDmDelayed =>
+      'We couldn\'t reach the moderation team directly just now, but your report was received and will be reviewed.';
+
+  @override
   String get reportLearnMore => 'Daha Fazla Bilgi';
 
   @override

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -2,12 +2,15 @@
 // ABOUTME: Replaces the legacy AlertDialog with a VineBottomSheet-based flow.
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/content_filter_reason_localizations.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -235,9 +238,25 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   @override
   Widget build(BuildContext context) {
     if (_submitted) {
+      final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+      final moderationPubkey = ref
+          .read(moderationLabelServiceProvider)
+          .divineModerationPubkeyHex;
+      // The moderation conversation is an ordinary NIP-17 thread; deep-link
+      // straight to it so the user can follow up about their report. Null
+      // when we have no current pubkey (signed out) — the button hides.
+      final moderationConversationId =
+          (currentPubkey != null && currentPubkey.isNotEmpty)
+          ? DmRepository.computeConversationId([
+              currentPubkey,
+              moderationPubkey,
+            ])
+          : null;
       return _ReportConfirmationView(
         isFromShareMenu: widget.isFromShareMenu,
         moderationDmFailed: _moderationDmFailed,
+        moderationPubkey: moderationPubkey,
+        moderationConversationId: moderationConversationId,
       );
     }
 
@@ -514,6 +533,8 @@ class _ReportConfirmationView extends StatelessWidget {
   const _ReportConfirmationView({
     required this.isFromShareMenu,
     required this.moderationDmFailed,
+    required this.moderationPubkey,
+    required this.moderationConversationId,
   });
 
   final bool isFromShareMenu;
@@ -522,6 +543,15 @@ class _ReportConfirmationView extends StatelessWidget {
   /// send. The report itself still succeeded; this only drives a calm
   /// informational notice so the user isn't misled.
   final bool moderationDmFailed;
+
+  /// The Divine moderation account pubkey, passed to the conversation
+  /// route so it can render the thread.
+  final String moderationPubkey;
+
+  /// The 1:1 conversation id between the current user and the moderation
+  /// account. Null when signed out — the "Message the moderation team"
+  /// affordance is hidden in that case.
+  final String? moderationConversationId;
 
   @override
   Widget build(BuildContext context) {
@@ -588,6 +618,28 @@ class _ReportConfirmationView extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 24),
+          if (moderationConversationId case final conversationId?) ...[
+            DivineButton(
+              label: l10n.reportContactModeration,
+              type: DivineButtonType.secondary,
+              expanded: true,
+              onPressed: () {
+                // Capture the router before popping the sheet so the push
+                // doesn't run against a defunct context.
+                final router = GoRouter.of(context);
+                final navigator = Navigator.of(context);
+                navigator.pop();
+                if (isFromShareMenu) {
+                  navigator.pop();
+                }
+                router.push(
+                  ConversationPage.pathForId(conversationId),
+                  extra: [moderationPubkey],
+                );
+              },
+            ),
+            const SizedBox(height: 8),
+          ],
           DivineButton(
             label: l10n.reportClose,
             expanded: true,

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -170,6 +170,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   final ScrollController _scrollController = ScrollController();
   bool _isSubmitting = false;
   bool _submitted = false;
+  bool _moderationDmFailed = false;
   String? _errorMessage;
   bool _scrollWhenKeyboardOpens = false;
   double _previousViewInsetsBottom = 0;
@@ -234,7 +235,10 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
   @override
   Widget build(BuildContext context) {
     if (_submitted) {
-      return _ReportConfirmationView(isFromShareMenu: widget.isFromShareMenu);
+      return _ReportConfirmationView(
+        isFromShareMenu: widget.isFromShareMenu,
+        moderationDmFailed: _moderationDmFailed,
+      );
     }
 
     final l10n = context.l10n;
@@ -414,6 +418,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
           // Send DM to moderation team with report details (TC-025/026)
           final dmRepo = ref.read(dmRepositoryProvider);
           final labelService = ref.read(moderationLabelServiceProvider);
+          var moderationDmFailed = false;
           try {
             await dmRepo.sendMessage(
               recipientPubkey: labelService.divineModerationPubkeyHex,
@@ -422,8 +427,17 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
                 eventId: _eventId,
                 details: _detailsController.text.trim(),
               ),
+              // Moderation reports carry user identity + reported content;
+              // never let them degrade to a metadata-leaking NIP-04
+              // plaintext duplicate. NIP-17 gift wrap only.
+              skipNip04Fallback: true,
             );
           } catch (e) {
+            // The report itself already succeeded (relay + Zendesk); the
+            // moderation DM is a secondary notification. Don't fail the
+            // flow, but surface the outcome instead of swallowing it so
+            // the user isn't told the team was reached when it wasn't.
+            moderationDmFailed = true;
             Log.warning(
               'Failed to send moderation DM: $e',
               name: 'ReportContentDialog',
@@ -432,7 +446,10 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
           }
 
           if (mounted) {
-            setState(() => _submitted = true);
+            setState(() {
+              _submitted = true;
+              _moderationDmFailed = moderationDmFailed;
+            });
             final controller = widget.draggableController;
             if (controller != null && controller.isAttached) {
               controller.animateTo(
@@ -494,9 +511,17 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
 // =============================================================================
 
 class _ReportConfirmationView extends StatelessWidget {
-  const _ReportConfirmationView({required this.isFromShareMenu});
+  const _ReportConfirmationView({
+    required this.isFromShareMenu,
+    required this.moderationDmFailed,
+  });
 
   final bool isFromShareMenu;
+
+  /// Whether the secondary NIP-17 DM to the moderation team failed to
+  /// send. The report itself still succeeded; this only drives a calm
+  /// informational notice so the user isn't misled.
+  final bool moderationDmFailed;
 
   @override
   Widget build(BuildContext context) {
@@ -530,6 +555,13 @@ class _ReportConfirmationView extends StatelessWidget {
             l10n.reportReceivedReviewNotice,
             style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
           ),
+          if (moderationDmFailed) ...[
+            const SizedBox(height: 12),
+            Text(
+              l10n.reportModerationDmDelayed,
+              style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceMuted),
+            ),
+          ],
           const SizedBox(height: 8),
           GestureDetector(
             onTap: () async {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -831,6 +831,42 @@ class DmRepository {
   // Send - Text (Kind 14)
   // -------------------------------------------------------------------------
 
+  /// Resolves [pubkey]'s NIP-17 DM inbox relays from their kind-10050
+  /// "DM relays list" event.
+  ///
+  /// Returns the relay URLs the recipient prefers to receive gift-wrapped
+  /// DMs on, or `null` when no kind-10050 event is found (NIP-17: such a
+  /// user "is not ready to receive messages"). Callers route the gift
+  /// wrap to these relays; a `null` result lets the caller fall back to
+  /// the default relay pool so reachability is preserved for recipients
+  /// who have not advertised a DM inbox. Resolution failures degrade to
+  /// `null` rather than throwing, so a relay hiccup never blocks a send.
+  Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
+    try {
+      final events = await _nostrClient.queryEvents([
+        nostr_filter.Filter(
+          authors: [pubkey],
+          kinds: [EventKind.dmRelaysList],
+          limit: 1,
+        ),
+      ]);
+      if (events.isEmpty) return null;
+      // Newest wins for a replaceable event served from multiple relays.
+      events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      final relays = <String>{
+        for (final tag in events.first.tags)
+          if (tag.length >= 2 && tag[0] == 'relay' && tag[1].isNotEmpty) tag[1],
+      };
+      return relays.isEmpty ? null : relays.toList();
+    } on Object catch (e) {
+      Log.warning(
+        'Failed to resolve DM inbox relays for $pubkey: $e',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+  }
+
   /// Send a text message to a 1:1 conversation.
   ///
   /// Throws [StateError] if the repository has not been initialized.
@@ -901,9 +937,17 @@ class DmRepository {
       );
     }
 
+    // Route the gift wrap to the recipient's NIP-17 DM inbox relays
+    // (kind 10050) when they advertise one; null falls back to the
+    // default relay pool so reachability is preserved for recipients who
+    // have not published a DM inbox. Resolved after the queue enqueue
+    // above so the optimistic UI echo is never delayed by this lookup.
+    final inboxRelays = await resolveDmInboxRelays(recipientPubkey);
+
     final result = await _messageService!.sendRumor(
       rumorEvent: rumor,
       recipientPubkey: recipientPubkey,
+      targetRelays: inboxRelays,
     );
 
     if (result.success) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -67,6 +67,25 @@ const Set<int> _supportedDmKinds = {
   EventKind.fileMessage, // 15
 };
 
+const _relayLoopbackHosts = <String>{
+  'localhost',
+  '127.0.0.1',
+  '10.0.2.2',
+  '::1',
+};
+
+bool _isAllowedDmRelayUrl(String url) {
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;
+  if (uri.path.startsWith('//')) return false;
+  final scheme = uri.scheme.toLowerCase();
+  if (scheme == 'wss') return true;
+  if (scheme == 'ws') {
+    return _relayLoopbackHosts.contains(uri.host.toLowerCase());
+  }
+  return false;
+}
+
 /// Repository for NIP-17 direct message operations.
 ///
 /// Manages the full DM lifecycle:
@@ -855,7 +874,11 @@ class DmRepository {
       events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       final relays = <String>{
         for (final tag in events.first.tags)
-          if (tag.length >= 2 && tag[0] == 'relay' && tag[1].isNotEmpty) tag[1],
+          if (tag.length >= 2 &&
+              tag[0] == 'relay' &&
+              tag[1].isNotEmpty &&
+              _isAllowedDmRelayUrl(tag[1]))
+            tag[1],
       };
       return relays.isEmpty ? null : relays.toList();
     } on Object catch (e) {

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -96,6 +96,7 @@ class NIP17MessageService {
   Future<NIP17SendResult> sendRumor({
     required Event rumorEvent,
     required String recipientPubkey,
+    List<String>? targetRelays,
   }) async {
     try {
       Log.info(
@@ -136,8 +137,17 @@ class NIP17MessageService {
         category: LogCategory.system,
       );
 
-      // Publish the recipient's gift wrap
-      final sentEvent = await _nostrService.publishEvent(giftWrapEvent);
+      // Publish the recipient's gift wrap. Route it to the recipient's
+      // NIP-17 kind-10050 DM inbox relays when known (so non-diVine users
+      // who only read their own inbox relays actually receive it); fall
+      // back to the default pool otherwise. The no-targetRelays call shape
+      // is kept identical to preserve existing behavior.
+      final sentEvent = (targetRelays != null && targetRelays.isNotEmpty)
+          ? await _nostrService.publishEvent(
+              giftWrapEvent,
+              targetRelays: targetRelays,
+            )
+          : await _nostrService.publishEvent(giftWrapEvent);
 
       if (sentEvent is! PublishSuccess) {
         const errorMsg = 'Message publish failed to relays';

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2063,6 +2063,45 @@ void main() {
         );
       });
 
+      test('drops disallowed relay urls from kind-10050 events', () async {
+        stubQuery([
+          kind10050Event([
+            'wss://valid.example',
+            'ws://localhost:7777',
+            'ws://10.0.2.2:7777',
+            'ws://attacker.example',
+            'http://attacker.example',
+            'https://attacker.example',
+            'wss://http://attacker.example',
+            '',
+          ]),
+        ]);
+        final repository = createRepository();
+        expect(
+          await repository.resolveDmInboxRelays(_validPubkeyB),
+          [
+            'wss://valid.example',
+            'ws://localhost:7777',
+            'ws://10.0.2.2:7777',
+          ],
+        );
+      });
+
+      test(
+        'returns null when all kind-10050 relay urls are disallowed',
+        () async {
+          stubQuery([
+            kind10050Event([
+              'ws://attacker.example',
+              'http://attacker.example',
+              'wss://https://attacker.example',
+            ]),
+          ]);
+          final repository = createRepository();
+          expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+        },
+      );
+
       test('picks the newest event when relays return several', () async {
         stubQuery([
           kind10050Event(['wss://old.example']),

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -145,6 +145,17 @@ void main() {
         ),
       ).thenAnswer((_) async => []);
 
+      // Default for resolveDmInboxRelays(), which sendMessage now calls on
+      // every send: recipient has no kind-10050 list, so the gift wrap
+      // falls back to the default relay pool (existing behavior).
+      when(
+        () => mockNostrClient.queryEvents(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => <Event>[]);
+
       // Stub backfillCurrentUserHasSent for _backfillCurrentUserHasSent().
       when(
         () => mockConversationsDao.backfillCurrentUserHasSent(any()),
@@ -1994,6 +2005,105 @@ void main() {
     // -----------------------------------------------------------------
     // loadOlderMessages pagination
     // -----------------------------------------------------------------
+
+    group('resolveDmInboxRelays', () {
+      Event kind10050Event(List<String> relays, {int createdAt = 1700000000}) {
+        return Event(
+          _validPubkeyB,
+          EventKind.dmRelaysList,
+          [
+            for (final r in relays) ['relay', r],
+          ],
+          '',
+          createdAt: createdAt,
+        );
+      }
+
+      void stubQuery(List<Event> events) {
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((_) async => events);
+      }
+
+      test('returns relay urls from the kind-10050 relay tags', () async {
+        stubQuery([
+          kind10050Event(['wss://inbox.example', 'wss://inbox2.example']),
+        ]);
+        final repository = createRepository();
+        expect(
+          await repository.resolveDmInboxRelays(_validPubkeyB),
+          ['wss://inbox.example', 'wss://inbox2.example'],
+        );
+      });
+
+      test('returns null when no kind-10050 event exists', () async {
+        // setUp already stubs queryEvents -> [].
+        final repository = createRepository();
+        expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+      });
+
+      test('returns null when the event has no relay tags', () async {
+        stubQuery([kind10050Event(const [])]);
+        final repository = createRepository();
+        expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+      });
+
+      test('de-duplicates relay urls', () async {
+        stubQuery([
+          kind10050Event(['wss://a.example', 'wss://a.example']),
+        ]);
+        final repository = createRepository();
+        expect(
+          await repository.resolveDmInboxRelays(_validPubkeyB),
+          ['wss://a.example'],
+        );
+      });
+
+      test('picks the newest event when relays return several', () async {
+        stubQuery([
+          kind10050Event(['wss://old.example']),
+          kind10050Event(['wss://new.example'], createdAt: 1700000500),
+        ]);
+        final repository = createRepository();
+        expect(
+          await repository.resolveDmInboxRelays(_validPubkeyB),
+          ['wss://new.example'],
+        );
+      });
+
+      test('queries kind-10050 for the requested author', () async {
+        stubQuery(const []);
+        final repository = createRepository();
+        await repository.resolveDmInboxRelays(_validPubkeyB);
+        final captured =
+            verify(
+                  () => mockNostrClient.queryEvents(
+                    captureAny(),
+                    subscriptionId: any(named: 'subscriptionId'),
+                    useCache: any(named: 'useCache'),
+                  ),
+                ).captured.single
+                as List<nostr_filter.Filter>;
+        expect(captured.single.kinds, [EventKind.dmRelaysList]);
+        expect(captured.single.authors, [_validPubkeyB]);
+      });
+
+      test('returns null and does not throw when the query errors', () async {
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenThrow(Exception('relay down'));
+        final repository = createRepository();
+        expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
+      });
+    });
 
     group('loadOlderMessages', () {
       test('queries until:oldest with limit 50', () async {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -51,6 +51,44 @@ void main() {
       expect(service.nostrService, same(mockNostrClient));
     });
 
+    group('sendRumor relay targeting', () {
+      test(
+        'routes the recipient gift wrap to the provided targetRelays',
+        () async {
+          final captured = <List<String>?>[];
+          when(
+            () => mockNostrClient.publishEvent(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((invocation) async {
+            captured.add(
+              invocation.namedArguments[#targetRelays] as List<String>?,
+            );
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
+          });
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'routed message',
+          );
+          await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+            targetRelays: const ['wss://inbox.example.com'],
+          );
+
+          // The first publish is the recipient gift wrap; it must be routed
+          // to the recipient's NIP-17 DM inbox relays (the self-wrap, if any,
+          // follows with no targetRelays).
+          expect(captured, isNotEmpty);
+          expect(captured.first, const ['wss://inbox.example.com']);
+        },
+      );
+    });
+
     group('sendPrivateMessage', () {
       test('returns success with gift wrap event details', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(

--- a/mobile/packages/nostr_sdk/lib/event_kind.dart
+++ b/mobile/packages/nostr_sdk/lib/event_kind.dart
@@ -85,6 +85,11 @@ class EventKind {
 
   static const int relayListMetadata = 10002;
 
+  /// NIP-17 DM relay list ("DM inbox"). A replaceable event whose `relay`
+  /// tags advertise where the author prefers to receive gift-wrapped
+  /// (kind 1059) direct messages.
+  static const int dmRelaysList = 10050;
+
   static const int profileBadges = 10008;
 
   static const int bookmarksList = 10003;

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -442,6 +442,10 @@ const _knownUntranslatedDebt = {
   // divine.video/safety" link). Falls back to English in non-English
   // locales until translated.
   'reportLearnMoreAt',
+  // Added by the moderation-report confirmation state. English ships;
+  // other locales fall back until the next translation pass.
+  'reportModerationDmDelayed',
+  'reportContactModeration',
   // Added by the desktop save-to-Downloads log export flow. Other locales
   // fall back to English until the next translation pass.
   'supportLogsSavedTo',

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -661,6 +661,7 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -737,6 +738,7 @@ void main() {
           recipientPubkey: ModerationLabelService.fallbackModerationPubkeyHex,
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).called(1);
     });
@@ -752,6 +754,7 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: captureAny(named: 'content'),
           replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).captured;
 
@@ -779,6 +782,7 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenThrow(Exception('DM relay unreachable'));
 
@@ -790,6 +794,37 @@ void main() {
         findsOneWidget,
         reason: 'Report should succeed even if DM fails',
       );
+      // C9: the swallowed DM failure is now surfaced as a calm notice
+      // instead of only a log line.
+      expect(find.text(l10n.reportModerationDmDelayed), findsOneWidget);
+    });
+
+    testWidgets('moderation DM opts out of the NIP-04 fallback (privacy)', (
+      tester,
+    ) async {
+      await setLargeSurface(tester);
+      await openAndSubmitReport(tester);
+
+      // C8: moderation reports carry user identity + reported content and
+      // must never degrade to a metadata-leaking NIP-04 plaintext duplicate.
+      verify(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: true,
+        ),
+      ).called(1);
+    });
+
+    testWidgets('does not show the DM-delayed notice when the DM succeeds', (
+      tester,
+    ) async {
+      await setLargeSurface(tester);
+      await openAndSubmitReport(tester);
+
+      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
+      expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
     });
 
     testWidgets(
@@ -801,6 +836,7 @@ void main() {
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
             replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
           ),
         ).thenThrow(Exception('No keys available'));
 
@@ -858,6 +894,7 @@ void main() {
             recipientPubkey: any(named: 'recipientPubkey'),
             content: any(named: 'content'),
             replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
           ),
         );
       },
@@ -888,6 +925,7 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -970,6 +1008,7 @@ void main() {
             recipientPubkey: any(named: 'recipientPubkey'),
             content: captureAny(named: 'content'),
             replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
           ),
         ).captured;
 
@@ -1021,6 +1060,7 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
           replyToId: any(named: 'replyToId'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -1130,6 +1170,7 @@ void main() {
             recipientPubkey: any(named: 'recipientPubkey'),
             content: captureAny(named: 'content'),
             replyToId: any(named: 'replyToId'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
           ),
         ).captured;
 

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -827,6 +827,85 @@ void main() {
       expect(find.text(l10n.reportModerationDmDelayed), findsNothing);
     });
 
+    Widget buildSubjectWithAuth(MockAuthService auth) {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showDialog<void>(
+                    context: context,
+                    builder: (_) =>
+                        Material(child: ReportContentDialog(video: testVideo)),
+                  ),
+                  child: const Text('Open Report'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      return testProviderScope(
+        mockNostrService: mockNostrClient,
+        mockAuthService: auth,
+        mockModerationLabelService: mockModerationLabelService,
+        additionalOverrides: [
+          contentReportingServiceProvider.overrideWith(
+            (ref) async => mockReportingService,
+          ),
+          dmRepositoryProvider.overrideWithValue(mockDmRepository),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+    }
+
+    Future<void> openSubmitWithAuth(
+      WidgetTester tester,
+      MockAuthService a,
+    ) async {
+      await tester.pumpWidget(buildSubjectWithAuth(a));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open Report'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.reportReasonSpam));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'shows the "Message the moderation team" affordance when signed in',
+      (tester) async {
+        final mockAuth = createMockAuthService();
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(
+          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738',
+        );
+
+        await setLargeSurface(tester);
+        await openSubmitWithAuth(tester, mockAuth);
+
+        expect(find.text(l10n.reportContactModeration), findsOneWidget);
+      },
+    );
+
+    testWidgets('hides the contact-moderation affordance when signed out', (
+      tester,
+    ) async {
+      // createMockAuthService stubs currentPublicKeyHex -> null.
+      await setLargeSurface(tester);
+      await openSubmitWithAuth(tester, createMockAuthService());
+
+      expect(find.text(l10n.reportReceivedTitle), findsOneWidget);
+      expect(find.text(l10n.reportContactModeration), findsNothing);
+    });
+
     testWidgets(
       'report succeeds when DM send throws (unauthenticated/no keys)',
       (tester) async {


### PR DESCRIPTION
## Summary

Second slice of the #570 (NIP-17 moderation DM) work — the **moderation-communication** pieces that don't depend on backend/ops. Independent of the security-crypto PR (#4943); targets `main`. Three delineated commits.

### 1. Route NIP-17 sends to the recipient's kind-10050 DM inbox relays
Per NIP-17, a gift wrap **MUST** be published to the recipient's kind-10050 "DM relays list", or a Nostr user who only reads their own inbox relays never receives it (the TC-SOCIAL-025 gap). `EventKind.dmRelaysList`; `DmRepository.resolveDmInboxRelays` (newest/dedup, `null`→default-pool fallback); `targetRelays` threaded through `sendRumor`→`publishEvent` (conditional shape preserves existing stubs); resolved after the queue enqueue so the optimistic echo isn't delayed.

### 2. Harden the moderation report DM (C8 + C9)
- **C8**: `skipNip04Fallback: true` — moderation reports never degrade to a metadata-leaking NIP-04 plaintext duplicate.
- **C9**: a failed moderation DM was swallowed; now surfaced as a calm, non-blocking notice (`reportModerationDmDelayed`). The report still succeeds via relay + Zendesk.

### 3. "Message the moderation team" entry point
A secondary button on the report confirmation screen deep-links into the NIP-17 conversation with the moderation account (reusing the minor-account-review nav pattern); hidden when signed out.

## Test plan
- [x] `dm_repository` 279, `nostr_sdk` 275, `report_content_dialog` 33 widget tests, `flutter analyze` clean, `gen-l10n` regenerated.

## Scope / follow-ups
- **No behavior change** until recipients advertise kind-10050 (the routing falls back to broadcast otherwise — universal today, see ops #4946).
- **Deferred / decisions:** C10 moderation-pubkey pin is a security/rotation tradeoff held for sign-off (#4948).
- **Backend/ops:** divine-moderation-service#169 (server-side kind-10050 + Zendesk bridge), #4946 (ops: publish moderation@ kind-10050, relay accept kind-10050, Keycast), #4947 (operator surface).

Refs #570