### PR TITLE
feat(db): SQLCipher at-rest encryption — foundation + device-QA plan (#570) [DRAFT]

### DIFF
--- a/mobile/docs/sqlcipher_at_rest_plan.md
+++ b/mobile/docs/sqlcipher_at_rest_plan.md
@@ -1,0 +1,117 @@
+# SQLCipher at-rest encryption for the local DB (#570, finding C2)
+
+Status: **device-QA-gated draft.** This PR commits only the pure,
+unit-tested key-pragma helper (`formatCipherKeyPragma`,
+`connection_native.dart`). The native-lib swap, the app-layer key
+bootstrap, the connection wiring, and the one-time plaintext→encrypted
+migration are specified here and must be **validated on real devices**
+before they land — they cannot be exercised in CI (the host test VM uses
+`NativeDatabase.memory()` and never loads the SQLCipher native libraries).
+
+## Why
+
+DMs (and the rest of the shared `divine_db.db`: drafts, pending uploads,
+pending actions, outgoing DMs, reactions, reposts, notifications,
+bookmarks, NIP-05 verifications) are stored **plaintext at rest** today
+(`connection_native.dart` opens a plain `NativeDatabase`; `db_client`
+has no SQLCipher). For a moderation account holding reports about users,
+plaintext-at-rest is materially more sensitive. Decision (#570): encrypt
+at rest before the T&S moderation launch.
+
+## What is NOT in scope
+
+- **Web / IndexedDB** (`connection_web.dart`): SQLCipher is native-only.
+  Web at-rest encryption is deferred behind the existing OPFS migration
+  (`#373`). Desktop/macOS **is** covered by `sqlcipher_flutter_libs`.
+- **Backend D1 retention**: the backend stores DMs plaintext indefinitely
+  in `dm_log` — a separate data-minimization item (tracked separately).
+
+## Implementation steps
+
+### 1. Native lib swap (build-config; device QA)
+`mobile/pubspec.yaml:293` — replace `sqlite3_flutter_libs: ^0.5.40` with
+`sqlcipher_flutter_libs: ^0.5.x` (same simolus3 family). Both `db_client`
+and `cache_sync` resolve `package:sqlite3` to the cipher build, so one
+lib covers both. Run `flutter pub get`; commit the `pubspec.lock` delta.
+**QA: full device builds on iOS, Android, and macOS** — this changes the
+linked SQLite for the whole app.
+
+### 2. Key bootstrap (app layer)
+New `mobile/lib/services/database_encryption_bootstrap.dart`:
+- Call `sqlcipher_flutter_libs`' `applyWorkaroundToOpenSqlite3OnOldAndroidVersions()`
+  and `open.overrideForAll(openCipherOnAndroid())` (per the package docs)
+  so `package:sqlite3` binds the cipher build **before** the first
+  `AppDatabase()` open.
+- Read-or-generate a **32-byte CSPRNG** key in `flutter_secure_storage`
+  under `db.cipher.key.v1`, hex-encoded (64 chars). Generate once; never
+  log it; never derive it from anything guessable.
+
+### 3. Key custody respects the layer boundary
+`db_client` stays low-level and must **not** import
+`flutter_secure_storage`. The app reads the key and **injects** it.
+Add `openEncryptedConnection({required String rawKeyHex})` to the three
+connection variants:
+- `connection_native.dart` (real): `NativeDatabase(file, setup: (raw) =>
+  raw.execute(formatCipherKeyPragma(rawKeyHex)))` — `formatCipherKeyPragma`
+  is the helper committed in this PR.
+- `connection_web.dart` (delegate-and-ignore — no native cipher on web).
+- `connection_stub.dart` (throw `UnsupportedError`).
+
+### 4. Provider wiring
+- `dbCipherKeyProvider` seeded at app root via
+  `ProviderScope(overrides: [dbCipherKeyProvider.overrideWithValue(key)])`
+  after the bootstrap resolves the key.
+- `database_provider.dart` opens `AppDatabase(openEncryptedConnection(
+  rawKeyHex: ref.watch(dbCipherKeyProvider)))`.
+
+### 5. One-time in-place migration (the dangerous part — device QA)
+**Recommended: in-place rekey via `sqlcipher_export`, NOT wipe-and-resync.**
+Rationale: the DM store is **not** standalone — it shares `divine_db.db`
+with drafts, pending uploads, pending publishes, etc. Wipe-and-resync
+would re-fetch DMs from relays via `DmSyncState` but **permanently
+destroy** all other local-only rows — unacceptable.
+
+Safe-by-construction sequence (gate one-time by bumping `dbCacheVersion`
+2→3, reusing the existing version-file mechanism in
+`connection_native.dart`):
+
+1. Detect a **plaintext** `divine_db.db` (open with no key / probe
+   `PRAGMA cipher_version`).
+2. `ATTACH DATABASE '<new>.enc' AS encrypted KEY "x'<key>'";`
+3. `SELECT sqlcipher_export('encrypted');`
+4. `DETACH DATABASE encrypted;`
+5. **Verify** the encrypted file opens with the key and the expected
+   tables/row-counts match the plaintext source.
+6. **Only then** atomically swap (reuse the existing rename +
+   `_moveSidecars` sidecar handling), keeping the plaintext file as a
+   timestamped backup until the next successful launch.
+7. On **any** failure at steps 2–6: keep using the plaintext DB, report
+   to Crashlytics, and retry next launch. Never delete the source before
+   the encrypted copy is verified.
+
+### 6. Open product decision (key loss)
+`flutter_secure_storage` can be cleared (OS keystore reset, restore to a
+new device without keychain migration). If the key is lost, the encrypted
+DB is unrecoverable. Decide: **wipe-and-resync DMs** (acceptable — they
+re-fetch from relays) vs **block**. Recommended: on
+"key missing but encrypted DB present", wipe + resync (DMs only) and
+regenerate the key, surfacing a one-time notice. This is a product call.
+
+## Device-QA checklist (must pass before un-drafting)
+- [ ] iOS / Android / macOS build + launch with `sqlcipher_flutter_libs`.
+- [ ] Fresh install: DB is created encrypted; `PRAGMA cipher_version`
+      is non-empty; the file is not readable by plain `sqlite3`.
+- [ ] Upgrade from a populated **plaintext** DB: migration runs once,
+      all tables + row counts preserved, app fully functional, plaintext
+      backup present then cleaned on next launch.
+- [ ] Force-kill mid-migration → next launch recovers (plaintext intact,
+      retried), no data loss.
+- [ ] Key-loss path (clear keystore): chosen recovery behavior (§6) works
+      and does not brick the app.
+- [ ] No measurable regression on cold-start DB open on a low-end device
+      (SQLCipher adds ~5–15%).
+- [ ] Key never appears in logs / Crashlytics.
+
+## Committed in this PR
+- `formatCipherKeyPragma(rawKeyHex)` + 5 unit tests — the raw-key PRAGMA
+  builder used by step 3. Pure and testable; the rest is device-QA-gated.

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -27,6 +27,36 @@ QueryExecutor openConnection() {
 bool get _isFlutterTestProcess =>
     Platform.executable.contains('flutter_tester');
 
+/// Builds the SQLCipher `PRAGMA key` statement for a **raw** 32-byte key.
+///
+/// The key is supplied as 64 hex characters and wrapped in SQLCipher's
+/// raw-key form (`x'...'`) so SQLCipher uses the bytes verbatim and skips
+/// PBKDF2 derivation — appropriate when the key is a CSPRNG-generated
+/// 32-byte value held in the platform keystore (flutter_secure_storage),
+/// not a human passphrase.
+///
+/// This is the foundational building block for at-rest DM encryption
+/// (see `mobile/docs/sqlcipher_at_rest_plan.md`). It is deliberately the
+/// only part committed as code here and is `@visibleForTesting`: it is
+/// the sole piece of the SQLCipher work that can be unit-tested without
+/// the native cipher libraries — the host test VM uses an in-memory
+/// database (`NativeDatabase.memory()` above) and never loads them, so
+/// the encrypted-open path and the in-place migration must be validated
+/// on-device (see the plan's QA checklist).
+///
+/// Throws [ArgumentError] if [rawKeyHex] is not exactly 64 hex characters.
+@visibleForTesting
+String formatCipherKeyPragma(String rawKeyHex) {
+  if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(rawKeyHex)) {
+    throw ArgumentError.value(
+      rawKeyHex,
+      'rawKeyHex',
+      'must be exactly 64 hex characters (a raw 32-byte SQLCipher key)',
+    );
+  }
+  return 'PRAGMA key = "x\'$rawKeyHex\'";';
+}
+
 /// Get path to shared database file
 ///
 /// Path: {appSupport}/openvine/database/divine_db.db

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -404,6 +404,37 @@ void main() {
       expect(File('$newPath-shm').existsSync(), isFalse);
     });
   });
+
+  group('formatCipherKeyPragma', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+
+    test('wraps a 64-hex key in the SQLCipher raw-key PRAGMA form', () {
+      expect(
+        formatCipherKeyPragma(validKey),
+        equals('PRAGMA key = "x\'$validKey\'";'),
+      );
+    });
+
+    test('accepts upper-case hex', () {
+      expect(
+        formatCipherKeyPragma(validKey.toUpperCase()),
+        equals('PRAGMA key = "x\'${validKey.toUpperCase()}\'";'),
+      );
+    });
+
+    test('rejects a key that is too short', () {
+      expect(() => formatCipherKeyPragma('abcd'), throwsArgumentError);
+    });
+
+    test('rejects a key with non-hex characters', () {
+      expect(() => formatCipherKeyPragma('z' * 64), throwsArgumentError);
+    });
+
+    test('rejects an empty key (no accidental plaintext open)', () {
+      expect(() => formatCipherKeyPragma(''), throwsArgumentError);
+    });
+  });
 }
 
 void _createSqliteDatabase(


### PR DESCRIPTION
> **Draft — device QA gates this.** Encrypting the local DB with SQLCipher cannot be validated in CI (the host test VM uses `NativeDatabase.memory()` and never loads the cipher native libs). This PR commits the **pure, unit-tested foundation** + a complete implementation/migration/QA plan; the native-lib swap, app bootstrap wiring, and the destructive in-place migration are intentionally **not** shipped as un-runnable code.

## Summary

Finding **C2** of #570: DMs (and the rest of the shared `divine_db.db`) are stored **plaintext at rest**. For a moderation account holding reports about users this is materially sensitive, so the decision was to encrypt at rest before the T&S launch.

## What's in this PR (committed, verified)
- **`formatCipherKeyPragma(rawKeyHex)`** in `connection_native.dart` — builds the SQLCipher raw-key `PRAGMA key = "x'...'"` from a 64-hex (32-byte CSPRNG) key. This is the one piece that's pure and unit-testable.
- **5 unit tests** (format / upper-case / too-short / non-hex / empty-rejects). `db_client`: 27 tests pass, analyze clean.
- **`mobile/docs/sqlcipher_at_rest_plan.md`** — the full remaining plan.

## What's device-QA-gated (in the plan, not committed)
1. **Native-lib swap** `sqlite3_flutter_libs` → `sqlcipher_flutter_libs` (affects the whole app's SQLite; needs iOS/Android/macOS device builds).
2. **App-layer key bootstrap** (CSPRNG key in `flutter_secure_storage`, cipher-lib override before first open).
3. **`openEncryptedConnection({rawKeyHex})`** across the 3 connection variants (key injected from the app — `db_client` stays low-level).
4. **One-time in-place rekey migration** via `sqlcipher_export`, **safe-by-construction**: verify-the-encrypted-copy-before-swap, keep a plaintext backup, retry on failure, never delete the source first. Wipe-and-resync is rejected because the DM store shares `divine_db.db` with drafts / pending uploads / pending publishes.
5. **Key-loss product decision** (keystore reset → wipe+resync DMs vs block).

## Why a draft, not a merge
A destructive migration over real users' shared DB that I cannot execute in this environment must be validated on real devices first. The plan's **device-QA checklist** gates un-drafting.

Refs #570