### PR TITLE
fix(test): de-flake minor-account-review under-13 support screen test

### DIFF
--- a/mobile/test/screens/minor_account_review_under13_support_screen_test.dart
+++ b/mobile/test/screens/minor_account_review_under13_support_screen_test.dart
@@ -12,6 +12,11 @@ void main() {
 
   group('MinorAccountReviewUnder13SupportScreen', () {
     testWidgets('shows copy affordances and copies values', (tester) async {
+      // Pin a tall surface so the scrollable guidance content fits and no
+      // button sits at the obscured bottom edge of the default 800x600
+      // viewport (flaky off-screen/ignore-pointer tap in CI).
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       String? copiedText;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, (call) async {
@@ -60,6 +65,8 @@ void main() {
       expect(find.byTooltip('Copy support email'), findsOneWidget);
       expect(find.byTooltip('Copy case ID'), findsOneWidget);
 
+      await tester.ensureVisible(find.byTooltip('Copy support email'));
+      await tester.pumpAndSettle();
       await tester.tap(find.byTooltip('Copy support email'));
       await tester.pumpAndSettle();
 
@@ -69,6 +76,10 @@ void main() {
     testWidgets('opens email with the prepared under-13 guidance', (
       tester,
     ) async {
+      // See the surface-size note above: keeps "Open email app" (a bottom
+      // button in a scrollable ListView) fully hittable in CI.
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       String? sentToEmail;
       String? sentSubject;
       String? sentBody;
@@ -113,6 +124,8 @@ void main() {
         ),
       );
 
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Open email app'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Open email app'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
Closes #4950

## Problem

`test/screens/minor_account_review_under13_support_screen_test.dart` → "opens email with the prepared under-13 guidance" intermittently fails in CI with an **off-screen / ignore-pointer tap** on "Open email app":

```
Warning: A call to tap() ... derived an Offset (Offset(440.0, 540.0)) that
would not hit test on the specified widget. Maybe the widget is actually
off-screen, or another widget is obscuring it ...
Expected: 'support@divine.video'  Which: not an <Instance of 'String'>
```

The button is the **last item in a scrollable `ListView`**, so at the default 800×600 test surface it sits at the bottom edge, where an overlay can absorb the pointer during the async loading→content settle (the screen's status provider is async). It **passes in isolation**, which hid the flake; full-suite timing exposes it. (Surfaced while working on #570 — the failure is unrelated to that change, which lives in separate test isolates.)

## Fix

Matches the established surface-size-pinning precedent (#4721):
- Pin a tall `800×1600` surface (with `addTearDown` reset) so the content fits and no tap target sits at the obscured bottom edge.
- `ensureVisible` the tap targets before tapping.
- Applied to both tests in the file. **No production code change.**

## Test plan
- [x] Both tests pass locally; `dart format` + `flutter analyze` clean.
- CI validates the de-flake (it passes locally regardless of the fix).