### PR TITLE
test(nip44): make vector fixture lookup workspace-safe

### DIFF
--- a/mobile/packages/nostr_sdk/test/nip44/nip44_v2_vectors_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip44/nip44_v2_vectors_test.dart
@@ -1,8 +1,8 @@
 // ABOUTME: Conformance test for the NIP-44 v2 implementation against the
 // ABOUTME: official cross-implementation test vectors (paulmillr/nip44).
 //
-// The vendored fixture `fixtures/nip44.vectors.json` is pinned by NIP-44 to
-// sha256 269ed0f69e4c192512cc779e78c555090cebc7c785b609e338a62afc3ce25040.
+// The vendored fixture `fixtures/nip44.vectors.json` is pinned by NIP-44; the
+// expected sha256 is enforced at runtime against `_vectorsFixtureSha256`.
 // This is the first NIP-44 vector coverage in the repo; it asserts both the
 // `valid.*` round-trips AND that `invalid.decrypt` payloads throw — a forged
 // MAC, bad padding, or wrong version must never decrypt to plaintext.
@@ -48,7 +48,13 @@ void main() {
     setUpAll(() {
       final file = _vectorsFixtureFile();
       final bytes = file.readAsBytesSync();
-      expect(sha256.convert(bytes).toString(), equals(_vectorsFixtureSha256));
+      expect(
+        sha256.convert(bytes).toString(),
+        equals(_vectorsFixtureSha256),
+        reason:
+            'nip44.vectors.json drifted from the NIP-44 pinned sha256; '
+            're-vendor from paulmillr/nip44 or update the pin deliberately',
+      );
       final v2 =
           (jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>)['v2']
               as Map<String, dynamic>;

--- a/mobile/packages/nostr_sdk/test/nip44/nip44_v2_vectors_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip44/nip44_v2_vectors_test.dart
@@ -11,13 +11,34 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hex/hex.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
 
+const _vectorsFixtureSha256 =
+    '269ed0f69e4c192512cc779e78c555090cebc7c785b609e338a62afc3ce25040';
+
 Uint8List _hexBytes(String hex) => Uint8List.fromList(HEX.decode(hex));
 String _hex(List<int> bytes) => HEX.encode(bytes);
+
+File _vectorsFixtureFile() {
+  final candidates = [
+    File('test/nip44/fixtures/nip44.vectors.json'),
+    File('packages/nostr_sdk/test/nip44/fixtures/nip44.vectors.json'),
+  ];
+
+  for (final file in candidates) {
+    if (file.existsSync()) {
+      return file;
+    }
+  }
+
+  throw StateError(
+    'Could not find nip44.vectors.json from ${Directory.current.path}',
+  );
+}
 
 void main() {
   group('NIP44V2 official vectors', () {
@@ -25,9 +46,11 @@ void main() {
     late Map<String, dynamic> invalid;
 
     setUpAll(() {
-      final file = File('test/nip44/fixtures/nip44.vectors.json');
+      final file = _vectorsFixtureFile();
+      final bytes = file.readAsBytesSync();
+      expect(sha256.convert(bytes).toString(), equals(_vectorsFixtureSha256));
       final v2 =
-          (jsonDecode(file.readAsStringSync()) as Map<String, dynamic>)['v2']
+          (jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>)['v2']
               as Map<String, dynamic>;
       valid = v2['valid'] as Map<String, dynamic>;
       invalid = v2['invalid'] as Map<String, dynamic>;


### PR DESCRIPTION
Refs #570

## Summary
- make the NIP-44 vector fixture lookup work from both the package root and the mobile workspace root
- enforce the documented fixture sha256 at runtime so fixture drift is caught by the test

## Verification
- mise exec flutter@3.44.0 -- flutter analyze packages/nostr_sdk/test/nip44/nip44_v2_vectors_test.dart
- mise exec flutter@3.44.0 -- flutter test test/nip44/nip44_v2_vectors_test.dart (from mobile/packages/nostr_sdk)
- mise exec flutter@3.44.0 -- flutter test packages/nostr_sdk/test/nip44/nip44_v2_vectors_test.dart (from mobile)
- pre-push hook analyzer and changed-file test passed