### PR TITLE
fix(ci): handle FlutterFramework SPM deployment target

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -65,7 +65,16 @@ definitions:
 
         files.each do |path|
           contents = File.read(path)
-          updated = contents.gsub('.iOS("13.0")', '.iOS("16.0")')
+          updated = contents
+            .gsub('.iOS("13.0")', '.iOS("16.0")')
+            .gsub('.iOS(.v13)', '.iOS("16.0")')
+
+          unless updated.include?('.iOS("16.0")')
+            updated = updated.sub(
+              /(let package = Package\(\n\s*name: "[^"]+",\n)/,
+              "\\1    platforms: [\n        .iOS(\"16.0\")\n    ],\n",
+            )
+          end
 
           unless updated.include?('.iOS("16.0")')
             abort("expected #{path} to declare iOS 16.0")


### PR DESCRIPTION
Closes #4958

## Summary
- make the Codemagic iOS SPM deployment-target patch handle generated packages with no `platforms` block
- keep existing support for `.iOS("13.0")`, and add support for `.iOS(.v13)`
- fixes the iOS build failure where `FlutterFramework/Package.swift` did not declare iOS 16.0

## Verification
- Reproduced the previous abort locally against generated `ios/Flutter/ephemeral/Packages/.packages/FlutterFramework/Package.swift`
- Ran `flutter pub get && flutter build ios --config-only` from `mobile/`
- Ran the patched Ruby block against generated package manifests:
  - `FlutterGeneratedPluginSwiftPackage/Package.swift already targets iOS 16.0`
  - `patched .../FlutterFramework/Package.swift to iOS 16.0`
- `git diff --check`
- pre-push hook: no merge conflicts with main; no Dart files changed
