### PR TITLE
fix(ci): harden iOS SPM target patch

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -68,15 +68,21 @@ definitions:
           updated = contents
             .gsub('.iOS("13.0")', '.iOS("16.0")')
             .gsub('.iOS(.v13)', '.iOS("16.0")')
+          has_ios_16_target = updated.match?(/\.iOS\(("16\.0"|\.v16)\)/)
 
-          unless updated.include?('.iOS("16.0")')
+          unless has_ios_16_target
+            if updated.match?(/^\s*platforms:\s*\[/)
+              abort("expected #{path} platforms block to declare iOS 16.0")
+            end
+
             updated = updated.sub(
               /(let package = Package\(\n\s*name: "[^"]+",\n)/,
               "\\1    platforms: [\n        .iOS(\"16.0\")\n    ],\n",
             )
+            has_ios_16_target = updated.match?(/\.iOS\(("16\.0"|\.v16)\)/)
           end
 
-          unless updated.include?('.iOS("16.0")')
+          unless has_ios_16_target
             abort("expected #{path} to declare iOS 16.0")
           end
 


### PR DESCRIPTION
Refs #4958
Follow-up to #4957.

## Summary
- keep the merged iOS SPM deployment-target patch from #4957
- avoid injecting a second platforms block when a generated manifest already has one
- accept both string and enum iOS 16 target forms before patching

## Verification
- Ruby compile check for the embedded Codemagic script
- Fixture behavior check for no platforms block, string 13.0, enum v13, enum v16, and existing non-16 platforms block
- git diff --check