### PR TITLE
fix(feed): paginate for you recommendations with cursors

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -373,6 +373,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
+    if (state.source.type == VideoFeedSourceType.forYou &&
+        state.paginationCursor == null) {
+      emit(state.copyWith(hasMore: false));
+      return;
+    }
+
     emit(state.copyWith(isLoadingMore: true));
 
     try {
@@ -428,7 +434,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           videos: updatedVideos,
           // Only stop pagination when the server returns nothing.
           // Fewer than _pageSize can happen due to server-side filtering.
-          hasMore: result.hasMore ?? result.videos.isNotEmpty,
+          hasMore: _hasMoreForSource(
+            state.source,
+            result,
+            fallbackHasMore: result.videos.isNotEmpty,
+          ),
           isLoadingMore: false,
           videoListSources: mergedSources,
           listOnlyVideoIds: mergedListOnly,
@@ -681,10 +691,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           videos: validVideos,
           // Only stop pagination when no results at all.
           // Fewer than _pageSize can happen due to server-side filtering.
-          hasMore:
-              result.hasMore ??
-              (source.type != VideoFeedSourceType.subscribedList &&
-                  validVideos.isNotEmpty),
+          hasMore: _hasMoreForSource(
+            source,
+            result,
+            fallbackHasMore:
+                source.type != VideoFeedSourceType.subscribedList &&
+                validVideos.isNotEmpty,
+          ),
           clearError: true,
           videoListSources: result.videoListSources,
           listOnlyVideoIds: result.listOnlyVideoIds,
@@ -729,6 +742,19 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         );
       }
     }
+  }
+
+  bool _hasMoreForSource(
+    VideoFeedSource source,
+    HomeFeedResult result, {
+    required bool fallbackHasMore,
+  }) {
+    final upstreamHasMore = result.hasMore ?? fallbackHasMore;
+    if (source.type != VideoFeedSourceType.forYou) {
+      return upstreamHasMore;
+    }
+
+    return upstreamHasMore && result.paginationCursor != null;
   }
 
   /// Fetch videos for a specific mode from the repository.

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -383,9 +383,15 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       final oldestCreatedAt = state.videos
           .map((v) => v.createdAt)
           .reduce((a, b) => a < b ? a : b);
-      final cursor = oldestCreatedAt - 1;
+      final until = oldestCreatedAt - 1;
 
-      final result = await _fetchVideosForSource(state.source, until: cursor);
+      final result = await _fetchVideosForSource(
+        state.source,
+        until: state.source.type == VideoFeedSourceType.forYou ? null : until,
+        paginationCursor: state.source.type == VideoFeedSourceType.forYou
+            ? state.paginationCursor
+            : null,
+      );
 
       // Filter out videos without valid URLs
       final validNewVideos = result.videos
@@ -422,10 +428,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           videos: updatedVideos,
           // Only stop pagination when the server returns nothing.
           // Fewer than _pageSize can happen due to server-side filtering.
-          hasMore: result.videos.isNotEmpty,
+          hasMore: result.hasMore ?? result.videos.isNotEmpty,
           isLoadingMore: false,
           videoListSources: mergedSources,
           listOnlyVideoIds: mergedListOnly,
+          paginationCursor: result.paginationCursor,
+          clearPaginationCursor: result.paginationCursor == null,
         ),
       );
 
@@ -641,6 +649,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
               status: VideoFeedStatus.success,
               videos: cachedValid,
               hasMore: true,
+              clearPaginationCursor: true,
               clearError: true,
             ),
           );
@@ -673,11 +682,14 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           // Only stop pagination when no results at all.
           // Fewer than _pageSize can happen due to server-side filtering.
           hasMore:
-              source.type != VideoFeedSourceType.subscribedList &&
-              validVideos.isNotEmpty,
+              result.hasMore ??
+              (source.type != VideoFeedSourceType.subscribedList &&
+                  validVideos.isNotEmpty),
           clearError: true,
           videoListSources: result.videoListSources,
           listOnlyVideoIds: result.listOnlyVideoIds,
+          paginationCursor: result.paginationCursor,
+          clearPaginationCursor: result.paginationCursor == null,
         ),
       );
 
@@ -732,13 +744,21 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   Future<HomeFeedResult> _fetchVideosForSource(
     VideoFeedSource source, {
     int? until,
+    String? paginationCursor,
     bool skipCache = false,
   }) => switch (source.type) {
-    VideoFeedSourceType.forYou => _videosRepository.getRecommendedVideos(
-      userPubkey: _userPubkey,
-      until: until,
-      skipCache: skipCache,
-    ),
+    VideoFeedSourceType.forYou =>
+      paginationCursor == null
+          ? _videosRepository.getRecommendedVideos(
+              userPubkey: _userPubkey,
+              until: until,
+              skipCache: skipCache,
+            )
+          : _videosRepository.getRecommendedVideos(
+              userPubkey: _userPubkey,
+              cursor: paginationCursor,
+              skipCache: skipCache,
+            ),
     VideoFeedSourceType.following => _videosRepository.getHomeFeedVideos(
       authors: _followRepository.followingPubkeys,
       userPubkey: _userPubkey,

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -143,6 +143,7 @@ final class VideoFeedBlocState extends Equatable {
     this.videoListSources = const {},
     this.listOnlyVideoIds = const {},
     this.creatorProfiles = const {},
+    this.paginationCursor,
   }) : source =
            source ??
            (mode == FeedMode.following
@@ -165,6 +166,9 @@ final class VideoFeedBlocState extends Equatable {
 
   /// Whether more videos can be loaded via pagination.
   final bool hasMore;
+
+  /// Opaque cursor for cursor-backed feeds.
+  final String? paginationCursor;
 
   /// Whether a load-more operation is in progress.
   final bool isLoadingMore;
@@ -224,6 +228,8 @@ final class VideoFeedBlocState extends Equatable {
     Map<String, Set<String>>? videoListSources,
     Set<String>? listOnlyVideoIds,
     Map<String, UserProfile>? creatorProfiles,
+    String? paginationCursor,
+    bool clearPaginationCursor = false,
   }) {
     return VideoFeedBlocState(
       status: status ?? this.status,
@@ -238,6 +244,9 @@ final class VideoFeedBlocState extends Equatable {
       videoListSources: videoListSources ?? this.videoListSources,
       listOnlyVideoIds: listOnlyVideoIds ?? this.listOnlyVideoIds,
       creatorProfiles: creatorProfiles ?? this.creatorProfiles,
+      paginationCursor: clearPaginationCursor
+          ? null
+          : (paginationCursor ?? this.paginationCursor),
     );
   }
 
@@ -253,5 +262,6 @@ final class VideoFeedBlocState extends Equatable {
     videoListSources,
     listOnlyVideoIds,
     creatorProfiles,
+    paginationCursor,
   ];
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1907,6 +1907,7 @@ class FunnelcakeApiClient {
   /// [fallback] is the strategy when personalization is unavailable
   /// (`'popular'` or `'recent'`, defaults to `'popular'`).
   /// [category] is an optional hashtag/category filter.
+  /// [cursor] is the opaque cursor returned by a previous response.
   ///
   /// Returns a [RecommendationsResponse] with videos and source.
   ///
@@ -1924,6 +1925,7 @@ class FunnelcakeApiClient {
     int limit = 20,
     String fallback = 'popular',
     String? category,
+    String? cursor,
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
@@ -1941,6 +1943,9 @@ class FunnelcakeApiClient {
     };
     if (category != null && category.isNotEmpty) {
       queryParams['category'] = category;
+    }
+    if (cursor != null && cursor.isNotEmpty) {
+      queryParams['cursor'] = cursor;
     }
     _addViewerPreferenceQueryParameters(
       queryParams,
@@ -1973,10 +1978,16 @@ class FunnelcakeApiClient {
             .toList();
 
         final source = raw['source'] as String? ?? 'unknown';
+        final pagination = raw['pagination'] as Map<String, dynamic>?;
+        final rawHasMore = raw['has_more'] ?? pagination?['has_more'];
+        final rawNextCursor = raw['next_cursor'] ?? pagination?['next_cursor'];
+        final hasMore = rawHasMore is bool ? rawHasMore : videos.isNotEmpty;
 
         return RecommendationsResponse(
           videos: videos,
           source: source,
+          hasMore: hasMore,
+          nextCursor: rawNextCursor?.toString(),
           rawBody: response.body,
         );
       } else if (response.statusCode == 404) {

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -4150,6 +4150,31 @@ void main() {
         expect(uri.queryParameters['category'], equals('comedy'));
       });
 
+      test('sends recommendations cursor for paginated requests', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response('{"videos": [], "source": "popular"}', 200),
+        );
+
+        await client.getRecommendations(
+          pubkey: testPubkey,
+          cursor: 'rec-page-2',
+        );
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.path, equals('/api/users/$testPubkey/recommendations'));
+        expect(uri.queryParameters['cursor'], equals('rec-page-2'));
+      });
+
       test('sends viewer language and country hints', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),
@@ -4334,6 +4359,8 @@ void main() {
           expect(result.videos, hasLength(1));
           expect(result.videos.first.id, equals('rec-env-1'));
           expect(result.source, equals('personalized'));
+          expect(result.hasMore, isTrue);
+          expect(result.nextCursor, equals('opaque-1'));
         },
       );
     }); // end group('getRecommendations')

--- a/mobile/packages/models/lib/src/recommendations_response.dart
+++ b/mobile/packages/models/lib/src/recommendations_response.dart
@@ -11,6 +11,8 @@ class RecommendationsResponse {
   const RecommendationsResponse({
     required this.videos,
     required this.source,
+    this.nextCursor,
+    this.hasMore = false,
     this.rawBody,
   });
 
@@ -22,6 +24,12 @@ class RecommendationsResponse {
   /// Possible values: `"personalized"`, `"popular"`, `"recent"`,
   /// or `"error"`.
   final String source;
+
+  /// Cursor for fetching the next recommendations page.
+  final String? nextCursor;
+
+  /// Whether the recommendations endpoint has another page.
+  final bool hasMore;
 
   /// The raw JSON response body from the API, if available.
   final String? rawBody;

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2251,28 +2251,16 @@ class VideosRepository {
     return _funnelcakeApiClient.getBulkVideoStats(eventIds);
   }
 
-  /// Fetches the initial For You page from recommendations, then paginates
-  /// with popular videos once the personalized page is exhausted.
+  /// Fetches For You videos from the recommendations endpoint.
   Future<HomeFeedResult> getRecommendedVideos({
     required String? userPubkey,
     int limit = _defaultLimit,
     int? until,
+    String? cursor,
     bool skipCache = false,
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
-    if (until != null) {
-      return HomeFeedResult(
-        videos: await getPopularVideos(
-          limit: limit,
-          until: until,
-          skipCache: skipCache,
-          preferredLanguages: preferredLanguages,
-          viewerCountry: viewerCountry,
-        ),
-      );
-    }
-
     final effectiveUserPubkey =
         userPubkey ??
         (_nostrClient.publicKey.isNotEmpty ? _nostrClient.publicKey : null);
@@ -2290,12 +2278,21 @@ class VideosRepository {
       );
     }
 
-    final response = await _funnelcakeApiClient.getRecommendations(
-      pubkey: effectiveUserPubkey,
-      limit: limit,
-      preferredLanguages: preferredLanguages,
-      viewerCountry: viewerCountry,
-    );
+    final recommendationCursor = cursor ?? until?.toString();
+    final response = recommendationCursor == null
+        ? await _funnelcakeApiClient.getRecommendations(
+            pubkey: effectiveUserPubkey,
+            limit: limit,
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          )
+        : await _funnelcakeApiClient.getRecommendations(
+            pubkey: effectiveUserPubkey,
+            limit: limit,
+            cursor: recommendationCursor,
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          );
     final videos = _transformVideoStats(response.videos);
     if (videos.isEmpty) {
       return HomeFeedResult(
@@ -2309,7 +2306,12 @@ class VideosRepository {
       );
     }
 
-    return HomeFeedResult(videos: videos, rawResponseBody: response.rawBody);
+    return HomeFeedResult(
+      videos: videos,
+      paginationCursor: response.nextCursor,
+      hasMore: response.hasMore,
+      rawResponseBody: response.rawBody,
+    );
   }
 
   /// Fetches personalized video recommendations.

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9776,48 +9776,64 @@ void main() {
         },
       );
 
-      test('uses popular pagination for subsequent forYou pages', () async {
-        final popular = _createVideoStats(
-          id: 'popular-page-2-video',
-          pubkey: 'popular-pubkey',
-          dTag: 'popular-dtag',
-          videoUrl: 'https://example.com/popular-page-2.mp4',
-        );
-        when(
-          () => mockFunnelcakeClient.getWatchingVideos(
-            limit: any(named: 'limit'),
-            before: any(named: 'before'),
-          ),
-        ).thenAnswer((_) async => [popular]);
+      test(
+        'uses recommendations pagination for subsequent forYou pages',
+        () async {
+          final recommended = _createVideoStats(
+            id: 'recommended-page-2-video',
+            pubkey: 'recommended-pubkey',
+            dTag: 'recommended-dtag',
+            videoUrl: 'https://example.com/recommended-page-2.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              cursor: any(named: 'cursor'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [recommended],
+              source: 'personalized',
+              nextCursor: 'rec-page-3',
+              hasMore: true,
+            ),
+          );
 
-        final repo = VideosRepository(
-          nostrClient: mockNostrClient,
-          funnelcakeApiClient: mockFunnelcakeClient,
-        );
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
 
-        final result = await repo.getRecommendedVideos(
-          userPubkey: 'user-pubkey',
-          limit: 10,
-          until: 1700000000,
-        );
-
-        expect(result.videos, hasLength(1));
-        expect(result.videos.single.id, equals('popular-page-2-video'));
-        verifyNever(
-          () => mockFunnelcakeClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
-          ),
-        );
-        verify(
-          () => mockFunnelcakeClient.getWatchingVideos(
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
             limit: 10,
-            before: 1700000000,
-          ),
-        ).called(1);
-      });
+            cursor: 'rec-page-2',
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.single.id, equals('recommended-page-2-video'));
+          expect(result.paginationCursor, equals('rec-page-3'));
+          expect(result.hasMore, isTrue);
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: 'user-pubkey',
+              limit: 10,
+              cursor: 'rec-page-2',
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockFunnelcakeClient.getWatchingVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          );
+        },
+      );
 
       test(
         'propagates recommendation errors without popular fallback',

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9836,6 +9836,65 @@ void main() {
       );
 
       test(
+        'uses timestamp fallback as recommendation cursor when provided',
+        () async {
+          final recommended = _createVideoStats(
+            id: 'recommended-until-video',
+            pubkey: 'recommended-pubkey',
+            dTag: 'recommended-dtag',
+            videoUrl: 'https://example.com/recommended-until.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              cursor: any(named: 'cursor'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [recommended],
+              source: 'personalized',
+              nextCursor: 'rec-page-3',
+              hasMore: true,
+            ),
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+            until: 1700000000,
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.single.id, equals('recommended-until-video'));
+          expect(result.paginationCursor, equals('rec-page-3'));
+          expect(result.hasMore, isTrue);
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: 'user-pubkey',
+              limit: 10,
+              cursor: '1700000000',
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockFunnelcakeClient.getWatchingVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          );
+        },
+      );
+
+      test(
         'propagates recommendation errors without popular fallback',
         () async {
           when(

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1159,14 +1159,22 @@ void main() {
               userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: moreVideos));
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: moreVideos,
+              paginationCursor: 'rec-page-3',
+              hasMore: true,
+            ),
+          );
         },
         build: createBloc,
         seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
           videos: createTestVideos(pageSize, startTimestamp: 2000),
+          paginationCursor: 'rec-page-2',
         ),
         act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
         expect: () => [
@@ -1185,7 +1193,7 @@ void main() {
             () => mockVideosRepository.getRecommendedVideos(
               userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
-              until: 1995,
+              cursor: 'rec-page-2',
             ),
           ).called(1);
           verifyNever(

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -62,9 +62,7 @@ void main() {
       when(
         () => mockCuratedListRepository.subscribedListsStream,
       ).thenAnswer((_) => curatedListsController.stream);
-      when(
-        () => mockCuratedListRepository.getSubscribedLists(),
-      ).thenReturn([]);
+      when(() => mockCuratedListRepository.getSubscribedLists()).thenReturn([]);
 
       when(
         () => mockProfileRepository.fetchBatchProfiles(
@@ -309,6 +307,33 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'marks forYou exhausted when recommendations omit next cursor',
+        setUp: () {
+          final videos = createTestVideos(5);
+
+          when(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(videos: videos, hasMore: true),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const VideoFeedStarted()),
+        expect: () => [
+          const VideoFeedBlocState(),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.mode, 'mode', FeedMode.forYou)
+              .having((s) => s.hasMore, 'hasMore', false),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'restores saved following mode from SharedPreferences before loading',
         setUp: () async {
           final videos = createTestVideos(5);
@@ -514,9 +539,7 @@ void main() {
               ),
         ],
         verify: (_) async {
-          verifyNever(
-            () => mockVideosRepository.getVideosForList(any()),
-          );
+          verifyNever(() => mockVideosRepository.getVideosForList(any()));
 
           final sharedPreferences = await SharedPreferences.getInstance();
           expect(sharedPreferences.getString('selected_feed_mode'), isNull);
@@ -1014,9 +1037,9 @@ void main() {
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'following fetches followed creators without subscribed list refs',
         setUp: () {
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([
-            'pubkey',
-          ]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(['pubkey']);
           when(
             () => mockVideosRepository.getHomeFeedVideos(
               authors: ['pubkey'],
@@ -1203,6 +1226,30 @@ void main() {
               userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'stops forYou pagination when the current page has no cursor',
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: createTestVideos(pageSize, startTimestamp: 2000),
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having((s) => s.hasMore, 'hasMore', false),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
               skipCache: any(named: 'skipCache'),
             ),
           );
@@ -2042,9 +2089,8 @@ void main() {
           mode: FeedMode.following,
           videos: createTestVideos(3),
         ),
-        act: (bloc) => bloc.add(
-          VideoFeedCuratedListsChanged([createTestList()]),
-        ),
+        act: (bloc) =>
+            bloc.add(VideoFeedCuratedListsChanged([createTestList()])),
         expect: () => [
           isA<VideoFeedBlocState>()
               .having((s) => s.subscribedLists, 'lists', hasLength(1))
@@ -2085,9 +2131,8 @@ void main() {
           ),
           videos: createTestVideos(3),
         ),
-        act: (bloc) => bloc.add(
-          VideoFeedCuratedListsChanged([createTestList()]),
-        ),
+        act: (bloc) =>
+            bloc.add(VideoFeedCuratedListsChanged([createTestList()])),
         expect: () => [
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.loading)


### PR DESCRIPTION
Closes #4962

## Summary
- keep For You pagination on the recommendations endpoint instead of falling back to Popular/Watching when loading more
- thread recommendation cursors through the API client, repository, and VideoFeedBloc state
- parse recommendation pagination metadata and preserve legacy pagination behavior when metadata is absent

## Motivation
Staging still showed already-watched videos in For You after backend watched-video filtering because the mobile load-more path switched from recommendations to Popular. That bypassed the viewer-specific exclusion logic entirely.

## Validation
- mise exec -- flutter test test/src/funnelcake_api_client_test.dart --plain-name "getRecommendations" (from mobile/packages/funnelcake_api_client)
- mise exec -- flutter test test/src/videos_repository_test.dart --plain-name "getRecommendedVideos" (from mobile/packages/videos_repository)
- mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart (from mobile)
- mise exec -- flutter analyze (from mobile)
- pre-push hook: analyzer and changed-file tests passed

## Visuals
No visual UI change.