### PR TITLE
fix(feed): filter blocked/muted authors on detail surfaces via shouldHideVideo (#4782)

### DIFF
--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -312,12 +312,14 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
       }).firstOrNull;
 
       if (cached != null) {
-        foundVideos.add(cached);
-        Log.debug(
-          '📋 Found addressable video in cache: ${cached.title ?? cached.id}',
-          name: 'CuratedListVideoEvents',
-          category: LogCategory.video,
-        );
+        if (!videoEventService.shouldHideVideo(cached)) {
+          foundVideos.add(cached);
+          Log.debug(
+            '📋 Found addressable video in cache: ${cached.title ?? cached.id}',
+            name: 'CuratedListVideoEvents',
+            category: LogCategory.video,
+          );
+        }
       } else {
         Log.debug(
           '📋 Cache miss for coord: $coord (pubkey=$pubkey, dTag=$dTag)',
@@ -506,12 +508,14 @@ Stream<List<VideoEvent>> videoEventsByIds(
       }).firstOrNull;
 
       if (cached != null) {
-        foundVideos.add(cached);
-        Log.debug(
-          '📋 Found addressable video in cache: ${cached.title ?? cached.id}',
-          name: 'VideoEventsByIds',
-          category: LogCategory.video,
-        );
+        if (!videoEventService.shouldHideVideo(cached)) {
+          foundVideos.add(cached);
+          Log.debug(
+            '📋 Found addressable video in cache: ${cached.title ?? cached.id}',
+            name: 'VideoEventsByIds',
+            category: LogCategory.video,
+          );
+        }
       } else {
         // Log what we're looking for vs what's in cache for debugging
         final matchingPubkey = allCachedVideos

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -563,7 +563,7 @@ final class CuratedListVideoEventsProvider
 }
 
 String _$curatedListVideoEventsHash() =>
-    r'379ee7233fbab78c7b7dda7386218f7022718af5';
+    r'c74a136634eea5ad4ec744156164e2a24b9305ef';
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
@@ -652,7 +652,7 @@ final class VideoEventsByIdsProvider
   }
 }
 
-String _$videoEventsByIdsHash() => r'8a7dd8c695166347375e19083c117ca7a7f46b21';
+String _$videoEventsByIdsHash() => r'5e8ecb9a7517462193b7648f9a0fcd9483407741';
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -854,6 +854,9 @@ class _VideosGridContentState extends ConsumerState<_VideosGridContent> {
   Widget build(BuildContext context) {
     ref.watch(divineHostFilterVersionProvider);
     ref.watch(contentFilterVersionProvider);
+    // Re-filter the grid when a block/mute arrives so a newly blocked author's
+    // videos disappear without leaving the screen (#4782 residual leak).
+    ref.watch(blocklistVersionProvider);
     final videoEventService = ref.read(videoEventServiceProvider);
     if (_isLoading) {
       return const Center(child: BrandedLoadingIndicator(size: 60));

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -485,9 +485,19 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool get shouldFilterNonDivineVideos =>
       _divineHostFilterService?.showDivineHostedOnly ?? false;
 
-  /// Returns true when this video should be hidden by the Divine-hosted-only
-  /// preference.
+  /// Returns true when this video should be hidden — either because its author
+  /// is blocked/muted (the viewer blocked them, or they blocked the viewer via
+  /// kind-30000 `d=block` / muted via kind-10000), or because the viewer's
+  /// Divine-hosted-only preference is on and the video is not Divine-hosted.
+  ///
+  /// Detail/by-id surfaces (sound detail, video detail, curated lists,
+  /// notifications) resolve videos directly and bypass the reception-time
+  /// blocklist filter, so the blocklist check lives here at the shared
+  /// chokepoint rather than at each call site.
   bool shouldHideVideo(VideoEvent video) {
+    if (_blocklistRepository?.shouldFilterFromFeeds(video.pubkey) ?? false) {
+      return true;
+    }
     return shouldFilterNonDivineVideos && !video.isFromDivineServer;
   }
 

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -19,13 +20,34 @@ class _MockAuthService extends Mock implements AuthService {}
 class _MockPeopleListsRepository extends Mock
     implements PeopleListsRepository {}
 
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
 // Full-length 64-char Nostr pubkeys — never truncate.
 const String _ownerA =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const String _ownerB =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const String _blockedAuthor =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 
 final DateTime _frozenNow = DateTime.utc(2026, 4, 20, 12);
+
+VideoEvent _video({
+  required String id,
+  required String pubkey,
+  String? dTag,
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: _frozenNow.millisecondsSinceEpoch ~/ 1000,
+    content: '',
+    timestamp: _frozenNow,
+    title: id,
+    videoUrl: 'https://example.com/$id.mp4',
+    rawTags: dTag == null ? const {} : {'d': dTag},
+  );
+}
 
 UserList _buildList({
   required String id,
@@ -264,6 +286,44 @@ void main() {
         verify(
           () => mockRepository.watchLists(ownerPubkey: _ownerB),
         ).called(1);
+      },
+    );
+  });
+
+  group(videoEventsByIdsProvider, () {
+    test(
+      'filters hidden addressable videos found in the local cache',
+      () async {
+        const dTag = 'blocked-video';
+        const coord = '34236:$_blockedAuthor:$dTag';
+        final blockedVideo = _video(
+          id: 'blocked-video-event',
+          pubkey: _blockedAuthor,
+          dTag: dTag,
+        );
+        final videoEventService = _MockVideoEventService();
+        when(() => videoEventService.discoveryVideos).thenReturn(const []);
+        when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+        when(() => videoEventService.profileVideos).thenReturn([blockedVideo]);
+        when(
+          () => videoEventService.shouldHideVideo(blockedVideo),
+        ).thenReturn(true);
+
+        final container = ProviderContainer(
+          overrides: [
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+          ],
+        );
+        addTearDown(container.dispose);
+        final provider = videoEventsByIdsProvider([coord]);
+        final subscription = container.listen(provider, (_, _) {});
+        addTearDown(subscription.close);
+
+        await expectLater(
+          container.read(provider.future),
+          completion(isEmpty),
+        );
+        verify(() => videoEventService.shouldHideVideo(blockedVideo)).called(1);
       },
     );
   });

--- a/mobile/test/services/video_event_service_blocklist_sweep_test.dart
+++ b/mobile/test/services/video_event_service_blocklist_sweep_test.dart
@@ -201,4 +201,77 @@ void main() {
       },
     );
   });
+
+  // Regression for #4782: detail/by-id surfaces (sound detail, video detail,
+  // curated lists, notifications) gate only on shouldHideVideo and bypass the
+  // reception-time blocklist filter, so shouldHideVideo itself must consult the
+  // blocklist or a blocked/muted author's videos leak onto those surfaces.
+  group('VideoEventService.shouldHideVideo blocklist filtering', () {
+    late VideoEventService service;
+    late ContentBlocklistRepository blocklistRepo;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+      blocklistRepo = ContentBlocklistRepository();
+      service.setBlocklistRepository(blocklistRepo);
+    });
+
+    tearDown(() {
+      service.dispose();
+      blocklistRepo.dispose();
+    });
+
+    test('hides a video whose author is filtered from feeds', () async {
+      const author =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      await blocklistRepo.blockUser(author);
+
+      expect(
+        service.shouldHideVideo(_video(id: 'v1', pubkey: author)),
+        isTrue,
+      );
+    });
+
+    test('does not hide a non-blocked author (Divine-host filter off)', () {
+      const author =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      expect(
+        service.shouldHideVideo(_video(id: 'v1', pubkey: author)),
+        isFalse,
+      );
+    });
+
+    test('does not throw and returns false with no blocklist repository', () {
+      final localNostr = _MockNostrClient();
+      when(() => localNostr.isInitialized).thenReturn(true);
+      when(() => localNostr.connectedRelayCount).thenReturn(1);
+      when(
+        () => localNostr.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      final localService = VideoEventService(
+        localNostr,
+        subscriptionManager: subscriptionManager,
+      );
+      addTearDown(localService.dispose);
+
+      const author =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      expect(
+        localService.shouldHideVideo(_video(id: 'v1', pubkey: author)),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Description

A blocked/muted author's videos still appeared on detail/by-id surfaces even though their profile correctly gates as **Account not available** — the residual half of #4782 that #4887 (hashtag + profile-by-author REST feeds) did not cover.

**Root cause:** `VideoEventService.shouldHideVideo` enforced **only** the Divine-hosted-only preference and was blocklist-blind. Detail/by-id surfaces resolve videos directly (cache or `nostrService.fetchEventById`) and **bypass** the reception-time blocklist filter (`video_event_service.dart:2203/2493/4165`), then gate only on `shouldHideVideo`:

- sound detail — `sound_detail_screen.dart:834,864`
- video detail (deep link) — `video_detail_screen.dart:285`
- curated/people lists — `list_providers.dart:386,588`
- notifications — `notifications/view/notifications_view.dart:337`

**Fix:** fold `ContentBlocklistRepository.shouldFilterFromFeeds` (= own-blocks | `hasMutedUs` kind-10000 | `hasBlockedUs` kind-30000 `d=block`) into `shouldHideVideo`, the single chokepoint every one of those surfaces already consults — so the leak closes at all of them in one place. Also watch `blocklistVersionProvider` on the sound screen so a block/mute arriving while viewing re-filters the grid, matching the profile gates.

**Backend note:** divine-funnelcake has no kind-30000 block materialization and its kind-10000 mute filter is wrong-direction + auth-gated; mobile sends no identity on REST reads — so client-side filtering is the only enforcement available (verified), consistent with #4887.

Closes #4967.

## Out of Scope (tracked separately)

- `SqliteException(1032 = SQLITE_READONLY_DBMOVED)` — root-caused to Clear Cache deleting the open DB: #4968.
- Multi-account block/mute persistence false-positive: #4969.
- divine-web parity for the same leak: divinevideo/divine-web#399.
- "Account not available" copy/design (`TODO(SofiaRey)`).

## Verification

- `mise exec -- dart format` (clean) · `flutter analyze lib test` → **No issues found**
- `flutter test test/services/video_event_service_blocklist_sweep_test.dart` (3 new `shouldHideVideo` blocklist tests) **+ all existing pass**
- Re-ran every `shouldHideVideo` consumer suite — `video_event_resolver_test`, `video_detail_screen_test`, `notifications_view_test`, `sound_detail_screen_test`, `list_providers_test` — all green (no regression; `_blocklistRepository` is null in those, so behavior is unchanged there).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)