### PR TITLE
fix(ci): remove archive-time Crashlytics upload

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -219,6 +219,8 @@ definitions:
     - &upload_dsyms_to_crashlytics
       name: Upload dSYMs to Firebase Crashlytics
       script: |
+        # Upload dSYMs after archive so Xcode signing does not depend on a
+        # DerivedData-specific FlutterFire build phase path.
         DSYM_DIR="build/ios/archive/Runner.xcarchive/dSYMs"
 
         if [ ! -d "$DSYM_DIR" ]; then

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -410,7 +410,6 @@ workflows:
       - *check_ios_extension_signing_contract
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
-      - *install_flutterfire
       - *enable_spm
       - *prepare_ios_spm_packages
       - *pod_install
@@ -463,7 +462,6 @@ workflows:
       events: []
     scripts:
       - *clean_ios_workspace_state
-      - *install_flutterfire
       - *enable_spm
       - *flutter_pub_get
       - *pod_install
@@ -596,7 +594,6 @@ workflows:
       events: []
     scripts:
       - *clean_ios_workspace_state
-      - *install_flutterfire
       - *enable_spm
       - *flutter_pub_get
       - *pod_install

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -237,11 +237,36 @@ definitions:
         if [ -z "$UPLOAD_SYMBOLS" ]; then
           UPLOAD_SYMBOLS=$(find . -path "*/FirebaseCrashlytics*" -name "upload-symbols" -type f 2>/dev/null | head -1)
         fi
+        if [ -z "$UPLOAD_SYMBOLS" ]; then
+          UPLOAD_SYMBOLS=$(find build/ios/SourcePackages -path "*/firebase-ios-sdk*/Crashlytics/upload-symbols" -type f 2>/dev/null | head -1)
+        fi
+        if [ -z "$UPLOAD_SYMBOLS" ] && [ -f "build/ios/SourcePackages/checkouts/firebase-ios-sdk/upload-symbols" ]; then
+          UPLOAD_SYMBOLS="build/ios/SourcePackages/checkouts/firebase-ios-sdk/upload-symbols"
+        fi
 
         if [ -z "$UPLOAD_SYMBOLS" ]; then
-          echo "ERROR: upload-symbols tool not found. Searching all locations..."
+          FIREBASE_IOS_SDK_VERSION=$(ruby -rjson -e '
+            data = JSON.parse(File.read("ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved"))
+            pin = data.fetch("pins").find { |item| item.fetch("identity") == "firebase-ios-sdk" }
+            abort("firebase-ios-sdk not found in Package.resolved") unless pin
+            state = pin.fetch("state")
+            puts(state["version"] || state.fetch("revision"))
+          ')
+          FIREBASE_IOS_SDK_DIR="$CM_BUILD_DIR/.firebase-ios-sdk-$FIREBASE_IOS_SDK_VERSION"
+
+          echo "upload-symbols not found in build outputs; fetching firebase-ios-sdk $FIREBASE_IOS_SDK_VERSION"
+          rm -rf "$FIREBASE_IOS_SDK_DIR"
+          git clone --depth 1 --branch "$FIREBASE_IOS_SDK_VERSION" \
+            https://github.com/firebase/firebase-ios-sdk.git \
+            "$FIREBASE_IOS_SDK_DIR"
+
+          UPLOAD_SYMBOLS="$FIREBASE_IOS_SDK_DIR/Crashlytics/upload-symbols"
+        fi
+
+        if [ ! -f "$UPLOAD_SYMBOLS" ]; then
+          echo "ERROR: upload-symbols tool not found at $UPLOAD_SYMBOLS"
           find "$HOME" -name "upload-symbols" -type f 2>/dev/null || true
-          find . -name "upload-symbols" -type f 2>/dev/null || true
+          find "$CM_BUILD_DIR" -name "upload-symbols" -type f 2>/dev/null || true
           exit 1
         fi
 

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -346,7 +346,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				F4D10BEA6CFC4738B7665C3A /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				0D799AD529A428A1CE054136 /* FlutterFire: "flutterfire upload-crashlytics-symbols" */,
 				A11C0546913CF84FD97FA55A /* [CP] Embed Pods Frameworks */,
 				0439C9E33AA6B9E50AD033CE /* [CP] Copy Pods Resources */,
 			);
@@ -482,24 +481,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		0D799AD529A428A1CE054136 /* FlutterFire: "flutterfire upload-crashlytics-symbols" */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "FlutterFire: \"flutterfire upload-crashlytics-symbols\"";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\n#!/bin/bash\nset -e  # Exit on error\n\n# Skip dSYM upload for Debug builds\nif [ \"$CONFIGURATION\" = \"Debug\" ]; then\n  echo \"FlutterFire: Skipping dSYM upload for Debug build\"\n  exit 0\nfi\n\necho \"========================================\"\necho \"FlutterFire: Starting dSYM upload\"\necho \"========================================\"\n\n# Set PATH with explicit locations, checking if directories exist\nPATH=\"$PATH:$HOME/.pub-cache/bin\"\n[ -d \"$FLUTTER_ROOT/bin\" ] && PATH=\"$PATH:$FLUTTER_ROOT/bin\"\n[ -d \"$PUB_CACHE/bin\" ] && PATH=\"$PATH:$PUB_CACHE/bin\"\n[ -d \"/usr/local/bin\" ] && PATH=\"$PATH:/usr/local/bin\"\n\n# Try common Flutter installation locations if FLUTTER_ROOT not set\nif [ -z \"$FLUTTER_ROOT\" ]; then\n  [ -d \"$HOME/fvm/default/bin\" ] && PATH=\"$PATH:$HOME/fvm/default/bin\"\n  [ -d \"$HOME/flutter/bin\" ] && PATH=\"$PATH:$HOME/flutter/bin\"\n  [ -d \"/usr/local/flutter/bin\" ] && PATH=\"$PATH:/usr/local/flutter/bin\"\nfi\n\necho \"PATH configured: $PATH\"\necho \"Checking for flutterfire command...\"\nwhich flutterfire || echo \"WARNING: flutterfire not found in PATH\"\n\nif [ -z \"$PODS_ROOT\" ] || [ ! -d \"$PODS_ROOT/FirebaseCrashlytics\" ]; then\n  # Cannot use \"BUILD_DIR%/Build/*\" as per Firebase documentation, it points to \"flutter-project/build/ios/*\" path which doesn't have run script\n  DERIVED_DATA_PATH=$(echo \"$BUILD_ROOT\" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')\n  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\"${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n  echo \"Using SPM Crashlytics script: $PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\"\nelse\n  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\"$PODS_ROOT/FirebaseCrashlytics/run\"\n  echo \"Using CocoaPods Crashlytics script: $PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\"\nfi\n\necho \"dSYM folder: ${DWARF_DSYM_FOLDER_PATH}\"\necho \"dSYM file: ${DWARF_DSYM_FILE_NAME}\"\necho \"Uploading dSYMs to Firebase Crashlytics...\"\n\n# Command to upload symbols script used to upload symbols to Firebase server\nflutterfire upload-crashlytics-symbols --upload-symbols-script-path=\"$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\" --platform=ios --apple-project-path=\"${SRCROOT}\" --env-platform-name=\"${PLATFORM_NAME}\" --env-configuration=\"${CONFIGURATION}\" --env-project-dir=\"${PROJECT_DIR}\" --env-built-products-dir=\"${BUILT_PRODUCTS_DIR}\" --env-dwarf-dsym-folder-path=\"${DWARF_DSYM_FOLDER_PATH}\" --env-dwarf-dsym-file-name=\"${DWARF_DSYM_FILE_NAME}\" --env-infoplist-path=\"${INFOPLIST_PATH}\" --default-config=default\n\necho \"========================================\"\necho \"FlutterFire: dSYM upload completed successfully\"\necho \"========================================\"\n";
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/mobile/macos/Podfile
+++ b/mobile/macos/Podfile
@@ -6,6 +6,9 @@ ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 # Use CDN source for CocoaPods specs
 source 'https://cdn.cocoapods.org/'
 
+# Suppress master specs repo warning
+install! 'cocoapods', :warn_for_unused_master_specs_repo => false
+
 project 'Runner', {
   'Debug' => :debug,
   'Profile' => :release,

--- a/mobile/test/screens/minor_account_review_screen_test.dart
+++ b/mobile/test/screens/minor_account_review_screen_test.dart
@@ -134,6 +134,12 @@ void main() {
         findsOneWidget,
       );
       // Three boxes total: why / family / come-back-at-13.
+      await tester.scrollUntilVisible(
+        find.text(l10n.minorAccountReviewUnder13ComeBackTitle),
+        200,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
       expect(
         find.text(l10n.minorAccountReviewUnder13ComeBackTitle),
         findsOneWidget,


### PR DESCRIPTION
## Summary
- remove the Runner Xcode build phase that ran `flutterfire upload-crashlytics-symbols` during archive
- keep dSYM upload in the existing Codemagic post-archive `Upload dSYMs to Firebase Crashlytics` step
- harden the minor-account review widget test that CI exposed by scrolling to the offscreen under-13 card before asserting its copy

Fixes #4972.

## Why
The Codemagic `Build and sign iOS` step now gets past signing, then fails inside Xcode's archive because the FlutterFire build phase hardcodes a DerivedData SPM path:

`SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`

In the failing build, that file does not exist, so the archive exits with `ProcessException: No such file or directory` before Codemagic can reach its more defensive dSYM upload step.

Uploading after archive keeps signing independent from Firebase's generated SPM checkout layout and avoids duplicate Crashlytics dSYM upload paths.

The first CI run also exposed a stale widget-test assumption: the under-13 "When you turn 13" card is below the initially built portion of a `ListView`. The test now scrolls to that card before asserting its text.

## Verification
- `ruby -ryaml -e 'YAML.load_file("codemagic.yaml"); puts "codemagic.yaml parses"'`
- `plutil -lint mobile/ios/Runner.xcodeproj/project.pbxproj`
- `git diff --check`
- `mise exec flutter@3.44.0 -- flutter build ios --config-only`
- `xcodebuild -list -project mobile/ios/Runner.xcodeproj`
- `mise exec flutter@3.44.0 -- flutter test test/screens/minor_account_review_screen_test.dart --test-randomize-ordering-seed=3591734514`
- `mise exec flutter@3.44.0 -- flutter analyze`
