### PR TITLE
fix(dm): recover full conversation list after reinstall (#4953)

### DIFF
--- a/mobile/docs/plans/2026-04-05-dm-scaling-fix-implementation.md
+++ b/mobile/docs/plans/2026-04-05-dm-scaling-fix-implementation.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Superseded note (#4973):** The single-page `loadOlderMessages()` pagination primitive described below (Task 13) was never wired to a production caller and has been removed. Full DM-history recovery after a reinstall is now handled by the one-time, resumable, page-capped `DmRepository.backfillHistoryIfNeeded()` drain (gated by `DmSyncState.historyDrainComplete` / resumed via `historyDrainCursor`), triggered from `ConversationListBloc` on inbox open. See #4953 / PR #4973. Trust the current code over the `loadOlderMessages()` references in this historical plan.
+
 **Goal:** Make DM processing lazy (inbox-gated), bounded (count-based windowing), and non-blocking (isolate decryption for local signers) so cold start and scale do not degrade with lifetime DM count.
 
 **Architecture:** `DmRepository.initialize()` stops auto-starting the gift-wrap subscription. `startListening()` and `stopListening()` are called from the inbox screen's BLoC on mount/dispose. The subscription filter switches between a `limit: 50` first-open path and a `since: newestSyncedAt - 2d` steady-state path, with explicit `loadOlderMessages()` pagination. The 10-second poller is removed. Decryption for local-key signers is offloaded via `compute()` to keep the UI isolate responsive.

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -3,6 +3,8 @@
 // ABOUTME: updates, marking conversations as read, and splitting conversations
 // ABOUTME: into normal inbox vs message requests based on follow state.
 
+import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
@@ -47,6 +49,15 @@ class ConversationListBloc
     // The gift-wrap subscription is started by `dmRepositoryProvider` for
     // the whole authenticated session — this BLoC just consumes the
     // already-running stream via the DAO. See #2931.
+
+    // Recover the full DM history once per install. After a reinstall the
+    // live subscription's first-open window (limit:50) only persists the
+    // most-recent conversations; this idempotent, one-time, background
+    // drain backfills the rest so the list is complete. Triggered here (on
+    // inbox open) because relay discovery has reliably finished by the time
+    // the user navigates to Messages — fetching against the full relay
+    // pool, not the divine-only pool present at cold start. See #4953.
+    unawaited(_dmRepository.backfillHistoryIfNeeded());
 
     // Only show the loading spinner and reset limit on first load.
     if (state.status == ConversationListStatus.initial) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -406,18 +406,20 @@ class DmRepository {
   /// transaction integrity, and sync-boundary tracking apply
   /// automatically. Returns the raw events so the caller can advance its
   /// own pagination cursor by their outer `created_at`.
-  Future<List<Event>> _fetchHistoryPage({
+  Future<List<Event>?> _fetchHistoryPage({
     required int until,
     required int limit,
     required String subscriptionId,
+    String? pubkey,
   }) async {
+    final ownerPubkey = pubkey ?? _userPubkey;
     final filter = nostr_filter.Filter(
       kinds: [
         EventKind.giftWrap,
         EventKind.directMessage,
         EventKind.eventDeletion,
       ],
-      p: [_userPubkey],
+      p: [ownerPubkey],
       until: until,
       limit: limit,
     );
@@ -427,8 +429,10 @@ class DmRepository {
       subscriptionId: subscriptionId,
       useCache: false,
     );
+    if (pubkey != null && (_disposed || _userPubkey != pubkey)) return null;
 
     for (final event in events) {
+      if (pubkey != null && (_disposed || _userPubkey != pubkey)) return null;
       await _handleIncomingEvent(event);
     }
     return events;
@@ -476,7 +480,11 @@ class DmRepository {
     if (existing != null) return existing;
     final drain = _runHistoryDrain();
     _historyDrain = drain;
-    unawaited(drain.whenComplete(() => _historyDrain = null));
+    unawaited(
+      drain.whenComplete(() {
+        if (identical(_historyDrain, drain)) _historyDrain = null;
+      }),
+    );
     return drain;
   }
 
@@ -522,7 +530,9 @@ class DmRepository {
           until: cursor,
           limit: DmHistoryDrainConfig.pageSize,
           subscriptionId: 'dm_drain_${pubkey}_$page',
+          pubkey: pubkey,
         );
+        if (events == null) return;
         pagesRun++;
         totalEvents += events.length;
         if (events.isEmpty) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -572,6 +572,13 @@ class DmRepository {
         error: e,
         stackTrace: stackTrace,
       );
+      if (e is StateError || e is TypeError || e is RangeError) {
+        _errorReporter?.call(
+          e,
+          stackTrace,
+          site: DmRepositoryReportableSites.historyDrainUnexpectedFailure,
+        );
+      }
     }
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -67,6 +67,24 @@ const Set<int> _supportedDmKinds = {
   EventKind.fileMessage, // 15
 };
 
+/// Tuning for the one-time full-history drain
+/// (`DmRepository.backfillHistoryIfNeeded`).
+///
+/// The drain pages relays newest→oldest until the relay runs out of
+/// events or [maxPages] is reached, whichever comes first. The cap is a
+/// safety valve for pathological histories: because the drain walks
+/// newest-first and a conversation appears as soon as *any* of its
+/// messages is persisted, the most-recent [maxPages] × [pageSize] window
+/// already contains the latest message of essentially every active
+/// conversation.
+abstract class DmHistoryDrainConfig {
+  /// Events requested per relay page.
+  static const int pageSize = 100;
+
+  /// Maximum pages fetched in a single drain (≈ [pageSize] × this events).
+  static const int maxPages = 50;
+}
+
 const _relayLoopbackHosts = <String>{
   'localhost',
   '127.0.0.1',
@@ -173,6 +191,11 @@ class DmRepository {
   /// emitting stale denormalized previews before repairs land.
   Future<void>? _postAuthMaintenance;
 
+  /// The in-flight one-time history drain, shared by concurrent callers so
+  /// repeated [backfillHistoryIfNeeded] calls (e.g. every inbox open) never
+  /// launch overlapping drains. Cleared when the drain settles.
+  Future<void>? _historyDrain;
+
   /// User-scoped subscription ID to prevent collision when the provider
   /// rebuilds during auth transitions (old unsubscribe won't kill new sub).
   String _subscriptionId = 'dm_inbox';
@@ -243,6 +266,9 @@ class DmRepository {
   void _resetState() {
     _disposed = true;
     _eventLock = null;
+    // Drop the in-flight history drain so the next user can start a fresh
+    // one; the running loop bails on the _userPubkey change.
+    _historyDrain = null;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     unawaited(_giftWrapSubscription?.cancel());
@@ -374,22 +400,17 @@ class DmRepository {
     // isolate. See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
   }
 
-  /// Fetches an older page of DM events (gift wraps, NIP-04, deletions)
-  /// from the relay, bounded above by [DmSyncState.oldestSyncedAt]. The
-  /// filter uses `until:` so the relay returns events *older* than the
-  /// current pagination boundary, capped to 50 by `limit`.
-  ///
-  /// No-op if [DmSyncState] is unset or no sync has happened yet — in
-  /// that case the caller should invoke [startListening] instead to
-  /// establish a baseline.
-  ///
-  /// Events flow through [_handleIncomingEvent] so dedup, transaction
-  /// integrity, and sync-boundary tracking apply automatically.
-  Future<void> loadOlderMessages() async {
-    if (!isInitialized) return;
-    final oldest = _syncState?.oldestSyncedAt(_userPubkey);
-    if (oldest == null) return;
-
+  /// Fetches a single older page of DM events (gift wraps, NIP-04,
+  /// deletions) from the relay older than [until] (inclusive), capped to
+  /// [limit]. Each event flows through [_handleIncomingEvent] so dedup,
+  /// transaction integrity, and sync-boundary tracking apply
+  /// automatically. Returns the raw events so the caller can advance its
+  /// own pagination cursor by their outer `created_at`.
+  Future<List<Event>> _fetchHistoryPage({
+    required int until,
+    required int limit,
+    required String subscriptionId,
+  }) async {
     final filter = nostr_filter.Filter(
       kinds: [
         EventKind.giftWrap,
@@ -397,18 +418,136 @@ class DmRepository {
         EventKind.eventDeletion,
       ],
       p: [_userPubkey],
-      until: oldest,
-      limit: 50,
+      until: until,
+      limit: limit,
     );
 
     final events = await _nostrClient.queryEvents(
       [filter],
-      subscriptionId: 'dm_older_${DateTime.now().millisecondsSinceEpoch}',
+      subscriptionId: subscriptionId,
       useCache: false,
     );
 
     for (final event in events) {
       await _handleIncomingEvent(event);
+    }
+    return events;
+  }
+
+  /// Fetches one older page of DM events bounded above by
+  /// [DmSyncState.oldestSyncedAt].
+  ///
+  /// No-op if [DmSyncState] is unset or no sync has happened yet — in
+  /// that case the caller should invoke [startListening] instead to
+  /// establish a baseline. For full-history recovery after a reinstall use
+  /// [backfillHistoryIfNeeded], which pages to completion.
+  Future<void> loadOlderMessages() async {
+    if (!isInitialized) return;
+    final oldest = _syncState?.oldestSyncedAt(_userPubkey);
+    if (oldest == null) return;
+
+    await _fetchHistoryPage(
+      until: oldest,
+      limit: 50,
+      subscriptionId: 'dm_older_${DateTime.now().millisecondsSinceEpoch}',
+    );
+  }
+
+  /// Recovers the user's full DM history from relays once per install.
+  ///
+  /// On reinstall the local DB and [DmSyncState] are wiped, so the live
+  /// subscription's bounded first-open window (`limit:50`) only persists
+  /// the most-recent conversations; the rest are absent from the
+  /// conversation list (a pure local-DB projection) with no UI path to
+  /// recover them. This drains older pages newest→oldest until the relay
+  /// is exhausted (or [DmHistoryDrainConfig.maxPages] is reached),
+  /// backfilling every conversation that still has events on a relay.
+  /// See #4953.
+  ///
+  /// Idempotent and resumable: returns immediately once a clean drain has
+  /// completed for the user ([DmSyncState.historyDrainComplete]); an
+  /// interrupted drain resumes from the persisted boundary on the next
+  /// call. Concurrent callers share one in-flight run. Runs in the
+  /// background — per-event decryption already offloads to a [compute]
+  /// isolate — so it is safe to fire-and-forget from the inbox BLoC on
+  /// every open.
+  Future<void> backfillHistoryIfNeeded() {
+    final existing = _historyDrain;
+    if (existing != null) return existing;
+    final drain = _runHistoryDrain();
+    _historyDrain = drain;
+    unawaited(drain.whenComplete(() => _historyDrain = null));
+    return drain;
+  }
+
+  Future<void> _runHistoryDrain() async {
+    if (!isInitialized) return;
+    final syncState = _syncState;
+    if (syncState == null) return;
+    // Pin the user for the whole drain so an account switch mid-drain can
+    // never mark the wrong pubkey complete or query for the new user.
+    final pubkey = _userPubkey;
+    if (syncState.historyDrainComplete(pubkey)) return;
+
+    try {
+      // The relay filters `until:` on the OUTER gift-wrap created_at, which
+      // NIP-59 randomizes up to 2 days into the past — so the cursor tracks
+      // fetched events' outer timestamps, NOT the rumor times recorded in
+      // oldestSyncedAt. Seed from oldestSyncedAt when the live subscription
+      // has already discovered a boundary (resume below it); else now.
+      var cursor =
+          syncState.oldestSyncedAt(pubkey) ??
+          DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      var reachedEnd = false;
+      for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
+        // Bail if the user switched or the repository was torn down.
+        if (_disposed || _userPubkey != pubkey) return;
+        final events = await _fetchHistoryPage(
+          until: cursor,
+          limit: DmHistoryDrainConfig.pageSize,
+          subscriptionId: 'dm_drain_${pubkey}_$page',
+        );
+        if (events.isEmpty) {
+          reachedEnd = true;
+          break;
+        }
+
+        // Step strictly below the oldest event seen so the loop always
+        // makes progress. `until` is inclusive, so re-requesting the
+        // boundary on a saturated page is absorbed by hasGiftWrap dedup
+        // rather than lost.
+        final minCreatedAt = events
+            .map((event) => event.createdAt)
+            .reduce((a, b) => a < b ? a : b);
+        cursor = minCreatedAt < cursor ? minCreatedAt : cursor - 1;
+        if (cursor <= 0) {
+          reachedEnd = true;
+          break;
+        }
+      }
+
+      if (!reachedEnd) {
+        Log.warning(
+          'DM history drain hit the ${DmHistoryDrainConfig.maxPages}-page '
+          'cap for $pubkey; messages older than the most recent '
+          '~${DmHistoryDrainConfig.maxPages * DmHistoryDrainConfig.pageSize} '
+          'events were not backfilled.',
+          category: LogCategory.system,
+        );
+      }
+
+      await syncState.markHistoryDrainComplete(pubkey);
+    } on Object catch (e, stackTrace) {
+      // Relay/IO failures are expected on flaky networks and are NOT
+      // reportable (see error_handling.md). Leaving historyDrainComplete
+      // unset lets the next inbox open resume the drain.
+      Log.error(
+        'DM history drain failed (will resume on next inbox open): $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -401,25 +401,26 @@ class DmRepository {
   }
 
   /// Fetches a single older page of DM events (gift wraps, NIP-04,
-  /// deletions) from the relay older than [until] (inclusive), capped to
-  /// [limit]. Each event flows through [_handleIncomingEvent] so dedup,
-  /// transaction integrity, and sync-boundary tracking apply
-  /// automatically. Returns the raw events so the caller can advance its
-  /// own pagination cursor by their outer `created_at`.
+  /// deletions) addressed to [pubkey] from the relay older than [until]
+  /// (inclusive), capped to [limit]. Each event flows through
+  /// [_handleIncomingEvent] so dedup, transaction integrity, and
+  /// sync-boundary tracking apply automatically. Returns the raw events so
+  /// the caller can advance its own pagination cursor by their outer
+  /// `created_at`, or `null` if the user switched / the repository was torn
+  /// down mid-fetch (so the caller stops paging for the stale user).
   Future<List<Event>?> _fetchHistoryPage({
     required int until,
     required int limit,
     required String subscriptionId,
-    String? pubkey,
+    required String pubkey,
   }) async {
-    final ownerPubkey = pubkey ?? _userPubkey;
     final filter = nostr_filter.Filter(
       kinds: [
         EventKind.giftWrap,
         EventKind.directMessage,
         EventKind.eventDeletion,
       ],
-      p: [ownerPubkey],
+      p: [pubkey],
       until: until,
       limit: limit,
     );
@@ -429,32 +430,13 @@ class DmRepository {
       subscriptionId: subscriptionId,
       useCache: false,
     );
-    if (pubkey != null && (_disposed || _userPubkey != pubkey)) return null;
+    if (_disposed || _userPubkey != pubkey) return null;
 
     for (final event in events) {
-      if (pubkey != null && (_disposed || _userPubkey != pubkey)) return null;
+      if (_disposed || _userPubkey != pubkey) return null;
       await _handleIncomingEvent(event);
     }
     return events;
-  }
-
-  /// Fetches one older page of DM events bounded above by
-  /// [DmSyncState.oldestSyncedAt].
-  ///
-  /// No-op if [DmSyncState] is unset or no sync has happened yet — in
-  /// that case the caller should invoke [startListening] instead to
-  /// establish a baseline. For full-history recovery after a reinstall use
-  /// [backfillHistoryIfNeeded], which pages to completion.
-  Future<void> loadOlderMessages() async {
-    if (!isInitialized) return;
-    final oldest = _syncState?.oldestSyncedAt(_userPubkey);
-    if (oldest == null) return;
-
-    await _fetchHistoryPage(
-      until: oldest,
-      limit: 50,
-      subscriptionId: 'dm_older_${DateTime.now().millisecondsSinceEpoch}',
-    );
   }
 
   /// Recovers the user's full DM history from relays once per install.
@@ -514,9 +496,12 @@ class DmRepository {
       // The relay filters `until:` on the OUTER gift-wrap created_at, which
       // NIP-59 randomizes up to 2 days into the past — so the cursor tracks
       // fetched events' outer timestamps, NOT the rumor times recorded in
-      // oldestSyncedAt. Seed from oldestSyncedAt when the live subscription
-      // has already discovered a boundary (resume below it); else now.
+      // oldestSyncedAt. Resume from the persisted drain cursor when an
+      // earlier run was interrupted or page-capped; otherwise seed below
+      // the live subscription's discovered boundary (oldestSyncedAt); else
+      // now.
       var cursor =
+          syncState.historyDrainCursor(pubkey) ??
           syncState.oldestSyncedAt(pubkey) ??
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
@@ -552,24 +537,31 @@ class DmRepository {
           reachedEnd = true;
           break;
         }
+        // Persist the boundary so an interrupted or page-capped run
+        // resumes from here on the next inbox open rather than restarting
+        // from the top.
+        await syncState.setHistoryDrainCursor(pubkey, cursor);
       }
 
-      if (!reachedEnd) {
+      if (reachedEnd) {
+        await syncState.markHistoryDrainComplete(pubkey);
+        Log.info(
+          'DM history drain complete for $pubkey: '
+          'pages=$pagesRun, eventsFetched=$totalEvents',
+          category: LogCategory.system,
+        );
+      } else {
+        // Page cap hit: leave historyDrainComplete unset and the cursor
+        // persisted so the next inbox open resumes the remaining history
+        // instead of permanently truncating it for heavy users. See #4953.
         Log.warning(
-          'DM history drain hit the ${DmHistoryDrainConfig.maxPages}-page '
-          'cap for $pubkey; messages older than the most recent '
-          '~${DmHistoryDrainConfig.maxPages * DmHistoryDrainConfig.pageSize} '
-          'events were not backfilled.',
+          'DM history drain paused at the page cap '
+          '(${DmHistoryDrainConfig.maxPages}) for $pubkey after '
+          '$totalEvents events; will resume from the persisted cursor '
+          '($cursor) on the next inbox open.',
           category: LogCategory.system,
         );
       }
-
-      await syncState.markHistoryDrainComplete(pubkey);
-      Log.info(
-        'DM history drain complete for $pubkey: '
-        'pages=$pagesRun, eventsFetched=$totalEvents, reachedEnd=$reachedEnd',
-        category: LogCategory.system,
-      );
     } on Object catch (e, stackTrace) {
       // Relay/IO failures are expected on flaky networks and are NOT
       // reportable (see error_handling.md). Leaving historyDrainComplete

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -487,7 +487,20 @@ class DmRepository {
     // Pin the user for the whole drain so an account switch mid-drain can
     // never mark the wrong pubkey complete or query for the new user.
     final pubkey = _userPubkey;
-    if (syncState.historyDrainComplete(pubkey)) return;
+    if (syncState.historyDrainComplete(pubkey)) {
+      Log.info(
+        'DM history drain skipped for $pubkey: already complete',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    Log.info(
+      'DM history drain starting for $pubkey '
+      '(connected relays ${_nostrClient.connectedRelayCount}/'
+      '${_nostrClient.configuredRelayCount})',
+      category: LogCategory.system,
+    );
 
     try {
       // The relay filters `until:` on the OUTER gift-wrap created_at, which
@@ -500,6 +513,8 @@ class DmRepository {
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
       var reachedEnd = false;
+      var pagesRun = 0;
+      var totalEvents = 0;
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
         // Bail if the user switched or the repository was torn down.
         if (_disposed || _userPubkey != pubkey) return;
@@ -508,6 +523,8 @@ class DmRepository {
           limit: DmHistoryDrainConfig.pageSize,
           subscriptionId: 'dm_drain_${pubkey}_$page',
         );
+        pagesRun++;
+        totalEvents += events.length;
         if (events.isEmpty) {
           reachedEnd = true;
           break;
@@ -538,6 +555,11 @@ class DmRepository {
       }
 
       await syncState.markHistoryDrainComplete(pubkey);
+      Log.info(
+        'DM history drain complete for $pubkey: '
+        'pages=$pagesRun, eventsFetched=$totalEvents, reachedEnd=$reachedEnd',
+        category: LogCategory.system,
+      );
     } on Object catch (e, stackTrace) {
       // Relay/IO failures are expected on flaky networks and are NOT
       // reportable (see error_handling.md). Leaving historyDrainComplete

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -47,4 +47,9 @@ abstract class DmRepositoryReportableSites {
   /// after the recipient publish landed.
   static const String sendMessageOuterTransaction =
       'sendMessage.outerTransaction';
+
+  /// `backfillHistoryIfNeeded`: the history drain hit a programming
+  /// invariant failure while paging or processing recovered events.
+  static const String historyDrainUnexpectedFailure =
+      'historyDrain.unexpectedFailure';
 }

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -1,13 +1,15 @@
 // ABOUTME: Persists per-pubkey DM sync boundaries so subsequent inbox
 // ABOUTME: opens can fetch only new events via a `since:` filter.
 //
-// Stores two integers per user pubkey in SharedPreferences:
+// Stores per user pubkey in SharedPreferences:
 //   - newestSyncedAt: highest `created_at` successfully processed
 //   - oldestSyncedAt: lowest `created_at` successfully processed
+//   - historyDrainComplete: whether the one-time full-history drain is done
+//   - historyDrainCursor: the drain's resumable pagination boundary
 //
-// Both values are unix seconds matching Nostr event timestamps. Used
-// by DmRepository to bound subscription and pagination queries so
-// cost is proportional to recent activity, not lifetime message count.
+// Timestamps are unix seconds matching Nostr event timestamps. Used by
+// DmRepository to bound subscription and pagination queries so cost is
+// proportional to recent activity, not lifetime message count.
 // See docs/plans/2026-04-05-dm-scaling-fix-design.md.
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -21,6 +23,7 @@ class DmSyncState {
   static const _newestPrefix = 'dm.newestSyncedAt.';
   static const _oldestPrefix = 'dm.oldestSyncedAt.';
   static const _drainCompletePrefix = 'dm.historyDrainComplete.';
+  static const _drainCursorPrefix = 'dm.historyDrainCursor.';
 
   /// Returns the newest (highest) `created_at` unix timestamp we have
   /// successfully processed for [pubkey], or `null` if nothing has been
@@ -59,9 +62,33 @@ class DmSyncState {
       _prefs.getBool('$_drainCompletePrefix$pubkey') ?? false;
 
   /// Records that the one-time full-history drain finished cleanly for
-  /// [pubkey] so it never runs again until the state is cleared.
+  /// [pubkey] so it never runs again until the state is cleared. Also
+  /// clears the resume cursor, which is only meaningful for an
+  /// in-progress drain.
   Future<void> markHistoryDrainComplete(String pubkey) async {
     await _prefs.setBool('$_drainCompletePrefix$pubkey', true);
+    await _prefs.remove('$_drainCursorPrefix$pubkey');
+  }
+
+  /// The outer gift-wrap `created_at` (unix seconds) the history drain has
+  /// paged down to for [pubkey], or `null` if no drain has persisted a
+  /// boundary yet.
+  ///
+  /// The drain persists this after every page so an interrupted or
+  /// page-capped run resumes from the exact boundary on the next inbox
+  /// open instead of restarting from [oldestSyncedAt] (and, on a page-cap,
+  /// instead of permanently truncating older history). Tracks the
+  /// randomized **outer** gift-wrap timestamp that the relay's `until:`
+  /// filters on — not the rumor times in [oldestSyncedAt]. Cleared once
+  /// the drain completes or the state is reset. See #4953.
+  int? historyDrainCursor(String pubkey) =>
+      _prefs.getInt('$_drainCursorPrefix$pubkey');
+
+  /// Persists the history drain's pagination [cursor] (an outer gift-wrap
+  /// `created_at` in unix seconds) for [pubkey] so the next run resumes
+  /// from it.
+  Future<void> setHistoryDrainCursor(String pubkey, int cursor) async {
+    await _prefs.setInt('$_drainCursorPrefix$pubkey', cursor);
   }
 
   /// Removes all sync state for [pubkey]. Called on account switch.
@@ -69,6 +96,7 @@ class DmSyncState {
     await _prefs.remove('$_newestPrefix$pubkey');
     await _prefs.remove('$_oldestPrefix$pubkey');
     await _prefs.remove('$_drainCompletePrefix$pubkey');
+    await _prefs.remove('$_drainCursorPrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -82,7 +110,8 @@ class DmSyncState {
           (key) =>
               key.startsWith(_newestPrefix) ||
               key.startsWith(_oldestPrefix) ||
-              key.startsWith(_drainCompletePrefix),
+              key.startsWith(_drainCompletePrefix) ||
+              key.startsWith(_drainCursorPrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -20,6 +20,7 @@ class DmSyncState {
 
   static const _newestPrefix = 'dm.newestSyncedAt.';
   static const _oldestPrefix = 'dm.oldestSyncedAt.';
+  static const _drainCompletePrefix = 'dm.historyDrainComplete.';
 
   /// Returns the newest (highest) `created_at` unix timestamp we have
   /// successfully processed for [pubkey], or `null` if nothing has been
@@ -46,10 +47,28 @@ class DmSyncState {
     }
   }
 
+  /// Whether the one-time full-history drain has completed for [pubkey].
+  ///
+  /// `false` after a reinstall (SharedPreferences is wiped) or account
+  /// switch, which is what arms `DmRepository.backfillHistoryIfNeeded` to
+  /// re-fetch the full conversation backlog. Distinct from
+  /// [newestSyncedAt]/[oldestSyncedAt], which the live subscription
+  /// advances on its very first event and therefore cannot gate a
+  /// "did we drain everything" decision. See #4953.
+  bool historyDrainComplete(String pubkey) =>
+      _prefs.getBool('$_drainCompletePrefix$pubkey') ?? false;
+
+  /// Records that the one-time full-history drain finished cleanly for
+  /// [pubkey] so it never runs again until the state is cleared.
+  Future<void> markHistoryDrainComplete(String pubkey) async {
+    await _prefs.setBool('$_drainCompletePrefix$pubkey', true);
+  }
+
   /// Removes all sync state for [pubkey]. Called on account switch.
   Future<void> clear(String pubkey) async {
     await _prefs.remove('$_newestPrefix$pubkey');
     await _prefs.remove('$_oldestPrefix$pubkey');
+    await _prefs.remove('$_drainCompletePrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -61,7 +80,9 @@ class DmSyncState {
         .getKeys()
         .where(
           (key) =>
-              key.startsWith(_newestPrefix) || key.startsWith(_oldestPrefix),
+              key.startsWith(_newestPrefix) ||
+              key.startsWith(_oldestPrefix) ||
+              key.startsWith(_drainCompletePrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -42,6 +42,7 @@ class _FakeEvent extends Fake implements Event {}
 class _FakeDmSyncState implements DmSyncState {
   int? newestOverride;
   int? oldestOverride;
+  bool drainCompleteOverride = false;
   final List<({String pubkey, int createdAt})> recorded =
       <({String pubkey, int createdAt})>[];
 
@@ -50,6 +51,14 @@ class _FakeDmSyncState implements DmSyncState {
 
   @override
   int? oldestSyncedAt(String pubkey) => oldestOverride;
+
+  @override
+  bool historyDrainComplete(String pubkey) => drainCompleteOverride;
+
+  @override
+  Future<void> markHistoryDrainComplete(String pubkey) async {
+    drainCompleteOverride = true;
+  }
 
   @override
   Future<void> recordSeen(String pubkey, {required int createdAt}) async {
@@ -66,12 +75,14 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> clear(String pubkey) async {
     newestOverride = null;
     oldestOverride = null;
+    drainCompleteOverride = false;
   }
 
   @override
   Future<void> clearAll() async {
     newestOverride = null;
     oldestOverride = null;
+    drainCompleteOverride = false;
     recorded.clear();
   }
 }
@@ -2187,6 +2198,138 @@ void main() {
             useCache: any(named: 'useCache'),
           ),
         );
+      });
+    });
+
+    group('backfillHistoryIfNeeded', () {
+      // Kind-5 deletions with no tags flow through _handleIncomingEvent
+      // with zero decryption / DAO side effects, so they exercise the
+      // drain's pagination control flow in isolation.
+      Event deletion(int createdAt) => Event(
+        _validPubkeyA,
+        EventKind.eventDeletion,
+        const <List<String>>[],
+        '',
+        createdAt: createdAt,
+      );
+
+      void stubFiniteHistory(List<Event> history, List<int?> capturedUntil) {
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((inv) async {
+          final filters =
+              inv.positionalArguments.first as List<nostr_filter.Filter>;
+          final until = filters.single.until;
+          capturedUntil.add(until);
+          // Mirror NIP-01 `until` (inclusive) semantics.
+          return history
+              .where((e) => e.createdAt <= (until ?? 1 << 31))
+              .toList();
+        });
+      }
+
+      test(
+        'pages newest→oldest from oldestSyncedAt until the relay is empty, '
+        'then marks the drain complete',
+        () async {
+          final capturedUntil = <int?>[];
+          stubFiniteHistory([
+            deletion(50),
+            deletion(40),
+            deletion(30),
+          ], capturedUntil);
+
+          final syncState = _FakeDmSyncState()..oldestOverride = 100;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Seeded from oldestSyncedAt, then strictly decreasing.
+          expect(capturedUntil.first, 100);
+          for (var i = 1; i < capturedUntil.length; i++) {
+            expect(capturedUntil[i]! < capturedUntil[i - 1]!, isTrue);
+          }
+          // Terminated on an empty page and recorded completion.
+          expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
+
+      test('is a no-op when the drain already completed', () async {
+        final syncState = _FakeDmSyncState()..drainCompleteOverride = true;
+        final repository = createRepository(syncState: syncState);
+
+        await repository.backfillHistoryIfNeeded();
+
+        verifyNever(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        );
+      });
+
+      test('is a no-op when no sync state is wired', () async {
+        final repository = createRepository();
+
+        await repository.backfillHistoryIfNeeded();
+
+        verifyNever(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        );
+      });
+
+      test('stops at the page cap and still marks complete', () async {
+        var calls = 0;
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((inv) async {
+          calls++;
+          final filters =
+              inv.positionalArguments.first as List<nostr_filter.Filter>;
+          final until = filters.single.until!;
+          // Infinite descending supply: only the maxPages cap can stop it.
+          return [deletion(until - 1)];
+        });
+
+        final syncState = _FakeDmSyncState()..oldestOverride = 1000000;
+        final repository = createRepository(syncState: syncState);
+
+        await repository.backfillHistoryIfNeeded();
+
+        expect(calls, DmHistoryDrainConfig.maxPages);
+        expect(syncState.drainCompleteOverride, isTrue);
+      });
+
+      test('shares one in-flight run across concurrent calls', () async {
+        final capturedUntil = <int?>[];
+        stubFiniteHistory([deletion(50)], capturedUntil);
+
+        final syncState = _FakeDmSyncState()..oldestOverride = 100;
+        final repository = createRepository(syncState: syncState);
+
+        // Two simultaneous triggers (e.g. rapid inbox re-opens).
+        await Future.wait([
+          repository.backfillHistoryIfNeeded(),
+          repository.backfillHistoryIfNeeded(),
+        ]);
+
+        // A single drain pages until=100 → 50 → 49(empty) = 3 queries. Two
+        // overlapping drains would have doubled that and re-seeded at 100.
+        expect(capturedUntil, [100, 50, 49]);
+        expect(syncState.drainCompleteOverride, isTrue);
       });
     });
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -43,7 +43,9 @@ class _FakeDmSyncState implements DmSyncState {
   int? newestOverride;
   int? oldestOverride;
   bool drainCompleteOverride = false;
+  int? drainCursorOverride;
   final List<String> markedCompletePubkeys = <String>[];
+  final List<int> persistedDrainCursors = <int>[];
   final List<({String pubkey, int createdAt})> recorded =
       <({String pubkey, int createdAt})>[];
 
@@ -60,6 +62,16 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> markHistoryDrainComplete(String pubkey) async {
     markedCompletePubkeys.add(pubkey);
     drainCompleteOverride = true;
+    drainCursorOverride = null;
+  }
+
+  @override
+  int? historyDrainCursor(String pubkey) => drainCursorOverride;
+
+  @override
+  Future<void> setHistoryDrainCursor(String pubkey, int cursor) async {
+    drainCursorOverride = cursor;
+    persistedDrainCursors.add(cursor);
   }
 
   @override
@@ -78,6 +90,7 @@ class _FakeDmSyncState implements DmSyncState {
     newestOverride = null;
     oldestOverride = null;
     drainCompleteOverride = false;
+    drainCursorOverride = null;
   }
 
   @override
@@ -85,6 +98,7 @@ class _FakeDmSyncState implements DmSyncState {
     newestOverride = null;
     oldestOverride = null;
     drainCompleteOverride = false;
+    drainCursorOverride = null;
     recorded.clear();
   }
 }
@@ -2015,10 +2029,6 @@ void main() {
       );
     });
 
-    // -----------------------------------------------------------------
-    // loadOlderMessages pagination
-    // -----------------------------------------------------------------
-
     group('resolveDmInboxRelays', () {
       Event kind10050Event(List<String> relays, {int createdAt = 1700000000}) {
         return Event(
@@ -2157,52 +2167,6 @@ void main() {
       });
     });
 
-    group('loadOlderMessages', () {
-      test('queries until:oldest with limit 50', () async {
-        const oldest = 1699000000;
-        final syncState = _FakeDmSyncState()..oldestOverride = oldest;
-        when(
-          () => mockNostrClient.queryEvents(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            useCache: any(named: 'useCache'),
-          ),
-        ).thenAnswer((_) async => <Event>[]);
-
-        final repository = createRepository(syncState: syncState);
-
-        await repository.loadOlderMessages();
-
-        final captured =
-            verify(
-                  () => mockNostrClient.queryEvents(
-                    captureAny(),
-                    subscriptionId: any(named: 'subscriptionId'),
-                    useCache: any(named: 'useCache'),
-                  ),
-                ).captured.single
-                as List<nostr_filter.Filter>;
-        expect(captured, hasLength(1));
-        expect(captured.single.until, oldest);
-        expect(captured.single.limit, 50);
-      });
-
-      test('is a no-op when oldest is null', () async {
-        final syncState = _FakeDmSyncState();
-        final repository = createRepository(syncState: syncState);
-
-        await repository.loadOlderMessages();
-
-        verifyNever(
-          () => mockNostrClient.queryEvents(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            useCache: any(named: 'useCache'),
-          ),
-        );
-      });
-    });
-
     group('backfillHistoryIfNeeded', () {
       // Kind-5 deletions with no tags flow through _handleIncomingEvent
       // with zero decryption / DAO side effects, so they exercise the
@@ -2257,6 +2221,10 @@ void main() {
           }
           // Terminated on an empty page and recorded completion.
           expect(syncState.drainCompleteOverride, isTrue);
+          // The boundary is persisted while paging and cleared once the
+          // drain completes cleanly.
+          expect(syncState.persistedDrainCursors, isNotEmpty);
+          expect(syncState.drainCursorOverride, isNull);
         },
       );
 
@@ -2289,31 +2257,115 @@ void main() {
         );
       });
 
-      test('stops at the page cap and still marks complete', () async {
-        var calls = 0;
-        when(
-          () => mockNostrClient.queryEvents(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            useCache: any(named: 'useCache'),
-          ),
-        ).thenAnswer((inv) async {
-          calls++;
-          final filters =
-              inv.positionalArguments.first as List<nostr_filter.Filter>;
-          final until = filters.single.until!;
-          // Infinite descending supply: only the maxPages cap can stop it.
-          return [deletion(until - 1)];
-        });
+      test(
+        'stops at the page cap, leaves the drain incomplete, and persists '
+        'a resume cursor',
+        () async {
+          var calls = 0;
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            calls++;
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            final until = filters.single.until!;
+            // Infinite descending supply: only the maxPages cap can stop it.
+            return [deletion(until - 1)];
+          });
 
-        final syncState = _FakeDmSyncState()..oldestOverride = 1000000;
-        final repository = createRepository(syncState: syncState);
+          final syncState = _FakeDmSyncState()..oldestOverride = 1000000;
+          final repository = createRepository(syncState: syncState);
 
-        await repository.backfillHistoryIfNeeded();
+          await repository.backfillHistoryIfNeeded();
 
-        expect(calls, DmHistoryDrainConfig.maxPages);
-        expect(syncState.drainCompleteOverride, isTrue);
-      });
+          expect(calls, DmHistoryDrainConfig.maxPages);
+          // Cap hit: do NOT declare the drain complete, or heavy users would
+          // permanently lose history older than the cap. Persist the
+          // boundary so the next inbox open resumes instead of restarting.
+          // See #4953.
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(syncState.drainCursorOverride, isNotNull);
+          expect(syncState.drainCursorOverride, lessThan(1000000));
+          // The boundary is persisted after EVERY page (not just the last),
+          // so an interruption at any point resumes from the latest page.
+          expect(
+            syncState.persistedDrainCursors,
+            hasLength(DmHistoryDrainConfig.maxPages),
+          );
+        },
+      );
+
+      test(
+        'resumes from the persisted drain cursor instead of oldestSyncedAt',
+        () async {
+          final capturedUntil = <int?>[];
+          stubFiniteHistory([deletion(40), deletion(30)], capturedUntil);
+
+          // A prior page-capped run advanced the cursor far below the live
+          // subscription's oldestSyncedAt boundary.
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 1000
+            ..drainCursorOverride = 45;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Seeded from the persisted cursor (45), not oldestSyncedAt (1000).
+          expect(capturedUntil.first, 45);
+          // The resumed run reaches EOSE and finally records completion.
+          expect(syncState.drainCompleteOverride, isTrue);
+          expect(syncState.markedCompletePubkeys, isNotEmpty);
+        },
+      );
+
+      test(
+        'an exception mid-drain keeps the cursor and resumes on the next run',
+        () async {
+          var calls = 0;
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            calls++;
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            final until = filters.single.until!;
+            // Page 0 advances + persists the cursor; page 1 fails.
+            if (calls == 1) return [deletion(until - 1)];
+            throw Exception('relay boom');
+          });
+
+          final syncState = _FakeDmSyncState()..oldestOverride = 1000;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Failed mid-drain: not complete, but the cursor is preserved.
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          final resumeCursor = syncState.drainCursorOverride;
+          expect(resumeCursor, isNotNull);
+          expect(resumeCursor, lessThan(1000));
+
+          // The next inbox open resumes from the persisted cursor (not
+          // oldestSyncedAt) and finishes once the relay returns empty.
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(capturedUntil.first, resumeCursor);
+          expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
 
       test('shares one in-flight run across concurrent calls', () async {
         final capturedUntil = <int?>[];

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2351,6 +2351,7 @@ void main() {
           // Failed mid-drain: not complete, but the cursor is preserved.
           expect(syncState.drainCompleteOverride, isFalse);
           expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(reporterCalls, isEmpty);
           final resumeCursor = syncState.drainCursorOverride;
           expect(resumeCursor, isNotNull);
           expect(resumeCursor, lessThan(1000));
@@ -2364,6 +2365,34 @@ void main() {
 
           expect(capturedUntil.first, resumeCursor);
           expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
+
+      test(
+        'reports unexpected programming failures without marking complete',
+        () async {
+          final error = StateError('bad drain state');
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenThrow(error);
+
+          final syncState = _FakeDmSyncState()..oldestOverride = 1000;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+          expect(reporterCalls, hasLength(1));
+          expect(reporterCalls.single.error, same(error));
+          expect(
+            reporterCalls.single.site,
+            DmRepositoryReportableSites.historyDrainUnexpectedFailure,
+          );
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -43,6 +43,7 @@ class _FakeDmSyncState implements DmSyncState {
   int? newestOverride;
   int? oldestOverride;
   bool drainCompleteOverride = false;
+  final List<String> markedCompletePubkeys = <String>[];
   final List<({String pubkey, int createdAt})> recorded =
       <({String pubkey, int createdAt})>[];
 
@@ -57,6 +58,7 @@ class _FakeDmSyncState implements DmSyncState {
 
   @override
   Future<void> markHistoryDrainComplete(String pubkey) async {
+    markedCompletePubkeys.add(pubkey);
     drainCompleteOverride = true;
   }
 
@@ -2331,6 +2333,87 @@ void main() {
         expect(capturedUntil, [100, 50, 49]);
         expect(syncState.drainCompleteOverride, isTrue);
       });
+
+      test(
+        'stale account-switch drain does not clear or process the new drain',
+        () async {
+          final syncState = _FakeDmSyncState()..oldestOverride = 100;
+          final repository = createRepository(syncState: syncState);
+          final oldQueryStarted = Completer<void>();
+          final newQueryStarted = Completer<void>();
+          final oldQueryRelease = Completer<void>();
+          final newQueryRelease = Completer<void>();
+          final queriedPubkeys = <String>[];
+
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            final pubkey = filters.single.p!.single;
+            queriedPubkeys.add(pubkey);
+
+            if (pubkey == _validPubkeyA) {
+              oldQueryStarted.complete();
+              await oldQueryRelease.future;
+              return [
+                Event(
+                  _validPubkeyA,
+                  EventKind.eventDeletion,
+                  [
+                    ['e', _rumorEventId],
+                  ],
+                  '',
+                  createdAt: 90,
+                ),
+              ];
+            }
+
+            newQueryStarted.complete();
+            await newQueryRelease.future;
+            return <Event>[];
+          });
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final oldDrain = repository.backfillHistoryIfNeeded();
+          await oldQueryStarted.future;
+
+          repository.setCredentials(
+            userPubkey: _validPubkeyB,
+            signer: LocalNostrSigner(_validPrivateKey),
+            messageService: mockMessageService,
+          );
+          final newDrain = repository.backfillHistoryIfNeeded();
+          await newQueryStarted.future;
+
+          oldQueryRelease.complete();
+          await oldDrain;
+
+          // The old drain's whenComplete must not wipe the new in-flight drain.
+          expect(repository.backfillHistoryIfNeeded(), same(newDrain));
+
+          newQueryRelease.complete();
+          await newDrain;
+
+          expect(queriedPubkeys, [_validPubkeyA, _validPubkeyB]);
+          verifyNever(
+            () => mockDirectMessagesDao.getMessageById(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+          expect(syncState.markedCompletePubkeys, [_validPubkeyB]);
+        },
+      );
     });
 
     // -----------------------------------------------------------------

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -115,5 +115,44 @@ void main() {
         expect(prefs.getString('unrelated_key'), equals('keep_me'));
       },
     );
+
+    group('historyDrainComplete', () {
+      test('defaults to false when nothing persisted', () {
+        expect(state.historyDrainComplete(pkA), isFalse);
+      });
+
+      test('markHistoryDrainComplete flips the flag to true', () async {
+        await state.markHistoryDrainComplete(pkA);
+
+        expect(state.historyDrainComplete(pkA), isTrue);
+      });
+
+      test('is scoped per pubkey', () async {
+        await state.markHistoryDrainComplete(pkA);
+
+        expect(state.historyDrainComplete(pkA), isTrue);
+        expect(state.historyDrainComplete(pkB), isFalse);
+      });
+
+      test('clear re-arms the drain for the given pubkey only', () async {
+        await state.markHistoryDrainComplete(pkA);
+        await state.markHistoryDrainComplete(pkB);
+
+        await state.clear(pkA);
+
+        expect(state.historyDrainComplete(pkA), isFalse);
+        expect(state.historyDrainComplete(pkB), isTrue);
+      });
+
+      test('clearAll re-arms the drain for every pubkey', () async {
+        await state.markHistoryDrainComplete(pkA);
+        await state.markHistoryDrainComplete(pkB);
+
+        await state.clearAll();
+
+        expect(state.historyDrainComplete(pkA), isFalse);
+        expect(state.historyDrainComplete(pkB), isFalse);
+      });
+    });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -154,5 +154,53 @@ void main() {
         expect(state.historyDrainComplete(pkB), isFalse);
       });
     });
+
+    group('historyDrainCursor', () {
+      test('defaults to null when nothing persisted', () {
+        expect(state.historyDrainCursor(pkA), isNull);
+      });
+
+      test('setHistoryDrainCursor round-trips the value', () async {
+        await state.setHistoryDrainCursor(pkA, 1699000000);
+
+        expect(state.historyDrainCursor(pkA), equals(1699000000));
+      });
+
+      test('is scoped per pubkey', () async {
+        await state.setHistoryDrainCursor(pkA, 1000);
+
+        expect(state.historyDrainCursor(pkA), equals(1000));
+        expect(state.historyDrainCursor(pkB), isNull);
+      });
+
+      test('markHistoryDrainComplete clears the cursor', () async {
+        await state.setHistoryDrainCursor(pkA, 1000);
+
+        await state.markHistoryDrainComplete(pkA);
+
+        expect(state.historyDrainCursor(pkA), isNull);
+        expect(state.historyDrainComplete(pkA), isTrue);
+      });
+
+      test('clear removes the cursor for the given pubkey only', () async {
+        await state.setHistoryDrainCursor(pkA, 1000);
+        await state.setHistoryDrainCursor(pkB, 2000);
+
+        await state.clear(pkA);
+
+        expect(state.historyDrainCursor(pkA), isNull);
+        expect(state.historyDrainCursor(pkB), equals(2000));
+      });
+
+      test('clearAll removes the cursor for every pubkey', () async {
+        await state.setHistoryDrainCursor(pkA, 1000);
+        await state.setHistoryDrainCursor(pkB, 2000);
+
+        await state.clearAll();
+
+        expect(state.historyDrainCursor(pkA), isNull);
+        expect(state.historyDrainCursor(pkB), isNull);
+      });
+    });
   });
 }

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -86,6 +86,10 @@ void main() {
       // Stub subscription lifecycle methods (#2766).
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
+      // One-time history drain fired on every inbox open (#4953).
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
     });
 
     ConversationListBloc createBloc() => ConversationListBloc(
@@ -104,6 +108,18 @@ void main() {
     });
 
     group('ConversationListStarted', () {
+      blocTest<ConversationListBloc, ConversationListState>(
+        'triggers the one-time DM history drain on open (#4953)',
+        setUp: () {
+          _stubStreams(mockDmRepository);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ConversationListStarted()),
+        verify: (_) {
+          verify(() => mockDmRepository.backfillHistoryIfNeeded()).called(1);
+        },
+      );
+
       blocTest<ConversationListBloc, ConversationListState>(
         'emits [loading, loaded] when stream emits conversations',
         setUp: () {
@@ -1053,6 +1069,9 @@ void main() {
       when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
     });
 
     blocTest<ConversationListBloc, ConversationListState>(

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -83,6 +83,9 @@ void main() {
 
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
     });
 
     test('has correct route constants', () {

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -48,6 +48,9 @@ void main() {
       when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
 
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
       when(() => mockAuthService.isAuthenticated).thenReturn(true);


### PR DESCRIPTION
## Description

After uninstall → reinstall → re-login on the **same** account, the Messages tab showed only a random subset of DM chats ("often around 4"), with the rest unrecoverable.

**Root cause:** On reinstall the local Drift DB **and** `DmSyncState` (SharedPreferences) are both wiped, so `newestSyncedAt == null` → the live gift-wrap subscription opens its bounded first-open window `{kinds:[1059,4,5], p:[me], limit:50}`. The conversation list is a **pure local-DB projection**, and the only relay backfill (`loadOlderMessages`) was **never wired to the UI**, so any conversation not represented in that ~50-event window stayed permanently missing. The "~4 / random" quality is amplified by a startup race: on reinstall the relay pool is divine-only until background NIP-65 discovery finishes, and `startListening()` fires before that — so the first-open fetch hits a partial pool and nothing re-subscribes when relays are added.

**Fix:** A one-time, resumable, capped, **background history drain** (`DmRepository.backfillHistoryIfNeeded`) that pages relays newest→oldest to EOSE through the existing `_handleIncomingEvent` pipeline, gated by a new `DmSyncState.historyDrainComplete` flag. It is triggered from `ConversationListBloc` on inbox open — by which point relay discovery has reliably completed, so it queries the full pool. The pagination cursor tracks the **outer** gift-wrap `created_at` (what the relay's `until:` filters on, not the rumor time in `oldestSyncedAt`), steps strictly downward (dedup absorbs boundary ties), and the run is pinned to the user so an account switch mid-drain can't mark the wrong pubkey complete.

This **preserves the DM scaling fix** (`docs/plans/2026-04-05-dm-scaling-fix-design.md`): cold start still does zero DM work, steady-state still uses `since: newest-2d`, decryption stays off the UI isolate, and the drain runs once and is bounded by `maxPages` (logs if the cap truncates — no silent loss).

**Related Issue:** Closes #4953

## Out of Scope

NIP-17 receive-side completeness (read **and** publish the user's *own* kind-10050 DM inbox relays — RC2/RC3) is a separate follow-up issue. It is independent of this fix and is not required to close #4953: divine-mobile never publishes a kind-10050, so the reporter has none and the drain over the default/full pool is the correct fix for their case.

## Verification

- `flutter analyze lib test integration_test` → **No issues found**
- `dart format --set-exit-if-changed` on all changed files → clean
- New unit tests:
  - `DmSyncState`: drain-complete flag get/set, per-pubkey scope, `clear`/`clearAll` re-arm
  - `DmRepository.backfillHistoryIfNeeded`: pages newest→oldest from `oldestSyncedAt` to empty then marks complete; idempotent when already complete; no-op without sync state; stops at the page cap; concurrent calls share one in-flight run
  - `ConversationListBloc`: triggers the drain on `ConversationListStarted`
  - Extended the cold-start regression guard (construct + `setCredentials` still does zero relay/DB work)
- Full DM + inbox suite: **682 tests pass** (`packages/dm_repository/test`, `test/blocs/dm`, `test/screens/inbox`)

### Manual test plan (for the reporter / QA)
1. On a device with many DM chats, note the full list.
2. Uninstall, reinstall, log into the same account, open Messages → full list repopulates within a few seconds.
3. Force-quit mid-load, reopen Messages → drain resumes and completes.
4. Reopen Messages later → no extra relay traffic (drain flag set); new incoming DMs still arrive.
5. Cold start without opening Messages → zero DM relay queries.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)