### PR TITLE
fix(video-editor): ensure speed-up feature works correctly

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1840,10 +1840,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: b31ada4812ab9a295bcdcd1e693f35ef3b5dcca689eece15fd519fc093617613
+      sha256: fb173de8e408103c72f75b1009131cc46a8721e08e4e00b18703e5aa1ebeb87f
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.4"
+    version: "1.17.5"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -296,7 +296,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.17.4
+  pro_video_editor: ^1.17.5
   pro_image_editor: ^12.4.8
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

On Android devices, speeding up a video clip with custom audio caused an issue where the video kept its original duration and froze at the end. This PR fixes the problem by updating `pro_video_editor`, as the actual fix was implemented in that package.


**Related Issue:** Closes #4975

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
