### PR TITLE
fix(timeline): rebase markers after clip reorder and trim

### DIFF
--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -42,6 +42,7 @@ class TimelineOverlayBloc
     on<TimelineOverlayTotalDurationChanged>(_onTotalDurationChanged);
     on<TimelineMarkerAdded>(_onMarkerAdded);
     on<TimelineMarkerRemoved>(_onMarkerRemoved);
+    on<TimelineMarkersRebased>(_onMarkersRebased);
     on<TimelineOverlayWaveformLoaded>(_onWaveformLoaded);
     on<TimelineOverlayAudioVolumeChanged>(
       _onAudioVolumeChanged,
@@ -517,6 +518,14 @@ class TimelineOverlayBloc
         timelineMarkersRevision: state.timelineMarkersRevision + 1,
       ),
     );
+  }
+
+  void _onMarkersRebased(
+    TimelineMarkersRebased event,
+    Emitter<TimelineOverlayState> emit,
+  ) {
+    final markers = event.markers.toSet().toList()..sort();
+    emit(state.copyWith(timelineMarkers: markers));
   }
 
   static List<Duration> _clampMarkers(

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -179,6 +179,20 @@ class TimelineMarkerRemoved extends TimelineOverlayEvent {
   List<Object?> get props => [position];
 }
 
+/// Replace marker positions after a clip-order change.
+///
+/// This intentionally does not bump [TimelineOverlayState.timelineMarkersRevision]:
+/// clip reorder writes the rebased markers together with the clip order in one
+/// editor-history entry.
+class TimelineMarkersRebased extends TimelineOverlayEvent {
+  const TimelineMarkersRebased(this.markers);
+
+  final List<Duration> markers;
+
+  @override
+  List<Object?> get props => [markers];
+}
+
 /// Attach extracted waveform samples to a sound item.
 class TimelineOverlayWaveformLoaded extends TimelineOverlayEvent {
   const TimelineOverlayWaveformLoaded({

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -102,19 +102,29 @@ extension VideoEditorExtensions on ProImageEditorState {
   void setClipState(
     List<DivineVideoClip> clips, {
     bool skipUpdateHistory = false,
+    List<Duration>? timelineMarkers,
   }) {
     final serialized = clips.map((c) => c.toJson()).toList();
+    final meta = {
+      ...stateManager.activeMeta,
+      VideoEditorConstants.clipsStateHistoryKey: serialized,
+      if (timelineMarkers != null)
+        VideoEditorConstants.timelineMarkersStateHistoryKey: timelineMarkers
+            .map((marker) => marker.inMilliseconds)
+            .toList(),
+    };
 
     if (!skipUpdateHistory) {
-      addHistory(
-        meta: {
-          ...stateManager.activeMeta,
-          VideoEditorConstants.clipsStateHistoryKey: serialized,
-        },
-      );
+      addHistory(meta: meta);
     } else {
       stateManager.activeMeta[VideoEditorConstants.clipsStateHistoryKey] =
           serialized;
+      if (timelineMarkers != null) {
+        stateManager.activeMeta[VideoEditorConstants
+            .timelineMarkersStateHistoryKey] = timelineMarkers
+            .map((marker) => marker.inMilliseconds)
+            .toList();
+      }
     }
     setState(() {});
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -4,7 +4,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
@@ -73,6 +72,8 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
 
   /// Whether a trim handle drag is in progress — disables scroll physics.
   bool _isTrimming = false;
+  List<DivineVideoClip>? _clipTrimStartClips;
+  List<Duration>? _clipTrimStartMarkers;
 
   @override
   void initState() {
@@ -133,9 +134,14 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
           listenWhen: (prev, curr) => prev.totalDuration != curr.totalDuration,
           listener: (context, state) {
             _totalDuration = state.totalDuration;
-            context.read<TimelineOverlayBloc>().add(
+            final overlayBloc = context.read<TimelineOverlayBloc>();
+            overlayBloc.add(
               TimelineOverlayTotalDurationChanged(state.totalDuration),
             );
+            final rebasedMarkers = _rebasedClipTrimMarkers(state.clips);
+            if (rebasedMarkers != null) {
+              overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+            }
           },
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
@@ -291,13 +297,23 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   // -- Reorder callbacks ----------------------------------------------------
 
   void _onClipsReordered(List<DivineVideoClip> reorderedClips) {
-    context.read<ClipEditorBloc>().add(ClipEditorInitialized(reorderedClips));
+    final clipBloc = context.read<ClipEditorBloc>();
+    final overlayBloc = context.read<TimelineOverlayBloc>();
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: clipBloc.state.clips,
+      newClips: reorderedClips,
+      markers: overlayBloc.state.timelineMarkers,
+    );
+
+    clipBloc.add(ClipEditorInitialized(reorderedClips));
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
     context.read<VideoEditorMainBloc>().add(
       const VideoEditorExternalPauseRequested(isPaused: true),
     );
-    // Persist reorder as a new history entry so it can be undone.
+    // Persist reorder and marker rebasing as one history entry so undo
+    // restores a consistent timeline.
     final editor = VideoEditorScope.of(context).editor;
-    editor?.setClipState(reorderedClips);
+    editor?.setClipState(reorderedClips, timelineMarkers: rebasedMarkers);
   }
 
   void _onReorderChanged(bool isReordering) {
@@ -339,25 +355,46 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     setState(() => _isTrimming = isTrimming);
     final editor = VideoEditorScope.of(context).requireEditor;
     final clipEditorBloc = context.read<ClipEditorBloc>();
+    final overlayBloc = context.read<TimelineOverlayBloc>();
 
     if (isTrimming) {
+      _clipTrimStartClips = List<DivineVideoClip>.of(
+        clipEditorBloc.state.clips,
+      );
+      _clipTrimStartMarkers = List<Duration>.of(
+        overlayBloc.state.timelineMarkers,
+      );
       clipEditorBloc.add(const ClipEditorTrimDragStarted());
 
       context.read<VideoEditorMainBloc>().add(
         const VideoEditorExternalPauseRequested(isPaused: true),
       );
     } else {
+      final rebasedMarkers =
+          _rebasedClipTrimMarkers(clipEditorBloc.state.clips) ??
+          overlayBloc.state.timelineMarkers;
+      overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
       clipEditorBloc.add(const ClipEditorTrimDragEnded());
 
-      final clips = clipEditorBloc.state.clips.map((e) => e.toJson()).toList();
-
-      editor.addHistory(
-        meta: {
-          ...editor.stateManager.activeMeta,
-          VideoEditorConstants.clipsStateHistoryKey: clips,
-        },
+      editor.setClipState(
+        clipEditorBloc.state.clips,
+        timelineMarkers: rebasedMarkers,
       );
+      _clipTrimStartClips = null;
+      _clipTrimStartMarkers = null;
     }
+  }
+
+  List<Duration>? _rebasedClipTrimMarkers(List<DivineVideoClip> clips) {
+    final oldClips = _clipTrimStartClips;
+    final markers = _clipTrimStartMarkers;
+    if (oldClips == null || markers == null) return null;
+
+    return rebaseTimelineMarkersForClipState(
+      oldClips: oldClips,
+      newClips: clips,
+      markers: markers,
+    );
   }
 
   // -- Clip tap callback ----------------------------------------------------

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -40,6 +40,127 @@ Duration? clipSourcePositionToTimelinePosition(
   return null;
 }
 
+/// Reprojects marker positions after clip order, trim, or speed changes.
+///
+/// Timeline markers are stored as absolute composition times because the
+/// ruler, snapping, and painter all operate in timeline coordinates. The user
+/// experience is clip-source based, though: a marker placed on source second 5
+/// of clip B should follow clip B when reordered, and disappear if source
+/// second 5 is trimmed out. This converts:
+///
+///   old absolute time -> old clip id + source position -> new absolute time
+List<Duration> rebaseTimelineMarkersForClipState({
+  required List<DivineVideoClip> oldClips,
+  required List<DivineVideoClip> newClips,
+  required List<Duration> markers,
+}) {
+  if (markers.isEmpty || oldClips.isEmpty || newClips.isEmpty) {
+    return const [];
+  }
+
+  final newClipStarts = <String, Duration>{};
+  final newClipsById = <String, DivineVideoClip>{};
+  var newCursor = Duration.zero;
+  for (final clip in newClips) {
+    newClipStarts[clip.id] = newCursor;
+    newClipsById[clip.id] = clip;
+    newCursor += clip.playbackDuration;
+  }
+
+  final rebased = <Duration>{};
+  for (final marker in markers) {
+    final anchor = _timelineMarkerAnchorForPosition(oldClips, marker);
+    if (anchor == null) continue;
+
+    final newStart = newClipStarts[anchor.clipId];
+    final newClip = newClipsById[anchor.clipId];
+    if (newStart == null || newClip == null) continue;
+
+    final playbackOffset = _sourcePositionToPlaybackOffset(
+      newClip,
+      anchor.sourcePosition,
+    );
+    if (playbackOffset == null) continue;
+
+    rebased.add(newStart + playbackOffset);
+  }
+
+  return rebased.toList()..sort();
+}
+
+_TimelineMarkerAnchor? _timelineMarkerAnchorForPosition(
+  List<DivineVideoClip> clips,
+  Duration marker,
+) {
+  var cursor = Duration.zero;
+  for (var i = 0; i < clips.length; i++) {
+    final clip = clips[i];
+    final duration = clip.playbackDuration;
+    final end = cursor + duration;
+    final isLast = i == clips.length - 1;
+
+    if (marker < end || isLast) {
+      return _TimelineMarkerAnchor(
+        clip.id,
+        _playbackOffsetToSourcePosition(
+          clip,
+          _clampDuration(marker - cursor, duration),
+        ),
+      );
+    }
+
+    cursor = end;
+  }
+
+  return null;
+}
+
+Duration _playbackOffsetToSourcePosition(
+  DivineVideoClip clip,
+  Duration playbackOffset,
+) {
+  final speed = clip.playbackSpeed ?? 1.0;
+  final sourceOffset = speed <= 0 || speed == 1.0
+      ? playbackOffset
+      : Duration(
+          microseconds: (playbackOffset.inMicroseconds * speed).round(),
+        );
+
+  return clip.trimStart + _clampDuration(sourceOffset, clip.trimmedDuration);
+}
+
+Duration? _sourcePositionToPlaybackOffset(
+  DivineVideoClip clip,
+  Duration sourcePosition,
+) {
+  final visibleStart = clip.trimStart;
+  final visibleEnd = clip.duration - clip.trimEnd;
+  if (sourcePosition < visibleStart || sourcePosition > visibleEnd) {
+    return null;
+  }
+
+  final sourceOffset = sourcePosition - visibleStart;
+  final speed = clip.playbackSpeed ?? 1.0;
+  if (speed <= 0 || speed == 1.0) return sourceOffset;
+
+  return Duration(
+    microseconds: (sourceOffset.inMicroseconds / speed).round(),
+  );
+}
+
+Duration _clampDuration(Duration value, Duration max) {
+  if (value < Duration.zero) return Duration.zero;
+  if (value > max) return max;
+  return value;
+}
+
+class _TimelineMarkerAnchor {
+  const _TimelineMarkerAnchor(this.clipId, this.sourcePosition);
+
+  final String clipId;
+  final Duration sourcePosition;
+}
+
 /// Converts a composite playback [position] to the corresponding scroll
 /// offset in the timeline content, accounting for the
 /// [TimelineConstants.clipGap]-wide gap between adjacent clip strips.

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -880,6 +880,30 @@ void main() {
         expect: () => <TimelineOverlayState>[],
       );
     });
+
+    group(TimelineMarkersRebased, () {
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'replaces markers without bumping the history revision',
+        build: TimelineOverlayBloc.new,
+        seed: () => const TimelineOverlayState(
+          timelineMarkers: [Duration(seconds: 1)],
+          timelineMarkersRevision: 4,
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineMarkersRebased([
+            Duration(seconds: 5),
+            Duration(seconds: 2),
+            Duration(seconds: 2),
+          ]),
+        ),
+        expect: () => const [
+          TimelineOverlayState(
+            timelineMarkers: [Duration(seconds: 2), Duration(seconds: 5)],
+            timelineMarkersRevision: 4,
+          ),
+        ],
+      );
+    });
   });
 
   group(TimelineOverlayState, () {

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -397,6 +397,214 @@ void main() {
     });
   });
 
+  group(rebaseTimelineMarkersForClipState, () {
+    test('keeps a marker attached to the same clip source position', () {
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+        _clip('c', 2),
+        _clip('d', 4),
+      ];
+      final newClips = [
+        _clip('d', 4),
+        _clip('b', 5),
+        _clip('a', 3),
+        _clip('c', 2),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 5)],
+        ),
+        equals([const Duration(seconds: 6)]),
+      );
+    });
+
+    test('sorts rebased markers from multiple clips', () {
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+        _clip('c', 2),
+      ];
+      final newClips = [
+        _clip('c', 2),
+        _clip('a', 3),
+        _clip('b', 5),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [
+            const Duration(seconds: 4),
+            const Duration(seconds: 9),
+          ],
+        ),
+        equals([
+          const Duration(seconds: 1),
+          const Duration(seconds: 6),
+        ]),
+      );
+    });
+
+    test('respects trimmed and speed-adjusted playback duration', () {
+      final oldClips = [
+        _clip('intro', 10, speed: 2.0),
+        _clip(
+          'target',
+          10,
+          speed: 2.0,
+          trimStart: const Duration(seconds: 2),
+        ),
+      ];
+      final newClips = [
+        _clip(
+          'target',
+          10,
+          speed: 2.0,
+          trimStart: const Duration(seconds: 2),
+        ),
+        _clip('intro', 10, speed: 2.0),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 6)],
+        ),
+        equals([const Duration(seconds: 1)]),
+      );
+    });
+
+    test('anchors an exact internal boundary to the following clip', () {
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+        _clip('c', 2),
+      ];
+      final newClips = [
+        _clip('c', 2),
+        _clip('b', 5),
+        _clip('a', 3),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 3)],
+        ),
+        equals([const Duration(seconds: 2)]),
+      );
+    });
+
+    test('drops a marker when its source position is trimmed from the end', () {
+      final oldClips = [_clip('clip', 6)];
+      final newClips = [
+        _clip('clip', 6, trimEnd: const Duration(seconds: 3)),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 5)],
+        ),
+        isEmpty,
+      );
+    });
+
+    test(
+      'drops a marker when its source position is trimmed from the start',
+      () {
+        final oldClips = [_clip('clip', 6)];
+        final newClips = [
+          _clip('clip', 6, trimStart: const Duration(seconds: 3)),
+        ];
+
+        expect(
+          rebaseTimelineMarkersForClipState(
+            oldClips: oldClips,
+            newClips: newClips,
+            markers: [const Duration(seconds: 2)],
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test('moves a visible source marker when trimStart advances', () {
+      final oldClips = [_clip('clip', 6)];
+      final newClips = [
+        _clip('clip', 6, trimStart: const Duration(seconds: 3)),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 5)],
+        ),
+        equals([const Duration(seconds: 2)]),
+      );
+    });
+
+    test('keeps marker anchored to source time across speed changes', () {
+      final oldClips = [_clip('clip', 10)];
+      final newClips = [_clip('clip', 10, speed: 2.0)];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 6)],
+        ),
+        equals([const Duration(seconds: 3)]),
+      );
+    });
+
+    test('drops markers whose source clip no longer exists', () {
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+      ];
+      final newClips = [_clip('a', 3)];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 4)],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('clamps a marker past the timeline end to the last clip end', () {
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+      ];
+      final newClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 20)],
+        ),
+        equals([const Duration(seconds: 8)]),
+      );
+    });
+  });
+
   group('DivineVideoClip.playbackDuration', () {
     test('null speed → same as trimmedDuration', () {
       final clip = _clip('a', 10);


### PR DESCRIPTION
Closes #4980

## Description

Timeline markers were stored as absolute composition times and did not move when the user reordered or trimmed clips. A marker placed on source-second 5 of clip B would remain at timeline-second 5 even after clip B was dragged to a different position.

This PR introduces `rebaseTimelineMarkersForClipState`, a pure geometry helper that converts:

```
old absolute timeline time -> (clip id + source position) -> new absolute timeline time
```

It is called in three places:

| Trigger | Where |
|---|---|
| Clip reorder via drag | `_onClipsReordered` in `video_editor_timeline.dart` |
| Clip trim drag end | `_onTrimDragChanged` trim-end path |
| Clip trim live preview while total duration changes | `totalDuration` BlocListener during an active trim drag |

**Marker drop / clamp rules** — deliberate behaviour:
- A marker whose source position is trimmed out (start or end) is **dropped**.
- A marker whose clip is removed from the composition is **dropped**.
- A marker placed exactly on a clip boundary is anchored to the **following** clip.
- A marker beyond the total timeline end is clamped to the last clip's end.

**History consistency** — `setClipState` now accepts an optional `timelineMarkers` argument and writes both clips and markers into a **single** undo entry. Undo/redo restores a consistent timeline because `_syncMainCapabilities` in `video_editor_canvas.dart` already reads `stateManager.timelineMarkers` back into the overlay bloc on every history navigation.

The new `TimelineMarkersRebased` event intentionally does **not** bump `timelineMarkersRevision` — clip reorder and trim completion already write a combined history entry, so no separate revision bump is needed.

**Related Issue:** Closes #4903

## Out of Scope

- Widget-level integration tests for the three call-sites (requires a full `ProImageEditor` scope; see existing note in repo memory — widget tests for this timeline are not a reliable proxy for on-device behaviour).
- Rebasing markers for clip speed changes, deletion, duplication, and split. The geometry helper supports the needed coordinate conversion, but those call sites are intentionally tracked separately in #4985.

## Verification

```
flutter test test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart \
            test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
# -> All 113 tests passed
flutter analyze lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart \
              lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart \
              lib/extensions/video_editor_extensions.dart \
              lib/blocs/video_editor/timeline_overlay/
# -> No issues found
```

Manual on-device: place a marker -> reorder clips -> verify marker follows the clip; trim a clip to cut the marker out -> verify it disappears; undo -> verify marker returns to original position.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
