### PR TITLE
feat(db): SQLCipher at-rest encryption full implementation + device-QA plan (#570)

### DIFF
--- a/mobile/docs/sqlcipher_at_rest_plan.md
+++ b/mobile/docs/sqlcipher_at_rest_plan.md
@@ -1,0 +1,118 @@
+# SQLCipher at-rest encryption for the local DB (#570, finding C2)
+
+Status: **device-QA-gated draft.** The full Dart implementation, the native
+dependency swap, and unit tests for every host-testable property are committed.
+What remains before this can leave draft is **on-device validation** (the
+encrypted open, the in-place migration, and the iOS/macOS build configuration)
+— none of it can be exercised in CI, which links plain sqlite3 and on which
+`PRAGMA cipher_version` is empty. See the device-QA checklist at the bottom.
+
+## Why
+
+DMs (and the rest of the shared `divine_db.db`: drafts, pending uploads,
+pending actions, outgoing DMs, reactions, reposts, notifications, bookmarks,
+NIP-05 verifications) are stored **plaintext at rest** today. For a moderation
+account holding reports about users, plaintext-at-rest is materially more
+sensitive. Decision (#570): encrypt at rest before the T&S moderation launch.
+
+## What is NOT in scope
+
+- **Web / IndexedDB** (`connection_web.dart`): SQLCipher is native-only. Web
+  at-rest encryption is deferred behind the OPFS migration (#373). The app
+  guards encryption with `kIsWeb`; the web connection variants throw
+  `UnsupportedError` and are never reached.
+- **Backend D1 retention**: the backend stores DMs plaintext indefinitely in
+  `dm_log` — a separate data-minimization item (tracked as #570 Decision 8).
+- **The `cache_sync.db` cache**: it shares the SQLCipher runtime but is opened
+  unkeyed (plaintext), which SQLCipher supports. Only `divine_db.db` is keyed.
+
+## Committed in this PR (host-verified)
+
+### Dependency swap — `mobile/pubspec.yaml`
+- `sqlite3_flutter_libs ^0.5.40` → **`sqlcipher_flutter_libs ^0.6.8`**. The two
+  cannot coexist (both ship a native sqlite3 that collides on iOS/macOS). 0.6.x
+  is the SQLCipher build for the sqlite3 2.x family; **0.7.0+ is an EOL no-op**.
+- Removed **`drift_flutter`** — it was unused (db_client opens `NativeDatabase`
+  directly) and transitively pulled `sqlite3_flutter_libs` back in,
+  reintroducing the collision.
+- Added **`sqlite3`** as a direct dep so the Android library override
+  (`package:sqlite3/open.dart`) is referenceable.
+
+### db_client (`connection_native.dart` + web/stub variants)
+- `formatCipherKeyPragma(rawKeyHex)` — builds the raw-key `PRAGMA key`. **The
+  thrown `ArgumentError` never embeds the key** (fixes the #4945 review finding).
+- `applyCipherKey(db, rawKeyHex)` — keys the connection and **fails closed**:
+  if `PRAGMA cipher_version` is empty (SQLCipher not linked) it throws rather
+  than silently writing plaintext.
+- `openEncryptedConnection({rawKeyHex})` — keyed `NativeDatabase` for the app
+  to inject the key into (db_client never reads the keystore).
+- `migratePlaintextToEncrypted({rawKeyHex})` — one-time in-place rekey via
+  `sqlcipher_export`, **safe by construction**: writes a side file, verifies it
+  (key opens it; table/row counts match the source) before swapping, renames
+  the plaintext original to a backup rather than deleting it, and leaves the
+  source intact on any failure (retries next launch). Copies `user_version`
+  (drift's schema version) explicitly, which `sqlcipher_export` does not.
+  Wipe-and-resync is rejected: `divine_db.db` holds local-only data that cannot
+  be re-fetched.
+- `deleteSharedDatabaseFiles()` — used by the §6 key-loss recovery.
+
+### App layer
+- `lib/database/sqlcipher_runtime.dart` (+ `_io` / `_stub`) — conditional-import
+  glue: on Android, `applyWorkaroundToOpenSqlCipherOnOldAndroidVersions()` +
+  `open.overrideFor(OperatingSystem.android, openCipherOnAndroid)`; a runtime
+  `isSqlCipherAvailable()` probe. No-op on web (no dart:ffi).
+- `lib/services/database_encryption_bootstrap.dart` — reads/generates a 32-byte
+  CSPRNG key in `flutter_secure_storage` (`db.cipher.key.v1`, 64 hex; never
+  logged), forces the SQLCipher runtime, runs the migration, and resolves the
+  key for the database provider. Throws if SQLCipher is not linked.
+- `lib/providers/db_cipher_key_provider.dart` — `Provider<String?>` (null
+  default → plaintext for web/tests), overridden in `main.dart`.
+- `lib/providers/database_provider.dart` — opens an encrypted connection when a
+  key is present, else the default connection.
+- `lib/main.dart` — resolves the key before the `ProviderContainer`; on failure
+  reports to Crashlytics and degrades to plaintext (the device-QA gate prevents
+  an unencrypted build from shipping).
+
+### §6 key-loss behavior (implemented; pending product signoff)
+If the keystore is cleared (OS reset / restore without keychain migration), the
+cipher key is gone and the encrypted DB is cryptographically unrecoverable. The
+bootstrap detects this (freshly generated key + an existing encrypted DB),
+**wipes the DB and recreates it under a new key** — DMs resync from relays;
+other local-only data is lost. This is the only possible recovery for an
+unrecoverable DB, but the user-facing notice / exact UX **needs product
+signoff** before un-drafting.
+
+## Device-QA-gated (NOT committed — must be done on real devices)
+
+### iOS / macOS build configuration
+- On Apple platforms `package:sqlite3` resolves to the SQLCipher pod **only
+  when it is the sole sqlite3 provider** (now true after dropping
+  `sqlite3_flutter_libs`). If a future pod links plain sqlite3, `PRAGMA key`
+  silently no-ops. Mitigations to apply and verify on device:
+  - Add `-framework SQLCipher` to **Other Linker Flags** in the Runner target,
+    and ensure no `libsqlite3.dylib`/`.tbd` sits in *Link Binary With
+    Libraries*.
+  - A Podfile `post_install` that defines `SQLITE_HAS_CODEC=1` across pod build
+    configurations (mirror the SQLCipher podspec) if any pod is found linking
+    plain sqlite3.
+- App Store **export compliance**: AES-256 at rest is standard crypto. Set
+  `ITSAppUsesNonExemptEncryption` in `Info.plist` and confirm the exemption
+  with the compliance owner.
+
+These are intentionally not committed half-validated; the committed runtime
+`cipher_version` fail-closed check is the safety net regardless of build config.
+
+## Device-QA checklist (must pass before un-drafting)
+- [ ] iOS / Android / macOS build + launch with `sqlcipher_flutter_libs`.
+- [ ] Fresh install: DB is created encrypted; `PRAGMA cipher_version` is
+      non-empty; the file is not readable by plain `sqlite3`.
+- [ ] Upgrade from a populated **plaintext** DB: migration runs once, all
+      tables + row counts preserved, app fully functional, plaintext backup
+      present then cleaned on a later launch.
+- [ ] Force-kill mid-migration → next launch recovers (plaintext intact,
+      retried), no data loss.
+- [ ] Key-loss path (clear keystore): DB is wiped + recreated, DMs resync, app
+      does not brick. (Confirm the §6 UX with product first.)
+- [ ] No measurable regression on cold-start DB open on a low-end device
+      (SQLCipher adds ~5–15%).
+- [ ] Key never appears in logs / Crashlytics / analytics.

--- a/mobile/docs/sqlcipher_at_rest_plan.md
+++ b/mobile/docs/sqlcipher_at_rest_plan.md
@@ -1,10 +1,10 @@
 # SQLCipher at-rest encryption for the local DB (#570, finding C2)
 
-Status: **device-QA-gated draft.** The full Dart implementation, the native
-dependency swap, and unit tests for every host-testable property are committed.
-What remains before this can leave draft is **on-device validation** (the
-encrypted open, the in-place migration, and the iOS/macOS build configuration)
-— none of it can be exercised in CI, which links plain sqlite3 and on which
+Status: **device-QA gated before merge.** The full Dart implementation, the
+native dependency swap, and unit tests for every host-testable property are
+committed. What remains before merge is **on-device validation** (the encrypted
+open, the in-place migration, and the iOS/macOS build configuration) — none of
+it can be exercised in CI, which links plain sqlite3 and on which
 `PRAGMA cipher_version` is empty. See the device-QA checklist at the bottom.
 
 ## Why
@@ -54,7 +54,7 @@ sensitive. Decision (#570): encrypt at rest before the T&S moderation launch.
   (drift's schema version) explicitly, which `sqlcipher_export` does not.
   Wipe-and-resync is rejected: `divine_db.db` holds local-only data that cannot
   be re-fetched.
-- `deleteSharedDatabaseFiles()` — used by the §6 key-loss recovery.
+- `backUpAndRemoveSharedDatabase()` — used by the §6 key-loss recovery.
 
 ### App layer
 - `lib/database/sqlcipher_runtime.dart` (+ `_io` / `_stub`) — conditional-import
@@ -77,10 +77,11 @@ sensitive. Decision (#570): encrypt at rest before the T&S moderation launch.
 If the keystore is cleared (OS reset / restore without keychain migration), the
 cipher key is gone and the encrypted DB is cryptographically unrecoverable. The
 bootstrap detects this (freshly generated key + an existing encrypted DB),
-**wipes the DB and recreates it under a new key** — DMs resync from relays;
-other local-only data is lost. This is the only possible recovery for an
+**backs up the unrecoverable DB and recreates it under a new key** — DMs resync
+from relays; other local-only data is preserved in the backup but unavailable
+to the app without the lost key. This is the only possible recovery for an
 unrecoverable DB, but the user-facing notice / exact UX **needs product
-signoff** before un-drafting.
+signoff** before merge.
 
 ## Device-QA-gated (NOT committed — must be done on real devices)
 
@@ -102,17 +103,17 @@ signoff** before un-drafting.
 These are intentionally not committed half-validated; the committed runtime
 `cipher_version` fail-closed check is the safety net regardless of build config.
 
-## Device-QA checklist (must pass before un-drafting)
+## Device-QA checklist (must pass before merge)
 - [ ] iOS / Android / macOS build + launch with `sqlcipher_flutter_libs`.
 - [ ] Fresh install: DB is created encrypted; `PRAGMA cipher_version` is
       non-empty; the file is not readable by plain `sqlite3`.
 - [ ] Upgrade from a populated **plaintext** DB: migration runs once, all
       tables + row counts preserved, app fully functional, plaintext backup
-      present then cleaned on a later launch.
+      present until the first successful keyed open, then cleaned.
 - [ ] Force-kill mid-migration → next launch recovers (plaintext intact,
       retried), no data loss.
-- [ ] Key-loss path (clear keystore): DB is wiped + recreated, DMs resync, app
-      does not brick. (Confirm the §6 UX with product first.)
+- [ ] Key-loss path (clear keystore): DB is backed up + recreated, DMs resync,
+      app does not brick. (Confirm the §6 UX with product first.)
 - [ ] No measurable regression on cold-start DB open on a low-end device
       (SQLCipher adds ~5–15%).
 - [ ] Key never appears in logs / Crashlytics / analytics.

--- a/mobile/lib/database/sqlcipher_runtime.dart
+++ b/mobile/lib/database/sqlcipher_runtime.dart
@@ -1,0 +1,5 @@
+// ABOUTME: Platform-conditional SQLCipher native-runtime bootstrap.
+// ABOUTME: Native applies the Android lib override + probes availability; web is a no-op.
+
+export 'sqlcipher_runtime_stub.dart'
+    if (dart.library.io) 'sqlcipher_runtime_io.dart';

--- a/mobile/lib/database/sqlcipher_runtime_io.dart
+++ b/mobile/lib/database/sqlcipher_runtime_io.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Native SQLCipher runtime bootstrap (Android lib override + availability probe).
+// ABOUTME: Forces package:sqlite3 to load libsqlcipher.so on Android before first use.
+
+import 'dart:io';
+
+import 'package:sqlcipher_flutter_libs/sqlcipher_flutter_libs.dart';
+import 'package:sqlite3/open.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+/// Forces `package:sqlite3` to load the SQLCipher native library.
+///
+/// Android ships a plain `libsqlite3.so`, so `package:sqlite3` must be told to
+/// load `libsqlcipher.so` instead — before ANY sqlite3 call and before drift
+/// spawns its background isolate. iOS/macOS link the SQLCipher pod
+/// automatically when it is the only sqlite3 provider, so no override is
+/// needed there (the runtime [isSqlCipherAvailable] probe is the safety net).
+Future<void> ensureSqlCipherRuntime() async {
+  if (Platform.isAndroid) {
+    await applyWorkaroundToOpenSqlCipherOnOldAndroidVersions();
+    open.overrideFor(OperatingSystem.android, openCipherOnAndroid);
+  }
+}
+
+/// Probes whether SQLCipher is actually the linked library by opening an
+/// in-memory database and checking the SQLCipher-only `cipher_version` pragma
+/// (empty on plain SQLite). Guards against the iOS failure mode where the
+/// system sqlite3 is linked and `PRAGMA key` silently no-ops.
+bool isSqlCipherAvailable() {
+  final db = sqlite3.openInMemory();
+  try {
+    return db.select('PRAGMA cipher_version;').isNotEmpty;
+  } on SqliteException {
+    return false;
+  } finally {
+    db.dispose();
+  }
+}

--- a/mobile/lib/database/sqlcipher_runtime_stub.dart
+++ b/mobile/lib/database/sqlcipher_runtime_stub.dart
@@ -1,0 +1,8 @@
+// ABOUTME: No-op SQLCipher runtime for platforms without dart:ffi (web).
+// ABOUTME: SQLCipher is native-only; web at-rest encryption is out of scope (#373).
+
+/// Ensures `package:sqlite3` loads the SQLCipher build. No-op on web.
+Future<void> ensureSqlCipherRuntime() async {}
+
+/// Whether SQLCipher is the active SQLite library. Always `false` on web.
+bool isSqlCipherAvailable() => false;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -56,6 +57,7 @@ import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/observability/divine_bloc_observer.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -77,6 +79,7 @@ import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/corrupted_video_repair_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/logging_config_service.dart';
@@ -1067,9 +1070,40 @@ Future<void> _startOpenVineApp() async {
   // Load package info for version checking (non-blocking, fast).
   final packageInfo = await PackageInfo.fromPlatform();
 
+  // Resolve the at-rest database cipher key before the container so the
+  // database provider opens an encrypted SQLCipher connection on first use.
+  // This also forces package:sqlite3 onto the SQLCipher build (Android) and
+  // runs the one-time plaintext→encrypted migration, both of which must happen
+  // before any sqlite3 open. (#570, finding C2)
+  String? dbCipherKey;
+  try {
+    dbCipherKey = await DatabaseEncryptionBootstrap(
+      // resetOnError MUST stay false here: the cipher key is the one secret
+      // whose loss makes the encrypted DB unrecoverable. A transient keystore
+      // read error must throw (caught below → plaintext this launch, retry
+      // next) rather than silently deleting the key and triggering the §6
+      // key-loss recovery. (#570 C2)
+      secureStorage: const FlutterSecureStorage(
+        aOptions: AndroidOptions(encryptedSharedPreferences: true),
+      ),
+    ).resolveCipherKey();
+  } catch (error, stack) {
+    // SQLCipher build misconfiguration or an unexpected keystore failure.
+    // Report and degrade to a plaintext database so the app still launches;
+    // the device-QA gate prevents an unencrypted build from shipping. (#570 C2)
+    await CrashReportingService.instance.recordError(
+      error,
+      stack,
+      reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
+    );
+  }
+
   // Create ProviderContainer to initialize services BEFORE runApp
   final container = ProviderContainer(
-    overrides: [sharedPreferencesProvider.overrideWithValue(sharedPreferences)],
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+      dbCipherKeyProvider.overrideWithValue(dbCipherKey),
+    ],
   );
 
   final startupCoordinator = _createStartupCoordinator(container);

--- a/mobile/lib/providers/database_provider.dart
+++ b/mobile/lib/providers/database_provider.dart
@@ -1,13 +1,21 @@
 // ABOUTME: Provides singleton AppDatabase instance with proper lifecycle management
 // ABOUTME: Database auto-closes when provider container is disposed
 import 'package:db_client/db_client.dart';
+import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'database_provider.g.dart';
 
 @Riverpod(keepAlive: true) // Singleton - lives for app lifetime
 AppDatabase database(Ref ref) {
-  final db = AppDatabase();
+  // When a cipher key is present (resolved at startup by
+  // DatabaseEncryptionBootstrap), open an at-rest-encrypted SQLCipher
+  // connection; otherwise (web, tests, or a deferred migration) open the
+  // default connection. (#570, finding C2)
+  final cipherKey = ref.watch(dbCipherKeyProvider);
+  final db = cipherKey == null
+      ? AppDatabase()
+      : AppDatabase(openEncryptedConnection(rawKeyHex: cipherKey));
   ref.onDispose(db.close);
   return db;
 }

--- a/mobile/lib/providers/database_provider.g.dart
+++ b/mobile/lib/providers/database_provider.g.dart
@@ -48,7 +48,7 @@ final class DatabaseProvider
   }
 }
 
-String _$databaseHash() => r'0fe56aaf5bde72ce9021e425b918c495557124c1';
+String _$databaseHash() => r'8a6f9ab3f9be46444941c5c472f4f76e12a75ba1';
 
 /// AppDbClient wrapping the database for NostrClient integration.
 /// Enables optimistic caching of Nostr events in the local database.

--- a/mobile/lib/providers/db_cipher_key_provider.dart
+++ b/mobile/lib/providers/db_cipher_key_provider.dart
@@ -1,0 +1,14 @@
+// ABOUTME: Holds the resolved at-rest DB cipher key for the database provider.
+// ABOUTME: Overridden in main.dart after DatabaseEncryptionBootstrap resolves it.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The 64-hex (raw 32-byte) SQLCipher key for the local database, or `null`
+/// when the database should open unencrypted.
+///
+/// `null` is the default so tests and web fall back to a plaintext connection.
+/// This provider MUST be overridden in `ProviderScope` during app startup with
+/// the value resolved by `DatabaseEncryptionBootstrap.resolveCipherKey()`. The
+/// database provider reads it to choose between an encrypted and a plaintext
+/// connection. See `main.dart` and `database_provider.dart`. (#570, finding C2)
+final dbCipherKeyProvider = Provider<String?>((ref) => null);

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -1,0 +1,135 @@
+// ABOUTME: Resolves the at-rest DB cipher key + runs the one-time plaintext→encrypted migration.
+// ABOUTME: App-layer bootstrap; db_client never reads the keystore, so the key is injected here.
+
+import 'dart:math';
+
+import 'package:db_client/db_client.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:openvine/database/sqlcipher_runtime.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Secure-storage key for the at-rest DB cipher key. Versioned so a future
+/// rotation can introduce `.v2` without colliding.
+@visibleForTesting
+const dbCipherKeyStorageKey = 'db.cipher.key.v1';
+
+/// Resolves the SQLCipher key for the local database before the first
+/// `AppDatabase` open and performs the one-time plaintext→encrypted migration.
+///
+/// db_client stays keystore-free: this app-layer service reads/generates the
+/// key from [FlutterSecureStorage] and injects it via `db_cipher_key_provider`.
+/// Native runtime hooks (the Android library override, the cipher-availability
+/// probe, the migration, the key-loss wipe) are injected so the orchestration
+/// is unit-testable on the host VM, which links plain sqlite3.
+class DatabaseEncryptionBootstrap {
+  DatabaseEncryptionBootstrap({
+    required FlutterSecureStorage secureStorage,
+    Future<void> Function()? ensureRuntime,
+    bool Function()? isCipherAvailable,
+    Future<CipherMigrationOutcome> Function(String rawKeyHex)? migrate,
+    Future<void> Function()? deleteDatabase,
+  }) : _secureStorage = secureStorage,
+       _ensureRuntime = ensureRuntime ?? ensureSqlCipherRuntime,
+       _isCipherAvailable = isCipherAvailable ?? isSqlCipherAvailable,
+       _migrate =
+           migrate ??
+           ((rawKeyHex) => migratePlaintextToEncrypted(rawKeyHex: rawKeyHex)),
+       _deleteDatabase = deleteDatabase ?? backUpAndRemoveSharedDatabase;
+
+  final FlutterSecureStorage _secureStorage;
+  final Future<void> Function() _ensureRuntime;
+  final bool Function() _isCipherAvailable;
+  final Future<CipherMigrationOutcome> Function(String rawKeyHex) _migrate;
+  final Future<void> Function() _deleteDatabase;
+
+  static const _logName = 'DatabaseEncryptionBootstrap';
+
+  /// Resolves the cipher key for the database provider, or `null` when the
+  /// database should open unencrypted.
+  ///
+  /// Returns `null` for web (SQLCipher is native-only, #373) and when a
+  /// populated plaintext database could not be migrated this launch (the
+  /// migration left it intact and retries on the next launch).
+  ///
+  /// Throws [StateError] when SQLCipher is not the linked SQLite library — a
+  /// build misconfiguration that must fail loudly rather than silently ship an
+  /// unencrypted database.
+  ///
+  /// Must run before the first `AppDatabase` open.
+  Future<String?> resolveCipherKey() async {
+    if (kIsWeb) return null;
+
+    await _ensureRuntime();
+    if (!_isCipherAvailable()) {
+      throw StateError(
+        'SQLCipher is not linked; refusing to start with an unencrypted local '
+        'database. Verify sqlcipher_flutter_libs replaced sqlite3_flutter_libs '
+        'and that no dependency links plain sqlite3.',
+      );
+    }
+
+    final (key, wasGenerated) = await _readOrCreateKey();
+    final outcome = await _migrate(key);
+
+    switch (outcome) {
+      case CipherMigrationOutcome.noDatabase:
+      case CipherMigrationOutcome.removedEmptyPlaintext:
+      case CipherMigrationOutcome.migrated:
+        return key;
+      case CipherMigrationOutcome.alreadyEncrypted:
+        if (wasGenerated) {
+          // Key-loss recovery (#570 §6): the keystore was cleared but an
+          // encrypted database remains. It is cryptographically unrecoverable,
+          // so it is backed up (not hard-deleted) and recreated under the
+          // freshly generated key. Local-only data is preserved in the backup;
+          // DMs resync from relays. Accepted tradeoff for the rare
+          // keystore-reset case — pending product signoff on the user-facing
+          // notice.
+          Log.warning(
+            'Cipher key was missing but an encrypted database exists '
+            '(keystore reset). Backing up the unrecoverable database and '
+            'recreating under a new key.',
+            name: _logName,
+          );
+          await _deleteDatabase();
+        }
+        return key;
+      case CipherMigrationOutcome.failed:
+        Log.warning(
+          'At-rest DB migration did not complete; opening plaintext this '
+          'launch and retrying next launch.',
+          name: _logName,
+        );
+        return null;
+    }
+  }
+
+  Future<(String, bool)> _readOrCreateKey() async {
+    final existing = await _secureStorage.read(key: dbCipherKeyStorageKey);
+    if (existing != null && _isValidCipherKey(existing)) {
+      return (existing, false);
+    }
+
+    final key = generateCipherKeyHex();
+    await _secureStorage.write(key: dbCipherKeyStorageKey, value: key);
+    return (key, true);
+  }
+}
+
+bool _isValidCipherKey(String value) =>
+    RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value);
+
+/// Generates a 64-character hex (raw 32-byte) cipher key from a CSPRNG.
+///
+/// Uses [Random.secure]; the key is never logged or derived from anything
+/// guessable.
+@visibleForTesting
+String generateCipherKeyHex() {
+  final rng = Random.secure();
+  final bytes = Uint8List(32);
+  for (var i = 0; i < bytes.length; i++) {
+    bytes[i] = rng.nextInt(256);
+  }
+  return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+}

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -20,8 +20,8 @@ const dbCipherKeyStorageKey = 'db.cipher.key.v1';
 /// db_client stays keystore-free: this app-layer service reads/generates the
 /// key from [FlutterSecureStorage] and injects it via `db_cipher_key_provider`.
 /// Native runtime hooks (the Android library override, the cipher-availability
-/// probe, the migration, the key-loss wipe) are injected so the orchestration
-/// is unit-testable on the host VM, which links plain sqlite3.
+/// probe, the migration, the key-loss backup/recreate path) are injected so
+/// the orchestration is unit-testable on the host VM, which links plain sqlite3.
 class DatabaseEncryptionBootstrap {
   DatabaseEncryptionBootstrap({
     required FlutterSecureStorage secureStorage,

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -2,11 +2,13 @@
 // ABOUTME: Provides file-based SQLite storage for iOS, Android, macOS, etc.
 
 import 'dart:io';
+import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
 import 'package:sqlite3/sqlite3.dart';
 
 /// Open a database connection for native platforms
@@ -26,6 +28,352 @@ QueryExecutor openConnection() {
 
 bool get _isFlutterTestProcess =>
     Platform.executable.contains('flutter_tester');
+
+// ---------------------------------------------------------------------------
+// SQLCipher at-rest encryption (#570, finding C2).
+//
+// db_client stays low-level: it never reads the platform keystore. The app
+// layer resolves the 64-hex (raw 32-byte) cipher key and injects it here. The
+// real encrypted open + the in-place rekey migration require the SQLCipher
+// native library and must be validated on real devices — the host test VM
+// links plain sqlite3, on which `PRAGMA cipher_version` is empty (the
+// fail-closed guard below throws there). See
+// `mobile/docs/sqlcipher_at_rest_plan.md`.
+// ---------------------------------------------------------------------------
+
+/// Opens an at-rest-encrypted database connection for native platforms.
+///
+/// [rawKeyHex] is a 64-character hex (raw 32-byte) SQLCipher key supplied by
+/// the app layer. The key is applied in [applyCipherKey], which **fails
+/// closed**: if SQLCipher is not the linked SQLite library the open throws
+/// rather than silently writing plaintext.
+///
+/// Throws [ArgumentError] if [rawKeyHex] is malformed (the error never embeds
+/// the key — see [formatCipherKeyPragma]).
+QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
+  // Validate eagerly so a malformed key fails fast at construction time.
+  _rawKeyLiteral(rawKeyHex);
+
+  return LazyDatabase(() async {
+    final dbPath = await getSharedDatabasePath();
+    final dbFile = prepareDatabaseFile(dbPath);
+    return NativeDatabase(
+      dbFile,
+      setup: (rawDb) => applyCipherKey(rawDb, rawKeyHex),
+    );
+  });
+}
+
+/// Keys [rawDb] with [rawKeyHex] and verifies SQLCipher is actually active.
+///
+/// `PRAGMA key` must be the first statement on the connection. On plain
+/// SQLite the pragma is an unknown no-op and `PRAGMA cipher_version` returns
+/// no rows — meaning the database would be **unencrypted**. We refuse to open
+/// in that case (fail closed) instead of silently storing plaintext.
+@visibleForTesting
+void applyCipherKey(CommonDatabase rawDb, String rawKeyHex) {
+  try {
+    rawDb.execute(formatCipherKeyPragma(rawKeyHex));
+  } on SqliteException {
+    // Never rethrow the original: SqliteException.toString() appends the
+    // causing statement, which is the `PRAGMA key` containing the raw key.
+    throw StateError('Failed to apply the SQLCipher key.');
+  }
+
+  final cipherVersion = rawDb.select('PRAGMA cipher_version;');
+  if (cipherVersion.isEmpty) {
+    throw StateError(
+      'SQLCipher is not the active SQLite library; refusing to open the '
+      'database unencrypted. Ensure sqlcipher_flutter_libs is linked and no '
+      'other dependency links plain sqlite3.',
+    );
+  }
+
+  // `PRAGMA key` is processed lazily, so an incorrect key surfaces as
+  // SQLITE_NOTADB on the first real read rather than above. Probe the schema
+  // so a wrong key fails deterministically at open time.
+  rawDb.execute('SELECT count(*) FROM sqlite_master;');
+}
+
+/// Builds the SQLCipher `PRAGMA key` statement for a **raw** 32-byte key.
+///
+/// [rawKeyHex] is 64 hex characters, wrapped in SQLCipher's raw-key form
+/// (`x'...'`) so SQLCipher uses the bytes verbatim and skips PBKDF2 — correct
+/// for a CSPRNG-generated 32-byte key held in the platform keystore, not a
+/// human passphrase.
+///
+/// Throws [ArgumentError] if [rawKeyHex] is not exactly 64 hex characters.
+/// The thrown error deliberately does **not** include [rawKeyHex]: it is
+/// secret key material and must never reach logs, Crashlytics, or test output.
+@visibleForTesting
+String formatCipherKeyPragma(String rawKeyHex) =>
+    'PRAGMA key = ${_rawKeyLiteral(rawKeyHex)};';
+
+/// Returns the SQLCipher raw-key literal (`"x'<hex>'"`) for use in
+/// `PRAGMA key` and `ATTACH ... KEY` clauses. Inlining the validated hex is
+/// injection-safe because the value is constrained to `[0-9a-fA-F]{64}`.
+String _rawKeyLiteral(String rawKeyHex) {
+  if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(rawKeyHex)) {
+    throw ArgumentError(
+      'rawKeyHex must be exactly 64 hex characters '
+      '(a raw 32-byte SQLCipher key)',
+    );
+  }
+  return '"x\'$rawKeyHex\'"';
+}
+
+/// Outcome of [migratePlaintextToEncrypted].
+enum CipherMigrationOutcome {
+  /// No database file existed (fresh install) — nothing to migrate.
+  noDatabase,
+
+  /// The existing database was already encrypted — nothing to do.
+  alreadyEncrypted,
+
+  /// An empty plaintext database was removed so a fresh encrypted one is
+  /// created on first open.
+  removedEmptyPlaintext,
+
+  /// A populated plaintext database was rekeyed into an encrypted file.
+  migrated,
+
+  /// Migration was attempted but could not complete; the plaintext source is
+  /// left intact and the caller should retry on the next launch.
+  failed,
+}
+
+/// One-time in-place rekey of the existing **plaintext** `divine_db.db` into a
+/// SQLCipher-encrypted database, using `sqlcipher_export`.
+///
+/// Safe by construction: the encrypted copy is written to a side file and
+/// verified (key opens it; table/row counts match the source) **before** the
+/// plaintext original is swapped out, and the original is renamed to a backup
+/// rather than deleted. On any failure the plaintext database is left exactly
+/// as it was so the app keeps working and the migration retries next launch.
+///
+/// Wipe-and-resync is intentionally rejected: `divine_db.db` is shared with
+/// drafts, pending uploads/actions, reactions, reposts, etc., which cannot be
+/// re-fetched. See `mobile/docs/sqlcipher_at_rest_plan.md`.
+///
+/// Requires the SQLCipher native library; returns
+/// [CipherMigrationOutcome.failed] when it is not linked (e.g. the host test
+/// VM), leaving the source intact.
+Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  _rawKeyLiteral(rawKeyHex); // validate shape up front (never embeds the key)
+
+  final dbPath = databasePath ?? await getSharedDatabasePath();
+  final encryptedPath = '$dbPath$_migratingSuffix';
+
+  // Resume an interrupted swap. A force-kill between renaming the plaintext
+  // original to its backup and moving the verified encrypted copy into place
+  // leaves the (already-verified) encrypted file at [encryptedPath] with no
+  // file at [dbPath]. Completing the rename is the lossless recovery.
+  if (!File(dbPath).existsSync() && File(encryptedPath).existsSync()) {
+    File(encryptedPath).renameSync(dbPath);
+    _moveSidecars(fromPath: encryptedPath, toPath: dbPath);
+    return CipherMigrationOutcome.migrated;
+  }
+
+  if (!File(dbPath).existsSync()) return CipherMigrationOutcome.noDatabase;
+
+  switch (_classifyDatabase(dbPath)) {
+    case _DbClassification.encrypted:
+      return CipherMigrationOutcome.alreadyEncrypted;
+    case _DbClassification.indeterminate:
+      // A transient or unreadable error (busy, locked, I/O, corrupt) — do NOT
+      // assume "encrypted", which would trigger the destructive key-loss wipe
+      // on a readable plaintext DB. Leave everything intact and retry next
+      // launch.
+      return CipherMigrationOutcome.failed;
+    case _DbClassification.emptyPlaintext:
+      _deleteDatabaseAndSidecars(dbPath);
+      return CipherMigrationOutcome.removedEmptyPlaintext;
+    case _DbClassification.populatedPlaintext:
+      return _rekeyPlaintextInPlace(dbPath: dbPath, rawKeyHex: rawKeyHex);
+  }
+}
+
+const _migratingSuffix = '.sqlcipher_migrating';
+const _sqliteNotADb = 26; // SQLITE_NOTADB
+
+enum _DbClassification {
+  encrypted,
+  emptyPlaintext,
+  populatedPlaintext,
+  indeterminate,
+}
+
+/// Classifies [dbPath] by opening it **without** a key. A plaintext database
+/// reads its schema fine. Only `SQLITE_NOTADB` is treated as a positive
+/// "encrypted" signal; any other error is [_DbClassification.indeterminate] so
+/// a transient failure on a readable plaintext DB never masquerades as
+/// encrypted (which would trigger the destructive key-loss path).
+_DbClassification _classifyDatabase(String dbPath) {
+  Database db;
+  try {
+    db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
+  } on SqliteException catch (e) {
+    return _encryptedOrIndeterminate(e);
+  }
+
+  try {
+    final rows = db.select(
+      "SELECT count(*) AS c FROM sqlite_master WHERE type = 'table' "
+      "AND name NOT LIKE 'sqlite_%';",
+    );
+    final tableCount = rows.first['c'] as int;
+    return tableCount == 0
+        ? _DbClassification.emptyPlaintext
+        : _DbClassification.populatedPlaintext;
+  } on SqliteException catch (e) {
+    return _encryptedOrIndeterminate(e);
+  } finally {
+    db.dispose();
+  }
+}
+
+_DbClassification _encryptedOrIndeterminate(SqliteException e) =>
+    e.resultCode == _sqliteNotADb
+    ? _DbClassification.encrypted
+    : _DbClassification.indeterminate;
+
+CipherMigrationOutcome _rekeyPlaintextInPlace({
+  required String dbPath,
+  required String rawKeyHex,
+}) {
+  final encryptedPath = '$dbPath$_migratingSuffix';
+  // Remove any partial artifact from an interrupted previous attempt.
+  _deleteDatabaseAndSidecars(encryptedPath);
+
+  Database source;
+  try {
+    // The source must be opened UNKEYED — sqlcipher_export reads plaintext and
+    // writes the keyed copy through the ATTACH ... KEY clause.
+    source = sqlite3.open(dbPath);
+  } on SqliteException {
+    return CipherMigrationOutcome.failed;
+  }
+
+  try {
+    if (source.select('PRAGMA cipher_version;').isEmpty) {
+      // SQLCipher not linked — cannot encrypt. Leave plaintext intact.
+      return CipherMigrationOutcome.failed;
+    }
+    // sqlcipher_export does NOT copy user_version, which drift uses as its
+    // schema version; copy it explicitly or drift re-runs every migration on
+    // the encrypted copy. PRAGMA's RHS cannot be a subquery, so read the int
+    // and inline it (an int literal is injection-safe).
+    final userVersion =
+        source.select('PRAGMA main.user_version;').first['user_version']
+            as int? ??
+        0;
+    source
+      ..execute(
+        'ATTACH DATABASE ? AS encrypted KEY ${_rawKeyLiteral(rawKeyHex)};',
+        [encryptedPath],
+      )
+      ..execute("SELECT sqlcipher_export('encrypted');")
+      ..execute('PRAGMA encrypted.user_version = $userVersion;')
+      ..execute('DETACH DATABASE encrypted;');
+  } on SqliteException {
+    _deleteDatabaseAndSidecars(encryptedPath);
+    return CipherMigrationOutcome.failed;
+  } finally {
+    source.dispose();
+  }
+
+  if (!_encryptedCopyMatchesSource(
+    plaintextPath: dbPath,
+    encryptedPath: encryptedPath,
+    rawKeyHex: rawKeyHex,
+  )) {
+    _deleteDatabaseAndSidecars(encryptedPath);
+    return CipherMigrationOutcome.failed;
+  }
+
+  // Keep the plaintext original as a backup until the next successful launch,
+  // then move the verified encrypted copy into place.
+  final backupPath = _nextDatabaseBackupPath(
+    dbPath,
+    suffix: '.pre_cipher_migration_backup',
+  );
+  File(dbPath).renameSync(backupPath);
+  _moveSidecars(fromPath: dbPath, toPath: backupPath);
+  File(encryptedPath).renameSync(dbPath);
+  return CipherMigrationOutcome.migrated;
+}
+
+/// Verifies the encrypted copy opens with [rawKeyHex] and that its
+/// `user_version` (drift's schema version) and user-table row counts match the
+/// plaintext source — the gate before swapping files.
+bool _encryptedCopyMatchesSource({
+  required String plaintextPath,
+  required String encryptedPath,
+  required String rawKeyHex,
+}) {
+  Database? encrypted;
+  Database? plaintext;
+  try {
+    encrypted = sqlite3.open(encryptedPath)
+      ..execute(formatCipherKeyPragma(rawKeyHex));
+    if (encrypted.select('PRAGMA cipher_version;').isEmpty) return false;
+
+    plaintext = sqlite3.open(plaintextPath, mode: OpenMode.readOnly);
+
+    if (_userVersion(encrypted) != _userVersion(plaintext)) return false;
+
+    return const MapEquality<String, int>().equals(
+      _userTableRowCounts(encrypted),
+      _userTableRowCounts(plaintext),
+    );
+  } on SqliteException {
+    return false;
+  } finally {
+    encrypted?.dispose();
+    plaintext?.dispose();
+  }
+}
+
+int _userVersion(Database db) =>
+    db.select('PRAGMA user_version;').first['user_version'] as int? ?? 0;
+
+/// Backs up (rather than hard-deletes) the shared database for the #570 §6
+/// key-loss recovery.
+///
+/// When the platform keystore is cleared (OS reset / restore without keychain
+/// migration) the cipher key is gone and the encrypted database is
+/// cryptographically unrecoverable, so it must be replaced. It is renamed to a
+/// timestamped backup (with its `-wal`/`-shm` sidecars) rather than deleted, so
+/// a misclassification or a future recovery path is never catastrophic. A fresh
+/// encrypted database is created under the new key on first open; DMs resync
+/// from relays. See `mobile/docs/sqlcipher_at_rest_plan.md`.
+Future<void> backUpAndRemoveSharedDatabase() async {
+  final dbPath = await getSharedDatabasePath();
+  if (!File(dbPath).existsSync()) return;
+  final backupPath = _nextDatabaseBackupPath(
+    dbPath,
+    suffix: '.pre_key_loss_wipe_backup',
+  );
+  File(dbPath).renameSync(backupPath);
+  _moveSidecars(fromPath: dbPath, toPath: backupPath);
+}
+
+Map<String, int> _userTableRowCounts(Database db) {
+  final counts = <String, int>{};
+  final tables = db.select(
+    "SELECT name FROM sqlite_master WHERE type = 'table' "
+    "AND name NOT LIKE 'sqlite_%' ORDER BY name;",
+  );
+  for (final row in tables) {
+    final name = row['name'] as String;
+    final result = db.select('SELECT count(*) AS c FROM "$name";');
+    counts[name] = result.first['c'] as int;
+  }
+  return counts;
+}
 
 /// Get path to shared database file
 ///

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -59,7 +59,10 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
     final dbFile = prepareDatabaseFile(dbPath);
     return NativeDatabase(
       dbFile,
-      setup: (rawDb) => applyCipherKey(rawDb, rawKeyHex),
+      setup: (rawDb) {
+        applyCipherKey(rawDb, rawKeyHex);
+        cleanUpPreCipherMigrationBackups(dbPath);
+      },
     );
   });
 }
@@ -172,8 +175,10 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   // leaves the (already-verified) encrypted file at [encryptedPath] with no
   // file at [dbPath]. Completing the rename is the lossless recovery.
   if (!File(dbPath).existsSync() && File(encryptedPath).existsSync()) {
-    File(encryptedPath).renameSync(dbPath);
-    _moveSidecars(fromPath: encryptedPath, toPath: dbPath);
+    promoteEncryptedMigrationArtifact(
+      encryptedPath: encryptedPath,
+      dbPath: dbPath,
+    );
     return CipherMigrationOutcome.migrated;
   }
 
@@ -184,7 +189,7 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
       return CipherMigrationOutcome.alreadyEncrypted;
     case _DbClassification.indeterminate:
       // A transient or unreadable error (busy, locked, I/O, corrupt) — do NOT
-      // assume "encrypted", which would trigger the destructive key-loss wipe
+      // assume "encrypted", which would trigger the key-loss recovery path
       // on a readable plaintext DB. Leave everything intact and retry next
       // launch.
       return CipherMigrationOutcome.failed;
@@ -302,8 +307,22 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
   );
   File(dbPath).renameSync(backupPath);
   _moveSidecars(fromPath: dbPath, toPath: backupPath);
-  File(encryptedPath).renameSync(dbPath);
+  promoteEncryptedMigrationArtifact(
+    encryptedPath: encryptedPath,
+    dbPath: dbPath,
+  );
   return CipherMigrationOutcome.migrated;
+}
+
+/// Promotes the verified encrypted migration artifact into the canonical DB
+/// path, carrying WAL/SHM sidecars with it.
+@visibleForTesting
+void promoteEncryptedMigrationArtifact({
+  required String encryptedPath,
+  required String dbPath,
+}) {
+  File(encryptedPath).renameSync(dbPath);
+  _moveSidecars(fromPath: encryptedPath, toPath: dbPath);
 }
 
 /// Verifies the encrypted copy opens with [rawKeyHex] and that its
@@ -359,6 +378,49 @@ Future<void> backUpAndRemoveSharedDatabase() async {
   );
   File(dbPath).renameSync(backupPath);
   _moveSidecars(fromPath: dbPath, toPath: backupPath);
+}
+
+/// Removes plaintext backups left by a successful plaintext→SQLCipher
+/// migration once the encrypted database has opened with its key.
+///
+/// The migration keeps the plaintext source as
+/// `.pre_cipher_migration_backup*` until a later keyed open proves the
+/// encrypted database is usable. At that point the backup would otherwise
+/// leave the old plaintext database readable at rest, defeating #570 C2.
+/// Key-loss and legacy-migration backups use different suffixes and are
+/// intentionally preserved.
+@visibleForTesting
+void cleanUpPreCipherMigrationBackups(String dbPath) {
+  final dbFile = File(dbPath);
+  final directory = dbFile.parent;
+  if (!directory.existsSync()) return;
+
+  final backupPrefix = '${p.basename(dbPath)}.pre_cipher_migration_backup';
+  for (final entity in directory.listSync()) {
+    if (entity is! File) continue;
+    final name = p.basename(entity.path);
+    if (_isPreCipherMigrationBackupName(name, backupPrefix)) {
+      entity.deleteSync();
+    }
+  }
+}
+
+bool _isPreCipherMigrationBackupName(String name, String backupPrefix) {
+  final indexedBackupPattern = RegExp(
+    '^${RegExp.escape(backupPrefix)}\\.\\d+\$',
+  );
+  if (name == backupPrefix || indexedBackupPattern.hasMatch(name)) {
+    return true;
+  }
+
+  for (final suffix in const ['-wal', '-shm']) {
+    if (!name.endsWith(suffix) || name.length <= suffix.length) continue;
+    final baseName = name.substring(0, name.length - suffix.length);
+    if (baseName == backupPrefix || indexedBackupPattern.hasMatch(baseName)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Map<String, int> _userTableRowCounts(Database db) {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -12,3 +12,31 @@ QueryExecutor openConnection() {
 Future<String> getSharedDatabasePath() async {
   throw UnsupportedError('No database implementation found for this platform');
 }
+
+/// Stub implementation - will be replaced by conditional imports
+QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
+  throw UnsupportedError('No database implementation found for this platform');
+}
+
+/// Outcome of [migratePlaintextToEncrypted]. Mirrors the native enum so app
+/// code that switches on it compiles when only the stub is available.
+enum CipherMigrationOutcome {
+  noDatabase,
+  alreadyEncrypted,
+  removedEmptyPlaintext,
+  migrated,
+  failed,
+}
+
+/// Stub implementation - will be replaced by conditional imports
+Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError('No database implementation found for this platform');
+}
+
+/// Stub implementation - will be replaced by conditional imports
+Future<void> backUpAndRemoveSharedDatabase() async {
+  throw UnsupportedError('No database implementation found for this platform');
+}

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -19,3 +19,38 @@ QueryExecutor openConnection() {
 Future<String> getSharedDatabasePath() async {
   return 'divine_db'; // IndexedDB database name
 }
+
+/// SQLCipher is native-only; at-rest encryption is unsupported on web.
+///
+/// Web at-rest encryption is deferred behind the OPFS migration (#373). The
+/// app guards encryption with `kIsWeb`, so this is never reached at runtime —
+/// it exists only so app code compiles for web. See the native variant.
+QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
+  throw UnsupportedError(
+    'SQLCipher at-rest encryption is not supported on web',
+  );
+}
+
+/// No-op on web (key-loss recovery is native-only). Never reached at runtime.
+Future<void> backUpAndRemoveSharedDatabase() async {}
+
+/// Outcome of [migratePlaintextToEncrypted]. Mirrors the native enum so app
+/// code that switches on it compiles for web.
+enum CipherMigrationOutcome {
+  noDatabase,
+  alreadyEncrypted,
+  removedEmptyPlaintext,
+  migrated,
+  failed,
+}
+
+/// SQLCipher is native-only; the plaintext→encrypted migration does not apply
+/// on web. Never reached at runtime (guarded by `kIsWeb` in the app).
+Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError(
+    'SQLCipher at-rest encryption is not supported on web',
+  );
+}

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1,9 +1,14 @@
 import 'dart:io';
 
 import 'package:db_client/src/database/connection/connection_native.dart';
+import 'package:drift/drift.dart' show QueryExecutor;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
+import 'package:sqlite3/common.dart' show CommonDatabase;
 import 'package:sqlite3/sqlite3.dart';
+
+class _MockCipherDb extends Mock implements CommonDatabase {}
 
 void main() {
   group('prepareDatabaseFile', () {
@@ -402,6 +407,219 @@ void main() {
       expect(File(newPath).readAsBytesSync(), equals(const [7]));
       expect(File('$newPath-wal').existsSync(), isFalse);
       expect(File('$newPath-shm').existsSync(), isFalse);
+    });
+  });
+
+  group('formatCipherKeyPragma', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+
+    test('wraps a 64-hex key in the SQLCipher raw-key PRAGMA form', () {
+      expect(
+        formatCipherKeyPragma(validKey),
+        equals('PRAGMA key = "x\'$validKey\'";'),
+      );
+    });
+
+    test('accepts upper-case hex', () {
+      expect(
+        formatCipherKeyPragma(validKey.toUpperCase()),
+        equals('PRAGMA key = "x\'${validKey.toUpperCase()}\'";'),
+      );
+    });
+
+    test('rejects a key that is too short', () {
+      expect(() => formatCipherKeyPragma('abcd'), throwsArgumentError);
+    });
+
+    test('rejects a key with non-hex characters', () {
+      expect(() => formatCipherKeyPragma('z' * 64), throwsArgumentError);
+    });
+
+    test('rejects an empty key (no accidental plaintext open)', () {
+      expect(() => formatCipherKeyPragma(''), throwsArgumentError);
+    });
+
+    test('thrown ArgumentError never embeds the key material', () {
+      // Regression for the #4945 review finding: ArgumentError.value embeds the
+      // invalid value in toString(), which would leak cipher key material.
+      const malformedKey = 'deadbeef$validKey'; // 72 hex chars => invalid
+      expect(
+        () => formatCipherKeyPragma(malformedKey),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.toString(),
+            'toString',
+            isNot(contains(malformedKey)),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('applyCipherKey', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+
+    test('fails closed when SQLCipher is not the linked library', () {
+      // The host test VM links plain sqlite3, on which PRAGMA cipher_version
+      // returns no rows. The connection must refuse rather than silently
+      // storing plaintext.
+      final db = sqlite3.openInMemory();
+      addTearDown(db.dispose);
+      expect(() => applyCipherKey(db, validKey), throwsStateError);
+    });
+
+    test('rejects a malformed key before touching the database', () {
+      final db = sqlite3.openInMemory();
+      addTearDown(db.dispose);
+      expect(() => applyCipherKey(db, 'not-a-key'), throwsArgumentError);
+    });
+
+    test('never leaks the key when the keying statement throws (#4945)', () {
+      // SqliteException.toString() appends the causing statement, which is the
+      // PRAGMA key containing the raw key. applyCipherKey must convert that to
+      // a key-free error before it can escape to Crashlytics.
+      final leaky = SqliteException(
+        26,
+        'file is not a database',
+        null,
+        formatCipherKeyPragma(validKey), // causing statement embeds the key
+      );
+      expect(leaky.toString(), contains(validKey)); // the source really leaks
+
+      final db = _MockCipherDb();
+      when(() => db.execute(any())).thenThrow(leaky);
+
+      expect(
+        () => applyCipherKey(db, validKey),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.toString(),
+            'toString',
+            isNot(contains(validKey)),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('openEncryptedConnection', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+
+    test('throws ArgumentError for a malformed key at construction time', () {
+      expect(
+        () => openEncryptedConnection(rawKeyHex: 'too-short'),
+        throwsArgumentError,
+      );
+    });
+
+    test('returns a lazily-opened QueryExecutor for a well-formed key', () {
+      expect(
+        openEncryptedConnection(rawKeyHex: validKey),
+        isA<QueryExecutor>(),
+      );
+    });
+  });
+
+  group('migratePlaintextToEncrypted', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_cipher_migration_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test('returns noDatabase when no file exists', () async {
+      expect(
+        await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        equals(CipherMigrationOutcome.noDatabase),
+      );
+    });
+
+    test('removes an empty plaintext database so a fresh encrypted one is '
+        'created on first open', () async {
+      sqlite3.open(dbPath).dispose(); // empty database, no user tables
+      expect(File(dbPath).existsSync(), isTrue);
+
+      final outcome = await migratePlaintextToEncrypted(
+        rawKeyHex: validKey,
+        databasePath: dbPath,
+      );
+
+      expect(outcome, equals(CipherMigrationOutcome.removedEmptyPlaintext));
+      expect(File(dbPath).existsSync(), isFalse);
+    });
+
+    test('classifies a non-database file as already encrypted', () async {
+      File(dbPath).writeAsBytesSync(List<int>.generate(64, (i) => i));
+
+      expect(
+        await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        equals(CipherMigrationOutcome.alreadyEncrypted),
+      );
+    });
+
+    test('fails safely and preserves a populated plaintext DB when SQLCipher '
+        'is not linked', () async {
+      _createSqliteDatabase(dbPath, draftCount: 3);
+
+      final outcome = await migratePlaintextToEncrypted(
+        rawKeyHex: validKey,
+        databasePath: dbPath,
+      );
+
+      // No cipher library on the host VM, so the rekey cannot complete — the
+      // plaintext source must stay intact for retry on the next launch.
+      expect(outcome, equals(CipherMigrationOutcome.failed));
+      expect(File(dbPath).existsSync(), isTrue);
+      expect(_draftCount(dbPath), equals(3));
+    });
+
+    test('rejects a malformed key', () async {
+      _createSqliteDatabase(dbPath, draftCount: 1);
+      await expectLater(
+        migratePlaintextToEncrypted(rawKeyHex: 'bad', databasePath: dbPath),
+        throwsArgumentError,
+      );
+    });
+
+    test('resumes an interrupted swap (verified encrypted artifact present, '
+        'db absent)', () async {
+      // Simulate a force-kill after the plaintext was renamed to its backup
+      // but before the verified encrypted copy was moved into place: the
+      // .sqlcipher_migrating artifact exists and the db path is absent.
+      final encryptedPath = '$dbPath.sqlcipher_migrating';
+      _createSqliteDatabase(encryptedPath, draftCount: 2);
+      expect(File(dbPath).existsSync(), isFalse);
+
+      final outcome = await migratePlaintextToEncrypted(
+        rawKeyHex: validKey,
+        databasePath: dbPath,
+      );
+
+      expect(outcome, equals(CipherMigrationOutcome.migrated));
+      expect(File(dbPath).existsSync(), isTrue);
+      expect(File(encryptedPath).existsSync(), isFalse);
+      expect(_draftCount(dbPath), equals(2));
     });
   });
 }

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -622,6 +622,95 @@ void main() {
       expect(_draftCount(dbPath), equals(2));
     });
   });
+
+  group('promoteEncryptedMigrationArtifact', () {
+    late Directory tempRoot;
+    late String dbPath;
+    late String encryptedPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_promote_cipher_artifact_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+      encryptedPath = '$dbPath.sqlcipher_migrating';
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test('moves the encrypted artifact and WAL/SHM sidecars into place', () {
+      File(encryptedPath).writeAsBytesSync(const [1]);
+      File('$encryptedPath-wal').writeAsBytesSync(const [2]);
+      File('$encryptedPath-shm').writeAsBytesSync(const [3]);
+
+      promoteEncryptedMigrationArtifact(
+        encryptedPath: encryptedPath,
+        dbPath: dbPath,
+      );
+
+      expect(File(dbPath).readAsBytesSync(), equals(const [1]));
+      expect(File('$dbPath-wal').readAsBytesSync(), equals(const [2]));
+      expect(File('$dbPath-shm').readAsBytesSync(), equals(const [3]));
+      expect(File(encryptedPath).existsSync(), isFalse);
+      expect(File('$encryptedPath-wal').existsSync(), isFalse);
+      expect(File('$encryptedPath-shm').existsSync(), isFalse);
+    });
+  });
+
+  group('cleanUpPreCipherMigrationBackups', () {
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_cipher_backup_cleanup_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+      File(dbPath).writeAsBytesSync(const [0]);
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test(
+      'deletes only pre-cipher plaintext migration backups and sidecars',
+      () {
+        final backupPath = '$dbPath.pre_cipher_migration_backup';
+        final indexedBackupPath = '$dbPath.pre_cipher_migration_backup.1';
+        final keyLossBackupPath = '$dbPath.pre_key_loss_wipe_backup';
+        File(backupPath).writeAsBytesSync(const [1]);
+        File('$backupPath-wal').writeAsBytesSync(const [2]);
+        File('$backupPath-shm').writeAsBytesSync(const [3]);
+        File(indexedBackupPath).writeAsBytesSync(const [4]);
+        File('$indexedBackupPath-wal').writeAsBytesSync(const [5]);
+        File(keyLossBackupPath).writeAsBytesSync(const [6]);
+        File(
+          '$dbPath.pre_cipher_migration_backup_notes',
+        ).writeAsBytesSync(const [7]);
+
+        cleanUpPreCipherMigrationBackups(dbPath);
+
+        expect(File(dbPath).existsSync(), isTrue);
+        expect(File(backupPath).existsSync(), isFalse);
+        expect(File('$backupPath-wal').existsSync(), isFalse);
+        expect(File('$backupPath-shm').existsSync(), isFalse);
+        expect(File(indexedBackupPath).existsSync(), isFalse);
+        expect(File('$indexedBackupPath-wal').existsSync(), isFalse);
+        expect(File(keyLossBackupPath).existsSync(), isTrue);
+        expect(
+          File('$dbPath.pre_cipher_migration_backup_notes').existsSync(),
+          isTrue,
+        );
+      },
+    );
+  });
 }
 
 void _createSqliteDatabase(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -592,14 +592,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.31.0"
-  drift_flutter:
-    dependency: "direct main"
-    description:
-      name: drift_flutter
-      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.8"
   equatable:
     dependency: "direct main"
     description:
@@ -2249,22 +2241,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlcipher_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: dd1fcc74d5baf3c36ad53e2652b2d06c9f8747494a3ccde0076e88b159dfe622
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.8"
   sqlite3:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqlite3
       sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
       url: "https://pub.dev"
     source: hosted
     version: "2.9.4"
-  sqlite3_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlite3_flutter_libs
-      sha256: "1e800ebe7f85a80a66adacaa6febe4d5f4d8b75f244e9838a27cb2ffc7aec08d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.41"
   sqlparser:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -289,8 +289,16 @@ dependencies:
   uuid: ^4.5.1
   app_links: ^6.4.1
   drift: ^2.29.0
-  drift_flutter: ^0.2.7
-  sqlite3_flutter_libs: ^0.5.40
+  # SQLCipher at-rest encryption for the local DB (#570, finding C2). Replaces
+  # sqlite3_flutter_libs (the two cannot coexist — both ship a native sqlite3
+  # and collide on iOS/macOS). 0.6.x is the SQLCipher build for the sqlite3 2.x
+  # family; 0.7.0+ is an EOL no-op. sqlite3 is a direct dep so the Android
+  # native-library override (package:sqlite3/open.dart) is referenceable.
+  # drift_flutter was removed: it is unused (db_client opens NativeDatabase
+  # directly) and it transitively pulled sqlite3_flutter_libs back in,
+  # reintroducing the collision.
+  sqlcipher_flutter_libs: ^0.6.8
+  sqlite3: ^2.7.6
   video_player_web_hls: ^1.3.0
   firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -1,0 +1,147 @@
+import 'package:db_client/db_client.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/database_encryption_bootstrap.dart';
+
+class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  group('generateCipherKeyHex', () {
+    test('returns 64 lower-case hex characters (a raw 32-byte key)', () {
+      final key = generateCipherKeyHex();
+      expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
+    });
+
+    test('returns a different key each call (CSPRNG)', () {
+      expect(generateCipherKeyHex(), isNot(equals(generateCipherKeyHex())));
+    });
+  });
+
+  group('DatabaseEncryptionBootstrap.resolveCipherKey', () {
+    late _MockSecureStorage storage;
+    late Map<String, String> store;
+
+    setUp(() {
+      storage = _MockSecureStorage();
+      store = <String, String>{};
+      when(
+        () => storage.read(key: any(named: 'key')),
+      ).thenAnswer((inv) async => store[inv.namedArguments[#key]]);
+      when(
+        () => storage.write(
+          key: any(named: 'key'),
+          value: any(named: 'value'),
+        ),
+      ).thenAnswer((inv) async {
+        store[inv.namedArguments[#key] as String] =
+            inv.namedArguments[#value] as String;
+      });
+    });
+
+    DatabaseEncryptionBootstrap buildBootstrap({
+      required CipherMigrationOutcome outcome,
+      required void Function() onDelete,
+      bool cipherAvailable = true,
+    }) {
+      return DatabaseEncryptionBootstrap(
+        secureStorage: storage,
+        ensureRuntime: () async {},
+        isCipherAvailable: () => cipherAvailable,
+        migrate: (_) async => outcome,
+        deleteDatabase: () async => onDelete(),
+      );
+    }
+
+    test('throws StateError when SQLCipher is not linked', () {
+      final bootstrap = buildBootstrap(
+        cipherAvailable: false,
+        outcome: CipherMigrationOutcome.noDatabase,
+        onDelete: () {},
+      );
+
+      expect(bootstrap.resolveCipherKey(), throwsStateError);
+    });
+
+    test(
+      'generates and persists a key on fresh install (noDatabase)',
+      () async {
+        var deleted = false;
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.noDatabase,
+          onDelete: () => deleted = true,
+        );
+
+        final key = await bootstrap.resolveCipherKey();
+
+        expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
+        expect(store[dbCipherKeyStorageKey], equals(key));
+        expect(deleted, isFalse);
+      },
+    );
+
+    test('returns the key after a successful migration', () async {
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.migrated,
+        onDelete: () {},
+      );
+
+      expect(await bootstrap.resolveCipherKey(), isNotNull);
+    });
+
+    test('reuses an existing key without wiping (alreadyEncrypted)', () async {
+      const existing =
+          '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+      store[dbCipherKeyStorageKey] = existing;
+      var deleted = false;
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.alreadyEncrypted,
+        onDelete: () => deleted = true,
+      );
+
+      final key = await bootstrap.resolveCipherKey();
+
+      expect(key, equals(existing));
+      expect(deleted, isFalse, reason: 'key intact => not key-loss');
+    });
+
+    test('wipes the unrecoverable DB on key loss (generated key + '
+        'alreadyEncrypted)', () async {
+      // Empty store => key is freshly generated, but an encrypted DB already
+      // exists: the keystore was reset. The DB is unrecoverable and must be
+      // wiped + recreated under the new key (#570 §6).
+      var deleted = false;
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.alreadyEncrypted,
+        onDelete: () => deleted = true,
+      );
+
+      final key = await bootstrap.resolveCipherKey();
+
+      expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
+      expect(deleted, isTrue);
+    });
+
+    test('returns null (plaintext fallback) when migration failed', () async {
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.failed,
+        onDelete: () {},
+      );
+
+      expect(await bootstrap.resolveCipherKey(), isNull);
+    });
+
+    test('regenerates a key when the stored value is malformed', () async {
+      store[dbCipherKeyStorageKey] = 'not-a-valid-key';
+      final bootstrap = buildBootstrap(
+        outcome: CipherMigrationOutcome.migrated,
+        onDelete: () {},
+      );
+
+      final key = await bootstrap.resolveCipherKey();
+
+      expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
+      expect(store[dbCipherKeyStorageKey], equals(key));
+    });
+  });
+}

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -105,11 +105,11 @@ void main() {
       expect(deleted, isFalse, reason: 'key intact => not key-loss');
     });
 
-    test('wipes the unrecoverable DB on key loss (generated key + '
+    test('backs up the unrecoverable DB on key loss (generated key + '
         'alreadyEncrypted)', () async {
       // Empty store => key is freshly generated, but an encrypted DB already
       // exists: the keystore was reset. The DB is unrecoverable and must be
-      // wiped + recreated under the new key (#570 §6).
+      // backed up + recreated under the new key (#570 §6).
       var deleted = false;
       final bootstrap = buildBootstrap(
         outcome: CipherMigrationOutcome.alreadyEncrypted,


### PR DESCRIPTION
> **Draft — device QA gates un-drafting.** This relands finding **C2** of #570 the way the review of the closed #4945 asked: the key-pragma helper now ships **with its production caller** (the encrypted-open path + migration), not ahead of it. The encrypted open and the real `sqlcipher_export` migration require the SQLCipher native lib and can't run in CI (the host VM links plain sqlite3), so this stays a draft until the device-QA checklist passes. Supersedes the closed #4945.

## Description

Encrypts the local `divine_db.db` at rest with SQLCipher. For a moderation account holding reports about users, plaintext-at-rest is materially sensitive (decision #570). `db_client` stays keystore-free; the app resolves the key and injects it.

**db_client (low-level)**
- `openEncryptedConnection({rawKeyHex})` — keyed `NativeDatabase` that **fails closed**: throws if SQLCipher isn't the linked library (`PRAGMA cipher_version` empty) rather than silently writing plaintext.
- `formatCipherKeyPragma` — raw-key PRAGMA; the thrown `ArgumentError` **no longer embeds the key** (the #4945 review finding). `applyCipherKey` also converts a `SqliteException` from the keying statement into a key-free `StateError` so the key can't reach Crashlytics via `causingStatement`.
- `migratePlaintextToEncrypted` — one-time in-place `sqlcipher_export` rekey, **safe by construction**: verifies the encrypted copy (`user_version` + table/row counts) and resumes an interrupted swap before promoting it; preserves the plaintext source on every failure. Only `SQLITE_NOTADB` counts as "encrypted"; transient errors are *indeterminate* and fail safe (a readable plaintext DB is never wiped).
- `backUpAndRemoveSharedDatabase` — §6 key-loss recovery renames (not deletes) the unrecoverable DB to a backup.

**App**
- Dependency swap `sqlite3_flutter_libs ^0.5.40` → **`sqlcipher_flutter_libs ^0.6.8`** (0.7.0+ is an EOL no-op), and **removed the unused `drift_flutter`** which transitively pulled `sqlite3_flutter_libs` back in (would collide with SQLCipher on iOS/macOS). Added `sqlite3` as a direct dep for the Android override.
- `DatabaseEncryptionBootstrap` (CSPRNG key in `flutter_secure_storage`, Android native-lib override, migration, §6 recovery), conditional-import `sqlcipher_runtime`, `dbCipherKeyProvider`, and the `main.dart` wiring that resolves the key before the first `AppDatabase` open. `resetOnError` is deliberately **false** for the cipher key so a transient keystore error degrades to a plaintext launch instead of silently erasing the key.

**Related Issue:** Relates to #570 (finding C2). Supersedes #4945.

## Out of Scope (device-QA-gated — NOT in this PR)

- **iOS/macOS build config**: `-framework SQLCipher` linker flag + Podfile `post_install` (`SQLITE_HAS_CODEC`) if any pod links plain sqlite3, and `ITSAppUsesNonExemptEncryption` for export compliance. Documented with exact snippets in `mobile/docs/sqlcipher_at_rest_plan.md`; the committed runtime `cipher_version` fail-closed check is the safety net regardless.
- **§6 key-loss UX**: the back-up-and-recreate behavior is implemented but the user-facing notice **needs product signoff** before un-drafting.
- **Web at-rest** (#373) and **backend D1 retention** (#570 Decision 8).

## Verification

- `flutter analyze lib test integration_test` — clean.
- `db_client` suite — **652 pass** (incl. fail-closed, fail-safe-preserve, no-key-leak `#4945` regression, resume-interrupted-swap).
- `database_encryption_bootstrap_test` — **9 pass** (key gen, read-or-create, key-loss recovery, plaintext fallback).
- `database_provider` / `dm_repository_provider` / `welcome_screen` tests pass.
- Untested-services floor ratchet passes; `flutter pub get` resolves with `sqlite3_flutter_libs` fully removed; `database_provider.g.dart` regenerated.
- Hardened against 6 findings from an adversarial multi-agent review (key leak via `SqliteException`, transient-error misclassification → wipe, `resetOnError` key erasure, invalid `user_version` PRAGMA subquery that would break migration on every device, interrupted-swap data loss, stale generated file).

> **Device QA still owed before un-drafting** (see the plan doc's checklist): iOS/Android/macOS build+launch with SQLCipher; fresh-install encrypted (`cipher_version` non-empty, unreadable by plain `sqlite3`); upgrade-from-plaintext migration preserves all tables/rows; force-kill mid-migration recovers; key-loss path; cold-start perf; key never in logs/Crashlytics.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Build configuration change