### PR TITLE
fix(inbox): limit notification label text to one line with ellipsis

### DIFF
--- a/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
@@ -113,6 +113,8 @@ class _ToggleButton extends StatelessWidget {
               children: [
                 Text(
                   label,
+                  maxLines: 1,
+                  overflow: .ellipsis,
                   textScaler: TextScaler.noScaling,
                   style:
                       VineTheme.titleMediumFont(

--- a/mobile/test/screens/inbox/widgets/inbox_segmented_toggle_test.dart
+++ b/mobile/test/screens/inbox/widgets/inbox_segmented_toggle_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests rendering of labels, notification badge, and tap interactions.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
@@ -129,19 +130,10 @@ void main() {
           ),
         );
 
-        expect(tester.takeException(), isNull);
-
-        final notificationsLabel = tester.widget<Text>(
+        final notificationsLabel = tester.renderObject<RenderParagraph>(
           find.text(l10n.settingsNotifications),
         );
-        expect(notificationsLabel.maxLines, equals(1));
-        expect(notificationsLabel.overflow, equals(TextOverflow.ellipsis));
-
-        final messagesLabel = tester.widget<Text>(
-          find.text(l10n.inboxMessagesTab),
-        );
-        expect(messagesLabel.maxLines, equals(1));
-        expect(messagesLabel.overflow, equals(TextOverflow.ellipsis));
+        expect(notificationsLabel.didExceedMaxLines, isTrue);
       });
     });
 

--- a/mobile/test/screens/inbox/widgets/inbox_segmented_toggle_test.dart
+++ b/mobile/test/screens/inbox/widgets/inbox_segmented_toggle_test.dart
@@ -103,6 +103,46 @@ void main() {
         expect(find.text('99+'), findsOneWidget);
         expect(find.text('150'), findsNothing);
       });
+
+      testWidgets('limits localized labels to one line with ellipsis', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('de'));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            locale: const Locale('de'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.topLeft,
+                child: SizedBox(
+                  width: 180,
+                  child: InboxSegmentedToggle(
+                    selected: InboxTab.messages,
+                    onChanged: (_) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+
+        final notificationsLabel = tester.widget<Text>(
+          find.text(l10n.settingsNotifications),
+        );
+        expect(notificationsLabel.maxLines, equals(1));
+        expect(notificationsLabel.overflow, equals(TextOverflow.ellipsis));
+
+        final messagesLabel = tester.widget<Text>(
+          find.text(l10n.inboxMessagesTab),
+        );
+        expect(messagesLabel.maxLines, equals(1));
+        expect(messagesLabel.overflow, equals(TextOverflow.ellipsis));
+      });
     });
 
     group('interactions', () {


### PR DESCRIPTION
Closes #4983

## Description

A minor fix that limits the button text to one line with an ellipsis, as it was overflowing strangely in languages where the text was longer, such as German.

| Before | After |
| ------- | ----- |
|      <img width="322" alt="Before" src="https://github.com/user-attachments/assets/804c5380-63e6-4a1f-9488-f8a2c5530b06" />   |      <img width="322" alt="Bildschirmfoto 2026-06-08 um 15 56 44" src="https://github.com/user-attachments/assets/fd54b617-860f-40e2-bf4e-24c7997c4c20" />     | 

**Related Issue:** 

## Out of Scope

<!--- Note any intentionally excluded follow-up work or confirm "None". -->

## Verification

<!--- List the checks you ran, for example `flutter analyze` or targeted tests. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore