### PR TITLE
fix(reaction): centre DM reaction emoji on Android (#4954)

### DIFF
--- a/mobile/packages/divine_ui/lib/src/reaction/reaction_chip.dart
+++ b/mobile/packages/divine_ui/lib/src/reaction/reaction_chip.dart
@@ -4,6 +4,7 @@
 // ABOUTME: or retry icon joins.
 
 import 'package:divine_ui/src/theme/vine_theme.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Visual variant of a [ReactionChip]. Drives the background tint, the
@@ -109,12 +110,19 @@ class ReactionChip extends StatelessWidget {
     // `leadingDistribution: even` splits any residual leading equally
     // above and below — the glyph now sits on the chip's centerline.
     //
-    // The horizontal `Transform.translate(2, 0)` compensates for
-    // Apple's emoji font having a small left-side bearing built into
-    // its em-box: without it, the glyph reads as slightly left of the
-    // chip's geometric centre.
+    // The horizontal nudge re-centres Apple Color Emoji, whose advance
+    // box carries a small left-side bearing that otherwise reads as the
+    // glyph sitting left of the chip centre. Noto Color Emoji (Android
+    // and the other platforms) has symmetric bearings, so advance-box
+    // centering already lands it centred there — applying the nudge
+    // unconditionally pushed the glyph off-centre to the right on
+    // Android (#4954). Gate it to Apple platforms only.
+    const appleEmojiLeftBearingNudge = 2.0;
+    final isAppleEmojiFont =
+        defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS;
     final emojiText = Transform.translate(
-      offset: const Offset(2, 0),
+      offset: Offset(isAppleEmojiFont ? appleEmojiLeftBearingNudge : 0, 0),
       child: Text(
         emoji,
         style: const TextStyle(

--- a/mobile/packages/divine_ui/test/src/reaction/reaction_chip_test.dart
+++ b/mobile/packages/divine_ui/test/src/reaction/reaction_chip_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Strict-coverage tests for ReactionChip variants.
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -141,6 +142,44 @@ void main() {
       );
       final opacity = tester.widget<Opacity>(find.byType(Opacity));
       expect(opacity.opacity, closeTo(1.0, 0.001));
+    });
+
+    // The emoji is nudged right only on Apple platforms to cancel Apple
+    // Color Emoji's left-side bearing; Noto (Android et al.) is symmetric
+    // and must not be nudged, or the glyph drifts off-centre right (#4954).
+    group('emoji horizontal nudge', () {
+      final cases = <(TargetPlatform, double)>[
+        (TargetPlatform.iOS, 2),
+        (TargetPlatform.macOS, 2),
+        (TargetPlatform.android, 0),
+        (TargetPlatform.linux, 0),
+      ];
+      for (final (platform, expectedDx) in cases) {
+        testWidgets('translates emoji by $expectedDx dp on $platform', (
+          tester,
+        ) async {
+          debugDefaultTargetPlatformOverride = platform;
+          try {
+            await pump(
+              tester,
+              const ReactionChip(
+                emoji: '🔥',
+                count: 1,
+                variant: ReactionChipVariant.theirs,
+              ),
+            );
+            final transform = tester.widget<Transform>(
+              find.descendant(
+                of: find.byType(ReactionChip),
+                matching: find.byType(Transform),
+              ),
+            );
+            expect(transform.transform.storage[12], expectedDx);
+          } finally {
+            debugDefaultTargetPlatformOverride = null;
+          }
+        });
+      }
     });
   });
 }


### PR DESCRIPTION
## Description

Reaction chips in direct messages rendered their emoji glyph off-centre
(drifting right) on Android.

**Root cause:** `ReactionChip` wrapped the emoji in a
`Transform.translate(offset: Offset(2, 0))` to cancel the left-side
bearing baked into **Apple Color Emoji**'s advance box. That nudge was
applied **unconditionally**. **Noto Color Emoji** — the font on Android
and the other non-Apple platforms — has symmetric bearings, so the same
2 dp shift pushed the glyph off-centre to the right instead of correcting
anything.

**Fix:** Gate the nudge to Apple platforms via `defaultTargetPlatform`
(`iOS`/`macOS` → 2 dp, everything else → 0 dp). Apple keeps its
correction; Android now renders dead-centre.

### Steps to reproduce (from the issue)

1. Open a direct message conversation **on Android**.
2. Add a reaction to a message.
3. View the reaction chip below the message.

**Before:** the emoji sits visibly right of the chip's centre.
**After:** the emoji is centred within the chip.

**Related Issue:** Closes #4954

## Out of Scope

- The pre-existing redundant `borderRadius` ternary in `reaction_chip.dart`
  (both branches identical) is left untouched to keep this fix scoped.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze lib/src/reaction/reaction_chip.dart test/src/reaction/reaction_chip_test.dart` — no issues
- `flutter test test/src/reaction/reaction_chip_test.dart` (divine_ui) — new parametrized group passes: emoji translated **2 dp on iOS/macOS**, **0 dp on Android/Linux**
  - Note: the pre-existing `invokes onTap when tapped` test fails **locally** on this machine due to the InkSparkle ink-ripple `FragmentProgram.fromAsset` shader asset not loading in the local package test harness. Verified it fails identically on clean `origin/main` (not introduced by this change); it passes in CI.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
