### PR TITLE
fix(notifications): keep most-recent timestamp when consolidating follows

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1468,7 +1468,21 @@ class NotificationRepository {
     );
   }
 
-  /// Consolidates follow notifications — keeps the earliest per pubkey.
+  /// Consolidates follow notifications — keeps the most recent per pubkey.
+  ///
+  /// Kind 3 (contact list) is a replaceable event: a single follower can
+  /// produce several follow notifications over time (re-publishes, plus
+  /// the same logical follow arriving via both the REST page and the
+  /// realtime bridge). Collapsing them to one row per `sourcePubkey` keeps
+  /// the Follows tab from showing the same person repeatedly.
+  ///
+  /// The surviving row must carry the *latest* `createdAt`, not the
+  /// earliest. The feed sorts newest-first and paginates, so stamping a
+  /// recent follow with a stale timestamp sinks it below older
+  /// notifications — potentially off the first page entirely, which
+  /// surfaces as an empty "Follows" tab even though the follow exists.
+  /// Keeping the most recent timestamp also matches the realtime path,
+  /// which inserts new follows at the top of the snapshot.
   List<RelayNotification> _consolidateFollows(List<RelayNotification> raw) {
     final followsByPubkey = <String, RelayNotification>{};
     final result = <RelayNotification>[];
@@ -1477,7 +1491,7 @@ class NotificationRepository {
       final kind = _mapNotificationKind(n);
       if (kind == NotificationKind.follow) {
         final existing = followsByPubkey[n.sourcePubkey];
-        if (existing == null || n.createdAt.isBefore(existing.createdAt)) {
+        if (existing == null || n.createdAt.isAfter(existing.createdAt)) {
           followsByPubkey[n.sourcePubkey] = n;
         }
       } else {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -76,7 +76,7 @@ const _hydrationLimit = 50;
 /// 4. Group like/comment/repost by `(referencedEventId, kind)` into
 ///    [VideoNotification]s — threshold 1
 /// 5. Map follow/mention/system into [ActorNotification]s
-/// 6. Consolidate follow duplicates (keep earliest per source pubkey)
+/// 6. Consolidate follow duplicates (keep most recent per source pubkey)
 /// 7. Truncate long comment text
 class NotificationRepository {
   /// Creates a [NotificationRepository].

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1050,7 +1050,7 @@ void main() {
 
     group('follow consolidation', () {
       test('2 follows from same pubkey become 1 $ActorNotification '
-          'with earliest timestamp', () async {
+          'with most-recent timestamp', () async {
         final earlier = DateTime(2025);
         final later = DateTime(2025, 1, 5);
         stubNotifications([
@@ -1080,7 +1080,11 @@ void main() {
         expect(page.items, hasLength(1));
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.follow));
-        expect(item.timestamp, equals(earlier));
+        // The consolidated row carries the most recent follow timestamp so a
+        // fresh follow surfaces at the top of the Follows tab rather than
+        // being buried (and paginated off the first page) with a stale
+        // timestamp.
+        expect(item.timestamp, equals(later));
       });
 
       test('follows from different pubkeys are not consolidated', () async {
@@ -1109,6 +1113,61 @@ void main() {
 
         expect(page.items, hasLength(2));
       });
+
+      test(
+        'a re-published follow sorts above older notifications by its '
+        'latest timestamp',
+        () async {
+          // A replaceable kind-3 contact list arrives twice for the same
+          // follower: once with a stale timestamp and once fresh. The
+          // consolidated row must inherit the fresh timestamp so it sorts
+          // above an older like — otherwise the follow sinks below the fold
+          // and the Follows tab reads "no activity" (regression for the
+          // reported follows-tab bug).
+          final stale = DateTime(2025);
+          final older = DateTime(2025, 1, 3);
+          final fresh = DateTime(2025, 1, 10);
+          stubNotifications([
+            makeNotification(
+              id: 'follow_stale',
+              sourcePubkey: 'follower_pub',
+              notificationType: 'follow',
+              sourceKind: 3,
+              referencedEventId: null,
+              createdAt: stale,
+            ),
+            makeNotification(
+              id: 'old_like',
+              sourcePubkey: 'liker_pub',
+              referencedEventId: 'video_a',
+              createdAt: older,
+            ),
+            makeNotification(
+              id: 'follow_fresh',
+              sourcePubkey: 'follower_pub',
+              notificationType: 'follow',
+              sourceKind: 3,
+              referencedEventId: null,
+              createdAt: fresh,
+            ),
+          ]);
+          stubProfiles({
+            'follower_pub': makeProfile(
+              'follower_pub',
+              displayName: 'Follower',
+            ),
+            'liker_pub': makeProfile('liker_pub', displayName: 'Liker'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(2));
+          final follow = page.items.first as ActorNotification;
+          expect(follow.type, equals(NotificationKind.follow));
+          expect(follow.actor.pubkey, equals('follower_pub'));
+          expect(follow.timestamp, equals(fresh));
+        },
+      );
     });
 
     group('comments stay individual when on different videos', () {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1114,60 +1114,54 @@ void main() {
         expect(page.items, hasLength(2));
       });
 
-      test(
-        'a re-published follow sorts above older notifications by its '
-        'latest timestamp',
-        () async {
-          // A replaceable kind-3 contact list arrives twice for the same
-          // follower: once with a stale timestamp and once fresh. The
-          // consolidated row must inherit the fresh timestamp so it sorts
-          // above an older like — otherwise the follow sinks below the fold
-          // and the Follows tab reads "no activity" (regression for the
-          // reported follows-tab bug).
-          final stale = DateTime(2025);
-          final older = DateTime(2025, 1, 3);
-          final fresh = DateTime(2025, 1, 10);
-          stubNotifications([
-            makeNotification(
-              id: 'follow_stale',
-              sourcePubkey: 'follower_pub',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              createdAt: stale,
-            ),
-            makeNotification(
-              id: 'old_like',
-              sourcePubkey: 'liker_pub',
-              referencedEventId: 'video_a',
-              createdAt: older,
-            ),
-            makeNotification(
-              id: 'follow_fresh',
-              sourcePubkey: 'follower_pub',
-              notificationType: 'follow',
-              sourceKind: 3,
-              referencedEventId: null,
-              createdAt: fresh,
-            ),
-          ]);
-          stubProfiles({
-            'follower_pub': makeProfile(
-              'follower_pub',
-              displayName: 'Follower',
-            ),
-            'liker_pub': makeProfile('liker_pub', displayName: 'Liker'),
-          });
+      test('a re-published follow sorts above older notifications by its '
+          'latest timestamp', () async {
+        // A replaceable kind-3 contact list arrives twice for the same
+        // follower: once with a stale timestamp and once fresh. The
+        // consolidated row must inherit the fresh timestamp so it sorts
+        // above an older like — otherwise the follow sinks below the fold
+        // and the Follows tab reads "no activity" (regression for the
+        // reported follows-tab bug).
+        final stale = DateTime(2025);
+        final older = DateTime(2025, 1, 3);
+        final fresh = DateTime(2025, 1, 10);
+        stubNotifications([
+          makeNotification(
+            id: 'follow_stale',
+            sourcePubkey: 'follower_pub',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            createdAt: stale,
+          ),
+          makeNotification(
+            id: 'old_like',
+            sourcePubkey: 'liker_pub',
+            referencedEventId: 'video_a',
+            createdAt: older,
+          ),
+          makeNotification(
+            id: 'follow_fresh',
+            sourcePubkey: 'follower_pub',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+            createdAt: fresh,
+          ),
+        ]);
+        stubProfiles({
+          'follower_pub': makeProfile('follower_pub', displayName: 'Follower'),
+          'liker_pub': makeProfile('liker_pub', displayName: 'Liker'),
+        });
 
-          final page = await repository.getNotifications();
+        final page = await repository.getNotifications();
 
-          expect(page.items, hasLength(2));
-          final follow = page.items.first as ActorNotification;
-          expect(follow.type, equals(NotificationKind.follow));
-          expect(follow.actor.pubkey, equals('follower_pub'));
-          expect(follow.timestamp, equals(fresh));
-        },
-      );
+        expect(page.items, hasLength(2));
+        final follow = page.items.first as ActorNotification;
+        expect(follow.type, equals(NotificationKind.follow));
+        expect(follow.actor.pubkey, equals('follower_pub'));
+        expect(follow.timestamp, equals(fresh));
+      });
     });
 
     group('comments stay individual when on different videos', () {


### PR DESCRIPTION
## Summary

Fixes the "Follows" tab in the notifications inbox reading **"no activity"** even when the user has new followers (#4928).

## Root cause

Follow notifications come from replaceable kind-3 contact-list events. A single follower can produce several follow notifications over time (re-publishes of their contact list, plus the same logical follow arriving via both the REST page and the realtime bridge). `NotificationRepository._consolidateFollows` collapses these to one row per `sourcePubkey` — which is correct — but it kept the **earliest** `createdAt`.

The feed sorts newest-first and paginates. Stamping a fresh follow with a stale timestamp sank it below older likes/comments and could push it off the first page entirely, so the Follows tab appeared empty.

## Fix

Keep the **most recent** follow timestamp per pubkey instead of the earliest. This also matches the realtime path, which already inserts new follows at the top of the snapshot.

## Changes

- `notification_repository.dart`: `_consolidateFollows` now keeps the latest `createdAt` (`isAfter` instead of `isBefore`); expanded the dartdoc to explain why.
- `notification_repository_test.dart`: updated the consolidation timestamp assertion and added a regression test proving a re-published follow sorts above an older notification by its latest timestamp.

## Testing

- `flutter test` in `packages/notification_repository` — all 127 tests pass.
- `dart format` + `flutter analyze` on both changed files — clean.

Closes #4928