### PR TITLE
fix(drafts): migrate legacy drafts atomically to stop disappearing drafts

### DIFF
--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -52,10 +52,38 @@ class DraftStorageService {
         final draftMap = rawJson as Map<String, dynamic>;
         final draft = DivineVideoDraft.fromJson(draftMap, documentsPath);
 
-        // Upsert draft row (clips stripped from JSON blob)
+        // Persist the draft and its clips atomically. A non-transactional
+        // migration could be interrupted (e.g. the app is backgrounded or
+        // killed right after an OS update) between writing the draft row
+        // and its clip rows, leaving a draft with 0 clips. Readers treat
+        // such rows as corrupted and permanently delete them, silently
+        // destroying the user's drafts. Committing both in one transaction
+        // guarantees a draft is never observed without its clips.
         final draftJson = draft.toJson();
+        // Remove clips from JSON blob – they live in their own table.
         draftJson.remove('clips');
-        await _draftsDao.upsertDraft(
+
+        final clipDataList = <DraftClipData>[];
+        for (var i = 0; i < draft.clips.length; i++) {
+          final clip = draft.clips[i];
+          clipDataList.add(
+            DraftClipData(
+              id: clip.id,
+              orderIndex: i,
+              durationMs: clip.duration.inMilliseconds,
+              recordedAt: clip.recordedAt,
+              data: json.encode(clip.toJson()),
+              filePath: clip.video.file?.path != null
+                  ? p.basename(clip.video.file!.path)
+                  : null,
+              thumbnailPath: clip.thumbnailPath != null
+                  ? p.basename(clip.thumbnailPath!)
+                  : null,
+            ),
+          );
+        }
+
+        await _draftsDao.saveDraftWithClips(
           id: draft.id,
           title: draft.title,
           description: draft.description,
@@ -71,28 +99,9 @@ class DraftStorageService {
           renderedThumbnailPath: draft.finalRenderedClip?.thumbnailPath != null
               ? p.basename(draft.finalRenderedClip!.thumbnailPath!)
               : null,
+          clipDataList: clipDataList,
+          ownerPubkey: ownerPubkey,
         );
-
-        // Insert clips with composite IDs so draft clips
-        // don't collide with library clips sharing the same
-        // clip.id primary key.
-        for (var i = 0; i < draft.clips.length; i++) {
-          final clip = draft.clips[i];
-          await _clipsDao.upsertClip(
-            id: '${draft.id}:${clip.id}',
-            draftId: draft.id,
-            orderIndex: i,
-            durationMs: clip.duration.inMilliseconds,
-            recordedAt: clip.recordedAt,
-            data: json.encode(clip.toJson()),
-            filePath: clip.video.file?.path != null
-                ? p.basename(clip.video.file!.path)
-                : null,
-            thumbnailPath: clip.thumbnailPath != null
-                ? p.basename(clip.thumbnailPath!)
-                : null,
-          );
-        }
         successCount++;
       } catch (e) {
         Log.error(

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -893,6 +893,41 @@ void main() {
         // Old format creates a single clip
         expect(drafts.first.clips, hasLength(1));
       });
+
+      // Regression for #4852: migrated drafts must be written together with
+      // their clips in a single transaction. A draft row persisted without
+      // its clip rows is treated as corrupted and permanently deleted on the
+      // next read (see the "removes corrupted drafts with 0 clips" tests),
+      // which silently wipes the user's drafts after an app update.
+      test('commits clip rows with the draft so reads do not delete it',
+          () async {
+        final draftJson = buildDraftJson(
+          id: 'draft_atomic',
+          clips: [
+            buildClipJson(id: 'clip_atomic_1', filePath: 'a1.mp4'),
+            buildClipJson(id: 'clip_atomic_2', filePath: 'a2.mp4'),
+          ],
+        );
+        SharedPreferences.setMockInitialValues({
+          'vine_drafts': json.encode([draftJson]),
+        });
+
+        await service.migrateOldDrafts();
+
+        // The migrated draft must have its clip rows persisted, otherwise the
+        // corrupted-draft sweep in getAllDrafts would delete it.
+        final clipRows = await database.clipsDao.getClipsByDraftId(
+          'draft_atomic',
+        );
+        expect(clipRows, hasLength(2));
+
+        // Running the destructive read twice must not remove the draft.
+        await service.getAllDrafts();
+        final drafts = await service.getAllDrafts();
+        expect(drafts, hasLength(1));
+        expect(drafts.first.id, equals('draft_atomic'));
+        expect(drafts.first.clips, hasLength(2));
+      });
     });
   });
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -899,35 +899,37 @@ void main() {
       // its clip rows is treated as corrupted and permanently deleted on the
       // next read (see the "removes corrupted drafts with 0 clips" tests),
       // which silently wipes the user's drafts after an app update.
-      test('commits clip rows with the draft so reads do not delete it',
-          () async {
-        final draftJson = buildDraftJson(
-          id: 'draft_atomic',
-          clips: [
-            buildClipJson(id: 'clip_atomic_1', filePath: 'a1.mp4'),
-            buildClipJson(id: 'clip_atomic_2', filePath: 'a2.mp4'),
-          ],
-        );
-        SharedPreferences.setMockInitialValues({
-          'vine_drafts': json.encode([draftJson]),
-        });
+      test(
+        'commits clip rows with the draft so reads do not delete it',
+        () async {
+          final draftJson = buildDraftJson(
+            id: 'draft_atomic',
+            clips: [
+              buildClipJson(id: 'clip_atomic_1', filePath: 'a1.mp4'),
+              buildClipJson(id: 'clip_atomic_2', filePath: 'a2.mp4'),
+            ],
+          );
+          SharedPreferences.setMockInitialValues({
+            'vine_drafts': json.encode([draftJson]),
+          });
 
-        await service.migrateOldDrafts();
+          await service.migrateOldDrafts();
 
-        // The migrated draft must have its clip rows persisted, otherwise the
-        // corrupted-draft sweep in getAllDrafts would delete it.
-        final clipRows = await database.clipsDao.getClipsByDraftId(
-          'draft_atomic',
-        );
-        expect(clipRows, hasLength(2));
+          // The migrated draft must have its clip rows persisted, otherwise the
+          // corrupted-draft sweep in getAllDrafts would delete it.
+          final clipRows = await database.clipsDao.getClipsByDraftId(
+            'draft_atomic',
+          );
+          expect(clipRows, hasLength(2));
 
-        // Running the destructive read twice must not remove the draft.
-        await service.getAllDrafts();
-        final drafts = await service.getAllDrafts();
-        expect(drafts, hasLength(1));
-        expect(drafts.first.id, equals('draft_atomic'));
-        expect(drafts.first.clips, hasLength(2));
-      });
+          // Running the destructive read twice must not remove the draft.
+          await service.getAllDrafts();
+          final drafts = await service.getAllDrafts();
+          expect(drafts, hasLength(1));
+          expect(drafts.first.id, equals('draft_atomic'));
+          expect(drafts.first.clips, hasLength(2));
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Users reported that **all their drafts disappeared after updating the app** (#4852). The triage note guessed a missing `video_drafts` table, but that table does not exist anywhere in the codebase and the attached logs contain no `SqliteException` — the real mechanism is a non-transactional legacy migration combined with the existing corrupted-draft sweep.

`DraftStorageService.migrateOldDrafts()` migrated legacy SharedPreferences drafts to Drift by writing the draft row first, then inserting clip rows one-by-one **outside any transaction**. This migration runs on app start right after authentication — exactly when an OS update is most likely to have just relaunched the app and the user may background/kill it. If the process was interrupted between the draft insert and the clip inserts, the draft row was persisted with **zero clip rows**.

The read paths (`getAllDrafts` / `getDraftsByPublishStatuses`) intentionally treat a draft with zero clips as corrupted and **permanently delete it** (this behavior is pinned by existing tests and is correct for genuinely corrupted rows). So an interrupted migration left orphan draft rows that the very next read silently wiped — the user's drafts vanished.

### Fix

Persist the draft and its clips in a single transaction via the existing `DraftsDao.saveDraftWithClips()` (the same atomic path `saveDraft` already uses), so a draft is never observed — or swept — without its clips. Migrated rows are now also tagged with the current `ownerPubkey`, matching `saveDraft` for multi-account isolation parity.

The intentional corrupted-row cleanup is left untouched; this PR removes the partial state that produced false corrupted rows in the first place.

**Related Issue:** Closes #4852

## Out of Scope

- The pre-existing `getAllDrafts` 0-clip cleanup is intentional (pinned by tests) and is kept as-is.
- Recovering drafts already destroyed on affected devices is not possible from the client; this prevents further loss.

## Verification

- `flutter analyze lib/services/draft_storage_service.dart test/services/draft_storage_service_test.dart` — No issues found
- `flutter test test/services/draft_storage_service_test.dart` — 28/28 passing (incl. new regression test "commits clip rows with the draft so reads do not delete it")
- `flutter test test/src/database/daos/drafts_dao_test.dart` (db_client) — 24/24 passing

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
