### PR TITLE
fix(profile): preserve tapped fullscreen video

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -14,6 +14,7 @@ import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/media_availability_checker.dart';
+import 'package:openvine/utils/video_identity.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'fullscreen_feed_event.dart';
@@ -109,8 +110,6 @@ class FullscreenFeedBloc
   final MediaAvailabilityChecker _availabilityChecker;
   StreamSubscription<bool>? _hasMoreSubscription;
   StreamSubscription<String>? _removedIdsSubscription;
-  bool _initialTargetResolved = false;
-  bool _userChangedIndex = false;
 
   /// Queue of video IDs waiting to be cached in the background.
   final Queue<_CacheRequest> _cacheQueue = Queue<_CacheRequest>();
@@ -175,13 +174,16 @@ class FullscreenFeedBloc
           category: LogCategory.video,
         );
 
-        final nextIndex = _nextIndexForVideos(videos);
+        final indexResolution = _nextIndexForVideos(videos);
 
         return state.copyWith(
           status: FullscreenFeedStatus.ready,
           videos: videos,
-          currentIndex: nextIndex,
+          currentIndex: indexResolution.index,
           isLoadingMore: false,
+          initialTargetResolved:
+              state.initialTargetResolved ||
+              indexResolution.initialTargetResolved,
         );
       },
       onError: (error, stackTrace) {
@@ -196,24 +198,28 @@ class FullscreenFeedBloc
     );
   }
 
-  int _nextIndexForVideos(List<VideoEvent> videos) {
+  ({int index, bool initialTargetResolved}) _nextIndexForVideos(
+    List<VideoEvent> videos,
+  ) {
     if (videos.isEmpty) {
-      return state.currentIndex;
+      return (index: state.currentIndex, initialTargetResolved: false);
     }
 
     final currentVideo = state.currentVideo;
     final preservedIndex = currentVideo == null
         ? -1
-        : _indexOfVideoIdentity(videos, currentVideo);
+        : indexOfMatchingVideo(videos, currentVideo);
     if (preservedIndex >= 0) {
-      _initialTargetResolved = true;
-      return preservedIndex;
+      return (index: preservedIndex, initialTargetResolved: true);
     }
 
-    if (!_userChangedIndex && !_initialTargetResolved) {
-      final initialTargetIndex = _indexOfInitialTarget(videos);
+    if (!state.userChangedIndex && !state.initialTargetResolved) {
+      final initialTargetIndex = indexOfVideoIdentity(
+        videos,
+        videoId: _initialVideoId,
+        stableId: _initialStableId,
+      );
       if (initialTargetIndex >= 0) {
-        _initialTargetResolved = true;
         Log.debug(
           'FullscreenFeedBloc: resolved initial target '
           'videoId=$_initialVideoId stableId=$_initialStableId '
@@ -221,34 +227,20 @@ class FullscreenFeedBloc
           name: 'FullscreenFeedBloc',
           category: LogCategory.video,
         );
-        return initialTargetIndex;
+        return (index: initialTargetIndex, initialTargetResolved: true);
       }
 
       if (_initialVideoId == null && _initialStableId == null) {
-        _initialTargetResolved = true;
+        return (
+          index: state.currentIndex.clamp(0, videos.length - 1),
+          initialTargetResolved: true,
+        );
       }
     }
 
-    return state.currentIndex.clamp(0, videos.length - 1);
-  }
-
-  int _indexOfInitialTarget(List<VideoEvent> videos) {
-    final initialVideoId = _initialVideoId;
-    final initialStableId = _initialStableId;
-    if (initialVideoId == null && initialStableId == null) return -1;
-
-    return videos.indexWhere(
-      (video) =>
-          (initialVideoId != null && video.id == initialVideoId) ||
-          (initialStableId != null && video.stableId == initialStableId),
-    );
-  }
-
-  int _indexOfVideoIdentity(List<VideoEvent> videos, VideoEvent target) {
-    return videos.indexWhere(
-      (video) =>
-          video.id == target.id ||
-          (target.stableId.isNotEmpty && video.stableId == target.stableId),
+    return (
+      index: state.currentIndex.clamp(0, videos.length - 1),
+      initialTargetResolved: false,
     );
   }
 
@@ -299,15 +291,18 @@ class FullscreenFeedBloc
     FullscreenFeedIndexChanged event,
     Emitter<FullscreenFeedState> emit,
   ) {
-    if (event.index == state.currentIndex) return;
-    _userChangedIndex = true;
-    _initialTargetResolved = true;
-
     final clampedIndex = state.videos.isEmpty
         ? 0
         : event.index.clamp(0, state.videos.length - 1);
+    if (clampedIndex == state.currentIndex) return;
 
-    emit(state.copyWith(currentIndex: clampedIndex));
+    emit(
+      state.copyWith(
+        currentIndex: clampedIndex,
+        userChangedIndex: true,
+        initialTargetResolved: true,
+      ),
+    );
   }
 
   /// Handle video ready for caching - enqueue for background caching.

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -205,14 +205,6 @@ class FullscreenFeedBloc
       return (index: state.currentIndex, initialTargetResolved: false);
     }
 
-    final currentVideo = state.currentVideo;
-    final preservedIndex = currentVideo == null
-        ? -1
-        : indexOfMatchingVideo(videos, currentVideo);
-    if (preservedIndex >= 0) {
-      return (index: preservedIndex, initialTargetResolved: true);
-    }
-
     if (!state.userChangedIndex && !state.initialTargetResolved) {
       final initialTargetIndex = indexOfVideoIdentity(
         videos,
@@ -236,6 +228,14 @@ class FullscreenFeedBloc
           initialTargetResolved: true,
         );
       }
+    }
+
+    final currentVideo = state.currentVideo;
+    final preservedIndex = currentVideo == null
+        ? -1
+        : indexOfMatchingVideo(videos, currentVideo);
+    if (preservedIndex >= 0) {
+      return (index: preservedIndex, initialTargetResolved: true);
     }
 
     return (

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -58,6 +58,8 @@ class FullscreenFeedBloc
   FullscreenFeedBloc({
     required Stream<List<VideoEvent>> videosStream,
     required int initialIndex,
+    String? initialVideoId,
+    String? initialStableId,
     Stream<bool>? hasMoreStream,
     Stream<String>? removedIdsStream,
     MediaCacheManager? mediaCache,
@@ -66,6 +68,8 @@ class FullscreenFeedBloc
     OnRemoveVideo? onRemoveVideo,
     MediaAvailabilityChecker? availabilityChecker,
   }) : _videosStream = videosStream,
+       _initialVideoId = initialVideoId,
+       _initialStableId = initialStableId,
        _hasMoreStream = hasMoreStream,
        _removedIdsStream = removedIdsStream,
        _onLoadMore = onLoadMore,
@@ -94,6 +98,8 @@ class FullscreenFeedBloc
   }
 
   final Stream<List<VideoEvent>> _videosStream;
+  final String? _initialVideoId;
+  final String? _initialStableId;
   final Stream<bool>? _hasMoreStream;
   final Stream<String>? _removedIdsStream;
   final VoidCallback? _onLoadMore;
@@ -103,6 +109,8 @@ class FullscreenFeedBloc
   final MediaAvailabilityChecker _availabilityChecker;
   StreamSubscription<bool>? _hasMoreSubscription;
   StreamSubscription<String>? _removedIdsSubscription;
+  bool _initialTargetResolved = false;
+  bool _userChangedIndex = false;
 
   /// Queue of video IDs waiting to be cached in the background.
   final Queue<_CacheRequest> _cacheQueue = Queue<_CacheRequest>();
@@ -167,15 +175,7 @@ class FullscreenFeedBloc
           category: LogCategory.video,
         );
 
-        final currentVideoId = state.currentVideo?.id;
-        final preservedIndex = currentVideoId == null
-            ? -1
-            : videos.indexWhere((video) => video.id == currentVideoId);
-        final nextIndex = preservedIndex >= 0
-            ? preservedIndex
-            : videos.isEmpty
-            ? 0
-            : state.currentIndex.clamp(0, videos.length - 1);
+        final nextIndex = _nextIndexForVideos(videos);
 
         return state.copyWith(
           status: FullscreenFeedStatus.ready,
@@ -193,6 +193,62 @@ class FullscreenFeedBloc
         // Return current state to keep showing existing videos
         return state;
       },
+    );
+  }
+
+  int _nextIndexForVideos(List<VideoEvent> videos) {
+    if (videos.isEmpty) {
+      return state.currentIndex;
+    }
+
+    final currentVideo = state.currentVideo;
+    final preservedIndex = currentVideo == null
+        ? -1
+        : _indexOfVideoIdentity(videos, currentVideo);
+    if (preservedIndex >= 0) {
+      _initialTargetResolved = true;
+      return preservedIndex;
+    }
+
+    if (!_userChangedIndex && !_initialTargetResolved) {
+      final initialTargetIndex = _indexOfInitialTarget(videos);
+      if (initialTargetIndex >= 0) {
+        _initialTargetResolved = true;
+        Log.debug(
+          'FullscreenFeedBloc: resolved initial target '
+          'videoId=$_initialVideoId stableId=$_initialStableId '
+          'index=$initialTargetIndex',
+          name: 'FullscreenFeedBloc',
+          category: LogCategory.video,
+        );
+        return initialTargetIndex;
+      }
+
+      if (_initialVideoId == null && _initialStableId == null) {
+        _initialTargetResolved = true;
+      }
+    }
+
+    return state.currentIndex.clamp(0, videos.length - 1);
+  }
+
+  int _indexOfInitialTarget(List<VideoEvent> videos) {
+    final initialVideoId = _initialVideoId;
+    final initialStableId = _initialStableId;
+    if (initialVideoId == null && initialStableId == null) return -1;
+
+    return videos.indexWhere(
+      (video) =>
+          (initialVideoId != null && video.id == initialVideoId) ||
+          (initialStableId != null && video.stableId == initialStableId),
+    );
+  }
+
+  int _indexOfVideoIdentity(List<VideoEvent> videos, VideoEvent target) {
+    return videos.indexWhere(
+      (video) =>
+          video.id == target.id ||
+          (target.stableId.isNotEmpty && video.stableId == target.stableId),
     );
   }
 
@@ -244,6 +300,8 @@ class FullscreenFeedBloc
     Emitter<FullscreenFeedState> emit,
   ) {
     if (event.index == state.currentIndex) return;
+    _userChangedIndex = true;
+    _initialTargetResolved = true;
 
     final clampedIndex = state.videos.isEmpty
         ? 0

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -29,6 +29,8 @@ final class FullscreenFeedState extends Equatable {
     this.canLoadMore = false,
     this.removedVideoIds = const <String>{},
     this.pendingSkipTarget,
+    this.initialTargetResolved = false,
+    this.userChangedIndex = false,
   });
 
   /// The current status.
@@ -57,6 +59,14 @@ final class FullscreenFeedState extends Equatable {
   /// [FullscreenFeedSkipAcknowledged] once it has consumed the signal so a
   /// subsequent removal can produce a new skip.
   final int? pendingSkipTarget;
+
+  /// Whether the launch target has been reconciled against a non-empty source
+  /// list. Kept in state so stream replays and user index changes can be
+  /// coordinated without mutable BLoC fields.
+  final bool initialTargetResolved;
+
+  /// Whether the user has manually moved the feed cursor since launch.
+  final bool userChangedIndex;
 
   /// The current video, if available.
   VideoEvent? get currentVideo =>
@@ -93,6 +103,8 @@ final class FullscreenFeedState extends Equatable {
     bool? canLoadMore,
     Set<String>? removedVideoIds,
     int? pendingSkipTarget,
+    bool? initialTargetResolved,
+    bool? userChangedIndex,
     bool clearPendingSkipTarget = false,
   }) {
     return FullscreenFeedState(
@@ -105,6 +117,9 @@ final class FullscreenFeedState extends Equatable {
       pendingSkipTarget: clearPendingSkipTarget
           ? null
           : (pendingSkipTarget ?? this.pendingSkipTarget),
+      initialTargetResolved:
+          initialTargetResolved ?? this.initialTargetResolved,
+      userChangedIndex: userChangedIndex ?? this.userChangedIndex,
     );
   }
 
@@ -118,5 +133,7 @@ final class FullscreenFeedState extends Equatable {
     canLoadMore,
     removedVideoIds,
     pendingSkipTarget,
+    initialTargetResolved,
+    userChangedIndex,
   ];
 }

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -1256,7 +1256,7 @@ String? _resolveSha256ForParams(VideoControllerParams params) {
     sha256 = _extractSha256FromUrl(params.videoUrl);
     if (sha256 != null) {
       Log.debug(
-        '🔐 Extracted sha256 from URL: ${sha256.substring(0, 8)}...',
+        '🔐 Extracted sha256 from URL: $sha256',
         name: 'IndividualVideoController',
         category: LogCategory.video,
       );

--- a/mobile/lib/providers/seen_videos_notifier.dart
+++ b/mobile/lib/providers/seen_videos_notifier.dart
@@ -57,9 +57,7 @@ class SeenVideosNotifier extends _$SeenVideosNotifier {
     // Persist to storage
     await _service?.markVideoAsSeen(videoId);
 
-    Log.debug(
-      'Marked video as seen: ${videoId.substring(0, videoId.length > 8 ? 8 : videoId.length)}... (total: ${newSeenIds.length})',
-    );
+    Log.debug('Marked video as seen: $videoId (total: ${newSeenIds.length})');
   }
 
   /// Record video view with metrics

--- a/mobile/lib/providers/seen_videos_notifier.g.dart
+++ b/mobile/lib/providers/seen_videos_notifier.g.dart
@@ -45,7 +45,7 @@ final class SeenVideosNotifierProvider
 }
 
 String _$seenVideosNotifierHash() =>
-    r'4abc2beebe5767ef986a0c84e12ffae9685c63a1';
+    r'11e527c825dd2b21de09445aeaf4a14299cb7700';
 
 /// Notifier for managing seen videos state reactively
 

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -249,9 +249,8 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     observers: _buildRouterObservers(),
     // Refresh router when auth or account-review state changes
     refreshListenable: refreshListenable,
-    errorBuilder: (context, state) => RouteErrorScreen(
-      message: context.l10n.routeUnknownPath,
-    ),
+    errorBuilder: (context, state) =>
+        RouteErrorScreen(message: context.l10n.routeUnknownPath),
     redirect: (context, state) {
       // Rewrite divine.video universal-link URLs to internal paths before the
       // auth/match logic runs. Android delivers the full intent URL (scheme +
@@ -1362,6 +1361,8 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             return PooledFullscreenVideoFeedScreen(
               videosStream: extra.videosStream,
               initialIndex: extra.initialIndex,
+              initialVideoId: extra.initialVideoId,
+              initialStableId: extra.initialStableId,
               onLoadMore: extra.onLoadMore,
               hasMoreStream: extra.hasMoreStream,
               removedIdsStream: extra.removedIdsStream,
@@ -1377,6 +1378,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               npub: '',
               userIdHex: extra.userIdHex,
               videoIndex: extra.initialIndex,
+              videos: extra.seedVideos,
               initialVideoId: extra.initialVideoId,
               initialStableId: extra.initialStableId,
               contextTitleOverride: extra.contextTitle,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -54,6 +54,8 @@ class PooledFullscreenVideoFeedArgs {
   const PooledFullscreenVideoFeedArgs({
     required this.videosStream,
     required this.initialIndex,
+    this.initialVideoId,
+    this.initialStableId,
     this.onLoadMore,
     this.hasMoreStream,
     this.removedIdsStream,
@@ -69,6 +71,14 @@ class PooledFullscreenVideoFeedArgs {
 
   /// Initial video index to start playback.
   final int initialIndex;
+
+  /// Optional specific video identity to resolve against the first non-empty
+  /// source list. This survives empty-first streams and source reordering.
+  final String? initialVideoId;
+
+  /// Optional stable id fallback for addressable videos whose event id may
+  /// change after metadata updates.
+  final String? initialStableId;
 
   /// Callback to trigger pagination on the source.
   final VoidCallback? onLoadMore;
@@ -110,6 +120,7 @@ class ProfilePooledFullscreenVideoFeedArgs {
   const ProfilePooledFullscreenVideoFeedArgs({
     required this.userIdHex,
     required this.initialIndex,
+    this.seedVideos = const [],
     this.initialVideoId,
     this.initialStableId,
     this.contextTitle,
@@ -118,6 +129,7 @@ class ProfilePooledFullscreenVideoFeedArgs {
 
   final String userIdHex;
   final int initialIndex;
+  final List<VideoEvent> seedVideos;
   final String? initialVideoId;
   final String? initialStableId;
   final String? contextTitle;
@@ -142,6 +154,8 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   const PooledFullscreenVideoFeedScreen({
     required this.videosStream,
     required this.initialIndex,
+    this.initialVideoId,
+    this.initialStableId,
     this.onLoadMore,
     this.hasMoreStream,
     this.removedIdsStream,
@@ -155,6 +169,8 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
 
   final Stream<List<VideoEvent>> videosStream;
   final int initialIndex;
+  final String? initialVideoId;
+  final String? initialStableId;
   final VoidCallback? onLoadMore;
   final Stream<bool>? hasMoreStream;
 
@@ -189,6 +205,8 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
           create: (_) => FullscreenFeedBloc(
             videosStream: videosStream,
             initialIndex: initialIndex,
+            initialVideoId: initialVideoId,
+            initialStableId: initialStableId,
             hasMoreStream: hasMoreStream,
             removedIdsStream: removedIdsStream,
             onLoadMore: onLoadMore,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -121,7 +121,7 @@ class UserProfile {
       UserProfile(
         npub: keyContainer.npub,
         publicKeyHex: keyContainer.publicKeyHex,
-        displayName: NostrKeyUtils.maskKey(keyContainer.npub),
+        displayName: keyContainer.npub,
       );
 
   final String npub;
@@ -1188,7 +1188,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       Log.debug(
-        '📱 Public key: ${NostrKeyUtils.maskKey(keyContainer.npub)}',
+        '📱 Public key: ${keyContainer.npub}',
         name: 'AuthService',
         category: LogCategory.auth,
       );
@@ -2272,7 +2272,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _currentProfile = UserProfile(
         npub: npub,
         publicKeyHex: userPubkey,
-        displayName: NostrKeyUtils.maskKey(npub),
+        displayName: npub,
       );
 
       _setAuthState(AuthState.authenticated);
@@ -2613,7 +2613,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _currentProfile = UserProfile(
         npub: npub,
         publicKeyHex: pubkey,
-        displayName: NostrKeyUtils.maskKey(npub),
+        displayName: npub,
       );
 
       _setAuthState(AuthState.authenticated);
@@ -2676,7 +2676,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       Log.debug(
-        '📱 Public key: ${NostrKeyUtils.maskKey(keyContainer.npub)}',
+        '📱 Public key: ${keyContainer.npub}',
         name: 'AuthService',
         category: LogCategory.auth,
       );
@@ -2756,7 +2756,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       Log.debug(
-        '📱 Public key: ${NostrKeyUtils.maskKey(keyContainer.npub)}',
+        '📱 Public key: ${keyContainer.npub}',
         name: 'AuthService',
         category: LogCategory.auth,
       );
@@ -4543,7 +4543,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _currentProfile = UserProfile(
       npub: keyContainer.npub,
       publicKeyHex: keyContainer.publicKeyHex,
-      displayName: NostrKeyUtils.maskKey(keyContainer.npub),
+      displayName: keyContainer.npub,
     );
 
     // Store current user pubkey in SharedPreferences for router redirect checks
@@ -5128,7 +5128,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Map<String, dynamic> get userStats => {
     'is_authenticated': isAuthenticated,
     'auth_state': authState.name,
-    'npub': currentNpub != null ? NostrKeyUtils.maskKey(currentNpub!) : null,
+    'npub': currentNpub,
     'key_created_at': _currentProfile?.keyCreatedAt?.toIso8601String(),
     'last_access_at': _currentProfile?.lastAccessAt?.toIso8601String(),
     'has_error': _lastError != null,

--- a/mobile/lib/services/broken_video_tracker.dart
+++ b/mobile/lib/services/broken_video_tracker.dart
@@ -115,7 +115,7 @@ class BrokenVideoTracker {
       await _saveBrokenVideos();
 
       Log.warning(
-        '🚫 Marked video as broken: $videoId... (reason: $reason)',
+        '🚫 Marked video as broken: $videoId (reason: $reason)',
         name: 'BrokenVideoTracker',
         category: LogCategory.system,
       );
@@ -134,7 +134,7 @@ class BrokenVideoTracker {
       await _saveBrokenVideos();
 
       Log.info(
-        '✅ Unmarked video as broken: $videoId...',
+        '✅ Unmarked video as broken: $videoId',
         name: 'BrokenVideoTracker',
         category: LogCategory.system,
       );

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1196,7 +1196,7 @@ class CuratedListService extends ChangeNotifier {
         (event) {
           receivedEvents.add(event);
           Log.debug(
-            'Received list event from relay: ${event.id}...',
+            'Received list event from relay: ${event.id}',
             name: 'CuratedListService',
             category: LogCategory.system,
           );

--- a/mobile/lib/services/identity_manager_service.dart
+++ b/mobile/lib/services/identity_manager_service.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:nostr_key_manager/nostr_key_manager.dart' show SecureKeyStorage;
-import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -115,7 +114,7 @@ class IdentityManagerService {
         (identity) => identity.npub == currentKeyContainer.npub,
       );
 
-      final displayName = NostrKeyUtils.maskKey(currentKeyContainer.npub);
+      final displayName = currentKeyContainer.npub;
 
       if (existingIndex >= 0) {
         // Update existing identity
@@ -233,7 +232,7 @@ class IdentityManagerService {
 
       await _persistIdentities();
       Log.debug(
-        '📱️ Removed identity with npub: ${NostrKeyUtils.maskKey(npub)}',
+        '📱️ Removed identity with npub: $npub',
         name: 'IdentityManagerService',
         category: LogCategory.system,
       );

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -234,7 +234,7 @@ class SeenVideosService {
         watchDuration: watchDuration,
       );
       Log.debug(
-        '📱 Updated video metrics: ${videoId.substring(0, videoId.length > 8 ? 8 : videoId.length)}... (loops: ${existing.loopCount}, watch: ${existing.totalWatchDuration.inSeconds}s)',
+        '📱 Updated video metrics: $videoId (loops: ${existing.loopCount}, watch: ${existing.totalWatchDuration.inSeconds}s)',
         name: 'SeenVideosService',
         category: LogCategory.system,
       );
@@ -249,7 +249,7 @@ class SeenVideosService {
         lastWatchDuration: watchDuration ?? Duration.zero,
       );
       Log.debug(
-        '📱️ Marking video as seen: ${videoId.substring(0, videoId.length > 8 ? 8 : videoId.length)}...',
+        '📱️ Marking video as seen: $videoId',
         name: 'SeenVideosService',
         category: LogCategory.system,
       );
@@ -332,7 +332,7 @@ class SeenVideosService {
     }
 
     Log.debug(
-      '📱️ Marking video as unseen: ${videoId.substring(0, videoId.length > 8 ? 8 : videoId.length)}...',
+      '📱️ Marking video as unseen: $videoId',
       name: 'SeenVideosService',
       category: LogCategory.system,
     );

--- a/mobile/lib/services/subscribed_list_video_cache.dart
+++ b/mobile/lib/services/subscribed_list_video_cache.dart
@@ -132,11 +132,8 @@ class SubscribedListVideoCache extends ChangeNotifier {
 
     // Log each list for debugging
     for (final list in subscribedLists) {
-      final shortId = list.id.length > 8
-          ? '${list.id.substring(0, 8)}...'
-          : list.id;
       Log.debug(
-        '  📋 List "${list.name}" ($shortId): '
+        '  📋 List "${list.name}" (${list.id}): '
         '${list.videoEventIds.length} video IDs',
         name: 'SubscribedListVideoCache',
         category: LogCategory.video,
@@ -144,13 +141,10 @@ class SubscribedListVideoCache extends ChangeNotifier {
     }
 
     if (subscribedLists.isEmpty && subscribedIds.isNotEmpty) {
-      final sampleIds = subscribedIds
-          .take(3)
-          .map((id) => id.length > 8 ? id.substring(0, 8) : id)
-          .join(', ');
+      final sampleIds = subscribedIds.take(3).join(', ');
       Log.warning(
         '⚠️ Have ${subscribedIds.length} subscribed IDs but 0 lists loaded! '
-        'IDs: $sampleIds...',
+        'IDs: $sampleIds',
         name: 'SubscribedListVideoCache',
         category: LogCategory.video,
       );

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1305,7 +1305,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
       Log.info(
-        '  - Authors: ${authors?.length ?? 'all'} ${authors?.isNotEmpty == true ? "(first: ${authors!.first}...)" : ""}',
+        '  - Authors: ${authors?.length ?? 'all'} ${authors?.isNotEmpty == true ? "(first: ${authors!.first})" : ""}',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
@@ -2192,7 +2192,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // Skip repost events if reposts are disabled
       if (event.kind == 16 && !(_includeReposts[subscriptionType] ?? false)) {
         Log.warning(
-          '⏩ Skipping repost event ${event.id}... (reposts disabled)',
+          '⏩ Skipping repost event ${event.id} (reposts disabled)',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -2212,7 +2212,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // Check if content is blocked
       if (_blocklistRepository?.shouldFilterFromFeeds(event.pubkey) == true) {
         Log.verbose(
-          'Filtering blocked content from ${event.pubkey}...',
+          'Filtering blocked content from ${event.pubkey}',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -2465,7 +2465,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
 
       Log.debug(
-        '📥 Received historical $subscriptionType event: kind=${event.kind}, author=${event.pubkey}..., id=${event.id}...',
+        '📥 Received historical $subscriptionType event: kind=${event.kind}, author=${event.pubkey}, id=${event.id}',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
@@ -2482,7 +2482,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // Skip repost events if reposts are disabled
       if (event.kind == 16 && !(_includeReposts[subscriptionType] ?? false)) {
         Log.warning(
-          '⏩ Skipping historical repost event ${event.id}... (reposts disabled)',
+          '⏩ Skipping historical repost event ${event.id} (reposts disabled)',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -2502,7 +2502,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // Check if content is blocked
       if (_blocklistRepository?.shouldFilterFromFeeds(event.pubkey) == true) {
         Log.verbose(
-          'Filtering blocked historical content from ${event.pubkey}...',
+          'Filtering blocked historical content from ${event.pubkey}',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -2524,7 +2524,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       if (NIP71VideoKinds.isVideoKind(event.kind)) {
         // Direct video event
         Log.verbose(
-          'Processing historical video event ${event.id}...',
+          'Processing historical video event ${event.id}',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -2767,7 +2767,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
 
     Log.info(
-      'Querying historical videos for user=$pubkey... until=${until != null ? DateTime.fromMillisecondsSinceEpoch(until * 1000) : 'none'} limit=$limit',
+      'Querying historical videos for user=$pubkey until=${until != null ? DateTime.fromMillisecondsSinceEpoch(until * 1000) : 'none'} limit=$limit',
       name: 'VideoEventService',
       category: LogCategory.video,
     );
@@ -2799,7 +2799,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // Set timeout for receiving events
       final timeoutTimer = Timer(const Duration(seconds: 5), () {
         Log.info(
-          'Historical query timeout for user=$pubkey... - received $receivedCount events',
+          'Historical query timeout for user=$pubkey - received $receivedCount events',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -2819,7 +2819,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           timeoutTimer.cancel();
           if (!completer.isCompleted) {
             Log.info(
-              'Historical query stream completed for user=$pubkey... - received $receivedCount events',
+              'Historical query stream completed for user=$pubkey - received $receivedCount events',
               name: 'VideoEventService',
               category: LogCategory.video,
             );
@@ -2830,7 +2830,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           timeoutTimer.cancel();
           if (!completer.isCompleted) {
             Log.error(
-              'Historical query stream error for user=$pubkey...: $error',
+              'Historical query stream error for user=$pubkey: $error',
               name: 'VideoEventService',
               category: LogCategory.video,
             );
@@ -2844,7 +2844,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       await streamSubscription.cancel();
 
       Log.info(
-        'Historical user videos query completed - received $receivedCount events for user=$pubkey...',
+        'Historical user videos query completed - received $receivedCount events for user=$pubkey',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
@@ -2853,7 +2853,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       notifyListeners();
     } catch (e) {
       Log.error(
-        'Failed to query historical user videos for user=$pubkey...: $e',
+        'Failed to query historical user videos for user=$pubkey: $e',
         name: 'VideoEventService',
         category: LogCategory.video,
       );

--- a/mobile/lib/services/video_loading_metrics.dart
+++ b/mobile/lib/services/video_loading_metrics.dart
@@ -44,7 +44,7 @@ class VideoLoadingMetrics {
     _activeSessions[videoId] = session;
 
     final message =
-        '🎬 STARTED tracking video loading #$_metricsCount for $videoId... - $videoUrl';
+        '🎬 STARTED tracking video loading #$_metricsCount for $videoId - $videoUrl';
     UnifiedLogger.info(message, name: 'VideoLoadingMetrics');
 
     // Notify visual overlay
@@ -59,7 +59,7 @@ class VideoLoadingMetrics {
     session.controllerCreationStart = DateTime.now();
 
     UnifiedLogger.debug(
-      'Controller creation started for $videoId...',
+      'Controller creation started for $videoId',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -76,7 +76,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     UnifiedLogger.debug(
-      'Controller creation completed for $videoId... in ${duration}ms',
+      'Controller creation completed for $videoId in ${duration}ms',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -89,7 +89,7 @@ class VideoLoadingMetrics {
     session.networkInitStart = DateTime.now();
 
     UnifiedLogger.debug(
-      'Network initialization started for $videoId...',
+      'Network initialization started for $videoId',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -106,7 +106,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     UnifiedLogger.info(
-      'First network response for $videoId... in ${duration}ms',
+      'First network response for $videoId in ${duration}ms',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -119,7 +119,7 @@ class VideoLoadingMetrics {
     session.videoInitStart = DateTime.now();
 
     UnifiedLogger.debug(
-      'Video initialization started for $videoId...',
+      'Video initialization started for $videoId',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -136,7 +136,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     UnifiedLogger.info(
-      'Video initialization completed for $videoId... in ${duration}ms',
+      'Video initialization completed for $videoId in ${duration}ms',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -153,7 +153,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     UnifiedLogger.info(
-      'First frame ready for $videoId... in ${totalDuration}ms total',
+      'First frame ready for $videoId in ${totalDuration}ms total',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -171,7 +171,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     final message =
-        '▶️ PLAYBACK STARTED for $videoId... in ${totalDuration}ms total';
+        '▶️ PLAYBACK STARTED for $videoId in ${totalDuration}ms total';
     UnifiedLogger.info(message, name: 'VideoLoadingMetrics');
     FeedPerformanceTracker().markVideoSwipeComplete(videoId);
 
@@ -196,7 +196,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     UnifiedLogger.error(
-      'Video loading failed for $videoId... after ${totalDuration}ms: $errorType - $errorMessage',
+      'Video loading failed for $videoId after ${totalDuration}ms: $errorType - $errorMessage',
       name: 'VideoLoadingMetrics',
     );
 
@@ -215,7 +215,7 @@ class VideoLoadingMetrics {
     session.bufferingEvents.add(_BufferingEvent(startTime: DateTime.now()));
 
     UnifiedLogger.debug(
-      'Buffering started for $videoId...',
+      'Buffering started for $videoId',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -237,7 +237,7 @@ class VideoLoadingMetrics {
         .inMilliseconds;
 
     UnifiedLogger.debug(
-      'Buffering ended for $videoId... after ${duration}ms',
+      'Buffering ended for $videoId after ${duration}ms',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -257,7 +257,7 @@ class VideoLoadingMetrics {
     if (segmentCount != null) session.segmentCount = segmentCount;
 
     UnifiedLogger.debug(
-      'Network stats for $videoId... - '
+      'Network stats for $videoId - '
       'Downloaded: ${bytesDownloaded ?? 'N/A'} bytes, '
       'Bandwidth: ${bandwidth?.toStringAsFixed(2) ?? 'N/A'} Mbps, '
       'Segments: ${segmentCount ?? 'N/A'}',
@@ -284,7 +284,7 @@ class VideoLoadingMetrics {
     );
 
     UnifiedLogger.debug(
-      'Segment $segmentIndex loaded for $videoId... ($segmentSizeBytes bytes in ${loadTimeMs}ms)',
+      'Segment $segmentIndex loaded for $videoId ($segmentSizeBytes bytes in ${loadTimeMs}ms)',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -301,7 +301,7 @@ class VideoLoadingMetrics {
     session.failedSegments.add(segmentIndex);
 
     UnifiedLogger.warning(
-      'Segment $segmentIndex failed for $videoId... - $errorMessage',
+      'Segment $segmentIndex failed for $videoId - $errorMessage',
       name: 'VideoLoadingMetrics',
     );
   }
@@ -314,7 +314,7 @@ class VideoLoadingMetrics {
     session.totalSegments = totalSegments;
 
     UnifiedLogger.debug(
-      'Video $videoId... has $totalSegments segments',
+      'Video $videoId has $totalSegments segments',
       name: 'VideoLoadingMetrics',
     );
   }

--- a/mobile/lib/utils/video_identity.dart
+++ b/mobile/lib/utils/video_identity.dart
@@ -1,0 +1,30 @@
+import 'package:models/models.dart';
+
+/// Returns the first index whose video identity matches the supplied event id
+/// or stable id. Event id wins when both identities are supplied.
+int indexOfVideoIdentity(
+  List<VideoEvent> videos, {
+  String? videoId,
+  String? stableId,
+  String? pubkey,
+}) {
+  if (videoId == null && stableId == null) return -1;
+
+  return videos.indexWhere(
+    (video) =>
+        (videoId != null && video.id == videoId) ||
+        (stableId != null &&
+            video.stableId == stableId &&
+            (pubkey == null || video.pubkey == pubkey)),
+  );
+}
+
+/// Returns the first index whose identity matches [target].
+int indexOfMatchingVideo(List<VideoEvent> videos, VideoEvent target) {
+  return indexOfVideoIdentity(
+    videos,
+    videoId: target.id,
+    stableId: target.stableId,
+    pubkey: target.pubkey,
+  );
+}

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -139,6 +139,8 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
             // stream before FullscreenFeedBloc attaches.
             videosStream: _videosController.stream.startWith(effectiveVideos),
             initialIndex: resolvedIndex,
+            initialVideoId: widget.initialVideoId,
+            initialStableId: widget.initialStableId,
             trafficSource: ViewTrafficSource.profile,
             contextTitle: contextTitle,
             onLoadMore: hasMoreContent

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/utils/video_identity.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Fullscreen video feed view for profile screens.
@@ -163,10 +164,10 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
     final initialVideoId = widget.initialVideoId;
     final initialStableId = widget.initialStableId;
     if (initialVideoId != null || initialStableId != null) {
-      final resolved = videos.indexWhere(
-        (video) =>
-            (initialVideoId != null && video.id == initialVideoId) ||
-            (initialStableId != null && video.stableId == initialStableId),
+      final resolved = indexOfVideoIdentity(
+        videos,
+        videoId: initialVideoId,
+        stableId: initialStableId,
       );
       if (resolved >= 0) return resolved;
     }

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -201,6 +201,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
       extra: ProfilePooledFullscreenVideoFeedArgs(
         userIdHex: widget.userIdHex,
         initialIndex: resolvedIndex,
+        seedVideos: videos,
         initialVideoId: tappedVideo.id,
         initialStableId: tappedVideo.stableId,
       ),

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -18,6 +18,7 @@ import 'package:openvine/mixins/grid_prefetch_mixin.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/utils/video_identity.dart';
 import 'package:openvine/widgets/profile/pending_collaborator_invite_banner_cubit.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_more_sliver.dart';
@@ -185,12 +186,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     final videos = currentFeedVideos.isNotEmpty
         ? currentFeedVideos
         : displayedVideos;
-    final index = videos.indexWhere(
-      (video) =>
-          video.id == tappedVideo.id ||
-          (video.pubkey == tappedVideo.pubkey &&
-              video.stableId == tappedVideo.stableId),
-    );
+    final index = indexOfMatchingVideo(videos, tappedVideo);
     final resolvedIndex = index >= 0 ? index : fallbackIndex;
 
     // Pre-warm adjacent videos before navigation

--- a/mobile/lib/widgets/video_feed_item/video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/video_error_overlay.dart
@@ -372,7 +372,7 @@ Future<void> _precacheAuthHeaders(
       sha256 = _extractSha256FromUrl(controllerParams.videoUrl);
       if (sha256 != null) {
         Log.debug(
-          '🔐 [PRECACHE] Extracted sha256 from URL: ${sha256.substring(0, 8)}...',
+          '🔐 [PRECACHE] Extracted sha256 from URL: $sha256',
           name: 'VideoErrorOverlay',
           category: LogCategory.video,
         );
@@ -409,7 +409,7 @@ Future<void> _precacheAuthHeaders(
 
     // Generate auth header
     Log.debug(
-      '🔐 [PRECACHE] Generating auth header with sha256=${sha256.substring(0, 16)}...',
+      '🔐 [PRECACHE] Generating auth header with sha256=$sha256',
       name: 'VideoErrorOverlay',
       category: LogCategory.video,
     );

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -248,7 +248,9 @@ class MediaCacheManager extends CacheManager {
                  config.cacheKey,
                  stalePeriod: config.stalePeriod,
                  maxNrOfCacheObjects: config.maxNrOfCacheObjects,
-                 repo: SafeCacheInfoRepository(databaseName: config.cacheKey),
+                 repo:
+                     repoOverride ??
+                     SafeCacheInfoRepository(databaseName: config.cacheKey),
                  // Non-null on the non-web branch (kIsWeb == false here);
                  // the public ctor only nulls fileServiceClient on web.
                  // ignore: unnecessary_null_checks

--- a/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
+++ b/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
@@ -6,6 +6,9 @@ import 'package:http/io_client.dart';
 import 'package:media_cache/src/cancellable_downloader.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+bool _cupertinoUnavailable = false;
+bool _cronetUnavailable = false;
+
 /// `dart:io` implementation that selects the best native HTTP stack.
 ///
 /// Prefers `cupertino_http` on Apple platforms and `cronet_http` on Android,
@@ -38,7 +41,7 @@ CancellableDownloader createPlatformDownloaderImpl({
   // Windows and Linux keep the dart:io / IOClient path.
   // coverage:ignore-start
   final useCupertino = Platform.isIOS || (Platform.isMacOS && !isDebugMode);
-  if (useCupertino) {
+  if (useCupertino && !_cupertinoUnavailable) {
     try {
       final cfg = URLSessionConfiguration.defaultSessionConfiguration()
         ..timeoutIntervalForRequest = connectionTimeout
@@ -47,23 +50,35 @@ CancellableDownloader createPlatformDownloaderImpl({
         CupertinoClient.fromSessionConfiguration(cfg),
       );
     } on Object catch (e, st) {
+      _cupertinoUnavailable = true;
       Log.warning(
         'MediaCache: cupertino_http init failed, '
-        'falling back to dart:io HttpClient: $e\n$st',
+        'using dart:io HttpClient for the rest of this process: $e',
+        name: 'MediaCache',
+        category: LogCategory.video,
+      );
+      Log.debug(
+        'MediaCache: cupertino_http init stack trace: $st',
         name: 'MediaCache',
         category: LogCategory.video,
       );
     }
-  } else if (Platform.isAndroid) {
+  } else if (Platform.isAndroid && !_cronetUnavailable) {
     try {
       // `cronet_http` does not expose per-client connect/idle timeout knobs.
       // On Android, `connectionTimeout` and `idleTimeout` therefore do not
       // apply while Cronet is active.
       return HttpCancellableDownloader(CronetClient.defaultCronetEngine());
     } on Object catch (e, st) {
+      _cronetUnavailable = true;
       Log.warning(
         'MediaCache: cronet_http init failed, '
-        'falling back to dart:io HttpClient: $e\n$st',
+        'using dart:io HttpClient for the rest of this process: $e',
+        name: 'MediaCache',
+        category: LogCategory.video,
+      );
+      Log.debug(
+        'MediaCache: cronet_http init stack trace: $st',
         name: 'MediaCache',
         category: LogCategory.video,
       );

--- a/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
+++ b/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
@@ -2,12 +2,31 @@ import 'dart:io';
 
 import 'package:cronet_http/cronet_http.dart';
 import 'package:cupertino_http/cupertino_http.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/io_client.dart';
 import 'package:media_cache/src/cancellable_downloader.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-bool _cupertinoUnavailable = false;
-bool _cronetUnavailable = false;
+/// Factory for a platform-native [CancellableDownloader].
+typedef NativeDownloaderFactory = CancellableDownloader Function();
+
+final _nativeFallbackState = _NativeDownloaderFallbackState();
+
+final class _NativeDownloaderFallbackState {
+  bool cupertinoUnavailable = false;
+  bool cronetUnavailable = false;
+
+  void reset() {
+    cupertinoUnavailable = false;
+    cronetUnavailable = false;
+  }
+}
+
+/// Clears the per-process native downloader fallback latches.
+@visibleForTesting
+void resetPlatformDownloaderFallbackStateForTesting() {
+  _nativeFallbackState.reset();
+}
 
 /// `dart:io` implementation that selects the best native HTTP stack.
 ///
@@ -20,6 +39,11 @@ CancellableDownloader createPlatformDownloaderImpl({
   required bool allowBadCertificatesInDebug,
   required bool isDebugMode,
   required bool isWeb,
+  @visibleForTesting bool? isIOSOverride,
+  @visibleForTesting bool? isMacOSOverride,
+  @visibleForTesting bool? isAndroidOverride,
+  @visibleForTesting NativeDownloaderFactory? cupertinoDownloaderFactory,
+  @visibleForTesting NativeDownloaderFactory? cronetDownloaderFactory,
 }) {
   if (isWeb) {
     return HttpCancellableDownloader(IOClient(HttpClient()));
@@ -39,18 +63,20 @@ CancellableDownloader createPlatformDownloaderImpl({
   // self-signed local relays keeps working; release/profile macOS
   // builds use NSURLSession.
   // Windows and Linux keep the dart:io / IOClient path.
+  final isIOS = isIOSOverride ?? Platform.isIOS;
+  final isMacOS = isMacOSOverride ?? Platform.isMacOS;
+  final isAndroid = isAndroidOverride ?? Platform.isAndroid;
   // coverage:ignore-start
-  final useCupertino = Platform.isIOS || (Platform.isMacOS && !isDebugMode);
-  if (useCupertino && !_cupertinoUnavailable) {
+  final useCupertino = isIOS || (isMacOS && !isDebugMode);
+  if (useCupertino && !_nativeFallbackState.cupertinoUnavailable) {
     try {
-      final cfg = URLSessionConfiguration.defaultSessionConfiguration()
-        ..timeoutIntervalForRequest = connectionTimeout
-        ..httpMaximumConnectionsPerHost = maxConnectionsPerHost;
-      return HttpCancellableDownloader(
-        CupertinoClient.fromSessionConfiguration(cfg),
-      );
+      return cupertinoDownloaderFactory?.call() ??
+          _createCupertinoDownloader(
+            connectionTimeout: connectionTimeout,
+            maxConnectionsPerHost: maxConnectionsPerHost,
+          );
     } on Object catch (e, st) {
-      _cupertinoUnavailable = true;
+      _nativeFallbackState.cupertinoUnavailable = true;
       Log.warning(
         'MediaCache: cupertino_http init failed, '
         'using dart:io HttpClient for the rest of this process: $e',
@@ -63,14 +89,14 @@ CancellableDownloader createPlatformDownloaderImpl({
         category: LogCategory.video,
       );
     }
-  } else if (Platform.isAndroid && !_cronetUnavailable) {
+  } else if (isAndroid && !_nativeFallbackState.cronetUnavailable) {
     try {
       // `cronet_http` does not expose per-client connect/idle timeout knobs.
       // On Android, `connectionTimeout` and `idleTimeout` therefore do not
       // apply while Cronet is active.
-      return HttpCancellableDownloader(CronetClient.defaultCronetEngine());
+      return cronetDownloaderFactory?.call() ?? _createCronetDownloader();
     } on Object catch (e, st) {
-      _cronetUnavailable = true;
+      _nativeFallbackState.cronetUnavailable = true;
       Log.warning(
         'MediaCache: cronet_http init failed, '
         'using dart:io HttpClient for the rest of this process: $e',
@@ -99,3 +125,24 @@ CancellableDownloader createPlatformDownloaderImpl({
 
   return HttpCancellableDownloader(IOClient(httpClient));
 }
+
+// coverage:ignore-start
+CancellableDownloader _createCupertinoDownloader({
+  required Duration connectionTimeout,
+  required int maxConnectionsPerHost,
+}) {
+  final cfg = URLSessionConfiguration.defaultSessionConfiguration()
+    ..timeoutIntervalForRequest = connectionTimeout
+    ..httpMaximumConnectionsPerHost = maxConnectionsPerHost;
+  return HttpCancellableDownloader(
+    CupertinoClient.fromSessionConfiguration(cfg),
+  );
+}
+// coverage:ignore-end
+
+// coverage:ignore-start
+CancellableDownloader _createCronetDownloader() {
+  return HttpCancellableDownloader(CronetClient.defaultCronetEngine());
+}
+
+// coverage:ignore-end

--- a/mobile/packages/media_cache/test/src/media_cache_manager_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_test.dart
@@ -715,6 +715,10 @@ void main() {
     group('close', () {
       test('closes the legacy file-service HTTP client', () async {
         final tracker = _TrackingIOClient();
+        final repo = MockCacheInfoRepository();
+        when(repo.open).thenAnswer((_) async => true);
+        when(repo.getAllObjects).thenAnswer((_) async => []);
+        when(repo.close).thenAnswer((_) async => true);
 
         // Construction kicks off an async open() on the parent
         // CacheManager's repo store; that pipeline is unrelated to the
@@ -726,7 +730,7 @@ void main() {
               config: MediaCacheConfig(
                 cacheKey: 'close_test_${DateTime.now().millisecondsSinceEpoch}',
               ),
-              repoOverride: MockCacheInfoRepository(),
+              repoOverride: repo,
               fileServiceClientOverride: tracker,
             );
 

--- a/mobile/packages/media_cache/test/src/platform_downloader_factory_io_test.dart
+++ b/mobile/packages/media_cache/test/src/platform_downloader_factory_io_test.dart
@@ -4,6 +4,8 @@ import 'package:media_cache/src/platform_downloader_factory_io.dart';
 
 void main() {
   group('createPlatformDownloaderImpl', () {
+    setUp(resetPlatformDownloaderFallbackStateForTesting);
+
     test('returns HttpCancellableDownloader when isWeb is true', () {
       final downloader = createPlatformDownloaderImpl(
         connectionTimeout: const Duration(seconds: 1),
@@ -28,6 +30,86 @@ void main() {
       );
 
       expect(downloader, isA<HttpCancellableDownloader>());
+    });
+
+    test('latches cupertino init failure for the process', () {
+      var nativeAttempts = 0;
+
+      final firstDownloader = createPlatformDownloaderImpl(
+        connectionTimeout: const Duration(seconds: 2),
+        idleTimeout: const Duration(seconds: 2),
+        maxConnectionsPerHost: 2,
+        allowBadCertificatesInDebug: false,
+        isDebugMode: false,
+        isWeb: false,
+        isIOSOverride: true,
+        isMacOSOverride: false,
+        isAndroidOverride: false,
+        cupertinoDownloaderFactory: () {
+          nativeAttempts++;
+          throw StateError('cupertino unavailable');
+        },
+      );
+
+      final secondDownloader = createPlatformDownloaderImpl(
+        connectionTimeout: const Duration(seconds: 2),
+        idleTimeout: const Duration(seconds: 2),
+        maxConnectionsPerHost: 2,
+        allowBadCertificatesInDebug: false,
+        isDebugMode: false,
+        isWeb: false,
+        isIOSOverride: true,
+        isMacOSOverride: false,
+        isAndroidOverride: false,
+        cupertinoDownloaderFactory: () {
+          nativeAttempts++;
+          throw StateError('cupertino should be latched off');
+        },
+      );
+
+      expect(firstDownloader, isA<HttpCancellableDownloader>());
+      expect(secondDownloader, isA<HttpCancellableDownloader>());
+      expect(nativeAttempts, 1);
+    });
+
+    test('latches cronet init failure for the process', () {
+      var nativeAttempts = 0;
+
+      final firstDownloader = createPlatformDownloaderImpl(
+        connectionTimeout: const Duration(seconds: 2),
+        idleTimeout: const Duration(seconds: 2),
+        maxConnectionsPerHost: 2,
+        allowBadCertificatesInDebug: false,
+        isDebugMode: false,
+        isWeb: false,
+        isIOSOverride: false,
+        isMacOSOverride: false,
+        isAndroidOverride: true,
+        cronetDownloaderFactory: () {
+          nativeAttempts++;
+          throw StateError('cronet unavailable');
+        },
+      );
+
+      final secondDownloader = createPlatformDownloaderImpl(
+        connectionTimeout: const Duration(seconds: 2),
+        idleTimeout: const Duration(seconds: 2),
+        maxConnectionsPerHost: 2,
+        allowBadCertificatesInDebug: false,
+        isDebugMode: false,
+        isWeb: false,
+        isIOSOverride: false,
+        isMacOSOverride: false,
+        isAndroidOverride: true,
+        cronetDownloaderFactory: () {
+          nativeAttempts++;
+          throw StateError('cronet should be latched off');
+        },
+      );
+
+      expect(firstDownloader, isA<HttpCancellableDownloader>());
+      expect(secondDownloader, isA<HttpCancellableDownloader>());
+      expect(nativeAttempts, 1);
     });
   });
 }

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -416,6 +416,54 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'unresolved initial identity wins over fallback current video',
+        build: () => createBloc(
+          initialVideoId: 'target-video',
+          initialStableId: 'stable-target-video',
+        ),
+        act: (bloc) async {
+          final fallback = createTestVideo('fallback-video');
+          final target = createTestVideo(
+            'target-video',
+            rawTags: const {'d': 'stable-target-video'},
+          );
+
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([fallback]);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([createTestVideo('newer-video'), target]);
+        },
+        wait: const Duration(milliseconds: 200),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having((s) => s.currentIndex, 'currentIndex', 0)
+              .having(
+                (s) => s.currentVideo?.id,
+                'currentVideo',
+                'fallback-video',
+              )
+              .having(
+                (s) => s.initialTargetResolved,
+                'initialTargetResolved',
+                false,
+              ),
+          isA<FullscreenFeedState>()
+              .having((s) => s.currentIndex, 'currentIndex', 1)
+              .having(
+                (s) => s.currentVideo?.id,
+                'currentVideo',
+                'target-video',
+              )
+              .having(
+                (s) => s.initialTargetResolved,
+                'initialTargetResolved',
+                true,
+              ),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'cancels previous subscription when started again',
         build: createBloc,
         act: (bloc) async {

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -166,12 +166,16 @@ void main() {
           videos: [video],
           currentIndex: 5,
           isLoadingMore: true,
+          initialTargetResolved: true,
+          userChangedIndex: true,
         );
 
         expect(updated.status, FullscreenFeedStatus.ready);
         expect(updated.videos, [video]);
         expect(updated.currentIndex, 5);
         expect(updated.isLoadingMore, isTrue);
+        expect(updated.initialTargetResolved, isTrue);
+        expect(updated.userChangedIndex, isTrue);
       });
 
       test('copyWith preserves values when not specified', () {
@@ -211,6 +215,8 @@ void main() {
           false,
           <String>{},
           null,
+          false,
+          false,
         ]);
       });
 

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -70,6 +70,8 @@ void main() {
 
     FullscreenFeedBloc createBloc({
       int initialIndex = 0,
+      String? initialVideoId,
+      String? initialStableId,
       void Function()? onLoadMore,
       Stream<bool>? hasMoreStream,
       MediaCacheManager? mediaCache,
@@ -79,6 +81,8 @@ void main() {
     }) => FullscreenFeedBloc(
       videosStream: videosController.stream,
       initialIndex: initialIndex,
+      initialVideoId: initialVideoId,
+      initialStableId: initialStableId,
       onLoadMore: onLoadMore,
       hasMoreStream: hasMoreStream,
       mediaCache: mediaCache ?? mockMediaCache,
@@ -221,9 +225,7 @@ void main() {
           videoUrl: 'https://example.com/video1.mp4',
           rawTags: const {'views': '0'},
         );
-        final updatedVideo = baseVideo.copyWith(
-          rawTags: const {'views': '42'},
-        );
+        final updatedVideo = baseVideo.copyWith(rawTags: const {'views': '42'});
 
         final baseState = FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
@@ -338,6 +340,72 @@ void main() {
           isA<FullscreenFeedState>()
               .having((s) => s.currentIndex, 'currentIndex', 2)
               .having((s) => s.currentVideo?.id, 'currentVideo', 'video2'),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'preserves initial index through empty-first source emissions',
+        build: () => createBloc(initialIndex: 4),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add(const []);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('video0'),
+            createTestVideo('video1'),
+            createTestVideo('video2'),
+            createTestVideo('video3'),
+            createTestVideo('video4'),
+          ]);
+        },
+        wait: const Duration(milliseconds: 200),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having((s) => s.videos, 'videos', isEmpty)
+              .having((s) => s.currentIndex, 'currentIndex', 4),
+          isA<FullscreenFeedState>()
+              .having((s) => s.videos.length, 'videos count', 5)
+              .having((s) => s.currentIndex, 'currentIndex', 4)
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'video4'),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'resolves initial video identity when source order changes',
+        build: () => createBloc(
+          initialIndex: 1,
+          initialVideoId: 'target-video',
+          initialStableId: 'stable-target-video',
+        ),
+        act: (bloc) async {
+          final target = createTestVideo(
+            'target-video',
+            rawTags: const {'d': 'stable-target-video'},
+          );
+
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add(const []);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('newer-video'),
+            createTestVideo('another-video'),
+            target,
+          ]);
+        },
+        wait: const Duration(milliseconds: 200),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having((s) => s.videos, 'videos', isEmpty)
+              .having((s) => s.currentIndex, 'currentIndex', 1),
+          isA<FullscreenFeedState>()
+              .having((s) => s.currentIndex, 'currentIndex', 2)
+              .having(
+                (s) => s.currentVideo?.id,
+                'currentVideo',
+                'target-video',
+              ),
         ],
       );
 
@@ -1208,10 +1276,7 @@ void main() {
         act: (bloc) async {
           bloc.add(const FullscreenFeedStarted());
           await Future<void>.delayed(Duration.zero);
-          videosController.add([
-            createTestVideo('a'),
-            createTestVideo('b'),
-          ]);
+          videosController.add([createTestVideo('a'), createTestVideo('b')]);
           await Future<void>.delayed(Duration.zero);
           bloc.add(const FullscreenFeedVideoRemoved('a'));
           await Future<void>.delayed(Duration.zero);
@@ -1311,10 +1376,7 @@ void main() {
           // Schedule the removal AFTER the bloc subscribes inside _onStarted.
           Future<void>(() async {
             await Future<void>.delayed(const Duration(milliseconds: 1));
-            videosController.add([
-              createTestVideo('a'),
-              createTestVideo('b'),
-            ]);
+            videosController.add([createTestVideo('a'), createTestVideo('b')]);
             await Future<void>.delayed(const Duration(milliseconds: 1));
             removedController.add('a');
           });

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _FakeSystemVolumeListener implements SystemVolumeListener {
+  @override
+  void hideSystemUI() {}
+
+  @override
+  StreamSubscription<double> listen(void Function(double volume) onData) {
+    return const Stream<double>.empty().listen(onData);
+  }
+}
+
+const _profilePubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+VideoEvent _video(
+  String id, {
+  required int createdAt,
+  String? stableId,
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: _profilePubkey,
+    createdAt: createdAt,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+    title: 'Video $id',
+    videoUrl: 'https://example.com/$id.mp4',
+    thumbnailUrl: 'https://example.com/$id.jpg',
+    rawTags: stableId == null ? const {} : {'d': stableId},
+  );
+}
+
+void main() {
+  group(ProfileVideoFeedView, () {
+    late _MockVideosRepository videosRepository;
+    late _MockVideoEventService videoEventService;
+    late _MockContentBlocklistRepository blocklistRepository;
+
+    setUp(() {
+      videosRepository = _MockVideosRepository();
+      videoEventService = _MockVideoEventService();
+      blocklistRepository = _MockContentBlocklistRepository();
+
+      when(
+        () => videoEventService.authorVideos(any()),
+      ).thenReturn(const <VideoEvent>[]);
+      when(
+        () => videoEventService.filterVideoList(any()),
+      ).thenAnswer((i) => i.positionalArguments.first as List<VideoEvent>);
+      when(
+        () => videoEventService.isVideoLocallyDeleted(any()),
+      ).thenReturn(false);
+      when(
+        () => videoEventService.subscribeToUserVideos(any()),
+      ).thenAnswer((_) async {});
+      when(() => videoEventService.addListener(any())).thenReturn(null);
+      when(() => videoEventService.removeListener(any())).thenReturn(null);
+      when(
+        () => videoEventService.addVideoUpdateListener(any()),
+      ).thenReturn(() {});
+      when(
+        () => videoEventService.addNewVideoListener(any()),
+      ).thenReturn(() {});
+      when(
+        () => videoEventService.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
+      when(
+        () => blocklistRepository.shouldFilterFromFeeds(any()),
+      ).thenReturn(false);
+    });
+
+    testWidgets(
+      'seeds fullscreen with the tapped video before live profile videos load',
+      (tester) async {
+        const targetStableId = 'stable-target';
+        final newest = _video('newest-video', createdAt: 3000);
+        final target = _video(
+          'target-video',
+          createdAt: 2000,
+          stableId: targetStableId,
+        );
+        final oldest = _video('oldest-video', createdAt: 1000);
+        final seedVideos = [newest, target, oldest];
+
+        when(
+          () => videosRepository.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: any(named: 'offset'),
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer(
+          (_) async => const AuthorFeedResult(
+            authorPubkey: _profilePubkey,
+            hasMore: false,
+          ),
+        );
+
+        await tester.pumpWidget(
+          testProviderScope(
+            additionalOverrides: [
+              videosRepositoryProvider.overrideWithValue(videosRepository),
+              videoEventServiceProvider.overrideWithValue(videoEventService),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                blocklistRepository,
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: BlocProvider(
+                create: (_) => VideoVolumeCubit(
+                  sharedPreferences: createMockSharedPreferences(),
+                  systemVolumeListener: _FakeSystemVolumeListener(),
+                ),
+                child: ProfileVideoFeedView(
+                  npub: 'npub1profile',
+                  userIdHex: _profilePubkey,
+                  videoIndex: 0,
+                  videos: seedVideos,
+                  initialVideoId: target.id,
+                  initialStableId: targetStableId,
+                  contextTitleOverride: 'Profile',
+                  onPageChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.runAsync(() async {
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        final contentContext = tester.element(
+          find.byType(FullscreenFeedContent),
+        );
+        final fullscreenBloc = contentContext.read<FullscreenFeedBloc>();
+
+        expect(fullscreenBloc.state.status, FullscreenFeedStatus.ready);
+        expect(fullscreenBloc.state.videos, seedVideos);
+        expect(fullscreenBloc.state.currentIndex, 1);
+        expect(fullscreenBloc.state.currentVideo?.id, target.id);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -7,6 +7,7 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
@@ -15,6 +16,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/widgets/profile/profile_videos_grid.dart';
@@ -189,6 +191,63 @@ void main() {
 
         expect(find.byType(SliverGrid), findsOneWidget);
       });
+
+      testWidgets(
+        'tapping a published tile passes seed videos and tapped identity',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final videos = _createTestVideos(pubkey: _ownPubkey, count: 4);
+          Object? capturedExtra;
+          final profileFeedCubit = _stubbedProfileFeedCubit();
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => testProviderScope(
+                  mockAuthService: mockAuth,
+                  child: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockBloc,
+                    child: Scaffold(
+                      body: BlocProvider<ProfileFeedCubit>.value(
+                        value: profileFeedCubit,
+                        child: ProfileVideosGrid(
+                          videos: videos,
+                          userIdHex: _ownPubkey,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: PooledFullscreenVideoFeedScreen.path,
+                builder: (context, state) {
+                  capturedExtra = state.extra;
+                  return const SizedBox.shrink();
+                },
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          );
+
+          await tester.tap(find.bySemanticsLabel('Video thumbnail 3'));
+          await tester.pumpAndSettle();
+
+          final args = capturedExtra as ProfilePooledFullscreenVideoFeedArgs?;
+          expect(args, isNotNull);
+          expect(args!.initialIndex, 2);
+          expect(args.initialVideoId, videos[2].id);
+          expect(args.initialStableId, videos[2].stableId);
+          expect(args.seedVideos, videos);
+        },
+      );
 
       testWidgets('shows persistent pending invite banner on own profile', (
         tester,

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -249,6 +249,73 @@ void main() {
         },
       );
 
+      testWidgets(
+        'active upload placeholder does not offset published tap target',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final draft = _createTestDraft();
+          when(() => mockBloc.state).thenReturn(
+            BackgroundPublishState(
+              uploads: [
+                BackgroundUpload(draft: draft, result: null, progress: 0.5),
+              ],
+            ),
+          );
+
+          final videos = _createTestVideos(pubkey: _ownPubkey, count: 4);
+          Object? capturedExtra;
+          final profileFeedCubit = _stubbedProfileFeedCubit();
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => testProviderScope(
+                  mockAuthService: mockAuth,
+                  child: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockBloc,
+                    child: Scaffold(
+                      body: BlocProvider<ProfileFeedCubit>.value(
+                        value: profileFeedCubit,
+                        child: ProfileVideosGrid(
+                          videos: videos,
+                          userIdHex: _ownPubkey,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: PooledFullscreenVideoFeedScreen.path,
+                builder: (context, state) {
+                  capturedExtra = state.extra;
+                  return const SizedBox.shrink();
+                },
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          );
+
+          expect(find.byType(PartialCircleSpinner), findsOneWidget);
+          await tester.tap(find.bySemanticsLabel('Video thumbnail 3'));
+          await tester.pumpAndSettle();
+
+          final args = capturedExtra as ProfilePooledFullscreenVideoFeedArgs?;
+          expect(args, isNotNull);
+          expect(args!.initialIndex, 1);
+          expect(args.initialVideoId, videos[1].id);
+          expect(args.initialStableId, videos[1].stableId);
+          expect(args.seedVideos, videos);
+        },
+      );
+
       testWidgets('shows persistent pending invite banner on own profile', (
         tester,
       ) async {


### PR DESCRIPTION
## Summary
- preserve the tapped profile video by full event id/stable id when opening pooled fullscreen feeds
- seed profile fullscreen routes with the current grid videos so empty-first streams do not fall back to the latest video
- reduce repeated media-cache platform fallback stack traces and remove truncated Nostr id logging in touched paths

Fixes #4989
Fixes #4990
Fixes #4991
Fixes #4992

## Verification
- mise exec -- flutter test test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
- mise exec -- flutter test test/widgets/profile/profile_videos_grid_test.dart
- mise exec -- flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
- mise exec -- flutter test test/src/platform_downloader_factory_io_test.dart (mobile/packages/media_cache)
- mise exec -- flutter test (mobile/packages/media_cache)
- mise exec -- flutter analyze
- mise exec -- flutter test
- pre-push hook: analyzer, generated-file verification, changed-file tests