### PR TITLE
fix(profile): backfill partial profile video loads

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -170,7 +170,9 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     );
 
     if (!isClosed && result?.isFromCache == true) {
-      await _doRefresh(emit);
+      await _doRefresh(emit, backfillInitialPage: true);
+    } else if (!isClosed && result != null) {
+      await _backfillInitialRestPage(emit);
     }
   }
 
@@ -184,7 +186,10 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     Emitter<ProfileFeedState> emit,
   ) => _doRefresh(emit);
 
-  Future<void> _doRefresh(Emitter<ProfileFeedState> emit) async {
+  Future<void> _doRefresh(
+    Emitter<ProfileFeedState> emit, {
+    bool backfillInitialPage = false,
+  }) async {
     emit(
       state.copyWith(
         isRefreshing: true,
@@ -200,6 +205,9 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       mergeWithCurrent: false,
       skipCache: true,
     );
+    if (backfillInitialPage && !isClosed) {
+      await _backfillInitialRestPage(emit);
+    }
   }
 
   Future<AuthorFeedResult?> _loadFromRest(
@@ -239,6 +247,57 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         ),
       );
       return null;
+    }
+  }
+
+  Future<void> _backfillInitialRestPage(Emitter<ProfileFeedState> emit) async {
+    var targetCount = AppConstants.paginationBatchSize;
+    final totalVideoCount = state.totalVideoCount;
+    if (totalVideoCount != null && totalVideoCount < targetCount) {
+      targetCount = totalVideoCount;
+    }
+
+    while (!isClosed &&
+        state.hasMoreContent &&
+        state.nextOffset != null &&
+        state.videos.length < targetCount) {
+      final offset = state.nextOffset;
+      if (offset == null) return;
+
+      final beforeCount = state.videos.length;
+      final AuthorFeedResult result;
+      try {
+        result = await _videosRepository.getAuthorFeed(
+          authorPubkey: _authorPubkey,
+          offset: offset,
+        );
+        if (isClosed) return;
+      } on Object catch (error, stackTrace) {
+        if (isClosed) return;
+        addError(error, stackTrace);
+        emit(state.copyWith(hasLoadMoreError: true));
+        return;
+      }
+
+      if (result.videos.isEmpty) {
+        emit(state.copyWith(hasMoreContent: false));
+        return;
+      }
+
+      final enriched = await _enrichVideos(result.videos);
+      if (isClosed) return;
+      _applyRestPage(
+        emit,
+        pageVideos: enriched,
+        totalCount: result.totalCount,
+        nextOffset: result.nextOffset,
+        hasMore: result.hasMore,
+        mergeWithCurrent: true,
+      );
+
+      if (state.videos.length <= beforeCount && state.nextOffset == offset) {
+        return;
+      }
     }
   }
 

--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -280,6 +280,17 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       }
 
       if (result.videos.isEmpty) {
+        if (_isAdvancingRestPage(result, offset)) {
+          _applyRestPage(
+            emit,
+            pageVideos: const [],
+            totalCount: result.totalCount,
+            nextOffset: result.nextOffset,
+            hasMore: result.hasMore,
+            mergeWithCurrent: true,
+          );
+          continue;
+        }
         emit(state.copyWith(hasMoreContent: false));
         return;
       }
@@ -314,12 +325,24 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
 
     try {
       if (state.nextOffset != null) {
+        final offset = state.nextOffset;
         final result = await _videosRepository.getAuthorFeed(
           authorPubkey: _authorPubkey,
-          offset: state.nextOffset,
+          offset: offset,
         );
         if (isClosed) return;
         if (result.videos.isEmpty) {
+          if (_isAdvancingRestPage(result, offset)) {
+            _applyRestPage(
+              emit,
+              pageVideos: const [],
+              totalCount: result.totalCount,
+              nextOffset: result.nextOffset,
+              hasMore: result.hasMore,
+              mergeWithCurrent: true,
+            );
+            return;
+          }
           emit(state.copyWith(hasMoreContent: false, isLoadingMore: false));
           return;
         }
@@ -371,6 +394,13 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       addError(error, stackTrace);
       emit(state.copyWith(isLoadingMore: false, hasLoadMoreError: true));
     }
+  }
+
+  bool _isAdvancingRestPage(AuthorFeedResult result, int? previousOffset) {
+    final nextOffset = result.nextOffset;
+    return result.hasMore == true &&
+        nextOffset != null &&
+        nextOffset != previousOffset;
   }
 
   void _applyRestPage(

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1983,10 +1983,16 @@ class VideosRepository {
           authorPubkey: authorPubkey,
           videos: merged,
           totalCount: response.totalCount,
-          nextOffset: response.nextOffset ?? ((offset ?? 0) + hydrated.length),
-          hasMore:
-              response.hasMore ??
-              (hydrated.length >= _authorFeedPaginationBatchSize),
+          nextOffset: _nextAuthorFeedOffset(
+            response: response,
+            offset: offset,
+            fetchedCount: hydrated.length,
+          ),
+          hasMore: _authorFeedHasMore(
+            response: response,
+            offset: offset,
+            fetchedCount: hydrated.length,
+          ),
         );
 
         if (isInitialPage) {
@@ -2004,6 +2010,35 @@ class VideosRepository {
       videos: seedOnly,
       hasMore: seedOnly.length >= _authorFeedHasMoreThreshold,
     );
+  }
+
+  int? _nextAuthorFeedOffset({
+    required VideosByAuthorResponse response,
+    required int? offset,
+    required int fetchedCount,
+  }) {
+    final currentOffset = offset ?? 0;
+    if (response.nextOffset != null) return response.nextOffset;
+    if (!_authorFeedHasMore(
+      response: response,
+      offset: offset,
+      fetchedCount: fetchedCount,
+    )) {
+      return null;
+    }
+    return currentOffset + fetchedCount;
+  }
+
+  bool _authorFeedHasMore({
+    required VideosByAuthorResponse response,
+    required int? offset,
+    required int fetchedCount,
+  }) {
+    if (response.hasMore != null) return response.hasMore!;
+    final totalCount = response.totalCount;
+    final currentOffset = offset ?? 0;
+    if (totalCount != null) return currentOffset + fetchedCount < totalCount;
+    return fetchedCount >= _authorFeedPaginationBatchSize;
   }
 
   /// Hydrates author REST videos with engagement counts: bulk-stats first

--- a/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
@@ -159,10 +159,32 @@ void main() {
 
         final result = await repository.getAuthorFeed(authorPubkey: _author);
 
-        // Envelope omitted -> nextOffset = offset(0) + restCount(1); hasMore is
-        // false because 1 < the 50-row page size.
-        expect(result.nextOffset, equals(1));
+        // Envelope omitted and the page is underfilled, so the repository
+        // treats it as the final page instead of surfacing a dangling offset.
+        expect(result.nextOffset, isNull);
         expect(result.hasMore, isFalse);
+      },
+    );
+
+    test(
+      'infers next offset from total count when legacy responses omit '
+      'pagination metadata',
+      () async {
+        stubAuthor(
+          VideosByAuthorResponse(
+            videos: [
+              _stats(id: 'a', dTag: 'a'),
+              _stats(id: 'b', dTag: 'b'),
+            ],
+            totalCount: 5,
+          ),
+        );
+
+        final result = await repository.getAuthorFeed(authorPubkey: _author);
+
+        expect(result.videos.map((video) => video.id), ['a', 'b']);
+        expect(result.nextOffset, equals(2));
+        expect(result.hasMore, isTrue);
       },
     );
 

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -246,6 +247,45 @@ void main() {
       },
     );
 
+    test(
+      'cold load: backfill skips empty advancing REST pages',
+      () async {
+        h.stubAuthorFeedSequence([
+          _result(
+            [_video('a', createdAt: 5000), _video('b', createdAt: 4000)],
+            totalCount: 4,
+            nextOffset: 2,
+            hasMore: true,
+          ),
+          _result(const [], totalCount: 4, nextOffset: 3, hasMore: true),
+          _result(
+            [_video('c', createdAt: 3000), _video('d', createdAt: 2000)],
+            totalCount: 4,
+            hasMore: false,
+          ),
+        ]);
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue(times: 8);
+
+        expect(cubit.state.videos.map((video) => video.id), [
+          'a',
+          'b',
+          'c',
+          'd',
+        ]);
+        expect(cubit.state.hasMoreContent, isFalse);
+        expect(cubit.state.nextOffset, isNull);
+        verify(
+          () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 2),
+        ).called(1);
+        verify(
+          () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 3),
+        ).called(1);
+      },
+    );
+
     test('cold load: REST failure, no relay -> failure + addError', () async {
       h.stubAuthorFeedThrows(Exception('boom'));
       final cubit = h.build();
@@ -296,6 +336,35 @@ void main() {
         expect(cubit.state.videos.map((v) => v.id), ['a', 'b']);
         expect(cubit.state.nextOffset, 100);
         expect(cubit.state.hasMoreContent, isFalse);
+        expect(cubit.state.isLoadingMore, isFalse);
+      },
+    );
+
+    test(
+      'loadMore REST: empty advancing page keeps REST pagination active',
+      () async {
+        final initialVideos = [
+          for (var i = 0; i < AppConstants.paginationBatchSize; i++)
+            _video('initial-$i', createdAt: 5000 - i),
+        ];
+        final cubit = await buildReady(
+          _result(initialVideos, nextOffset: 50, hasMore: true),
+        );
+        addTearDown(cubit.close);
+        clearInteractions(h.repo);
+
+        h.stubAuthorFeed(
+          _result(const [], nextOffset: 100, hasMore: true),
+        );
+        cubit.add(const ProfileFeedLoadMoreRequested());
+        await pumpEventQueue();
+
+        expect(cubit.state.videos.map((video) => video.id), [
+          for (var i = 0; i < AppConstants.paginationBatchSize; i++)
+            'initial-$i',
+        ]);
+        expect(cubit.state.nextOffset, 100);
+        expect(cubit.state.hasMoreContent, isTrue);
         expect(cubit.state.isLoadingMore, isFalse);
       },
     );

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -210,6 +210,42 @@ void main() {
       },
     );
 
+    test(
+      'cold load: partial first page backfills to a complete initial page',
+      () async {
+        h.stubAuthorFeedSequence([
+          _result(
+            [_video('a', createdAt: 4000), _video('b', createdAt: 3000)],
+            totalCount: 4,
+            nextOffset: 2,
+            hasMore: true,
+          ),
+          _result(
+            [_video('c', createdAt: 2000), _video('d')],
+            totalCount: 4,
+            hasMore: false,
+          ),
+        ]);
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue(times: 5);
+
+        expect(cubit.state.status, ProfileFeedStatus.ready);
+        expect(cubit.state.videos.map((video) => video.id), [
+          'a',
+          'b',
+          'c',
+          'd',
+        ]);
+        expect(cubit.state.hasMoreContent, isFalse);
+        expect(cubit.state.nextOffset, isNull);
+        verify(
+          () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 2),
+        ).called(1);
+      },
+    );
+
     test('cold load: REST failure, no relay -> failure + addError', () async {
       h.stubAuthorFeedThrows(Exception('boom'));
       final cubit = h.build();


### PR DESCRIPTION
## Summary
- backfill profile-feed cold loads when the first REST page is partial but pagination reports more content
- fix legacy author-feed pagination inference so underfilled pages do not expose dangling offsets, while totalCount still advances offsets correctly
- add regression coverage for partial first-page profile loads and legacy author-feed metadata

Fixes #4986

## Verification
- mise exec -- flutter analyze
- mise exec -- flutter test test/blocs/profile_feed/profile_feed_cubit_test.dart
- mise exec -- flutter test --coverage (from mobile/packages/videos_repository)
- mise exec -- flutter test
- pre-push hook analyzer and changed-file tests