### PR TITLE
fix(language): remove ChangeNotifier from preference service

### DIFF
--- a/mobile/lib/services/language_preference_service.dart
+++ b/mobile/lib/services/language_preference_service.dart
@@ -11,12 +11,13 @@ import 'package:unified_logger/unified_logger.dart';
 /// self-labeling (`L`/`l` tags with ISO-639-1 namespace).
 ///
 /// When no custom language is set, the device's OS language is used.
-class LanguagePreferenceService extends ChangeNotifier {
+class LanguagePreferenceService {
   /// SharedPreferences key for the content language preference
   static const String prefsKey = 'content_language';
 
   String? _customLanguage;
   Future<void>? _initializeFuture;
+  final Set<VoidCallback> _listeners = {};
 
   /// Whether the user has overridden the default device language.
   bool get isCustomLanguageSet => _customLanguage != null;
@@ -55,7 +56,7 @@ class LanguagePreferenceService extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(prefsKey, languageCode);
       _customLanguage = languageCode;
-      notifyListeners();
+      _notifyListeners();
 
       Log.debug(
         'Content language set to: $languageCode',
@@ -77,7 +78,7 @@ class LanguagePreferenceService extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(prefsKey);
       _customLanguage = null;
-      notifyListeners();
+      _notifyListeners();
 
       Log.debug(
         'Content language cleared, using device default',
@@ -123,5 +124,39 @@ class LanguagePreferenceService extends ChangeNotifier {
   /// if not found in the supported languages map.
   static String displayNameFor(String languageCode) {
     return supportedLanguages[languageCode] ?? languageCode.toUpperCase();
+  }
+
+  /// Register a listener for content-language preference changes.
+  void addListener(VoidCallback listener) {
+    _listeners.add(listener);
+  }
+
+  /// Remove a listener previously registered with [addListener].
+  void removeListener(VoidCallback listener) {
+    _listeners.remove(listener);
+  }
+
+  /// Release registered listeners when the provider is disposed.
+  void dispose() {
+    _listeners.clear();
+  }
+
+  void _notifyListeners() {
+    for (final listener in List<VoidCallback>.of(_listeners)) {
+      try {
+        listener();
+      } catch (error, stackTrace) {
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: error,
+            stack: stackTrace,
+            library: 'language preference service',
+            context: ErrorDescription(
+              'while dispatching content-language preference notifications',
+            ),
+          ),
+        );
+      }
+    }
   }
 }

--- a/mobile/test/services/language_preference_service_test.dart
+++ b/mobile/test/services/language_preference_service_test.dart
@@ -2,8 +2,7 @@
 // ABOUTME: Verifies language preference storage, device default fallback, and
 // custom language override behavior
 
-import 'dart:ui';
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -84,6 +83,42 @@ void main() {
 
         expect(notifications, equals(1));
       });
+
+      test('does not notify removed listeners', () async {
+        await service.initialize();
+        var notifications = 0;
+        void listener() {
+          notifications++;
+        }
+
+        service.addListener(listener);
+        service.removeListener(listener);
+
+        await service.setContentLanguage('pt');
+
+        expect(notifications, isZero);
+      });
+
+      test('continues notifying listeners after one throws', () async {
+        await service.initialize();
+        final reportedErrors = <FlutterErrorDetails>[];
+        final originalOnError = FlutterError.onError;
+        FlutterError.onError = reportedErrors.add;
+        addTearDown(() => FlutterError.onError = originalOnError);
+
+        var notifications = 0;
+        service
+          ..addListener(() => throw StateError('listener failed'))
+          ..addListener(() {
+            notifications++;
+          });
+
+        await service.setContentLanguage('pt');
+
+        expect(notifications, equals(1));
+        expect(reportedErrors, hasLength(1));
+        expect(reportedErrors.single.exception, isA<StateError>());
+      });
     });
 
     group('clearContentLanguage', () {
@@ -121,6 +156,19 @@ void main() {
         await service.clearContentLanguage();
 
         expect(notifications, equals(1));
+      });
+
+      test('does not notify listeners after dispose', () async {
+        await service.initialize();
+        var notifications = 0;
+        service.addListener(() {
+          notifications++;
+        });
+
+        service.dispose();
+        await service.clearContentLanguage();
+
+        expect(notifications, isZero);
       });
     });
 


### PR DESCRIPTION
## Summary
- remove ChangeNotifier inheritance from LanguagePreferenceService
- keep explicit listener callbacks for feed preference invalidation
- preserve ChangeNotifier-style error isolation while dispatching listeners
- add listener removal, disposal, and throwing-listener coverage

Fixes #4996
Refs #4744

## Root cause
The ChangeNotifier boundary ratchet began scanning mobile/lib and LanguagePreferenceService was an existing ChangeNotifier outside the sanctioned allowlist. Rather than add another sanctioned exception, this removes the unnecessary ChangeNotifier dependency while preserving the service's listener behavior.

## Validation
- bash scripts/check_changenotifier_boundary.sh
- bash scripts/check_native_transport_security.sh
- bash scripts/check_raw_logging.sh
- bash scripts/check_riverpod_boundary.sh
- bash scripts/check_ui_service_boundary.sh
- bash scripts/check_skip_ceiling.sh
- bash scripts/check_future_delayed_ceiling.sh
- bash scripts/check_untested_services_floor.sh
- dart format --output=none --set-exit-if-changed lib test integration_test
- flutter analyze lib test integration_test
- flutter test test/services/language_preference_service_test.dart test/providers/feed_viewer_preference_hints_test.dart test/blocs/language_setting/language_setting_cubit_test.dart
- dart run build_runner build --delete-conflicting-outputs
- flutter gen-l10n