### PR TITLE
fix(playback): handle HTTP 202 as transient and abort stale source fallbacks

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -86,6 +86,10 @@ VideoErrorType classifyVideoError({
 }
 
 bool _mentionsHttpStatus(String lower, int status) {
-  if (!lower.contains('http') && !lower.contains('status')) return false;
+  if (!lower.contains('http') &&
+      !lower.contains('status') &&
+      !lower.contains('response code')) {
+    return false;
+  }
   return RegExp('(^|[^0-9])$status([^0-9]|\$)').hasMatch(lower);
 }

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -59,6 +59,12 @@ VideoErrorType classifyVideoError({
   String? source,
 }) {
   final lower = (errorMessage ?? '').toLowerCase();
+  // Divine derivative URLs can legitimately return HTTP 202 while MP4/HLS
+  // processing catches up after upload. Treat that as transient playback
+  // failure, not as proof that the blob is missing.
+  if (_mentionsHttpStatus(lower, 202)) {
+    return VideoErrorType.generic;
+  }
   if (lower.contains('401') || lower.contains('unauthorized')) {
     return VideoErrorType.ageRestricted;
   }
@@ -77,4 +83,9 @@ VideoErrorType classifyVideoError({
   }
 
   return VideoErrorType.generic;
+}
+
+bool _mentionsHttpStatus(String lower, int status) {
+  if (!lower.contains('http') && !lower.contains('status')) return false;
+  return RegExp('(^|[^0-9])$status([^0-9]|\$)').hasMatch(lower);
 }

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -1,5 +1,25 @@
 import 'package:divine_video_player/divine_video_player.dart';
 
+/// Signals that source loading was cancelled because the owning controller
+/// window moved on while fallbacks were still in flight.
+class SourceLoadAborted implements Exception {
+  /// Creates an abort signal for the stale source load at [index].
+  const SourceLoadAborted({
+    required this.index,
+    required this.source,
+  });
+
+  /// Feed index whose source load was aborted.
+  final int index;
+
+  /// Source URL being attempted when the load became stale.
+  final String source;
+
+  @override
+  String toString() =>
+      'Source load aborted for stale controller index $index source=$source';
+}
+
 /// Sequentially attempts each URL in [sources] until one loads successfully.
 ///
 /// Returns a record of `(source, attemptIndex)` for the URL that opened.
@@ -11,12 +31,20 @@ Future<(String, int)> setSourceWithFallbacks({
   required List<String> sources,
   required void Function(String) log,
   Map<String, String>? Function(String source)? httpHeadersForSource,
+  bool Function()? isLoadCurrent,
 }) async {
   Object? lastError;
   StackTrace? lastStackTrace;
 
+  void abortIfStale(String source) {
+    if (isLoadCurrent != null && !isLoadCurrent()) {
+      throw SourceLoadAborted(index: index, source: source);
+    }
+  }
+
   for (var attemptIndex = 0; attemptIndex < sources.length; attemptIndex++) {
     final source = sources[attemptIndex];
+    abortIfStale(source);
     try {
       await controller.setSource(
         VideoClip.network(
@@ -24,8 +52,12 @@ Future<(String, int)> setSourceWithFallbacks({
           httpHeaders: httpHeadersForSource?.call(source) ?? const {},
         ),
       );
+      abortIfStale(source);
       return (source, attemptIndex);
+    } on SourceLoadAborted {
+      rethrow;
     } on Object catch (error, stackTrace) {
+      abortIfStale(source);
       lastError = error;
       lastStackTrace = stackTrace;
       final nextAttempt = attemptIndex + 1;

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -804,6 +804,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             sources: playbackSources,
             log: _log,
             httpHeadersForSource: httpHeadersForSource,
+            isLoadCurrent: ownsInit,
           );
           if (!guardInitOwnership('setSourceWithFallbacks(cache)')) return;
           _sources.register(index, playbackSources, openedSourceIdx);
@@ -823,6 +824,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           sources: playbackSources,
           log: _log,
           httpHeadersForSource: httpHeadersForSource,
+          isLoadCurrent: ownsInit,
         );
         if (!guardInitOwnership('setSourceWithFallbacks(network)')) return;
         _sources.register(index, playbackSources, openedSourceIdx);

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -184,6 +184,26 @@ void main() {
       );
     });
 
+    test('returns generic for Android response-code 202 messages', () {
+      expect(
+        classifyVideoError(
+          errorMessage: 'Response code: 202',
+          source: 'https://media.divine.video/$_hash/720p.mp4',
+        ),
+        equals(VideoErrorType.generic),
+      );
+    });
+
+    test('does not classify unrelated numbers as HTTP 202', () {
+      expect(
+        classifyVideoError(
+          errorMessage: 'Response completed in 2025 ms',
+          source: 'https://media.divine.video/$_hash/720p.mp4',
+        ),
+        equals(VideoErrorType.notFound),
+      );
+    });
+
     test('returns notFound when source is a Divine blob URL', () {
       expect(
         classifyVideoError(source: _rawUrl),

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -174,6 +174,16 @@ void main() {
       );
     });
 
+    test('returns generic for HTTP 202 while Divine derivatives process', () {
+      expect(
+        classifyVideoError(
+          errorMessage: 'CoreMediaErrorDomain error -12667 - HTTP 202',
+          source: 'https://media.divine.video/$_hash/720p.mp4',
+        ),
+        equals(VideoErrorType.generic),
+      );
+    });
+
     test('returns notFound when source is a Divine blob URL', () {
       expect(
         classifyVideoError(source: _rawUrl),

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -1,4 +1,5 @@
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/src/utils/source_loader.dart';
 
@@ -112,6 +113,68 @@ void main() {
       expect(clips[1].httpHeaders, equals(headers));
     });
 
+    test(
+      'aborts stale fallback without logging all sources failed',
+      () async {
+        var isCurrent = true;
+        final controller = _DisposedDuringFallbackController(
+          onDisposedFallback: () => isCurrent = false,
+        );
+        addTearDown(controller.dispose);
+
+        await expectLater(
+          () => setSourceWithFallbacks(
+            index: 0,
+            controller: controller,
+            sources: ['derivedMp4', 'hls', 'raw'],
+            log: logs.add,
+            isLoadCurrent: () => isCurrent,
+          ),
+          throwsA(isA<SourceLoadAborted>()),
+        );
+
+        expect(controller.attempts, equals(2));
+        expect(logs, hasLength(1));
+        expect(logs.single, contains('failedSource=derivedMp4'));
+        expect(logs.single, contains('retrySource=hls'));
+        expect(
+          logs.any((line) => line.contains('All sources failed')),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'aborts when the controller goes stale after a source opens',
+      () async {
+        var isCurrent = true;
+        final controller = _StaleAfterSuccessController(
+          onOpened: () => isCurrent = false,
+        );
+        addTearDown(controller.dispose);
+
+        await expectLater(
+          () => setSourceWithFallbacks(
+            index: 3,
+            controller: controller,
+            sources: ['derivedMp4', 'hls', 'raw'],
+            log: logs.add,
+            isLoadCurrent: () => isCurrent,
+          ),
+          throwsA(
+            isA<SourceLoadAborted>()
+                .having((e) => e.index, 'index', 3)
+                .having((e) => e.source, 'source', 'derivedMp4'),
+          ),
+        );
+
+        // Only the first source is attempted; the post-open staleness check
+        // aborts before returning a record or trying any fallback.
+        expect(controller.attempts, equals(1));
+        expect(logs, isEmpty);
+      },
+    );
+
     test('rethrows when all sources fail', () async {
       final controller = FakeController()
         ..setSourceError = Exception('always fails');
@@ -190,5 +253,39 @@ class _RecordingControllerWithOneFailure extends FakeController {
       _failed = true;
       throw Exception('first source error');
     }
+  }
+}
+
+class _DisposedDuringFallbackController extends FakeController {
+  _DisposedDuringFallbackController({required this.onDisposedFallback});
+
+  final VoidCallback onDisposedFallback;
+  int attempts = 0;
+
+  @override
+  Future<void> setSource(VideoClip clip) async {
+    attempts++;
+    if (attempts == 1) {
+      throw Exception('HTTP 202 Accepted');
+    }
+
+    onDisposedFallback();
+    throw StateError('Controller has been disposed.');
+  }
+}
+
+/// A [FakeController] whose first [setSource] succeeds but marks the load
+/// stale (e.g. the feed window scrolled past) before the caller can register
+/// the opened source.
+class _StaleAfterSuccessController extends FakeController {
+  _StaleAfterSuccessController({required this.onOpened});
+
+  final VoidCallback onOpened;
+  int attempts = 0;
+
+  @override
+  Future<void> setSource(VideoClip clip) async {
+    attempts++;
+    onOpened();
   }
 }

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -164,7 +164,15 @@ void main() {
           throwsA(
             isA<SourceLoadAborted>()
                 .having((e) => e.index, 'index', 3)
-                .having((e) => e.source, 'source', 'derivedMp4'),
+                .having((e) => e.source, 'source', 'derivedMp4')
+                .having(
+                  (e) => e.toString(),
+                  'message',
+                  contains(
+                    'Source load aborted for stale controller index 3 '
+                    'source=derivedMp4',
+                  ),
+                ),
           ),
         );
 


### PR DESCRIPTION
## Description

Fixes the race reported in #4999: freshly uploaded videos triggered a terminal "all sources failed" error in the feed while server-side derivatives (MP4 / HLS) were still being generated.

**Two root causes, two fixes:**

### 1. HTTP 202 misclassified as `notFound` (`playback_sources.dart`)

When ExoPlayer / AVPlayer received an HTTP 202 "Accepted" response from a still-transcoding derivative URL, `classifyVideoError` fell through to the Divine-blob heuristic and returned `VideoErrorType.notFound`. A 202 is by definition transient — the derivative will exist once processing completes. It is now classified as `VideoErrorType.generic` (retryable), keeping the error overlay dismissible while the server catches up.

The detection helper `_mentionsHttpStatus` requires an explicit `http`/`status` keyword in the message **and** uses digit-boundary anchors `(^|[^0-9])202([^0-9]|$)` so that unrelated numbers (timestamps, years) are never misidentified.

### 2. Controller disposal during fallback silently logged as "all sources failed" (`source_loader.dart` + `infinite_video_feed.dart`)

`setSourceWithFallbacks` iterated the fallback list even after the owning controller was disposed (e.g. because the feed window scrolled past during the `await`). The `StateError('Controller has been disposed.')` then propagated as a genuine failure, triggering `_errors.add(index)` and the error overlay for the wrong reason.

**Fix:** a new optional `bool Function()? isLoadCurrent` parameter is checked at three points per loop iteration:

| Check point | Purpose |
|---|---|
| Before `setSource` (loop start) | Skip the attempt entirely if already stale |
| After successful `setSource` returns | Abort before returning a record if the window moved on while awaiting |
| In the `catch` block, before logging | Prevent "All sources failed" log for a stale controller |

When stale, a `SourceLoadAborted` (a typed `Exception` subclass) is thrown and re-thrown through the catch handler. At the call-site in `infinite_video_feed.dart`, the existing `!ownsInit()` check in the outer error handler returns early — no error is added, no error overlay appears.

**Related Issue:** Closes #4999

## Out of Scope

- Automatic 202 retry / defer with back-off. The current fix ensures a freshly uploaded video plays from the raw blob (available immediately after upload, before any derivative is generated) and makes the error overlay retryable when all sources including raw fail. An explicit retry timer is a separate design decision.

## Verification

```
flutter test \
  packages/infinite_video_feed/test/src/utils/source_loader_test.dart \
  packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
# → All 30 tests passed
flutter analyze packages/infinite_video_feed/lib/src/utils/ \
               packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
# → No issues found
```

Manual on-device: publish a video → immediately navigate to profile feed → verify it plays from the raw blob without showing an error overlay while the 720p derivative is still processing.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)