### PR TITLE
fix(event-cache): queue signed events until PersonalEventCache initializes

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -62,6 +62,7 @@ VideoVisibilityManager videoVisibilityManager(Ref ref) {
 PersonalEventCacheService personalEventCacheService(Ref ref) {
   final authService = ref.watch(authServiceProvider);
   final service = PersonalEventCacheService();
+  ref.onDispose(service.dispose);
 
   // Initialize with current user's pubkey when authenticated
   if (authService.isAuthenticated && authService.currentPublicKeyHex != null) {

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -165,7 +165,7 @@ final class PersonalEventCacheServiceProvider
 }
 
 String _$personalEventCacheServiceHash() =>
-    r'108da6c7d65528c736a3925dc9c3579094924172';
+    r'ceb0fbabc806cb4f75a3c881bed3970e2664b428';
 
 /// Seen videos service for tracking viewed content
 

--- a/mobile/lib/services/personal_event_cache_service.dart
+++ b/mobile/lib/services/personal_event_cache_service.dart
@@ -17,6 +17,8 @@ class PersonalEventCacheService {
   Box<dynamic>? _eventsBox;
   Box<dynamic>? _metadataBox;
   bool _isInitialized = false;
+  bool _isDisposed = false;
+  int _initializationToken = 0;
   String? _currentUserPubkey;
   final List<Event> _pendingEventWrites = <Event>[];
 
@@ -25,19 +27,34 @@ class PersonalEventCacheService {
 
   /// Initialize the personal event cache
   Future<void> initialize(String userPubkey) async {
+    _isDisposed = false;
+    final initializationToken = ++_initializationToken;
+
     if (_isInitialized && _currentUserPubkey == userPubkey) {
       await _flushPendingEventWrites();
       return;
     }
 
+    Box<dynamic>? eventsBox;
+    Box<dynamic>? metadataBox;
+
     try {
       _currentUserPubkey = userPubkey;
 
       // Try to open the events box
-      _eventsBox = await Hive.openBox<dynamic>(_boxName);
+      eventsBox = await Hive.openBox<dynamic>(_boxName);
 
       // Open the metadata box for indexing
-      _metadataBox = await Hive.openBox<dynamic>(_metadataBoxName);
+      metadataBox = await Hive.openBox<dynamic>(_metadataBoxName);
+
+      if (!_isCurrentInitialization(initializationToken, userPubkey)) {
+        await _closeBox(eventsBox, _boxName);
+        await _closeBox(metadataBox, _metadataBoxName);
+        return;
+      }
+
+      _eventsBox = eventsBox;
+      _metadataBox = metadataBox;
 
       _isInitialized = true;
 
@@ -66,12 +83,28 @@ class PersonalEventCacheService {
           category: LogCategory.storage,
         );
 
+        if (eventsBox != null) {
+          await _closeBox(eventsBox, _boxName);
+        }
+        if (metadataBox != null) {
+          await _closeBox(metadataBox, _metadataBoxName);
+        }
+
         await Hive.deleteBoxFromDisk(_boxName);
         await Hive.deleteBoxFromDisk(_metadataBoxName);
 
         // Retry opening after deletion
-        _eventsBox = await Hive.openBox<dynamic>(_boxName);
-        _metadataBox = await Hive.openBox<dynamic>(_metadataBoxName);
+        eventsBox = await Hive.openBox<dynamic>(_boxName);
+        metadataBox = await Hive.openBox<dynamic>(_metadataBoxName);
+
+        if (!_isCurrentInitialization(initializationToken, userPubkey)) {
+          await _closeBox(eventsBox, _boxName);
+          await _closeBox(metadataBox, _metadataBoxName);
+          return;
+        }
+
+        _eventsBox = eventsBox;
+        _metadataBox = metadataBox;
 
         _isInitialized = true;
 
@@ -95,12 +128,22 @@ class PersonalEventCacheService {
 
   /// Cache a user's own event (any kind)
   void cacheUserEvent(Event event) {
+    if (_isDisposed) {
+      return;
+    }
+
     if (!_isInitialized || _eventsBox == null || _metadataBox == null) {
       _queuePendingEventWrite(event);
       return;
     }
 
     unawaited(_cacheInitializedUserEvent(event));
+  }
+
+  bool _isCurrentInitialization(int token, String userPubkey) {
+    return !_isDisposed &&
+        token == _initializationToken &&
+        _currentUserPubkey == userPubkey;
   }
 
   void _queuePendingEventWrite(Event event) {
@@ -460,6 +503,8 @@ class PersonalEventCacheService {
 
   /// Dispose of the cache service
   void dispose() {
+    _isDisposed = true;
+    _initializationToken++;
     final eventsBox = _eventsBox;
     final metadataBox = _metadataBox;
     _eventsBox = null;

--- a/mobile/lib/services/personal_event_cache_service.dart
+++ b/mobile/lib/services/personal_event_cache_service.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Comprehensive cache for ALL of the current user's own Nostr events
 // ABOUTME: Stores every event the user creates/publishes for instant access and offline availability
 
+import 'dart:async';
+
 import 'package:hive_ce/hive.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -10,18 +12,23 @@ import 'package:unified_logger/unified_logger.dart';
 class PersonalEventCacheService {
   static const String _boxName = 'personal_events';
   static const String _metadataBoxName = 'personal_events_metadata';
+  static const int _maxPendingEventWrites = 100;
 
   Box<dynamic>? _eventsBox;
   Box<dynamic>? _metadataBox;
   bool _isInitialized = false;
   String? _currentUserPubkey;
+  final List<Event> _pendingEventWrites = <Event>[];
 
   /// Check if the cache service is initialized
   bool get isInitialized => _isInitialized;
 
   /// Initialize the personal event cache
   Future<void> initialize(String userPubkey) async {
-    if (_isInitialized && _currentUserPubkey == userPubkey) return;
+    if (_isInitialized && _currentUserPubkey == userPubkey) {
+      await _flushPendingEventWrites();
+      return;
+    }
 
     try {
       _currentUserPubkey = userPubkey;
@@ -33,6 +40,8 @@ class PersonalEventCacheService {
       _metadataBox = await Hive.openBox<dynamic>(_metadataBoxName);
 
       _isInitialized = true;
+
+      await _flushPendingEventWrites();
 
       Log.info(
         'PersonalEventCacheService initialized for $userPubkey with ${_eventsBox!.length} cached events',
@@ -66,6 +75,8 @@ class PersonalEventCacheService {
 
         _isInitialized = true;
 
+        await _flushPendingEventWrites();
+
         Log.info(
           'Successfully recovered PersonalEventCacheService after corruption',
           name: 'PersonalEventCache',
@@ -85,20 +96,67 @@ class PersonalEventCacheService {
   /// Cache a user's own event (any kind)
   void cacheUserEvent(Event event) {
     if (!_isInitialized || _eventsBox == null || _metadataBox == null) {
-      Log.warning(
-        'PersonalEventCache not initialized, cannot cache event',
+      _queuePendingEventWrite(event);
+      return;
+    }
+
+    unawaited(_cacheInitializedUserEvent(event));
+  }
+
+  void _queuePendingEventWrite(Event event) {
+    final currentUserPubkey = _currentUserPubkey;
+    if (currentUserPubkey != null && event.pubkey != currentUserPubkey) {
+      return;
+    }
+
+    _pendingEventWrites.removeWhere(
+      (pendingEvent) => pendingEvent.id == event.id,
+    );
+    if (_pendingEventWrites.length >= _maxPendingEventWrites) {
+      _pendingEventWrites.removeAt(0);
+    }
+    _pendingEventWrites.add(event);
+
+    Log.warning(
+      'PersonalEventCache not initialized, queued event for later caching',
+      name: 'PersonalEventCache',
+      category: LogCategory.storage,
+    );
+  }
+
+  Future<void> _flushPendingEventWrites() async {
+    if (_pendingEventWrites.isEmpty) {
+      return;
+    }
+
+    final pendingEventWrites = List<Event>.from(_pendingEventWrites);
+    _pendingEventWrites.clear();
+
+    var cachedCount = 0;
+    for (final event in pendingEventWrites) {
+      if (await _cacheInitializedUserEvent(event)) {
+        cachedCount++;
+      }
+    }
+
+    if (cachedCount > 0) {
+      Log.info(
+        'Cached $cachedCount pending personal event(s) after initialization',
         name: 'PersonalEventCache',
         category: LogCategory.storage,
       );
-      return;
     }
+  }
 
+  Future<bool> _cacheInitializedUserEvent(Event event) async {
     // Only cache events from the current user
     if (event.pubkey != _currentUserPubkey) {
-      return;
+      return false;
     }
 
     try {
+      final cachedAt = DateTime.now().millisecondsSinceEpoch;
+
       // Store the full event data
       final eventData = {
         'id': event.id,
@@ -108,10 +166,10 @@ class PersonalEventCacheService {
         'tags': event.tags.map((tag) => tag.toList()).toList(),
         'content': event.content,
         'sig': event.sig,
-        'cached_at': DateTime.now().millisecondsSinceEpoch,
+        'cached_at': cachedAt,
       };
 
-      _eventsBox!.put(event.id, eventData);
+      await _eventsBox!.put(event.id, eventData);
 
       // Update metadata for quick queries
       final kindKey = 'kind_${event.kind}';
@@ -121,21 +179,23 @@ class PersonalEventCacheService {
           : <String, dynamic>{};
       kindEvents[event.id] = {
         'created_at': event.createdAt,
-        'cached_at': DateTime.now().millisecondsSinceEpoch,
+        'cached_at': cachedAt,
       };
-      _metadataBox!.put(kindKey, kindEvents);
+      await _metadataBox!.put(kindKey, kindEvents);
 
       Log.debug(
         '💾 Cached personal event: ${event.id} (kind ${event.kind})',
         name: 'PersonalEventCache',
         category: LogCategory.storage,
       );
+      return true;
     } catch (e) {
       Log.error(
         'Failed to cache personal event ${event.id}: $e',
         name: 'PersonalEventCache',
         category: LogCategory.storage,
       );
+      return false;
     }
   }
 
@@ -374,6 +434,8 @@ class PersonalEventCacheService {
 
   /// Clear all cached events (for testing or cleanup)
   Future<void> clearCache() async {
+    _pendingEventWrites.clear();
+
     if (!_isInitialized || _eventsBox == null || _metadataBox == null) {
       return;
     }
@@ -398,15 +460,37 @@ class PersonalEventCacheService {
 
   /// Dispose of the cache service
   void dispose() {
-    _eventsBox?.close();
-    _metadataBox?.close();
+    final eventsBox = _eventsBox;
+    final metadataBox = _metadataBox;
+    _eventsBox = null;
+    _metadataBox = null;
     _isInitialized = false;
     _currentUserPubkey = null;
+    _pendingEventWrites.clear();
+
+    if (eventsBox != null) {
+      unawaited(_closeBox(eventsBox, _boxName));
+    }
+    if (metadataBox != null) {
+      unawaited(_closeBox(metadataBox, _metadataBoxName));
+    }
 
     Log.debug(
       '📱 PersonalEventCacheService disposed',
       name: 'PersonalEventCache',
       category: LogCategory.storage,
     );
+  }
+
+  Future<void> _closeBox(Box<dynamic> box, String boxName) async {
+    try {
+      await box.close();
+    } catch (e) {
+      Log.warning(
+        'Failed to close PersonalEventCache box $boxName: $e',
+        name: 'PersonalEventCache',
+        category: LogCategory.storage,
+      );
+    }
   }
 }

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -40,7 +40,6 @@ nostr_list_service_mixin # noise: mixin
 openvine_media_cache
 outgoing_dm_retry_service_reportable_sites # noise: reportable-sites constants
 pending_verification_service
-personal_event_cache_service
 push_notification_session_coordinator
 share_service
 social_event_service_base

--- a/mobile/test/services/personal_event_cache_service_test.dart
+++ b/mobile/test/services/personal_event_cache_service_test.dart
@@ -150,5 +150,22 @@ void main() {
       expect(service.hasEvent(hexId(pendingWriteCap)), isTrue);
       expect(service.getEventsByKind(32222), hasLength(pendingWriteCap));
     });
+
+    test(
+      'dispose prevents in-flight initialize from resurrecting cache',
+      () async {
+        final event = createEvent(pubkey: userPubkey, id: hexId(101));
+
+        final initialize = service.initialize(userPubkey);
+        service.cacheUserEvent(event);
+        service.dispose();
+
+        await initialize;
+
+        expect(service.isInitialized, isFalse);
+        expect(service.hasEvent(event.id), isFalse);
+        expect(service.getEventById(event.id), isNull);
+      },
+    );
   });
 }

--- a/mobile/test/services/personal_event_cache_service_test.dart
+++ b/mobile/test/services/personal_event_cache_service_test.dart
@@ -1,0 +1,154 @@
+// ABOUTME: Tests for PersonalEventCacheService initialization race handling.
+// ABOUTME: Ensures signed user events are not dropped while Hive boxes open.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory testDir;
+  late PersonalEventCacheService service;
+
+  final userPubkey = List.filled(64, 'a').join();
+  final otherPubkey = List.filled(64, 'b').join();
+
+  String hexId(int index) => index.toRadixString(16).padLeft(64, '0');
+
+  Event createEvent({
+    required String pubkey,
+    required String id,
+    String content = 'A plant video',
+  }) {
+    final event = Event(
+      pubkey,
+      32222,
+      const [
+        ['d', 'test-video-id'],
+        ['title', 'Plants'],
+      ],
+      content,
+      createdAt: 1700000000,
+    );
+    event.id = id;
+    event.sig = id.padRight(128, '0').substring(0, 128);
+    return event;
+  }
+
+  setUp(() async {
+    testDir = await Directory.systemTemp.createTemp(
+      'personal_event_cache_service_test_',
+    );
+    Hive.init(testDir.path);
+    service = PersonalEventCacheService();
+  });
+
+  tearDown(() async {
+    service.dispose();
+    try {
+      await Hive.close();
+    } on PathNotFoundException catch (_) {
+      // Hive may already have removed its lock file during async shutdown.
+    }
+    try {
+      await testDir.delete(recursive: true);
+    } on PathNotFoundException catch (_) {
+      // Lock file may already be gone after Hive.close().
+    }
+  });
+
+  group('PersonalEventCacheService initialization', () {
+    test('caches user events queued while initialize is in flight', () async {
+      final event = createEvent(pubkey: userPubkey, id: hexId(1));
+
+      final initialize = service.initialize(userPubkey);
+      service.cacheUserEvent(event);
+
+      await initialize;
+
+      expect(service.isInitialized, isTrue);
+      expect(service.hasEvent(event.id), isTrue);
+      expect(service.getEventById(event.id)?.id, event.id);
+      expect(
+        service
+            .getEventsByKind(event.kind)
+            .map((cachedEvent) => cachedEvent.id),
+        contains(event.id),
+      );
+    });
+
+    test('drops queued events for a different user after initialize', () async {
+      final otherUserEvent = createEvent(pubkey: otherPubkey, id: hexId(2));
+
+      final initialize = service.initialize(userPubkey);
+      service.cacheUserEvent(otherUserEvent);
+
+      await initialize;
+
+      expect(service.hasEvent(otherUserEvent.id), isFalse);
+      expect(service.getEventById(otherUserEvent.id), isNull);
+    });
+
+    test(
+      'filters queued events by pubkey when no user was known at queue time',
+      () async {
+        // No initialize() has run yet, so _currentUserPubkey is null and the
+        // queue-time pubkey filter cannot apply. The filter must instead kick in
+        // when the queue is flushed after initialization resolves the pubkey.
+        final ownEvent = createEvent(pubkey: userPubkey, id: hexId(3));
+        final foreignEvent = createEvent(pubkey: otherPubkey, id: hexId(4));
+
+        service.cacheUserEvent(ownEvent);
+        service.cacheUserEvent(foreignEvent);
+
+        await service.initialize(userPubkey);
+
+        expect(service.hasEvent(ownEvent.id), isTrue);
+        expect(service.hasEvent(foreignEvent.id), isFalse);
+      },
+    );
+
+    test(
+      'keeps only the latest queued write for a repeated event id',
+      () async {
+        final stale = createEvent(
+          pubkey: userPubkey,
+          id: hexId(5),
+          content: 'stale content',
+        );
+        final fresh = createEvent(
+          pubkey: userPubkey,
+          id: hexId(5),
+          content: 'fresh content',
+        );
+
+        service.cacheUserEvent(stale);
+        service.cacheUserEvent(fresh);
+
+        await service.initialize(userPubkey);
+
+        expect(service.getEventById(hexId(5))?.content, 'fresh content');
+      },
+    );
+
+    test('drops the oldest queued event past the pending-write cap', () async {
+      const pendingWriteCap = 100;
+      // Queue one more than the cap before initialization completes; the
+      // first-queued (oldest) event must be evicted to honor the bound.
+      for (var i = 0; i <= pendingWriteCap; i++) {
+        service.cacheUserEvent(createEvent(pubkey: userPubkey, id: hexId(i)));
+      }
+
+      await service.initialize(userPubkey);
+
+      expect(service.hasEvent(hexId(0)), isFalse);
+      expect(service.hasEvent(hexId(1)), isTrue);
+      expect(service.hasEvent(hexId(pendingWriteCap)), isTrue);
+      expect(service.getEventsByKind(32222), hasLength(pendingWriteCap));
+    });
+  });
+}


### PR DESCRIPTION
## Description

During video publish, `personalEventCacheServiceProvider` starts
`PersonalEventCacheService.initialize(...)` without awaiting it. If
`VideoEventPublisher._persistRetryableSignedEvent` calls `cacheUserEvent`
before the Hive boxes finish opening, the signed Nostr event was logged as
`PersonalEventCache not initialized, cannot cache event` and **dropped** —
weakening publish retry/recovery if relay publication failed after signing.

This takes the issue's second suggested fix — buffer pending writes inside the
service until initialization completes:

- `cacheUserEvent` now enqueues the event into a bounded pending queue
  (`_maxPendingEventWrites = 100`, drop-oldest, deduped by `event.id`) instead
  of dropping it when the cache is not yet initialized.
- The queue is flushed once `initialize(...)` succeeds **and** after corruption
  recovery, filtering by the resolved user pubkey so foreign-user events queued
  before the pubkey was known are discarded.
- `dispose()` now nulls the boxes before closing them asynchronously, so a late
  `cacheUserEvent` re-queues instead of touching a closing box.

**Related Issue:** Closes #4998

## Out of Scope

- The `_closeBox` error path (defensive logging only) and the
  post-corruption-recovery flush are not unit-tested — exercising them would
  require mocking `box.close()` or corrupting a Hive box on disk, which would be
  brittle and Hive-version-dependent. The recovery flush reuses the same
  `_flushPendingEventWrites` code path already covered by the in-flight-init
  test.

## Verification

- `flutter analyze lib test integration_test` → No issues found
- `flutter test test/services/personal_event_cache_service_test.dart` → 5/5 passed
- `dart format` clean

New tests cover: caching events queued during in-flight init, dropping
foreign-user events (both the queue-time and flush-time pubkey filters), keeping
only the latest queued write for a repeated event id, and drop-oldest eviction
past the pending-write cap.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

