### PR TITLE
fix(upload): preserve uploaded thumbnail URL on success (#4997)

### DIFF
--- a/mobile/lib/models/pending_upload.dart
+++ b/mobile/lib/models/pending_upload.dart
@@ -222,10 +222,10 @@ class PendingUpload {
     DateTime? createdAt,
     String? cloudinaryPublicId,
     String? videoId,
-    String? cdnUrl,
+    Object? cdnUrl = _pendingUploadUnset,
     String? errorMessage,
     double? uploadProgress,
-    String? thumbnailPath,
+    Object? thumbnailPath = _pendingUploadUnset,
     String? title,
     String? description,
     List<String>? hashtags,
@@ -237,9 +237,9 @@ class PendingUpload {
     Duration? videoDuration,
     Duration? thumbnailTimestamp,
     String? proofManifestJson,
-    String? streamingMp4Url,
-    String? streamingHlsUrl,
-    String? fallbackUrl,
+    Object? streamingMp4Url = _pendingUploadUnset,
+    Object? streamingHlsUrl = _pendingUploadUnset,
+    Object? fallbackUrl = _pendingUploadUnset,
     Object? resumableSession = _pendingUploadUnset,
   }) => PendingUpload(
     id: id ?? this.id,
@@ -249,10 +249,14 @@ class PendingUpload {
     createdAt: createdAt ?? this.createdAt,
     cloudinaryPublicId: cloudinaryPublicId ?? this.cloudinaryPublicId,
     videoId: videoId ?? this.videoId,
-    cdnUrl: cdnUrl ?? this.cdnUrl,
+    cdnUrl: identical(cdnUrl, _pendingUploadUnset)
+        ? this.cdnUrl
+        : cdnUrl as String?,
     errorMessage: errorMessage ?? this.errorMessage,
     uploadProgress: uploadProgress ?? this.uploadProgress,
-    thumbnailPath: thumbnailPath ?? this.thumbnailPath,
+    thumbnailPath: identical(thumbnailPath, _pendingUploadUnset)
+        ? this.thumbnailPath
+        : thumbnailPath as String?,
     title: title ?? this.title,
     description: description ?? this.description,
     hashtags: hashtags ?? this.hashtags,
@@ -265,9 +269,15 @@ class PendingUpload {
     thumbnailTimestampMillis:
         (thumbnailTimestamp ?? this.thumbnailTimestamp)?.inMilliseconds,
     proofManifestJson: proofManifestJson ?? this.proofManifestJson,
-    streamingMp4Url: streamingMp4Url ?? this.streamingMp4Url,
-    streamingHlsUrl: streamingHlsUrl ?? this.streamingHlsUrl,
-    fallbackUrl: fallbackUrl ?? this.fallbackUrl,
+    streamingMp4Url: identical(streamingMp4Url, _pendingUploadUnset)
+        ? this.streamingMp4Url
+        : streamingMp4Url as String?,
+    streamingHlsUrl: identical(streamingHlsUrl, _pendingUploadUnset)
+        ? this.streamingHlsUrl
+        : streamingHlsUrl as String?,
+    fallbackUrl: identical(fallbackUrl, _pendingUploadUnset)
+        ? this.fallbackUrl
+        : fallbackUrl as String?,
     resumableSession: identical(resumableSession, _pendingUploadUnset)
         ? this.resumableSession
         : resumableSession as BlossomResumableUploadSession?,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -2106,13 +2106,29 @@ class UploadManager {
   /// Create successful upload with metadata
   PendingUpload _createSuccessfulUpload(PendingUpload upload, dynamic result) {
     // Handle both BlossomUploadResult and DirectUploadResult structures
-    String? thumbnailUrl;
+    String? resultThumbnailUrl;
     try {
       // Get thumbnailUrl from upload result (both services should provide it)
-      thumbnailUrl = result.thumbnailUrl as String?;
+      resultThumbnailUrl = result.thumbnailUrl as String?;
     } catch (e) {
       // Fallback if thumbnailUrl is not available
-      thumbnailUrl = null;
+      resultThumbnailUrl = null;
+    }
+
+    final existingThumbnailUrl = upload.thumbnailPath;
+    String? thumbnailUrl;
+    if (_isHttpUrl(resultThumbnailUrl)) {
+      thumbnailUrl = resultThumbnailUrl;
+    } else if (_isHttpUrl(existingThumbnailUrl)) {
+      thumbnailUrl = existingThumbnailUrl;
+    }
+
+    if (resultThumbnailUrl != null && !_isHttpUrl(resultThumbnailUrl)) {
+      Log.error(
+        '⚠️ thumbnailUrl is not an HTTP URL: $resultThumbnailUrl',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
     }
 
     Log.info(
@@ -2121,7 +2137,7 @@ class UploadManager {
       category: LogCategory.system,
     );
     Log.info(
-      '📸 Upload result thumbnail URL: $thumbnailUrl',
+      '📸 Upload result thumbnail URL: $resultThumbnailUrl',
       name: 'UploadManager',
       category: LogCategory.system,
     );

--- a/mobile/packages/models/lib/src/pending_upload.dart
+++ b/mobile/packages/models/lib/src/pending_upload.dart
@@ -16,6 +16,8 @@ import 'dart:math' as math;
 import 'package:meta/meta.dart';
 import 'package:models/src/native_proof_data.dart';
 
+const Object _pendingUploadUnset = Object();
+
 /// Status of a video upload to Cloudinary
 enum UploadStatus {
   pending, // Waiting to start upload
@@ -156,10 +158,10 @@ class PendingUpload {
     DateTime? createdAt,
     String? cloudinaryPublicId,
     String? videoId,
-    String? cdnUrl,
+    Object? cdnUrl = _pendingUploadUnset,
     String? errorMessage,
     double? uploadProgress,
-    String? thumbnailPath,
+    Object? thumbnailPath = _pendingUploadUnset,
     String? title,
     String? description,
     List<String>? hashtags,
@@ -170,9 +172,9 @@ class PendingUpload {
     int? videoHeight,
     Duration? videoDuration,
     String? proofManifestJson,
-    String? streamingMp4Url,
-    String? streamingHlsUrl,
-    String? fallbackUrl,
+    Object? streamingMp4Url = _pendingUploadUnset,
+    Object? streamingHlsUrl = _pendingUploadUnset,
+    Object? fallbackUrl = _pendingUploadUnset,
   }) => PendingUpload(
     id: id ?? this.id,
     localVideoPath: localVideoPath ?? this.localVideoPath,
@@ -181,10 +183,14 @@ class PendingUpload {
     createdAt: createdAt ?? this.createdAt,
     cloudinaryPublicId: cloudinaryPublicId ?? this.cloudinaryPublicId,
     videoId: videoId ?? this.videoId,
-    cdnUrl: cdnUrl ?? this.cdnUrl,
+    cdnUrl: identical(cdnUrl, _pendingUploadUnset)
+        ? this.cdnUrl
+        : cdnUrl as String?,
     errorMessage: errorMessage ?? this.errorMessage,
     uploadProgress: uploadProgress ?? this.uploadProgress,
-    thumbnailPath: thumbnailPath ?? this.thumbnailPath,
+    thumbnailPath: identical(thumbnailPath, _pendingUploadUnset)
+        ? this.thumbnailPath
+        : thumbnailPath as String?,
     title: title ?? this.title,
     description: description ?? this.description,
     hashtags: hashtags ?? this.hashtags,
@@ -195,9 +201,15 @@ class PendingUpload {
     videoHeight: videoHeight ?? this.videoHeight,
     videoDurationMillis: (videoDuration ?? this.videoDuration)?.inMilliseconds,
     proofManifestJson: proofManifestJson ?? this.proofManifestJson,
-    streamingMp4Url: streamingMp4Url ?? this.streamingMp4Url,
-    streamingHlsUrl: streamingHlsUrl ?? this.streamingHlsUrl,
-    fallbackUrl: fallbackUrl ?? this.fallbackUrl,
+    streamingMp4Url: identical(streamingMp4Url, _pendingUploadUnset)
+        ? this.streamingMp4Url
+        : streamingMp4Url as String?,
+    streamingHlsUrl: identical(streamingHlsUrl, _pendingUploadUnset)
+        ? this.streamingHlsUrl
+        : streamingHlsUrl as String?,
+    fallbackUrl: identical(fallbackUrl, _pendingUploadUnset)
+        ? this.fallbackUrl
+        : fallbackUrl as String?,
   );
 
   /// Check if the upload is in a terminal state

--- a/mobile/packages/models/test/src/pending_upload_copy_with_test.dart
+++ b/mobile/packages/models/test/src/pending_upload_copy_with_test.dart
@@ -1,0 +1,56 @@
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PendingUpload copyWith', () {
+    test('preserves URL fields when omitted', () {
+      final upload =
+          PendingUpload.create(
+            localVideoPath: '/path/to/video.mp4',
+            nostrPubkey: 'pubkey123',
+          ).copyWith(
+            cdnUrl: 'https://media.divine.video/video.mp4',
+            thumbnailPath: 'https://media.divine.video/thumb.jpg',
+            streamingMp4Url: 'https://media.divine.video/stream.mp4',
+            streamingHlsUrl: 'https://media.divine.video/stream.m3u8',
+            fallbackUrl: 'https://media.divine.video/fallback.mp4',
+          );
+
+      final copied = upload.copyWith(status: UploadStatus.readyToPublish);
+
+      expect(copied.cdnUrl, equals(upload.cdnUrl));
+      expect(copied.thumbnailPath, equals(upload.thumbnailPath));
+      expect(copied.streamingMp4Url, equals(upload.streamingMp4Url));
+      expect(copied.streamingHlsUrl, equals(upload.streamingHlsUrl));
+      expect(copied.fallbackUrl, equals(upload.fallbackUrl));
+    });
+
+    test('clears URL fields when explicitly set to null', () {
+      final upload =
+          PendingUpload.create(
+            localVideoPath: '/path/to/video.mp4',
+            nostrPubkey: 'pubkey123',
+          ).copyWith(
+            cdnUrl: 'https://media.divine.video/video.mp4',
+            thumbnailPath: 'https://media.divine.video/thumb.jpg',
+            streamingMp4Url: 'https://media.divine.video/stream.mp4',
+            streamingHlsUrl: 'https://media.divine.video/stream.m3u8',
+            fallbackUrl: 'https://media.divine.video/fallback.mp4',
+          );
+
+      final cleared = upload.copyWith(
+        cdnUrl: null,
+        thumbnailPath: null,
+        streamingMp4Url: null,
+        streamingHlsUrl: null,
+        fallbackUrl: null,
+      );
+
+      expect(cleared.cdnUrl, isNull);
+      expect(cleared.thumbnailPath, isNull);
+      expect(cleared.streamingMp4Url, isNull);
+      expect(cleared.streamingHlsUrl, isNull);
+      expect(cleared.fallbackUrl, isNull);
+    });
+  });
+}

--- a/mobile/test/models/pending_upload_copy_with_test.dart
+++ b/mobile/test/models/pending_upload_copy_with_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/pending_upload.dart';
+
+void main() {
+  group('PendingUpload copyWith', () {
+    test('preserves URL fields when omitted', () {
+      final upload =
+          PendingUpload.create(
+            localVideoPath: '/path/to/video.mp4',
+            nostrPubkey: 'pubkey123',
+          ).copyWith(
+            cdnUrl: 'https://media.divine.video/video.mp4',
+            thumbnailPath: 'https://media.divine.video/thumb.jpg',
+            streamingMp4Url: 'https://media.divine.video/stream.mp4',
+            streamingHlsUrl: 'https://media.divine.video/stream.m3u8',
+            fallbackUrl: 'https://media.divine.video/fallback.mp4',
+          );
+
+      final copied = upload.copyWith(status: UploadStatus.readyToPublish);
+
+      expect(copied.cdnUrl, equals(upload.cdnUrl));
+      expect(copied.thumbnailPath, equals(upload.thumbnailPath));
+      expect(copied.streamingMp4Url, equals(upload.streamingMp4Url));
+      expect(copied.streamingHlsUrl, equals(upload.streamingHlsUrl));
+      expect(copied.fallbackUrl, equals(upload.fallbackUrl));
+    });
+
+    test('clears URL fields when explicitly set to null', () {
+      final upload =
+          PendingUpload.create(
+            localVideoPath: '/path/to/video.mp4',
+            nostrPubkey: 'pubkey123',
+          ).copyWith(
+            cdnUrl: 'https://media.divine.video/video.mp4',
+            thumbnailPath: 'https://media.divine.video/thumb.jpg',
+            streamingMp4Url: 'https://media.divine.video/stream.mp4',
+            streamingHlsUrl: 'https://media.divine.video/stream.m3u8',
+            fallbackUrl: 'https://media.divine.video/fallback.mp4',
+          );
+
+      final cleared = upload.copyWith(
+        cdnUrl: null,
+        thumbnailPath: null,
+        streamingMp4Url: null,
+        streamingHlsUrl: null,
+        fallbackUrl: null,
+      );
+
+      expect(cleared.cdnUrl, isNull);
+      expect(cleared.thumbnailPath, isNull);
+      expect(cleared.streamingMp4Url, isNull);
+      expect(cleared.streamingHlsUrl, isNull);
+      expect(cleared.fallbackUrl, isNull);
+    });
+  });
+}

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -205,20 +205,75 @@ void main() {
       },
     );
 
+    test('resumeInterruptedUpload keeps existing CDN thumbnail over a '
+        'non-HTTP result thumbnail', () async {
+      const cdnThumbnailUrl = 'https://media.divine.video/thumb-existing';
+      const localThumbnailPath = '/var/cache/thumbnails/frame.jpg';
+      final upload =
+          PendingUpload.create(
+            localVideoPath: videoFile.path,
+            nostrPubkey: 'test-pubkey',
+            title: 'Video with uploaded thumbnail',
+          ).copyWith(
+            status: UploadStatus.uploading,
+            thumbnailPath: cdnThumbnailUrl,
+            uploadProgress: 0.8,
+          );
+
+      final box = Hive.box<PendingUpload>('pending_uploads');
+      await box.put(upload.id, upload);
+
+      when(
+        () => mockBlossomService.uploadVideo(
+          videoFile: any(named: 'videoFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          hashtags: any(named: 'hashtags'),
+          proofManifestJson: any(named: 'proofManifestJson'),
+          resumableSession: any(named: 'resumableSession'),
+          onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer(
+        // The upload result carries a non-HTTP thumbnail (a stale local
+        // path). It must never overwrite the already-uploaded CDN URL.
+        (_) async => const BlossomUploadResult(
+          success: true,
+          videoId: 'video-with-thumbnail',
+          url: 'https://media.divine.video/video-with-thumbnail',
+          fallbackUrl: 'https://media.divine.video/video-with-thumbnail',
+          thumbnailUrl: localThumbnailPath,
+        ),
+      );
+
+      uploadManager.resumeInterruptedUpload(upload.id);
+
+      await TestHelpers.waitForCondition(() {
+        final currentUpload = uploadManager.getUpload(upload.id);
+        return currentUpload?.status == UploadStatus.readyToPublish;
+      });
+
+      final completedUpload = uploadManager.getUpload(upload.id);
+      expect(completedUpload, isNotNull);
+      expect(completedUpload!.videoId, equals('video-with-thumbnail'));
+      expect(completedUpload.thumbnailPath, equals(cdnThumbnailUrl));
+      expect(completedUpload.thumbnailPath, isNot(equals(localThumbnailPath)));
+    });
+
     test(
-      'resumeInterruptedUpload keeps existing CDN thumbnail over a '
-      'non-HTTP result thumbnail',
+      'resumeInterruptedUpload clears existing non-HTTP thumbnail when result '
+      'does not provide a valid URL',
       () async {
-        const cdnThumbnailUrl = 'https://media.divine.video/thumb-existing';
         const localThumbnailPath = '/var/cache/thumbnails/frame.jpg';
         final upload =
             PendingUpload.create(
               localVideoPath: videoFile.path,
               nostrPubkey: 'test-pubkey',
-              title: 'Video with uploaded thumbnail',
+              title: 'Video with stale thumbnail',
             ).copyWith(
               status: UploadStatus.uploading,
-              thumbnailPath: cdnThumbnailUrl,
+              thumbnailPath: localThumbnailPath,
               uploadProgress: 0.8,
             );
 
@@ -238,14 +293,11 @@ void main() {
             onProgress: any(named: 'onProgress'),
           ),
         ).thenAnswer(
-          // The upload result carries a non-HTTP thumbnail (a stale local
-          // path). It must never overwrite the already-uploaded CDN URL.
           (_) async => const BlossomUploadResult(
             success: true,
-            videoId: 'video-with-thumbnail',
-            url: 'https://media.divine.video/video-with-thumbnail',
-            fallbackUrl: 'https://media.divine.video/video-with-thumbnail',
-            thumbnailUrl: localThumbnailPath,
+            videoId: 'video-without-thumbnail',
+            url: 'https://media.divine.video/video-without-thumbnail',
+            fallbackUrl: 'https://media.divine.video/video-without-thumbnail',
           ),
         );
 
@@ -258,12 +310,8 @@ void main() {
 
         final completedUpload = uploadManager.getUpload(upload.id);
         expect(completedUpload, isNotNull);
-        expect(completedUpload!.videoId, equals('video-with-thumbnail'));
-        expect(completedUpload.thumbnailPath, equals(cdnThumbnailUrl));
-        expect(
-          completedUpload.thumbnailPath,
-          isNot(equals(localThumbnailPath)),
-        );
+        expect(completedUpload!.videoId, equals('video-without-thumbnail'));
+        expect(completedUpload.thumbnailPath, isNull);
       },
     );
 

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -153,6 +153,121 @@ void main() {
     );
 
     test(
+      'resumeInterruptedUpload preserves existing thumbnail URL when result omits one',
+      () async {
+        const thumbnailUrl = 'https://media.divine.video/thumb-existing';
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: 'test-pubkey',
+              title: 'Video with generated thumbnail',
+            ).copyWith(
+              status: UploadStatus.uploading,
+              thumbnailPath: thumbnailUrl,
+              uploadProgress: 0.8,
+            );
+
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(upload.id, upload);
+
+        when(
+          () => mockBlossomService.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => const BlossomUploadResult(
+            success: true,
+            videoId: 'video-with-thumbnail',
+            url: 'https://media.divine.video/video-with-thumbnail',
+            fallbackUrl: 'https://media.divine.video/video-with-thumbnail',
+          ),
+        );
+
+        uploadManager.resumeInterruptedUpload(upload.id);
+
+        await TestHelpers.waitForCondition(() {
+          final currentUpload = uploadManager.getUpload(upload.id);
+          return currentUpload?.status == UploadStatus.readyToPublish;
+        });
+
+        final completedUpload = uploadManager.getUpload(upload.id);
+        expect(completedUpload, isNotNull);
+        expect(completedUpload!.videoId, equals('video-with-thumbnail'));
+        expect(completedUpload.thumbnailPath, equals(thumbnailUrl));
+      },
+    );
+
+    test(
+      'resumeInterruptedUpload keeps existing CDN thumbnail over a '
+      'non-HTTP result thumbnail',
+      () async {
+        const cdnThumbnailUrl = 'https://media.divine.video/thumb-existing';
+        const localThumbnailPath = '/var/cache/thumbnails/frame.jpg';
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: 'test-pubkey',
+              title: 'Video with uploaded thumbnail',
+            ).copyWith(
+              status: UploadStatus.uploading,
+              thumbnailPath: cdnThumbnailUrl,
+              uploadProgress: 0.8,
+            );
+
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(upload.id, upload);
+
+        when(
+          () => mockBlossomService.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer(
+          // The upload result carries a non-HTTP thumbnail (a stale local
+          // path). It must never overwrite the already-uploaded CDN URL.
+          (_) async => const BlossomUploadResult(
+            success: true,
+            videoId: 'video-with-thumbnail',
+            url: 'https://media.divine.video/video-with-thumbnail',
+            fallbackUrl: 'https://media.divine.video/video-with-thumbnail',
+            thumbnailUrl: localThumbnailPath,
+          ),
+        );
+
+        uploadManager.resumeInterruptedUpload(upload.id);
+
+        await TestHelpers.waitForCondition(() {
+          final currentUpload = uploadManager.getUpload(upload.id);
+          return currentUpload?.status == UploadStatus.readyToPublish;
+        });
+
+        final completedUpload = uploadManager.getUpload(upload.id);
+        expect(completedUpload, isNotNull);
+        expect(completedUpload!.videoId, equals('video-with-thumbnail'));
+        expect(completedUpload.thumbnailPath, equals(cdnThumbnailUrl));
+        expect(
+          completedUpload.thumbnailPath,
+          isNot(equals(localThumbnailPath)),
+        );
+      },
+    );
+
+    test(
       'resumeInterruptedUpload falls back to failed when session expires',
       () async {
         final upload =


### PR DESCRIPTION
## Description

After a successful publish, `UploadManager._createSuccessfulUpload` derived the
final `thumbnailPath` directly from `result.thumbnailUrl`. For the Blossom/CDN
flow that value is often `null` (the thumbnail is uploaded separately and its
CDN URL is already stored on `upload.thumbnailPath`), and it can occasionally be
a **non-HTTP value** (a stale local cache path).

The fix makes the thumbnail selection explicit and validated: prefer a valid
HTTP URL from `result.thumbnailUrl`, otherwise fall back to a valid HTTP
`upload.thumbnailPath`, and never persist a non-HTTP value. This guarantees the
already-uploaded CDN thumbnail survives into the final `PendingUpload` record.

### A note on the original root-cause analysis

The issue hypothesised that `copyWith(thumbnailPath: null)` overwrote the URL
with `null`. In practice `PendingUpload.copyWith` uses
`thumbnailPath ?? this.thumbnailPath`, so an explicit `null` never cleared the
field — the literal `null` scenario was already preserved. The behaviour the
fix genuinely changes (and the one that could corrupt the record) is a
**non-HTTP `result.thumbnailUrl` overwriting a valid CDN URL**. The new
regression test pins exactly that case and **fails without this fix** (it would
otherwise persist `/var/cache/thumbnails/frame.jpg` over the CDN URL).

**Related Issue:** Closes #4997

## Out of Scope

Because `copyWith` ignores explicit `null`, `_createSuccessfulUpload` still
cannot *clear* an existing non-HTTP `thumbnailPath` (e.g. when a thumbnail
upload fails and only a local path was ever set). The same applies to
`cdnUrl` / `streamingMp4Url` / `fallbackUrl`. This is a pre-existing limitation
unrelated to #4997; a clean fix would add a clear-sentinel to `copyWith`
(as already exists for `resumableSession`). Not addressed here to keep scope
tight.

## Verification

- `dart format` (both changed files)
- `flutter analyze lib/services/upload_manager.dart test/services/upload_manager_resumable_upload_test.dart` → No issues found
- `flutter test test/services/upload_manager_resumable_upload_test.dart` → all 13 tests pass
- Confirmed the new regression test **fails** when the `_createSuccessfulUpload`
  change is reverted (true regression guard)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
 