### PR TITLE
fix(timeline): rebase markers for speed, delete, duplicate, split

### DIFF
--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -111,6 +111,11 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
         ref.read(videoEditorProvider.notifier).invalidateFinalRenderedClip();
 
         if (_editor != null) {
+          // A split subdivides one clip at the same total span, so no marker
+          // moves — a marker on the left half stays on the start clip, one on
+          // the right stays on the end clip. Persist the current markers in
+          // the same history entry as the split clips so undo/redo restores a
+          // consistent timeline.
           _editor!.addHistory(
             meta: {
               ..._editor!.stateManager.activeMeta,
@@ -119,6 +124,10 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
                   .clips
                   .map((e) => e.toJson())
                   .toList(),
+              VideoEditorConstants.timelineMarkersStateHistoryKey:
+                  _timelineOverlayBloc.state.timelineMarkers
+                      .map((marker) => marker.inMilliseconds)
+                      .toList(),
             },
           );
         }

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -2,12 +2,14 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 
 /// Controls shown when a clip is in editing mode: Delete, Copy, Split, Done.
 class TimelineClipControls extends StatefulWidget {
@@ -55,6 +57,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
 
   Future<void> _setPlaybackSpeed(BuildContext context) async {
     final bloc = context.read<ClipEditorBloc>();
+    final overlayBloc = context.read<TimelineOverlayBloc>();
     final state = bloc.state;
     if (state.currentClipIndex < 0 ||
         state.currentClipIndex >= state.clips.length) {
@@ -74,11 +77,21 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     if (result == null || !mounted) return;
 
     final updated = clip.copyWith(playbackSpeed: result);
-    bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: updated));
-
-    editor.setClipState(
-      state.clips.map((c) => c.id == clip.id ? updated : c).toList(),
+    final newClips = state.clips
+        .map((c) => c.id == clip.id ? updated : c)
+        .toList();
+    // A speed change rescales the clip's playbackDuration, shifting every
+    // later clip — rebase markers by source position so they follow.
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: state.clips,
+      newClips: newClips,
+      markers: overlayBloc.state.timelineMarkers,
     );
+
+    bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: updated));
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+
+    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
   }
 
   void _requestExtractAudio(BuildContext context) {
@@ -91,9 +104,19 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
 
   void _deleteClip(BuildContext context) {
     final bloc = context.read<ClipEditorBloc>();
+    final overlayBloc = context.read<TimelineOverlayBloc>();
     final state = bloc.state;
     final clipId = state.clips[state.currentClipIndex].id;
     final editor = VideoEditorScope.of(context).requireEditor;
+
+    final newClips = state.clips.where((clip) => clip.id != clipId).toList();
+    // Markers on the removed clip are dropped; markers on later clips shift
+    // earlier — rebase by source position so both rules are honoured.
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: state.clips,
+      newClips: newClips,
+      markers: overlayBloc.state.timelineMarkers,
+    );
 
     bloc.add(ClipEditorClipRemoved(clipId));
 
@@ -102,13 +125,13 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     }
     bloc.add(const ClipEditorEditingStopped());
 
-    editor.setClipState(
-      state.clips.where((clip) => clip.id != clipId).toList(),
-    );
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
   }
 
   void _duplicateClip(BuildContext context) {
     final bloc = context.read<ClipEditorBloc>();
+    final overlayBloc = context.read<TimelineOverlayBloc>();
     final state = bloc.state;
     final clip = state.clips[state.currentClipIndex];
     final editor = VideoEditorScope.of(context).requireEditor;
@@ -119,11 +142,22 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
           '${DateTime.now().millisecondsSinceEpoch}',
     );
 
+    final newClips = [...state.clips, copy];
+    // The copy is appended at the end, so existing markers keep their
+    // positions; rebase for consistency and to persist markers in the
+    // same history entry as the clip change.
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: state.clips,
+      newClips: newClips,
+      markers: overlayBloc.state.timelineMarkers,
+    );
+
     bloc
       ..add(ClipEditorClipInserted(index: state.clips.length, clip: copy))
       ..add(const ClipEditorEditingStopped());
 
-    editor.setClipState([...state.clips, copy]);
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
   }
 
   void _splitClip(BuildContext context) {

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -584,6 +584,35 @@ void main() {
       );
     });
 
+    test('keeps earlier markers in place when a clip is appended', () {
+      // Mirrors the clip-duplication call site: the copy is added at the
+      // end, so markers on the existing clips must not move.
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+      ];
+      final newClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+        _clip('a_copy', 3),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [
+            const Duration(seconds: 1),
+            const Duration(seconds: 6),
+          ],
+        ),
+        equals([
+          const Duration(seconds: 1),
+          const Duration(seconds: 6),
+        ]),
+      );
+    });
+
     test('clamps a marker past the timeline end to the last clip end', () {
       final oldClips = [
         _clip('a', 3),

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -567,6 +567,26 @@ void main() {
       );
     });
 
+    test('shifts later markers when a preceding clip speed changes', () {
+      final oldClips = [
+        _clip('intro', 4),
+        _clip('target', 6),
+      ];
+      final newClips = [
+        _clip('intro', 4, speed: 2.0),
+        _clip('target', 6),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 6)],
+        ),
+        equals([const Duration(seconds: 4)]),
+      );
+    });
+
     test('drops markers whose source clip no longer exists', () {
       final oldClips = [
         _clip('a', 3),
@@ -581,6 +601,27 @@ void main() {
           markers: [const Duration(seconds: 4)],
         ),
         isEmpty,
+      );
+    });
+
+    test('shifts later markers earlier when a preceding clip is removed', () {
+      final oldClips = [
+        _clip('a', 3),
+        _clip('b', 5),
+        _clip('c', 4),
+      ];
+      final newClips = [
+        _clip('a', 3),
+        _clip('c', 4),
+      ];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 10)],
+        ),
+        equals([const Duration(seconds: 5)]),
       );
     });
 


### PR DESCRIPTION
## Description

PR #4979 wired the pure `rebaseTimelineMarkersForClipState` helper into clip **reorder** and **trim** only. The remaining composition-changing call sites still left timeline markers at stale absolute positions. This completes the work, persisting rebased markers in the **same** editor-history entry as the clip change (matching the reorder/trim behaviour) so undo/redo stays consistent.

Call sites covered:

| Trigger | Where | Behaviour |
|---|---|---|
| Clip speed change | `_setPlaybackSpeed` in `video_editor_timeline_clip_controls.dart` | Rescaling `playbackDuration` shifts every later clip → markers rebased by source position. |
| Clip deletion | `_deleteClip` | Markers on the removed clip are dropped; markers on later clips shift earlier. |
| Clip duplication | `_duplicateClip` | Copy is appended at the end → existing markers keep their positions (rebased for consistency + single-entry persistence). |
| Split completion | `onFinalClipInvalidated` in `video_editor_screen.dart` | A split subdivides one clip at the same total span, so no marker moves — a marker in the left half stays on the start clip, one in the right stays on the end clip. The current markers are persisted into the split's history entry. |

**Split semantics** were confirmed with the issue owner: markers stay put (left-of-split stays with the start clip, right-of-split with the end clip), since a split preserves every absolute timeline position.

**Related Issue:** Closes #4985

## Out of Scope

- Widget-level integration tests for the four call sites. As documented in #4979, these require a full `ProImageEditor` scope (the editor isn't mockable for `setClipState` / `addHistory`). The pure geometry helper is unit-tested instead, and the call-site wiring mirrors the proven reorder/trim pattern.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze lib test` — No issues found
- `flutter test` — geometry, clip-controls, overlay-bloc, timeline, and scaffold suites all pass (118+ tests). Added a geometry unit test for the append/duplicate path (speed re-anchor and clip-removal drop were already covered).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)