### PR TITLE
fix(videos_repository): split live engagement counts in author-feed hydration

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1934,7 +1934,8 @@ class VideosRepository {
   ///    v2 envelope (`totalCount`/`nextOffset`/`hasMore`); maps via
   ///    `toVideoEvents()` (drops NIP-40 expired only — **no** block/content
   ///    filtering, so the cubit can re-filter on every emit, #4782); hydrates
-  ///    engagement counts (bulk-stats then per-video views, existing-wins);
+  ///    engagement counts (bulk-stats then per-video views, filling live
+  ///    `nostr*` counts only so the display seed can't double-count, #3384);
   ///    drops backend-leaked p-tagged collaborator events
   ///    (`v.pubkey != authorPubkey`); merges with [relaySeed] under the #3384
   ///    cross-source max policy; caches the initial page.
@@ -2042,10 +2043,14 @@ class VideosRepository {
   }
 
   /// Hydrates author REST videos with engagement counts: bulk-stats first
-  /// (loops/views/reactions/comments/reposts), then a per-video views-endpoint
-  /// pass for rows still missing a view count. Uses **existing-wins** (`??`)
-  /// semantics — distinct from [_hydrateVideosWithBulkStats]'s stale-zero
-  /// heuristic — to preserve profile-feed count parity (#3384).
+  /// (loops/views), then a per-video views-endpoint pass for rows still missing
+  /// a view count.
+  ///
+  /// Bulk stats are **live** Nostr engagement counts, so reactions/comments/
+  /// reposts fill only the live `nostr*Count` fields (via `??`); the archival
+  /// import counts in `original*` are left untouched. Keeping the two sources
+  /// split is what lets the display seed (archival `original*` + live `nostr*`)
+  /// add them without double-counting (#3384).
   Future<List<VideoEvent>> _hydrateAuthorRestVideos(
     List<VideoEvent> videos,
   ) async {
@@ -2094,10 +2099,12 @@ class VideosRepository {
       return video.copyWith(
         rawTags: mergedTags,
         originalLoops: stats.loops ?? video.originalLoops,
-        originalLikes: video.originalLikes ?? stats.reactions,
-        originalComments: video.originalComments ?? stats.comments,
-        originalReposts: video.originalReposts ?? stats.reposts,
-        nostrLikeCount: video.nostrLikeCount ?? 0,
+        originalLikes: video.originalLikes,
+        originalComments: video.originalComments,
+        originalReposts: video.originalReposts,
+        nostrLikeCount: video.nostrLikeCount ?? stats.reactions,
+        nostrCommentCount: video.nostrCommentCount ?? stats.comments,
+        nostrRepostCount: video.nostrRepostCount ?? stats.reposts,
       );
     }).toList();
   }

--- a/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
@@ -21,6 +21,9 @@ VideoStats _stats({
   String pubkey = _author,
   String dTag = 'd',
   String videoUrl = 'https://example.com/v.mp4',
+  int reactions = 0,
+  int comments = 0,
+  int reposts = 0,
   Map<String, String> rawTags = const {},
 }) {
   return VideoStats(
@@ -32,9 +35,9 @@ VideoStats _stats({
     title: 'Test',
     thumbnail: 'https://example.com/t.jpg',
     videoUrl: videoUrl,
-    reactions: 0,
-    comments: 0,
-    reposts: 0,
+    reactions: reactions,
+    comments: comments,
+    reposts: reposts,
     engagementScore: 0,
     rawTags: rawTags,
   );
@@ -105,7 +108,7 @@ void main() {
       expect(result.hasMore, isTrue);
     });
 
-    test('hydrates REST videos with bulk stats (existing-wins)', () async {
+    test('hydrates REST videos with bulk stats (loops + views)', () async {
       when(() => funnelcake.getBulkVideoStats(any())).thenAnswer(
         (_) async => const BulkVideoStatsResponse(
           stats: {
@@ -132,6 +135,59 @@ void main() {
       expect(video.rawTags['views'], equals('14'));
       verifyNever(() => funnelcake.getVideoViews(any()));
     });
+
+    test(
+      'keeps live counts in nostr* fields so the display seed cannot '
+      'double-count (#3384)',
+      () async {
+        // A native diVine video carries no archival likes/comments/reposts
+        // rawTags, so toVideoEvent leaves original* null and seeds the live
+        // nostr*Count from the author endpoint. Bulk stats report the SAME
+        // live counts (one backend source). Filling original* from bulk stats
+        // here would make the display seed (original* + nostr*) double.
+        when(() => funnelcake.getBulkVideoStats(any())).thenAnswer(
+          (_) async => const BulkVideoStatsResponse(
+            stats: {
+              'a': BulkVideoStatsEntry(
+                eventId: 'a',
+                reactions: 6,
+                comments: 3,
+                reposts: 2,
+                views: 14,
+                loops: 7,
+              ),
+            },
+          ),
+        );
+        stubAuthor(
+          VideosByAuthorResponse(
+            videos: [_stats(id: 'a', reactions: 6, comments: 3, reposts: 2)],
+          ),
+        );
+
+        final video = (await repository.getAuthorFeed(
+          authorPubkey: _author,
+        )).videos.single;
+
+        // Archival baselines stay untouched; live counts land only in nostr*.
+        expect(video.originalLikes, isNull);
+        expect(video.originalComments, isNull);
+        expect(video.originalReposts, isNull);
+        expect(video.nostrLikeCount, equals(6));
+        expect(video.nostrCommentCount, equals(3));
+        expect(video.nostrRepostCount, equals(2));
+
+        // The display seed is archival + live (see liveLikeCountSeed); with the
+        // two sources split it equals the single backend count, not 2x.
+        int seed(int? archival, int? live) => (archival ?? 0) + (live ?? 0);
+        expect(seed(video.originalLikes, video.nostrLikeCount), equals(6));
+        expect(
+          seed(video.originalComments, video.nostrCommentCount),
+          equals(3),
+        );
+        expect(seed(video.originalReposts, video.nostrRepostCount), equals(2));
+      },
+    );
 
     test(
       'treats a fractional view count as present, skipping the views endpoint',


### PR DESCRIPTION
## Summary

`getAuthorFeed`'s `_hydrateAuthorVideosWithBulkStats` doubled the like / comment / repost counts shown on the **profile fullscreen feed** for native diVine videos.

`VideoStats.toVideoEvent()` already seeds the live `nostr*Count` fields from the author-endpoint counts. The hydration pass then *also* filled the archival `original*` fields from bulk stats (the same backend counts). Because the display seed is `liveLikeCountSeed = (originalLikes ?? 0) + (nostrLikeCount ?? 0)`, a native video with no archival Vine tag (`originalLikes == null`) ended up seeding `VideoInteractionsBloc` (`feed_videos.dart:608-610`) with `X + X = 2X`.

This is the same double-count that commit `94de3d4ba` ("fix(feed): keep hydrated engagement counts split") removed from the home feed and the old `profile_feed_provider`. That fix merged ~12 min before the `ProfileFeedCubit` migration (#4937) and ~16 min after `getAuthorFeed` (#4931), so the new author-feed hydration raced past it and never got the corrected split.

## What changed

- `_hydrateAuthorVideosWithBulkStats` now fills **only** the live `nostrLikeCount` / `nostrCommentCount` / `nostrRepostCount` fields from bulk stats (single source) and leaves the archival `original*` baselines untouched — mirroring the corrected provider hydration.
- Corrected the method/`getAuthorFeed` doc comments (the old "existing-wins preserves #3384 parity" wording described the buggy pre-fix behavior).
- Added a regression test asserting the display seed equals the single backend count (not 2×); extended the `_stats` test helper with engagement params and renamed the misleading `(existing-wins)` test.

## Testing

- `flutter test packages/videos_repository` — **405 passed**, including the new `keeps live counts in nostr* fields so the display seed cannot double-count (#3384)` test.
- Package **100% line-coverage gate held** (1005/1005).
- `flutter analyze lib test integration_test` — clean.

The regression test fails on the pre-fix code (`originalLikes` would be `6`, seed `12`), so it guards against re-introduction.

## Context

The profile-feed → `ProfileFeedCubit` refactor (the structural work) already merged via #4790, #4931, and #4937, but #4937's `Fixes:` lines targeted its follow-up children (#4933 / #4934) rather than the umbrella task, so #4788 stayed open. This is the final behavior-parity fix for that migration, so it closes #4788.

Fixes #4788
