### PR TITLE
feat(blocklist): read our own kind 10000 mute list (#948)

### DIFF
--- a/mobile/packages/content_blocklist_repository/lib/src/blocklist_change.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/blocklist_change.dart
@@ -19,6 +19,12 @@ enum BlocklistOp {
   /// Someone unmuted us — removed from the mutual-mute set.
   unmuted,
 
+  /// We muted someone — added via our own kind 10000 mute list.
+  mutedByUs,
+
+  /// We unmuted someone — removed from our own kind 10000 mute list.
+  unmutedByUs,
+
   /// Someone blocked us — added to the blocked-by-others set.
   blockedUs,
 
@@ -48,9 +54,13 @@ class BlocklistChange {
   /// `false` when the change removes the pubkey, restoring visibility on
   /// the next pagination.
   bool get isAddition => switch (op) {
-    BlocklistOp.blocked || BlocklistOp.muted || BlocklistOp.blockedUs => true,
+    BlocklistOp.blocked ||
+    BlocklistOp.muted ||
+    BlocklistOp.mutedByUs ||
+    BlocklistOp.blockedUs => true,
     BlocklistOp.unblocked ||
     BlocklistOp.unmuted ||
+    BlocklistOp.unmutedByUs ||
     BlocklistOp.unblockedUs => false,
   };
 

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Content blocklist service for filtering unwanted content from feeds
-// ABOUTME: Maintains internal blocklist while allowing explicit profile visits
-// ABOUTME: Persists blocks to SharedPreferences and publishes kind 30000
+// ABOUTME: Tracks our blocks, our kind-10000 mutes, and mutual block/mute state
+// ABOUTME: Persists to SharedPreferences and publishes kind 30000
 
 import 'dart:async';
 import 'dart:convert';
@@ -17,6 +17,9 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// SharedPreferences key for persisted block list
 const _blockedUsersPrefsKey = 'blocked_users_list';
+
+/// SharedPreferences key for our own kind-10000 muted authors
+const _mutedUsersPrefsKey = 'muted_users_list';
 
 /// SharedPreferences key for severed followers (follow broken by block)
 const _severedFollowersPrefsKey = 'severed_followers_list';
@@ -45,6 +48,7 @@ class ContentBlocklistRepository {
     // Initialize with the specific npub requested
     _addInitialBlockedContent();
     _loadBlockedUsers();
+    _loadMutedUsers();
     _loadSeveredFollowers();
     Log.info(
       'ContentBlocklistRepository initialized with '
@@ -66,6 +70,13 @@ class ContentBlocklistRepository {
 
   // Mutual mute blocklist (populated from kind 10000 events)
   final Set<String> _mutualMuteBlocklist = <String>{};
+
+  // Authors we muted via our own kind 10000 mute list. Read-only mirror of
+  // relay state: this app has no mute-authoring UI, so the newest own
+  // kind 10000 event (published from any Nostr client) replaces this set
+  // wholesale. Only public 'p' tags are read; NIP-51 encrypted (private)
+  // mute entries are not supported.
+  final Set<String> _mutedPubkeys = <String>{};
 
   // Latest replaceable kind-10000 mute-list event timestamp per author.
   // Prevent stale relay delivery order from resurrecting old mute state.
@@ -126,9 +137,7 @@ class ContentBlocklistRepository {
 
   ContentPolicyState _buildCurrentState() => ContentPolicyState(
     currentUserPubkey: _ourPubkey,
-    // TODO(rabble): populate from our own kind 10000 once personal-mute
-    // reading is wired; tracking in follow-up to the content-policy epic.
-    mutedPubkeys: const {},
+    mutedPubkeys: Set.unmodifiable(_mutedPubkeys),
     blockedPubkeys: Set.unmodifiable({
       ..._internalBlocklist,
       ..._runtimeBlocklist,
@@ -196,6 +205,53 @@ class ContentBlocklistRepository {
     } on Object catch (e) {
       Log.error(
         'Failed to persist blocked users: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// Load persisted muted authors from SharedPreferences.
+  ///
+  /// This is the hydration cache that covers the window between app start
+  /// and relay delivery of our own kind 10000 event.
+  void _loadMutedUsers() {
+    final prefs = _prefs;
+    if (prefs == null) return;
+
+    final stored = prefs.getString(_mutedUsersPrefsKey);
+    if (stored == null || stored.isEmpty) return;
+
+    try {
+      final list = (jsonDecode(stored) as List<dynamic>).cast<String>();
+      _mutedPubkeys.addAll(list);
+      Log.info(
+        'Loaded ${list.length} muted authors from persistence',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    } on Object catch (e) {
+      Log.error(
+        'Failed to load persisted muted authors: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// Save muted authors to SharedPreferences
+  ///
+  /// Awaits the platform write so the data survives an immediate app kill.
+  Future<void> _saveMutedUsers() async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+
+    try {
+      final json = jsonEncode(_mutedPubkeys.toList());
+      await prefs.setString(_mutedUsersPrefsKey, json);
+    } on Object catch (e) {
+      Log.error(
+        'Failed to persist muted authors: $e',
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
@@ -345,15 +401,23 @@ class ContentBlocklistRepository {
   ///
   /// Filters content from:
   /// - Users we blocked (internal + runtime blocklist)
+  /// - Users we muted via our own kind 10000 mute list
   /// - Users who mutually muted us (kind 10000)
   /// - Users who blocked us (kind 30000, d=block) — hides our content
   ///   from their feeds and their content from ours
   bool shouldFilterFromFeeds(String pubkey) {
     return _internalBlocklist.contains(pubkey) ||
         _runtimeBlocklist.contains(pubkey) ||
+        _mutedPubkeys.contains(pubkey) ||
         _mutualMuteBlocklist.contains(pubkey) ||
         _blockedByOthers.contains(pubkey);
   }
+
+  /// Check if we muted another user via our own kind 10000 mute list.
+  ///
+  /// Mutes are authored from other Nostr clients (this app has no mute
+  /// action); this reflects the latest own kind 10000 event seen on relays.
+  bool isMutedByUs(String pubkey) => _mutedPubkeys.contains(pubkey);
 
   /// Check if another user has muted us (mutual mute blocking)
   ///
@@ -502,8 +566,15 @@ class ContentBlocklistRepository {
     'total_blocks': totalBlockedCount,
   };
 
-  /// Start background sync of mutual mute lists (NIP-51 kind 10000)
-  /// Subscribes to kind 10000 events WHERE our pubkey appears in 'p' tags
+  /// Start background sync of mute lists (NIP-51 kind 10000).
+  ///
+  /// Subscribes to two filter sets in a single subscription:
+  /// 1. Kind 10000 events WHERE our pubkey appears in 'p' tags — detects
+  ///    when other users mute us (mutual mute).
+  /// 2. Our own kind 10000 event — mutes the user authored from other
+  ///    Nostr clients (this app has no mute action), and relay-based
+  ///    restoration after reinstall, mirroring the kind 30000 block
+  ///    restore in [syncBlockListsInBackground].
   Future<void> syncMuteListsInBackground(
     NostrClient nostrService,
     String ourPubkey,
@@ -535,11 +606,14 @@ class ContentBlocklistRepository {
     );
 
     try {
-      // Subscribe to kind 10000 (mute list) events WHERE our pubkey is in
-      // 'p' tags
-      final filter = Filter(kinds: const [10000])..p = [ourPubkey];
+      // Filter 1: others' mute lists that include our pubkey (mutual mute)
+      final mutualFilter = Filter(kinds: const [10000])..p = [ourPubkey];
 
-      final subscription = nostrService.subscribe([filter]);
+      // Filter 2: our own mute list (mutes authored from other clients +
+      // relay-based restoration after reinstall)
+      final ownFilter = Filter(authors: [ourPubkey], kinds: const [10000]);
+
+      final subscription = nostrService.subscribe([mutualFilter, ownFilter]);
 
       _mutualMuteSyncStarted = true;
       _mutualMuteSubscriptionId =
@@ -635,8 +709,11 @@ class ContentBlocklistRepository {
     }
   }
 
-  /// Handle incoming kind 10000 mute list events
-  /// Adds/removes muter based on whether our pubkey is in their 'p' tags
+  /// Handle incoming kind 10000 mute list events.
+  ///
+  /// Routes our own mute list to [_handleOwnMuteListEvent]; for other
+  /// authors, adds/removes the muter based on whether our pubkey is in
+  /// their 'p' tags (mutual mute).
   void _handleMuteListEvent(Event event) {
     if (event.kind != 10000) {
       Log.warning(
@@ -644,6 +721,11 @@ class ContentBlocklistRepository {
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
+      return;
+    }
+
+    if (event.pubkey == _ourPubkey) {
+      _handleOwnMuteListEvent(event);
       return;
     }
 
@@ -701,6 +783,65 @@ class ContentBlocklistRepository {
         );
       }
     }
+  }
+
+  /// Replace our muted-authors set from our latest kind 10000 event.
+  ///
+  /// Kind 10000 is replaceable and this app never authors mutes, so the
+  /// newest own event is the complete list and replaces [_mutedPubkeys]
+  /// wholesale — unlike [_handleOwnBlockListEvent], which merges to
+  /// protect locally-authored blocks that may not have reached relays.
+  /// Our own pubkey is excluded so a malformed self-referential mute list
+  /// can never filter the user's own content (#2192).
+  void _handleOwnMuteListEvent(Event event) {
+    final ourPubkey = event.pubkey;
+    final createdAt = event.createdAt;
+    final latestSeen = _latestMuteListEventCreatedAtByAuthor[ourPubkey];
+
+    if (latestSeen != null && createdAt < latestSeen) {
+      Log.debug(
+        'Ignoring stale own mute list event '
+        '(createdAt=$createdAt < latestSeen=$latestSeen)',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    _latestMuteListEventCreatedAtByAuthor[ourPubkey] = createdAt;
+
+    final relayMuted = <String>{};
+    for (final tag in event.tags) {
+      if (tag.isNotEmpty &&
+          tag[0] == 'p' &&
+          tag.length >= 2 &&
+          tag[1] != ourPubkey) {
+        relayMuted.add(tag[1]);
+      }
+    }
+
+    final added = relayMuted.difference(_mutedPubkeys);
+    final removed = _mutedPubkeys.difference(relayMuted);
+    if (added.isEmpty && removed.isEmpty) return;
+
+    _mutedPubkeys
+      ..removeAll(removed)
+      ..addAll(added);
+    unawaited(_saveMutedUsers());
+    for (final pubkey in added) {
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.mutedByUs));
+    }
+    for (final pubkey in removed) {
+      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unmutedByUs));
+    }
+    _notifyChanged();
+
+    Log.info(
+      'Synced own mute list: +${added.length} -${removed.length} '
+      '(total: ${_mutedPubkeys.length})',
+      name: 'ContentBlocklistRepository',
+      category: LogCategory.system,
+    );
   }
 
   /// Handle incoming kind 30000 block list events (d=block).

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -293,11 +293,13 @@ void main() {
         const additions = [
           BlocklistOp.blocked,
           BlocklistOp.muted,
+          BlocklistOp.mutedByUs,
           BlocklistOp.blockedUs,
         ];
         const removals = [
           BlocklistOp.unblocked,
           BlocklistOp.unmuted,
+          BlocklistOp.unmutedByUs,
           BlocklistOp.unblockedUs,
         ];
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -363,7 +363,7 @@ void main() {
     });
 
     test(
-      'syncMuteListsInBackground subscribes to kind 10000 with our pubkey',
+      'syncMuteListsInBackground subscribes to mutual and own kind 10000',
       () async {
         const ourPubkey = 'test_our_pubkey_hex';
 
@@ -379,11 +379,15 @@ void main() {
         verify(() => mockNostrService.subscribe(any())).called(1);
 
         expect(capturedFilters, isNotNull);
-        expect(capturedFilters!.length, equals(1));
+        expect(capturedFilters!.length, equals(2));
 
-        final filter = capturedFilters![0] as Filter;
-        expect(filter.kinds, contains(10000));
-        expect(filter.p, contains(ourPubkey));
+        final mutualFilter = capturedFilters![0] as Filter;
+        expect(mutualFilter.kinds, contains(10000));
+        expect(mutualFilter.p, contains(ourPubkey));
+
+        final ownFilter = capturedFilters![1] as Filter;
+        expect(ownFilter.kinds, contains(10000));
+        expect(ownFilter.authors, contains(ourPubkey));
       },
     );
 
@@ -637,6 +641,237 @@ void main() {
         expect(service.shouldFilterFromFeeds(blockedByUsPubkey), isTrue);
       },
     );
+  });
+
+  group('ContentBlocklistRepository - Own Mute List Sync', () {
+    const ourPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000001';
+    const mutedPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000002';
+    const otherMutedPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000003';
+
+    late ContentBlocklistRepository service;
+    late _MockNostrClient mockNostrService;
+    late StreamController<Event> controller;
+
+    Event ownMuteListEvent({
+      required List<String> mutedPubkeys,
+      required int createdAt,
+      String id = 'own-mute-event-id',
+    }) =>
+        Event(
+            ourPubkey,
+            10000,
+            [
+              for (final pubkey in mutedPubkeys) ['p', pubkey],
+            ],
+            '',
+            createdAt: createdAt,
+          )
+          ..id = id
+          ..sig = 'signature';
+
+    setUp(() {
+      service = ContentBlocklistRepository();
+      mockNostrService = _MockNostrClient();
+      controller = StreamController<Event>();
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => controller.stream);
+    });
+
+    tearDown(() async {
+      await controller.close();
+    });
+
+    test('own kind 10000 event populates muted authors', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [mutedPubkey, otherMutedPubkey],
+          createdAt: now,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(service.isMutedByUs(mutedPubkey), isTrue);
+      expect(service.isMutedByUs(otherMutedPubkey), isTrue);
+      expect(service.shouldFilterFromFeeds(mutedPubkey), isTrue);
+      expect(
+        service.currentState.mutedPubkeys,
+        containsAll(<String>{mutedPubkey, otherMutedPubkey}),
+      );
+      // Mutes are not blocks — the block-specific queries stay false.
+      expect(service.isBlocked(mutedPubkey), isFalse);
+      expect(service.hasMutedUs(mutedPubkey), isFalse);
+    });
+
+    test('newer own event replaces the muted set (unmute)', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [mutedPubkey, otherMutedPubkey],
+          createdAt: now,
+          id: 'own-mute-event-id-1',
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [otherMutedPubkey],
+          createdAt: now + 60,
+          id: 'own-mute-event-id-2',
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(service.isMutedByUs(mutedPubkey), isFalse);
+      expect(service.shouldFilterFromFeeds(mutedPubkey), isFalse);
+      expect(service.isMutedByUs(otherMutedPubkey), isTrue);
+    });
+
+    test('ignores stale older own mute event', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [],
+          createdAt: now + 60,
+          id: 'own-mute-event-id-newer',
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [mutedPubkey],
+          createdAt: now,
+          id: 'own-mute-event-id-older',
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(service.isMutedByUs(mutedPubkey), isFalse);
+      expect(service.shouldFilterFromFeeds(mutedPubkey), isFalse);
+    });
+
+    test('excludes our own pubkey from a self-referential mute list', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [ourPubkey, mutedPubkey],
+          createdAt: now,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // A malformed self-referential list must never filter our own
+      // content (#2192).
+      expect(service.isMutedByUs(ourPubkey), isFalse);
+      expect(service.shouldFilterFromFeeds(ourPubkey), isFalse);
+      expect(service.isMutedByUs(mutedPubkey), isTrue);
+    });
+
+    test('own mute event does not touch the mutual-mute set', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      // Our own list naming our own pubkey-of-interest must route to the
+      // own-mute handler, not register as "they muted us".
+      controller.add(
+        ownMuteListEvent(mutedPubkeys: [mutedPubkey], createdAt: now),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(service.hasMutedUs(ourPubkey), isFalse);
+      expect(service.hasMutedUs(mutedPubkey), isFalse);
+      expect(service.isMutedByUs(mutedPubkey), isTrue);
+    });
+
+    test('emits mutedByUs and unmutedByUs on the changes stream', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final changes = <BlocklistChange>[];
+      final subscription = service.changes.listen(changes.add);
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [mutedPubkey],
+          createdAt: now,
+          id: 'own-mute-event-id-1',
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [],
+          createdAt: now + 60,
+          id: 'own-mute-event-id-2',
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        changes,
+        containsAllInOrder([
+          const BlocklistChange(
+            pubkey: mutedPubkey,
+            op: BlocklistOp.mutedByUs,
+          ),
+          const BlocklistChange(
+            pubkey: mutedPubkey,
+            op: BlocklistOp.unmutedByUs,
+          ),
+        ]),
+      );
+      expect(
+        changes.firstWhere((c) => c.op == BlocklistOp.mutedByUs).isAddition,
+        isTrue,
+      );
+      expect(
+        changes.firstWhere((c) => c.op == BlocklistOp.unmutedByUs).isAddition,
+        isFalse,
+      );
+
+      await subscription.cancel();
+    });
+
+    test('persists muted authors and rehydrates at construction', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final persistedService = ContentBlocklistRepository(prefs: prefs);
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await persistedService.syncMuteListsInBackground(
+        mockNostrService,
+        ourPubkey,
+      );
+      controller.add(
+        ownMuteListEvent(mutedPubkeys: [mutedPubkey], createdAt: now),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(persistedService.isMutedByUs(mutedPubkey), isTrue);
+
+      // A fresh instance over the same prefs hydrates the muted set
+      // before any relay event arrives.
+      final rehydrated = ContentBlocklistRepository(prefs: prefs);
+      expect(rehydrated.isMutedByUs(mutedPubkey), isTrue);
+      expect(rehydrated.shouldFilterFromFeeds(mutedPubkey), isTrue);
+      expect(rehydrated.currentState.mutedPubkeys, contains(mutedPubkey));
+
+      persistedService.dispose();
+      rehydrated.dispose();
+    });
   });
 
   group('ContentBlocklistRepository - Block List Sync', () {
@@ -1083,6 +1318,17 @@ void main() {
       final service = ContentBlocklistRepository(prefs: prefs);
 
       expect(service.totalBlockedCount, equals(0));
+    });
+
+    test('ignores corrupt muted authors JSON without throwing', () async {
+      SharedPreferences.setMockInitialValues({
+        'muted_users_list': 'not valid json',
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      expect(service.currentState.mutedPubkeys, isEmpty);
     });
 
     test('loads existing severed followers from SharedPreferences', () async {

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -846,6 +846,31 @@ void main() {
       await subscription.cancel();
     });
 
+    test('continues when persisting muted authors throws', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenThrow(Exception('disk full'));
+
+      final failingService = ContentBlocklistRepository(prefs: mockPrefs);
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await failingService.syncMuteListsInBackground(
+        mockNostrService,
+        ourPubkey,
+      );
+      controller.add(
+        ownMuteListEvent(mutedPubkeys: [mutedPubkey], createdAt: now),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // The in-memory set still updates even though the write failed.
+      expect(failingService.isMutedByUs(mutedPubkey), isTrue);
+
+      failingService.dispose();
+    });
+
     test('persists muted authors and rehydrates at construction', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
Closes #948

## Description

Authors the user muted via their **own NIP-51 kind 10000 mute list** were never filtered anywhere in the app:

- `ContentBlocklistRepository` only subscribed to kind 10000 events that *name us* (mutual mute), never to our own mute list.
- `currentState` hardcoded `mutedPubkeys: const {}`, so `PubkeyMuteRule` could never fire even with `contentPolicyV2` enabled.
- `shouldFilterFromFeeds` (the live legacy enforcement) had no own-mute set.

Since this app has no mute-authoring UI, the practical impact is that mute lists published from **other Nostr clients** by the same user were silently ignored on mobile.

### Changes

- The kind 10000 sync now subscribes with a second filter for our own mute list (`authors: [ourPubkey]`), mirroring the kind 30000 block-list restore in `syncBlockListsInBackground`.
- `_handleOwnMuteListEvent` **replaces** the muted set wholesale from the newest own event (kind 10000 is replaceable and the app never authors mutes, so the latest event is the complete source of truth — unlike the block restore, which merges to protect locally-authored blocks). Stale relay deliveries are ignored via the existing per-author timestamp guard.
- Muted authors persist to SharedPreferences (`muted_users_list`) so filtering is hydrated before relay sync completes.
- `shouldFilterFromFeeds` and `ContentPolicyState.mutedPubkeys` both include the set; every existing block-filter call site (feeds, search, comments, profiles, notifications) inherits the behavior with no wiring changes. `_notifyChanged()` bumps `blocklistVersionProvider` for reactive surfaces.
- New `BlocklistOp.mutedByUs` / `unmutedByUs` ops on the `changes` stream (consumers use `isAddition`, which covers them).
- Our own pubkey is excluded from the parsed list so a malformed self-referential mute list can never filter the user's own content (#2192 guard).

### Scope notes

- Only public `p` tags are read; NIP-51 encrypted (private) mute entries are out of scope.
- Per-account storage namespacing and reset-on-account-switch are deliberately **not** in this PR — that is #4969, planned as its own PR (see `tasks/plan_948.md` in the issue plan).

**Related Issue:** #948 (PR 1 of the completion plan — see the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444))

## Verification

- `mise exec -- dart format` on changed files
- `flutter analyze lib test integration_test` — no issues
- `flutter test packages/content_blocklist_repository` — 76/76 pass (8 new tests: populate, replace/unmute, stale-event guard, self-reference exclusion, mutual-set isolation, changes-stream ops, persistence rehydration, corrupt-JSON guard)
- `flutter test test/services/video_event_service_blocklist_sweep_test.dart test/unit/services/video_event_service_search_test.dart test/providers/video_events_provider_blocklist_test.dart` — pass

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
