### PR TITLE
test(l10n): pin the content-policy disclosure invariant (#948)

### DIFF
--- a/mobile/test/l10n/disclosure_invariant_test.dart
+++ b/mobile/test/l10n/disclosure_invariant_test.dart
@@ -1,0 +1,140 @@
+// ABOUTME: Pins the content-policy disclosure invariant: the app must never
+// ABOUTME: tell a user they have been blocked or muted by another user.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Phrases that would reveal a block/mute relationship to the blocked user.
+///
+/// The disclosure invariant (see
+/// `docs/superpowers/specs/2026-04-23-content-policy-layer-design.md`)
+/// requires plausible deniability: gating is *absence* of content or
+/// affordances, never an explanation. Copy about the user's own blocks
+/// ("Blocked users", "Block user", "You blocked …") is fine — these
+/// patterns target the other direction only.
+final _forbiddenPatterns = [
+  RegExp('blocked you', caseSensitive: false),
+  RegExp('blocks you', caseSensitive: false),
+  RegExp('has blocked', caseSensitive: false),
+  RegExp('blocked by', caseSensitive: false),
+  RegExp('muted you', caseSensitive: false),
+  RegExp('mutes you', caseSensitive: false),
+  RegExp('not accepting', caseSensitive: false),
+];
+
+/// Matches single- or double-quoted Dart string literals on one line.
+/// Applied per line (comment lines excluded) so apostrophes in doc
+/// comments cannot open a phantom multi-line "literal".
+final _stringLiteral = RegExp(
+  "'(?:[^'\\\\\\n]|\\\\.)*'|\"(?:[^\"\\\\\\n]|\\\\.)*\"",
+);
+
+List<String> _violationsIn(String content, {required bool literalsOnly}) {
+  if (!literalsOnly) {
+    return [
+      for (final pattern in _forbiddenPatterns)
+        if (pattern.hasMatch(content)) 'matches "${pattern.pattern}"',
+    ];
+  }
+  final violations = <String>[];
+  final lines = content.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (line.trimLeft().startsWith('//')) continue;
+    for (final literal in _stringLiteral.allMatches(line)) {
+      final haystack = literal.group(0)!;
+      for (final pattern in _forbiddenPatterns) {
+        if (pattern.hasMatch(haystack)) {
+          violations.add(
+            'line ${i + 1}: $haystack matches "${pattern.pattern}"',
+          );
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+List<String> _violationsInArbFile(File file) {
+  final arb = (jsonDecode(file.readAsStringSync()) as Map)
+      .cast<String, Object?>();
+  final violations = <String>[];
+
+  for (final entry in arb.entries) {
+    final value = entry.value;
+    if (entry.key.startsWith('@') || value is! String) continue;
+
+    for (final violation in _violationsIn(
+      value,
+      literalsOnly: false,
+    )) {
+      violations.add('${entry.key}: $violation');
+    }
+  }
+
+  return violations;
+}
+
+void main() {
+  group('disclosure invariant', () {
+    test('localized copy never reveals a block/mute relationship', () {
+      final arbFiles = Directory('lib/l10n')
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.arb'))
+          .toList();
+      expect(arbFiles, isNotEmpty, reason: 'expected ARB files in lib/l10n');
+
+      final violations = <String>[
+        for (final file in arbFiles)
+          for (final v in _violationsInArbFile(file)) '${file.path}: $v',
+      ];
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'User-facing copy must never disclose that someone blocked or '
+            'muted the user. Gate with absence, not explanation.',
+      );
+    });
+
+    test(
+      'hardcoded string literals never reveal a block/mute relationship',
+      () {
+        final dartFiles = Directory('lib')
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where(
+              (f) =>
+                  f.path.endsWith('.dart') &&
+                  !f.path.contains('l10n/generated') &&
+                  !f.path.endsWith('.g.dart') &&
+                  !f.path.endsWith('.freezed.dart'),
+            )
+            .toList();
+        expect(dartFiles, isNotEmpty, reason: 'expected Dart files in lib/');
+
+        final violations = <String>[
+          for (final file in dartFiles)
+            for (final v in _violationsIn(
+              file.readAsStringSync(),
+              literalsOnly: true,
+            ))
+              '${file.path}: $v',
+        ];
+
+        expect(
+          violations,
+          isEmpty,
+          reason:
+              'String literals must never disclose that someone blocked or '
+              'muted the user — not in copy, logs, or analytics labels. '
+              'Gate with absence, not explanation.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #948

## Description

Adds the negative-assertion test from the content-policy spec (`docs/superpowers/specs/2026-04-23-content-policy-layer-design.md`, "Disclosure tests"): the app must never tell a user they have been blocked or muted by another user. Until now this invariant survived by convention only.

The test scans:
- every `lib/l10n/*.arb` value, and
- every non-comment Dart string literal under `lib/` (copy, log messages, analytics labels),

for relationship-revealing phrases ("blocked you", "has blocked", "blocked by", "muted you", "not accepting", …). Copy about the user's **own** blocks ("Blocked users", "Block user") is intentionally not matched — the forbidden direction is revealing *they* blocked *us*.

The codebase passes clean today; this pins it.

### Coverage inventory note (why this PR is small)

The spec's companion "surface regression tests" (blocked-author absence per surface) already exist from prior PRs, verified per-surface: `videos_repository` (all three search phases + feeds), `profile_repository` (people search), `comments_repository`, `notification_repository`, `video_events_provider_blocklist_test`, `hashtag_feed_blocklist_filter_test`, profile-feed cubit tests, VES sweep tests, and DM conversation filtering in the `content_blocklist_repository` package. The disclosure check was the only missing piece.

**Related Issue:** #948 (test workstream of the completion plan — see the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444))

## Verification

- `flutter test test/l10n/disclosure_invariant_test.dart` — 2/2 pass
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean

## Type of Change

- [x] Test improvement
