### PR TITLE
feat(moderation): engagement-list block filters + search blocklist reactivity (#948)

### DIFF
--- a/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
+++ b/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
@@ -43,6 +43,10 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
     );
     on<HashtagSearchLoadMore>(_onLoadMore, transformer: sequential());
     on<HashtagSearchCleared>(_onCleared);
+    on<HashtagSearchBlocklistChanged>(
+      _onBlocklistChanged,
+      transformer: restartable(),
+    );
   }
 
   final HashtagRepository _hashtagRepository;
@@ -66,6 +70,25 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
       return;
     }
 
+    await _runSearch(query, emit);
+  }
+
+  /// Re-runs the current search after a block/unblock so results pass
+  /// through the repository's block filter again. Bypasses the same-query
+  /// guard in [_onQueryChanged] on purpose — the query is unchanged but
+  /// the result set is not.
+  Future<void> _onBlocklistChanged(
+    HashtagSearchBlocklistChanged event,
+    Emitter<HashtagSearchState> emit,
+  ) async {
+    if (state.query.isEmpty) return;
+    await _runSearch(state.query, emit);
+  }
+
+  Future<void> _runSearch(
+    String query,
+    Emitter<HashtagSearchState> emit,
+  ) async {
     emit(
       state.copyWith(
         status: HashtagSearchStatus.loading,

--- a/mobile/lib/blocs/hashtag_search/hashtag_search_event.dart
+++ b/mobile/lib/blocs/hashtag_search/hashtag_search_event.dart
@@ -22,6 +22,12 @@ final class HashtagSearchQueryChanged extends HashtagSearchEvent {
   List<Object?> get props => [query];
 }
 
+/// The blocklist changed — re-run the current search so blocked authors
+/// disappear from (or reappear in) still-open results.
+final class HashtagSearchBlocklistChanged extends HashtagSearchEvent {
+  const HashtagSearchBlocklistChanged();
+}
+
 /// Request to load the next page of hashtag results.
 final class HashtagSearchLoadMore extends HashtagSearchEvent {
   const HashtagSearchLoadMore();

--- a/mobile/lib/blocs/list_search/list_search_bloc.dart
+++ b/mobile/lib/blocs/list_search/list_search_bloc.dart
@@ -1,6 +1,7 @@
 // ABOUTME: BLoC for searching curated video lists (kind 30005) and people lists (kind 30000).
 // ABOUTME: Merges both streams via a tagged union and uses emit.forEach for safe lifecycle.
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -51,6 +52,10 @@ class ListSearchBloc extends Bloc<ListSearchEvent, ListSearchState> {
       transformer: debounceRestartable(),
     );
     on<ListSearchCleared>(_onCleared);
+    on<ListSearchBlocklistChanged>(
+      _onBlocklistChanged,
+      transformer: restartable(),
+    );
   }
 
   final CuratedListRepository _curatedListRepository;
@@ -74,6 +79,22 @@ class ListSearchBloc extends Bloc<ListSearchEvent, ListSearchState> {
       return;
     }
 
+    await _runSearch(query, emit);
+  }
+
+  /// Re-runs the current search after a block/unblock so results pass
+  /// through the repository's block filter again. Bypasses the same-query
+  /// guard in [_onQueryChanged] on purpose — the query is unchanged but
+  /// the result set is not.
+  Future<void> _onBlocklistChanged(
+    ListSearchBlocklistChanged event,
+    Emitter<ListSearchState> emit,
+  ) async {
+    if (state.query.isEmpty) return;
+    await _runSearch(state.query, emit);
+  }
+
+  Future<void> _runSearch(String query, Emitter<ListSearchState> emit) async {
     emit(
       state.copyWith(
         status: ListSearchStatus.loading,

--- a/mobile/lib/blocs/list_search/list_search_event.dart
+++ b/mobile/lib/blocs/list_search/list_search_event.dart
@@ -22,6 +22,12 @@ final class ListSearchQueryChanged extends ListSearchEvent {
   List<Object?> get props => [query];
 }
 
+/// The blocklist changed — re-run the current search so blocked authors
+/// disappear from (or reappear in) still-open results.
+final class ListSearchBlocklistChanged extends ListSearchEvent {
+  const ListSearchBlocklistChanged();
+}
+
 /// Request to clear search results and reset to initial state.
 final class ListSearchCleared extends ListSearchEvent {
   const ListSearchCleared();

--- a/mobile/lib/blocs/video_search/video_search_bloc.dart
+++ b/mobile/lib/blocs/video_search/video_search_bloc.dart
@@ -50,6 +50,10 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
     on<VideoSearchCleared>(_onCleared);
     on<VideoSearchSortChanged>(_onSortChanged, transformer: restartable());
     on<VideoSearchLoadMore>(_onLoadMore, transformer: sequential());
+    on<VideoSearchBlocklistChanged>(
+      _onBlocklistChanged,
+      transformer: restartable(),
+    );
   }
 
   final VideosRepository _videosRepository;
@@ -75,6 +79,23 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
 
     await _search(
       query: query,
+      sort: state.sort,
+      emit: emit,
+      sessionId: _beginSearchSession(),
+    );
+  }
+
+  /// Re-runs the current search after a block/unblock so results pass
+  /// through the repository's block filter again. Bypasses the same-query
+  /// guard in [_onQueryChanged] on purpose — the query is unchanged but
+  /// the result set is not.
+  Future<void> _onBlocklistChanged(
+    VideoSearchBlocklistChanged event,
+    Emitter<VideoSearchState> emit,
+  ) async {
+    if (state.query.isEmpty) return;
+    await _search(
+      query: state.query,
       sort: state.sort,
       emit: emit,
       sessionId: _beginSearchSession(),

--- a/mobile/lib/blocs/video_search/video_search_event.dart
+++ b/mobile/lib/blocs/video_search/video_search_event.dart
@@ -22,6 +22,12 @@ final class VideoSearchQueryChanged extends VideoSearchEvent {
   List<Object?> get props => [query];
 }
 
+/// The blocklist changed — re-run the current search so blocked authors
+/// disappear from (or reappear in) still-open results.
+final class VideoSearchBlocklistChanged extends VideoSearchEvent {
+  const VideoSearchBlocklistChanged();
+}
+
 /// Request to clear search results and reset to initial state
 final class VideoSearchCleared extends VideoSearchEvent {
   const VideoSearchCleared();

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -421,6 +421,7 @@ LikesRepository likesRepository(Ref ref) {
   final repository = LikesRepository(
     nostrClient: nostrClient,
     localStorage: localStorage,
+    blockFilter: createBlockedAuthorFilter(ref),
     isOnline: () =>
         connectionStatus.isOnline && authService.canPublishNostrWritesNow,
     queueOfflineAction: pendingActionService != null
@@ -509,6 +510,7 @@ RepostsRepository repostsRepository(Ref ref) {
   final repository = RepostsRepository(
     nostrClient: nostrClient,
     localStorage: localStorage,
+    blockFilter: createBlockedAuthorFilter(ref),
     isOnline: () =>
         connectionStatus.isOnline && authService.canPublishNostrWritesNow,
     queueOfflineAction: pendingActionService != null

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -946,7 +946,7 @@ final class LikesRepositoryProvider
   }
 }
 
-String _$likesRepositoryHash() => r'a1d44aa6295dae971a6138b20b34ac03d4bd6385';
+String _$likesRepositoryHash() => r'fc6229af119fdde9c92deaa2280f26e3ce3bfb00';
 
 /// Provider for RepostsRepository instance
 ///
@@ -1019,4 +1019,4 @@ final class RepostsRepositoryProvider
   }
 }
 
-String _$repostsRepositoryHash() => r'af28cfc80599f6784cf9a98563b5358712684f49';
+String _$repostsRepositoryHash() => r'4d3840d9b241111ec4c7e95830e08932048eba31';

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -91,17 +91,51 @@ class SearchResultsPage extends ConsumerWidget {
           ),
         ),
       ],
-      child: Scaffold(
-        // bg/surface — matches SearchResultsView's body background so the
-        // app bar area (which doesn't paint its own background) doesn't
-        // show through to the root scaffold's darker default.
-        backgroundColor: VineTheme.surfaceBackground,
-        body: _SearchResultsBody(
-          initialQuery: initialQuery ?? '',
-          requestFocusOnMount: requestFocusOnMount,
+      child: _BlocklistRefreshListener(
+        child: Scaffold(
+          // bg/surface — matches SearchResultsView's body background so the
+          // app bar area (which doesn't paint its own background) doesn't
+          // show through to the root scaffold's darker default.
+          backgroundColor: VineTheme.surfaceBackground,
+          body: _SearchResultsBody(
+            initialQuery: initialQuery ?? '',
+            requestFocusOnMount: requestFocusOnMount,
+          ),
         ),
       ),
     );
+  }
+}
+
+/// Re-runs the active searches when the blocklist changes, so an author
+/// blocked from a result's profile disappears from still-open search
+/// results without a manual re-search (and reappears after an unblock).
+///
+/// Re-dispatching the current query is safe: every search bloc debounces
+/// and uses a restartable transformer, and results are re-fetched through
+/// repository paths that apply the block filter.
+class _BlocklistRefreshListener extends ConsumerWidget {
+  const _BlocklistRefreshListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<int>(blocklistVersionProvider, (previous, next) {
+      if (previous == next) return;
+      context.read<VideoSearchBloc>().add(const VideoSearchBlocklistChanged());
+      context.read<HashtagSearchBloc>().add(
+        const HashtagSearchBlocklistChanged(),
+      );
+      context.read<ListSearchBloc>().add(const ListSearchBlocklistChanged());
+      // UserSearchBloc has no same-query guard (see its _onQueryChanged),
+      // so re-dispatching the current query re-runs the search as-is.
+      final userQuery = context.read<UserSearchBloc>().state.query;
+      if (userQuery.isNotEmpty) {
+        context.read<UserSearchBloc>().add(UserSearchQueryChanged(userQuery));
+      }
+    });
+    return child;
   }
 }
 

--- a/mobile/packages/likes_repository/lib/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/likes_repository.dart
@@ -8,6 +8,7 @@
 /// - Various typed exceptions for error handling
 library;
 
+export 'src/blocked_liker_filter.dart';
 export 'src/db_likes_local_storage.dart';
 export 'src/exceptions.dart';
 export 'src/likes_local_storage.dart';

--- a/mobile/packages/likes_repository/lib/src/blocked_liker_filter.dart
+++ b/mobile/packages/likes_repository/lib/src/blocked_liker_filter.dart
@@ -1,0 +1,10 @@
+// ABOUTME: Filter callback for liker pubkeys in the repository layer.
+// ABOUTME: Allows app to inject blocklist/mute logic without coupling.
+
+/// Filter callback for liker pubkeys.
+///
+/// Returns `true` if the user with [pubkey] should be hidden from
+/// engagement lists (user is blocked/muted).
+///
+/// This keeps the repository decoupled from app-level services.
+typedef BlockedLikerFilter = bool Function(String pubkey);

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:likes_repository/src/blocked_liker_filter.dart';
 import 'package:likes_repository/src/exceptions.dart';
 import 'package:likes_repository/src/likes_local_storage.dart';
 import 'package:likes_repository/src/models/like_record.dart';
@@ -66,18 +67,25 @@ class LikesRepository {
   /// - [localStorage]: Optional local storage for persistence
   /// - [isOnline]: Optional callback to check connectivity status
   /// - [queueOfflineAction]: Optional callback to queue actions when offline
+  /// - [blockFilter]: Optional callback to hide blocked/muted users from
+  ///   engagement lists ([fetchEventLikers])
   LikesRepository({
     required NostrClient nostrClient,
     LikesLocalStorage? localStorage,
     IsOnlineCallback? isOnline,
     QueueOfflineActionCallback? queueOfflineAction,
+    BlockedLikerFilter? blockFilter,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _isOnline = isOnline,
-       _queueOfflineAction = queueOfflineAction;
+       _queueOfflineAction = queueOfflineAction,
+       _blockFilter = blockFilter;
 
   final NostrClient _nostrClient;
   final LikesLocalStorage? _localStorage;
+
+  /// Callback to hide blocked/muted users from engagement lists
+  final BlockedLikerFilter? _blockFilter;
 
   /// Callback to check if the device is online
   final IsOnlineCallback? _isOnline;
@@ -1162,6 +1170,7 @@ class LikesRepository {
   /// Filters out:
   /// - Reactions with content `'-'` (downvotes)
   /// - Reactions deleted via Kind 5 deletion events from their author
+  /// - Likers hidden by the injected block filter (blocked/muted users)
   ///
   /// Pubkeys are deduplicated (a user who liked via both `e` and `a` tags
   /// only appears once) and ordered by reaction recency, most recent first.
@@ -1241,6 +1250,7 @@ class LikesRepository {
       final likerPubkeys = <String>[];
       final seenPubkeys = <String>{};
       for (final event in survivors) {
+        if (_blockFilter?.call(event.pubkey) ?? false) continue;
         if (seenPubkeys.add(event.pubkey)) {
           likerPubkeys.add(event.pubkey);
         }

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -75,12 +75,14 @@ void main() {
       bool withLocalStorage = true,
       IsOnlineCallback? isOnline,
       QueueOfflineActionCallback? queueOfflineAction,
+      BlockedLikerFilter? blockFilter,
     }) {
       return LikesRepository(
         nostrClient: mockNostrClient,
         localStorage: withLocalStorage ? mockLocalStorage : null,
         isOnline: isOnline,
         queueOfflineAction: queueOfflineAction,
+        blockFilter: blockFilter,
       );
     }
 
@@ -2223,6 +2225,31 @@ void main() {
 
         expect(likers, hasLength(2));
         expect(likers, [likerB, likerA]);
+      });
+
+      test('excludes likers hidden by the block filter', () async {
+        final blockedReaction = createReaction(
+          id: 'reaction_blocked',
+          authorPubkey: likerA,
+          createdAt: 1700000100,
+        );
+        final allowedReaction = createReaction(
+          id: 'reaction_allowed',
+          authorPubkey: likerB,
+          createdAt: 1699999900,
+        );
+
+        mockQueryEventsSequence([
+          [blockedReaction, allowedReaction],
+          <Event>[],
+        ]);
+
+        repository = createRepository(
+          blockFilter: (pubkey) => pubkey == likerA,
+        );
+        expect(await repository.fetchEventLikers(eventId: targetEventId), [
+          likerB,
+        ]);
       });
 
       test('excludes pubkeys whose only reactions are downvotes', () async {

--- a/mobile/packages/reposts_repository/lib/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/reposts_repository.dart
@@ -1,6 +1,7 @@
 /// Repository for managing user reposts (Kind 16 generic reposts) with Nostr.
 library;
 
+export 'src/blocked_reposter_filter.dart';
 export 'src/db_reposts_local_storage.dart';
 export 'src/exceptions.dart';
 export 'src/models/models.dart';

--- a/mobile/packages/reposts_repository/lib/src/blocked_reposter_filter.dart
+++ b/mobile/packages/reposts_repository/lib/src/blocked_reposter_filter.dart
@@ -1,0 +1,10 @@
+// ABOUTME: Filter callback for reposter pubkeys in the repository layer.
+// ABOUTME: Allows app to inject blocklist/mute logic without coupling.
+
+/// Filter callback for reposter pubkeys.
+///
+/// Returns `true` if the user with [pubkey] should be hidden from
+/// engagement lists (user is blocked/muted).
+///
+/// This keeps the repository decoupled from app-level services.
+typedef BlockedReposterFilter = bool Function(String pubkey);

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:reposts_repository/src/blocked_reposter_filter.dart';
 import 'package:reposts_repository/src/exceptions.dart';
 import 'package:reposts_repository/src/models/repost_record.dart';
 import 'package:reposts_repository/src/models/reposts_sync_result.dart';
@@ -59,18 +60,25 @@ class RepostsRepository {
   /// - [localStorage]: Optional local storage for persistence
   /// - [isOnline]: Optional callback to check connectivity status
   /// - [queueOfflineAction]: Optional callback to queue actions when offline
+  /// - [blockFilter]: Optional callback to hide blocked/muted users from
+  ///   engagement lists ([fetchEventReposters])
   RepostsRepository({
     required NostrClient nostrClient,
     RepostsLocalStorage? localStorage,
     IsOnlineCallback? isOnline,
     QueueOfflineRepostCallback? queueOfflineAction,
+    BlockedReposterFilter? blockFilter,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _isOnline = isOnline,
-       _queueOfflineAction = queueOfflineAction;
+       _queueOfflineAction = queueOfflineAction,
+       _blockFilter = blockFilter;
 
   final NostrClient _nostrClient;
   final RepostsLocalStorage? _localStorage;
+
+  /// Callback to hide blocked/muted users from engagement lists
+  final BlockedReposterFilter? _blockFilter;
 
   /// Callback to check if the device is online
   final IsOnlineCallback? _isOnline;
@@ -750,8 +758,9 @@ class RepostsRepository {
   /// the other.
   ///
   /// Filters out reposts deleted via Kind 5 deletion events from their
-  /// author. Pubkeys are deduplicated and ordered by repost recency,
-  /// most recent first.
+  /// author, and reposters hidden by the injected block filter
+  /// (blocked/muted users). Pubkeys are deduplicated and ordered by
+  /// repost recency, most recent first.
   ///
   /// Parameters:
   /// - [eventId]: Hex event ID of the target event (required).
@@ -825,6 +834,7 @@ class RepostsRepository {
       final orderedPubkeys = <String>[];
       final seen = <String>{};
       for (final event in liveReposts) {
+        if (_blockFilter?.call(event.pubkey) ?? false) continue;
         if (seen.add(event.pubkey)) {
           orderedPubkeys.add(event.pubkey);
         }

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -1458,6 +1458,41 @@ void main() {
         expect(result, isEmpty);
       });
 
+      test('excludes reposters hidden by the block filter', () async {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        wireQueryEvents(
+          eFilterEvents: [
+            createReposterEvent(
+              id: 'repost_blocked',
+              pubkey: 'blocked_reposter',
+              kind: EventKind.genericRepost,
+              createdAt: now,
+              tags: [
+                ['e', testEventId],
+              ],
+            ),
+            createReposterEvent(
+              id: 'repost_allowed',
+              pubkey: 'allowed_reposter',
+              kind: EventKind.genericRepost,
+              createdAt: now - 100,
+              tags: [
+                ['e', testEventId],
+              ],
+            ),
+          ],
+        );
+
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+          blockFilter: (pubkey) => pubkey == 'blocked_reposter',
+        );
+
+        expect(await repository.fetchEventReposters(eventId: testEventId), [
+          'allowed_reposter',
+        ]);
+      });
+
       test('returns reposter pubkeys ordered by recency', () async {
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         wireQueryEvents(

--- a/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
+++ b/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
@@ -348,6 +348,48 @@ void main() {
       );
     });
 
+    group('HashtagSearchBlocklistChanged', () {
+      blocTest<HashtagSearchBloc, HashtagSearchState>(
+        're-runs the current search, bypassing the same-query guard',
+        setUp: () {
+          when(
+            () => mockHashtagRepository.searchHashtags(query: 'music'),
+          ).thenAnswer((_) async => ['music']);
+        },
+        build: createBloc,
+        seed: () => const HashtagSearchState(
+          status: HashtagSearchStatus.success,
+          query: 'music',
+          results: ['music', 'musicvideo'],
+        ),
+        act: (bloc) => bloc.add(const HashtagSearchBlocklistChanged()),
+        expect: () => [
+          isA<HashtagSearchState>().having(
+            (s) => s.status,
+            'status',
+            HashtagSearchStatus.loading,
+          ),
+          isA<HashtagSearchState>().having(
+            (s) => s.status,
+            'status',
+            HashtagSearchStatus.success,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockHashtagRepository.searchHashtags(query: 'music'),
+          ).called(1);
+        },
+      );
+
+      blocTest<HashtagSearchBloc, HashtagSearchState>(
+        'does nothing when no search is active',
+        build: createBloc,
+        act: (bloc) => bloc.add(const HashtagSearchBlocklistChanged()),
+        expect: () => <HashtagSearchState>[],
+      );
+    });
+
     group('HashtagSearchLoadMore', () {
       blocTest<HashtagSearchBloc, HashtagSearchState>(
         'appends results and updates offset',

--- a/mobile/test/blocs/list_search/list_search_bloc_test.dart
+++ b/mobile/test/blocs/list_search/list_search_bloc_test.dart
@@ -321,6 +321,42 @@ void main() {
       );
     });
 
+    group(ListSearchBlocklistChanged, () {
+      blocTest<ListSearchBloc, ListSearchState>(
+        're-runs the current search, bypassing the same-query guard',
+        build: buildBloc,
+        seed: () => const ListSearchState(
+          status: ListSearchStatus.success,
+          query: 'videos',
+        ),
+        act: (bloc) => bloc.add(const ListSearchBlocklistChanged()),
+        expect: () => [
+          isA<ListSearchState>().having(
+            (s) => s.status,
+            'status',
+            ListSearchStatus.loading,
+          ),
+          isA<ListSearchState>().having(
+            (s) => s.status,
+            'status',
+            ListSearchStatus.success,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => curatedListRepository.searchAllLists('videos'),
+          ).called(1);
+        },
+      );
+
+      blocTest<ListSearchBloc, ListSearchState>(
+        'does nothing when no search is active',
+        build: buildBloc,
+        act: (bloc) => bloc.add(const ListSearchBlocklistChanged()),
+        expect: () => <ListSearchState>[],
+      );
+    });
+
     group(ListSearchCleared, () {
       blocTest<ListSearchBloc, ListSearchState>(
         'resets to initial state',

--- a/mobile/test/blocs/video_search/video_search_bloc_test.dart
+++ b/mobile/test/blocs/video_search/video_search_bloc_test.dart
@@ -422,6 +422,54 @@ void main() {
       );
     });
 
+    group('VideoSearchBlocklistChanged', () {
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        're-runs the current search, bypassing the same-query guard',
+        build: createBloc,
+        seed: () => VideoSearchState(
+          status: VideoSearchStatus.success,
+          query: 'flutter',
+          videos: [createVideo(id: 'v1', title: 'Flutter Tutorial')],
+        ),
+        act: (bloc) => bloc.add(const VideoSearchBlocklistChanged()),
+        expect: () => [
+          isA<VideoSearchState>().having(
+            (s) => s.status,
+            'status',
+            VideoSearchStatus.searching,
+          ),
+          isA<VideoSearchState>().having(
+            (s) => s.status,
+            'status',
+            VideoSearchStatus.success,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.searchVideos(
+              query: 'flutter',
+              sort: any(named: 'sort'),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'does nothing when no search is active',
+        build: createBloc,
+        act: (bloc) => bloc.add(const VideoSearchBlocklistChanged()),
+        expect: () => <VideoSearchState>[],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.searchVideos(
+              query: any(named: 'query'),
+              sort: any(named: 'sort'),
+            ),
+          );
+        },
+      );
+    });
+
     group('VideoSearchCleared', () {
       blocTest<VideoSearchBloc, VideoSearchState>(
         'resets to initial state',

--- a/mobile/test/screens/search_results/view/search_results_page_test.dart
+++ b/mobile/test/screens/search_results/view/search_results_page_test.dart
@@ -1,11 +1,16 @@
 @Tags(['skip_very_good_optimization'])
+import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hashtag_repository/hashtag_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/search_results/widgets/widgets.dart';
+import 'package:people_lists_repository/people_lists_repository.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
@@ -14,16 +19,30 @@ class _MockVideosRepository extends Mock implements VideosRepository {}
 
 class _MockHashtagRepository extends Mock implements HashtagRepository {}
 
+class _MockCuratedListRepository extends Mock
+    implements CuratedListRepository {}
+
+class _MockPeopleListsRepository extends Mock
+    implements PeopleListsRepository {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(defaultVideoSearchSort);
+  });
+
   group(SearchResultsPage, () {
     late MockProfileRepository mockProfileRepository;
     late _MockVideosRepository mockVideosRepository;
     late _MockHashtagRepository mockHashtagRepository;
+    late _MockCuratedListRepository mockCuratedListRepository;
+    late _MockPeopleListsRepository mockPeopleListsRepository;
 
     setUp(() {
       mockProfileRepository = createMockProfileRepository();
       mockVideosRepository = _MockVideosRepository();
       mockHashtagRepository = _MockHashtagRepository();
+      mockCuratedListRepository = _MockCuratedListRepository();
+      mockPeopleListsRepository = _MockPeopleListsRepository();
     });
 
     Widget createTestWidget() {
@@ -33,9 +52,90 @@ void main() {
         additionalOverrides: [
           videosRepositoryProvider.overrideWithValue(mockVideosRepository),
           hashtagRepositoryProvider.overrideWithValue(mockHashtagRepository),
+          curatedListRepositoryProvider.overrideWithValue(
+            mockCuratedListRepository,
+          ),
+          peopleListsRepositoryProvider.overrideWithValue(
+            mockPeopleListsRepository,
+          ),
         ],
       );
     }
+
+    testWidgets('re-runs active searches when the blocklist changes', (
+      tester,
+    ) async {
+      when(
+        () => mockVideosRepository.searchVideos(
+          query: any(named: 'query'),
+          sort: any(named: 'sort'),
+        ),
+      ).thenAnswer((_) => Stream.value(const <VideoEvent>[]));
+      when(
+        () => mockProfileRepository.searchUsersProgressive(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+          sortBy: any(named: 'sortBy'),
+          hasVideos: any(named: 'hasVideos'),
+          boostPubkeys: any(named: 'boostPubkeys'),
+        ),
+      ).thenAnswer((_) => const Stream<ProgressiveSearchResult>.empty());
+      when(
+        () => mockHashtagRepository.searchHashtags(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => const <String>[]);
+      when(
+        () => mockCuratedListRepository.searchAllLists(any()),
+      ).thenAnswer((_) => Stream.value(const <CuratedList>[]));
+      when(
+        () => mockPeopleListsRepository.searchPublicLists(any()),
+      ).thenAnswer((_) => Stream.value(const <PeopleListSearchResult>[]));
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'andy');
+      // Advance past the search debounce window so the blocs fire.
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      verify(
+        () => mockVideosRepository.searchVideos(
+          query: 'andy',
+          sort: any(named: 'sort'),
+        ),
+      ).called(1);
+
+      // A block/unblock anywhere in the app bumps the blocklist version.
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SearchResultsPage)),
+      );
+      container.read(blocklistVersionProvider.notifier).increment();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+
+      // The still-open searches re-ran through the (block-filtering)
+      // repository paths.
+      verify(
+        () => mockVideosRepository.searchVideos(
+          query: 'andy',
+          sort: any(named: 'sort'),
+        ),
+      ).called(1);
+      verify(
+        () => mockHashtagRepository.searchHashtags(
+          query: 'andy',
+          limit: any(named: 'limit'),
+        ),
+      ).called(greaterThanOrEqualTo(2));
+
+      // Dispose and drain pending debounce timers.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 400));
+    });
 
     testWidgets('shows the empty-query idle placeholder in default mode', (
       tester,


### PR DESCRIPTION
Closes #948

## Description

Two related gap-closures from the #948 completion plan (see the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444)), one commit each:

### 1. Engagement lists — `likes_repository` / `reposts_repository` block-filter hooks

The who-liked / who-reposted lists were the last content surfaces with **no block filter anywhere on their path**: `fetchEventLikers` and `fetchEventReposters` returned raw relay pubkeys, so a blocked user still surfaced as a profile row in `VideoEngagementListScreen`. Both repositories now take the same injectable `blockFilter` seam the comments/profile/notification repositories already use, wired through the flag-switched `createBlockedAuthorFilter` (legacy `shouldFilterFromFeeds` today, content-policy engine under `contentPolicyV2`). Display counts still come from funnelcake stats — only the visible list is filtered.

### 2. Search reactivity — open results re-run on block/unblock

Blocking an author from a search result's profile left their content visible when returning to the still-open results (next search was clean; the open one never re-filtered). The search page now listens to `blocklistVersionProvider` and re-runs active searches:

- `VideoSearchBloc` / `HashtagSearchBloc` / `ListSearchBloc` gain a `*BlocklistChanged` event that re-runs the current query **bypassing the same-query guard** (re-dispatching the query is a no-op in these blocs by design). This mirrors the existing `*BlocklistChanged` idiom in the followers/DM blocs.
- `UserSearchBloc` deliberately has no same-query guard (documented in its handler), so the listener re-dispatches its current query as-is.
- Re-fetching (rather than client-side re-filtering of held state) means unblock also restores content, matching the spec's cache-invalidation model.

### Bootstrap-hydration note (plan Task 1.4, no code needed)

Verified during this work: blocklist hydration is synchronous in the `ContentBlocklistRepository` constructor and every repository's `blockFilter` is wired at provider construction before any fetch, so the spec's "hydrate before first fetch" invariant holds structurally. Pinned by the existing package test "currentState reflects persisted blocks at construction".

**Related Issue:** #948

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test packages/likes_repository packages/reposts_repository` — 293/293 (2 new block-filter tests)
- `flutter test test/blocs/video_search test/blocs/hashtag_search test/blocs/list_search test/blocs/user_search` — 122/122 (6 new)
- `flutter test test/screens/search_results/view/search_results_page_test.dart` — incl. new end-to-end reactivity test (enter query → bump blocklist version → repositories re-queried)
- `flutter test test/screens/video_engagement test/screens/feed/pooled_video_feed_item_repo_swap_test.dart test/widgets/video_feed_item/feed_videos_repo_swap_test.dart` — pass
- `dart format` — clean

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
