### PR TITLE
fix(feed): warm next video before preload grace

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -216,11 +216,12 @@ class InfiniteVideoFeed extends StatefulWidget {
   final Duration slowLoadThreshold;
 
   /// How long to give the current video a bandwidth head-start before
-  /// initializing neighbour controllers (previous / next).
+  /// initializing the previous neighbour controller.
   ///
-  /// Neighbour init fires as soon as the current video renders its first
-  /// frame, or after this duration — whichever is earlier. Defaults to
-  /// 3 seconds, matching the legacy pooled_video_player behaviour.
+  /// The next neighbour initializes immediately after the current video so a
+  /// forward swipe does not land on a cold player. The previous neighbour init
+  /// fires as soon as the current video renders its first frame, or after this
+  /// duration — whichever is earlier. Defaults to 3 seconds.
   final Duration preloadGracePeriod;
 
   @override
@@ -564,9 +565,16 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
     if (_playerWindowGeneration != generation || !mounted) return;
 
-    // Give the current video a bandwidth head-start before loading
-    // neighbours. Wait for the first frame or the grace period — whichever
-    // comes first — so fast connections don't delay neighbour init at all.
+    if (widget.keepNextAlive &&
+        index + 1 <= lastIndex &&
+        !_controllers.containsKey(index + 1)) {
+      unawaited(_initController(index + 1));
+    }
+
+    // Give the current video a bandwidth head-start before loading the
+    // previous neighbour. The next neighbour is already warming above because
+    // forward swipes are the primary feed path and should not hit a cold
+    // controller.
     final currentController = _controllers[index];
     if (currentController != null) {
       await _waitForFirstFrameOrGracePeriod(currentController);
@@ -578,12 +586,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         index - 1 >= 0 &&
         !_controllers.containsKey(index - 1)) {
       unawaited(_initController(index - 1));
-    }
-
-    if (widget.keepNextAlive &&
-        index + 1 <= lastIndex &&
-        !_controllers.containsKey(index + 1)) {
-      unawaited(_initController(index + 1));
     }
   }
 

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -24,7 +24,10 @@ class _NativePlayerHarness {
   static const _globalChannel = MethodChannel('divine_video_player');
   static const _codec = StandardMethodCodec();
 
-  Future<void> install({Iterable<int> playerIds = const <int>[0, 1, 2]}) async {
+  Future<void> install({
+    Iterable<int> playerIds = const <int>[0, 1, 2],
+    bool firstFrameRenderedOnListen = true,
+  }) async {
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
       _globalChannel,
       (call) async {
@@ -60,11 +63,11 @@ class _NativePlayerHarness {
           final call = _codec.decodeMethodCall(message);
           if (call.method == 'listen') {
             scheduleMicrotask(() async {
-              await sendEvent(playerId, const <Object?, Object?>{
+              await sendEvent(playerId, <Object?, Object?>{
                 'status': 'ready',
                 'videoWidth': 1280,
                 'videoHeight': 720,
-                'isFirstFrameRendered': true,
+                'isFirstFrameRendered': firstFrameRenderedOnListen,
               });
             });
           }
@@ -733,6 +736,46 @@ void main() {
           await harness.dispose();
         }
       });
+
+      testWidgets(
+        'initializes next controller before current first frame '
+        'or grace period',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(
+            playerIds: const <int>[0, 1],
+            firstFrameRenderedOnListen: false,
+          );
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  videos: [_makeVideo('current'), _makeVideo('next')],
+                  cache: cache,
+                  prefetchCount: 0,
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            expect(harness.methodCalls, contains('player_1:setClips'));
+            await harness.sendEvent(0, const <Object?, Object?>{
+              'status': 'ready',
+              'videoWidth': 1280,
+              'videoHeight': 720,
+              'isFirstFrameRendered': true,
+            });
+            await tester.pump();
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
 
       testWidgets('does not autoplay after becoming inactive mid-init', (
         tester,


### PR DESCRIPTION
## Summary
- Warm the next feed controller immediately after the current controller initializes, without waiting for the preload grace period.
- Keep the grace delay for the previous controller to preserve the current video's bandwidth head-start behavior.
- Add a regression test for slow first-frame rendering so forward preloading stays covered.

## Root cause
The feed waited for the current video's first frame, or the 3 second preload grace period, before initializing both neighbouring controllers. On slow loads, a quick forward swipe could still land on a cold next controller.

Closes #5008

## Verification
- mise exec -- flutter test from mobile/packages/infinite_video_feed
- mise exec -- flutter analyze from mobile
- pre-push hook: analyzer and changed widget test passed