### PR TITLE
fix(timeline): preserve markers in clip history writes

### DIFF
--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -85,13 +85,20 @@ extension VideoEditorExtensions on ProImageEditorState {
   void setVolumeState({
     required List<DivineVideoClip> clips,
     required List<AudioEvent> audioTracks,
+  }) => setClipAndAudioState(clips: clips, audioTracks: audioTracks);
+
+  /// Persists clips and audio tracks in a single history entry.
+  ///
+  /// Use this when an edit changes both the clip list and the sound timeline
+  /// so undo/redo restores the full timeline atomically.
+  void setClipAndAudioState({
+    required List<DivineVideoClip> clips,
+    required List<AudioEvent> audioTracks,
+    List<Duration>? timelineMarkers,
   }) {
     addHistory(
       meta: {
-        ...stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey: clips
-            .map((c) => c.toJson())
-            .toList(),
+        ..._clipHistoryMeta(clips, timelineMarkers: timelineMarkers),
         VideoEditorConstants.audioStateHistoryKey: audioTracks
             .map((e) => e.toJson())
             .toList(),
@@ -116,7 +123,7 @@ extension VideoEditorExtensions on ProImageEditorState {
     // Keep anchored (extracted, not-yet-moved) audio aligned to its source
     // clip after this clip edit, so trimming a clip's left edge produces a
     // J-Cut without losing sync. Only rewrite the audio key when a track
-    // actually moved — `rebaseAnchoredAudioForClipState` returns the same
+    // actually moved - `rebaseAnchoredAudioForClipState` returns the same
     // list instance otherwise.
     final currentTracks = stateManager.audioTracks;
     final rebasedTracks = rebaseAnchoredAudioForClipState(clips, currentTracks);
@@ -125,15 +132,12 @@ extension VideoEditorExtensions on ProImageEditorState {
         ? rebasedTracks.map((e) => e.toJson()).toList()
         : null;
 
-    final meta = {
-      ...stateManager.activeMeta,
-      VideoEditorConstants.clipsStateHistoryKey: serialized,
-      VideoEditorConstants.audioStateHistoryKey: ?serializedAudio,
-      if (timelineMarkers != null)
-        VideoEditorConstants.timelineMarkersStateHistoryKey: timelineMarkers
-            .map((marker) => marker.inMilliseconds)
-            .toList(),
-    };
+    final meta = _clipHistoryMeta(
+      clips,
+      serializedClips: serialized,
+      serializedAudio: serializedAudio,
+      timelineMarkers: timelineMarkers,
+    );
 
     if (!skipUpdateHistory) {
       addHistory(meta: meta);
@@ -144,13 +148,28 @@ extension VideoEditorExtensions on ProImageEditorState {
         stateManager.activeMeta[VideoEditorConstants.audioStateHistoryKey] =
             serializedAudio;
       }
-      if (timelineMarkers != null) {
-        stateManager.activeMeta[VideoEditorConstants
-            .timelineMarkersStateHistoryKey] = timelineMarkers
-            .map((marker) => marker.inMilliseconds)
-            .toList();
-      }
+      stateManager.activeMeta[VideoEditorConstants
+              .timelineMarkersStateHistoryKey] =
+          meta[VideoEditorConstants.timelineMarkersStateHistoryKey];
     }
     setState(() {});
+  }
+
+  Map<String, dynamic> _clipHistoryMeta(
+    List<DivineVideoClip> clips, {
+    List<Map<String, dynamic>>? serializedClips,
+    List<Map<String, dynamic>>? serializedAudio,
+    List<Duration>? timelineMarkers,
+  }) {
+    final markers = timelineMarkers ?? stateManager.timelineMarkers;
+    return {
+      ...stateManager.activeMeta,
+      VideoEditorConstants.clipsStateHistoryKey:
+          serializedClips ?? clips.map((c) => c.toJson()).toList(),
+      VideoEditorConstants.audioStateHistoryKey: ?serializedAudio,
+      VideoEditorConstants.timelineMarkersStateHistoryKey: markers
+          .map((marker) => marker.inMilliseconds)
+          .toList(),
+    };
   }
 }

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -17,6 +17,7 @@ import 'package:openvine/blocs/video_editor/sticker/video_editor_sticker_bloc.da
 import 'package:openvine/blocs/video_editor/text_editor/video_editor_text_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -299,14 +300,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
     clipEditorBloc.add(ClipEditorInitialized(updatedClips));
 
     if (_editor != null) {
-      _editor!.addHistory(
-        meta: {
-          ..._editor!.stateManager.activeMeta,
-          VideoEditorConstants.clipsStateHistoryKey: updatedClips
-              .map((e) => e.toJson())
-              .toList(),
-        },
-      );
+      _editor!.setClipState(updatedClips);
     }
   }
 

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -7,6 +7,7 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
@@ -230,17 +231,7 @@ class _AudioExtractionResultListener extends StatelessWidget {
     // combine with the new audio track for a single atomic history entry
     // so undo/redo reverts both the mute and the added track together.
     final updatedTracks = [...editor.stateManager.audioTracks, audioEvent];
-    editor.addHistory(
-      meta: {
-        ...editor.stateManager.activeMeta,
-        VideoEditorConstants.clipsStateHistoryKey: state.clips
-            .map((c) => c.toJson())
-            .toList(),
-        VideoEditorConstants.audioStateHistoryKey: updatedTracks
-            .map((e) => e.toJson())
-            .toList(),
-      },
-    );
+    editor.setClipAndAudioState(clips: state.clips, audioTracks: updatedTracks);
   }
 }
 

--- a/mobile/test/extensions/video_editor_extensions_test.dart
+++ b/mobile/test/extensions/video_editor_extensions_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _MockStateManager extends Mock implements StateManager {}
+
+DivineVideoClip _clip(String id) => DivineVideoClip(
+  id: id,
+  video: EditorVideo.file('/tmp/$id.mp4'),
+  duration: const Duration(seconds: 3),
+  recordedAt: DateTime(2026),
+  targetAspectRatio: .vertical,
+  originalAspectRatio: 9 / 16,
+);
+
+void main() {
+  late _MockProImageEditorState editor;
+  late _MockStateManager stateManager;
+
+  setUp(() {
+    editor = _MockProImageEditorState();
+    stateManager = _MockStateManager();
+
+    when(() => editor.stateManager).thenReturn(stateManager);
+    when(
+      () => editor.addHistory(
+        layers: any(named: 'layers'),
+        filters: any(named: 'filters'),
+        meta: any(named: 'meta'),
+        newLayer: any(named: 'newLayer'),
+        transformConfigs: any(named: 'transformConfigs'),
+        tuneAdjustments: any(named: 'tuneAdjustments'),
+        blur: any(named: 'blur'),
+        heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+        blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+      ),
+    ).thenAnswer((_) {});
+    when(() => editor.setState(any())).thenAnswer((invocation) {
+      final callback = invocation.positionalArguments.single as VoidCallback;
+      callback();
+    });
+  });
+
+  group('VideoEditorExtensions', () {
+    test('setClipState carries current timeline markers by default', () {
+      when(() => stateManager.activeMeta).thenReturn({
+        VideoEditorConstants.timelineMarkersStateHistoryKey: [1200, 2400],
+      });
+
+      editor.setClipState([_clip('clip-1')]);
+
+      final meta =
+          verify(
+                () => editor.addHistory(meta: captureAny(named: 'meta')),
+              ).captured.single
+              as Map<String, dynamic>;
+
+      expect(
+        meta[VideoEditorConstants.timelineMarkersStateHistoryKey],
+        equals([1200, 2400]),
+      );
+      expect(
+        meta[VideoEditorConstants.clipsStateHistoryKey],
+        isA<List<dynamic>>().having((clips) => clips.length, 'length', 1),
+      );
+    });
+
+    test('setClipAndAudioState carries current markers atomically', () {
+      const audio = AudioEvent(id: 'audio-1', pubkey: 'pub', createdAt: 1);
+      when(() => stateManager.activeMeta).thenReturn({
+        VideoEditorConstants.timelineMarkersStateHistoryKey: [1500],
+      });
+
+      editor.setClipAndAudioState(
+        clips: [_clip('clip-1')],
+        audioTracks: const [audio],
+      );
+
+      final meta =
+          verify(
+                () => editor.addHistory(meta: captureAny(named: 'meta')),
+              ).captured.single
+              as Map<String, dynamic>;
+
+      expect(
+        meta[VideoEditorConstants.timelineMarkersStateHistoryKey],
+        equals([1500]),
+      );
+      expect(
+        meta[VideoEditorConstants.audioStateHistoryKey],
+        equals([audio.toJson()]),
+      );
+      expect(
+        meta[VideoEditorConstants.clipsStateHistoryKey],
+        isA<List<dynamic>>().having((clips) => clips.length, 'length', 1),
+      );
+    });
+
+    test('setClipState updates current markers when skipping history', () {
+      final activeMeta = <String, dynamic>{
+        VideoEditorConstants.timelineMarkersStateHistoryKey: [900],
+      };
+      when(() => stateManager.activeMeta).thenReturn(activeMeta);
+
+      editor.setClipState([_clip('clip-1')], skipUpdateHistory: true);
+
+      expect(
+        activeMeta[VideoEditorConstants.timelineMarkersStateHistoryKey],
+        equals([900]),
+      );
+      expect(
+        activeMeta[VideoEditorConstants.clipsStateHistoryKey],
+        isA<List<dynamic>>().having((clips) => clips.length, 'length', 1),
+      );
+      verifyNever(() => editor.addHistory(meta: any(named: 'meta')));
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -181,7 +181,9 @@ void main() {
           initialState: const ClipEditorState(),
         );
         when(() => mockEditor.stateManager).thenReturn(mockStateManager);
-        when(() => mockStateManager.activeMeta).thenReturn(const {});
+        when(() => mockStateManager.activeMeta).thenReturn({
+          VideoEditorConstants.timelineMarkersStateHistoryKey: [1250],
+        });
         when(
           () => mockEditor.addHistory(
             layers: any(named: 'layers'),
@@ -217,6 +219,10 @@ void main() {
         expect(
           captured[VideoEditorConstants.audioStateHistoryKey],
           equals([audioEvent.toJson()]),
+        );
+        expect(
+          captured[VideoEditorConstants.timelineMarkersStateHistoryKey],
+          equals([1250]),
         );
       },
     );


### PR DESCRIPTION
Closes #5017

## Description

Hardens the timeline marker history path after #5005 by routing the remaining clip-state history writes through shared editor extensions instead of hand-rolled addHistory metadata maps.

Changes:

- Adds setClipAndAudioState for atomic clip + audio history writes.
- Makes setClipState carry the current timeline markers by default when explicit rebased markers are not passed.
- Routes external clip sync and audio extraction history writes through the shared helpers.
- Adds extension-level tests and strengthens the scaffold audio extraction test to assert marker preservation.

## Verification

- mise exec -- flutter analyze lib test
- mise exec -- flutter test test/extensions/video_editor_extensions_test.dart test/widgets/video_editor/video_editor_scaffold_test.dart test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
- mise exec -- flutter test
- pre-push hook: analyze + changed-file tests