### PR TITLE
fix(feed): preserve home video position

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -431,7 +431,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       return null;
     },
     routes: [
-      // Shell keeps tab navigators alive
+      // Shell owns the shared scaffold and bottom navigation. Individual tab
+      // route state that must survive a child swap is restored explicitly from
+      // route params or tab-position providers.
       ShellRoute(
         builder: (context, state, child) {
           final location = state.uri.toString();
@@ -443,16 +445,23 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: VideoFeedPage.pathWithIndex,
             name: VideoFeedPage.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.home,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const VideoFeedPage(),
-                  settings: const RouteSettings(name: VideoFeedPage.routeName),
+            pageBuilder: (ctx, st) {
+              final rawIndex =
+                  int.tryParse(st.pathParameters['index'] ?? '') ?? 0;
+              final initialIndex = rawIndex < 0 ? 0 : rawIndex;
+              return NoTransitionPage(
+                key: st.pageKey,
+                child: Navigator(
+                  key: NavigatorKeys.home,
+                  onGenerateRoute: (r) => MaterialPageRoute(
+                    builder: (_) => VideoFeedPage(initialIndex: initialIndex),
+                    settings: const RouteSettings(
+                      name: VideoFeedPage.routeName,
+                    ),
+                  ),
                 ),
-              ),
-            ),
+              );
+            },
           ),
 
           // EXPLORE tab - grid mode (no index)

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -228,6 +228,12 @@ bool _isAuthEntryLocation(String location) {
       location == MinorAccountReviewUnder13Screen.path;
 }
 
+@visibleForTesting
+int homeInitialIndexFromPathParameters(Map<String, String> pathParameters) {
+  final rawIndex = int.tryParse(pathParameters['index'] ?? '') ?? 0;
+  return rawIndex < 0 ? 0 : rawIndex;
+}
+
 final goRouterProvider = Provider<GoRouter>((ref) {
   // Use ref.read to avoid recreating the router on auth state changes
   final authService = ref.read(authServiceProvider);
@@ -446,9 +452,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             path: VideoFeedPage.pathWithIndex,
             name: VideoFeedPage.routeName,
             pageBuilder: (ctx, st) {
-              final rawIndex =
-                  int.tryParse(st.pathParameters['index'] ?? '') ?? 0;
-              final initialIndex = rawIndex < 0 ? 0 : rawIndex;
+              final initialIndex = homeInitialIndexFromPathParameters(
+                st.pathParameters,
+              );
               return NoTransitionPage(
                 key: st.pageKey,
                 child: Navigator(

--- a/mobile/lib/router/providers/last_tab_position_provider.dart
+++ b/mobile/lib/router/providers/last_tab_position_provider.dart
@@ -49,6 +49,17 @@ class LastTabPosition extends Notifier<Map<RouteType, int>> {
     // For routes that always have an index (home, notifications, profile), default to 0
     return state[type] ?? 0;
   }
+
+  /// Records a tab position without forcing a route change.
+  ///
+  /// Home uses this while the user swipes between videos. Updating the URL for
+  /// every page change would rebuild the shell route and churn the feed, but
+  /// the bottom nav still needs the latest index when returning to Home.
+  void recordPosition(RouteType type, int index) {
+    final normalized = index < 0 ? 0 : index;
+    if (state[type] == normalized) return;
+    state = {...state, type: normalized};
+  }
 }
 
 final lastTabPositionProvider =

--- a/mobile/lib/router/providers/last_tab_position_provider.dart
+++ b/mobile/lib/router/providers/last_tab_position_provider.dart
@@ -14,6 +14,8 @@ class LastTabPosition extends Notifier<Map<RouteType, int>> {
       final ctx = next.asData?.value;
       if (ctx == null) return;
 
+      if (ctx.type == RouteType.home) return;
+
       // Only track video-based routes
       if (ctx.type == RouteType.videoRecorder ||
           ctx.type == RouteType.videoEditor ||

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -36,10 +36,17 @@ class VideoFeedPage extends ConsumerWidget {
   /// Build path for a specific index.
   static String pathForIndex(int index) => '/home/$index';
 
-  const VideoFeedPage({this.initialMode = FeedMode.forYou, super.key});
+  const VideoFeedPage({
+    this.initialMode = FeedMode.forYou,
+    this.initialIndex = 0,
+    super.key,
+  });
 
   /// The feed mode to start with. Defaults to [FeedMode.forYou].
   final FeedMode initialMode;
+
+  /// The video index restored from the Home route or last-tab position.
+  final int initialIndex;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -58,9 +65,7 @@ class VideoFeedPage extends ConsumerWidget {
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
 
     return MultiBlocProvider(
-      key: ValueKey(
-        'video-feed-$showDivineHostedOnly-$contentFilterVersion',
-      ),
+      key: ValueKey('video-feed-$showDivineHostedOnly-$contentFilterVersion'),
       providers: [
         BlocProvider(
           create: (_) => VideoFeedBloc(
@@ -77,14 +82,17 @@ class VideoFeedPage extends ConsumerWidget {
         ),
         BlocProvider(create: (_) => VideoPlaybackStatusCubit()),
       ],
-      child: const VideoFeedView(),
+      child: VideoFeedView(initialIndex: initialIndex),
     );
   }
 }
 
 @visibleForTesting
 class VideoFeedView extends ConsumerStatefulWidget {
-  const VideoFeedView({super.key});
+  const VideoFeedView({this.initialIndex = 0, super.key});
+
+  /// The video index to show when the feed first mounts.
+  final int initialIndex;
 
   @override
   ConsumerState<VideoFeedView> createState() => _VideoFeedViewState();
@@ -110,6 +118,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// Tracks the current fractional page position for scroll-driven overlay opacity.
   late final ValueNotifier<double> _pagePosition;
 
+  /// Tracks the active Home video without forcing route updates while swiping.
+  late int _currentIndex;
+
   /// Feed-scoped Auto playback state. Owned by this state so tests can drive
   /// the screen without also wiring the cubit externally; exposed to children
   /// via `BlocProvider.value` in [build] so the rail control and feed items
@@ -119,7 +130,8 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   @override
   void initState() {
     super.initState();
-    _pagePosition = ValueNotifier<double>(0);
+    _currentIndex = widget.initialIndex;
+    _pagePosition = ValueNotifier<double>(_currentIndex.toDouble());
     WidgetsBinding.instance.addObserver(this);
   }
 
@@ -147,9 +159,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
   @override
   Widget build(BuildContext context) {
-    // Pause/resume when navigating away from/back to home tab.
-    // The home navigator's GlobalKey keeps this widget alive across
-    // tab switches, so we must explicitly pause on tab change.
+    // Pause/resume when navigating away from/back to home tab. Some pushed
+    // routes keep this widget mounted, so playback must follow route context
+    // instead of assuming disposal handles every transition.
     ref.listen(pageContextProvider, (_, next) {
       final routeType = next.asData?.value.type;
       if (routeType == null) return;
@@ -209,7 +221,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
             BlocListener<VideoFeedBloc, VideoFeedBlocState>(
               listenWhen: (previous, current) => previous.mode != current.mode,
               listener: (_, _) {
+                _currentIndex = 0;
                 _pagePosition.value = 0;
+                ref
+                    .read(lastTabPositionProvider.notifier)
+                    .recordPosition(RouteType.home, 0);
               },
             ),
             // Mark UI ready when videos first become available.
@@ -260,11 +276,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                     FeedVideos(
                       videos: state.videos,
                       contextTitle: state.feedContextTitle,
+                      currentIndex: _currentIndex,
                       isActive: _isNewFeedActive,
                       hasMore: state.hasMore,
                       isLoadingMore: state.isLoadingMore,
                       trafficSource: ViewTrafficSource.home,
                       onActiveVideoChanged: (video, index) {
+                        _currentIndex = index;
+                        ref
+                            .read(lastTabPositionProvider.notifier)
+                            .recordPosition(RouteType.home, index);
                         _resumeAutoAdvanceAfterSwipe();
                         FeedPerformanceTracker().startVideoSwipeTracking(
                           video.id,
@@ -303,6 +324,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// last known state via `orElse`.
   Future<void> _refreshFeed(BuildContext context) async {
     final bloc = context.read<VideoFeedBloc>();
+    _currentIndex = 0;
+    _pagePosition.value = 0;
+    ref
+        .read(lastTabPositionProvider.notifier)
+        .recordPosition(RouteType.home, 0);
     bloc.add(const VideoFeedRefreshRequested());
     await bloc.stream.firstWhere(
       (s) =>

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -130,9 +130,14 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   @override
   void initState() {
     super.initState();
-    _currentIndex = widget.initialIndex;
+    _currentIndex = widget.initialIndex < 0 ? 0 : widget.initialIndex;
     _pagePosition = ValueNotifier<double>(_currentIndex.toDouble());
     WidgetsBinding.instance.addObserver(this);
+  }
+
+  int _clampIndexForItemCount(int index, int itemCount) {
+    if (itemCount == 0) return 0;
+    return index.clamp(0, itemCount - 1);
   }
 
   @override
@@ -244,6 +249,28 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
           ],
           child: BlocBuilder<VideoFeedBloc, VideoFeedBlocState>(
             builder: (context, state) {
+              final itemCount = state.videos.length;
+              final clampedIndex = _clampIndexForItemCount(
+                _currentIndex,
+                itemCount,
+              );
+              if (clampedIndex != _currentIndex) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  if (_currentIndex >= 0 && _currentIndex < itemCount) return;
+                  final normalized = _clampIndexForItemCount(
+                    _currentIndex,
+                    itemCount,
+                  );
+                  if (_currentIndex == normalized) return;
+                  _currentIndex = normalized;
+                  _pagePosition.value = normalized.toDouble();
+                  ref
+                      .read(lastTabPositionProvider.notifier)
+                      .recordPosition(RouteType.home, normalized);
+                });
+              }
+
               // Loading state (including initial state before first load)
               if (state.isLoading) {
                 return const Center(child: BrandedLoadingIndicator());
@@ -251,7 +278,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
               // Error state
               if (state.status == VideoFeedStatus.failure) {
-                return _FeedErrorWidget(error: state.error);
+                return _FeedErrorWidget(
+                  error: state.error,
+                  onRetry: () => _refreshFeed(context),
+                );
               }
 
               // Empty state
@@ -276,7 +306,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                     FeedVideos(
                       videos: state.videos,
                       contextTitle: state.feedContextTitle,
-                      currentIndex: _currentIndex,
+                      currentIndex: clampedIndex,
                       isActive: _isNewFeedActive,
                       hasMore: state.hasMore,
                       isLoadingMore: state.isLoadingMore,
@@ -340,9 +370,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 }
 
 class _FeedErrorWidget extends StatelessWidget {
-  const _FeedErrorWidget({this.error});
+  const _FeedErrorWidget({required this.onRetry, this.error});
 
   final VideoFeedError? error;
+  final Future<void> Function() onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -369,9 +400,7 @@ class _FeedErrorWidget extends StatelessWidget {
           ],
           const SizedBox(height: 24),
           ElevatedButton(
-            onPressed: () => context.read<VideoFeedBloc>().add(
-              const VideoFeedRefreshRequested(),
-            ),
+            onPressed: () => unawaited(onRetry()),
             child: Text(context.l10n.feedRetry),
           ),
         ],

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -298,6 +298,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   /// The feed index of the currently active (visible) video.
   int get currentIndex => _currentIndex;
 
+  int _clampIndex(int index) {
+    if (widget.videos.isEmpty) return 0;
+    return index.clamp(0, widget.videos.length - 1);
+  }
+
   /// Continuous page position for scroll-driven overlay effects.
   ///
   /// Value is 0-based and includes fractional positions while the page view
@@ -358,7 +363,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   @override
   void initState() {
     super.initState();
-    _currentIndex = widget.initialIndex;
+    _currentIndex = _clampIndex(widget.initialIndex);
     _volume = widget.initialVolume;
     _isActive = widget.isActive;
     _pagePosition = ValueNotifier<double>(_currentIndex.toDouble());
@@ -433,9 +438,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
     _teardownAllControllers();
 
-    _currentIndex = widget.videos.isEmpty
-        ? 0
-        : widget.initialIndex.clamp(0, widget.videos.length - 1);
+    _currentIndex = _clampIndex(widget.initialIndex);
     _pagePosition.value = _currentIndex.toDouble();
 
     _rebuild();

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -709,6 +709,28 @@ void main() {
         expect(key.currentState!.currentIndex, equals(0));
       });
 
+      testWidgets('clamps initialIndex to the available videos', (
+        tester,
+      ) async {
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = List.generate(3, (i) => _makeVideo('v$i'));
+
+        await tester.pumpWidget(
+          _wrapFeed(
+            InfiniteVideoFeed(
+              key: key,
+              videos: videos,
+              cache: cache,
+              initialIndex: 99,
+              preloadGracePeriod: Duration.zero,
+              prefetchCount: 0,
+            ),
+          ),
+        );
+
+        expect(key.currentState!.currentIndex, equals(2));
+      });
+
       testWidgets('does not autoplay when mounted inactive', (tester) async {
         DivineVideoPlayerController.resetIdCounterForTesting();
         final harness = _NativePlayerHarness(tester);

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -766,12 +766,11 @@ class VideosRepository {
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
-    final cacheKey =
-        'popular:v2:${variant.name}'
-        '${_popularPreferenceCacheSuffix(
-          preferredLanguages: preferredLanguages,
-          viewerCountry: viewerCountry,
-        )}';
+    final preferenceCacheSuffix = _popularPreferenceCacheSuffix(
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
+    final cacheKey = 'popular:v2:${variant.name}$preferenceCacheSuffix';
     if (!skipCache && until == null && cursor == null) {
       final cached = _inMemoryFeedCache?.get(cacheKey);
       if (cached != null) {
@@ -929,12 +928,12 @@ class VideosRepository {
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
+    final preferenceCacheSuffix = _popularPreferenceCacheSuffix(
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
     final cacheKey = variant != null
-        ? 'popular:v2:${variant.name}'
-              '${_popularPreferenceCacheSuffix(
-                preferredLanguages: preferredLanguages,
-                viewerCountry: viewerCountry,
-              )}'
+        ? 'popular:v2:${variant.name}$preferenceCacheSuffix'
         : period == null
         ? _popularCacheKey
         : 'popular:${period.wireValue}';
@@ -2405,10 +2404,22 @@ class VideosRepository {
     final effectiveUserPubkey =
         userPubkey ??
         (_nostrClient.publicKey.isNotEmpty ? _nostrClient.publicKey : null);
+    final preferenceCacheSuffix = _popularPreferenceCacheSuffix(
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
+    final cacheKey =
+        'recommended:${effectiveUserPubkey ?? 'anonymous'}'
+        '$preferenceCacheSuffix';
+    if (!skipCache && until == null && cursor == null) {
+      final cached = _inMemoryFeedCache?.get(cacheKey);
+      if (cached != null) return cached;
+    }
+
     if (effectiveUserPubkey == null ||
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
-      return HomeFeedResult(
+      final result = HomeFeedResult(
         videos: await getPopularVideos(
           limit: limit,
           until: until,
@@ -2417,6 +2428,10 @@ class VideosRepository {
           viewerCountry: viewerCountry,
         ),
       );
+      if (until == null && cursor == null) {
+        _inMemoryFeedCache?.set(cacheKey, result);
+      }
+      return result;
     }
 
     final recommendationCursor = cursor ?? until?.toString();
@@ -2436,7 +2451,7 @@ class VideosRepository {
           );
     final videos = _transformVideoStats(response.videos);
     if (videos.isEmpty) {
-      return HomeFeedResult(
+      final result = HomeFeedResult(
         videos: await getPopularVideos(
           limit: limit,
           until: until,
@@ -2445,14 +2460,22 @@ class VideosRepository {
           viewerCountry: viewerCountry,
         ),
       );
+      if (until == null && cursor == null) {
+        _inMemoryFeedCache?.set(cacheKey, result);
+      }
+      return result;
     }
 
-    return HomeFeedResult(
+    final result = HomeFeedResult(
       videos: videos,
       paginationCursor: response.nextCursor,
       hasMore: response.hasMore,
       rawResponseBody: response.rawBody,
     );
+    if (until == null && cursor == null) {
+      _inMemoryFeedCache?.set(cacheKey, result);
+    }
+    return result;
   }
 
   /// Fetches personalized video recommendations.

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2419,7 +2419,7 @@ class VideosRepository {
     if (effectiveUserPubkey == null ||
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
-      final result = HomeFeedResult(
+      return HomeFeedResult(
         videos: await getPopularVideos(
           limit: limit,
           until: until,
@@ -2428,10 +2428,6 @@ class VideosRepository {
           viewerCountry: viewerCountry,
         ),
       );
-      if (until == null && cursor == null) {
-        _inMemoryFeedCache?.set(cacheKey, result);
-      }
-      return result;
     }
 
     final recommendationCursor = cursor ?? until?.toString();
@@ -2451,7 +2447,7 @@ class VideosRepository {
           );
     final videos = _transformVideoStats(response.videos);
     if (videos.isEmpty) {
-      final result = HomeFeedResult(
+      return HomeFeedResult(
         videos: await getPopularVideos(
           limit: limit,
           until: until,
@@ -2460,10 +2456,6 @@ class VideosRepository {
           viewerCountry: viewerCountry,
         ),
       );
-      if (until == null && cursor == null) {
-        _inMemoryFeedCache?.set(cacheKey, result);
-      }
-      return result;
     }
 
     final result = HomeFeedResult(

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9790,53 +9790,121 @@ void main() {
         ).called(1);
       });
 
-      test(
-        'passes viewer country hint to recommendations endpoint',
-        () async {
-          final recommended = _createVideoStats(
-            id: 'country-recommended-video',
-            pubkey: 'recommended-pubkey',
-            dTag: 'recommended-dtag',
-            videoUrl: 'https://example.com/country-recommended.mp4',
+      test('caches refreshed recommendations for feed remounts', () async {
+        var callCount = 0;
+        when(
+          () => mockFunnelcakeClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((_) async {
+          callCount += 1;
+          return RecommendationsResponse(
+            videos: [
+              _createVideoStats(
+                id: 'recommended-video-$callCount',
+                pubkey: 'recommended-pubkey-$callCount',
+                dTag: 'recommended-dtag-$callCount',
+                videoUrl: 'https://example.com/recommended-$callCount.mp4',
+              ),
+            ],
+            source: 'personalized',
+            nextCursor: 'cursor-$callCount',
+            hasMore: true,
           );
-          when(
-            () => mockFunnelcakeClient.getRecommendations(
-              pubkey: any(named: 'pubkey'),
-              limit: any(named: 'limit'),
-              fallback: any(named: 'fallback'),
-              category: any(named: 'category'),
-              preferredLanguages: any(named: 'preferredLanguages'),
-              viewerCountry: any(named: 'viewerCountry'),
-            ),
-          ).thenAnswer(
-            (_) async => RecommendationsResponse(
-              videos: [recommended],
-              source: 'personalized',
-            ),
-          );
+        });
 
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        final feedCache = InMemoryFeedCache();
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          inMemoryFeedCache: feedCache,
+        );
 
-          final result = await repo.getRecommendedVideos(
-            userPubkey: 'user-pubkey',
+        final refreshed = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+          skipCache: true,
+        );
+        final cachedAfterRefresh = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+        );
+        final secondRefresh = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+          skipCache: true,
+        );
+        final cachedAfterSecondRefresh = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+        );
+
+        expect(refreshed.videos.single.id, equals('recommended-video-1'));
+        expect(
+          cachedAfterRefresh.videos.single.id,
+          equals('recommended-video-1'),
+        );
+        expect(secondRefresh.videos.single.id, equals('recommended-video-2'));
+        expect(
+          cachedAfterSecondRefresh.videos.single.id,
+          equals('recommended-video-2'),
+        );
+        expect(cachedAfterSecondRefresh.paginationCursor, equals('cursor-2'));
+        expect(cachedAfterSecondRefresh.hasMore, isTrue);
+        verify(
+          () => mockFunnelcakeClient.getRecommendations(
+            pubkey: 'user-pubkey',
+            limit: any(named: 'limit'),
+          ),
+        ).called(2);
+      });
+
+      test('passes viewer country hint to recommendations endpoint', () async {
+        final recommended = _createVideoStats(
+          id: 'country-recommended-video',
+          pubkey: 'recommended-pubkey',
+          dTag: 'recommended-dtag',
+          videoUrl: 'https://example.com/country-recommended.mp4',
+        );
+        when(
+          () => mockFunnelcakeClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer(
+          (_) async => RecommendationsResponse(
+            videos: [recommended],
+            source: 'personalized',
+          ),
+        );
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+          limit: 10,
+          viewerCountry: 'BR',
+        );
+
+        expect(result.videos, hasLength(1));
+        expect(result.videos.single.id, equals('country-recommended-video'));
+        verify(
+          () => mockFunnelcakeClient.getRecommendations(
+            pubkey: 'user-pubkey',
             limit: 10,
             viewerCountry: 'BR',
-          );
-
-          expect(result.videos, hasLength(1));
-          expect(result.videos.single.id, equals('country-recommended-video'));
-          verify(
-            () => mockFunnelcakeClient.getRecommendations(
-              pubkey: 'user-pubkey',
-              limit: 10,
-              viewerCountry: 'BR',
-            ),
-          ).called(1);
-        },
-      );
+          ),
+        ).called(1);
+      });
 
       test(
         'falls back to popular videos when no pubkey is available',

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9994,6 +9994,77 @@ void main() {
       );
 
       test(
+        'does not cache empty-recommendations popular fallback as recommended',
+        () async {
+          final popular = _createVideoStats(
+            id: 'popular-video',
+            pubkey: 'popular-pubkey',
+            dTag: 'popular-dtag',
+            videoUrl: 'https://example.com/popular.mp4',
+          );
+          final recommended = _createVideoStats(
+            id: 'recommended-video',
+            pubkey: 'recommended-pubkey',
+            dTag: 'recommended-dtag',
+            videoUrl: 'https://example.com/recommended.mp4',
+          );
+          var recommendationCallCount = 0;
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer((_) async {
+            recommendationCallCount += 1;
+            if (recommendationCallCount == 1) {
+              return const RecommendationsResponse(
+                videos: [],
+                source: 'popular',
+              );
+            }
+            return RecommendationsResponse(
+              videos: [recommended],
+              source: 'personalized',
+            );
+          });
+          when(
+            () => mockFunnelcakeClient.getWatchingVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer((_) async => [popular]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            inMemoryFeedCache: InMemoryFeedCache(),
+          );
+
+          final fallback = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+          final recovered = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(fallback.videos.single.id, equals('popular-video'));
+          expect(recovered.videos.single.id, equals('recommended-video'));
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: 'user-pubkey',
+              limit: 10,
+            ),
+          ).called(2);
+        },
+      );
+
+      test(
         'falls back to popular videos when recommendations are unavailable',
         () async {
           final popular = _createVideoEvent(
@@ -10029,6 +10100,71 @@ void main() {
           );
           verify(
             () => mockNostrClient.queryEvents(any(), useCache: false),
+          ).called(1);
+        },
+      );
+
+      test(
+        'does not cache unavailable-recommendations fallback as recommended',
+        () async {
+          var recommendationsAvailable = false;
+          final popular = _createVideoEvent(
+            id: 'popular-video',
+            pubkey: 'popular-pubkey',
+            videoUrl: 'https://example.com/popular.mp4',
+            createdAt: 1700000000,
+          );
+          final recommended = _createVideoStats(
+            id: 'recommended-video',
+            pubkey: 'recommended-pubkey',
+            dTag: 'recommended-dtag',
+            videoUrl: 'https://example.com/recommended.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.isAvailable,
+          ).thenAnswer((_) => recommendationsAvailable);
+          when(
+            () => mockNostrClient.queryEvents(any(), useCache: false),
+          ).thenAnswer((_) async => [popular]);
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [recommended],
+              source: 'personalized',
+            ),
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            inMemoryFeedCache: InMemoryFeedCache(),
+          );
+
+          final fallback = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+          recommendationsAvailable = true;
+          final recovered = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(fallback.videos.single.id, equals('popular-video'));
+          expect(recovered.videos.single.id, equals('recommended-video'));
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              pubkey: 'user-pubkey',
+              limit: 10,
+            ),
           ).called(1);
         },
       );

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -252,33 +252,6 @@ void main() {
   // builder regions reintroduce Uri.decodeComponent — the exact regression
   // that originally caused the crash.
   group('Builder regression guard (#3413)', () {
-    test('home builder threads route index into VideoFeedPage', () {
-      final source = File('lib/router/app_router.dart').readAsStringSync();
-
-      final homePathOffset = source.indexOf(
-        'path: VideoFeedPage.pathWithIndex',
-      );
-      final explorePathOffset = source.indexOf('path: ExploreScreen.path');
-      expect(
-        homePathOffset,
-        isNonNegative,
-        reason:
-            'Home GoRoute marker not found in app_router.dart. '
-            'Update this regression test to match the new marker.',
-      );
-      expect(
-        explorePathOffset,
-        greaterThan(homePathOffset),
-        reason:
-            'Explore GoRoute marker not found after Home GoRoute. '
-            'Update this regression test to match the new layout.',
-      );
-
-      final homeRegion = source.substring(homePathOffset, explorePathOffset);
-      expect(homeRegion, contains("st.pathParameters['index']"));
-      expect(homeRegion, contains('VideoFeedPage(initialIndex: initialIndex)'));
-    });
-
     test('hashtag and search builders do not call Uri.decodeComponent', () {
       final source = File('lib/router/app_router.dart').readAsStringSync();
 
@@ -345,6 +318,24 @@ void main() {
             'Search-results builder must derive focus from the routed URI so '
             'Explore, mentions, and deep links can express distinct intent.',
       );
+    });
+  });
+
+  group('Home route builder', () {
+    test('parses and normalizes the routed home index', () {
+      expect(
+        homeInitialIndexFromPathParameters(const {'index': '37'}),
+        equals(37),
+      );
+      expect(
+        homeInitialIndexFromPathParameters(const {'index': '-4'}),
+        equals(0),
+      );
+      expect(
+        homeInitialIndexFromPathParameters(const {'index': 'not-an-int'}),
+        equals(0),
+      );
+      expect(homeInitialIndexFromPathParameters(const {}), equals(0));
     });
   });
 }

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -93,16 +93,9 @@ void main() {
   // pulling in the full app provider graph.
   group('Path-parameter round-trip (#3413)', () {
     Future<
-      ({
-        String? capturedTag,
-        String? capturedQuery,
-        bool? requestFocusOnMount,
-      })
+      ({String? capturedTag, String? capturedQuery, bool? requestFocusOnMount})
     >
-    navigateAndCapture(
-      WidgetTester tester,
-      String location,
-    ) async {
+    navigateAndCapture(WidgetTester tester, String location) async {
       String? capturedTag;
       String? capturedQuery;
       bool? requestFocusOnMount;
@@ -110,10 +103,7 @@ void main() {
       final router = GoRouter(
         initialLocation: '/',
         routes: [
-          GoRoute(
-            path: '/',
-            builder: (_, _) => const SizedBox.shrink(),
-          ),
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
           GoRoute(
             path: HashtagScreenRouter.path,
             builder: (ctx, st) {
@@ -126,9 +116,7 @@ void main() {
             builder: (ctx, st) {
               capturedQuery = '';
               requestFocusOnMount =
-                  SearchResultsPage.requestFocusOnMountForRoute(
-                    st.uri,
-                  );
+                  SearchResultsPage.requestFocusOnMountForRoute(st.uri);
               return const SizedBox.shrink();
             },
           ),
@@ -137,9 +125,7 @@ void main() {
             builder: (ctx, st) {
               capturedQuery = st.pathParameters['query'];
               requestFocusOnMount =
-                  SearchResultsPage.requestFocusOnMountForRoute(
-                    st.uri,
-                  );
+                  SearchResultsPage.requestFocusOnMountForRoute(st.uri);
               return const SizedBox.shrink();
             },
           ),
@@ -186,19 +172,18 @@ void main() {
       },
     );
 
-    testWidgets(
-      'pathForEmptyQuery opens search without a prefilled query',
-      (tester) async {
-        final result = await navigateAndCapture(
-          tester,
-          SearchResultsPage.pathForEmptyQuery(requestFocusOnMount: true),
-        );
+    testWidgets('pathForEmptyQuery opens search without a prefilled query', (
+      tester,
+    ) async {
+      final result = await navigateAndCapture(
+        tester,
+        SearchResultsPage.pathForEmptyQuery(requestFocusOnMount: true),
+      );
 
-        expect(tester.takeException(), isNull);
-        expect(result.capturedQuery, isEmpty);
-        expect(result.requestFocusOnMount, isTrue);
-      },
-    );
+      expect(tester.takeException(), isNull);
+      expect(result.capturedQuery, isEmpty);
+      expect(result.requestFocusOnMount, isTrue);
+    });
 
     testWidgets(
       'pathForQuery with literal % round-trips through go_router decode',
@@ -206,10 +191,7 @@ void main() {
         const original = '100%';
         final result = await navigateAndCapture(
           tester,
-          SearchResultsPage.pathForQuery(
-            original,
-            requestFocusOnMount: false,
-          ),
+          SearchResultsPage.pathForQuery(original, requestFocusOnMount: false),
         );
 
         expect(tester.takeException(), isNull);
@@ -223,10 +205,7 @@ void main() {
         const original = '50% off deals';
         final result = await navigateAndCapture(
           tester,
-          SearchResultsPage.pathForQuery(
-            original,
-            requestFocusOnMount: false,
-          ),
+          SearchResultsPage.pathForQuery(original, requestFocusOnMount: false),
         );
 
         expect(tester.takeException(), isNull);
@@ -234,23 +213,19 @@ void main() {
       },
     );
 
-    testWidgets(
-      'pathForQuery can opt a prefilled route into mount focus',
-      (tester) async {
-        const original = 'alice';
-        final result = await navigateAndCapture(
-          tester,
-          SearchResultsPage.pathForQuery(
-            original,
-            requestFocusOnMount: true,
-          ),
-        );
+    testWidgets('pathForQuery can opt a prefilled route into mount focus', (
+      tester,
+    ) async {
+      const original = 'alice';
+      final result = await navigateAndCapture(
+        tester,
+        SearchResultsPage.pathForQuery(original, requestFocusOnMount: true),
+      );
 
-        expect(tester.takeException(), isNull);
-        expect(result.capturedQuery, equals(original));
-        expect(result.requestFocusOnMount, isTrue);
-      },
-    );
+      expect(tester.takeException(), isNull);
+      expect(result.capturedQuery, equals(original));
+      expect(result.requestFocusOnMount, isTrue);
+    });
 
     testWidgets(
       'pathForQuery keeps a prefilled route unfocused when not opted in',
@@ -258,10 +233,7 @@ void main() {
         const original = 'alice';
         final result = await navigateAndCapture(
           tester,
-          SearchResultsPage.pathForQuery(
-            original,
-            requestFocusOnMount: false,
-          ),
+          SearchResultsPage.pathForQuery(original, requestFocusOnMount: false),
         );
 
         expect(tester.takeException(), isNull);
@@ -280,15 +252,40 @@ void main() {
   // builder regions reintroduce Uri.decodeComponent — the exact regression
   // that originally caused the crash.
   group('Builder regression guard (#3413)', () {
+    test('home builder threads route index into VideoFeedPage', () {
+      final source = File('lib/router/app_router.dart').readAsStringSync();
+
+      final homePathOffset = source.indexOf(
+        'path: VideoFeedPage.pathWithIndex',
+      );
+      final explorePathOffset = source.indexOf('path: ExploreScreen.path');
+      expect(
+        homePathOffset,
+        isNonNegative,
+        reason:
+            'Home GoRoute marker not found in app_router.dart. '
+            'Update this regression test to match the new marker.',
+      );
+      expect(
+        explorePathOffset,
+        greaterThan(homePathOffset),
+        reason:
+            'Explore GoRoute marker not found after Home GoRoute. '
+            'Update this regression test to match the new layout.',
+      );
+
+      final homeRegion = source.substring(homePathOffset, explorePathOffset);
+      expect(homeRegion, contains("st.pathParameters['index']"));
+      expect(homeRegion, contains('VideoFeedPage(initialIndex: initialIndex)'));
+    });
+
     test('hashtag and search builders do not call Uri.decodeComponent', () {
       final source = File('lib/router/app_router.dart').readAsStringSync();
 
       final hashtagPathOffset = source.indexOf(
         'path: HashtagScreenRouter.path',
       );
-      final searchPathOffset = source.indexOf(
-        'path: SearchResultsPage.path',
-      );
+      final searchPathOffset = source.indexOf('path: SearchResultsPage.path');
       expect(
         hashtagPathOffset,
         isNonNegative,
@@ -342,9 +339,7 @@ void main() {
             'instead of relying on widget defaults.',
       );
       expect(
-        searchRegion.contains(
-          'SearchResultsPage.requestFocusOnMountForRoute(',
-        ),
+        searchRegion.contains('SearchResultsPage.requestFocusOnMountForRoute('),
         isTrue,
         reason:
             'Search-results builder must derive focus from the routed URI so '

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -6,6 +6,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart';
@@ -14,6 +15,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -89,9 +91,7 @@ void main() {
 
     testWidgets(
       'uses localized Following copy for an empty Following no-follow feed',
-      (
-        tester,
-      ) async {
+      (tester) async {
         await tester.pumpWidget(
           _buildEmptyFeedSubject(
             const VideoFeedBlocState(
@@ -162,9 +162,7 @@ void main() {
 
       await tester.tap(find.text('Explore Videos'));
 
-      verify(
-        () => router.go(ExploreScreen.pathForTab('popular')),
-      ).called(1);
+      verify(() => router.go(ExploreScreen.pathForTab('popular'))).called(1);
     });
 
     testWidgets('uses the design-system arrow on the Following empty CTA', (
@@ -231,6 +229,89 @@ void main() {
       await tester.pump(const Duration(seconds: 3));
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
+    });
+
+    testWidgets('passes restored home index to FeedVideos', (tester) async {
+      final videos = [
+        createTestVideoEvent(id: 'video-0'),
+        createTestVideoEvent(id: 'video-1'),
+        createTestVideoEvent(id: 'video-2'),
+      ];
+      final state = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: videos,
+      );
+      when(() => videoFeedBloc.state).thenReturn(state);
+      whenListen(
+        videoFeedBloc,
+        const Stream<VideoFeedBlocState>.empty(),
+        initialState: state,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const VideoFeedView(initialIndex: 2),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
+      expect(feedVideos.currentIndex, 2);
+    });
+
+    testWidgets('records active video index for home tab restoration', (
+      tester,
+    ) async {
+      final videos = [
+        createTestVideoEvent(id: 'video-0'),
+        createTestVideoEvent(id: 'video-1'),
+      ];
+      final state = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: videos,
+      );
+      when(() => videoFeedBloc.state).thenReturn(state);
+      whenListen(
+        videoFeedBloc,
+        const Stream<VideoFeedBlocState>.empty(),
+        initialState: state,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const VideoFeedView(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
+      feedVideos.onActiveVideoChanged!(videos[1], 1);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(VideoFeedView)),
+      );
+      expect(
+        container.read(lastTabPositionProvider)[RouteType.home],
+        equals(1),
+      );
     });
   });
 }

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -268,6 +268,43 @@ void main() {
       expect(feedVideos.currentIndex, 2);
     });
 
+    testWidgets('clamps restored home index to loaded videos', (tester) async {
+      final videos = [
+        createTestVideoEvent(id: 'video-0'),
+        createTestVideoEvent(id: 'video-1'),
+        createTestVideoEvent(id: 'video-2'),
+      ];
+      final state = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: videos,
+      );
+      when(() => videoFeedBloc.state).thenReturn(state);
+      whenListen(
+        videoFeedBloc,
+        const Stream<VideoFeedBlocState>.empty(),
+        initialState: state,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const VideoFeedView(initialIndex: 99),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
+      expect(feedVideos.currentIndex, 2);
+    });
+
     testWidgets('records active video index for home tab restoration', (
       tester,
     ) async {
@@ -312,6 +349,83 @@ void main() {
         container.read(lastTabPositionProvider)[RouteType.home],
         equals(1),
       );
+    });
+
+    testWidgets('home route emissions do not clobber recorded home index', (
+      tester,
+    ) async {
+      const bodyKey = Key('home-position-provider-body');
+      await tester.pumpWidget(
+        testMaterialApp(
+          additionalOverrides: [
+            routerLocationStreamProvider.overrideWith(
+              (_) => Stream.value('/home/0'),
+            ),
+          ],
+          home: const SizedBox.shrink(key: bodyKey),
+        ),
+      );
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byKey(bodyKey)),
+      );
+      final positions = container.read(lastTabPositionProvider.notifier);
+      positions.recordPosition(RouteType.home, 12);
+
+      await tester.pump();
+
+      expect(
+        container.read(lastTabPositionProvider)[RouteType.home],
+        equals(12),
+      );
+    });
+
+    testWidgets('retry resets home index before refreshing failed feed', (
+      tester,
+    ) async {
+      const state = VideoFeedBlocState(
+        status: VideoFeedStatus.failure,
+        error: VideoFeedError.loadFailed,
+      );
+      when(() => videoFeedBloc.state).thenReturn(state);
+      whenListen(
+        videoFeedBloc,
+        const Stream<VideoFeedBlocState>.empty(),
+        initialState: state,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const VideoFeedView(initialIndex: 4),
+          ),
+        ),
+      );
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(VideoFeedView)),
+      );
+      container
+          .read(lastTabPositionProvider.notifier)
+          .recordPosition(RouteType.home, 4);
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      expect(
+        container.read(lastTabPositionProvider)[RouteType.home],
+        equals(0),
+      );
+      verify(
+        () => videoFeedBloc.add(const VideoFeedRefreshRequested()),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Restores the Home feed route index into `VideoFeedPage` and `FeedVideos` so returning to Home can resume at the active video.
- Records Home's active video index in the existing tab-position provider without calling `context.go` on every swipe.
- Caches refreshed recommendation results in `videos_repository` so a recreated Home feed sees the same For You list instead of a new ordering.
- Corrects stale shell-route comments that implied inactive tab widgets are always kept alive.

## Root Cause

Home already had `/home/:index` and tab-position plumbing, but the routed index was never threaded into the feed. The Home feed also recreated its bloc when the shell child changed, and For You recommendations were not cached like other initial feed pages, so an index-only restore could land on a different list.

Closes #5020

## Validation

- `mise exec flutter@3.44.0 -- flutter analyze`
- `mise exec flutter@3.44.0 -- flutter test test/screens/feed/video_feed_page_test.dart test/router/app_router_test.dart`
- `mise exec flutter@3.44.0 -- flutter test test/src/videos_repository_test.dart --plain-name "caches refreshed recommendations for feed remounts"` from `mobile/packages/videos_repository`
- `mise exec flutter@3.44.0 -- flutter test --coverage` from `mobile/packages/videos_repository` (line coverage: 100.00%, 1009/1009)
- `mise exec flutter@3.44.0 -- flutter test` from `mobile`
- Pre-push hook analyzer and changed-file tests passed
