### PR TITLE
fix(feed): stop replaying stale For You feed on cold start

### DIFF
--- a/mobile/lib/blocs/video_feed/home_feed_cache.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_cache.dart
@@ -8,11 +8,15 @@ import 'package:models/models.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:videos_repository/videos_repository.dart';
 
-/// SharedPreferences key for cached home feed JSON.
-const homeFeedCacheKey = 'home_feed_cache';
+/// SharedPreferences key for cached Following feed JSON.
+///
+/// Previous app versions used the unscoped `home_feed_cache` key for both
+/// Following and For You. Keep this key Following-specific so stale For You
+/// payloads from older installs are ignored after upgrade.
+const homeFeedCacheKey = 'home_feed_cache_following_v1';
 
-/// SharedPreferences key for cached home feed timestamp.
-const homeFeedCacheTimeKey = 'home_feed_cache_time';
+/// SharedPreferences key for cached Following feed timestamp.
+const homeFeedCacheTimeKey = 'home_feed_cache_following_v1_time';
 
 /// Maximum age of cached home feed before it's considered stale.
 const homeFeedCacheMaxAge = Duration(hours: 1);

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -101,8 +101,18 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// [_onAutoRefreshRequested] to skip refreshes when data is fresh.
   DateTime? _lastRefreshedAt;
 
+  /// Whether [source] should be served from and written to the cross-restart
+  /// [HomeFeedCache] (SharedPreferences).
+  ///
+  /// Only the chronological `following` feed is cached. Its ordering is
+  /// inherently stable, so replaying the last response on cold start is a
+  /// harmless startup optimization.
+  ///
+  /// The `forYou` feed is deliberately excluded: it is a recommendation feed
+  /// that should reflect fresh server state on every cold start. Persisting
+  /// and replaying its exact contents/order made the feed look identical on
+  /// every app reopen within the cache window (see issue #3861).
   bool _usesHomeFeedCache(VideoFeedSource source) =>
-      source.type == VideoFeedSourceType.forYou ||
       source.type == VideoFeedSourceType.following;
 
   /// Handle feed started event.

--- a/mobile/test/blocs/video_feed/home_feed_cache_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_cache_test.dart
@@ -73,6 +73,23 @@ void main() {
         expect(result.videos[1].id, equals('video-1'));
       });
 
+      test(
+        'ignores legacy unscoped cache entries from older app versions',
+        () async {
+          final freshTime = DateTime.now().millisecondsSinceEpoch;
+
+          SharedPreferences.setMockInitialValues({
+            'home_feed_cache': validFeedJson(),
+            'home_feed_cache_time': freshTime,
+          });
+          final prefs = await SharedPreferences.getInstance();
+
+          final result = cache.read(prefs);
+
+          expect(result, isNull);
+        },
+      );
+
       test('returns null when cached JSON is invalid', () async {
         final freshTime = DateTime.now().millisecondsSinceEpoch;
 

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -2736,7 +2736,7 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'writes forYou raw response body to Home tab cache after fresh fetch',
+        'does not write forYou response to Home tab cache after fresh fetch',
         setUp: () {
           final videos = createTestVideos(3);
           when(() => mockCache.read(sharedPreferences)).thenReturn(null);
@@ -2759,12 +2759,10 @@ void main() {
         build: createBlocWithCache,
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         verify: (_) {
-          verify(
-            () => mockCache.write(
-              sharedPreferences,
-              '{"videos":[{"id":"for-you"}]}',
-            ),
-          ).called(1);
+          // forYou is a recommendation feed and must not be persisted to the
+          // cross-restart cache, otherwise the feed looks identical on every
+          // app reopen (issue #3861).
+          verifyNever(() => mockCache.write(any(), any()));
         },
       );
 
@@ -2829,9 +2827,8 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'serves cached Home tab data before fresh forYou recommendations',
+        'does not serve cached Home tab data for forYou recommendations',
         setUp: () {
-          final cachedVideos = createTestVideos(2, idPrefix: 'cached');
           final recommendedVideos = createTestVideos(
             3,
             idPrefix: 'recommended',
@@ -2839,7 +2836,7 @@ void main() {
 
           when(
             () => mockCache.read(sharedPreferences),
-          ).thenReturn(HomeFeedResult(videos: cachedVideos));
+          ).thenReturn(HomeFeedResult(videos: createTestVideos(2)));
           when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
           when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
           when(
@@ -2855,10 +2852,8 @@ void main() {
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
           const VideoFeedBlocState(),
-          isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'cached count', 2)
-              .having((s) => s.videos.first.id, 'first cached id', 'cached-0'),
+          // No cached state is emitted — the first success state is the fresh
+          // recommendations straight from the network (issue #3861).
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'recommended count', 3)
@@ -2869,7 +2864,10 @@ void main() {
               ),
         ],
         verify: (_) {
-          verify(() => mockCache.read(sharedPreferences)).called(1);
+          // forYou must never read the cross-restart cache, otherwise the feed
+          // is identical on every app reopen.
+          verifyNever(() => mockCache.read(any()));
+          verifyNever(() => mockCache.write(any(), any()));
         },
       );
 


### PR DESCRIPTION
Closes #5028

## Summary

Addresses the client-side stale-cache path for #3861. The For You page showed the exact same videos in the same order every time the app was reopened within the persisted cache window.

### Root cause

VideoFeedBloc uses a cross-restart HomeFeedCache in SharedPreferences to serve a feed instantly on cold start while fresh data loads. The cache stores the raw response body and replays it verbatim for up to one hour.

Before this PR, both Following and For You were eligible for that persisted replay. For You is a recommendation feed, so replaying its exact previous response made the feed look frozen on reopen.

### Fix

Scope the cross-restart HomeFeedCache to Following only:

- For You no longer reads from or writes to the persisted HomeFeedCache. It performs a fresh recommendation fetch on cold start.
- Following keeps the startup cache because its order is chronological and stable.
- The persisted HomeFeedCache keys are now Following-specific, so legacy unscoped cache payloads from older app versions are ignored instead of being replayed once into Following after upgrade.

### Notes / out of scope

- This PR should leave #3861 open. A fresh network fetch can still return the same ordering if the recommendations endpoint is deterministic for the user/content set.
- Follow-up #5027 tracks recommendation ordering/session freshness.
- The empty SubscriptionType.profile feed in the original logs remains separate and out of scope for this PR.

### Testing

- mise exec flutter@3.44.0 -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart test/blocs/video_feed/home_feed_cache_test.dart
- mise exec flutter@3.44.0 -- flutter analyze lib/blocs/video_feed/video_feed_bloc.dart lib/blocs/video_feed/home_feed_cache.dart test/blocs/video_feed/video_feed_bloc_test.dart test/blocs/video_feed/home_feed_cache_test.dart
